### PR TITLE
Show a clear message for sellers in Stripe-unsupported US territories

### DIFF
--- a/app/controllers/settings/payments_controller.rb
+++ b/app/controllers/settings/payments_controller.rb
@@ -50,8 +50,11 @@ class Settings::PaymentsController < Settings::BaseController
     if Compliance::Countries::USA.common_name == compliance_info.legal_entity_country
       zip_code = params.dig(:user, :is_business) ? params.dig(:user, :business_zip_code).presence : params.dig(:user, :zip_code).presence
       if zip_code
-        unless UsZipCodes.identify_state_code(zip_code).present?
+        state_code = UsZipCodes.identify_state_code(zip_code)
+        if state_code.blank?
           return redirect_with_error("You entered a ZIP Code that doesn't exist within your country.")
+        elsif Compliance::Countries.unsupported_us_territory_state_code?(state_code)
+          return redirect_with_error("Gumroad can't set up payouts for sellers in US territories like Guam, the US Virgin Islands, American Samoa, and the Northern Mariana Islands, because our payments provider doesn't support them yet. Puerto Rico and the 50 US states are supported.")
         end
       end
     end

--- a/lib/utilities/compliance/countries.rb
+++ b/lib/utilities/compliance/countries.rb
@@ -177,6 +177,15 @@ module Compliance
     # to Stripe onboarding.
     US_OUTLYING_AREAS_AS_STATES = %w[PR].freeze
 
+    # US territory state codes (as returned by `UsZipCodes.identify_state_code`) that Stripe Connect
+    # rejects, so a seller whose address resolves to one of these has no valid payout path. This is
+    # every US outlying area except the PR subset we can onboard under `country: "US"`.
+    UNSUPPORTED_US_TERRITORY_STATE_CODES = (US_OUTLYING_AREA_ALPHA2 - US_OUTLYING_AREAS_AS_STATES).freeze
+
+    def self.unsupported_us_territory_state_code?(state_code)
+      UNSUPPORTED_US_TERRITORY_STATE_CODES.include?(state_code)
+    end
+
     def self.subdivisions_for_select(alpha2)
       case alpha2
       when Compliance::Countries::USA.alpha2

--- a/spec/controllers/settings/payments_controller_spec.rb
+++ b/spec/controllers/settings/payments_controller_spec.rb
@@ -595,6 +595,26 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
         end
       end
 
+      describe "creator enters a ZIP code in a Stripe-unsupported US territory" do
+        it "rejects a Guam ZIP code with a clear unsupported-territory message" do
+          put :update, params: { user: params.merge(business_zip_code: "96910") }
+          expect(response).to redirect_to(settings_payments_path)
+          expect(response).to have_http_status :found
+          expect(session[:inertia_errors][:base]).to include("Gumroad can't set up payouts for sellers in US territories like Guam, the US Virgin Islands, American Samoa, and the Northern Mariana Islands, because our payments provider doesn't support them yet. Puerto Rico and the 50 US states are supported.")
+        end
+
+        it "rejects a US Virgin Islands ZIP code" do
+          put :update, params: { user: params.merge(business_zip_code: "00801") }
+          expect(response).to have_http_status :found
+          expect(session[:inertia_errors][:base]).to include("Gumroad can't set up payouts for sellers in US territories like Guam, the US Virgin Islands, American Samoa, and the Northern Mariana Islands, because our payments provider doesn't support them yet. Puerto Rico and the 50 US states are supported.")
+        end
+
+        it "allows a Puerto Rico ZIP code because Stripe onboards PR under country US" do
+          put :update, params: { user: params.merge(business_zip_code: "00601", state: "PR") }
+          expect(session[:inertia_errors]).to be_nil
+        end
+      end
+
       describe "user is verified" do
         before do
           put :update, params: { user: params }


### PR DESCRIPTION
## What

Sellers based in US territories that Stripe Connect rejects — Guam (GU), US Virgin Islands (VI), American Samoa (AS), Northern Mariana Islands (MP) — were silently stuck on the payment settings page with no explanation of why they couldn't set up payouts.

This adds an honest, specific error when a US seller's ZIP code resolves to one of those territories, instead of letting them dead-end.

## Why

A territory ZIP resolves to the territory's state code in our ZIP database (e.g. `96910 => GU`), so it *passed* the existing US ZIP validation. But that code is neither selectable in the state dropdown nor accepted by Stripe Connect, so the seller had no valid path forward and no signal about why.

Stripe explicitly rejects these as account/state values ("Stripe currently does not support US insular areas and freely associated states", verified against the real Stripe API). Puerto Rico is the one US outlying area Stripe accepts under `country: "US"`, so it is deliberately excluded from this check and continues to work.

This intentionally does **not** add the territories to the country/state dropdowns — doing so would just move the dead-end from signup into Stripe onboarding. Actually paying these sellers (e.g. PayPal-only payout routing) is a separate, larger change that needs product sign-off and will be filed as a follow-up.

`Compliance::Countries.unsupported_us_territory_state_code?` derives the rejected set from the existing `US_OUTLYING_AREA_ALPHA2` minus the supported PR subset, so it stays in sync if those constants change.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AI disclosure: drafted with Claude Opus 4.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783585624&installation_id=134400930&pr_number=5441&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5441&signature=35233c935ad2617f7799f42fad9b5c0460fa8e01dbb22f68e10e8dda92a33e5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit c9227c91df7118858a644ecba8d253601442da4e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->