### PR TITLE
Capture corrections in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,10 +188,10 @@ A great bug report includes:
 
 - Any issue with label `help wanted` is open for contributions - [view open issues](https://github.com/antiwork/gumroad/issues?q=state%3Aopen%20label%3A%22help%20wanted%22)
 
-## License
-
-By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE.md).
-
 ## When you're corrected, fix the docs
 
 If a maintainer corrects your approach in review — a convention, a workflow, a gotcha that isn't written down — don't just fix the code. Propose an edit to this guide in the same PR (or a fast follow-up) so the correction is captured once and never has to be repeated. The contributing guide should get a little smarter every time someone gets corrected.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,3 +191,7 @@ A great bug report includes:
 ## License
 
 By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE.md).
+
+## When you're corrected, fix the docs
+
+If a maintainer corrects your approach in review — a convention, a workflow, a gotcha that isn't written down — don't just fix the code. Propose an edit to this guide in the same PR (or a fast follow-up) so the correction is captured once and never has to be repeated. The contributing guide should get a little smarter every time someone gets corrected.


### PR DESCRIPTION
Adds a short section to the contributing guide: when a maintainer corrects your approach in review — a convention, workflow, or undocumented gotcha — propose an edit to this guide in the same PR so the correction is captured once and never has to be repeated. Keeps the guide compounding instead of relearning the same lessons.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5440"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783545461&installation_id=134400930&pr_number=5440&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5440&signature=7f380b08ba14a956d7d96e2035a19f0161c5017ad4b4a52c876c6d2771952a7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, security, or data impact.
> 
> **Overview**
> Adds a **When you're corrected, fix the docs** section to `CONTRIBUTING.md`, placed after **Help** and before **License**.
> 
> It tells contributors that when review surfaces an undocumented convention, workflow, or gotcha, they should update this guide in the same PR or a quick follow-up—not only fix the code—so the lesson is written down once.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a975dbd454ca15e3f6624b22a952f2466254ecd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->