### PR TITLE
Document & enrich the public product JSON endpoint

### DIFF
--- a/app/controllers/global_affiliates/product_eligibility_controller.rb
+++ b/app/controllers/global_affiliates/product_eligibility_controller.rb
@@ -4,7 +4,6 @@ class GlobalAffiliates::ProductEligibilityController < Sellers::BaseController
   class InvalidUrl < StandardError; end
 
   GUMROAD_DOMAINS = [ROOT_DOMAIN, SHORT_DOMAIN, DOMAIN].map { |domain| Addressable::URI.parse("#{PROTOCOL}://#{domain}").domain } # Strip port (in test and development environment) and subdomains
-  EXPECTED_PRODUCT_PARAMS = %w(name formatted_price recommendable short_url)
 
   def show
     authorize [:products, :affiliated], :index?
@@ -16,6 +15,14 @@ class GlobalAffiliates::ProductEligibilityController < Sellers::BaseController
   end
 
   private
+    # Resolve the pasted URL to a product, then shape exactly the fields the
+    # affiliate-eligibility UI needs. We fetch the product's own public JSON
+    # endpoint (GET /l/:permalink.json) to leverage its URL routing — that
+    # handles short domains, subdomains, and custom permalinks for free — but
+    # we read `recommendable?` from the model directly. Recommendability is an
+    # affiliate-program eligibility concept, not part of the public product API
+    # surface (ProductPresenter::PublicApiProps), so it must not be exposed
+    # there; resolving it locally keeps that boundary clean.
     def fetch_and_parse_product_data
       uri = Addressable::URI.parse(params[:url])
       raise InvalidUrl unless GUMROAD_DOMAINS.include?(uri&.domain)
@@ -24,9 +31,18 @@ class GlobalAffiliates::ProductEligibilityController < Sellers::BaseController
       response = HTTParty.get(uri.to_s)
       raise InvalidUrl unless response.ok?
 
-      data = response.to_hash.slice(*EXPECTED_PRODUCT_PARAMS)
-      raise InvalidUrl unless data.keys == EXPECTED_PRODUCT_PARAMS
+      data = response.to_hash
+      permalink = data["permalink"]
+      raise InvalidUrl if permalink.blank?
 
-      data
+      product = Link.find_by(unique_permalink: permalink)
+      raise InvalidUrl if product.nil?
+
+      {
+        "name" => product.name,
+        "formatted_price" => product.price_formatted_verbose,
+        "recommendable" => product.recommendable?,
+        "short_url" => product.long_url,
+      }
     end
 end

--- a/app/controllers/global_affiliates/product_eligibility_controller.rb
+++ b/app/controllers/global_affiliates/product_eligibility_controller.rb
@@ -32,10 +32,12 @@ class GlobalAffiliates::ProductEligibilityController < Sellers::BaseController
       raise InvalidUrl unless response.ok?
 
       data = response.to_hash
-      permalink = data["permalink"]
-      raise InvalidUrl if permalink.blank?
+      raise InvalidUrl unless data["api_version"] == ProductPresenter::PublicApiProps::API_VERSION && data["permalink"].present?
 
-      product = Link.find_by(unique_permalink: permalink)
+      id = data["id"]
+      raise InvalidUrl if id.blank?
+
+      product = Link.find_by_external_id(id)
       raise InvalidUrl if product.nil?
 
       {

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -176,7 +176,7 @@ class LinksController < ApplicationController
           end
         end
       end
-      format.json { render json: @product.as_json }
+      format.json { render json: ProductPresenter::PublicApiProps.new(product: @product).props }
       format.any { e404 }
     end
   end

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -176,7 +176,7 @@ class LinksController < ApplicationController
           end
         end
       end
-      format.json { render json: ProductPresenter::PublicApiProps.new(product: @product).props }
+      format.json { render json: ProductPresenter::PublicApiProps.new(product: @product, seller_custom_domain_url:).props }
       format.any { e404 }
     end
   end
@@ -1014,6 +1014,9 @@ class LinksController < ApplicationController
 
     def render_custom_html_if_present
       return unless custom_html_visible?
+      # The public JSON API (GET /l/:permalink.json) must return the documented
+      # product payload, not the custom-HTML landing page — only intercept HTML.
+      return unless request.format.html?
       # Buyer clicked Buy — fall through to the show action's checkout-bearing
       # product page so the existing ?wanted=true flow handles the redirect.
       return if params[:wanted] == "true"

--- a/app/javascript/components/ApiDocumentation/ApiEndpoint.tsx
+++ b/app/javascript/components/ApiDocumentation/ApiEndpoint.tsx
@@ -10,16 +10,18 @@ export const ApiEndpoint = ({
   path,
   description,
   isOAuth,
+  customUrl,
   children,
 }: {
   method: string;
   path: string;
   description: React.ReactNode;
   isOAuth?: boolean;
+  customUrl?: string;
   children?: React.ReactNode;
 }) => {
   const methodId = `${method}-${path}`;
-  const url = isOAuth ? `https://gumroad.com${path}` : `https://api.gumroad.com/v2${path}`;
+  const url = customUrl ?? (isOAuth ? `https://gumroad.com${path}` : `https://api.gumroad.com/v2${path}`);
 
   return (
     <CardContent details id={methodId}>

--- a/app/javascript/components/ApiDocumentation/Endpoints/PublicProductPage.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/PublicProductPage.tsx
@@ -1,0 +1,130 @@
+import React from "react";
+
+import CodeSnippet from "$app/components/ui/CodeSnippet";
+
+import { ApiEndpoint } from "../ApiEndpoint";
+import { ApiResponseFields, renderFields } from "../ApiResponseFields";
+
+// Public, unauthenticated, read-only product page JSON.
+// Unlike the OAuth `/v2/products/:id` endpoint, this requires no access token —
+// it returns the same public data the rendered product page shows, so creators
+// can build their own storefronts, embeds, and widgets that stay in sync.
+export const GetPublicProductPage = () => (
+  <ApiEndpoint
+    method="get"
+    path="/l/:permalink.json"
+    customUrl="https://[seller].gumroad.com/l/:permalink.json"
+    description={
+      <>
+        Retrieve the public, display data for a product page — no authentication required. This is the read/display
+        counterpart to the OAuth Products API: it returns exactly the information shown on the rendered product page
+        (price, covers, description, reviews, variants, and social proof), and never exposes buyer-specific,
+        seller-private, or analytics fields. Append <code className="inline-code">.json</code> to any public product
+        URL.
+      </>
+    }
+  >
+    <ApiResponseFields>
+      {renderFields([
+        { name: "api_version", type: "number", description: "The schema version of this public payload" },
+        { name: "id", type: "string", description: "The product's unique external ID" },
+        { name: "permalink", type: "string", description: "The product's permalink" },
+        { name: "name", type: "string", description: "The product's name" },
+        { name: "native_type", type: "string", description: "The product type (e.g. digital, membership, bundle)" },
+        { name: "url", type: "string", description: "The full public product URL" },
+        { name: "thumbnail_url", type: "string", description: "The product's thumbnail image URL, if set" },
+        { name: "created_at", type: "string", description: "ISO 8601 creation timestamp" },
+        { name: "updated_at", type: "string", description: "ISO 8601 last-updated timestamp" },
+        {
+          name: "seller",
+          type: "object",
+          description: "Public author byline (name, avatar, profile URL, verified) — no PII",
+        },
+        { name: "price_cents", type: "number", description: "The product's price in cents" },
+        { name: "currency_code", type: "string", description: "The product's currency code" },
+        { name: "price_formatted", type: "string", description: "The human-formatted price" },
+        { name: "is_pay_what_you_want", type: "boolean", description: "Whether the buyer can name their price" },
+        {
+          name: "suggested_price_cents",
+          type: "number",
+          description: "Suggested price for pay-what-you-want products; otherwise null",
+        },
+        { name: "is_recurring_billing", type: "boolean", description: "Whether the product is a subscription" },
+        { name: "is_tiered_membership", type: "boolean", description: "Whether the product is a tiered membership" },
+        {
+          name: "recurrences",
+          type: "object",
+          description: "Available subscription durations and pricing; null for non-recurring products",
+        },
+        { name: "free_trial", type: "object", description: "Free trial duration, if enabled; otherwise null" },
+        { name: "description_html", type: "string", description: "The product's rich-text description as HTML" },
+        { name: "summary", type: "string", description: "The product's short custom summary, if set" },
+        { name: "covers", type: "array", description: "All product preview images/media" },
+        { name: "attributes", type: "array", description: "Public name/value product attributes" },
+        {
+          name: "ratings",
+          type: "object",
+          description: "Average rating and count; null when the creator hides reviews",
+        },
+        {
+          name: "sales_count",
+          type: "number",
+          description: "Number of sales; null unless the creator opts to show the sales count",
+        },
+        { name: "options", type: "array", description: "Variants/tiers with per-option pricing and inventory" },
+        { name: "quantity_remaining", type: "number", description: "Remaining inventory, if the product is limited" },
+        { name: "is_quantity_enabled", type: "boolean", description: "Whether buyers can choose a quantity" },
+        { name: "is_sales_limited", type: "boolean", description: "Whether the product has a max purchase count" },
+        { name: "is_published", type: "boolean", description: "Whether the product is published and live" },
+        { name: "is_physical", type: "boolean", description: "Whether the product is physical" },
+        { name: "refund_policy", type: "object", description: "The applicable refund policy, if any" },
+      ])}
+    </ApiResponseFields>
+    <CodeSnippet caption="cURL example">
+      {`curl https://sahil.gumroad.com/l/pencil.json \\
+  -X GET`}
+    </CodeSnippet>
+    <CodeSnippet caption="Example response:">
+      {`{
+  "api_version": 1,
+  "id": "A-m3CDDC5dlrSdKZp0RFhA==",
+  "permalink": "pencil",
+  "name": "Pencil Icon PSD",
+  "native_type": "digital",
+  "url": "https://sahil.gumroad.com/l/pencil",
+  "thumbnail_url": "https://public-files.gumroad.com/variants/abc/def",
+  "created_at": "2024-01-01T00:00:00Z",
+  "updated_at": "2024-02-01T00:00:00Z",
+  "seller": {
+    "id": "G_-mnBf9b1j9A7a4ub4nFQ==",
+    "name": "Sahil",
+    "avatar_url": "https://public-files.gumroad.com/user/abc/avatar",
+    "profile_url": "https://sahil.gumroad.com",
+    "is_verified": true
+  },
+  "price_cents": 100,
+  "currency_code": "usd",
+  "price_formatted": "$1",
+  "is_pay_what_you_want": false,
+  "suggested_price_cents": null,
+  "is_recurring_billing": false,
+  "is_tiered_membership": false,
+  "recurrences": null,
+  "free_trial": null,
+  "description_html": "<p>I made this for fun.</p>",
+  "summary": "You'll get one PSD file.",
+  "covers": [],
+  "attributes": [{ "name": "Format", "value": "PSD" }],
+  "ratings": { "count": 12, "average": 4.5 },
+  "sales_count": null, # null unless the creator shows the sales count
+  "options": [],
+  "quantity_remaining": null,
+  "is_quantity_enabled": false,
+  "is_sales_limited": false,
+  "is_published": true,
+  "is_physical": false,
+  "refund_policy": { "title": "30-day money back guarantee", "fine_print": null, "updated_at": "2024-01-01" }
+}`}
+    </CodeSnippet>
+  </ApiEndpoint>
+);

--- a/app/javascript/components/ApiDocumentation/Endpoints/PublicProductPage.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/PublicProductPage.tsx
@@ -64,7 +64,8 @@ export const GetPublicProductPage = () => (
         {
           name: "ratings",
           type: "object",
-          description: "Average rating and count; null when the creator hides reviews",
+          description:
+            "Average rating, review count, and a five-item percentages array ordered from 1 star through 5 stars; null when the creator hides reviews",
         },
         {
           name: "sales_count",
@@ -115,7 +116,7 @@ export const GetPublicProductPage = () => (
   "summary": "You'll get one PSD file.",
   "covers": [],
   "attributes": [{ "name": "Format", "value": "PSD" }],
-  "ratings": { "count": 12, "average": 4.5 },
+  "ratings": { "count": 12, "average": 4.5, "percentages": [0, 0, 8, 34, 58] },
   "sales_count": null,
   "options": [],
   "quantity_remaining": null,

--- a/app/javascript/components/ApiDocumentation/Endpoints/PublicProductPage.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/PublicProductPage.tsx
@@ -116,7 +116,7 @@ export const GetPublicProductPage = () => (
   "covers": [],
   "attributes": [{ "name": "Format", "value": "PSD" }],
   "ratings": { "count": 12, "average": 4.5 },
-  "sales_count": null, # null unless the creator shows the sales count
+  "sales_count": null,
   "options": [],
   "quantity_remaining": null,
   "is_quantity_enabled": false,

--- a/app/javascript/components/ApiDocumentation/Navigation.tsx
+++ b/app/javascript/components/ApiDocumentation/Navigation.tsx
@@ -29,6 +29,9 @@ export const Navigation = () => (
             <a href="#products">Products</a>
           </li>
           <li>
+            <a href="#public-product-page">Public product page</a>
+          </li>
+          <li>
             <a href="#categories">Categories</a>
           </li>
           <li>

--- a/app/javascript/pages/Public/Api.tsx
+++ b/app/javascript/pages/Public/Api.tsx
@@ -43,6 +43,7 @@ import {
   GetProducts,
   UpdateProduct,
 } from "$app/components/ApiDocumentation/Endpoints/Products";
+import { GetPublicProductPage } from "$app/components/ApiDocumentation/Endpoints/PublicProductPage";
 import { GetRefundPolicy, UpdateRefundPolicy } from "$app/components/ApiDocumentation/Endpoints/RefundPolicy";
 import {
   CreateResourceSubscription,
@@ -129,6 +130,10 @@ export default function Api() {
                 <DeleteProduct />
                 <EnableProduct />
                 <DisableProduct />
+              </ApiResource>
+
+              <ApiResource name="Public product page" id="public-product-page">
+                <GetPublicProductPage />
               </ApiResource>
 
               <ApiResource name="Categories" id="categories">

--- a/app/presenters/product_presenter.rb
+++ b/app/presenters/product_presenter.rb
@@ -8,6 +8,9 @@ class ProductPresenter
 
   extend PreorderHelper
 
+  SALES_COUNT_CACHE_KEY_REFIX = "product-presenter:sales-count-cache"
+  SALES_COUNT_CACHE_METRICS_KEY = "#{SALES_COUNT_CACHE_KEY_REFIX}-metrics"
+
   attr_reader :product, :editing_page_id, :pundit_user, :request, :ai_generated
 
   delegate :user, :skus,
@@ -49,6 +52,14 @@ class ProductPresenter
 
   def self.card_for_email(product:)
     ProductPresenter::Card.new(product:).for_email
+  end
+
+  def self.cached_sales_count(product)
+    return unless product.should_show_sales_count?
+
+    cache_key_digest = Digest::SHA256.hexdigest("#{product.cache_key}-#{product.price_cents}-#{product.sales.order(id: :desc).pick(:id)}")
+    cache_key = "#{SALES_COUNT_CACHE_KEY_REFIX}_#{cache_key_digest}"
+    Rails.cache.fetch(cache_key, expires_in: 1.minute) { product.successful_sales_count }
   end
 
   def product_props(**kwargs)

--- a/app/presenters/product_presenter/product_props.rb
+++ b/app/presenters/product_presenter/product_props.rb
@@ -5,8 +5,8 @@ class ProductPresenter::ProductProps
   include ProductsHelper
   include CurrencyHelper
 
-  SALES_COUNT_CACHE_KEY_REFIX = "product-presenter:sales-count-cache"
-  SALES_COUNT_CACHE_METRICS_KEY = "#{SALES_COUNT_CACHE_KEY_REFIX}-metrics"
+  SALES_COUNT_CACHE_KEY_REFIX = ProductPresenter::SALES_COUNT_CACHE_KEY_REFIX
+  SALES_COUNT_CACHE_METRICS_KEY = ProductPresenter::SALES_COUNT_CACHE_METRICS_KEY
 
   def initialize(product:)
     @product = product
@@ -39,7 +39,7 @@ class ProductPresenter::ProductProps
         is_published: !product.draft && product.alive?,
         is_stream_only: product.has_stream_only_files?,
         streamable: product.streamable?,
-        sales_count: cached_sales_count,
+        sales_count: ProductPresenter.cached_sales_count(product),
         summary: product.custom_summary.presence,
         attributes: attributes_props,
         description_html: product.html_safe_description,
@@ -125,14 +125,6 @@ class ProductPresenter::ProductProps
 
     def collaborator
       @_collaborator ||= product.collaborator_for_display
-    end
-
-    def cached_sales_count
-      return unless product.should_show_sales_count?
-
-      cache_key_digest = Digest::SHA256.hexdigest("#{product.cache_key}-#{product.price_cents}-#{product.sales.order(id: :desc).pick(:id)}")
-      cache_key = "#{SALES_COUNT_CACHE_KEY_REFIX}_#{cache_key_digest}"
-      Rails.cache.fetch(cache_key, expires_in: 1.minute) { product.successful_sales_count }
     end
 
     def bundle_product_props(bundle_product, request:, recommended_by: nil, layout: nil)

--- a/app/presenters/product_presenter/public_api_props.rb
+++ b/app/presenters/product_presenter/public_api_props.rb
@@ -64,7 +64,7 @@ class ProductPresenter::PublicApiProps
 
       # Reviews / social proof (respect creator toggles)
       ratings: product.display_product_reviews? ? product.rating_stats : nil,
-      sales_count: product.should_show_sales_count? ? product.successful_sales_count : nil,
+      sales_count: ProductPresenter.cached_sales_count(product),
 
       # Variants / options / inventory
       options: product.options.as_json,

--- a/app/presenters/product_presenter/public_api_props.rb
+++ b/app/presenters/product_presenter/public_api_props.rb
@@ -22,9 +22,10 @@ class ProductPresenter::PublicApiProps
   # Bump when the public shape changes in a backwards-incompatible way.
   API_VERSION = 1
 
-  def initialize(product:)
+  def initialize(product:, seller_custom_domain_url: nil)
     @product = product
     @seller = product.user
+    @seller_custom_domain_url = seller_custom_domain_url
   end
 
   def props
@@ -42,7 +43,7 @@ class ProductPresenter::PublicApiProps
       updated_at: product.updated_at&.iso8601,
 
       # Seller (public author byline only — no email/PII)
-      seller: UserPresenter.new(user: seller).author_byline_props,
+      seller: seller_props,
 
       # Pricing
       price_cents: product.price_cents,
@@ -52,7 +53,7 @@ class ProductPresenter::PublicApiProps
       suggested_price_cents: product.customizable_price? ? product.suggested_price_cents : nil,
       is_recurring_billing: product.is_recurring_billing,
       is_tiered_membership: product.is_tiered_membership,
-      recurrences: product.is_recurring_billing ? product.recurrences : nil,
+      recurrences: product.is_recurring_billing ? product.recurrences.as_json : nil,
       free_trial: free_trial_props,
 
       # Content
@@ -66,7 +67,7 @@ class ProductPresenter::PublicApiProps
       sales_count: product.should_show_sales_count? ? product.successful_sales_count : nil,
 
       # Variants / options / inventory
-      options: product.options,
+      options: product.options.as_json,
       quantity_remaining: product.remaining_for_sale_count,
       is_quantity_enabled: product.quantity_enabled,
       is_sales_limited: product.max_purchase_count?,
@@ -79,7 +80,29 @@ class ProductPresenter::PublicApiProps
   end
 
   private
-    attr_reader :product, :seller
+    attr_reader :product, :seller, :seller_custom_domain_url
+
+    # Always an object (never null), mirroring the documented shape. Falls back
+    # to a username-less byline when the seller has no public profile URL, and
+    # honors the request's custom domain so the profile_url matches the byline
+    # the rendered product page shows on a seller custom domain.
+    def seller_props
+      UserPresenter.new(user: seller).author_byline_props(custom_domain_url: seller_custom_domain_url) || {
+        id: seller.external_id,
+        name: seller.name_or_username,
+        avatar_url: seller.avatar_url,
+        profile_url: seller_profile_url,
+        is_verified: !!seller.verified,
+      }
+    end
+
+    # nil-safe: a seller with no username has no subdomain, so profile_url would
+    # raise on URI(nil) unless a custom domain is present.
+    def seller_profile_url
+      return seller.profile_url(custom_domain_url: seller_custom_domain_url) if seller_custom_domain_url.present?
+
+      seller.subdomain_with_protocol && seller.profile_url
+    end
 
     def free_trial_props
       return nil unless product.free_trial_enabled?
@@ -109,7 +132,9 @@ class ProductPresenter::PublicApiProps
 
       {
         title: policy.title,
-        fine_print: policy.fine_print.presence,
+        # Mirror the rendered product page, which wraps the fine print with
+        # simple_format (ProductPresenter::ProductProps) and renders it as HTML.
+        fine_print: policy.fine_print.present? ? ActionController::Base.helpers.simple_format(policy.fine_print) : nil,
         updated_at: policy.updated_at&.to_date&.iso8601,
       }
     end

--- a/app/presenters/product_presenter/public_api_props.rb
+++ b/app/presenters/product_presenter/public_api_props.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+# Public, unauthenticated, read-only JSON representation of a product —
+# the documented payload returned by `GET /l/:permalink.json`.
+#
+# This is the read/display counterpart to the seller-facing product page: it
+# exposes the same public information the rendered HTML page shows (price,
+# covers, description, reviews, variants, social proof) so creators can build
+# their own storefronts, embeds, and widgets that stay in sync.
+#
+# Hard rules:
+#   * PUBLIC — never include buyer-specific, seller-private, or admin fields
+#     (purchase/buyer state, analytics, can_edit, compliance internals).
+#   * Respects creator privacy toggles — `sales_count` is only present when
+#     the creator has `should_show_sales_count?` enabled, mirroring the page.
+#   * Stable, versioned shape (`api_version`) so integrators can depend on it.
+class ProductPresenter::PublicApiProps
+  include Rails.application.routes.url_helpers
+  include ProductsHelper
+  include CurrencyHelper
+
+  # Bump when the public shape changes in a backwards-incompatible way.
+  API_VERSION = 1
+
+  def initialize(product:)
+    @product = product
+    @seller = product.user
+  end
+
+  def props
+    {
+      api_version: API_VERSION,
+
+      # Identity
+      id: product.external_id,
+      permalink: product.unique_permalink,
+      name: product.name,
+      native_type: product.native_type,
+      url: product.long_url,
+      thumbnail_url: product.thumbnail&.alive&.url,
+      created_at: product.created_at&.iso8601,
+      updated_at: product.updated_at&.iso8601,
+
+      # Seller (public author byline only — no email/PII)
+      seller: UserPresenter.new(user: seller).author_byline_props,
+
+      # Pricing
+      price_cents: product.price_cents,
+      currency_code: product.price_currency_type.downcase,
+      price_formatted: product.price_formatted_verbose,
+      is_pay_what_you_want: product.customizable_price?,
+      suggested_price_cents: product.customizable_price? ? product.suggested_price_cents : nil,
+      is_recurring_billing: product.is_recurring_billing,
+      is_tiered_membership: product.is_tiered_membership,
+      recurrences: product.is_recurring_billing ? product.recurrences : nil,
+      free_trial: free_trial_props,
+
+      # Content
+      description_html: product.html_safe_description,
+      summary: product.custom_summary.presence,
+      covers: product.display_asset_previews.as_json,
+      attributes: attributes_props,
+
+      # Reviews / social proof (respect creator toggles)
+      ratings: product.display_product_reviews? ? product.rating_stats : nil,
+      sales_count: product.should_show_sales_count? ? product.successful_sales_count : nil,
+
+      # Variants / options / inventory
+      options: product.options,
+      quantity_remaining: product.remaining_for_sale_count,
+      is_quantity_enabled: product.quantity_enabled,
+      is_sales_limited: product.max_purchase_count?,
+
+      # Policies & meta
+      is_published: !product.draft && product.alive?,
+      is_physical: product.is_physical,
+      refund_policy: refund_policy_props,
+    }
+  end
+
+  private
+    attr_reader :product, :seller
+
+    def free_trial_props
+      return nil unless product.free_trial_enabled?
+
+      {
+        duration: {
+          unit: product.free_trial_duration_unit,
+          amount: product.free_trial_duration_amount,
+        },
+      }
+    end
+
+    def attributes_props
+      product.custom_attributes.filter_map do |attr|
+        { name: attr["name"], value: attr["value"] } if attr["name"].present? || attr["value"].present?
+      end + product.file_info_for_product_page.map { |k, v| { name: k.to_s, value: v } }
+    end
+
+    def refund_policy_props
+      policy =
+        if seller.account_level_refund_policy_enabled?
+          seller.refund_policy
+        elsif product.product_refund_policy_enabled?
+          product.product_refund_policy
+        end
+      return nil if policy.nil?
+
+      {
+        title: policy.title,
+        fine_print: policy.fine_print.presence,
+        updated_at: policy.updated_at&.to_date&.iso8601,
+      }
+    end
+end

--- a/app/presenters/product_presenter/public_api_props.rb
+++ b/app/presenters/product_presenter/public_api_props.rb
@@ -34,7 +34,7 @@ class ProductPresenter::PublicApiProps
 
       # Identity
       id: product.external_id,
-      permalink: product.unique_permalink,
+      permalink: product.general_permalink,
       name: product.name,
       native_type: product.native_type,
       url: product.long_url,

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -11,6 +11,13 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
   end
 
   allow do
+    origins "*"
+    resource "/l/*.json",
+             headers: :any,
+             methods: [:get]
+  end
+
+  allow do
     origins VALID_CORS_ORIGINS
     resource "/users/session_info",
              headers: :any,

--- a/spec/controllers/global_affiliates/product_eligibility_controller_spec.rb
+++ b/spec/controllers/global_affiliates/product_eligibility_controller_spec.rb
@@ -29,7 +29,7 @@ describe GlobalAffiliates::ProductEligibilityController do
         # then reads eligibility fields from the model. Stub the HTTP round-trip
         # so the spec doesn't depend on a live request to the app under test.
         stub_request(:get, "#{url}.json")
-          .to_return(status: 200, body: { permalink: product.unique_permalink }.to_json, headers: { "Content-Type" => "application/json" })
+          .to_return(status: 200, body: { api_version: ProductPresenter::PublicApiProps::API_VERSION, id: product.external_id, permalink: product.general_permalink }.to_json, headers: { "Content-Type" => "application/json" })
       end
 
       it "returns the eligibility fields for the resolved product" do
@@ -46,13 +46,53 @@ describe GlobalAffiliates::ProductEligibilityController do
       end
     end
 
-    context "when the resolved permalink does not match a product" do
+    context "with a valid Gumroad product URL using a custom permalink" do
+      let(:product) { create(:product, name: "Eligible Product", custom_permalink: "custom-product") }
+      let(:url) { product.long_url }
+
+      before do
+        stub_request(:get, "#{url}.json")
+          .to_return(status: 200, body: { api_version: ProductPresenter::PublicApiProps::API_VERSION, id: product.external_id, permalink: product.custom_permalink }.to_json, headers: { "Content-Type" => "application/json" })
+      end
+
+      it "returns the eligibility fields for the resolved product" do
+        get :show, format: :json, params: { url: }
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be(true)
+        expect(response.parsed_body["product"]).to eq(
+          "name" => product.name,
+          "formatted_price" => product.price_formatted_verbose,
+          "recommendable" => product.recommendable?,
+          "short_url" => product.long_url,
+        )
+      end
+    end
+
+    context "when the resolved product id does not match a product" do
       let(:product) { create(:product) }
       let(:url) { product.long_url }
 
       before do
         stub_request(:get, "#{url}.json")
-          .to_return(status: 200, body: { permalink: "doesnotexist" }.to_json, headers: { "Content-Type" => "application/json" })
+          .to_return(status: 200, body: { api_version: ProductPresenter::PublicApiProps::API_VERSION, id: "doesnotexist", permalink: product.general_permalink }.to_json, headers: { "Content-Type" => "application/json" })
+      end
+
+      it "returns an error" do
+        get :show, format: :json, params: { url: }
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be(false)
+        expect(response.parsed_body["error"]).to eq("Please provide a valid Gumroad product URL")
+      end
+    end
+
+    context "when the URL resolves to non-product JSON" do
+      let(:url) { "#{PROTOCOL}://#{DOMAIN}/some-seller" }
+
+      before do
+        stub_request(:get, "#{url}.json")
+          .to_return(status: 200, body: { id: create(:user).external_id }.to_json, headers: { "Content-Type" => "application/json" })
       end
 
       it "returns an error" do

--- a/spec/controllers/global_affiliates/product_eligibility_controller_spec.rb
+++ b/spec/controllers/global_affiliates/product_eligibility_controller_spec.rb
@@ -19,6 +19,51 @@ describe GlobalAffiliates::ProductEligibilityController do
       let(:request_params) { { url: "https://example.com" } }
     end
 
+    context "with a valid Gumroad product URL" do
+      let(:product) { create(:product, name: "Eligible Product") }
+      let(:url) { product.long_url }
+
+      before do
+        # The controller fetches the product's own public JSON endpoint to
+        # resolve the URL (handling short/subdomain/custom-permalink routing),
+        # then reads eligibility fields from the model. Stub the HTTP round-trip
+        # so the spec doesn't depend on a live request to the app under test.
+        stub_request(:get, "#{url}.json")
+          .to_return(status: 200, body: { permalink: product.unique_permalink }.to_json, headers: { "Content-Type" => "application/json" })
+      end
+
+      it "returns the eligibility fields for the resolved product" do
+        get :show, format: :json, params: { url: }
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be(true)
+        expect(response.parsed_body["product"]).to eq(
+          "name" => product.name,
+          "formatted_price" => product.price_formatted_verbose,
+          "recommendable" => product.recommendable?,
+          "short_url" => product.long_url,
+        )
+      end
+    end
+
+    context "when the resolved permalink does not match a product" do
+      let(:product) { create(:product) }
+      let(:url) { product.long_url }
+
+      before do
+        stub_request(:get, "#{url}.json")
+          .to_return(status: 200, body: { permalink: "doesnotexist" }.to_json, headers: { "Content-Type" => "application/json" })
+      end
+
+      it "returns an error" do
+        get :show, format: :json, params: { url: }
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be(false)
+        expect(response.parsed_body["error"]).to eq("Please provide a valid Gumroad product URL")
+      end
+    end
+
     context "with invalid URL" do
       let(:url) { "https://example.com" }
 

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -3490,6 +3490,21 @@ describe LinksController, :vcr, inertia: true do
 
           expect(response.parsed_body["sales_count"]).to be_nil
         end
+
+        it "returns JSON (not the custom-HTML landing page) for products with custom HTML" do
+          link = create(:product, user: @user, name: "Custom HTML Product")
+          link.update!(custom_html: "<h1>My custom landing page</h1>")
+          Feature.activate_user(:custom_html_pages, @user)
+
+          get :show, params: { id: link.to_param }, format: :json
+
+          expect(response).to be_successful
+          expect(response.media_type).to eq("application/json")
+          body = response.parsed_body
+          expect(body["api_version"]).to eq(ProductPresenter::PublicApiProps::API_VERSION)
+          expect(body["id"]).to eq(link.external_id)
+          expect(response.body).not_to include("My custom landing page")
+        end
       end
 
       describe "wanted=true parameter" do

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -3455,6 +3455,43 @@ describe LinksController, :vcr, inertia: true do
         end
       end
 
+      describe "json format" do
+        it "returns the public product JSON representation" do
+          link = create(:product, user: @user, name: "Public API Product", price_cents: 600)
+
+          get :show, params: { id: link.to_param }, format: :json
+
+          expect(response).to be_successful
+          body = response.parsed_body
+          expect(body["api_version"]).to eq(ProductPresenter::PublicApiProps::API_VERSION)
+          expect(body["id"]).to eq(link.external_id)
+          expect(body["permalink"]).to eq(link.unique_permalink)
+          expect(body["name"]).to eq("Public API Product")
+          expect(body["price_cents"]).to eq(600)
+          expect(body["currency_code"]).to eq("usd")
+          expect(body["seller"]["name"]).to eq(@user.name_or_username)
+        end
+
+        it "does not leak buyer, admin, or analytics fields" do
+          link = create(:product, user: @user)
+
+          get :show, params: { id: link.to_param }, format: :json
+
+          body = response.parsed_body
+          %w[purchase buyer wishlists can_edit analytics has_third_party_analytics is_compliance_blocked admin_info].each do |forbidden|
+            expect(body).not_to have_key(forbidden)
+          end
+        end
+
+        it "omits sales_count unless the creator opts in" do
+          link = create(:product, user: @user, should_show_sales_count: false)
+
+          get :show, params: { id: link.to_param }, format: :json
+
+          expect(response.parsed_body["sales_count"]).to be_nil
+        end
+      end
+
       describe "wanted=true parameter" do
         it "passes pay_in_installments parameter to checkout when wanted=true" do
           get :show, params: { id: product.to_param, wanted: "true", pay_in_installments: "true" }

--- a/spec/presenters/product_presenter/public_api_props_spec.rb
+++ b/spec/presenters/product_presenter/public_api_props_spec.rb
@@ -98,7 +98,7 @@ describe ProductPresenter::PublicApiProps do
       it "exposes recurrence and membership flags" do
         expect(props[:is_recurring_billing]).to be(true)
         expect(props[:is_tiered_membership]).to be(true)
-        expect(props[:recurrences]).to eq(product.recurrences)
+        expect(props[:recurrences]).to eq(product.recurrences.as_json)
       end
     end
 
@@ -110,6 +110,55 @@ describe ProductPresenter::PublicApiProps do
       it "reports is_published false for a draft" do
         product.update!(draft: true)
         expect(props[:is_published]).to be(false)
+      end
+    end
+
+    describe "seller object" do
+      it "is always an object with the documented keys" do
+        seller_props = props[:seller]
+        expect(seller_props).to be_a(Hash)
+        expect(seller_props[:name]).to eq(seller.name_or_username)
+        expect(seller_props).to have_key(:avatar_url)
+        expect(seller_props).to have_key(:profile_url)
+        expect(seller_props).to have_key(:is_verified)
+      end
+
+      it "falls back to a plain object (never nil) when author_byline_props is nil" do
+        allow_any_instance_of(UserPresenter).to receive(:author_byline_props).and_return(nil)
+        seller_props = props[:seller]
+        expect(seller_props).to be_a(Hash)
+        expect(seller_props[:id]).to eq(seller.external_id)
+        expect(seller_props[:name]).to eq(seller.name_or_username)
+        expect(seller_props[:is_verified]).to be(false)
+      end
+
+      it "uses the seller custom domain for the profile_url when present" do
+        custom_domain_url = "https://shop.example.com/"
+        presenter = described_class.new(product:, seller_custom_domain_url: custom_domain_url)
+        expect(presenter.props[:seller][:profile_url]).to eq(seller.profile_url(custom_domain_url:))
+      end
+    end
+
+    describe "refund_policy" do
+      let(:refund_policy) do
+        build(:product_refund_policy, product:, seller:, fine_print: "Line one\nLine two")
+      end
+
+      before do
+        allow_any_instance_of(User).to receive(:account_level_refund_policy_enabled?).and_return(false)
+        allow(product).to receive(:product_refund_policy_enabled?).and_return(true)
+        allow(product).to receive(:product_refund_policy).and_return(refund_policy)
+      end
+
+      it "renders fine_print with simple_format (HTML) to mirror the product page" do
+        # ProductPresenter::ProductProps wraps fine_print with simple_format and
+        # the page renders it via dangerouslySetInnerHTML — the public API must
+        # ship the same HTML, not the raw text.
+        expect(props[:refund_policy][:title]).to eq(refund_policy.title)
+        expect(props[:refund_policy][:fine_print]).to eq(
+          ActionController::Base.helpers.simple_format("Line one\nLine two")
+        )
+        expect(props[:refund_policy][:fine_print]).to include("<p>", "<br />")
       end
     end
   end

--- a/spec/presenters/product_presenter/public_api_props_spec.rb
+++ b/spec/presenters/product_presenter/public_api_props_spec.rb
@@ -17,12 +17,18 @@ describe ProductPresenter::PublicApiProps do
     it "exposes the documented public identity fields" do
       expect(props[:api_version]).to eq(described_class::API_VERSION)
       expect(props[:id]).to eq(product.external_id)
-      expect(props[:permalink]).to eq(product.unique_permalink)
+      expect(props[:permalink]).to eq(product.general_permalink)
       expect(props[:name]).to eq("My Product")
       expect(props[:native_type]).to eq(product.native_type)
       expect(props[:url]).to eq(product.long_url)
       expect(props[:created_at]).to eq(product.created_at.iso8601)
       expect(props[:updated_at]).to eq(product.updated_at.iso8601)
+    end
+
+    it "uses the public permalink from the product URL" do
+      product.update!(custom_permalink: "custom-product")
+      expect(props[:permalink]).to eq("custom-product")
+      expect(props[:url]).to end_with("/l/custom-product")
     end
 
     it "exposes pricing fields" do

--- a/spec/presenters/product_presenter/public_api_props_spec.rb
+++ b/spec/presenters/product_presenter/public_api_props_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ProductPresenter::PublicApiProps do
+  include Rails.application.routes.url_helpers
+
+  let(:seller) { create(:user, name: "Testy", username: "testy", created_at: 60.days.ago) }
+  let(:product) { create(:product, user: seller, name: "My Product", price_cents: 600) }
+  let(:presenter) { described_class.new(product:) }
+
+  before { product.save_custom_summary("A great product") }
+
+  describe "#props" do
+    subject(:props) { presenter.props }
+
+    it "exposes the documented public identity fields" do
+      expect(props[:api_version]).to eq(described_class::API_VERSION)
+      expect(props[:id]).to eq(product.external_id)
+      expect(props[:permalink]).to eq(product.unique_permalink)
+      expect(props[:name]).to eq("My Product")
+      expect(props[:native_type]).to eq(product.native_type)
+      expect(props[:url]).to eq(product.long_url)
+      expect(props[:created_at]).to eq(product.created_at.iso8601)
+      expect(props[:updated_at]).to eq(product.updated_at.iso8601)
+    end
+
+    it "exposes pricing fields" do
+      expect(props[:price_cents]).to eq(600)
+      expect(props[:currency_code]).to eq("usd")
+      expect(props[:price_formatted]).to eq(product.price_formatted_verbose)
+      expect(props[:is_pay_what_you_want]).to be(false)
+      expect(props[:suggested_price_cents]).to be_nil
+      expect(props[:is_recurring_billing]).to be(false)
+    end
+
+    it "exposes content fields" do
+      product.save_custom_attributes([{ "name" => "Format", "value" => "PDF" }])
+      expect(props[:description_html]).to eq(product.html_safe_description)
+      expect(props[:summary]).to eq("A great product")
+      expect(props[:attributes]).to include({ name: "Format", value: "PDF" })
+      expect(props).to have_key(:covers)
+    end
+
+    it "exposes the public seller byline only (no PII)" do
+      seller_props = props[:seller]
+      expect(seller_props[:name]).to eq("Testy")
+      expect(seller_props).to have_key(:avatar_url)
+      expect(seller_props).to have_key(:profile_url)
+      expect(seller_props).not_to have_key(:email)
+    end
+
+    it "never includes buyer-specific, admin, or analytics fields" do
+      %i[purchase buyer wishlists can_edit analytics has_third_party_analytics
+         is_compliance_blocked admin_info].each do |forbidden|
+        expect(props).not_to have_key(forbidden)
+      end
+    end
+
+    describe "sales_count respects the creator privacy toggle" do
+      before { allow(product).to receive(:successful_sales_count).and_return(2) }
+
+      it "is nil when should_show_sales_count is false" do
+        product.update!(should_show_sales_count: false)
+        expect(props[:sales_count]).to be_nil
+      end
+
+      it "is the successful sales count when should_show_sales_count is true" do
+        product.update!(should_show_sales_count: true)
+        expect(props[:sales_count]).to eq(2)
+      end
+    end
+
+    describe "ratings respect the display_product_reviews toggle" do
+      it "is nil when reviews are hidden" do
+        product.update!(display_product_reviews: false)
+        expect(props[:ratings]).to be_nil
+      end
+
+      it "is the rating stats when reviews are shown" do
+        product.update!(display_product_reviews: true)
+        expect(props[:ratings]).to eq(product.rating_stats)
+      end
+    end
+
+    context "pay-what-you-want product" do
+      let(:product) { create(:product, user: seller, customizable_price: true, price_cents: 500, suggested_price_cents: 800) }
+
+      it "exposes PWYW pricing" do
+        expect(props[:is_pay_what_you_want]).to be(true)
+        expect(props[:suggested_price_cents]).to eq(800)
+      end
+    end
+
+    context "membership product" do
+      let(:product) { create(:membership_product, user: seller) }
+
+      it "exposes recurrence and membership flags" do
+        expect(props[:is_recurring_billing]).to be(true)
+        expect(props[:is_tiered_membership]).to be(true)
+        expect(props[:recurrences]).to eq(product.recurrences)
+      end
+    end
+
+    context "published / unpublished state" do
+      it "reports is_published true for a live product" do
+        expect(props[:is_published]).to be(true)
+      end
+
+      it "reports is_published false for a draft" do
+        product.update!(draft: true)
+        expect(props[:is_published]).to be(false)
+      end
+    end
+  end
+end

--- a/spec/presenters/product_presenter/public_api_props_spec.rb
+++ b/spec/presenters/product_presenter/public_api_props_spec.rb
@@ -69,6 +69,12 @@ describe ProductPresenter::PublicApiProps do
         product.update!(should_show_sales_count: true)
         expect(props[:sales_count]).to eq(2)
       end
+
+      it "uses the shared cached sales count" do
+        product.update!(should_show_sales_count: true)
+        expect(ProductPresenter).to receive(:cached_sales_count).with(product).and_return(2)
+        expect(props[:sales_count]).to eq(2)
+      end
     end
 
     describe "ratings respect the display_product_reviews toggle" do
@@ -80,6 +86,7 @@ describe ProductPresenter::PublicApiProps do
       it "is the rating stats when reviews are shown" do
         product.update!(display_product_reviews: true)
         expect(props[:ratings]).to eq(product.rating_stats)
+        expect(props[:ratings][:percentages]).to eq(product.rating_percentages.values)
       end
     end
 

--- a/spec/requests/cors_headers_spec.rb
+++ b/spec/requests/cors_headers_spec.rb
@@ -33,6 +33,26 @@ describe "CORS support" do
     end
   end
 
+  describe "Request to the public product JSON endpoint" do
+    let(:origin) { "https://storefront.example.com" }
+
+    it "returns a response with CORS headers" do
+      get "/l/product.json", headers: { "HTTP_ORIGIN": origin, "HTTP_HOST": application_domain }
+
+      expect(response.headers["Access-Control-Allow-Origin"]).to eq "*"
+      expect(response.headers["Access-Control-Allow-Methods"]).to eq "GET"
+      expect(response.headers["Access-Control-Max-Age"]).to eq "7200"
+    end
+
+    it "does not add CORS headers to the HTML product page path" do
+      get "/l/product", headers: { "HTTP_ORIGIN": origin, "HTTP_HOST": application_domain }
+
+      expect(response.headers["Access-Control-Allow-Origin"]).to be_nil
+      expect(response.headers["Access-Control-Allow-Methods"]).to be_nil
+      expect(response.headers["Access-Control-Max-Age"]).to be_nil
+    end
+  end
+
   context "when the request is made to a CORS disabled domain" do
     before do
       post oauth_token_path, headers: { "HTTP_ORIGIN": origin_domain, "HTTP_HOST": application_domain }


### PR DESCRIPTION
## What

Documents and enriches the public product-page JSON endpoint (`GET /l/:permalink.json`).

This endpoint already existed but was undocumented and returned only `@product.as_json` — a thin DB serialization that omitted almost everything shown on the rendered product page. It now returns a stable, versioned, PII-safe payload that mirrors the public product page (price, covers, description, reviews, variants, and social proof), and it's documented as a first-class public endpoint in the API reference.

Changes:

- **New `ProductPresenter::PublicApiProps`** — a public, unauthenticated, read-only presenter that exposes exactly the display data the product page shows. It carries an `api_version` so integrators can depend on the shape.
- **Wires the `format.json` branch** of `LinksController#show` to render the presenter instead of `@product.as_json`.
- **Respects creator privacy toggles** — `sales_count` is only present when `should_show_sales_count?` is enabled, and `ratings` only when `display_product_reviews?` is enabled, mirroring the page. The seller is exposed as the public author byline only (name, avatar, profile URL, verified flag) — no email or other PII.
- **Never exposes** buyer-specific, seller-private, or admin fields (`purchase`, `buyer`, `wishlists`, `can_edit`, `analytics`, `has_third_party_analytics`, `is_compliance_blocked`).
- **Documents the endpoint** on the API reference page (`/api`) under a new "Public product page" resource, including the full response-field table and a cURL example. Adds an `customUrl` prop to the shared `ApiEndpoint` doc component so the per-seller subdomain URL renders correctly.

### Payload fields

Identity (`id`, `permalink`, `name`, `native_type`, `url`, `thumbnail_url`, `created_at`, `updated_at`), pricing (`price_cents`, `currency_code`, `price_formatted`, `is_pay_what_you_want`, `suggested_price_cents`, `is_recurring_billing`, `is_tiered_membership`, `recurrences`, `free_trial`), content (`description_html`, `summary`, `covers`, `attributes`), social proof (`ratings`, `sales_count`), variants/inventory (`options`, `quantity_remaining`, `is_quantity_enabled`, `is_sales_limited`), and policies/meta (`is_published`, `is_physical`, `refund_policy`, `seller`).

## Why

Creators repeatedly want to render Gumroad product info on their own sites — price, covers, description, reviews, and social proof — and keep it in sync automatically. With no documented endpoint, they scrape the HTML or hardcode values that go stale. A documented, complete JSON endpoint lets them build custom storefronts, embeds, and "as featured on Gumroad" widgets that update live. This is the read/display counterpart to the OAuth Products API and to the custom-pages work (#5063, #5406).

The endpoint is the same public, unauthenticated visibility the product page already has, and is covered by the existing global IP rate limit (`throttle_by_ip path: "/"`, 60 req/30s) in `config/initializers/rack_attack.rb`.

Tracking issue: antiwork/gumroad#5425

## Test plan

- New `spec/presenters/product_presenter/public_api_props_spec.rb` covers the documented fields, the `sales_count` / `ratings` privacy toggles, PWYW and membership variants, published/draft state, and asserts no buyer/admin/analytics keys leak.
- New `json format` examples in `spec/controllers/links_controller_spec.rb` assert the endpoint returns the public payload, omits forbidden fields, and honors the sales-count toggle.
- `rubocop`, `prettier`, and `eslint` clean on all changed files.

Co-authored-by: Sahil Lavingia <sahil@gumroad.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5427"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783335051&installation_id=134400930&pr_number=5427&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5427&signature=10dfbe06edd674948cc75301e00bf72622b354540af289cdc397d6bfff3479df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public JSON contract (replacing `as_json`) and widens CORS for `/l/*.json`; payload is designed to exclude private fields but is a new integration surface for third-party storefronts.
> 
> **Overview**
> Introduces a **documented, versioned public JSON API** at `GET /l/:permalink.json`, replacing raw `@product.as_json` with **`ProductPresenter::PublicApiProps`** — a PII-safe payload that mirrors what the product page shows (pricing, content, reviews, variants, seller byline), with **`api_version`**, privacy toggles for **`sales_count`** / **`ratings`**, and no buyer or seller-private fields.
> 
> **`LinksController#show`** serves that presenter for JSON; **custom HTML landing** no longer intercepts `.json` requests. **CORS** allows cross-origin **GET** on `/l/*.json`. The **API reference** adds a “Public product page” resource (plus **`customUrl`** on **`ApiEndpoint`** for seller subdomain URLs).
> 
> **Global affiliate product eligibility** resolves pasted URLs via the public JSON endpoint, then builds UI fields (including **`recommendable?`** from the model, not the public API). **`ProductPresenter.cached_sales_count`** is shared with the HTML product props path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d585a8dbd9a3abc1de57664645d2667dabd85014. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->