### PR TITLE
Reduce Sentry traces_sample_rate by 10x

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -5,7 +5,7 @@ Sentry.init do |config|
   config.enabled_environments = %w[production staging]
   config.breadcrumbs_logger = [:active_support_logger, :http_logger]
   config.send_default_pii = true
-  config.traces_sample_rate = 0.01
+  config.traces_sample_rate = 0.001
   config.excluded_exceptions += [
     "ActionController::RoutingError",
     "ActionController::InvalidAuthenticityToken",


### PR DESCRIPTION
## What

Lower Sentry's `traces_sample_rate` from `0.01` to `0.001` in `config/initializers/sentry.rb` — a 10x reduction in performance trace sampling.

## Why

Performance transaction volume sent to Sentry is higher than needed for our monitoring purposes. Sampling 0.1% of traces (down from 1%) still provides a representative view of performance while reducing transaction quota usage and noise.

---

AI disclosure: drafted with Claude Opus 4.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783620666&installation_id=134400930&pr_number=5447&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5447&signature=9569b872d47763f1fe0cce5916a96829204bbcff8d2d5767a0186dc3bc785ca5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single observability tuning knob with no auth, data, or application logic changes; tradeoff is slightly sparser performance traces in Sentry.
> 
> **Overview**
> Lowers Sentry **performance trace sampling** in `config/initializers/sentry.rb` by changing `traces_sample_rate` from **0.01 (1%)** to **0.001 (0.1%)** — a 10× reduction in how many transactions are sent to Sentry in production and staging.
> 
> Error reporting and other Sentry settings are unchanged; only trace volume is affected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c73bb90992b06dfa54ea746ec54ca29faa3a0f65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->