### PR TITLE
Split audience members indexing onto its own feature flag

### DIFF
--- a/app/models/concerns/audience_member/searchable.rb
+++ b/app/models/concerns/audience_member/searchable.rb
@@ -6,14 +6,16 @@ module AudienceMember::Searchable
   PURCHASE_DETAIL_KEYS = %w[id product_id variant_ids price_cents created_at country].freeze
   AFFILIATE_DETAIL_KEYS = %w[id product_id created_at].freeze
 
-  # Audience members churn on every purchase and follow across all sellers, but only
-  # flag-enabled sellers are served from this index, so sellers without the flag don't
-  # enqueue indexing jobs. Enabling a seller must therefore be followed by a
-  # seller-scoped backfill: their documents only start syncing at flag-flip time.
+  # Audience members churn on every purchase and follow across all sellers, so only
+  # sellers being rolled out enqueue indexing jobs. The index_audience_members flag
+  # turns on syncing ahead of the audience_count_from_elasticsearch read flag: backfill
+  # and verify the data while counts still come from SQL, then flip the read flag on a
+  # complete index. The read flag also implies syncing so a mis-ordered rollout serves
+  # an index that is merely incomplete, never one that silently rots.
   module GatedAsyncIndexing
     private
       def send_to_elasticsearch(action)
-        return unless Feature.active?(:audience_count_from_elasticsearch, seller)
+        return unless Feature.active?(:index_audience_members, seller) || Feature.active?(:audience_count_from_elasticsearch, seller)
         super
       end
   end

--- a/spec/models/concerns/audience_member/searchable_spec.rb
+++ b/spec/models/concerns/audience_member/searchable_spec.rb
@@ -55,9 +55,9 @@ describe AudienceMember::Searchable, :freeze_time do
   end
 
   describe "indexing callbacks" do
-    it "enqueues indexing jobs on create, update, and destroy when the seller's flag is on" do
+    it "enqueues indexing jobs on create, update, and destroy when the seller's indexing flag is on" do
       seller = create(:user)
-      Feature.activate_user(:audience_count_from_elasticsearch, seller)
+      Feature.activate_user(:index_audience_members, seller)
 
       member = nil
       expect do
@@ -80,7 +80,16 @@ describe AudienceMember::Searchable, :freeze_time do
       expect(ElasticsearchIndexerWorker.jobs.last["args"]).to eq(["delete", { "record_id" => member.id, "class_name" => "AudienceMember" }])
     end
 
-    it "enqueues nothing when the seller's flag is off" do
+    it "enqueues indexing jobs when only the count flag is on" do
+      seller = create(:user)
+      Feature.activate_user(:audience_count_from_elasticsearch, seller)
+
+      expect do
+        create(:audience_member, seller:, purchases: [{ "id" => 1 }])
+      end.to change { ElasticsearchIndexerWorker.jobs.size }.by(2)
+    end
+
+    it "enqueues nothing when the seller's flags are off" do
       member = nil
       expect do
         member = create(:audience_member, purchases: [{ "id" => 1 }])


### PR DESCRIPTION
## What

Gates the audience members async indexing callbacks on a new `index_audience_members` Flipper flag (actor: seller) instead of the `audience_count_from_elasticsearch` read flag. The read flag still implies indexing, so enabling it without the new flag keeps documents syncing — a mis-ordered rollout serves an index that is merely incomplete, never one that silently goes stale.

## Why

With both paths on one flag, a seller's documents only start syncing at the same moment their counts switch to Elasticsearch, so every enablement races its backfill: counts visibly climb from zero while history is still indexing, and there is no way to verify ES↔SQL parity before users see ES-served numbers.

Splitting the write gate turns each seller's rollout into a calm sequence:

1. `Feature.activate_user(:index_audience_members, user)` — live changes start syncing; counts still come from SQL.
2. `Onetime::BackfillAudienceMembersIndex.process(seller_id: user.id)` — index history with no drift window, since live updates are already flowing.
3. Verify `AudienceMember.filter_count` against the SQL counts at leisure, while nothing is user-visible.
4. `Feature.activate_user(:audience_count_from_elasticsearch, user)` — flip reads on a complete, current index.

The eventual global rollout gets the same benefit: enable indexing for everyone, run the full backfill, then ramp the read flag by percentage against a finished index.

Follow-up to #5449.

## Before/After

Non-user-facing. Before: enabling a seller's ES counts started their indexing at the same instant, so the email form briefly undercounted until the backfill caught up. After: indexing is enabled and verified first; the user-visible flip happens on complete data.

_Draft — walkthrough video and staging QA steps to be added before marking ready for review._

## Test Results

```
spec/models/concerns/audience_member/searchable_spec.rb   23 examples, 0 failures
```

---

AI disclosure: implemented with Claude Code using the Claude Fable 5 model.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5454"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783779872&installation_id=134400930&pr_number=5454&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5454&signature=bd85336d96a09179eacc0e5d2c3f15c0e6936d049d79ad06a042540ca87b661d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small feature-flag change to indexing callbacks only; read paths unchanged and backward-compatible when only the count flag is on.
> 
> **Overview**
> Audience member Elasticsearch async indexing is now gated on **`index_audience_members`** (per seller), not only on **`audience_count_from_elasticsearch`**. Either flag still enqueues index/update/delete jobs via `GatedAsyncIndexing#send_to_elasticsearch`, so turning on the read flag without the new write flag keeps documents syncing.
> 
> This supports a two-step rollout: enable indexing and backfill while audience counts still use SQL, verify parity, then flip the read flag on a complete index. Comments in `searchable.rb` document that ordering. Specs now cover the indexing flag, the count-only flag, and the no-flag case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d8a36e6dc8d0047a24dcb60f5794712e16fe1f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->