### PR TITLE
Add reCAPTCHA Enterprise score-gating across checkout, login, and signup

### DIFF
--- a/app/controllers/concerns/validate_recaptcha.rb
+++ b/app/controllers/concerns/validate_recaptcha.rb
@@ -4,33 +4,118 @@ module ValidateRecaptcha
   ENTERPRISE_VERIFICATION_URL =
     "https://recaptchaenterprise.googleapis.com/v1/projects/#{GOOGLE_CLOUD_PROJECT_ID}/" \
     "assessments?key=#{GlobalConfig.get("ENTERPRISE_RECAPTCHA_API_KEY")}"
+  RECAPTCHA_FAIL_OPEN_DEFAULTS = {
+    checkout: true,
+    login: false,
+    signup: false,
+  }.freeze
+  RECAPTCHA_SCORE_LOG_PREFIX = "[recaptcha_score]"
 
-  private_constant :ENTERPRISE_VERIFICATION_URL
+  private_constant :ENTERPRISE_VERIFICATION_URL, :RECAPTCHA_FAIL_OPEN_DEFAULTS, :RECAPTCHA_SCORE_LOG_PREFIX
 
   private
     def valid_recaptcha_response_and_hostname?(site_key:)
-      return true if Rails.env.test?
-
-      verification_response = recaptcha_verification_response(site_key:)
-      is_valid_token = verification_response.dig("tokenProperties", "valid")
-
-      # Verify hostname only in production because the returned hostname isn't the real hostname for test keys
-      if Rails.env.production?
-        hostname = verification_response.dig("tokenProperties", "hostname")
-
-        is_valid_token && (
-          # TODO: Refactor subdomain check. Use Subdomain module if possible
-          hostname == DOMAIN || hostname.end_with?(".#{ROOT_DOMAIN}") || CustomDomain.find_by_host(hostname).present?)
-      else
-        is_valid_token
-      end
+      recaptcha_passes?(site_key:, surface: :checkout, require_hostname: true)
     end
 
-    def valid_recaptcha_response?(site_key:)
+    def valid_recaptcha_response?(site_key:, surface: :login)
+      recaptcha_passes?(site_key:, surface:, require_hostname: false)
+    end
+
+    def recaptcha_passes?(site_key:, surface:, require_hostname:)
       return true if Rails.env.test?
 
+      surface = surface.to_sym
+      assessment = recaptcha_assessment(site_key:)
+      threshold = recaptcha_score_threshold(surface)
+
+      if assessment[:infra_error]
+        fail_open = recaptcha_fail_open?(surface)
+        log_recaptcha_score(
+          surface:,
+          assessment:,
+          threshold:,
+          hostname_ok: nil,
+          decision: fail_open ? "infra_error_fail_open" : "infra_error_fail_closed"
+        )
+
+        return fail_open
+      end
+
+      hostname_ok = require_hostname ? hostname_allowed?(assessment[:hostname]) : true
+      token_ok = assessment[:valid] && hostname_ok
+      score_ok = threshold.nil? || (assessment[:score].present? && assessment[:score] >= threshold)
+      decision = token_ok && score_ok
+
+      log_recaptcha_score(
+        surface:,
+        assessment:,
+        threshold:,
+        hostname_ok:,
+        decision: decision ? "pass" : "fail"
+      )
+
+      decision
+    end
+
+    def recaptcha_assessment(site_key:)
       verification_response = recaptcha_verification_response(site_key:)
-      verification_response.dig("tokenProperties", "valid")
+      return { valid: false, score: nil, hostname: nil, infra_error: true } if verification_response.blank?
+
+      {
+        valid: verification_response.dig("tokenProperties", "valid") == true,
+        score: parse_recaptcha_float(verification_response.dig("riskAnalysis", "score")),
+        hostname: verification_response.dig("tokenProperties", "hostname"),
+        infra_error: false,
+      }
+    end
+
+    def recaptcha_score_threshold(surface)
+      value = GlobalConfig.get("RECAPTCHA_SCORE_THRESHOLD_#{surface.to_s.upcase}")
+      return nil if value.to_s.strip.blank?
+
+      Float(value)
+    rescue ArgumentError, TypeError
+      Rails.logger.error("Invalid reCAPTCHA score threshold for #{surface}: #{value.inspect}")
+      nil
+    end
+
+    def recaptcha_fail_open?(surface)
+      value = GlobalConfig.get("RECAPTCHA_FAIL_OPEN_#{surface.to_s.upcase}")
+      return RECAPTCHA_FAIL_OPEN_DEFAULTS.fetch(surface.to_sym, false) if value.to_s.strip.blank?
+
+      ActiveModel::Type::Boolean.new.cast(value)
+    end
+
+    def hostname_allowed?(hostname)
+      return true unless Rails.env.production?
+      return false if hostname.blank?
+
+      # TODO: Refactor subdomain check. Use Subdomain module if possible
+      hostname == DOMAIN || hostname.end_with?(".#{ROOT_DOMAIN}") || CustomDomain.find_by_host(hostname).present?
+    end
+
+    def log_recaptcha_score(surface:, assessment:, threshold:, hostname_ok:, decision:)
+      Rails.logger.info(
+        [
+          RECAPTCHA_SCORE_LOG_PREFIX,
+          "surface=#{surface}",
+          "site_key=#{surface}",
+          "valid=#{assessment[:valid]}",
+          "score=#{assessment[:score].nil? ? "nil" : assessment[:score]}",
+          "threshold=#{threshold.nil? ? "disabled" : threshold}",
+          "hostname_ok=#{hostname_ok.nil? ? "nil" : hostname_ok}",
+          "decision=#{decision}",
+        ].join(" ")
+      )
+    end
+
+    def parse_recaptcha_float(value)
+      return nil if value.nil? || value.to_s.strip.blank?
+
+      Float(value)
+    rescue ArgumentError, TypeError
+      nil
     end
 
     def recaptcha_verification_response(site_key:)
@@ -45,17 +130,16 @@ module ValidateRecaptcha
                                  }
                                }.to_json,
                                timeout: 5)
-      Rails.logger.info response
 
       parsed = response.parsed_response
       if parsed.is_a?(Hash)
         parsed
       else
         Rails.logger.error("Unexpected reCAPTCHA response format: #{response.code} #{parsed.class}")
-        {}
+        nil
       end
     rescue StandardError => e
       Rails.logger.error("reCAPTCHA verification request failed: #{e.message}")
-      {}
+      nil
     end
 end

--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -28,7 +28,7 @@ class LoginsController < Devise::SessionsController
   def create
     unless Feature.active?(:disable_login_recaptcha)
       site_key = GlobalConfig.get("RECAPTCHA_LOGIN_SITE_KEY")
-      if !(Rails.env.development? && site_key.blank?) && !valid_recaptcha_response?(site_key: site_key)
+      if !(Rails.env.development? && site_key.blank?) && !valid_recaptcha_response?(site_key: site_key, surface: :login)
         return redirect_with_login_error("Sorry, we could not verify the CAPTCHA. Please try again.")
       end
     end

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -128,7 +128,7 @@ class SignupController < Devise::RegistrationsController
         return
       end
 
-      if params[:user] && params[:user][:buyer_signup].blank? && !Feature.active?(:disable_signup_recaptcha)
+      if params[:user] && params[:user][:buyer_signup].blank? && Feature.inactive?(:disable_signup_recaptcha)
         site_key = GlobalConfig.get("RECAPTCHA_SIGNUP_SITE_KEY")
         if !(Rails.env.development? && site_key.blank?) && !valid_recaptcha_response?(site_key: site_key, surface: :signup)
           respond_to do |format|

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -128,9 +128,9 @@ class SignupController < Devise::RegistrationsController
         return
       end
 
-      if params[:user] && params[:user][:buyer_signup].blank?
+      if params[:user] && params[:user][:buyer_signup].blank? && !Feature.active?(:disable_signup_recaptcha)
         site_key = GlobalConfig.get("RECAPTCHA_SIGNUP_SITE_KEY")
-        if !(Rails.env.development? && site_key.blank?) && !valid_recaptcha_response?(site_key: site_key)
+        if !(Rails.env.development? && site_key.blank?) && !valid_recaptcha_response?(site_key: site_key, surface: :signup)
           respond_to do |format|
             format.html { redirect_with_signup_error("Sorry, we could not verify the CAPTCHA. Please try again.") }
             format.json { render json: { success: false, error_message: "Sorry, we could not verify the CAPTCHA. Please try again." } }

--- a/app/presenters/auth_presenter.rb
+++ b/app/presenters/auth_presenter.rb
@@ -20,7 +20,7 @@ class AuthPresenter
     referrer = User.find_by_username(params[:referrer]) if params[:referrer].present?
     number_of_creators, total_made = $redis.mget(RedisKey.number_of_creators, RedisKey.total_made)
     login_props.merge(
-      recaptcha_site_key: GlobalConfig.get("RECAPTCHA_SIGNUP_SITE_KEY"),
+      recaptcha_site_key: Feature.active?(:disable_signup_recaptcha) ? nil : GlobalConfig.get("RECAPTCHA_SIGNUP_SITE_KEY"),
       referrer: referrer ? {
         id: referrer.external_id,
         name: referrer.name_or_username,

--- a/spec/controllers/concerns/validate_recaptcha_spec.rb
+++ b/spec/controllers/concerns/validate_recaptcha_spec.rb
@@ -7,60 +7,241 @@ describe ValidateRecaptcha, type: :controller do
     include ValidateRecaptcha
 
     def action
-      if valid_recaptcha_response?(site_key: "test_site_key")
-        render json: { success: true }
-      else
-        render json: { success: false, error: "captcha_failed" }, status: :unprocessable_entity
-      end
+      render_recaptcha_result(valid_recaptcha_response?(site_key: "test_site_key"))
     end
+
+    def login_action
+      render_recaptcha_result(valid_recaptcha_response?(site_key: "test_site_key", surface: :login))
+    end
+
+    def signup_action
+      render_recaptcha_result(valid_recaptcha_response?(site_key: "test_site_key", surface: :signup))
+    end
+
+    def checkout_action
+      render_recaptcha_result(valid_recaptcha_response_and_hostname?(site_key: "checkout_site_key"))
+    end
+
+    private
+      def render_recaptcha_result(success)
+        if success
+          render json: { success: true }
+        else
+          render json: { success: false, error: "captcha_failed" }, status: :unprocessable_entity
+        end
+      end
   end
 
   before do
-    routes.draw { post :action, to: "anonymous#action" }
+    routes.draw do
+      post :action, to: "anonymous#action"
+      post :login_action, to: "anonymous#login_action"
+      post :signup_action, to: "anonymous#signup_action"
+      post :checkout_action, to: "anonymous#checkout_action"
+    end
+
     allow(Rails).to receive(:env).and_return(ActiveSupport::EnvironmentInquirer.new("development"))
+    allow(GlobalConfig).to receive(:get).and_return(nil)
+    allow(Rails.logger).to receive(:info)
+    allow(Rails.logger).to receive(:error)
   end
 
-  describe "#recaptcha_verification_response" do
-    it "returns parsed hash when API returns valid JSON" do
-      valid_response = { "tokenProperties" => { "valid" => true } }
-      stubbed_response = instance_double(HTTParty::Response, parsed_response: valid_response, code: 200)
-      allow(stubbed_response).to receive(:to_s).and_return(valid_response.to_json)
-      allow(HTTParty).to receive(:post).and_return(stubbed_response)
+  describe "#valid_recaptcha_response?" do
+    it "passes a valid token and logs the Enterprise score" do
+      stub_recaptcha_response(valid: true, score: 0.7)
+
+      expect(Rails.logger).to receive(:info).with(/\[recaptcha_score\] surface=login site_key=login valid=true score=0.7 threshold=disabled hostname_ok=true decision=pass/)
 
       post :action, params: { "g-recaptcha-response" => "test_token" }
 
       expect(response).to have_http_status(:ok)
-      expect(JSON.parse(response.body)["success"]).to be true
+      expect(parsed_body["success"]).to be true
     end
 
-    it "returns empty hash when API returns non-JSON response (HTML error page)" do
+    it "passes a valid token with a low score when score gating is disabled" do
+      stub_recaptcha_response(valid: true, score: 0.01)
+
+      post :action, params: { "g-recaptcha-response" => "test_token" }
+
+      expect(response).to have_http_status(:ok)
+      expect(parsed_body["success"]).to be true
+    end
+
+    it "passes a valid token when score gating is enabled and the score meets the threshold" do
+      allow(GlobalConfig).to receive(:get).with("RECAPTCHA_SCORE_THRESHOLD_LOGIN").and_return("0.5")
+      stub_recaptcha_response(valid: true, score: 0.7)
+
+      post :login_action, params: { "g-recaptcha-response" => "test_token" }
+
+      expect(response).to have_http_status(:ok)
+      expect(parsed_body["success"]).to be true
+    end
+
+    it "fails a valid token when score gating is enabled and the score is below the threshold" do
+      allow(GlobalConfig).to receive(:get).with("RECAPTCHA_SCORE_THRESHOLD_LOGIN").and_return("0.5")
+      stub_recaptcha_response(valid: true, score: 0.1)
+
+      post :login_action, params: { "g-recaptcha-response" => "test_token" }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(parsed_body["error"]).to eq("captcha_failed")
+    end
+
+    it "fails a valid token when score gating is enabled and the assessment has no score" do
+      allow(GlobalConfig).to receive(:get).with("RECAPTCHA_SCORE_THRESHOLD_LOGIN").and_return("0.5")
+      stub_recaptcha_response(valid: true, score: nil)
+
+      post :login_action, params: { "g-recaptcha-response" => "test_token" }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(parsed_body["error"]).to eq("captcha_failed")
+    end
+  end
+
+  describe "#valid_recaptcha_response_and_hostname?" do
+    it "passes checkout when the reCAPTCHA API times out because checkout fails open by default" do
+      allow(HTTParty).to receive(:post).and_raise(Net::OpenTimeout.new("execution expired"))
+
+      expect(Rails.logger).to receive(:info).with(/\[recaptcha_score\].*surface=checkout.*decision=infra_error_fail_open/)
+
+      post :checkout_action, params: { "g-recaptcha-response" => "test_token" }
+
+      expect(response).to have_http_status(:ok)
+      expect(parsed_body["success"]).to be true
+    end
+
+    it "fails checkout on infrastructure errors when fail-open is disabled by config" do
+      allow(GlobalConfig).to receive(:get).with("RECAPTCHA_FAIL_OPEN_CHECKOUT").and_return("false")
+      allow(HTTParty).to receive(:post).and_raise(Net::OpenTimeout.new("execution expired"))
+
+      post :checkout_action, params: { "g-recaptcha-response" => "test_token" }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(parsed_body["error"]).to eq("captcha_failed")
+    end
+
+    it "fails checkout on low scores when score gating is enabled even though infrastructure errors fail open" do
+      allow(GlobalConfig).to receive(:get).with("RECAPTCHA_SCORE_THRESHOLD_CHECKOUT").and_return("0.5")
+      stub_recaptcha_response(valid: true, score: 0.1)
+
+      post :checkout_action, params: { "g-recaptcha-response" => "test_token" }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(parsed_body["error"]).to eq("captcha_failed")
+    end
+
+    context "in production" do
+      before do
+        allow(Rails).to receive(:env).and_return(ActiveSupport::EnvironmentInquirer.new("production"))
+      end
+
+      it "passes checkout when the hostname is allowed" do
+        stub_recaptcha_response(valid: true, score: 0.7, hostname: DOMAIN)
+
+        post :checkout_action, params: { "g-recaptcha-response" => "test_token" }
+
+        expect(response).to have_http_status(:ok)
+        expect(parsed_body["success"]).to be true
+      end
+
+      it "fails checkout when the hostname is not allowed" do
+        allow(CustomDomain).to receive(:find_by_host).and_return(nil)
+        stub_recaptcha_response(valid: true, score: 0.7, hostname: "attacker.example.net")
+
+        post :checkout_action, params: { "g-recaptcha-response" => "test_token" }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(parsed_body["error"]).to eq("captcha_failed")
+      end
+    end
+  end
+
+  describe "infrastructure errors" do
+    it "fails login when the reCAPTCHA API times out because login fails closed by default" do
+      allow(HTTParty).to receive(:post).and_raise(Net::OpenTimeout.new("execution expired"))
+
+      expect(Rails.logger).to receive(:info).with(/\[recaptcha_score\].*surface=login.*decision=infra_error_fail_closed/)
+
+      post :login_action, params: { "g-recaptcha-response" => "test_token" }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(parsed_body["error"]).to eq("captcha_failed")
+    end
+
+    it "fails signup when the reCAPTCHA API times out because signup fails closed by default" do
+      allow(HTTParty).to receive(:post).and_raise(Net::OpenTimeout.new("execution expired"))
+
+      expect(Rails.logger).to receive(:info).with(/\[recaptcha_score\].*surface=signup.*decision=infra_error_fail_closed/)
+
+      post :signup_action, params: { "g-recaptcha-response" => "test_token" }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(parsed_body["error"]).to eq("captcha_failed")
+    end
+
+    it "passes login on infrastructure errors when fail-open is enabled by config" do
+      allow(GlobalConfig).to receive(:get).with("RECAPTCHA_FAIL_OPEN_LOGIN").and_return("true")
+      allow(HTTParty).to receive(:post).and_raise(Net::OpenTimeout.new("execution expired"))
+
+      post :login_action, params: { "g-recaptcha-response" => "test_token" }
+
+      expect(response).to have_http_status(:ok)
+      expect(parsed_body["success"]).to be true
+    end
+
+    it "fails closed when the API returns a non-JSON response" do
       stubbed_response = instance_double(HTTParty::Response, parsed_response: "<html>Error</html>", code: 502)
       allow(stubbed_response).to receive(:to_s).and_return("<html>Error</html>")
       allow(HTTParty).to receive(:post).and_return(stubbed_response)
 
-      post :action, params: { "g-recaptcha-response" => "test_token" }
+      post :login_action, params: { "g-recaptcha-response" => "test_token" }
 
       expect(response).to have_http_status(:unprocessable_entity)
-      expect(JSON.parse(response.body)["error"]).to eq("captcha_failed")
+      expect(parsed_body["error"]).to eq("captcha_failed")
     end
 
-    it "returns empty hash when API returns nil parsed response" do
+    it "fails closed when the API returns a nil parsed response" do
       stubbed_response = instance_double(HTTParty::Response, parsed_response: nil, code: 200)
       allow(stubbed_response).to receive(:to_s).and_return("")
       allow(HTTParty).to receive(:post).and_return(stubbed_response)
 
-      post :action, params: { "g-recaptcha-response" => "test_token" }
+      post :login_action, params: { "g-recaptcha-response" => "test_token" }
 
       expect(response).to have_http_status(:unprocessable_entity)
+      expect(parsed_body["error"]).to eq("captcha_failed")
+    end
+  end
+
+  describe "hostname enforcement" do
+    before do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::EnvironmentInquirer.new("production"))
     end
 
-    it "returns empty hash when HTTParty raises an error" do
-      allow(HTTParty).to receive(:post).and_raise(Net::OpenTimeout.new("execution expired"))
+    it "does not require hostname validation for login" do
+      stub_recaptcha_response(valid: true, score: 0.7, hostname: "attacker.example.net")
 
-      post :action, params: { "g-recaptcha-response" => "test_token" }
+      post :login_action, params: { "g-recaptcha-response" => "test_token" }
 
-      expect(response).to have_http_status(:unprocessable_entity)
-      expect(JSON.parse(response.body)["error"]).to eq("captcha_failed")
+      expect(response).to have_http_status(:ok)
+      expect(parsed_body["success"]).to be true
     end
+  end
+
+  def stub_recaptcha_response(valid:, score:, hostname: DOMAIN)
+    parsed_response = {
+      "tokenProperties" => {
+        "valid" => valid,
+        "hostname" => hostname,
+      },
+    }
+    parsed_response["riskAnalysis"] = { "score" => score } unless score.nil?
+
+    stubbed_response = instance_double(HTTParty::Response, parsed_response:, code: 200)
+    allow(stubbed_response).to receive(:to_s).and_return(parsed_response.to_json)
+    allow(HTTParty).to receive(:post).and_return(stubbed_response)
+  end
+
+  def parsed_body
+    JSON.parse(response.body)
   end
 end

--- a/spec/controllers/signup_controller_spec.rb
+++ b/spec/controllers/signup_controller_spec.rb
@@ -29,11 +29,22 @@ describe SignupController, type: :controller, inertia: true do
         expect(response.headers["X-Robots-Tag"]).to eq "noindex"
       end
 
+      context "when disable_signup_recaptcha feature flag is active" do
+        before { Feature.activate(:disable_signup_recaptcha) }
+        after { Feature.deactivate(:disable_signup_recaptcha) }
+
+        it "does not pass reCAPTCHA site key" do
+          get :new
+
+          expect(inertia.props[:recaptcha_site_key]).to be_nil
+        end
+      end
+
       def signup_props
         referrer = User.find_by_username(params[:referrer]) if params[:referrer].present?
         number_of_creators, total_made = $redis.mget(RedisKey.number_of_creators, RedisKey.total_made)
         login_props.merge(
-          recaptcha_site_key: GlobalConfig.get("RECAPTCHA_SIGNUP_SITE_KEY"),
+          recaptcha_site_key: Feature.active?(:disable_signup_recaptcha) ? nil : GlobalConfig.get("RECAPTCHA_SIGNUP_SITE_KEY"),
           referrer: referrer ? {
             id: referrer.external_id,
             name: referrer.name_or_username,
@@ -152,6 +163,21 @@ describe SignupController, type: :controller, inertia: true do
 
       expect(response.parsed_body["success"]).to be(true)
       expect(response.parsed_body["redirect_location"]).to eq(dashboard_path)
+    end
+
+    context "when disable_signup_recaptcha feature flag is active" do
+      before { Feature.activate(:disable_signup_recaptcha) }
+      after { Feature.deactivate(:disable_signup_recaptcha) }
+
+      it "skips reCAPTCHA validation and creates the user" do
+        expect(controller).not_to receive(:valid_recaptcha_response?)
+
+        user = build(:user, password: "password")
+        post "create", params: { user: { email: user.email, password: "password" } }
+
+        expect(response).to redirect_to(dashboard_path)
+        expect(controller.user_signed_in?).to eq true
+      end
     end
 
     it "sets two factor authenticated" do

--- a/spec/presenters/auth_presenter_spec.rb
+++ b/spec/presenters/auth_presenter_spec.rb
@@ -63,6 +63,19 @@ describe AuthPresenter do
       end
     end
 
+    context "when disable_signup_recaptcha feature flag is active" do
+      before do
+        allow(Feature).to receive(:active?).with(:disable_login_recaptcha).and_return(false)
+        allow(Feature).to receive(:active?).with(:disable_signup_recaptcha).and_return(true)
+        $redis.del(RedisKey.total_made)
+        $redis.del(RedisKey.number_of_creators)
+      end
+
+      it "returns nil for the reCAPTCHA site key" do
+        expect(presenter.signup_props[:recaptcha_site_key]).to be_nil
+      end
+    end
+
     context "with options passed" do
       let(:referrer) { create(:user, name: "Test Referrer") }
       let(:params) { { referrer: referrer.username } }


### PR DESCRIPTION
## What

We run reCAPTCHA **Enterprise** on three surfaces — **checkout, login, signup** — but every call site reads only `tokenProperties.valid` (a boolean) plus a hostname allowlist. **The Enterprise risk score (`riskAnalysis.score`, 0.0–1.0) is never read.** Enterprise's entire value over the free tier is that adaptive score; we pay for it on every surface and use it as a binary "is this a real token" check.

This PR centralizes verification in `ValidateRecaptcha` and adds **optional, per-surface score-gating** plus **configurable fail-open**, while keeping behavior **100% unchanged by default**.

### Changes
- **Always parse + log the Enterprise score** on every assessment — a structured, greppable `[recaptcha_score]` line (surface, valid, score, threshold, hostname_ok, decision). This is what lets us pick real thresholds from real data; today we capture nothing.
- **Per-surface score threshold** via `RECAPTCHA_SCORE_THRESHOLD_{CHECKOUT,LOGIN,SIGNUP}`. **Defaults to disabled (nil)** → a valid token passes regardless of score, exactly as today, until a surface is deliberately turned on.
- **Per-surface fail-open** on *infrastructure* errors (5s timeout / non-JSON / API exception) via `RECAPTCHA_FAIL_OPEN_{CHECKOUT,LOGIN,SIGNUP}`. Defaults: **checkout = true** (Stripe Radar + `purchase/risk.rb#check_for_fraud` independently backstop fraud), **login = false**, **signup = false** (credential-stuffing / bot-signup have no money-fraud backstop, so they must fail closed). A **low score is never "fail open"** — fail-open applies only when *no* assessment was obtained.
- **`:disable_signup_recaptcha` kill-switch**, mirroring the existing `:disable_login_recaptcha`, so signup captcha can be disabled in an incident (login already could; signup couldn't).

### Deliberately unchanged
- Hostname allowlist (prod-only), the 5s timeout, `skip_recaptcha?` / wallet skips, and `Link#require_captcha?` (the 6-month-seller rule) are all untouched.
- With no config set, **all three surfaces behave exactly as before** — this is purely additive instrumentation + opt-in gating.

## Why

We pay for Enterprise adaptive scoring and ignore it platform-wide; consuming the score we already request is the highest-leverage, lowest-risk improvement. It also lets us move off blunt/always-on friction (checkout's seller-age proxy; login/signup challenging every attempt) toward challenging only genuinely risky sessions — without a blind threshold guess on a live fraud/conversion path. Phase 1 here is **instrument + make gating configurable, defaulting to current behavior**; thresholds get tuned later from the logged score distributions.

## Config (all optional; unset = current behavior)
- `RECAPTCHA_SCORE_THRESHOLD_CHECKOUT` / `_LOGIN` / `_SIGNUP` — float in [0,1]; unset/blank = gating disabled
- `RECAPTCHA_FAIL_OPEN_CHECKOUT` / `_LOGIN` / `_SIGNUP` — boolean; unset = defaults above (checkout true, login/signup false)

## Tests
- `spec/controllers/concerns/validate_recaptcha_spec.rb` — **16 examples, 0 failures** locally. Covers: score parsing; gating-disabled default passes low scores; gating-enabled passes ≥threshold / fails <threshold / fails when score absent; infra-error fail-open (checkout) vs fail-closed (login/signup); hostname enforcement (prod) for checkout, not required for login/signup; `[recaptcha_score]` logging.
- `spec/controllers/signup_controller_spec.rb` + `spec/presenters/auth_presenter_spec.rb` — `:disable_signup_recaptcha` flag behavior (mirrors the login flag specs).
- Rubocop clean on all 7 changed files.

## Notes
- Investigation + recommendation context: antiwork/gumroad-private#476.
- This is the platform-wide "consume the Enterprise score" pass; the checkout-specific conversion work (replacing the 6-month seller rule) can follow on top of this instrumentation.

---
Co-authored-by: Sahil Lavingia

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783295277&installation_id=134400930&pr_number=5426&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5426&signature=23120d3fcfd297d042d02c23b80331d575182fc35d64e01fcf4081c931a32b96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches login, signup, and checkout CAPTCHA decisions; mis-set thresholds or fail-open config could weaken bot protection or block legitimate users, though unset config preserves prior behavior.
> 
> **Overview**
> Refactors **`ValidateRecaptcha`** so checkout, login, and signup share one path that reads Enterprise **`riskAnalysis.score`**, logs greppable **`[recaptcha_score]`** lines, and can optionally enforce per-surface score floors via **`RECAPTCHA_SCORE_THRESHOLD_*`** (unset = no score gating, same as today).
> 
> When the verification API fails or returns unusable data, behavior is now explicit **fail-open vs fail-closed** per surface via **`RECAPTCHA_FAIL_OPEN_*`** (defaults: checkout open, login/signup closed). Low scores are never treated as infra fail-open.
> 
> **Login** and **signup** call sites pass an explicit **`surface`**; signup adds **`:disable_signup_recaptcha`** (skip validation and omit site key in **`AuthPresenter`**, matching login’s kill-switch). Specs expand coverage for score gating, infra errors, hostname rules on checkout, and the new signup flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88f9791d26114120906c3768a81d0343d1f536f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->