### PR TITLE
Fix receipt 500 when order has no successful purchase (#483)

### DIFF
--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -249,6 +249,8 @@ class PurchasesController < ApplicationController
   end
 
   def resend_receipt
+    return e404 if receipt_orderable_missing?(@purchase)
+
     @purchase.resend_receipt
     head :no_content
   end
@@ -281,6 +283,8 @@ class PurchasesController < ApplicationController
     if (@purchase.purchaser && @purchase.purchaser == logged_in_user) ||
        (logged_in_user && logged_in_user.is_team_member?) ||
        (params[:email].present? && ActiveSupport::SecurityUtils.secure_compare(@purchase.email.downcase, params[:email].to_s.strip.downcase))
+      return e404 if receipt_orderable_missing?(@purchase)
+
       message = CustomerMailer.receipt(@purchase.id, for_email: false)
       # Generate the same markup used in the email
       Premailer::Rails::Hook.perform(message)
@@ -432,5 +436,16 @@ class PurchasesController < ApplicationController
       payment_method&.card&.wallet&.type == params[:wallet_type]
     rescue Stripe::StripeError
       render_error("Sorry, something went wrong.")
+    end
+
+    # The receipt/resend paths resolve a Chargeable that can promote a charge-backed
+    # purchase to its Order. When that Order has no successful purchase, the orderable
+    # has no buyer email and rendering/sending the receipt raises NoMethodError (see
+    # gumroad-private#483 / Sentry GUMROAD-4D). Treat that as a missing receipt (404)
+    # rather than 500ing. Order#email is nil-safe as of this change.
+    def receipt_orderable_missing?(purchase)
+      Charge::Chargeable.find_by_purchase_or_charge!(purchase:).orderable.email.blank?
+    rescue ActiveRecord::RecordNotFound
+      true
     end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -17,7 +17,7 @@ class Order < ApplicationRecord
             flag_query_mode: :bit_operator,
             check_for_column: false
 
-  delegate :card_type, :card_visual, :full_name, to: :purchase_with_payment_as_orderable
+  delegate :card_type, :card_visual, :full_name, to: :purchase_with_payment_as_orderable, allow_nil: true
 
   after_save :schedule_review_reminder!, if: :should_schedule_review_reminder?
 
@@ -38,15 +38,15 @@ class Order < ApplicationRecord
   end
 
   def email
-    purchase_as_orderable.email
+    purchase_as_orderable&.email
   end
 
   def locale
-    purchase_as_orderable.locale
+    purchase_as_orderable&.locale
   end
 
   def test?
-    purchase_as_orderable.is_test_purchase?
+    purchase_as_orderable&.is_test_purchase? || false
   end
 
   def send_charge_receipts
@@ -62,7 +62,7 @@ class Order < ApplicationRecord
   end
 
   def unsubscribe_buyer
-    purchase_as_orderable.unsubscribe_buyer
+    purchase_as_orderable&.unsubscribe_buyer
   end
 
   def schedule_review_reminder!

--- a/spec/controllers/purchases_controller_spec.rb
+++ b/spec/controllers/purchases_controller_spec.rb
@@ -983,6 +983,23 @@ describe PurchasesController, :vcr do
         expect(response).to be_successful
       end
 
+      context "when the order has no successful purchases" do
+        let(:purchase) { create(:failed_purchase, email: "test@example.com") }
+
+        before do
+          order = create(:order, purchases: [purchase])
+          create(:charge, order:, purchases: [purchase], seller: purchase.seller)
+        end
+
+        it "404s instead of enqueueing a receipt job" do
+          expect do
+            post :resend_receipt, params: { id: purchase.external_id }
+          end.to raise_error(ActionController::RoutingError)
+
+          expect(SendPurchaseReceiptJob.jobs.size).to eq(0)
+        end
+      end
+
       describe "gift purchase" do
         before do
           @product = create(:product_with_pdf_file)

--- a/spec/controllers/purchases_controller_spec.rb
+++ b/spec/controllers/purchases_controller_spec.rb
@@ -1599,6 +1599,24 @@ describe PurchasesController, :vcr do
         end
       end
 
+      context "when the order has no successful purchases" do
+        # A charge-backed purchase promotes the receipt's chargeable to its Order;
+        # when that Order has no successful purchase, the orderable has no email and
+        # the receipt used to 500 (gumroad-private#483 / Sentry GUMROAD-4D).
+        let(:purchase) { create(:failed_purchase, email: "test@example.com") }
+
+        before do
+          order = create(:order, purchases: [purchase])
+          create(:charge, order:, purchases: [purchase], seller: purchase.seller)
+        end
+
+        it "404s instead of raising NoMethodError" do
+          expect do
+            get :receipt, params: { id: purchase.external_id, email: "test@example.com" }
+          end.to raise_error(ActionController::RoutingError)
+        end
+      end
+
       context "when user is logged in as purchaser" do
         let(:user) { create(:user) }
         let(:purchase) { create(:purchase, email: "test@example.com", purchaser: user) }

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -89,17 +89,41 @@ describe Order do
     it "returns the email of the purchase" do
       expect(order.email).to eq(purchase.email)
     end
+
+    context "when there are no successful purchases" do
+      let(:purchase) { create(:failed_purchase) }
+
+      it "returns nil instead of raising" do
+        expect(order.email).to be_nil
+      end
+    end
   end
 
   describe "#locale" do
     it "returns the locale of the purchase" do
       expect(order.locale).to eq(purchase.locale)
     end
+
+    context "when there are no successful purchases" do
+      let(:purchase) { create(:failed_purchase) }
+
+      it "returns nil instead of raising" do
+        expect(order.locale).to be_nil
+      end
+    end
   end
 
   describe "#test?" do
     context "when the purchase is not a test purchase" do
       it "returns false" do
+        expect(order.test?).to eq(false)
+      end
+    end
+
+    context "when there are no successful purchases" do
+      let(:purchase) { create(:failed_purchase) }
+
+      it "returns false instead of raising" do
         expect(order.test?).to eq(false)
       end
     end


### PR DESCRIPTION
## What & why

Opening a receipt URL for a charge-backed purchase whose **Order has no successful purchase** returns **HTTP 500** with `NoMethodError: undefined method 'email' for nil`. Buyers see "Something broke" and lose access to the download (the receipt page also serves the download link).

Sentry **GUMROAD-4D** — 76 events / 11 users, ongoing since 2026-03-28.
Fixes antiwork/gumroad-private#483.

## Root cause

`Order#email` dereferences `purchase_as_orderable` (= `successful_purchases.first`), which is `nil` whenever every purchase on the order is `failed` / `in_progress` / a concluded preorder. `PurchasesController#receipt` resolves `@purchase` by external id with no state filter, and a charge-backed purchase promotes the mailer's chargeable to the `Charge` → `Order`, so a failed purchase's receipt URL reaches `Order#email` → `nil.email` → 500.

This is the **same nil-orderable bug as GUMROAD-KS**: #5287 nil-guarded only the gift methods, which relocated the crash from `customer_mailer.rb:38` to `:41`. A guard on `Order#email` alone would just move it again (footer `Order#test?`, then the `card_type` delegation). So this fixes it at two layers.

## Changes

**Controller (primary, user-facing)** — `app/controllers/purchases_controller.rb`
- `#receipt` and `#resend_receipt` return **404** when the resolved chargeable's orderable has no buyer email, instead of rendering/sending a receipt that can't exist. `#resend_receipt` otherwise pushed the same crash into Sidekiq via `SendPurchaseReceiptJob`.
- Legacy non-charge receipts (orderable is the purchase itself, always has an email) are unaffected.

**Model (defense-in-depth)** — `app/models/order.rb`
- `#email`, `#locale`, `#test?`, `#unsubscribe_buyer` are now nil-safe; `delegate :card_type, :card_visual, :full_name` gets `allow_nil: true`. This protects the other receipt/invoice entry points (`grouped_receipt`, `auto_invoice`, invoice presenters, receipt footer) from the same nil.

## Tests

- `spec/models/order_spec.rb` — `#email`/`#locale`/`#test?` return `nil`/`false` for a `:failed_purchase` instead of raising.
- `spec/controllers/purchases_controller_spec.rb` — a charge-backed failed purchase hitting `GET receipt` now 404s instead of raising `NoMethodError` (fails on `main`).

## Validation

- `ruby -c` clean on all 4 files; `rubocop` clean on the changed lines (2 pre-existing offenses at L673 are untouched).
- ⚠️ **Could not run the specs locally** — the test suite's `before(:suite)` hook requires Elasticsearch, and the local Docker daemon is unresponsive on this machine, so the suite can't boot. The specs are written against verified codebase patterns (factories `:failed_purchase`, `:order`, `:charge`; `RoutingError` for the 404 path) and the controller test is constructed to fail on `main`. **Leaning on CI to run them** — please confirm green before merge.

## Investigation

Full root-cause analysis (verified against `main`, incl. the GUMROAD-KS → GUMROAD-4D history and blast-radius map) is posted on antiwork/gumroad-private#483.

🤖 Authored with AI assistance (claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783650324&installation_id=134400930&pr_number=5448&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5448&signature=2fc082f2c69aad8d86608a2197987eb73c49ea2a4bf3d2d6cd04b101014b2c6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches buyer-facing receipt/download paths and order-level email delegation used by mailers; behavior change is intentional (500 → 404) but could hide edge cases if the guard is too broad.
> 
> **Overview**
> Fixes **HTTP 500** on receipt URLs when a charge-backed purchase’s **Order has no successful purchase** (failed/in-progress only), where mail/receipt code dereferenced a nil orderable email.
> 
> **`PurchasesController`** — `#receipt` and `#resend_receipt` now return **404** via `receipt_orderable_missing?`, which resolves the chargeable and treats a blank orderable email (or missing chargeable) as no receipt, instead of rendering or enqueueing `SendPurchaseReceiptJob`.
> 
> **`Order`** — `#email`, `#locale`, `#test?`, and `#unsubscribe_buyer` are nil-safe when there is no successful purchase; card-related delegation uses `allow_nil: true` so other receipt/invoice paths do not raise the same `NoMethodError`.
> 
> Specs cover the failed-purchase + charge/order scenario for **404** on receipt/resend and nil-safe `Order` accessors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bd38538e0a2f2ae6caef08f22b46453f0f31407. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->