### PR TITLE
Add an emergency-stop flag to the audience members backfill job

### DIFF
--- a/app/sidekiq/backfill_audience_members_index_job.rb
+++ b/app/sidekiq/backfill_audience_members_index_job.rb
@@ -4,7 +4,13 @@ class BackfillAudienceMembersIndexJob
   include Sidekiq::Job
   sidekiq_options queue: :mongo, retry: 5, lock: :until_executed
 
+  # Activating the flag makes all future jobs no-op (an emergency stop for an
+  # in-flight spread). Skipped ranges are consumed, not deferred: to resume,
+  # deactivate the flag, clear the backfill cursor, and re-run spread — every
+  # write is an idempotent full-document overwrite, so re-covering is harmless.
   def perform(start_id, end_id, seller_id = nil, batch_size = Onetime::BackfillAudienceMembersIndex::BATCH_SIZE)
+    return unless Feature.inactive?(:pause_audience_members_index_backfill)
+
     Onetime::BackfillAudienceMembersIndex.new(batch_size:, seller_id:).index_range(start_id, end_id)
   end
 end

--- a/spec/sidekiq/backfill_audience_members_index_job_spec.rb
+++ b/spec/sidekiq/backfill_audience_members_index_job_spec.rb
@@ -20,6 +20,18 @@ describe BackfillAudienceMembersIndexJob do
     expect(document).to eq(members.first.as_indexed_json)
   end
 
+  it "skips the range when the pause flag is active" do
+    member = create(:audience_member)
+    Feature.activate(:pause_audience_members_index_backfill)
+
+    described_class.new.perform(member.id, member.id)
+    AudienceMember.__elasticsearch__.refresh_index!
+
+    expect(EsClient.exists?(index: AudienceMember.index_name, id: member.id)).to eq(false)
+  ensure
+    Feature.deactivate(:pause_audience_members_index_backfill)
+  end
+
   it "scopes the range to the seller when seller_id is given" do
     seller = create(:user)
     member = create(:audience_member, seller:)


### PR DESCRIPTION
## What

`BackfillAudienceMembersIndexJob` now no-ops when the `pause_audience_members_index_backfill` Flipper flag is active (checked with `Feature.inactive?`). Activating the flag is an emergency stop for an in-flight backfill: every future range job executes as a no-op and releases its unique lock; nothing indexes.

## Why

A full backfill schedules thousands of range jobs up to days into the future. If the run has to stop mid-flight — cluster pressure, bad data, an incident — the obvious move of deleting the scheduled jobs is a trap: `lock: :until_executed` digests survive deletion, so identical re-enqueues after the incident would be silently dropped. Letting the jobs run and skip is the clean halt: locks release normally, and the queue drains itself.

Skipped ranges are consumed rather than deferred, so resuming after an incident is: deactivate the flag, clear the backfill redis cursor, re-run `spread`. Re-covering already-indexed ranges is harmless — every write is an idempotent full-document overwrite keyed on `_id`.

Follow-up to #5449/#5453, part of the full-rollout tooling.

## Before/After

Non-user-facing. Before: an in-flight backfill could only be stopped by deleting scheduled jobs (leaving stale unique locks) or letting it run to completion. After: `Feature.activate(:pause_audience_members_index_backfill)` halts it cleanly at any time, reversibly.

_Draft — walkthrough video and staging QA steps to be added before marking ready for review._

## Test Results

```
spec/sidekiq/backfill_audience_members_index_job_spec.rb   3 examples, 0 failures
```

---

AI disclosure: implemented with Claude Code using the Claude Fable 5 model.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5456"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783791110&installation_id=134400930&pr_number=5456&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5456&signature=33e0ad0d8379cfae74e4b2bc1db6353b7f9a980fcb847ec11713be3e61f0162c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is unchanged when the flag is off; the change only adds an optional no-op path for operational control during backfills.
> 
> **Overview**
> Adds an **emergency stop** for the audience members Elasticsearch backfill: when Flipper flag `pause_audience_members_index_backfill` is **on**, `BackfillAudienceMembersIndexJob` returns immediately and does not index its ID range.
> 
> This is meant for halting a large in-flight spread without deleting queued jobs (which would leave `until_executed` unique locks and block re-enqueues). Skipped ranges are not retried automatically; recovery is deactivate the flag, reset the backfill cursor, and re-run spread (re-indexing is safe as full-document overwrites). Inline comments document that behavior.
> 
> A spec asserts that with the flag active, performing the job leaves no document in the index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f248695126f01dad4ce76064229fea79c82801c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->