### PR TITLE
Serve email audience counts from Elasticsearch

### DIFF
--- a/app/models/audience_member.rb
+++ b/app/models/audience_member.rb
@@ -1,7 +1,18 @@
 # frozen_string_literal: true
 
 class AudienceMember < ApplicationRecord
+  include AudienceMember::Searchable
+
   VALID_FILTER_TYPES = %w[customer follower affiliate].freeze
+  FILTER_PARAM_KEYS = %i[
+    type
+    bought_product_ids bought_variant_ids
+    not_bought_product_ids not_bought_variant_ids
+    paid_more_than_cents paid_less_than_cents
+    created_after created_before
+    bought_from
+    affiliate_product_ids
+  ].freeze
 
   belongs_to :seller, class_name: "User"
   after_initialize :assign_default_details_value
@@ -11,19 +22,18 @@ class AudienceMember < ApplicationRecord
   validate :details_json_has_valid_format
   before_save :assign_derived_columns
 
+  def self.normalize_filter_params(params)
+    params = params.slice(*FILTER_PARAM_KEYS).compact_blank
+    if params[:type] && !params[:type].in?(VALID_FILTER_TYPES)
+      raise ArgumentError, "Invalid type: #{params[:type]}. Must be one of: #{VALID_FILTER_TYPES.join(', ')}"
+    end
+    params
+  end
+
   def self.filter(seller_id:, params: {}, with_ids: false)
-    params = params.slice(
-      :type,
-      :bought_product_ids, :bought_variant_ids,
-      :not_bought_product_ids, :not_bought_variant_ids,
-      :paid_more_than_cents, :paid_less_than_cents,
-      :created_after, :created_before,
-      :bought_from,
-      :affiliate_product_ids
-    ).compact_blank
+    params = normalize_filter_params(params)
 
     if params[:type]
-      raise ArgumentError, "Invalid type: #{params[:type]}. Must be one of: #{VALID_FILTER_TYPES.join(', ')}" unless params[:type].in?(VALID_FILTER_TYPES)
       types_sql = where(:seller_id => seller_id, params[:type] => true).to_sql
     end
 
@@ -156,7 +166,10 @@ class AudienceMember < ApplicationRecord
       if params[:affiliate_product_ids]
         json_filter = json_filter.where("jt.affiliate_product_id IN (?)", params[:affiliate_product_ids])
       end
-      json_filter = json_filter.where("jt.purchase_country = ?", params[:bought_from]) if params[:bought_from]
+      # COLLATE makes this binary-exact like the JSON_CONTAINS country subquery above and the
+      # Elasticsearch term query in AudienceMember::Searchable; the connection's default
+      # case-insensitive collation would otherwise match country spellings the other two reject.
+      json_filter = json_filter.where("jt.purchase_country = ? COLLATE utf8mb4_bin", params[:bought_from]) if params[:bought_from]
       # Joining a JSON_TABLE yields a row for each matching element in the JSON array.
       # Our business logic says that if a user has multiple purchases or affiliates matching the filters,
       # we should only return the most recent one. This is why we use max() and group() below, when we need the ids.

--- a/app/models/concerns/audience_member/searchable.rb
+++ b/app/models/concerns/audience_member/searchable.rb
@@ -1,0 +1,223 @@
+# frozen_string_literal: true
+
+module AudienceMember::Searchable
+  extend ActiveSupport::Concern
+
+  PURCHASE_DETAIL_KEYS = %w[id product_id variant_ids price_cents created_at country].freeze
+  AFFILIATE_DETAIL_KEYS = %w[id product_id created_at].freeze
+
+  included do
+    include Elasticsearch::Model
+    include SearchIndexModelCommon
+    include ElasticsearchModelAsyncCallbacks
+
+    index_name "audience_members"
+
+    settings number_of_shards: 1, number_of_replicas: 0, index: {
+      mapping: { nested_objects: { limit: 30_000 } }
+    }
+
+    mapping dynamic: :strict do
+      indexes :seller_id, type: :long
+      indexes :email, type: :keyword
+      indexes :customer, type: :boolean
+      indexes :follower, type: :boolean
+      indexes :affiliate, type: :boolean
+      indexes :min_paid_cents, type: :long
+      indexes :max_paid_cents, type: :long
+      indexes :min_created_at, type: :date
+      indexes :max_created_at, type: :date
+      indexes :min_purchase_created_at, type: :date
+      indexes :max_purchase_created_at, type: :date
+      indexes :follower_id, type: :long
+      indexes :follower_created_at, type: :date
+      indexes :min_affiliate_created_at, type: :date
+      indexes :max_affiliate_created_at, type: :date
+      indexes :purchases, type: :nested do
+        indexes :id, type: :long
+        indexes :product_id, type: :long
+        indexes :variant_ids, type: :long
+        indexes :price_cents, type: :long
+        indexes :created_at, type: :date
+        indexes :country, type: :keyword
+      end
+      indexes :affiliates, type: :nested do
+        indexes :id, type: :long
+        indexes :product_id, type: :long
+        indexes :created_at, type: :date
+      end
+    end
+
+    ATTRIBUTE_TO_SEARCH_FIELDS = {
+      "seller_id" => "seller_id",
+      "email" => "email",
+      "customer" => "customer",
+      "follower" => "follower",
+      "affiliate" => "affiliate",
+      "min_paid_cents" => "min_paid_cents",
+      "max_paid_cents" => "max_paid_cents",
+      "min_created_at" => "min_created_at",
+      "max_created_at" => "max_created_at",
+      "min_purchase_created_at" => "min_purchase_created_at",
+      "max_purchase_created_at" => "max_purchase_created_at",
+      "follower_created_at" => "follower_created_at",
+      "min_affiliate_created_at" => "min_affiliate_created_at",
+      "max_affiliate_created_at" => "max_affiliate_created_at",
+      "details" => %w[purchases follower_id affiliates],
+    }.freeze
+
+    def search_field_value(field_name)
+      details_hash = details || {}
+      case field_name
+      when "purchases"
+        Array.wrap(details_hash["purchases"]).map { _1.slice(*PURCHASE_DETAIL_KEYS) }
+      when "affiliates"
+        Array.wrap(details_hash["affiliates"]).map { _1.slice(*AFFILIATE_DETAIL_KEYS) }
+      when "follower_id"
+        details_hash.dig("follower", "id")
+      else
+        attributes[field_name]
+      end.as_json
+    end
+  end
+
+  class_methods do
+    def filter_count(seller_id:, params: {}, limit: nil)
+      options = {
+        index: index_name,
+        body: { query: filter_query(seller_id:, params:) },
+      }
+      options[:terminate_after] = limit if limit
+      EsClient.count(options)["count"]
+    end
+
+    # Builds an Elasticsearch query equivalent to the SQL built by AudienceMember.filter,
+    # so that counts computed here always match the recipients selected by the blast jobs.
+    def filter_query(seller_id:, params: {})
+      params = normalize_filter_params(params)
+
+      filter = [{ term: { seller_id: } }]
+      must_not = []
+
+      filter << { term: { params[:type] => true } } if params[:type]
+
+      if params[:bought_product_ids] || params[:bought_variant_ids]
+        filter << { nested: { path: "purchases", query: bought_products_or_variants_query(params) } }
+      end
+
+      if params[:not_bought_product_ids]
+        must_not << { nested: { path: "purchases", query: { terms: { "purchases.product_id" => params[:not_bought_product_ids] } } } }
+      end
+
+      if params[:not_bought_variant_ids]
+        must_not << { nested: { path: "purchases", query: { terms: { "purchases.variant_ids" => params[:not_bought_variant_ids] } } } }
+      end
+
+      filter << { range: { max_paid_cents: { gt: params[:paid_more_than_cents] } } } if params[:paid_more_than_cents]
+      filter << { range: { min_paid_cents: { lt: params[:paid_less_than_cents] } } } if params[:paid_less_than_cents]
+
+      if params[:created_after] || params[:created_before]
+        min_created_at_field, max_created_at_field = \
+          case params[:type]
+          when "customer" then [:min_purchase_created_at, :max_purchase_created_at]
+          when "follower" then [:follower_created_at, :follower_created_at]
+          when "affiliate" then [:min_affiliate_created_at, :max_affiliate_created_at]
+          else [:min_created_at, :max_created_at]
+          end
+        filter << { range: { max_created_at_field => { gt: params[:created_after] } } } if params[:created_after]
+        filter << { range: { min_created_at_field => { lt: params[:created_before] } } } if params[:created_before]
+      end
+
+      if params[:bought_from]
+        filter << { nested: { path: "purchases", query: { term: { "purchases.country" => params[:bought_from] } } } }
+      end
+
+      if params[:affiliate_product_ids]
+        filter << { nested: { path: "affiliates", query: { terms: { "affiliates.product_id" => params[:affiliate_product_ids] } } } }
+      end
+
+      single_record_clause = filter_single_record_clause(params)
+      filter << single_record_clause if single_record_clause
+
+      query = { bool: { filter: } }
+      query[:bool][:must_not] = must_not if must_not.any?
+      query
+    end
+
+    private
+      # Mirrors the JSON_TABLE subquery in AudienceMember.filter: when filters are combined,
+      # they must all match within a single purchase / follower / affiliate record of the member,
+      # not across different records.
+      def filter_single_record_clause(params)
+        single_record_filtering = (
+          (params[:bought_product_ids] || params[:bought_variant_ids] || params[:affiliate_product_ids]) \
+          && (params[:paid_more_than_cents] || params[:paid_less_than_cents] || params[:created_after] || params[:created_before] || params[:bought_from]))
+        single_record_filtering ||= (params[:paid_more_than_cents] && params[:paid_less_than_cents])
+        single_record_filtering ||= (params[:created_after] && params[:created_before])
+        return nil unless single_record_filtering
+
+        has_purchase_conditions = params.values_at(:bought_product_ids, :bought_variant_ids, :paid_more_than_cents, :paid_less_than_cents, :bought_from).any?
+        has_affiliate_conditions = params[:affiliate_product_ids].present?
+        has_date_conditions = params[:created_after].present? || params[:created_before].present?
+        date_fields = single_record_date_fields(params)
+
+        should = []
+
+        if !has_affiliate_conditions && (!has_date_conditions || date_fields.include?("purchase_created_at"))
+          conditions = []
+          conditions << bought_products_or_variants_query(params) if params[:bought_product_ids] || params[:bought_variant_ids]
+          conditions << { range: { "purchases.price_cents" => { gt: params[:paid_more_than_cents] } } } if params[:paid_more_than_cents]
+          conditions << { range: { "purchases.price_cents" => { lt: params[:paid_less_than_cents] } } } if params[:paid_less_than_cents]
+          conditions << { term: { "purchases.country" => params[:bought_from] } } if params[:bought_from]
+          conditions << { range: { "purchases.created_at" => { gt: params[:created_after] } } } if params[:created_after]
+          conditions << { range: { "purchases.created_at" => { lt: params[:created_before] } } } if params[:created_before]
+          should << { nested: { path: "purchases", query: { bool: { filter: conditions } } } } if conditions.any?
+        end
+
+        if !has_purchase_conditions && !has_affiliate_conditions && has_date_conditions && date_fields.include?("follower_created_at")
+          # The follower_id guard mirrors SQL's JSON_TABLE over the details JSON: rows whose
+          # details were cleared outside callbacks (GDPR erasure) produce no JSON records there,
+          # even when the denormalized follower_created_at column is still set.
+          conditions = [{ exists: { field: "follower_id" } }]
+          conditions << { range: { follower_created_at: { gt: params[:created_after] } } } if params[:created_after]
+          conditions << { range: { follower_created_at: { lt: params[:created_before] } } } if params[:created_before]
+          should << { bool: { filter: conditions } }
+        end
+
+        if !has_purchase_conditions && (!has_date_conditions || date_fields.include?("affiliate_created_at")) && (has_affiliate_conditions || has_date_conditions)
+          conditions = []
+          conditions << { terms: { "affiliates.product_id" => params[:affiliate_product_ids] } } if params[:affiliate_product_ids]
+          conditions << { range: { "affiliates.created_at" => { gt: params[:created_after] } } } if params[:created_after]
+          conditions << { range: { "affiliates.created_at" => { lt: params[:created_before] } } } if params[:created_before]
+          should << { nested: { path: "affiliates", query: { bool: { filter: conditions } } } } if conditions.any?
+        end
+
+        return { match_none: {} } if should.empty?
+
+        { bool: { should:, minimum_should_match: 1 } }
+      end
+
+      def single_record_date_fields(params)
+        if params[:type] == "customer"
+          %w[purchase_created_at]
+        elsif params[:type] == "follower"
+          if params[:bought_product_ids] || params[:bought_variant_ids]
+            %w[follower_created_at purchase_created_at]
+          else
+            %w[follower_created_at]
+          end
+        elsif params[:type] == "affiliate"
+          %w[affiliate_created_at]
+        else
+          %w[purchase_created_at follower_created_at affiliate_created_at]
+        end
+      end
+
+      def bought_products_or_variants_query(params)
+        bought = []
+        bought << { terms: { "purchases.product_id" => params[:bought_product_ids] } } if params[:bought_product_ids]
+        bought << { terms: { "purchases.variant_ids" => params[:bought_variant_ids] } } if params[:bought_variant_ids]
+        { bool: { should: bought, minimum_should_match: 1 } }
+      end
+  end
+end

--- a/app/models/concerns/audience_member/searchable.rb
+++ b/app/models/concerns/audience_member/searchable.rb
@@ -6,10 +6,23 @@ module AudienceMember::Searchable
   PURCHASE_DETAIL_KEYS = %w[id product_id variant_ids price_cents created_at country].freeze
   AFFILIATE_DETAIL_KEYS = %w[id product_id created_at].freeze
 
+  # Audience members churn on every purchase and follow across all sellers, but only
+  # flag-enabled sellers are served from this index, so sellers without the flag don't
+  # enqueue indexing jobs. Enabling a seller must therefore be followed by a
+  # seller-scoped backfill: their documents only start syncing at flag-flip time.
+  module GatedAsyncIndexing
+    private
+      def send_to_elasticsearch(action)
+        return unless Feature.active?(:audience_count_from_elasticsearch, seller)
+        super
+      end
+  end
+
   included do
     include Elasticsearch::Model
     include SearchIndexModelCommon
     include ElasticsearchModelAsyncCallbacks
+    prepend GatedAsyncIndexing
 
     index_name "audience_members"
 

--- a/app/models/installment.rb
+++ b/app/models/installment.rb
@@ -850,7 +850,11 @@ class Installment < ApplicationRecord
   end
 
   def audience_members_count(limit = nil)
-    AudienceMember.filter(seller_id:, params: audience_members_filter_params).limit(limit).count
+    if Feature.active?(:audience_count_from_elasticsearch, seller)
+      AudienceMember.filter_count(seller_id:, params: audience_members_filter_params, limit:)
+    else
+      AudienceMember.filter(seller_id:, params: audience_members_filter_params).limit(limit).count
+    end
   end
 
   def self.receivable_by_customers_of_product(product:, variant_external_id:)

--- a/app/services/gdpr_buyer_erasure_service.rb
+++ b/app/services/gdpr_buyer_erasure_service.rb
@@ -154,11 +154,42 @@ class GdprBuyerErasureService
 
     def anonymize_audience_members!
       conflict_seller_ids = AudienceMember.where(email: @anonymized_email).pluck(:seller_id)
-      AudienceMember.where(email: email, seller_id: conflict_seller_ids).delete_all if conflict_seller_ids.any?
-      counts[:audience_members] = AudienceMember.where(email: email).update_all(
+      if conflict_seller_ids.any?
+        conflicting_members = AudienceMember.where(email: email, seller_id: conflict_seller_ids)
+        deleted_member_ids = conflicting_members.ids
+        conflicting_members.delete_all
+        deleted_member_ids.each do |member_id|
+          ElasticsearchIndexerWorker.perform_async("delete", { "record_id" => member_id, "class_name" => "AudienceMember" })
+        end
+      end
+
+      anonymized_attributes = {
         email: @anonymized_email,
         details: nil,
-      )
+        customer: false,
+        follower: false,
+        affiliate: false,
+        min_paid_cents: nil,
+        max_paid_cents: nil,
+        min_created_at: nil,
+        max_created_at: nil,
+        min_purchase_created_at: nil,
+        max_purchase_created_at: nil,
+        follower_created_at: nil,
+        min_affiliate_created_at: nil,
+        max_affiliate_created_at: nil,
+      }
+      members = AudienceMember.where(email: email).to_a
+      counts[:audience_members] = AudienceMember.where(id: members.map(&:id)).update_all(anonymized_attributes)
+      # The indexer worker re-reads rows from a possibly-lagging replica; passing the
+      # document body inline guarantees the pre-erasure PII can never be re-indexed.
+      members.each do |member|
+        member.assign_attributes(anonymized_attributes)
+        ElasticsearchIndexerWorker.perform_async(
+          "index",
+          { "record_id" => member.id, "class_name" => "AudienceMember", "body" => member.as_indexed_json },
+        )
+      end
     end
 
     def anonymize_followers!

--- a/app/services/onetime/backfill_audience_members_index.rb
+++ b/app/services/onetime/backfill_audience_members_index.rb
@@ -5,40 +5,54 @@ class Onetime::BackfillAudienceMembersIndex
   REDIS_CURSOR_KEY = "onetime_backfill_audience_members_index_last_id"
   REDIS_FAILED_IDS_KEY = "onetime_backfill_audience_members_index_failed_ids"
 
-  def self.process(batch_size: BATCH_SIZE)
-    new(batch_size:).process
+  def self.process(batch_size: BATCH_SIZE, seller_id: nil)
+    new(batch_size:, seller_id:).process
   end
 
-  def initialize(batch_size: BATCH_SIZE)
+  def initialize(batch_size: BATCH_SIZE, seller_id: nil)
     @batch_size = batch_size
+    @seller_id = seller_id
   end
 
   def process
-    AudienceMember.__elasticsearch__.create_index! unless AudienceMember.__elasticsearch__.index_exists?
+    # Creating the index here instead would race the CreateAudienceMembersIndex migration's
+    # versioned-index-plus-alias layout, and a bulk write to a missing index would auto-create
+    # it with a dynamic mapping instead of the strict one.
+    raise "The #{AudienceMember.index_name} index is missing; run the CreateAudienceMembersIndex migration first" unless AudienceMember.__elasticsearch__.index_exists?
     $redis.sadd(RedisKey.elasticsearch_indexer_worker_ignore_404_errors_on_indices, AudienceMember.index_name)
 
     loop do
-      members = AudienceMember.where("id > ?", last_processed_id).order(:id).limit(batch_size).to_a
+      members = scope.where("id > ?", last_processed_id).order(:id).limit(batch_size).to_a
       break if members.empty?
 
       ReplicaLagWatcher.watch
       bulk_index(members)
-      $redis.set(REDIS_CURSOR_KEY, members.last.id)
+      $redis.set(cursor_key, members.last.id)
       puts "Indexed audience members up to id #{members.last.id}"
     end
 
     delete_stale_documents
-    $redis.srem(RedisKey.elasticsearch_indexer_worker_ignore_404_errors_on_indices, AudienceMember.index_name)
+    # After a seller-scoped run the other sellers' rows are still unindexed, so their
+    # partial-update jobs must keep ignoring 404s until the full backfill removes this entry.
+    $redis.srem(RedisKey.elasticsearch_indexer_worker_ignore_404_errors_on_indices, AudienceMember.index_name) if seller_id.nil?
 
     failed_count = $redis.scard(REDIS_FAILED_IDS_KEY)
     puts "Done. #{failed_count} members failed to index; ids are in the #{REDIS_FAILED_IDS_KEY} redis set." if failed_count > 0
   end
 
   private
-    attr_reader :batch_size
+    attr_reader :batch_size, :seller_id
+
+    def scope
+      seller_id ? AudienceMember.where(seller_id:) : AudienceMember.all
+    end
+
+    def cursor_key
+      seller_id ? "#{REDIS_CURSOR_KEY}_seller_#{seller_id}" : REDIS_CURSOR_KEY
+    end
 
     def last_processed_id
-      $redis.get(REDIS_CURSOR_KEY).to_i
+      $redis.get(cursor_key).to_i
     end
 
     def bulk_index(members)
@@ -65,7 +79,7 @@ class Onetime::BackfillAudienceMembersIndex
       response = EsClient.search(
         index: AudienceMember.index_name,
         scroll: "1m",
-        body: { query: { match_all: {} } },
+        body: { query: seller_id ? { term: { seller_id: } } : { match_all: {} } },
         size: batch_size,
         sort: ["_doc"],
         _source: false,

--- a/app/services/onetime/backfill_audience_members_index.rb
+++ b/app/services/onetime/backfill_audience_members_index.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+class Onetime::BackfillAudienceMembersIndex
+  BATCH_SIZE = 500
+  REDIS_CURSOR_KEY = "onetime_backfill_audience_members_index_last_id"
+  REDIS_FAILED_IDS_KEY = "onetime_backfill_audience_members_index_failed_ids"
+
+  def self.process(batch_size: BATCH_SIZE)
+    new(batch_size:).process
+  end
+
+  def initialize(batch_size: BATCH_SIZE)
+    @batch_size = batch_size
+  end
+
+  def process
+    AudienceMember.__elasticsearch__.create_index! unless AudienceMember.__elasticsearch__.index_exists?
+    $redis.sadd(RedisKey.elasticsearch_indexer_worker_ignore_404_errors_on_indices, AudienceMember.index_name)
+
+    loop do
+      members = AudienceMember.where("id > ?", last_processed_id).order(:id).limit(batch_size).to_a
+      break if members.empty?
+
+      ReplicaLagWatcher.watch
+      bulk_index(members)
+      $redis.set(REDIS_CURSOR_KEY, members.last.id)
+      puts "Indexed audience members up to id #{members.last.id}"
+    end
+
+    delete_stale_documents
+    $redis.srem(RedisKey.elasticsearch_indexer_worker_ignore_404_errors_on_indices, AudienceMember.index_name)
+
+    failed_count = $redis.scard(REDIS_FAILED_IDS_KEY)
+    puts "Done. #{failed_count} members failed to index; ids are in the #{REDIS_FAILED_IDS_KEY} redis set." if failed_count > 0
+  end
+
+  private
+    attr_reader :batch_size
+
+    def last_processed_id
+      $redis.get(REDIS_CURSOR_KEY).to_i
+    end
+
+    def bulk_index(members)
+      body = members.map do |member|
+        { index: { _index: AudienceMember.index_name, _id: member.id, data: member.as_indexed_json } }
+      end
+      response = EsClient.bulk(body:)
+      return unless response["errors"]
+
+      failed_items = response["items"].select { _1.dig("index", "error") }
+      failed_ids = failed_items.map { _1.dig("index", "_id") }
+      $redis.sadd(REDIS_FAILED_IDS_KEY, failed_ids)
+      Rails.logger.error(
+        "[#{self.class.name}] Failed to index audience members " \
+        "ids=#{failed_ids.join(',')} " \
+        "first_error=#{failed_items.first&.dig('index', 'error')}"
+      )
+    end
+
+    # Members destroyed while a batch was in flight can be re-created in ES by the bulk write
+    # after their async delete job already ran, so sweep the index for documents whose rows
+    # no longer exist.
+    def delete_stale_documents
+      response = EsClient.search(
+        index: AudienceMember.index_name,
+        scroll: "1m",
+        body: { query: { match_all: {} } },
+        size: batch_size,
+        sort: ["_doc"],
+        _source: false,
+      )
+
+      loop do
+        hits = response.dig("hits", "hits") || []
+        break if hits.empty?
+
+        document_ids = hits.map { _1["_id"].to_i }
+        existing_ids = AudienceMember.where(id: document_ids).pluck(:id).to_set
+        stale_ids = document_ids.reject { existing_ids.include?(_1) }
+        if stale_ids.any?
+          EsClient.bulk(body: stale_ids.map { { delete: { _index: AudienceMember.index_name, _id: _1 } } })
+          puts "Deleted #{stale_ids.size} stale documents"
+        end
+
+        response = EsClient.scroll(scroll_id: response["_scroll_id"], scroll: "1m")
+      end
+    ensure
+      EsClient.clear_scroll(scroll_id: response["_scroll_id"]) if response&.dig("_scroll_id")
+    end
+end

--- a/app/services/onetime/backfill_audience_members_index.rb
+++ b/app/services/onetime/backfill_audience_members_index.rb
@@ -32,8 +32,9 @@ class Onetime::BackfillAudienceMembersIndex
     end
 
     delete_stale_documents
-    # After a seller-scoped run the other sellers' rows are still unindexed, so their
-    # partial-update jobs must keep ignoring 404s until the full backfill removes this entry.
+    # Members updated between a seller's flag enablement and their backfill completing
+    # produce partial-update jobs for documents that don't exist yet, so the 404
+    # suppression must outlive seller-scoped runs; the full backfill removes it.
     $redis.srem(RedisKey.elasticsearch_indexer_worker_ignore_404_errors_on_indices, AudienceMember.index_name) if seller_id.nil?
 
     failed_count = $redis.scard(REDIS_FAILED_IDS_KEY)

--- a/db/migrate/20261130000007_create_audience_members_index.rb
+++ b/db/migrate/20261130000007_create_audience_members_index.rb
@@ -3,12 +3,7 @@
 class CreateAudienceMembersIndex < ActiveRecord::Migration[7.1]
   def up
     if Rails.env.production? || Rails.env.staging?
-      # The model's 1-shard/0-replica settings are sized for dev and test;
-      # production needs replica redundancy and shards small enough to relocate.
-      AudienceMember.__elasticsearch__.create_index!(
-        index: "audience_members_v1",
-        settings: AudienceMember.settings.to_hash.merge(number_of_shards: 4, number_of_replicas: 1)
-      )
+      AudienceMember.__elasticsearch__.create_index!(index: "audience_members_v1")
       EsClient.indices.put_alias(name: "audience_members", index: "audience_members_v1")
     else
       AudienceMember.__elasticsearch__.create_index!

--- a/db/migrate/20261130000007_create_audience_members_index.rb
+++ b/db/migrate/20261130000007_create_audience_members_index.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class CreateAudienceMembersIndex < ActiveRecord::Migration[7.1]
+  def up
+    if Rails.env.production? || Rails.env.staging?
+      # The model's 1-shard/0-replica settings are sized for dev and test;
+      # production needs replica redundancy and shards small enough to relocate.
+      AudienceMember.__elasticsearch__.create_index!(
+        index: "audience_members_v1",
+        settings: AudienceMember.settings.to_hash.merge(number_of_shards: 4, number_of_replicas: 1)
+      )
+      EsClient.indices.put_alias(name: "audience_members", index: "audience_members_v1")
+    else
+      AudienceMember.__elasticsearch__.create_index!
+    end
+  end
+
+  def down
+    if Rails.env.production? || Rails.env.staging?
+      EsClient.indices.delete_alias(name: "audience_members", index: "audience_members_v1")
+      AudienceMember.__elasticsearch__.delete_index!(index: "audience_members_v1")
+    else
+      AudienceMember.__elasticsearch__.delete_index!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_11_30_000006) do
+ActiveRecord::Schema[7.1].define(version: 2026_11_30_000007) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false

--- a/lib/utilities/dev_tools.rb
+++ b/lib/utilities/dev_tools.rb
@@ -38,6 +38,10 @@ class DevTools
           print "Importing #{model.name} user_id=#{user.id} => #{rel.count} records..."
           es_import_with_time(rel)
         end
+
+        rel = AudienceMember.where(seller_id: user.id)
+        print "Importing audience members seller_id=#{user.id} => #{rel.count} records..."
+        es_import_with_time(rel)
       end
 
       nil
@@ -54,7 +58,7 @@ class DevTools
       end
       ActiveRecord::Base.connection.enable_query_cache!
       without_loggers do
-        [Purchase, Link, Balance, Installment].each do |model|
+        [Purchase, Link, Balance, Installment, AudienceMember].each do |model|
           print "Recreating index and importing #{model.name} => #{model.count} records..."
           es_import_with_time(model, force: true)
         end

--- a/spec/models/concerns/audience_member/searchable_spec.rb
+++ b/spec/models/concerns/audience_member/searchable_spec.rb
@@ -55,10 +55,13 @@ describe AudienceMember::Searchable, :freeze_time do
   end
 
   describe "indexing callbacks" do
-    it "enqueues indexing jobs on create, update, and destroy" do
+    it "enqueues indexing jobs on create, update, and destroy when the seller's flag is on" do
+      seller = create(:user)
+      Feature.activate_user(:audience_count_from_elasticsearch, seller)
+
       member = nil
       expect do
-        member = create(:audience_member, purchases: [{ "id" => 1 }])
+        member = create(:audience_member, seller:, purchases: [{ "id" => 1 }])
       end.to change { ElasticsearchIndexerWorker.jobs.size }.by(2)
       expect(ElasticsearchIndexerWorker.jobs.last["args"]).to eq(["index", { "record_id" => member.id, "class_name" => "AudienceMember" }])
 
@@ -76,6 +79,16 @@ describe AudienceMember::Searchable, :freeze_time do
       end.to change { ElasticsearchIndexerWorker.jobs.size }.by(1)
       expect(ElasticsearchIndexerWorker.jobs.last["args"]).to eq(["delete", { "record_id" => member.id, "class_name" => "AudienceMember" }])
     end
+
+    it "enqueues nothing when the seller's flag is off" do
+      member = nil
+      expect do
+        member = create(:audience_member, purchases: [{ "id" => 1 }])
+        member.details["purchases"] << { "id" => 2, "product_id" => 2, "price_cents" => 200, "created_at" => 1.day.ago.iso8601 }
+        member.save!
+        member.destroy!
+      end.not_to change { ElasticsearchIndexerWorker.jobs.size }
+    end
   end
 
   describe ".filter_count", :sidekiq_inline, :elasticsearch_wait_for_refresh do
@@ -84,6 +97,7 @@ describe AudienceMember::Searchable, :freeze_time do
 
     before do
       recreate_model_index(AudienceMember)
+      Feature.activate_user(:audience_count_from_elasticsearch, seller)
     end
 
     it "counts all members of the seller with no params" do

--- a/spec/models/concerns/audience_member/searchable_spec.rb
+++ b/spec/models/concerns/audience_member/searchable_spec.rb
@@ -1,0 +1,332 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe AudienceMember::Searchable, :freeze_time do
+  describe "#as_indexed_json" do
+    it "includes all mapped fields" do
+      member = create(
+        :audience_member,
+        purchases: [{ id: 1, product_id: 2, variant_ids: [3, 4], price_cents: 500, created_at: 3.days.ago.iso8601, country: "United States" }],
+        follower: { id: 5, created_at: 7.days.ago.iso8601 },
+        affiliates: [{ id: 6, product_id: 7, created_at: 1.day.ago.iso8601 }],
+      ).reload
+
+      expect(member.as_indexed_json).to eq(
+        "seller_id" => member.seller_id,
+        "email" => member.email,
+        "customer" => true,
+        "follower" => true,
+        "affiliate" => true,
+        "min_paid_cents" => 500,
+        "max_paid_cents" => 500,
+        "min_created_at" => 7.days.ago.as_json,
+        "max_created_at" => 1.day.ago.as_json,
+        "min_purchase_created_at" => 3.days.ago.as_json,
+        "max_purchase_created_at" => 3.days.ago.as_json,
+        "follower_id" => 5,
+        "follower_created_at" => 7.days.ago.as_json,
+        "min_affiliate_created_at" => 1.day.ago.as_json,
+        "max_affiliate_created_at" => 1.day.ago.as_json,
+        "purchases" => [{ "id" => 1, "product_id" => 2, "variant_ids" => [3, 4], "price_cents" => 500, "created_at" => 3.days.ago.iso8601, "country" => "United States" }],
+        "affiliates" => [{ "id" => 6, "product_id" => 7, "created_at" => 1.day.ago.iso8601 }],
+      )
+    end
+
+    it "allows only a selection of fields to be used" do
+      member = create(:audience_member, follower: { id: 1, created_at: 7.days.ago.iso8601 }).reload
+
+      expect(member.as_indexed_json(only: ["seller_id", "follower_id"])).to eq(
+        "seller_id" => member.seller_id,
+        "follower_id" => 1,
+      )
+    end
+
+    it "handles rows with nil details" do
+      member = create(:audience_member, follower: { id: 1, created_at: 7.days.ago.iso8601 })
+      member.update_column(:details, nil)
+      member.reload
+
+      json = member.as_indexed_json
+      expect(json["purchases"]).to eq([])
+      expect(json["affiliates"]).to eq([])
+      expect(json["follower_id"]).to be_nil
+    end
+  end
+
+  describe "indexing callbacks" do
+    it "enqueues indexing jobs on create, update, and destroy" do
+      member = nil
+      expect do
+        member = create(:audience_member, purchases: [{ "id" => 1 }])
+      end.to change { ElasticsearchIndexerWorker.jobs.size }.by(2)
+      expect(ElasticsearchIndexerWorker.jobs.last["args"]).to eq(["index", { "record_id" => member.id, "class_name" => "AudienceMember" }])
+
+      expect do
+        member.details["purchases"] << { "id" => 2, "product_id" => 2, "price_cents" => 200, "created_at" => 1.day.ago.iso8601 }
+        member.save!
+      end.to change { ElasticsearchIndexerWorker.jobs.size }.by(2)
+      operation, options = ElasticsearchIndexerWorker.jobs.last["args"]
+      expect(operation).to eq("update")
+      expect(options["record_id"]).to eq(member.id)
+      expect(options["fields"]).to include("purchases", "max_paid_cents", "max_purchase_created_at")
+
+      expect do
+        member.destroy!
+      end.to change { ElasticsearchIndexerWorker.jobs.size }.by(1)
+      expect(ElasticsearchIndexerWorker.jobs.last["args"]).to eq(["delete", { "record_id" => member.id, "class_name" => "AudienceMember" }])
+    end
+  end
+
+  describe ".filter_count", :sidekiq_inline, :elasticsearch_wait_for_refresh do
+    let(:seller) { create(:user) }
+    let(:seller_id) { seller.id }
+
+    before do
+      recreate_model_index(AudienceMember)
+    end
+
+    it "counts all members of the seller with no params" do
+      create_member(follower: {})
+      create_member(purchases: [{}])
+      create(:audience_member)
+
+      expect_filter_count(2)
+    end
+
+    it "counts by type" do
+      create_member(purchases: [{}])
+      create_member(follower: {})
+      create_member(affiliates: [{}])
+      create_member(purchases: [{}], follower: {}, affiliates: [{}])
+
+      expect_filter_count(2, type: "customer")
+      expect_filter_count(2, type: "follower")
+      expect_filter_count(2, type: "affiliate")
+    end
+
+    it "raises error for invalid type" do
+      expect { AudienceMember.filter_count(seller_id:, params: { type: "invalid_type" }) }.to raise_error(ArgumentError, /Invalid type: invalid_type/)
+    end
+
+    it "counts by purchased and not-purchased products and variants" do
+      create_member(purchases: [{ "product_id" => 1 }])
+      create_member(purchases: [{ "product_id" => 2 }])
+      create_member(purchases: [{ "product_id" => 2, "variant_ids" => [1] }])
+      create_member(purchases: [{ "product_id" => 2, "variant_ids" => [2] }])
+      create_member(purchases: [{ "product_id" => 1 }, { "product_id" => 2, "variant_ids" => [1] }])
+      create_member(purchases: [{ "product_id" => 1 }, { "product_id" => 2, "variant_ids" => [1, 2] }])
+      create_member(follower: {})
+
+      expect_filter_count(3, bought_product_ids: [1])
+      expect_filter_count(5, bought_product_ids: [2])
+      expect_filter_count(6, bought_product_ids: [1, 2])
+      expect_filter_count(3, bought_variant_ids: [1])
+      expect_filter_count(2, bought_variant_ids: [2])
+      expect_filter_count(4, bought_product_ids: [1], bought_variant_ids: [1])
+      expect_filter_count(5, bought_product_ids: [2], bought_variant_ids: [2])
+
+      expect_filter_count(4, not_bought_product_ids: [1])
+      expect_filter_count(1, not_bought_product_ids: [1, 2])
+      expect_filter_count(4, not_bought_variant_ids: [1])
+      expect_filter_count(3, not_bought_variant_ids: [1, 2])
+      expect_filter_count(3, not_bought_product_ids: [1], not_bought_variant_ids: [1])
+
+      expect_filter_count(2, bought_product_ids: [2], not_bought_variant_ids: [1])
+    end
+
+    it "counts by prices, matching combined filters within a single purchase" do
+      create_member(purchases: [{ "price_cents" => 0 }])
+      create_member(purchases: [{ "price_cents" => 100 }])
+      create_member(purchases: [{ "price_cents" => 200 }])
+      create_member(purchases: [
+                      { "product_id" => 7, "variant_ids" => [1], "price_cents" => 0 },
+                      { "product_id" => 8, "variant_ids" => [2], "price_cents" => 200 },
+                      { "product_id" => 9, "variant_ids" => [3], "price_cents" => 200 },
+                    ])
+      create_member(follower: {})
+
+      expect_filter_count(3, paid_more_than_cents: 0)
+      expect_filter_count(3, paid_more_than_cents: 50)
+      expect_filter_count(2, paid_more_than_cents: 100)
+      expect_filter_count(0, paid_more_than_cents: 250)
+
+      expect_filter_count(4, paid_less_than_cents: 250)
+      expect_filter_count(3, paid_less_than_cents: 200)
+      expect_filter_count(2, paid_less_than_cents: 100)
+      expect_filter_count(0, paid_less_than_cents: 0)
+
+      expect_filter_count(1, paid_more_than_cents: 50, paid_less_than_cents: 150)
+
+      expect_filter_count(0, paid_more_than_cents: 0, bought_product_ids: [7])
+      expect_filter_count(0, paid_more_than_cents: 0, bought_variant_ids: [1])
+      expect_filter_count(1, paid_more_than_cents: 0, bought_product_ids: [7, 8])
+      expect_filter_count(1, paid_more_than_cents: 0, bought_variant_ids: [1, 2])
+      expect_filter_count(1, paid_more_than_cents: 100, bought_product_ids: [9], bought_variant_ids: [2])
+    end
+
+    it "counts members with multiple matching purchases once" do
+      create_member(purchases: [
+                      { "price_cents" => 100 },
+                      { "price_cents" => 200 },
+                    ])
+
+      expect_filter_count(1, paid_more_than_cents: 0, paid_less_than_cents: 300)
+    end
+
+    it "counts by creation dates" do
+      create_member(follower: { "created_at" => 5.days.ago.iso8601 })
+      create_member(follower: { "created_at" => 4.days.ago.iso8601 })
+      create_member(
+        follower: { "created_at" => 3.days.ago.iso8601 },
+        purchases: [{ "product_id" => 6, "created_at" => 2.days.ago.iso8601 }]
+      )
+      create_member(purchases: [
+                      { "product_id" => 7, "variant_ids" => [1], "created_at" => 5.days.ago.iso8601 },
+                      { "product_id" => 8, "variant_ids" => [2], "created_at" => 1.day.ago.iso8601 }
+                    ])
+
+      expect_filter_count(2, created_after: 4.days.ago.iso8601)
+      expect_filter_count(4, created_before: 2.days.ago.iso8601)
+      expect_filter_count(1, created_after: 4.days.ago.iso8601, created_before: 2.days.ago.iso8601)
+      expect_filter_count(0, created_after: 4.days.ago.iso8601, created_before: 2.days.ago.iso8601, bought_product_ids: [6])
+      expect_filter_count(1, created_after: 4.days.ago.iso8601, created_before: 1.day.ago.iso8601, bought_product_ids: [6])
+    end
+
+    it "counts by type-specific creation dates" do
+      create_member(follower: { "created_at" => 10.days.ago.iso8601 }, purchases: [{ "product_id" => 1, "created_at" => 3.days.ago.iso8601 }])
+      create_member(follower: { "created_at" => 3.days.ago.iso8601 }, purchases: [{ "product_id" => 1, "created_at" => 10.days.ago.iso8601 }])
+      create_member(follower: { "created_at" => 3.days.ago.iso8601 }, purchases: [{ "product_id" => 1, "created_at" => 2.days.ago.iso8601 }])
+      create_member(follower: { "created_at" => 3.days.ago.iso8601 }, purchases: [
+                      { "id" => 1, "product_id" => 1, "created_at" => 10.days.ago.iso8601 },
+                      { "id" => 2, "product_id" => 1, "created_at" => 1.hour.ago.iso8601 },
+                    ])
+
+      expect_filter_count(3, type: "customer", created_after: 5.days.ago.iso8601)
+      expect_filter_count(3, type: "follower", created_after: 5.days.ago.iso8601)
+      expect_filter_count(1, type: "follower", created_after: 5.days.ago.iso8601, created_before: 1.day.ago.iso8601, bought_product_ids: [1])
+      expect_filter_count(2, type: "customer", created_before: 5.days.ago.iso8601)
+
+      expect_filter_count(2, type: "customer", created_after: 5.days.ago.iso8601, created_before: 1.day.ago.iso8601)
+      expect_filter_count(3, type: "follower", created_after: 5.days.ago.iso8601, created_before: 1.day.ago.iso8601)
+    end
+
+    it "counts by affiliate creation dates" do
+      create_member(follower: { "created_at" => 1.day.ago.iso8601 }, affiliates: [{ "product_id" => 1, "created_at" => 10.days.ago.iso8601 }])
+      create_member(purchases: [{ "created_at" => 10.days.ago.iso8601 }], affiliates: [{ "product_id" => 1, "created_at" => 1.day.ago.iso8601 }])
+      create_member(affiliates: [{ "product_id" => 2, "created_at" => 3.days.ago.iso8601 }])
+
+      expect_filter_count(2, type: "affiliate", created_after: 5.days.ago.iso8601)
+      expect_filter_count(1, type: "affiliate", created_before: 5.days.ago.iso8601)
+      expect_filter_count(1, type: "affiliate", created_after: 5.days.ago.iso8601, created_before: 2.days.ago.iso8601)
+      expect_filter_count(1, type: "affiliate", affiliate_product_ids: [1], created_after: 2.days.ago.iso8601)
+    end
+
+    it "counts by country" do
+      create_member(purchases: [{ "product_id" => 1, "country" => "United States" }])
+      create_member(purchases: [{ "product_id" => 1, "country" => "Canada" }])
+      create_member(purchases: [
+                      { "product_id" => 1, "country" => "United States" },
+                      { "product_id" => 2, "country" => "Canada" }
+                    ])
+      create_member(follower: {})
+
+      expect_filter_count(2, bought_from: "United States")
+      expect_filter_count(2, bought_from: "Canada")
+      expect_filter_count(1, bought_from: "Canada", bought_product_ids: [1, 3])
+      expect_filter_count(0, bought_from: "Mexico")
+    end
+
+    it "matches countries exactly, not case-insensitively" do
+      create_member(purchases: [
+                      { "id" => 1, "product_id" => 4, "country" => "UNITED STATES" },
+                      { "id" => 2, "product_id" => 5, "country" => "United States" },
+                    ])
+
+      expect_filter_count(1, bought_from: "United States")
+      expect_filter_count(1, bought_from: "UNITED STATES")
+      expect_filter_count(0, bought_from: "United States", bought_product_ids: [4])
+      expect_filter_count(1, bought_from: "United States", bought_product_ids: [5])
+    end
+
+    it "counts consistently when cutoff dates carry timezone offsets" do
+      create_member(purchases: [{ "id" => 1, "product_id" => 1, "created_at" => "2026-06-01T07:30:00Z" }])
+      create_member(purchases: [{ "id" => 2, "product_id" => 1, "created_at" => "2026-06-01T08:30:00Z" }])
+
+      expect_filter_count(1, created_before: "2026-05-31T23:59:59-08:00")
+      expect_filter_count(1, created_after: "2026-05-31T23:59:59-08:00")
+      expect_filter_count(1, bought_product_ids: [1], created_after: "2026-05-31T23:59:59-08:00", created_before: "2026-06-01T02:00:00-07:00")
+    end
+
+    it "counts by affiliate products" do
+      create_member(affiliates: [{ "product_id" => 1 }])
+      create_member(affiliates: [{ "product_id" => 2 }])
+      create_member(affiliates: [
+                      { "product_id" => 1, "created_at" => 3.days.ago.iso8601 },
+                      { "product_id" => 2, "created_at" => 2.days.ago.iso8601 },
+                      { "product_id" => 3, "created_at" => 1.day.ago.iso8601 },
+                    ])
+
+      expect_filter_count(2, affiliate_product_ids: [1])
+      expect_filter_count(2, affiliate_product_ids: [2])
+      expect_filter_count(3, affiliate_product_ids: [1, 2])
+      expect_filter_count(0, affiliate_product_ids: [1, 2], created_after: 2.days.ago.iso8601)
+      expect_filter_count(1, affiliate_product_ids: [1, 2], created_after: 3.days.ago.iso8601)
+    end
+
+    it "counts nothing when purchase and affiliate filters must match a single record" do
+      create_member(
+        purchases: [{ "product_id" => 1, "price_cents" => 200 }],
+        affiliates: [{ "product_id" => 2 }],
+      )
+
+      expect_filter_count(1, bought_product_ids: [1], affiliate_product_ids: [2])
+      expect_filter_count(0, bought_product_ids: [1], affiliate_product_ids: [2], paid_more_than_cents: 100)
+    end
+
+    it "caps the count at the limit" do
+      create_member(purchases: [{ "product_id" => 1 }])
+      create_member(purchases: [{ "product_id" => 1 }])
+      create_member(purchases: [{ "product_id" => 1 }])
+
+      expect(AudienceMember.filter_count(seller_id:, params: { bought_product_ids: [1] }, limit: 2)).to eq(2)
+      expect(AudienceMember.filter_count(seller_id:, params: { bought_product_ids: [1] }, limit: 5)).to eq(3)
+    end
+
+    it "keeps counts in sync when a member's details change or the member is destroyed" do
+      member = create(:audience_member, seller:, follower: { "id" => 1, "created_at" => 7.days.ago.iso8601 })
+
+      expect_filter_count(0, type: "customer")
+      expect_filter_count(1, type: "follower")
+
+      member.details["purchases"] = [{ "id" => 1, "product_id" => 1, "price_cents" => 200, "created_at" => 1.day.ago.iso8601 }]
+      member.save!
+
+      expect_filter_count(1, type: "customer")
+      expect_filter_count(1, paid_more_than_cents: 150)
+      expect(EsClient.get(index: AudienceMember.index_name, id: member.id)["_source"]).to eq(member.reload.as_indexed_json)
+
+      member.destroy!
+
+      expect_filter_count(0)
+    end
+
+    it "excludes members whose details were cleared outside callbacks from single-record filters" do
+      member = create_member(follower: { "created_at" => 5.days.ago.iso8601 })
+      member.update_columns(details: nil)
+      ElasticsearchIndexerWorker.new.perform("index", { "record_id" => member.id, "class_name" => "AudienceMember" })
+
+      expect_filter_count(1, type: "follower", created_after: 10.days.ago.iso8601)
+      expect_filter_count(0, type: "follower", created_after: 10.days.ago.iso8601, created_before: 1.day.ago.iso8601)
+    end
+
+    def expect_filter_count(expected, params = {})
+      expect(AudienceMember.filter_count(seller_id:, params:)).to eq(expected)
+      expect(AudienceMember.filter(seller_id:, params:).count).to eq(expected)
+    end
+
+    def create_member(details = {})
+      create(:audience_member, seller:, **details.with_indifferent_access.slice(:purchases, :follower, :affiliates))
+    end
+  end
+end

--- a/spec/models/concerns/purchase/searchable_spec.rb
+++ b/spec/models/concerns/purchase/searchable_spec.rb
@@ -265,14 +265,11 @@ describe Purchase::Searchable do
     end
 
     it "updates related purchases when deactivated_at changes" do
-      audience_member = AudienceMember.find_by(email: @purchase_1.email, seller_id: @purchase_1.seller_id)
-
       @subscription.deactivate!
 
-      expect(ElasticsearchIndexerWorker.jobs.size).to eq(3)
+      expect(ElasticsearchIndexerWorker.jobs.size).to eq(2)
       expect(ElasticsearchIndexerWorker).to have_enqueued_sidekiq_job("update", "record_id" => @purchase_1.id, "class_name" => "Purchase", "fields" => ["subscription_deactivated_at"])
       expect(ElasticsearchIndexerWorker).to have_enqueued_sidekiq_job("update", "record_id" => @purchase_2.id, "class_name" => "Purchase", "fields" => ["subscription_deactivated_at"])
-      expect(ElasticsearchIndexerWorker).to have_enqueued_sidekiq_job("delete", "record_id" => audience_member.id, "class_name" => "AudienceMember")
     end
 
     it "does not update related purchases when unrelated attributes changes" do

--- a/spec/models/concerns/purchase/searchable_spec.rb
+++ b/spec/models/concerns/purchase/searchable_spec.rb
@@ -265,11 +265,14 @@ describe Purchase::Searchable do
     end
 
     it "updates related purchases when deactivated_at changes" do
+      audience_member = AudienceMember.find_by(email: @purchase_1.email, seller_id: @purchase_1.seller_id)
+
       @subscription.deactivate!
 
-      expect(ElasticsearchIndexerWorker.jobs.size).to eq(2)
+      expect(ElasticsearchIndexerWorker.jobs.size).to eq(3)
       expect(ElasticsearchIndexerWorker).to have_enqueued_sidekiq_job("update", "record_id" => @purchase_1.id, "class_name" => "Purchase", "fields" => ["subscription_deactivated_at"])
       expect(ElasticsearchIndexerWorker).to have_enqueued_sidekiq_job("update", "record_id" => @purchase_2.id, "class_name" => "Purchase", "fields" => ["subscription_deactivated_at"])
+      expect(ElasticsearchIndexerWorker).to have_enqueued_sidekiq_job("delete", "record_id" => audience_member.id, "class_name" => "AudienceMember")
     end
 
     it "does not update related purchases when unrelated attributes changes" do

--- a/spec/models/installment_spec.rb
+++ b/spec/models/installment_spec.rb
@@ -963,6 +963,23 @@ const b = 2;</code></pre>
       expect(@post.audience_members_count).to eq(2)
       expect(@post.audience_members_count(1)).to eq(1) # supports a limit, for extra performance
     end
+
+    context "when the audience_count_from_elasticsearch feature is active", :sidekiq_inline, :elasticsearch_wait_for_refresh do
+      before do
+        recreate_model_index(AudienceMember)
+        Feature.activate_user(:audience_count_from_elasticsearch, @post.seller)
+      end
+
+      it "counts audience members through Elasticsearch" do
+        expect(AudienceMember).to receive(:filter_count).exactly(3).times.and_call_original
+
+        expect(@post.audience_members_count).to eq(0)
+        create(:audience_member, seller: @post.seller, purchases: [{ "id" => 1 }])
+        create(:audience_member, seller: @post.seller, purchases: [{ "id" => 2 }])
+        expect(@post.audience_members_count).to eq(2)
+        expect(@post.audience_members_count(1)).to eq(1)
+      end
+    end
   end
 
   describe "#send_preview_email" do

--- a/spec/services/gdpr_buyer_erasure_service_spec.rb
+++ b/spec/services/gdpr_buyer_erasure_service_spec.rb
@@ -388,10 +388,54 @@ describe GdprBuyerErasureService do
           fresh = AudienceMember.new(seller: seller, email: buyer_email, details: { purchases: [{ id: 2 }] })
           fresh.save!(validate: false)
 
+          anonymized_member_ids = AudienceMember.where(email: buyer_email).where.not(id: fresh.id).ids
+          ElasticsearchIndexerWorker.jobs.clear
+
           expect { described_class.new(buyer_email, performed_by: admin).perform! }.not_to raise_error
           expect(AudienceMember.where(seller: seller, email: buyer_email).count).to eq(0)
           expect(AudienceMember.where(id: existing_anonymized.id)).to exist
           expect(AudienceMember.where(id: fresh.id)).not_to exist
+
+          indexer_args = ElasticsearchIndexerWorker.jobs.map { _1["args"] }
+          expect(indexer_args).to include(["delete", { "record_id" => fresh.id, "class_name" => "AudienceMember" }])
+          expect(anonymized_member_ids).to be_present
+          anonymized_member_ids.each do |member_id|
+            reindex_args = indexer_args.find { _1[0] == "index" && _1[1]["record_id"] == member_id }
+            expect(reindex_args).to be_present
+          end
+        end
+      end
+
+      describe "audience members Elasticsearch sync" do
+        it "reindexes anonymized members with the anonymized document passed inline" do
+          anonymized = described_class.new(buyer_email, performed_by: admin).send(:generate_anonymized_email)
+          member_ids = AudienceMember.where(email: buyer_email).ids
+          expect(member_ids).to be_present
+          ElasticsearchIndexerWorker.jobs.clear
+
+          described_class.new(buyer_email, performed_by: admin).perform!
+
+          audience_member_args = ElasticsearchIndexerWorker.jobs.map { _1["args"] }.select { _1[1]["class_name"] == "AudienceMember" }
+          expect(audience_member_args.count { _1[0] == "delete" }).to eq(0)
+          member_ids.each do |member_id|
+            reindex_args = audience_member_args.find { _1[0] == "index" && _1[1]["record_id"] == member_id }
+            expect(reindex_args).to be_present
+            expect(reindex_args[1]["body"]).to include(
+              "email" => anonymized,
+              "customer" => false,
+              "follower" => false,
+              "affiliate" => false,
+              "purchases" => [],
+              "affiliates" => [],
+              "follower_id" => nil,
+            )
+          end
+
+          AudienceMember.where(id: member_ids).each do |member|
+            expect(member.customer).to eq(false)
+            expect(member.min_paid_cents).to be_nil
+            expect(member.max_purchase_created_at).to be_nil
+          end
         end
       end
 

--- a/spec/services/onetime/backfill_audience_members_index_spec.rb
+++ b/spec/services/onetime/backfill_audience_members_index_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Onetime::BackfillAudienceMembersIndex do
+  before do
+    recreate_model_index(AudienceMember)
+    $redis.del(described_class::REDIS_CURSOR_KEY)
+    $redis.del(described_class::REDIS_FAILED_IDS_KEY)
+  end
+
+  it "bulk indexes all audience members in batches and tracks the cursor" do
+    members = create_list(:audience_member, 3)
+
+    described_class.process(batch_size: 2)
+    AudienceMember.__elasticsearch__.refresh_index!
+
+    members.each do |member|
+      expect(EsClient.exists?(index: AudienceMember.index_name, id: member.id)).to eq(true)
+    end
+    document = EsClient.get(index: AudienceMember.index_name, id: members.first.id)["_source"]
+    expect(document).to eq(members.first.as_indexed_json)
+    expect($redis.get(described_class::REDIS_CURSOR_KEY).to_i).to eq(members.last.id)
+  end
+
+  it "resumes from the stored cursor" do
+    members = create_list(:audience_member, 3)
+    $redis.set(described_class::REDIS_CURSOR_KEY, members.second.id)
+
+    described_class.process
+    AudienceMember.__elasticsearch__.refresh_index!
+
+    expect(EsClient.exists?(index: AudienceMember.index_name, id: members.first.id)).to eq(false)
+    expect(EsClient.exists?(index: AudienceMember.index_name, id: members.second.id)).to eq(false)
+    expect(EsClient.exists?(index: AudienceMember.index_name, id: members.last.id)).to eq(true)
+  end
+
+  it "removes documents whose members no longer exist" do
+    member = create(:audience_member)
+    deleted_member = create(:audience_member)
+
+    described_class.process
+    AudienceMember.__elasticsearch__.refresh_index!
+    expect(EsClient.exists?(index: AudienceMember.index_name, id: deleted_member.id)).to eq(true)
+
+    deleted_member.delete
+    described_class.process
+    AudienceMember.__elasticsearch__.refresh_index!
+
+    expect(EsClient.exists?(index: AudienceMember.index_name, id: member.id)).to eq(true)
+    expect(EsClient.exists?(index: AudienceMember.index_name, id: deleted_member.id)).to eq(false)
+  end
+
+  it "records members that fail to index without blocking the rest of the backfill" do
+    member = create(:audience_member)
+    other_member = create(:audience_member)
+    allow(EsClient).to receive(:bulk).and_wrap_original do |original, *args, **kwargs|
+      response = original.call(*args, **kwargs)
+      response["errors"] = true
+      response["items"] = [{ "index" => { "_id" => member.id.to_s, "error" => { "type" => "mapper_parsing_exception" } } }]
+      response
+    end
+
+    described_class.process(batch_size: 1)
+
+    expect($redis.smembers(described_class::REDIS_FAILED_IDS_KEY)).to eq([member.id.to_s])
+    expect($redis.get(described_class::REDIS_CURSOR_KEY).to_i).to eq(other_member.id)
+  end
+
+  it "suppresses indexer 404s only while the backfill is running" do
+    create(:audience_member)
+    ignore_set_during_run = nil
+    allow_any_instance_of(described_class).to receive(:delete_stale_documents) do
+      ignore_set_during_run = $redis.smembers(RedisKey.elasticsearch_indexer_worker_ignore_404_errors_on_indices)
+    end
+
+    described_class.process
+
+    expect(ignore_set_during_run).to include(AudienceMember.index_name)
+    expect($redis.smembers(RedisKey.elasticsearch_indexer_worker_ignore_404_errors_on_indices)).not_to include(AudienceMember.index_name)
+  end
+end

--- a/spec/services/onetime/backfill_audience_members_index_spec.rb
+++ b/spec/services/onetime/backfill_audience_members_index_spec.rb
@@ -9,6 +9,14 @@ describe Onetime::BackfillAudienceMembersIndex do
     $redis.del(described_class::REDIS_FAILED_IDS_KEY)
   end
 
+  it "raises when the index does not exist" do
+    AudienceMember.__elasticsearch__.delete_index!
+
+    expect do
+      described_class.process
+    end.to raise_error(/#{AudienceMember.index_name} index is missing/)
+  end
+
   it "bulk indexes all audience members in batches and tracks the cursor" do
     members = create_list(:audience_member, 3)
 
@@ -65,6 +73,56 @@ describe Onetime::BackfillAudienceMembersIndex do
 
     expect($redis.smembers(described_class::REDIS_FAILED_IDS_KEY)).to eq([member.id.to_s])
     expect($redis.get(described_class::REDIS_CURSOR_KEY).to_i).to eq(other_member.id)
+  end
+
+  context "when scoped to a seller" do
+    let(:seller) { create(:user) }
+    let(:cursor_key) { "#{described_class::REDIS_CURSOR_KEY}_seller_#{seller.id}" }
+
+    before do
+      $redis.del(cursor_key)
+    end
+
+    it "indexes only that seller's members and tracks a per-seller cursor" do
+      seller_members = create_list(:audience_member, 2, seller:)
+      other_member = create(:audience_member)
+
+      described_class.process(batch_size: 1, seller_id: seller.id)
+      AudienceMember.__elasticsearch__.refresh_index!
+
+      seller_members.each do |member|
+        expect(EsClient.exists?(index: AudienceMember.index_name, id: member.id)).to eq(true)
+      end
+      expect(EsClient.exists?(index: AudienceMember.index_name, id: other_member.id)).to eq(false)
+      expect($redis.get(cursor_key).to_i).to eq(seller_members.last.id)
+      expect($redis.get(described_class::REDIS_CURSOR_KEY)).to be_nil
+    end
+
+    it "removes only that seller's stale documents" do
+      stale_seller_member = create(:audience_member, seller:)
+      other_member = create(:audience_member)
+
+      described_class.process
+      AudienceMember.__elasticsearch__.refresh_index!
+      stale_seller_member.delete
+      other_member.delete
+
+      described_class.process(seller_id: seller.id)
+      AudienceMember.__elasticsearch__.refresh_index!
+
+      expect(EsClient.exists?(index: AudienceMember.index_name, id: stale_seller_member.id)).to eq(false)
+      expect(EsClient.exists?(index: AudienceMember.index_name, id: other_member.id)).to eq(true)
+    end
+
+    it "keeps suppressing indexer 404s after the run" do
+      create(:audience_member, seller:)
+
+      described_class.process(seller_id: seller.id)
+
+      expect($redis.smembers(RedisKey.elasticsearch_indexer_worker_ignore_404_errors_on_indices)).to include(AudienceMember.index_name)
+    ensure
+      $redis.srem(RedisKey.elasticsearch_indexer_worker_ignore_404_errors_on_indices, AudienceMember.index_name)
+    end
   end
 
   it "suppresses indexer 404s only while the backfill is running" do

--- a/spec/support/elasticsearch.rb
+++ b/spec/support/elasticsearch.rb
@@ -72,7 +72,7 @@ class ElasticsearchSetup
     end
 
     # Ensure indices are ready: same settings, same mapping, zero documents
-    models = [Link, Balance, Purchase, Installment, ConfirmedFollowerEvent, ProductPageView]
+    models = [Link, Balance, Purchase, Installment, ConfirmedFollowerEvent, ProductPageView, AudienceMember]
     models.each do |model|
       model.index_name("#{model.name.parameterize}-test")
     end


### PR DESCRIPTION
## What

- **Index audience members in Elasticsearch.** New `AudienceMember::Searchable` concern: one document per member with `nested` purchases/affiliates arrays and scalar follower/derived fields, kept in sync through the existing `ElasticsearchModelAsyncCallbacks` → `ElasticsearchIndexerWorker` pipeline — but only for flag-enabled sellers. Audience members churn on every purchase and follow across all sellers, so a prepended `GatedAsyncIndexing` module drops the indexing callbacks for sellers without the flag instead of enqueuing jobs for documents nobody queries.
- **Serve recipient counts from ES.** `AudienceMember.filter_count` translates the audience filter params into an ES `_count` query (`terminate_after` for capped counts) that structurally mirrors the SQL built by `AudienceMember.filter` — including the `JSON_TABLE` semantics where combined filters must match within a single purchase/follower/affiliate record.
- **Flag-gated rollout.** `Installment#audience_members_count` uses ES when the `audience_count_from_elasticsearch` Flipper flag is enabled for the seller; the MySQL path remains otherwise and continues to power the blast/workflow send jobs.
- **Index creation via migration.** `CreateAudienceMembersIndex` creates the index up front, using the versioned-index-plus-alias layout (`audience_members_v1` aliased as `audience_members`) the other ES index migrations use in production/staging. A callback write racing manual index creation would auto-create the index with a dynamic mapping instead of the strict one — so the backfill also refuses to run if the index is missing rather than creating it itself.
- **Backfill.** `Onetime::BackfillAudienceMembersIndex`: cursor-resumable bulk indexing with failed-id tracking in Redis and a stale-document sweep for members destroyed mid-backfill. Accepts `seller_id:` to backfill a single seller for a piloted rollout — seller-scoped runs keep their own Redis cursor, sweep only that seller's stale documents, and deliberately leave the indexer 404 suppression in place since other sellers' rows remain unindexed until the full run.
- **GDPR sync.** Buyer erasure writes with `update_all`/`delete_all` (no callbacks), so it now syncs the index explicitly and unconditionally — deletes already ignore 404s, and the anonymized inline body is the safe state to index regardless of the seller's flag — clearing the denormalized columns it previously left stale and passing the anonymized document body inline so a lagging replica read can never re-index pre-erasure PII.
- **SQL consistency fix.** The `JSON_TABLE` country comparison used the connection's case-insensitive collation while the coarse `JSON_CONTAINS` check is binary-exact; it now compares with `COLLATE utf8mb4_bin` so both — and the ES translation — agree.

## Why

Filtering an email audience by product, variant, or country runs `JSON_CONTAINS`/`JSON_TABLE` against the `details` JSON column on `audience_members`, which MySQL cannot index — every recipient count is a full scan of the seller's audience rows, evaluating the JSON path per row. For large sellers the count on the email form takes over a minute or times out (#5361). MySQL multi-valued indexes are not an option because a single member's purchases can exceed the ~1604-key-per-record limit (ERROR 3905 on save). Elasticsearch indexes array fields natively with no per-record limit, so the product/variant/country filters become indexed `terms`/`range` queries.

The ES query deliberately mirrors the SQL's structure (coarse member-level clauses + the same-record conjunction) rather than being written from scratch: the blast jobs still select recipients via the SQL path, so the displayed count must always equal the actual send. The parity spec battery runs the same filter scenarios through both engines and asserts identical counts pinned to literal values, including the degenerate combinations.

Closes #5361.

## Rollout

Because indexing is gated on the same flag as reads, a seller's documents only start syncing at flag-flip time — so each enablement is flag first, backfill immediately after (the count may briefly undercount until the backfill completes).

1. Deploy. The migration creates the index (with the strict mapping); the flag stays off, so nothing writes to it yet.
2. Console: `$redis.sadd(RedisKey.elasticsearch_indexer_worker_ignore_404_errors_on_indices, "audience_members")` so partial-update jobs racing a backfill no-op instead of retrying into the dead set. The full backfill clears this entry on completion; seller-scoped runs intentionally don't.
3. Pilot one seller: `Feature.activate_user(:audience_count_from_elasticsearch, user)` (live updates start syncing), then `Onetime::BackfillAudienceMembersIndex.process(seller_id: ...)` to index their history, then compare ES counts against the SQL counts on their installments. Every other seller keeps the MySQL path and produces no indexing load.
4. Wider rollout: enable the flag for the next cohort, run the full backfill (resumable via Redis cursor; per-document failures land in the `onetime_backfill_audience_members_index_failed_ids` set).

Follow-ups intentionally out of scope: moving the blast/workflow `with_ids` recipient selection and `resendable_to_non_openers_emails` to ES, and cleaning up legacy GDPR-anonymized rows whose denormalized columns are stale.

## Before/After

Before: on a large account, selecting a product under "Users who bought" leaves the recipient count loading for over a minute or it times out. After (flag on): the count is served by an indexed ES query.

_Draft — demo video and staging QA steps will be added before marking ready for review._

## Test Results

```
spec/models/concerns/audience_member/searchable_spec.rb        21 examples, 0 failures
spec/models/audience_member_spec.rb                             14 examples, 0 failures
spec/services/onetime/backfill_audience_members_index_spec.rb    9 examples, 0 failures
spec/services/gdpr_buyer_erasure_service_spec.rb                37 examples, 0 failures
spec/models/installment_spec.rb (#audience_members_count)        2 examples, 0 failures
spec/sidekiq/send_post_blast_emails_job_spec.rb
spec/sidekiq/send_workflow_post_emails_job_spec.rb
spec/controllers/api/internal/installments/*_counts_*           84 examples, 0 failures (combined)
spec/models/concerns/purchase/searchable_spec.rb
spec/modules/elasticsearch_model_async_callbacks_spec.rb
```

---

AI disclosure: implemented with Claude Code using the Claude Fable 5 model, including an adversarial multi-agent review pass over the SQL↔ES parity semantics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches GDPR erasure and PII indexing paths, and displayed counts must stay identical to SQL blast selection—parity bugs or stale ES docs would mislead senders.
> 
> **Overview**
> Adds **Elasticsearch-backed audience recipient counts** for email installments, gated by `audience_count_from_elasticsearch`, while blast/workflow recipient selection stays on MySQL `AudienceMember.filter`.
> 
> **Indexing & queries:** New `AudienceMember::Searchable` defines a strict `audience_members` index (nested purchases/affiliates, denormalized scalars), async sync via the existing indexer pipeline only when the flag is on for the seller. `filter_count` / `filter_query` mirror SQL filter semantics (including same-record `JSON_TABLE` conjunctions). Shared `normalize_filter_params` / `FILTER_PARAM_KEYS` centralize param handling.
> 
> **Rollout & ops:** Migration creates the index (versioned alias in prod/staging). `Onetime::BackfillAudienceMembersIndex` bulk-indexes with Redis cursor, failure tracking, stale-doc sweep, optional `seller_id`. Dev tools and ES test setup include `AudienceMember`.
> 
> **Integrations:** `Installment#audience_members_count` uses ES when flagged. **GDPR buyer erasure** clears denormalized columns, enqueues ES delete/index with inline anonymized bodies (no callback reliance). **SQL fix:** `bought_from` in the JSON_TABLE path uses `COLLATE utf8mb4_bin` to align with `JSON_CONTAINS` and ES country matching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9509d964993dd315fd97393fdbcc2b5e81e4ab01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->