### PR TITLE
Pause payouts after repeated failures to the same bank account

### DIFF
--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -13,6 +13,13 @@ class Payment < ApplicationRecord
   RETURNED = "returned"
   NON_TERMINAL_STATES = [CREATING, PROCESSING, UNCLAIMED, COMPLETED].freeze
 
+  # After this many consecutive failed/returned payouts to the same bank account, pause payouts and
+  # flag the account for review. Each failed Stripe payout round-trips funds through the creator's
+  # Connect account (transfer in, reverse out on failure), losing the FX spread every cycle and
+  # booking it against the creator's balance. Without a cap, a bad bank account bounces weekly for
+  # months and silently erodes real earnings. Pausing forces the payout details to be fixed first.
+  MAX_CONSECUTIVE_FAILED_PAYOUTS = 3
+
   belongs_to :user, optional: true
   belongs_to :bank_account, optional: true
   has_and_belongs_to_many :balances, join_table: "payments_balances"
@@ -87,6 +94,9 @@ class Payment < ApplicationRecord
 
     after_transition completed: :returned, do: :mark_balances_as_unpaid
     after_transition completed: :returned, do: :send_deposit_returned_email
+
+    after_transition any => :failed, do: :pause_payouts_after_repeated_failures
+    after_transition any => :returned, do: :pause_payouts_after_repeated_failures
 
     after_transition processing: %i[completed unclaimed], do: :send_deposit_email
 
@@ -258,6 +268,25 @@ class Payment < ApplicationRecord
 
     def log_transition
       logger.info "Payment: payment ID #{id} transitioned to #{state}"
+    end
+
+    def pause_payouts_after_repeated_failures
+      return if bank_account_id.blank?
+      return if user.nil? || user.payouts_paused?
+
+      payouts_for_bank_account = user.payments.where(bank_account_id:)
+      last_completed_at = payouts_for_bank_account.completed.maximum(:created_at)
+      failed_payouts = payouts_for_bank_account.where(state: [FAILED, RETURNED])
+      failed_payouts = failed_payouts.where("created_at > ?", last_completed_at) if last_completed_at
+      failed_count = failed_payouts.count
+      return if failed_count < MAX_CONSECUTIVE_FAILED_PAYOUTS
+
+      user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_SYSTEM)
+      user.comments.create!(
+        content: "Payouts paused automatically after #{failed_count} consecutive failed payouts to the same bank account. Verify the seller's payout details before resuming.",
+        comment_type: Comment::COMMENT_TYPE_ON_PROBATION,
+        author_name: "pause_payouts_after_repeated_failures"
+      )
     end
 
     def split_payment_validation

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -867,4 +867,82 @@ describe Payment do
       end
     end
   end
+
+  describe "pausing payouts after repeated failures" do
+    let(:user) { create(:user) }
+    let(:bank_account) { create(:ach_account, user:) }
+
+    def failed_payout
+      payment = create(:payment, user:, bank_account:, processor: PayoutProcessorType::STRIPE, state: "processing")
+      payment.mark_failed!
+      payment
+    end
+
+    it "pauses payouts and flags the account once the consecutive failure limit is reached" do
+      (Payment::MAX_CONSECUTIVE_FAILED_PAYOUTS - 1).times { failed_payout }
+      expect(user.reload.payouts_paused?).to be(false)
+
+      failed_payout
+
+      expect(user.reload.payouts_paused_internally).to be(true)
+      expect(user.payouts_paused_by_source).to eq(User::PAYOUT_PAUSE_SOURCE_SYSTEM)
+      comment = user.comments.with_type_on_probation.last
+      expect(comment.content).to include("#{Payment::MAX_CONSECUTIVE_FAILED_PAYOUTS} consecutive failed payouts")
+    end
+
+    it "pauses when a previously completed payout to the bank account is later returned" do
+      (Payment::MAX_CONSECUTIVE_FAILED_PAYOUTS - 1).times { failed_payout }
+
+      returned = create(:payment_completed, user:, bank_account:, processor: PayoutProcessorType::STRIPE,
+                                            stripe_transfer_id: "po_1", stripe_connect_account_id: "acct_1")
+      returned.mark_returned!
+
+      expect(user.reload.payouts_paused_internally).to be(true)
+    end
+
+    it "does not pause before the limit is reached" do
+      (Payment::MAX_CONSECUTIVE_FAILED_PAYOUTS - 1).times { failed_payout }
+
+      expect(user.reload.payouts_paused?).to be(false)
+      expect(user.comments.with_type_on_probation).to be_empty
+    end
+
+    it "counts only failures after the most recent completed payout to the bank account" do
+      (Payment::MAX_CONSECUTIVE_FAILED_PAYOUTS - 1).times { failed_payout }
+      create(:payment_completed, user:, bank_account:, processor: PayoutProcessorType::STRIPE,
+                                 stripe_transfer_id: "po_done", stripe_connect_account_id: "acct_1")
+
+      failed_payout
+
+      expect(user.reload.payouts_paused?).to be(false)
+    end
+
+    it "scopes the count to a single bank account so a new bank account starts fresh" do
+      (Payment::MAX_CONSECUTIVE_FAILED_PAYOUTS - 1).times { failed_payout }
+
+      other_bank_account = create(:ach_account_2, user:)
+      payment = create(:payment, user:, bank_account: other_bank_account, processor: PayoutProcessorType::STRIPE, state: "processing")
+      payment.mark_failed!
+
+      expect(user.reload.payouts_paused?).to be(false)
+    end
+
+    it "ignores payouts without a bank account, such as PayPal" do
+      (Payment::MAX_CONSECUTIVE_FAILED_PAYOUTS + 1).times do
+        payment = create(:payment, user:, processor: PayoutProcessorType::PAYPAL, state: "processing")
+        payment.mark_failed!
+      end
+
+      expect(user.reload.payouts_paused?).to be(false)
+    end
+
+    it "does not re-pause or duplicate notes when payouts are already paused" do
+      user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_ADMIN)
+
+      (Payment::MAX_CONSECUTIVE_FAILED_PAYOUTS + 1).times { failed_payout }
+
+      expect(user.reload.payouts_paused_by_source).to eq(User::PAYOUT_PAUSE_SOURCE_ADMIN)
+      expect(user.comments.with_type_on_probation).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
## What

Pause payouts and flag a creator's account for review once there have been `MAX_CONSECUTIVE_FAILED_PAYOUTS` (3) consecutive failed or returned payouts to the **same bank account**.

- The count is scoped per bank account and resets after any completed payout, so a creator who fixes their details by adding a new bank account starts fresh.
- Implemented as `after_transition any => :failed` / `any => :returned` hooks on `Payment`, reusing the existing internal-pause infrastructure (`payouts_paused_internally` + an on-probation comment), the same pattern already used to pause payouts on high chargeback rates.

## Why

When a Stripe payout to a creator's bank account fails, the internal transfer that moved funds into their Connect account — converting USD into the account's holding currency — is reversed. The FX spread on that round trip is booked as a negative credit against the creator's balance.

With no cap on retries, a bad bank account keeps bouncing on every weekly payout cycle. Each cycle repeats the transfer-and-reverse round trip and loses the FX spread again, compounding a negative balance that silently erodes the creator's real earnings — and the account is never surfaced for review. Pausing after a few consecutive failures stops the loss early and forces the payout details to be corrected before more cycles run. This is the highest-leverage, lowest-risk guard against that class of failure: it bounds the damage to a couple of cycles instead of letting it run indefinitely.

This is a backend-only change; there is no user-facing UI.

## Before/After

Backend-only, no UI surface. A walkthrough video of the payout-failure path still needs to be recorded before merge (I can't capture video from this environment).

## Test Results

New spec `spec/models/payment_spec.rb` — "pausing payouts after repeated failures":

```
7 examples, 0 failures
```

Covers: pausing at the limit, pausing on a later-returned payout, not pausing before the limit, resetting after a completed payout, per-bank-account scoping, ignoring bank-account-less (PayPal) payouts, and not re-pausing when already paused.

(The other 14 failures in the full `payment_spec.rb` run are pre-existing in this local environment — `create(:balance)` raising `Merchant account can't be blank` — and reproduce identically on a clean `main` with these changes stashed.)

---

🤖 AI disclosure: drafted with Claude Opus 4.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5443"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783607624&installation_id=134400930&pr_number=5443&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5443&signature=2f8e7ae2fd51196bed28bb0c46d3f296c2ab4eeda8928a315f8234ed39609d03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes payout eligibility on payment state transitions in a money path, though it reuses established pause/comment patterns and includes guards (per account, reset on success, no re-pause).
> 
> **Overview**
> Adds an automatic **payout pause** when a creator hits **3 consecutive failed or returned payouts** to the **same bank account**, using new `Payment::MAX_CONSECUTIVE_FAILED_PAYOUTS` and `pause_payouts_after_repeated_failures` on `failed`/`returned` state transitions.
> 
> The counter is **per bank account**, only counts failures **after the latest completed payout** to that account, skips payouts **without a bank account** (e.g. PayPal), and **does not override** an existing pause—then sets `payouts_paused_internally` with system source and an on-probation comment for review.
> 
> Specs cover the threshold, returned-after-completed, reset on success, per-account scoping, PayPal exclusion, and idempotency when already paused.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63ecc87909a963a789f9d8288c5c60f850d38e2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->