### PR TITLE
Serve the total audience count from the same engine as the filtered count

### DIFF
--- a/app/controllers/api/internal/installments/recipient_counts_controller.rb
+++ b/app/controllers/api/internal/installments/recipient_counts_controller.rb
@@ -24,7 +24,7 @@ class Api::Internal::Installments::RecipientCountsController < Api::Internal::Ba
     installment.seller = current_seller
 
     render json: {
-      audience_count: current_seller.audience_members.count,
+      audience_count: AudienceMember.count_for_seller(current_seller),
       recipient_count: installment.audience_members_count
     }
   end

--- a/app/models/concerns/audience_member/searchable.rb
+++ b/app/models/concerns/audience_member/searchable.rb
@@ -106,6 +106,17 @@ module AudienceMember::Searchable
       EsClient.count(options)["count"]
     end
 
+    # Total audience size from the same engine that serves the seller's filtered
+    # counts: numbers displayed side by side must come from one snapshot, or the
+    # engines' different sync latencies can show a filtered count above the total.
+    def count_for_seller(seller)
+      if Feature.active?(:audience_count_from_elasticsearch, seller)
+        filter_count(seller_id: seller.id)
+      else
+        seller.audience_members.count
+      end
+    end
+
     # Builds an Elasticsearch query equivalent to the SQL built by AudienceMember.filter,
     # so that counts computed here always match the recipients selected by the blast jobs.
     def filter_query(seller_id:, params: {})

--- a/spec/controllers/api/internal/installments/recipient_counts_controller_spec.rb
+++ b/spec/controllers/api/internal/installments/recipient_counts_controller_spec.rb
@@ -37,6 +37,25 @@ describe Api::Internal::Installments::RecipientCountsController do
       expect(response.parsed_body).to eq("recipient_count" => 5, "audience_count" => 5)
     end
 
+    context "when the seller's audience_count_from_elasticsearch flag is on" do
+      before do
+        recreate_model_index(AudienceMember)
+        Feature.activate_user(:audience_count_from_elasticsearch, seller)
+        AudienceMember.find_each { ElasticsearchIndexerWorker.new.perform("index", { "record_id" => _1.id, "class_name" => "AudienceMember" }) }
+        AudienceMember.__elasticsearch__.refresh_index!
+      end
+
+      it "serves both counts from Elasticsearch" do
+        expect(AudienceMember).to receive(:filter_count).with(seller_id: seller.id).and_call_original
+        expect(AudienceMember).to receive(:filter_count).with(seller_id: seller.id, params: hash_including(type: "follower"), limit: nil).and_call_original
+
+        get :show, params: { installment_type: "follower" }
+
+        expect(response).to be_successful
+        expect(response.parsed_body).to eq("recipient_count" => 2, "audience_count" => 5)
+      end
+    end
+
     it "returns counts for seller installment type" do
       get :show, params: { installment_type: "seller" }
       expect(response).to be_successful

--- a/spec/models/concerns/audience_member/searchable_spec.rb
+++ b/spec/models/concerns/audience_member/searchable_spec.rb
@@ -100,6 +100,32 @@ describe AudienceMember::Searchable, :freeze_time do
     end
   end
 
+  describe ".count_for_seller" do
+    let(:seller) { create(:user) }
+
+    it "counts from MySQL when the seller's flag is off" do
+      create_list(:audience_member, 2, seller:)
+
+      expect(AudienceMember).not_to receive(:filter_count)
+      expect(AudienceMember.count_for_seller(seller)).to eq(2)
+    end
+
+    context "when the seller's flag is on", :sidekiq_inline, :elasticsearch_wait_for_refresh do
+      before do
+        recreate_model_index(AudienceMember)
+        Feature.activate_user(:audience_count_from_elasticsearch, seller)
+      end
+
+      it "counts from Elasticsearch" do
+        create_list(:audience_member, 2, seller:)
+        create(:audience_member)
+
+        expect(AudienceMember).to receive(:filter_count).with(seller_id: seller.id).and_call_original
+        expect(AudienceMember.count_for_seller(seller)).to eq(2)
+      end
+    end
+  end
+
   describe ".filter_count", :sidekiq_inline, :elasticsearch_wait_for_refresh do
     let(:seller) { create(:user) }
     let(:seller_id) { seller.id }


### PR DESCRIPTION
## What

Adds `AudienceMember.count_for_seller(seller)` — the total audience count served from the same engine as the filtered count, selected by the seller's `audience_count_from_elasticsearch` flag — and uses it for `audience_count` in `RecipientCountsController`. Flag on: both numbers come from Elasticsearch; flag off: both come from MySQL, exactly as before.

## Why

The email form renders `recipient_count / audience_count` from a single response, but for flag-enabled sellers the numerator came from Elasticsearch while the denominator was always a MySQL `COUNT(*)`. The two engines have different sync latencies — a destroyed member leaves the MySQL count at commit but leaves the index ~4 seconds later (the async delete job's delay) — so a request landing in that window rendered an impossible display: a filtered count one higher than the total (observed in production as `560,349 / 560,348`).

Serving both numbers from one engine makes them a single snapshot, so the numerator can no longer exceed the denominator. For enabled sellers it also removes a full `COUNT(*)` over their audience rows from every recipient-count request — for the pilot seller that's a 560k-row count on each keystroke of the audience filter UI.

Follow-up to #5449.

## Before/After

Before: a seller with ES-served counts could briefly see `recipient_count > audience_count` on the email form after audience churn. After: both numbers come from the same engine and the display is internally consistent.

_Draft — walkthrough video and staging QA steps to be added before marking ready for review._

## Test Results

New model specs (`.count_for_seller` engine dispatch, both flag states) pass locally:

```
spec/models/concerns/audience_member/searchable_spec.rb -e count_for_seller   2 examples, 0 failures
```

The `recipient_counts_controller_spec.rb` suite (including the new ES-context example) currently cannot run in my local environment — every example in the file, including all pre-existing ones on a clean tree, fails at purchase-factory creation with a card-charge stub error (verified unrelated to this diff). Relying on CI for that file; will confirm green before marking ready.

---

AI disclosure: implemented with Claude Code using the Claude Fable 5 model.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783792463&installation_id=134400930&pr_number=5457&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5457&signature=e867bc2dd84e5d37160cdc96e3c66d1b51b53dfa9816847bbd0b5f049f2bd4f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production audience totals for flag-enabled sellers (Elasticsearch vs SQL) on a hot internal API path; behavior is gated and covered by specs but affects email UI numbers at scale.
> 
> **Overview**
> Fixes inconsistent **recipient_count / audience_count** on the installment recipient-count API when Elasticsearch-backed filtering is enabled for a seller.
> 
> **`RecipientCountsController`** now sets `audience_count` via **`AudienceMember.count_for_seller(current_seller)`** instead of a MySQL `COUNT(*)`, so the total uses the same engine as **`installment.audience_members_count`** (Elasticsearch `filter_count` when `audience_count_from_elasticsearch` is on; MySQL otherwise). That keeps the pair on one snapshot and avoids filtered counts briefly exceeding the total during index lag, while skipping large SQL counts for ES-enabled sellers.
> 
> Specs cover **`count_for_seller`** flag dispatch and a controller example that asserts both counts come from Elasticsearch when the flag is on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6f97e1ac49f5ed5b31d5e49c4a2b4fb0af10baa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->