### PR TITLE
Alert when Stripe balance is too low to cover upcoming seller payouts

### DIFF
--- a/app/business/payments/payouts/payout_estimates.rb
+++ b/app/business/payments/payouts/payout_estimates.rb
@@ -1,6 +1,26 @@
 # frozen_string_literal: true
 
 module PayoutEstimates
+  # Fast set-based estimate of the unpaid balance Gumroad holds for Stripe
+  # payouts up to a date. Gumroad-held Stripe balances live on the platform
+  # merchant accounts (user_id IS NULL), so this is a single indexed
+  # aggregation rather than the per-user loop in estimate_held_amount_cents.
+  #
+  # This skips the per-user payability gates (compliance, paused, minimum
+  # payout), so it slightly over-states the amount that will actually pay out
+  # this cycle -- the safe direction for "is the balance high enough?".
+  def self.estimate_gumroad_held_stripe_cents(date)
+    merchant_account_ids = MerchantAccount.where(
+      user_id: nil,
+      charge_processor_id: StripeChargeProcessor.charge_processor_id
+    ).ids
+
+    Balance.unpaid
+           .where(merchant_account_id: merchant_account_ids)
+           .where("date <= ?", date)
+           .sum(:amount_cents)
+  end
+
   def self.estimate_held_amount_cents(date, processor_type)
     payment_estimates = estimate_payments_for_balances_up_to_date_for_users(date, processor_type, User.holding_balance)
     holder_of_funds_amount_cents = Hash.new(0)

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -25,6 +25,14 @@ class HealthcheckController < ApplicationController
     render plain: "PayPal balance: #{message}", status:
   end
 
+  def stripe_balance
+    topup_not_needed = $redis.get(RedisKey.stripe_balance_topup_needed) == "false"
+    status = topup_not_needed ? :ok : :service_unavailable
+    message = topup_not_needed ? "topup not required" : "topup required"
+
+    render plain: "Stripe balance: #{message}", status:
+  end
+
   def purchases
     threshold = $redis.get(RedisKey.min_successful_purchases_in_last_10_minutes)
     count = Rails.cache.fetch("healthcheck:purchases:successful_last_10_minutes", expires_in: 30.seconds) do

--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -51,6 +51,8 @@ class RedisKey
     def unreviewed_users_data = "admin:unreviewed_users_data"
     def unreviewed_users_cutoff_date = "admin:unreviewed_users_cutoff_date"
     def paypal_topup_needed = "paypal:topup_needed"
+    def stripe_balance_topup_needed = "stripe:balance_topup_needed"
+    def stripe_minimum_balance_cents = "stripe:minimum_balance_cents"
     def min_successful_purchases_in_last_10_minutes = "healthcheck:min_successful_purchases_in_last_10_minutes"
     def email_router_fallback(user_id) = "email_router_fallback:#{user_id}"
     def mobile_minimum_version = "mobile:minimum_version"

--- a/app/services/stripe_balance_check_service.rb
+++ b/app/services/stripe_balance_check_service.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Determines whether Gumroad's Stripe platform balance is large enough to
+# fund the upcoming seller payouts. Stripe pays out Gumroad's balance to
+# Gumroad's bank automatically, and seller payouts (platform -> connected
+# account transfers) draw from the same balance, so the balance can be
+# starved before a payout cycle runs. This service powers a proactive alert
+# so the balance can be topped up before any seller payout fails.
+#
+# The minimum balance kept on top of the estimated upcoming payouts is
+# configured at runtime via Redis (RedisKey.stripe_minimum_balance_cents).
+class StripeBalanceCheckService
+  def initialize
+    @upcoming_payouts_cents = calculate_upcoming_payouts_cents
+    @minimum_balance_cents = $redis.get(RedisKey.stripe_minimum_balance_cents).to_i
+    @current_balance_cents = StripeTransferExternallyToGumroad.available_balances["usd"].to_i
+  end
+
+  attr_reader :upcoming_payouts_cents, :minimum_balance_cents, :current_balance_cents
+
+  def required_balance_cents
+    upcoming_payouts_cents + minimum_balance_cents
+  end
+
+  def topup_amount_cents
+    @topup_amount_cents ||= required_balance_cents - current_balance_cents
+  end
+
+  def topup_needed?
+    topup_amount_cents > 0
+  end
+
+  private
+    # Only the funds Gumroad itself holds need to come out of Gumroad's Stripe
+    # balance; balances held by Stripe are funded by Stripe directly.
+    def calculate_upcoming_payouts_cents
+      PayoutEstimates.estimate_gumroad_held_stripe_cents(
+        User::PayoutSchedule.next_scheduled_payout_end_date
+      )
+    end
+end

--- a/app/sidekiq/send_stripe_balance_check_notification_job.rb
+++ b/app/sidekiq/send_stripe_balance_check_notification_job.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class SendStripeBalanceCheckNotificationJob
+  include Sidekiq::Job
+  include CurrencyHelper
+  sidekiq_options retry: 1, queue: :default, lock: :until_executed
+
+  def perform
+    return unless Rails.env.production?
+
+    balance_check = StripeBalanceCheckService.new
+
+    $redis.set(RedisKey.stripe_balance_topup_needed, balance_check.topup_needed?)
+
+    return unless balance_check.topup_needed?
+
+    notification_msg = "Stripe balance needs to be #{formatted_dollar_amount(balance_check.required_balance_cents)} " \
+                       "(#{formatted_dollar_amount(balance_check.upcoming_payouts_cents)} for upcoming payouts + " \
+                       "#{formatted_dollar_amount(balance_check.minimum_balance_cents)} Stripe minimum balance) " \
+                       "to pay out all creators.\n" \
+                       "Current Stripe balance is #{formatted_dollar_amount(balance_check.current_balance_cents)}.\n" \
+                       "A top-up of #{formatted_dollar_amount(balance_check.topup_amount_cents)} is needed."
+
+    InternalNotificationWorker.perform_async("payments",
+                                             "Stripe Balance Check",
+                                             notification_msg,
+                                             "red")
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
   get "/healthcheck" => "healthcheck#index"
   get "/healthcheck/sidekiq" => "healthcheck#sidekiq"
   get "/healthcheck/paypal_balance" => "healthcheck#paypal_balance"
+  get "/healthcheck/stripe_balance" => "healthcheck#stripe_balance"
   get "/healthcheck/purchases" => "healthcheck#purchases"
 
   use_doorkeeper do

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -315,6 +315,10 @@ send_paypal_topup_notification_weekly:
   cron: "0 14 * * 1" # UTC 14:00 (9am ET) MON
   class: SendPaypalTopupNotificationJob
   description: Send a slack notification for the weekly PayPal topup status
+send_stripe_balance_check_notification:
+  cron: "0 14 * * *" # UTC 14:00 (9am ET) daily, ahead of the next day's UTC 10:00 seller payouts
+  class: SendStripeBalanceCheckNotificationJob
+  description: Notify if Gumroad's Stripe balance is too low to cover upcoming seller payouts
 sync_all_paypal_payouts:
   cron: "0 15 * * 4" # UTC 15:00 Thursday
   class: SyncStuckPayoutsJob

--- a/spec/business/payments/payouts/payout_estimates_spec.rb
+++ b/spec/business/payments/payouts/payout_estimates_spec.rb
@@ -53,6 +53,23 @@ describe PayoutEstimates do
     end
   end
 
+  describe "estimate_gumroad_held_stripe_cents" do
+    let(:date) { Date.today }
+    let(:gumroad_ma) { create(:merchant_account, user: nil, charge_processor_id: StripeChargeProcessor.charge_processor_id) }
+    let(:seller) { create(:user_with_compliance_info) }
+    let(:seller_ma) { create(:merchant_account, user: seller, charge_processor_id: StripeChargeProcessor.charge_processor_id) }
+
+    it "sums unpaid Gumroad-held balances up to the date, excluding Stripe-held, future, and paid balances" do
+      create(:balance, user: seller, date: date - 2, amount_cents: 100_00, merchant_account: gumroad_ma)
+      create(:balance, user: seller, date:,          amount_cents:  50_00, merchant_account: gumroad_ma)
+      create(:balance, user: seller, date: date + 1, amount_cents: 999_00, merchant_account: gumroad_ma)
+      create(:balance, user: seller, date: date - 1, amount_cents: 777_00, merchant_account: seller_ma)
+      create(:balance, user: seller, date: date - 3, amount_cents: 333_00, merchant_account: gumroad_ma, state: "paid")
+
+      expect(described_class.estimate_gumroad_held_stripe_cents(date)).to eq(150_00)
+    end
+  end
+
   describe "estimate_payments_for_balances_up_to_date_for_users" do
     describe "common payment cases (ACH via Stripe)" do
       let(:payout_date) { Date.today - 1 }

--- a/spec/controllers/healthcheck_controller_spec.rb
+++ b/spec/controllers/healthcheck_controller_spec.rb
@@ -109,6 +109,47 @@ describe HealthcheckController do
     end
   end
 
+  describe "GET 'stripe_balance'" do
+    context "when Stripe topup is not needed (Redis key is false)" do
+      before do
+        $redis.set(RedisKey.stripe_balance_topup_needed, "false")
+      end
+
+      it "returns HTTP success" do
+        get :stripe_balance
+
+        expect(response.status).to eq(200)
+        expect(response.body).to eq("Stripe balance: topup not required")
+      end
+    end
+
+    context "when Redis key is not set" do
+      before do
+        $redis.del(RedisKey.stripe_balance_topup_needed)
+      end
+
+      it "returns HTTP service_unavailable" do
+        get :stripe_balance
+
+        expect(response.status).to eq(503)
+        expect(response.body).to eq("Stripe balance: topup required")
+      end
+    end
+
+    context "when Stripe topup is needed (Redis key is true)" do
+      before do
+        $redis.set(RedisKey.stripe_balance_topup_needed, "true")
+      end
+
+      it "returns HTTP service_unavailable" do
+        get :stripe_balance
+
+        expect(response.status).to eq(503)
+        expect(response.body).to eq("Stripe balance: topup required")
+      end
+    end
+  end
+
   describe "GET 'purchases'" do
     let(:redis_key) { RedisKey.min_successful_purchases_in_last_10_minutes }
 

--- a/spec/services/stripe_balance_check_service_spec.rb
+++ b/spec/services/stripe_balance_check_service_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe StripeBalanceCheckService do
+  before do
+    allow(PayoutEstimates).to receive(:estimate_gumroad_held_stripe_cents)
+      .with(User::PayoutSchedule.next_scheduled_payout_end_date)
+      .and_return(300_000_00)
+    allow(StripeTransferExternallyToGumroad).to receive(:available_balances).and_return({ "usd" => 1_000_000_00 })
+    $redis.set(RedisKey.stripe_minimum_balance_cents, 100_000_00)
+  end
+
+  it "uses the Gumroad-held Stripe estimate as the upcoming payout amount" do
+    expect(described_class.new.upcoming_payouts_cents).to eq(300_000_00)
+  end
+
+  it "reads the minimum balance from redis" do
+    expect(described_class.new.minimum_balance_cents).to eq(100_000_00)
+  end
+
+  it "adds the minimum balance on top of the upcoming payouts" do
+    expect(described_class.new.required_balance_cents).to eq(400_000_00)
+  end
+
+  it "reads the available USD balance from Stripe" do
+    expect(described_class.new.current_balance_cents).to eq(1_000_000_00)
+  end
+
+  context "when the minimum balance is not configured" do
+    before { $redis.del(RedisKey.stripe_minimum_balance_cents) }
+
+    it "treats the minimum balance as zero" do
+      expect(described_class.new.minimum_balance_cents).to eq(0)
+    end
+  end
+
+  context "when the balance covers the upcoming payouts plus the minimum" do
+    it "does not need a top-up" do
+      service = described_class.new
+      expect(service.topup_needed?).to eq(false)
+      expect(service.topup_amount_cents).to eq(-600_000_00)
+    end
+  end
+
+  context "when the balance is below the upcoming payouts plus the minimum" do
+    before do
+      allow(StripeTransferExternallyToGumroad).to receive(:available_balances).and_return({ "usd" => 300_000_00 })
+    end
+
+    it "needs a top-up of the shortfall" do
+      service = described_class.new
+      expect(service.topup_needed?).to eq(true)
+      expect(service.topup_amount_cents).to eq(100_000_00)
+    end
+  end
+
+  context "when Stripe has no USD balance entry" do
+    before do
+      allow(StripeTransferExternallyToGumroad).to receive(:available_balances).and_return({})
+    end
+
+    it "treats the current balance as zero" do
+      expect(described_class.new.current_balance_cents).to eq(0)
+    end
+  end
+end

--- a/spec/sidekiq/send_stripe_balance_check_notification_job_spec.rb
+++ b/spec/sidekiq/send_stripe_balance_check_notification_job_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe SendStripeBalanceCheckNotificationJob do
+  describe "#perform" do
+    before do
+      allow(Rails.env).to receive(:production?).and_return(true)
+      allow(PayoutEstimates).to receive(:estimate_gumroad_held_stripe_cents).and_return(300_000_00)
+      $redis.set(RedisKey.stripe_minimum_balance_cents, 100_000_00)
+    end
+
+    context "when the balance is insufficient" do
+      before do
+        allow(StripeTransferExternallyToGumroad).to receive(:available_balances).and_return({ "usd" => 300_000_00 })
+      end
+
+      it "sends a notification with the required top-up and sets the redis key to true" do
+        notification_msg = "Stripe balance needs to be $400,000 ($300,000 for upcoming payouts + $100,000 Stripe minimum balance) to pay out all creators.\n"\
+                           "Current Stripe balance is $300,000.\n"\
+                           "A top-up of $100,000 is needed."
+
+        described_class.new.perform
+
+        expect(InternalNotificationWorker).to have_enqueued_sidekiq_job("payments", "Stripe Balance Check", notification_msg, "red")
+        expect($redis.get(RedisKey.stripe_balance_topup_needed)).to eq("true")
+      end
+    end
+
+    context "when the balance is sufficient" do
+      before do
+        allow(StripeTransferExternallyToGumroad).to receive(:available_balances).and_return({ "usd" => 1_000_000_00 })
+      end
+
+      it "does not notify and sets the redis key to false" do
+        described_class.new.perform
+
+        expect(InternalNotificationWorker.jobs.size).to eq(0)
+        expect($redis.get(RedisKey.stripe_balance_topup_needed)).to eq("false")
+      end
+    end
+
+    it "does nothing outside production" do
+      allow(Rails.env).to receive(:production?).and_return(false)
+
+      described_class.new.perform
+
+      expect(InternalNotificationWorker.jobs.size).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds a proactive monitor that flags when Gumroad's Stripe platform balance is too low to cover the upcoming seller payouts:

- **`StripeBalanceCheckService`** — computes the upcoming Gumroad-held Stripe payouts + a Stripe minimum balance, vs the available balance.
- **`SendStripeBalanceCheckNotificationJob`** — runs daily ahead of the UTC 10:00 seller-payout jobs and sends an internal payments notification (`InternalNotificationWorker`, the same channel as the PayPal balance alert) **only when** the balance is low. It records the result in Redis (`stripe:balance_topup_needed`).
- **`GET /healthcheck/stripe_balance`** — reads that Redis flag and returns `200` ("topup not required") or `503` ("topup required"), mirroring `/healthcheck/paypal_balance`, so an external monitor can page on it too. No amounts are exposed.

The alert fires when:

```
available USD Stripe balance  <  next cycle's Gumroad-held payouts  +  Stripe minimum balance
```

## Why

Stripe pays out Gumroad's platform balance to Gumroad's bank on its **own automatic schedule** (since ~May 2025; the code-driven sweep worker is disabled in prod via the `skip_transfer_from_stripe_to_bank` flag). Seller payouts are platform → connected-account transfers that **draw from that same balance**. When the balance gets drained before a payout cycle runs, seller payouts fail with *"insufficient funds in your Stripe account"* — which is exactly how the June 2 cycle surfaced: we only found out **after creators reported missing payouts**.

The fix is to know about it first. This mirrors the established `SendPaypalTopupNotificationJob` + `/healthcheck/paypal_balance` pattern so it slots into the team's existing payout-readiness routine — notifying only on the low-balance case, and exposing a monitorable healthcheck.

Design notes:
- **Upcoming-payout figure** uses a new `PayoutEstimates.estimate_gumroad_held_stripe_cents(date)` — a set-based aggregation that sums unpaid balances on the platform (Gumroad-held, `user_id IS NULL`) Stripe merchant accounts via the indexed `balances` aggregation. The existing `estimate_held_amount_cents` does a per-user loop that's too slow for a daily job. The new estimate **omits the per-user payability gates** (compliance, paused, minimum payout), so it slightly over-states what will actually pay out — the safe direction for a "is the balance high enough?" alert.
- **Stripe minimum balance** is added on top of the estimate to absorb a larger-than-estimated cycle or in-flight charges/refunds. Configured at runtime via Redis (`RedisKey.stripe_minimum_balance_cents`), following the same convention as other operational thresholds, and defaults to zero until set.
- **No numbers exposed publicly:** the healthcheck returns only "topup required" / "topup not required" + HTTP status. Amounts live only in the internal notification.
- **Scope:** checks the USD balance against a USD-denominated requirement, matching the existing bank-sweep worker's assumption. Monitoring only — does not change the payout mechanism or re-enable the code-driven sweep.

## Before / After

Non-user-facing (internal payments alerting + healthcheck). No UI. Notification fires only when the balance is low (amounts illustrative):

```
Stripe balance needs to be $X (... for upcoming payouts + ... Stripe minimum balance) to pay out all creators.
Current Stripe balance is $Y.
A top-up of $Z is needed.
```

Healthcheck: `GET /healthcheck/stripe_balance` → `200 "Stripe balance: topup not required"` or `503 "Stripe balance: topup required"`.

_Walkthrough video to be attached._

## Test Results

Specs cover the set-based estimate, the service, the job (notifies + sets flag when low, silent + sets flag when sufficient, non-prod no-op), and the healthcheck endpoint (200/503 for false/true/unset flag). All green locally:

```
estimate + service + job: 12 examples, 0 failures
healthcheck (stripe_balance): 3 examples, 0 failures
```

## Deploy note

Set the Stripe minimum balance in prod Redis (`RedisKey.stripe_minimum_balance_cents`) to enable the safety margin; until then the check still fires whenever the balance can't cover the upcoming payouts themselves.

---

AI disclosure: drafted with Claude Opus 4.8.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payout readiness and operational alerting around real money movement, but does not change payout execution—only adds estimates, Redis flags, and notifications.
> 
> **Overview**
> Adds **proactive Stripe platform balance monitoring** so payments can top up before seller payout cycles fail for insufficient funds, following the existing PayPal top-up alert pattern.
> 
> **`PayoutEstimates.estimate_gumroad_held_stripe_cents`** aggregates unpaid Gumroad-held Stripe balances (platform merchant accounts) in one query for the daily check; it intentionally skips per-user payability filters so the estimate errs high.
> 
> **`StripeBalanceCheckService`** compares live USD Stripe balance to upcoming Gumroad-held payouts (next scheduled payout end date) plus a Redis-configured minimum (`stripe:minimum_balance_cents`). **`SendStripeBalanceCheckNotificationJob`** runs daily in production, updates **`stripe:balance_topup_needed`**, and sends a red **`InternalNotificationWorker`** message only when short; **`GET /healthcheck/stripe_balance`** mirrors PayPal (503 when top-up needed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c74df3bf2ef92a84482a3d36f7a24795a1d25dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->