### PR TITLE
Document and enrich the public profile JSON endpoint

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,7 +28,7 @@ class UsersController < ApplicationController
         set_favicon_meta_tags(@user)
         render inertia: "Users/Show", props: ProfilePresenter.new(pundit_user:, seller: @user).profile_props(seller_custom_domain_url:, request:)
       end
-      format.json { render json: @user.as_json }
+      format.json { render json: ProfilePresenter::PublicApiProps.new(seller: @user).props }
       format.any { e404 }
     end
   end

--- a/app/javascript/components/ApiDocumentation/ApiEndpoint.tsx
+++ b/app/javascript/components/ApiDocumentation/ApiEndpoint.tsx
@@ -10,16 +10,18 @@ export const ApiEndpoint = ({
   path,
   description,
   isOAuth,
+  customUrl,
   children,
 }: {
   method: string;
   path: string;
   description: React.ReactNode;
   isOAuth?: boolean;
+  customUrl?: string;
   children?: React.ReactNode;
 }) => {
   const methodId = `${method}-${path}`;
-  const url = isOAuth ? `https://gumroad.com${path}` : `https://api.gumroad.com/v2${path}`;
+  const url = customUrl ?? (isOAuth ? `https://gumroad.com${path}` : `https://api.gumroad.com/v2${path}`);
 
   return (
     <CardContent details id={methodId}>

--- a/app/javascript/components/ApiDocumentation/Endpoints/PublicProfile.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/PublicProfile.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+
+import CodeSnippet from "$app/components/ui/CodeSnippet";
+
+import { ApiEndpoint } from "../ApiEndpoint";
+import { ApiResponseFields, renderFields } from "../ApiResponseFields";
+
+// Public, unauthenticated, read-only creator profile JSON.
+// Returns the same public information a visitor sees on a creator's profile
+// page — name, bio, avatar, social links, and their published products — so
+// anyone can build directories, storefronts, and widgets that stay in sync.
+// Never exposes seller-private fields (email, balance, tokens, tax info).
+export const GetPublicProfile = () => (
+  <ApiEndpoint
+    method="get"
+    path="/:username.json"
+    customUrl="https://[username].gumroad.com/.json"
+    description={
+      <>
+        Retrieve a creator's public profile — no authentication required. Returns the creator's display information
+        (name, bio, avatar, social links) along with the list of their published products. Append{" "}
+        <code className="inline-code">.json</code> to any creator profile URL. Never exposes seller-private fields such
+        as email, balance, or tax information.
+      </>
+    }
+  >
+    <ApiResponseFields>
+      {renderFields([
+        { name: "api_version", type: "number", description: "The schema version of this public payload" },
+        { name: "id", type: "string", description: "The creator's unique external ID" },
+        { name: "username", type: "string", description: "The creator's username (their profile subdomain)" },
+        { name: "name", type: "string", description: "The creator's display name (falls back to username)" },
+        { name: "bio", type: "string", description: "The creator's profile bio, if set; otherwise null" },
+        { name: "avatar_url", type: "string", description: "The creator's avatar image URL" },
+        { name: "profile_url", type: "string", description: "The full public profile URL" },
+        { name: "subdomain", type: "string", description: "The creator's profile subdomain" },
+        { name: "twitter_handle", type: "string", description: "The creator's Twitter/X handle, if set" },
+        { name: "is_verified", type: "boolean", description: "Whether the creator is verified" },
+        {
+          name: "products",
+          type: "array",
+          description:
+            "The creator's published products (id, permalink, name, native_type, url, thumbnail_url, price_cents, currency_code, price_formatted, is_pay_what_you_want, is_recurring_billing, ratings, sales_count). Capped at 100, newest first.",
+        },
+      ])}
+    </ApiResponseFields>
+    <CodeSnippet caption="cURL example">
+      {`curl https://sahil.gumroad.com/.json \\
+  -X GET`}
+    </CodeSnippet>
+    <CodeSnippet caption="Example response:">
+      {`{
+  "api_version": 1,
+  "id": "G_-mnBf9b1j9A7a4ub4nFQ==",
+  "username": "sahil",
+  "name": "Sahil",
+  "bio": "I make tools for creators.",
+  "avatar_url": "https://public-files.gumroad.com/user/abc/avatar",
+  "profile_url": "https://sahil.gumroad.com",
+  "subdomain": "sahil.gumroad.com",
+  "twitter_handle": "shl",
+  "is_verified": true,
+  "products": [
+    {
+      "id": "A-m3CDDC5dlrSdKZp0RFhA==",
+      "permalink": "pencil",
+      "name": "Pencil Icon PSD",
+      "native_type": "digital",
+      "url": "https://sahil.gumroad.com/l/pencil",
+      "thumbnail_url": "https://public-files.gumroad.com/variants/abc/def",
+      "price_cents": 100,
+      "currency_code": "usd",
+      "price_formatted": "$1",
+      "is_pay_what_you_want": false,
+      "is_recurring_billing": false,
+      "ratings": { "count": 12, "average": 4.5 },
+      "sales_count": null
+    }
+  ]
+}`}
+    </CodeSnippet>
+  </ApiEndpoint>
+);

--- a/app/javascript/components/ApiDocumentation/Navigation.tsx
+++ b/app/javascript/components/ApiDocumentation/Navigation.tsx
@@ -53,6 +53,9 @@ export const Navigation = () => (
             <a href="#user">User</a>
           </li>
           <li>
+            <a href="#public-profile">Public profile</a>
+          </li>
+          <li>
             <a href="#refund-policy">Refund policy</a>
           </li>
           <li>

--- a/app/javascript/pages/Public/Api.tsx
+++ b/app/javascript/pages/Public/Api.tsx
@@ -43,6 +43,7 @@ import {
   GetProducts,
   UpdateProduct,
 } from "$app/components/ApiDocumentation/Endpoints/Products";
+import { GetPublicProfile } from "$app/components/ApiDocumentation/Endpoints/PublicProfile";
 import { GetRefundPolicy, UpdateRefundPolicy } from "$app/components/ApiDocumentation/Endpoints/RefundPolicy";
 import {
   CreateResourceSubscription,
@@ -183,6 +184,10 @@ export default function Api() {
 
               <ApiResource name="User" id="user">
                 <GetUser />
+              </ApiResource>
+
+              <ApiResource name="Public profile" id="public-profile">
+                <GetPublicProfile />
               </ApiResource>
 
               <ApiResource name="Refund policy" id="refund-policy">

--- a/app/presenters/product_presenter.rb
+++ b/app/presenters/product_presenter.rb
@@ -10,6 +10,8 @@ class ProductPresenter
 
   SALES_COUNT_CACHE_KEY_REFIX = "product-presenter:sales-count-cache"
   SALES_COUNT_CACHE_METRICS_KEY = "#{SALES_COUNT_CACHE_KEY_REFIX}-metrics"
+  LATEST_SALE_ID_NOT_PROVIDED = Object.new.freeze
+  private_constant :LATEST_SALE_ID_NOT_PROVIDED
 
   attr_reader :product, :editing_page_id, :pundit_user, :request, :ai_generated
 
@@ -54,10 +56,11 @@ class ProductPresenter
     ProductPresenter::Card.new(product:).for_email
   end
 
-  def self.cached_sales_count(product)
+  def self.cached_sales_count(product, latest_sale_id: LATEST_SALE_ID_NOT_PROVIDED)
     return unless product.should_show_sales_count?
 
-    cache_key_digest = Digest::SHA256.hexdigest("#{product.cache_key}-#{product.price_cents}-#{product.sales.order(id: :desc).pick(:id)}")
+    latest_sale_id = product.sales.order(id: :desc).pick(:id) if latest_sale_id.equal?(LATEST_SALE_ID_NOT_PROVIDED)
+    cache_key_digest = Digest::SHA256.hexdigest("#{product.cache_key}-#{product.price_cents}-#{latest_sale_id}")
     cache_key = "#{SALES_COUNT_CACHE_KEY_REFIX}_#{cache_key_digest}"
     Rails.cache.fetch(cache_key, expires_in: 1.minute) { product.successful_sales_count }
   end

--- a/app/presenters/profile_presenter/public_api_props.rb
+++ b/app/presenters/profile_presenter/public_api_props.rb
@@ -18,6 +18,7 @@
 #   * Stable, versioned shape (`api_version`) so integrators can depend on it.
 class ProfilePresenter::PublicApiProps
   include Rails.application.routes.url_helpers
+  include ActionView::Helpers::OutputSafetyHelper
   include CurrencyHelper
 
   # Bump when the public shape changes in a backwards-incompatible way.
@@ -60,7 +61,10 @@ class ProfilePresenter::PublicApiProps
     attr_reader :seller, :seller_custom_domain_url
 
     def products_props
-      visible_profile_products.map do |product|
+      products = visible_profile_products
+      latest_sale_ids_by_product_id = latest_sale_ids_by_product_id(products)
+
+      products.map do |product|
         card_props = ProductPresenter.card_for_web(product:, show_seller: false, compute_description: false, compute_inventory: false)
 
         {
@@ -82,9 +86,15 @@ class ProfilePresenter::PublicApiProps
           is_pay_what_you_want: card_props[:is_pay_what_you_want],
           is_recurring_billing: product.is_recurring_billing,
           ratings: product.display_product_reviews? ? product.rating_stats : nil,
-          sales_count: ProductPresenter.cached_sales_count(product),
+          sales_count: ProductPresenter.cached_sales_count(product, latest_sale_id: latest_sale_ids_by_product_id[product.id]),
         }
       end
+    end
+
+    def latest_sale_ids_by_product_id(products)
+      return {} if products.blank?
+
+      Purchase.where(link_id: products.map(&:id)).group(:link_id).maximum(:id)
     end
 
     def product_url(product)

--- a/app/presenters/profile_presenter/public_api_props.rb
+++ b/app/presenters/profile_presenter/public_api_props.rb
@@ -100,7 +100,14 @@ class ProfilePresenter::PublicApiProps
     def product_url(product)
       return product.long_url if seller_custom_domain_url.blank?
 
-      short_link_url(product.general_permalink, host: seller_custom_domain_url.delete_suffix("/"))
+      uri = URI.parse(seller_custom_domain_url)
+      options = {
+        host: uri.host,
+        protocol: "#{uri.scheme}://",
+      }
+      options[:port] = uri.port if uri.port != uri.default_port
+
+      short_link_url(product.general_permalink, **options)
     end
 
     def visible_profile_products

--- a/app/presenters/profile_presenter/public_api_props.rb
+++ b/app/presenters/profile_presenter/public_api_props.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+# Public, unauthenticated, read-only JSON representation of a creator's profile —
+# the documented payload returned by `GET /:username.json` (the seller's
+# public profile page).
+#
+# This is the read/display counterpart to the rendered profile page: it exposes
+# the same public information a visitor sees (name, bio, avatar, social links,
+# and the creator's published products) so anyone can build their own
+# storefronts, directories, and widgets that stay in sync with the profile.
+#
+# Hard rules:
+#   * PUBLIC — never include seller-private or admin fields (email, balance,
+#     tokens, tax info, compliance internals). The bare `User#as_json` this
+#     replaces dumped every column; this allowlist fails CLOSED.
+#   * Lists only published, non-archived, non-deleted products, mirroring what
+#     the profile page renders to a logged-out visitor.
+#   * Stable, versioned shape (`api_version`) so integrators can depend on it.
+class ProfilePresenter::PublicApiProps
+  # Bump when the public shape changes in a backwards-incompatible way.
+  API_VERSION = 1
+
+  # Cap the inline product list so the endpoint stays cheap and predictable.
+  PRODUCTS_LIMIT = 100
+
+  def initialize(seller:)
+    @seller = seller
+  end
+
+  def props
+    {
+      api_version: API_VERSION,
+
+      # Identity
+      id: seller.external_id,
+      username: seller.username,
+      name: seller.name_or_username,
+      bio: seller.bio.presence,
+      avatar_url: seller.avatar_url,
+      profile_url: seller.profile_url,
+      subdomain: seller.subdomain,
+      twitter_handle: seller.twitter_handle,
+      is_verified: !!seller.verified,
+
+      # Published products (public, mirrors the profile page)
+      products: products_props,
+    }
+  end
+
+  private
+    attr_reader :seller
+
+    def products_props
+      published_products.map do |product|
+        {
+          id: product.external_id,
+          permalink: product.unique_permalink,
+          name: product.name,
+          native_type: product.native_type,
+          url: product.long_url,
+          thumbnail_url: product.thumbnail&.alive&.url,
+          price_cents: product.price_cents,
+          currency_code: product.price_currency_type.downcase,
+          price_formatted: product.price_formatted_verbose,
+          is_pay_what_you_want: product.customizable_price?,
+          is_recurring_billing: product.is_recurring_billing,
+          ratings: product.display_product_reviews? ? product.rating_stats : nil,
+          sales_count: product.should_show_sales_count? ? product.successful_sales_count : nil,
+        }
+      end
+    end
+
+    def published_products
+      seller.products
+            .alive
+            .not_archived
+            .order(created_at: :desc)
+            .limit(PRODUCTS_LIMIT)
+    end
+end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -4,12 +4,13 @@
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   public_profile_json_request = proc do |env|
     path = env["PATH_INFO"].to_s
-    host = env["HTTP_HOST"].presence || env["SERVER_NAME"].presence
+    request = Rack::Request.new(env)
+    host = request.host.presence
 
     if host.blank?
       false
     else
-      scheme = env["rack.url_scheme"].presence || PROTOCOL
+      scheme = request.scheme.presence || PROTOCOL
       route_params = Rails.application.routes.recognize_path("#{scheme}://#{host}#{path}", method: :get)
       route_params[:controller] == "users" && route_params[:action] == "show" && route_params[:format] == "json"
     end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -9,6 +9,8 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
 
     if host.blank?
       false
+    elsif path == "/.json"
+      UserCustomDomainConstraint.matches?(request)
     else
       scheme = request.scheme.presence || PROTOCOL
       route_params = Rails.application.routes.recognize_path("#{scheme}://#{host}#{path}", method: :get)

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -16,7 +16,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
       route_params = Rails.application.routes.recognize_path("#{scheme}://#{host}#{path}", method: :get)
       route_params[:controller] == "users" && route_params[:action] == "show" && route_params[:format] == "json"
     end
-  rescue ActionController::RoutingError
+  rescue ActionController::RoutingError, URI::InvalidURIError
     false
   end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -97,12 +97,36 @@ describe UsersController do
       end
     end
 
-    it "returns user json when json request is sent" do
-      link = create(:product, user: create(:user, username: "creator"), name: "onelolol")
+    describe "json format" do
+      let(:creator_user) { create(:user, username: "creator", name: "Creator Name", bio: "My bio") }
 
-      @request.host = "creator.test.gumroad.com"
-      get :show, params: { username: "creator", format: "json" }
-      expect(response.parsed_body).to eq(link.user.as_json)
+      before { @request.host = "creator.test.gumroad.com" }
+
+      it "returns the public profile API payload" do
+        product = create(:product, user: creator_user, name: "onelolol")
+
+        get :show, params: { username: "creator", format: "json" }
+
+        expect(response).to be_successful
+        body = response.parsed_body
+        expect(body["api_version"]).to eq(ProfilePresenter::PublicApiProps::API_VERSION)
+        expect(body["id"]).to eq(creator_user.external_id)
+        expect(body["username"]).to eq("creator")
+        expect(body["name"]).to eq("Creator Name")
+        expect(body["bio"]).to eq("My bio")
+        expect(body["products"].map { _1["name"] }).to include("onelolol")
+        expect(body["products"].first["id"]).to eq(product.external_id)
+      end
+
+      it "never leaks private seller fields" do
+        create(:product, user: creator_user)
+
+        get :show, params: { username: "creator", format: "json" }
+
+        expect(response.parsed_body.keys).not_to include(
+          "email", "password", "encrypted_password", "unpaid_balance_cents", "payment_address"
+        )
+      end
     end
 
     describe "redirection to subdomain for profile pages" do

--- a/spec/presenters/product_presenter_spec.rb
+++ b/spec/presenters/product_presenter_spec.rb
@@ -7,6 +7,22 @@ describe ProductPresenter do
   include PreorderHelper
   include ProductsHelper
 
+  describe ".cached_sales_count" do
+    it "uses the provided latest sale id without querying sales" do
+      product = instance_double(
+        Link,
+        should_show_sales_count?: true,
+        cache_key: "links/1-#{SecureRandom.hex}",
+        price_cents: 100,
+        successful_sales_count: 7,
+      )
+
+      expect(product).not_to receive(:sales)
+
+      expect(described_class.cached_sales_count(product, latest_sale_id: 123)).to eq(7)
+    end
+  end
+
   describe ".new_page_props" do
     let(:new_seller) { create(:named_seller) }
     let(:existing_seller) { create(:user) }

--- a/spec/presenters/profile_presenter/public_api_props_spec.rb
+++ b/spec/presenters/profile_presenter/public_api_props_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ProfilePresenter::PublicApiProps do
+  let(:seller) do
+    create(
+      :user,
+      name: "Testy McTest",
+      username: "testy",
+      bio: "I make great things.",
+      twitter_handle: "testy",
+    )
+  end
+  let(:presenter) { described_class.new(seller:) }
+
+  describe "#props" do
+    subject(:props) { presenter.props }
+
+    it "exposes the documented public identity fields" do
+      expect(props[:api_version]).to eq(described_class::API_VERSION)
+      expect(props[:id]).to eq(seller.external_id)
+      expect(props[:username]).to eq("testy")
+      expect(props[:name]).to eq("Testy McTest")
+      expect(props[:bio]).to eq("I make great things.")
+      expect(props[:twitter_handle]).to eq("testy")
+      expect(props[:profile_url]).to eq(seller.profile_url)
+      expect(props[:subdomain]).to eq(seller.subdomain)
+      expect(props).to have_key(:avatar_url)
+    end
+
+    it "exposes is_verified reflecting the seller flag" do
+      expect(props[:is_verified]).to be(false)
+      seller.update!(verified: true)
+      expect(described_class.new(seller:).props[:is_verified]).to be(true)
+    end
+
+    it "returns nil bio when the seller has none" do
+      seller.update!(bio: nil)
+      expect(described_class.new(seller:).props[:bio]).to be_nil
+    end
+
+    it "NEVER leaks private seller fields (email, balance, tokens)" do
+      expect(props.keys.map(&:to_s)).not_to include(
+        "email", "password", "unpaid_balance_cents", "balance",
+        "user_risk_state", "tax_id", "payment_address", "encrypted_password"
+      )
+    end
+
+    describe "products" do
+      let!(:published) do
+        create(:product, user: seller, name: "Published One", price_cents: 600, created_at: 2.days.ago)
+      end
+      let!(:second) do
+        create(:product, user: seller, name: "Published Two", price_cents: 1500, created_at: 1.day.ago)
+      end
+
+      it "lists the seller's published products with public fields" do
+        names = props[:products].map { _1[:name] }
+        expect(names).to contain_exactly("Published One", "Published Two")
+
+        entry = props[:products].find { _1[:name] == "Published One" }
+        expect(entry[:id]).to eq(published.external_id)
+        expect(entry[:permalink]).to eq(published.unique_permalink)
+        expect(entry[:url]).to eq(published.long_url)
+        expect(entry[:price_cents]).to eq(600)
+        expect(entry[:currency_code]).to eq("usd")
+        expect(entry[:price_formatted]).to eq(published.price_formatted_verbose)
+        expect(entry).to have_key(:thumbnail_url)
+      end
+
+      it "excludes unpublished, archived, and deleted products" do
+        create(:product, user: seller, name: "Draft", purchase_disabled_at: Time.current)
+        create(:product, user: seller, name: "Archived", archived: true)
+        create(:product, user: seller, name: "Deleted", deleted_at: Time.current)
+
+        names = props[:products].map { _1[:name] }
+        expect(names).to contain_exactly("Published One", "Published Two")
+      end
+
+      it "orders products newest-first" do
+        expect(props[:products].first[:name]).to eq("Published Two")
+      end
+
+      it "respects the sales_count creator toggle" do
+        published.update!(should_show_sales_count: false)
+        entry = props[:products].find { _1[:name] == "Published One" }
+        expect(entry[:sales_count]).to be_nil
+      end
+
+      it "caps the product list at PRODUCTS_LIMIT" do
+        stub_const("#{described_class}::PRODUCTS_LIMIT", 1)
+        expect(described_class.new(seller:).props[:products].size).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/presenters/profile_presenter/public_api_props_spec.rb
+++ b/spec/presenters/profile_presenter/public_api_props_spec.rb
@@ -184,7 +184,7 @@ describe ProfilePresenter::PublicApiProps do
 
       it "uses the shared product sales count cache" do
         allow(ProductPresenter).to receive(:cached_sales_count).and_return(nil)
-        allow(ProductPresenter).to receive(:cached_sales_count).with(published).and_return(42)
+        allow(ProductPresenter).to receive(:cached_sales_count).with(published, latest_sale_id: nil).and_return(42)
 
         entry = described_class.new(seller:).props[:products].find { _1[:name] == "Published One" }
         expect(entry[:sales_count]).to eq(42)

--- a/spec/requests/cors_headers_spec.rb
+++ b/spec/requests/cors_headers_spec.rb
@@ -89,6 +89,16 @@ describe "CORS support" do
       expect(response.headers["Access-Control-Max-Age"]).to be_nil
     end
 
+    it "does not raise or add CORS headers for malformed hosts" do
+      expect do
+        get "/seller.json", headers: { "HTTP_ORIGIN": origin, "HTTP_HOST": "evil{}host" }
+      end.not_to raise_error
+
+      expect(response.headers["Access-Control-Allow-Origin"]).to be_nil
+      expect(response.headers["Access-Control-Allow-Methods"]).to be_nil
+      expect(response.headers["Access-Control-Max-Age"]).to be_nil
+    end
+
     it "does not add CORS headers to the HTML profile page path" do
       get "/seller", headers: { "HTTP_ORIGIN": origin, "HTTP_HOST": application_domain }
 


### PR DESCRIPTION
Ref #5425

## What

Adds a public, unauthenticated profile JSON endpoint for creator profile URLs. It replaces the old raw `User#as_json` response with an allowlisted payload for public creator identity and products visible in public profile product sections.

The product list now follows the rendered profile: it walks public tabs in order, ignores unreferenced sections, filters hidden sold-out products, uses product-card pricing, keeps custom permalinks consistent with URLs, and reuses the product-page sales-count cache. Browser access is scoped to the public profile JSON routes only, including custom-domain profile JSON.

## Why

Creator profile `.json` URLs previously exposed private user columns. This keeps the endpoint useful for storefronts and widgets while making the public contract explicit, PII-safe, and consistent with what visitors can see on the profile page.

## Verification

RuboCop, ESLint, Prettier, `git diff --check`, `bin/test-confidence` at 99%, and `autoreview` clean. Direct RSpec is still blocked locally by MySQL not running.

---

This PR was implemented with AI assistance using gpt-5.5 xhigh.

🤖 Generated with [Hermes](https://hermes-agent.nousresearch.com)

Co-authored-by: Sahil Lavingia <sahil@gumroad.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783335815&installation_id=134400930&pr_number=5428&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5428&signature=fc496a789eb5507b2c86468a9043d8fd00dd68c8a9c3f255101815556b5a6763"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a previously leaky public JSON surface and broadens CORS for specific profile routes; behavior is heavily tested but alters the response contract for existing `.json` consumers.
> 
> **Overview**
> **Replaces creator profile `.json` responses** that previously dumped `User#as_json` with a versioned, allowlisted payload from `ProfilePresenter::PublicApiProps` (public identity plus up to 100 products from visible profile sections, aligned with the HTML profile). JSON requests **skip** the subdomain redirect so `/:username.json` works on the main domain.
> 
> **Product listing** follows profile tab/section order, filters unpublished/archived/hidden sold-out items, uses product-card pricing and custom-domain URLs, and batches latest sale IDs for `ProductPresenter.cached_sales_count`.
> 
> **CORS** is limited to public profile JSON routes (`/.json` on custom domains and `/:username.json`), with route recognition so unrelated `.json` paths do not get wildcard headers.
> 
> **API docs** add a **Public profile** section describing the unauthenticated endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d1348e9120cf76de3dc1876fb5b8d62fd690680. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->