### PR TITLE
Remove stale debug logging leftovers (TODO cleanup, #5438)

### DIFF
--- a/app/controllers/foreign_webhooks_controller.rb
+++ b/app/controllers/foreign_webhooks_controller.rb
@@ -89,8 +89,6 @@ class ForeignWebhooksController < ApplicationController
     notification_message = request.body.read
 
     Rails.logger.info("Incoming SNS (Transcoder): #{notification_message}")
-    # TODO(amir): remove this once elastic transcoder support gets back to us about why it's included and causing the json to be invalid.
-    Rails.logger.info("Incoming SNS from Elastic Transcoder contains the invalid characters? #{notification_message.include?('#012')}")
 
     notification_message.gsub!("#012", "")
     HandleSnsTranscoderEventWorker.perform_in(5.seconds, JSON.parse(notification_message))

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -150,8 +150,6 @@ class PurchasesController < ApplicationController
   end
 
   def update_subscription
-    # TODO (helen): Remove after debugging https://gumroad.slack.com/archives/C01DBV0A257/p1662042866645759
-    Rails.logger.info("purchases#update_subscription - id: #{@subscription.external_id} ; params: #{permitted_subscription_params}")
     result =
       Subscription::UpdaterService.new(subscription: @subscription,
                                        gumroad_guid: cookies[:_gumroad_guid],


### PR DESCRIPTION
## What

Removes two stale "remove after debugging" leftovers catalogued in #5438 (Group B). Both are debug log statements that have long outlived their purpose.

- **`purchases_controller#update_subscription`** — drops a `Rails.logger.info` params dump tied to a 2022 Slack debugging thread (`# TODO (helen): Remove after debugging …`). The Slack link was also flagged by the Slack-removal work in #5436.
- **`foreign_webhooks_controller#sns`** — drops the `"contains the invalid characters?"` probe log added while waiting on Elastic Transcoder support. **The actual fix stays** — `notification_message.gsub!("#012", "")` is untouched; only the diagnostic log line and its TODO are removed.

## What I deliberately did NOT remove

Two other "remove after debugging" comments from the catalog are **not** safe pure deletions, so I left them for a human call:

- `app/services/purchase/create_service.rb:152` — logs free purchases made with an offer code. That's a **fraud signal**, not innocent debug output; removing it drops monitoring.
- `app/services/order/create_service.rb:170` — the code under the TODO is a **load-bearing workaround** (sets `url_parameters` from referrer when missing). The TODO is gated on a root-cause fix that hasn't landed; deleting it would change behavior.

## Testing

No specs assert on either removed log line (grepped for the exact strings). Pure removals of diagnostic logging — no behavior change.

Part of #5438.

Co-authored-by: Sahil Lavingia <sahil.lavingia@gmail.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5439"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783528579&installation_id=134400930&pr_number=5439&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5439&signature=8b7fee48e8bb84ade8738370c6be3ce2423184753de0320275b93cf4900461a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only deletions; no changes to request handling, SNS sanitization, or subscription update logic.
> 
> **Overview**
> Removes two stale **debug-only** `Rails.logger.info` lines and their associated TODO comments from #5438 cleanup, with **no functional changes**.
> 
> In **`foreign_webhooks_controller#sns`**, the probe that logged whether Elastic Transcoder payloads contained `#012` is gone; **`notification_message.gsub!("#012", "")`** and the rest of SNS handling are unchanged. In **`purchases_controller#update_subscription`**, the params-dump log from a 2022 debugging thread is removed; **`Subscription::UpdaterService`** still runs as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56fa194913e9394d8c2383d3ccc7c331a8904e77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->