### PR TITLE
Run Gumroad's Stripe balance sweep after seller payouts

### DIFF
--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -82,7 +82,7 @@ send_reminders_for_outstanding_user_compliance_info_requests: # Duration: 5min
   class: SendRemindersForOutstandingUserComplianceInfoRequestsWorker
   description: Sends reminder emails for outstanding user compliance info requests.
 stripe_transfer_gumroads_available_balances_to_gumroads_bank_account: # Duration: <1sec
-  cron: "0 11 * * *" # UTC 11:00
+  cron: "0 18 * * *" # UTC 18:00, must run well after the weekly seller payouts (UTC 10:00) so their platform-balance debits clear before we sweep the remainder to Gumroad's bank
   class: StripeTransferGumroadsAvailableBalancesToGumroadsBankAccountWorker
   description: Transfers the available balances of Gumroad's Stripe account to the Gumroad bank account
 expire_rental_purchases: # Duration: 45sec


### PR DESCRIPTION
## What

Moves the daily job that sweeps Gumroad's platform Stripe balance to Gumroad's own bank account from **UTC 11:00 → UTC 18:00**, so it runs well after the weekly seller payouts (UTC 10:00) instead of an hour after they start.

## Why

Seller payouts and the Gumroad bank sweep both draw from the **same platform Stripe balance**:

- Seller payouts create platform → connected-account transfers, which debit the platform balance.
- The sweep (`Stripe::Payout.create` with no `stripe_account`) moves the remaining platform balance to Gumroad's corporate bank.

The sweep was scheduled at UTC 11:00, only one hour after the weekly seller-payout jobs begin at UTC 10:00. For a large batch, the per-account transfer debits don't all clear within that hour. When the sweep got ahead of them it drained the balance, and the in-flight seller transfers then failed with *"You have insufficient funds in your Stripe account."*

Running the sweep at UTC 18:00 lets the weekly seller-payout debits clear first, so we only sweep the genuine remainder. This reorders the two jobs against the shared balance; the worker's buffer logic is unchanged.

## Before / After

Non-user-facing (Sidekiq cron schedule). Single-line change:

```diff
-  cron: "0 11 * * *" # UTC 11:00
+  cron: "0 18 * * *" # UTC 18:00, must run well after the weekly seller payouts (UTC 10:00) ...
```

## Test Results

No application logic changed — only the cron time string in `config/sidekiq_schedule.yml`. YAML validated to parse and the entry resolves to `cron: "0 18 * * *"` for `StripeTransferGumroadsAvailableBalancesToGumroadsBankAccountWorker`. There is no spec covering the schedule file.

---

AI disclosure: drafted with Claude Opus 4.8.
