### PR TITLE
Pace the audience members backfill through Sidekiq

### DIFF
--- a/app/services/onetime/backfill_audience_members_index.rb
+++ b/app/services/onetime/backfill_audience_members_index.rb
@@ -2,6 +2,8 @@
 
 class Onetime::BackfillAudienceMembersIndex
   BATCH_SIZE = 500
+  ROWS_PER_JOB = 25_000
+  DEFAULT_SPREAD_DURATION = 30.minutes
   REDIS_CURSOR_KEY = "onetime_backfill_audience_members_index_last_id"
   REDIS_FAILED_IDS_KEY = "onetime_backfill_audience_members_index_failed_ids"
 
@@ -9,16 +11,19 @@ class Onetime::BackfillAudienceMembersIndex
     new(batch_size:, seller_id:).process
   end
 
-  def initialize(batch_size: BATCH_SIZE, seller_id: nil)
+  def self.spread(duration: DEFAULT_SPREAD_DURATION, rows_per_job: ROWS_PER_JOB, batch_size: BATCH_SIZE, seller_id: nil)
+    new(batch_size:, seller_id:, duration:, rows_per_job:).spread
+  end
+
+  def initialize(batch_size: BATCH_SIZE, seller_id: nil, duration: DEFAULT_SPREAD_DURATION, rows_per_job: ROWS_PER_JOB)
     @batch_size = batch_size
     @seller_id = seller_id
+    @duration = duration
+    @rows_per_job = rows_per_job
   end
 
   def process
-    # Creating the index here instead would race the CreateAudienceMembersIndex migration's
-    # versioned-index-plus-alias layout, and a bulk write to a missing index would auto-create
-    # it with a dynamic mapping instead of the strict one.
-    raise "The #{AudienceMember.index_name} index is missing; run the CreateAudienceMembersIndex migration first" unless AudienceMember.__elasticsearch__.index_exists?
+    ensure_index_exists!
     $redis.sadd(RedisKey.elasticsearch_indexer_worker_ignore_404_errors_on_indices, AudienceMember.index_name)
 
     loop do
@@ -41,8 +46,49 @@ class Onetime::BackfillAudienceMembersIndex
     puts "Done. #{failed_count} members failed to index; ids are in the #{REDIS_FAILED_IDS_KEY} redis set." if failed_count > 0
   end
 
+  # Paces the backfill through Sidekiq instead of running it inline: id ranges are
+  # enqueued as jobs spaced evenly so the whole run completes in roughly `duration`.
+  # Advances the cursor past the covered ranges, so a later `process` call only picks
+  # up members created since, runs the stale-document sweep, and finalizes the run.
+  def spread
+    ensure_index_exists!
+    $redis.sadd(RedisKey.elasticsearch_indexer_worker_ignore_404_errors_on_indices, AudienceMember.index_name)
+
+    ranges = []
+    last_id = last_processed_id
+    loop do
+      ids = scope.where("id > ?", last_id).order(:id).limit(rows_per_job).pluck(:id)
+      break if ids.empty?
+      ranges << [ids.first, ids.last]
+      last_id = ids.last
+    end
+    return puts("Nothing to index.") if ranges.empty?
+
+    interval = duration.to_f / ranges.size
+    ranges.each_with_index do |(start_id, end_id), index|
+      BackfillAudienceMembersIndexJob.perform_in(interval * index, start_id, end_id, seller_id, batch_size)
+    end
+    $redis.set(cursor_key, last_id)
+    puts "Enqueued #{ranges.size} jobs over ~#{(duration / 60).round} minutes. " \
+         "Once the queue drains, run process(seller_id: #{seller_id.inspect}) to index stragglers and sweep stale documents."
+  end
+
+  def index_range(start_id, end_id)
+    scope.where(id: start_id..end_id).in_batches(of: batch_size) do |batch|
+      ReplicaLagWatcher.watch
+      bulk_index(batch.to_a)
+    end
+  end
+
   private
-    attr_reader :batch_size, :seller_id
+    attr_reader :batch_size, :seller_id, :duration, :rows_per_job
+
+    def ensure_index_exists!
+      # Creating the index here instead would race the CreateAudienceMembersIndex migration's
+      # versioned-index-plus-alias layout, and a bulk write to a missing index would auto-create
+      # it with a dynamic mapping instead of the strict one.
+      raise "The #{AudienceMember.index_name} index is missing; run the CreateAudienceMembersIndex migration first" unless AudienceMember.__elasticsearch__.index_exists?
+    end
 
     def scope
       seller_id ? AudienceMember.where(seller_id:) : AudienceMember.all

--- a/app/sidekiq/backfill_audience_members_index_job.rb
+++ b/app/sidekiq/backfill_audience_members_index_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class BackfillAudienceMembersIndexJob
+  include Sidekiq::Job
+  sidekiq_options queue: :mongo, retry: 5, lock: :until_executed
+
+  def perform(start_id, end_id, seller_id = nil, batch_size = Onetime::BackfillAudienceMembersIndex::BATCH_SIZE)
+    Onetime::BackfillAudienceMembersIndex.new(batch_size:, seller_id:).index_range(start_id, end_id)
+  end
+end

--- a/spec/services/onetime/backfill_audience_members_index_spec.rb
+++ b/spec/services/onetime/backfill_audience_members_index_spec.rb
@@ -125,6 +125,65 @@ describe Onetime::BackfillAudienceMembersIndex do
     end
   end
 
+  describe ".spread" do
+    after do
+      $redis.srem(RedisKey.elasticsearch_indexer_worker_ignore_404_errors_on_indices, AudienceMember.index_name)
+    end
+
+    it "enqueues paced range jobs covering all members and advances the cursor" do
+      members = create_list(:audience_member, 5)
+
+      described_class.spread(duration: 30.minutes, rows_per_job: 2, batch_size: 100)
+
+      jobs = BackfillAudienceMembersIndexJob.jobs
+      expect(jobs.size).to eq(3)
+      expect(jobs.map { _1["args"] }).to eq([
+                                              [members[0].id, members[1].id, nil, 100],
+                                              [members[2].id, members[3].id, nil, 100],
+                                              [members[4].id, members[4].id, nil, 100],
+                                            ])
+      expect(jobs.first["at"]).to be_nil
+      expect(jobs.second["at"]).to be_within(2).of(10.minutes.from_now.to_f)
+      expect(jobs.third["at"]).to be_within(2).of(20.minutes.from_now.to_f)
+      expect($redis.get(described_class::REDIS_CURSOR_KEY).to_i).to eq(members.last.id)
+      expect($redis.smembers(RedisKey.elasticsearch_indexer_worker_ignore_404_errors_on_indices)).to include(AudienceMember.index_name)
+    end
+
+    it "scopes ranges to the seller and uses the per-seller cursor" do
+      seller = create(:user)
+      member = create(:audience_member, seller:)
+      create(:audience_member)
+
+      described_class.spread(seller_id: seller.id)
+
+      jobs = BackfillAudienceMembersIndexJob.jobs
+      expect(jobs.size).to eq(1)
+      expect(jobs.first["args"]).to eq([member.id, member.id, seller.id, described_class::BATCH_SIZE])
+      expect($redis.get("#{described_class::REDIS_CURSOR_KEY}_seller_#{seller.id}").to_i).to eq(member.id)
+      expect($redis.get(described_class::REDIS_CURSOR_KEY)).to be_nil
+    end
+
+    it "starts ranges after the stored cursor" do
+      members = create_list(:audience_member, 3)
+      $redis.set(described_class::REDIS_CURSOR_KEY, members.second.id)
+
+      described_class.spread
+
+      expect(BackfillAudienceMembersIndexJob.jobs.map { _1["args"] }).to eq(
+        [[members.third.id, members.third.id, nil, described_class::BATCH_SIZE]]
+      )
+    end
+
+    it "raises when the index does not exist" do
+      AudienceMember.__elasticsearch__.delete_index!
+
+      expect do
+        described_class.spread
+      end.to raise_error(/index is missing/)
+      expect(BackfillAudienceMembersIndexJob.jobs).to be_empty
+    end
+  end
+
   it "suppresses indexer 404s only while the backfill is running" do
     create(:audience_member)
     ignore_set_during_run = nil

--- a/spec/sidekiq/backfill_audience_members_index_job_spec.rb
+++ b/spec/sidekiq/backfill_audience_members_index_job_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe BackfillAudienceMembersIndexJob do
+  before do
+    recreate_model_index(AudienceMember)
+  end
+
+  it "indexes only members within the id range" do
+    members = create_list(:audience_member, 3)
+
+    described_class.new.perform(members.first.id, members.second.id)
+    AudienceMember.__elasticsearch__.refresh_index!
+
+    expect(EsClient.exists?(index: AudienceMember.index_name, id: members.first.id)).to eq(true)
+    expect(EsClient.exists?(index: AudienceMember.index_name, id: members.second.id)).to eq(true)
+    expect(EsClient.exists?(index: AudienceMember.index_name, id: members.third.id)).to eq(false)
+    document = EsClient.get(index: AudienceMember.index_name, id: members.first.id)["_source"]
+    expect(document).to eq(members.first.as_indexed_json)
+  end
+
+  it "scopes the range to the seller when seller_id is given" do
+    seller = create(:user)
+    member = create(:audience_member, seller:)
+    other_member = create(:audience_member)
+    range = [member.id, other_member.id].minmax
+
+    described_class.new.perform(range.first, range.last, seller.id)
+    AudienceMember.__elasticsearch__.refresh_index!
+
+    expect(EsClient.exists?(index: AudienceMember.index_name, id: member.id)).to eq(true)
+    expect(EsClient.exists?(index: AudienceMember.index_name, id: other_member.id)).to eq(false)
+  end
+end


### PR DESCRIPTION
## What

Adds a paced, async mode to `Onetime::BackfillAudienceMembersIndex` so the backfill can run through Sidekiq instead of inline in a console session:

- **`Onetime::BackfillAudienceMembersIndex.spread(duration:, rows_per_job:, batch_size:, seller_id:)`** slices the member id space into ranges (chunked id plucks, so memory stays bounded for the full 141M-row run) and enqueues one `BackfillAudienceMembersIndexJob` per range, spaced evenly across `duration` (default 30 minutes). The duration is configurable per invocation.
- **`BackfillAudienceMembersIndexJob`** (queue `mongo`, `lock: :until_executed`) indexes its id range in batches with `ReplicaLagWatcher` pacing — the same bulk-index path (and failed-id tracking) as the inline mode, exposed as `index_range`.
- `spread` advances the redis cursor past the covered ranges, so a follow-up `process` call after the queue drains only indexes members created since the enqueue, runs the stale-document sweep, and finalizes the run (clearing the 404 suppression for full runs). The console output says exactly that.

## Why

The inline backfill holds a console session open for the whole run and offers no control over pacing — fine for a single-seller pilot, but the eventual full backfill is hours of sequential work. Fanning out through Sidekiq survives console disconnects, and spacing the enqueues makes load on the replica and the ES cluster a deliberate choice (complete in ~30 minutes, or stretch over hours by passing a longer duration) instead of "as fast as one process can loop".

Range jobs are idempotent — each is a full-document overwrite keyed on `_id` — so Sidekiq retries replace the cursor as the resume mechanism, and `lock: :until_executed` makes accidental double-enqueues a no-op. The `mongo` queue is the designated home for one-time bulk-migration work, so backfill jobs never compete with product-critical queues.

Follow-up to #5449, which is now merged.

## Before/After

Non-user-facing. Before: `process(seller_id:)` loops sequentially in the console until done. After: `spread(seller_id:, duration: 30.minutes)` returns immediately, jobs land on the `mongo` queue paced across the window, then one `process` call sweeps and finalizes.

_Draft — walkthrough video and staging QA steps to be added before marking ready for review._

## Test Results

```
spec/services/onetime/backfill_audience_members_index_spec.rb   13 examples, 0 failures
spec/sidekiq/backfill_audience_members_index_job_spec.rb         2 examples, 0 failures
```

---

AI disclosure: implemented with Claude Code using the Claude Fable 5 model.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783779336&installation_id=134400930&pr_number=5453&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5453&signature=7ee72f5b17a749be92252bccb2be47e6b71695620156c4acbfd15d76c8278e10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches large-scale Elasticsearch bulk indexing and replica load, but jobs are idempotent overwrites on a dedicated queue with existing cursor and 404-suppression semantics.
> 
> **Overview**
> Adds a **paced Sidekiq path** for the audience-members Elasticsearch backfill so operators can enqueue work instead of holding an open console loop.
> 
> **`Onetime::BackfillAudienceMembersIndex.spread`** walks the id space in chunks (default 25k rows per range), enqueues **`BackfillAudienceMembersIndexJob`** with **`perform_in`** so jobs are spread across a configurable window (default 30 minutes), and advances the Redis cursor so a later **`process`** only handles stragglers, stale-doc cleanup, and full-run finalization. **`index_range`** reuses the existing bulk-index path with **`ReplicaLagWatcher`** per batch. Index-existence checks are moved to **`ensure_index_exists!`** for both **`process`** and **`spread`**.
> 
> The new job runs on the **`mongo`** queue with retries and **`lock: :until_executed`**. Specs cover spread pacing, seller/cursor scoping, and range indexing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c35a966e606118ed783ed81fac8cdaa9cd814c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->