### PR TITLE
Restore Guam and other US territories as PayPal payout countries

### DIFF
--- a/app/controllers/settings/payments_controller.rb
+++ b/app/controllers/settings/payments_controller.rb
@@ -15,10 +15,11 @@ class Settings::PaymentsController < Settings::BaseController
     end
     return unless current_seller.fetch_or_build_user_compliance_info.country.present?
 
-    # Block requests that would *change* a country field to a US outlying area, but allow
-    # unmigrated territory sellers (e.g. country: "Puerto Rico") to submit other settings
-    # changes — their form echoes back the current country value, which must not be
-    # treated as an attempted bypass. See issue gumroad-private#394.
+    # Block requests that would *change* a country field to a territory we model as a US state (PR),
+    # but allow unmigrated PR sellers (country: "Puerto Rico") to submit other settings changes — their
+    # form echoes back the current country value, which must not be treated as an attempted bypass. The
+    # other outlying areas are valid PayPal payout countries and are allowed. See issue
+    # gumroad-private#394.
     current_uci = current_seller.alive_user_compliance_info
     attempted_territory_change = [
       [params.dig(:user, :updated_country_code), current_uci&.legal_entity_country_code],
@@ -27,10 +28,10 @@ class Settings::PaymentsController < Settings::BaseController
     ].any? do |submitted, current|
       submitted.present? &&
         submitted != current &&
-        Compliance::Countries::US_OUTLYING_AREA_ALPHA2.include?(submitted)
+        Compliance::Countries::US_OUTLYING_AREAS_AS_STATES.include?(submitted)
     end
     if attempted_territory_change
-      return redirect_with_error("US outlying areas (Puerto Rico, Guam, US Virgin Islands, etc.) are not valid compliance countries. Select United States and your territory as state.")
+      return redirect_with_error("Puerto Rico is not a valid compliance country. Select United States and Puerto Rico as your state.")
     end
 
     compliance_info = current_seller.fetch_or_build_user_compliance_info
@@ -121,7 +122,7 @@ class Settings::PaymentsController < Settings::BaseController
   def set_country
     compliance_info = current_seller.fetch_or_build_user_compliance_info
     return head :forbidden if compliance_info.country.present?
-    return head :forbidden if Compliance::Countries::US_OUTLYING_AREA_ALPHA2.include?(params[:country])
+    return head :forbidden if Compliance::Countries::US_OUTLYING_AREAS_AS_STATES.include?(params[:country])
 
     compliance_info.dup_and_save! do |new_compliance_info|
       new_compliance_info.country = ISO3166::Country[params[:country]]&.common_name

--- a/lib/utilities/compliance/countries.rb
+++ b/lib/utilities/compliance/countries.rb
@@ -71,12 +71,21 @@ module Compliance
       RISK_PHYSICAL_BLOCKED_COUNTRY_CODES.include?(alpha2)
     end
 
-    # Subset of ISO 3166-1 codes that are US outlying areas (territories). These are not separate
-    # countries for Gumroad's compliance purposes — sellers and buyers from these locations enter
-    # the US country path with the territory as the `state`. Filtered out of the seller-side
-    # compliance country dropdown via `for_select_for_seller_compliance` so the catch-22 in
-    # issue #394 cannot recur for new signups.
+    # US outlying areas (territories) by ISO 3166-1 code. These are not sovereign countries, but ISO
+    # assigns them codes and `for_select` lists them. How each is handled for seller compliance depends
+    # on whether Stripe Connect accepts it — see `US_OUTLYING_AREAS_AS_STATES`.
     US_OUTLYING_AREA_ALPHA2 = %w[AS GU MP PR UM VI].freeze
+
+    # The US outlying areas we model as a US state (`country: "US"`, `state: <code>`) rather than as
+    # their own selectable country, because Stripe Connect onboards them under the US. Today that is
+    # only Puerto Rico. These are filtered out of the seller country dropdown and rejected as a
+    # compliance country, so a PR seller picks United States + state PR.
+    #
+    # The remaining outlying areas (Guam, US Virgin Islands, American Samoa, Northern Mariana Islands)
+    # Stripe rejects outright, so they stay selectable as their own country and route to PayPal payouts
+    # (`native_payouts_supported?` is false for them). #394 originally removed all six from the dropdown,
+    # which left those four with no payout path at all — this restores it.
+    US_OUTLYING_AREAS_AS_STATES = %w[PR].freeze
 
     def self.for_select
       ISO3166::Country.all.map do |country|
@@ -85,13 +94,13 @@ module Compliance
       end.sort_by { |pair| pair.last }
     end
 
-    # Same shape as `for_select`, but excludes US outlying areas because they are entered as US
-    # addresses with a territory state code. Used by seller-facing settings pages (compliance,
-    # billing) so sellers cannot pick a territory as their country and end up in the issue #394
-    # catch-22. Buyer-facing flows (checkout, invoice, customer addresses) should continue to use
-    # `for_select` because foreign billing addresses to these territories can be legitimate.
+    # Same shape as `for_select`, but excludes the outlying areas we model as US states (PR), so a
+    # seller cannot pick one as their country and end up in the issue #394 catch-22. The other outlying
+    # areas stay listed because they are valid PayPal payout countries. Buyer-facing flows (checkout,
+    # invoice, customer addresses) continue to use `for_select` because billing addresses to any
+    # territory can be legitimate.
     def self.for_select_for_seller_compliance
-      for_select.reject { |alpha2, _name| US_OUTLYING_AREA_ALPHA2.include?(alpha2) }
+      for_select.reject { |alpha2, _name| US_OUTLYING_AREAS_AS_STATES.include?(alpha2) }
     end
 
     GLOBE_SHOWING_AMERICAS_EMOJI = [127758].pack("U*")
@@ -170,13 +179,8 @@ module Compliance
       end
     end
 
-    # Puerto Rico is exposed in the US state dropdown because Stripe Connect onboards PR sellers under
-    # `country: "US"` with `state: "PR"`. The other US outlying areas (AS, GU, MP, UM, VI) are NOT in
-    # this allowlist because Stripe explicitly rejects them with "Stripe currently does not support US
-    # insular areas and freely associated states" — adding them would just move the catch-22 from signup
-    # to Stripe onboarding.
-    US_OUTLYING_AREAS_AS_STATES = %w[PR].freeze
-
+    # `US_OUTLYING_AREAS_AS_STATES` (PR) is exposed in the US state dropdown because Stripe Connect
+    # onboards those sellers under `country: "US"` with the territory as the `state`.
     def self.subdivisions_for_select(alpha2)
       case alpha2
       when Compliance::Countries::USA.alpha2

--- a/spec/controllers/settings/payments_controller_spec.rb
+++ b/spec/controllers/settings/payments_controller_spec.rb
@@ -161,27 +161,42 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
       expect(flash[:notice]).to eq("Thanks! You're all set.")
     end
 
-    describe "US outlying area rejection (issue #394)" do
+    describe "US outlying area handling (issue #394)" do
       def expect_territory_rejection_error
         expect(session[:inertia_errors][:base]).to include(
-          a_string_matching(/US outlying areas \(Puerto Rico, Guam, US Virgin Islands, etc\.\) are not valid compliance countries/)
+          a_string_matching(/Puerto Rico is not a valid compliance country/)
         )
       end
 
-      %w[AS GU MP PR UM VI].each do |territory|
-        it "rejects updated_country_code=#{territory}" do
-          put :update, params: { user: params.merge(updated_country_code: territory) }
-          expect_territory_rejection_error
-        end
+      it "rejects updated_country_code=PR" do
+        put :update, params: { user: params.merge(updated_country_code: "PR") }
+        expect_territory_rejection_error
+      end
 
-        it "rejects user[country]=#{territory} via the compliance update" do
+      it "rejects user[country]=PR via the compliance update" do
+        put :update, params: { user: params.merge(country: "PR", is_business: true) }
+        expect_territory_rejection_error
+      end
+
+      it "rejects user[business_country]=PR via the compliance update" do
+        put :update, params: { user: params.merge(business_country: "PR", is_business: true) }
+        expect_territory_rejection_error
+      end
+
+      %w[AS GU MP UM VI].each do |territory|
+        it "allows user[country]=#{territory} because it is a valid PayPal payout country" do
           put :update, params: { user: params.merge(country: territory, is_business: true) }
-          expect_territory_rejection_error
+          expect(session[:inertia_errors][:base]).to be_blank if session[:inertia_errors].present?
+          expect(session.dig(:inertia_errors, :base) || []).not_to include(
+            a_string_matching(/not a valid compliance country/)
+          )
         end
 
-        it "rejects user[business_country]=#{territory} via the compliance update" do
+        it "allows user[business_country]=#{territory} via the compliance update" do
           put :update, params: { user: params.merge(business_country: territory, is_business: true) }
-          expect_territory_rejection_error
+          expect(session.dig(:inertia_errors, :base) || []).not_to include(
+            a_string_matching(/not a valid compliance country/)
+          )
         end
       end
 
@@ -1715,12 +1730,24 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
       end
 
       describe "US outlying areas" do
-        %w[AS GU MP PR UM VI].each do |territory|
-          it "rejects #{territory} so the catch-22 in issue #394 cannot recur via direct POST" do
-            expect do
-              post :set_country, params: params.merge(country: territory), as: :json
-            end.not_to change { UserComplianceInfo.count }
-            expect(response).to be_forbidden
+        it "rejects PR so the catch-22 in issue #394 cannot recur via direct POST (PR is a US state)" do
+          expect do
+            post :set_country, params: params.merge(country: "PR"), as: :json
+          end.not_to change { UserComplianceInfo.count }
+          expect(response).to be_forbidden
+        end
+
+        {
+          "GU" => "Guam",
+          "VI" => "Virgin Islands, U.S.",
+          "AS" => "American Samoa",
+          "MP" => "Northern Mariana Islands",
+        }.each do |code, name|
+          it "allows #{code} because it routes to PayPal payouts" do
+            post :set_country, params: params.merge(country: code), as: :json
+            expect(response).to be_successful
+            user.reload
+            expect(user.fetch_or_build_user_compliance_info.country).to eq(name)
           end
         end
       end

--- a/spec/controllers/settings/payments_controller_spec.rb
+++ b/spec/controllers/settings/payments_controller_spec.rb
@@ -1742,6 +1742,7 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
           "VI" => "Virgin Islands, U.S.",
           "AS" => "American Samoa",
           "MP" => "Northern Mariana Islands",
+          "UM" => "United States Minor Outlying Islands",
         }.each do |code, name|
           it "allows #{code} because it routes to PayPal payouts" do
             post :set_country, params: params.merge(country: code), as: :json

--- a/spec/lib/utilities/compliance_spec.rb
+++ b/spec/lib/utilities/compliance_spec.rb
@@ -162,17 +162,22 @@ describe Compliance do
     end
 
     describe ".for_select_for_seller_compliance" do
-      it "excludes the six US outlying areas so sellers cannot pick a territory as their country" do
+      it "excludes Puerto Rico so sellers cannot pick the territory we model as a US state" do
         codes = Compliance::Countries.for_select_for_seller_compliance.map(&:first)
-        %w[AS GU MP PR UM VI].each do |territory|
-          expect(codes).not_to include(territory), "expected #{territory} to be excluded but it was present"
+        expect(codes).not_to include("PR")
+      end
+
+      it "keeps the other US outlying areas because they are valid PayPal payout countries" do
+        codes = Compliance::Countries.for_select_for_seller_compliance.map(&:first)
+        %w[AS GU MP UM VI].each do |territory|
+          expect(codes).to include(territory), "expected #{territory} to remain selectable but it was excluded"
         end
       end
 
       it "leaves every other country in place" do
         full = Compliance::Countries.for_select.map(&:first)
         filtered = Compliance::Countries.for_select_for_seller_compliance.map(&:first)
-        expect(full - filtered).to match_array(%w[AS GU MP PR UM VI])
+        expect(full - filtered).to match_array(%w[PR])
       end
     end
 

--- a/spec/presenters/settings_presenter_spec.rb
+++ b/spec/presenters/settings_presenter_spec.rb
@@ -273,21 +273,21 @@ describe SettingsPresenter do
 
     it "returns the correct props" do
       expect(presenter.third_party_analytics_props).to eq({
-        disable_third_party_analytics: false,
-        google_analytics_id: "",
-        facebook_pixel_id: "",
-        tiktok_pixel_id: "",
-        skip_free_sale_analytics: false,
-        facebook_meta_tag: "",
-        enable_verify_domain_third_party_services: false,
-        snippets: [{
-          id: third_party_analytic.external_id,
-          name: third_party_analytic.name,
-          location: third_party_analytic.location,
-          code: third_party_analytic.analytics_code,
-          product: third_party_analytic.link.unique_permalink,
-        }]
-      })
+                                                            disable_third_party_analytics: false,
+                                                            google_analytics_id: "",
+                                                            facebook_pixel_id: "",
+                                                            tiktok_pixel_id: "",
+                                                            skip_free_sale_analytics: false,
+                                                            facebook_meta_tag: "",
+                                                            enable_verify_domain_third_party_services: false,
+                                                            snippets: [{
+                                                              id: third_party_analytic.external_id,
+                                                              name: third_party_analytic.name,
+                                                              location: third_party_analytic.location,
+                                                              code: third_party_analytic.analytics_code,
+                                                              product: third_party_analytic.link.unique_permalink,
+                                                            }]
+                                                          })
     end
 
     context "when attributes are set" do
@@ -600,10 +600,11 @@ describe SettingsPresenter do
       expect(presenter.payments_props).to eq(@base_props)
     end
 
-    it "excludes US outlying areas from the seller compliance country dropdown" do
+    it "excludes Puerto Rico but keeps the other US outlying areas in the seller compliance country dropdown" do
       countries = presenter.payments_props[:countries]
-      %w[AS GU MP PR UM VI].each do |territory|
-        expect(countries).not_to have_key(territory), "expected #{territory} to be excluded from countries but it was present"
+      expect(countries).not_to have_key("PR")
+      %w[AS GU MP UM VI].each do |territory|
+        expect(countries).to have_key(territory), "expected #{territory} to remain selectable but it was excluded"
       end
       expect(countries).to have_key("US")
     end

--- a/spec/presenters/settings_presenter_spec.rb
+++ b/spec/presenters/settings_presenter_spec.rb
@@ -273,21 +273,21 @@ describe SettingsPresenter do
 
     it "returns the correct props" do
       expect(presenter.third_party_analytics_props).to eq({
-                                                            disable_third_party_analytics: false,
-                                                            google_analytics_id: "",
-                                                            facebook_pixel_id: "",
-                                                            tiktok_pixel_id: "",
-                                                            skip_free_sale_analytics: false,
-                                                            facebook_meta_tag: "",
-                                                            enable_verify_domain_third_party_services: false,
-                                                            snippets: [{
-                                                              id: third_party_analytic.external_id,
-                                                              name: third_party_analytic.name,
-                                                              location: third_party_analytic.location,
-                                                              code: third_party_analytic.analytics_code,
-                                                              product: third_party_analytic.link.unique_permalink,
-                                                            }]
-                                                          })
+        disable_third_party_analytics: false,
+        google_analytics_id: "",
+        facebook_pixel_id: "",
+        tiktok_pixel_id: "",
+        skip_free_sale_analytics: false,
+        facebook_meta_tag: "",
+        enable_verify_domain_third_party_services: false,
+        snippets: [{
+          id: third_party_analytic.external_id,
+          name: third_party_analytic.name,
+          location: third_party_analytic.location,
+          code: third_party_analytic.analytics_code,
+          product: third_party_analytic.link.unique_permalink,
+        }]
+      })
     end
 
     context "when attributes are set" do


### PR DESCRIPTION
Closes https://github.com/antiwork/gumroad-private/issues/478

## What

Restores Guam, the US Virgin Islands, American Samoa, and the Northern Mariana Islands as selectable seller countries that route to PayPal payouts. Puerto Rico stays a US state and remains excluded.

- Scope `for_select_for_seller_compliance` and the two compliance-country guards in `Settings::PaymentsController` (`#update`'s territory-change check and `#set_country`) to only the outlying areas we model as US states (`US_OUTLYING_AREAS_AS_STATES`, currently `PR`), instead of all six `US_OUTLYING_AREA_ALPHA2` codes.
- Update the error copy to name Puerto Rico specifically.

## Why

The Puerto Rico fix (#5322, for gumroad-private#394) filtered all six US outlying areas out of the seller country dropdown and rejected them as compliance countries. That was right for Puerto Rico, which simultaneously got a home as a US state (`country: "US"`, `state: "PR"`). The other four got no replacement.

Stripe Connect rejects Guam/USVI/American Samoa/Northern Mariana Islands outright ("Stripe currently does not support US insular areas and freely associated states"). Their only payout path is selecting the territory as their own country, which makes `native_payouts_supported?` return `false` and offers **PayPal**. Removing them from the dropdown left these sellers unable to set up any payout method: forced to pick "United States", funneled into Stripe, rejected.

This isn't theoretical — in production there are hundreds of sellers with `country` set to one of these territories, dozens with PayPal connected, and a meaningful number who have been paid out that way. #5322 quietly closed that path for new signups; this reopens it. Buyer-facing flows already used `for_select` and are unaffected.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AI disclosure: written with Claude Opus 4.8. Prompts: investigate why Guam sellers are stuck, confirm via production data that PayPal is their working payout path, and bring back the territories (except Puerto Rico) as payout countries.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783587050&installation_id=134400930&pr_number=5442&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5442&signature=9e5942cd2185f7da817697a77288e19d16f3f7622d208071934fa0a142f9eb36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes seller country selection and compliance guards on payments settings, which affects payout routing for US territories; scope is limited and covered by updated controller and compliance specs.
> 
> **Overview**
> Narrows seller compliance rules so **only Puerto Rico** is treated as “pick US + state PR,” while **Guam, USVI, American Samoa, Northern Mariana Islands, and UM** are selectable again as their own countries for **PayPal** payouts (Stripe does not onboard those territories).
> 
> `Compliance::Countries` now documents the split: `US_OUTLYING_AREAS_AS_STATES` is only `PR`, and `for_select_for_seller_compliance` excludes just PR instead of all six `US_OUTLYING_AREA_ALPHA2` codes. `Settings::PaymentsController` `#update` and `#set_country` use the same scoped list for blocks; rejection copy names Puerto Rico only.
> 
> Specs and presenter expectations are updated to reject PR but allow the other territories on compliance updates and initial country selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a3ed622ef4e30a1afae868712758e546f125ca1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->