### PR TITLE
Hide product cover area when there are no previews

### DIFF
--- a/app/javascript/components/Product/index.tsx
+++ b/app/javascript/components/Product/index.tsx
@@ -708,6 +708,8 @@ const Covers = ({ covers, mainCoverId }: { covers: AssetPreview[]; mainCoverId: 
   const [activeCoverId, setActiveCoverId] = React.useState(mainCoverId);
   useOnChange(() => setActiveCoverId(mainCoverId), [mainCoverId]);
 
+  if (covers.length === 0) return null;
+
   return (
     <CoversComponent
       covers={covers}

--- a/spec/requests/products/show/preview_spec.rb
+++ b/spec/requests/products/show/preview_spec.rb
@@ -59,6 +59,17 @@ describe("Product page previews", js: true, type: :system) do
     end
   end
 
+  context "when the product has no previews" do
+    let(:product) { create(:product) }
+
+    it "does not render the empty cover placeholder" do
+      visit product.long_url
+
+      expect(page).to have_selector("h1", text: product.name)
+      expect(page).to_not have_selector("[aria-label='Product preview']")
+    end
+  end
+
   describe "scrolling between previews" do
     let(:product) { create(:product) }
 


### PR DESCRIPTION
## What changed

A product with no uploaded cover still rendered the cover figure with the tiled placeholder background and reserved vertical space (`pb-[25%]`), leaving an empty watermarked box at the top of the product page.

This hides that area entirely when a product has no previews — the public product page's `Covers` wrapper now returns `null` when `covers.length === 0`, so the page starts cleanly at the product info bar.

## Why

On a cover-less product (e.g. a service/call product), the empty placeholder box reads like a broken/missing image rather than an intentional layout. Showing nothing is cleaner.

Reported live on https://gumclaw.gumroad.com/l/gzhptn — a call product with no cover renders the empty tiled box.

## Scope / safety

- Only the **public product page** wrapper (`Product/index.tsx`) is touched.
- The **editor** (`ProductEdit/ProductTab/CoverEditor.tsx`) is unaffected: it already gates on `covers.length` and renders its own upload `Placeholder` when empty, so the shared `Covers` component is never rendered there with an empty list. The drag-to-upload / "Add cover" affordance is unchanged.
- Products that *do* have covers are unchanged.

## Tests

Added a `spec/requests/products/show/preview_spec.rb` case: a product with no previews renders the product `<h1>` but does **not** render the `[aria-label='Product preview']` figure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only guard on the public product page wrapper; no auth, checkout, or editor cover upload paths touched.
> 
> **Overview**
> **Public product pages** no longer show an empty cover strip when a product has zero previews. The local `Covers` wrapper in `Product/index.tsx` now **returns `null`** when `covers.length === 0`, so the tiled placeholder and reserved `pb-[25%]` space are omitted and the layout starts at the product header/info.
> 
> Products with at least one cover behave as before. Cover editing in the product editor is unchanged.
> 
> A **system spec** asserts that a product with no asset previews still shows the product name but does **not** render `[aria-label='Product preview']`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3527046811da13d98d5246d9afef837363371740. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783362748&installation_id=134400930&pr_number=5430&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5430&signature=8a3392301af91a3d9489d44fbe0443d9b2281e1b064e7bcae8048e583b778caa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->