### PR TITLE
Add covering index on balances for payout held-amount estimation

### DIFF
--- a/db/migrate/20261130000006_add_payout_estimate_index_to_balances.rb
+++ b/db/migrate/20261130000006_add_payout_estimate_index_to_balances.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddPayoutEstimateIndexToBalances < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :balances,
+              [:state, :merchant_account_id, :date, :user_id],
+              name: "index_balances_on_state_merchant_account_date_for_payouts"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_11_30_000005) do
+ActiveRecord::Schema[7.1].define(version: 2026_11_30_000006) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -294,6 +294,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_11_30_000005) do
     t.string "currency", default: "usd"
     t.string "holding_currency", default: "usd"
     t.integer "holding_amount_cents", default: 0
+    t.index ["state", "merchant_account_id", "date", "user_id"], name: "index_balances_on_state_merchant_account_date_for_payouts"
     t.index ["user_id", "merchant_account_id", "date"], name: "index_on_user_merchant_account_date"
   end
 


### PR DESCRIPTION
## What

Adds an index on `balances` to support the payout held-amount estimate (`PayoutEstimates.estimate_held_amount_cents`):

```ruby
add_index :balances,
  [:state, :merchant_account_id, :date, :user_id],
  name: "index_balances_on_state_merchant_account_date_for_payouts"
```

## Why

The estimate sums unpaid balances up to a date for the platform (Gumroad-held) merchant accounts — roughly:

```sql
SELECT user_id, SUM(amount_cents) FROM balances
WHERE state = 'unpaid' AND merchant_account_id IN (...) AND date <= :date
GROUP BY user_id
```

The only existing index, `(user_id, merchant_account_id, date)`, **leads with `user_id`**, which this query doesn't constrain. So MySQL falls back to a **full index scan of the entire table** to reach the small subset of unpaid rows it actually needs — slow, and it gets slower as the table grows.

The new index leads with the equality/range filters (`state`, `merchant_account_id`, `date`) plus `user_id`, so MySQL scans only the unpaid rows instead of the whole table.

### Why `amount_cents` is not in the index

`balances.amount_cents` is incremented on **every sale, refund, chargeback, and credit** via `BalanceTransaction#update_balance!`. In InnoDB every index column is a key column, so including `amount_cents` would rewrite this index's entry on the hot purchase path — to save per-row PK lookups in a query that runs **once a day**. Not worth the write amplification, so it's left out; the `SUM` does PK lookups instead, which is fine for a daily job and still far faster than the full-table scan.

`balances` is a large table, but it is not `users`/`purchases`, so adding an index is permitted; the migration runs as an online schema change (`disable_ddl_transaction!`).

## Before / After

Non-user-facing (schema/index only). EXPLAIN before shows a full index scan of the table; after, the plan should select `index_balances_on_state_merchant_account_date_for_payouts` and scan only the unpaid rows. _Plan comparison to be attached once the index is built in a production-like environment._

## Test Results

Migration runs cleanly locally via the online schema-change tool; `schema.rb` updated (version `2026_11_30_000006`). No application code changed.

---

AI disclosure: drafted with Claude Opus 4.8.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Index creation on a large `balances` table can stress production during the online build; query behavior changes only via the optimizer, with no app logic touched.
> 
> **Overview**
> Adds a **composite index** on `balances` (`state`, `merchant_account_id`, `date`, `user_id`) so the daily **payout held-amount estimate** (`PayoutEstimates.estimate_held_amount_cents`) can filter unpaid Gumroad-held rows by state, merchant account, and date instead of scanning the full table via the existing user-first index.
> 
> The migration uses **`disable_ddl_transaction!`** for an online index build; **`schema.rb`** is bumped to version `2026_11_30_000006`. **`amount_cents` is intentionally omitted** from the index to avoid extra write amplification on balance updates from sales/refunds. No application code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f381567c853b81e1339a6678dd4d2f5a934c6bf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->