### PR TITLE
No-op indexer jobs for hard-deleted audience members

### DIFF
--- a/app/sidekiq/elasticsearch_indexer_worker.rb
+++ b/app/sidekiq/elasticsearch_indexer_worker.rb
@@ -6,6 +6,11 @@ class ElasticsearchIndexerWorker
 
   UPDATE_BY_QUERY_SCROLL_SIZE = 100
 
+  # Models whose rows are hard-deleted, so their index/update jobs can race the
+  # destroy and find the row legitimately missing. Every other indexed model is
+  # soft-deleted and a missing row there always indicates replica lag or a bug.
+  HARD_DELETED_CLASSES = %w[AudienceMember].freeze
+
   # Usage examples:
   # .perform("index", { "class_name" => "Link", "record_id" => 1 } )
   # .perform("delete", { "class_name" => "Link", "record_id" => 1 } )
@@ -52,6 +57,18 @@ class ElasticsearchIndexerWorker
       client_params[:ignore] << 404
       EsClient.delete(client_params)
     end
+  rescue ActiveRecord::RecordNotFound
+    # For hard-deleted models a row already gone when its index/update job runs
+    # is normal: the destroy's own after_commit enqueued the delete that removes
+    # the document, so retrying would never succeed. Everything else — including
+    # a freshly written row not yet visible on a lagging replica — keeps the
+    # retries that exist to ride the lag out, and the primary re-check stops lag
+    # from masquerading as a deletion.
+    raise unless params["class_name"].in?(HARD_DELETED_CLASSES)
+
+    ActiveRecord::Base.connection.stick_to_primary!
+    searched_id = params["record_id"]
+    raise if searched_id.nil? || params.fetch("class_name").constantize.exists?(searched_id)
   end
 
   def self.columns_to_fields(columns, mapping:)

--- a/spec/sidekiq/elasticsearch_indexer_worker_spec.rb
+++ b/spec/sidekiq/elasticsearch_indexer_worker_spec.rb
@@ -107,6 +107,55 @@ describe ElasticsearchIndexerWorker, :elasticsearch_wait_for_refresh do
       end
     end
 
+    context "when the record is missing" do
+      it "no-ops index and update jobs for a hard-deleted AudienceMember" do
+        member = create(:audience_member)
+        member_id = member.id
+        member.destroy!
+
+        expect(EsClient).not_to receive(:index)
+        expect(EsClient).not_to receive(:update)
+
+        described_class.new.perform(
+          "index",
+          "class_name" => "AudienceMember",
+          "record_id" => member_id
+        )
+        described_class.new.perform(
+          "update",
+          "class_name" => "AudienceMember",
+          "record_id" => member_id,
+          "fields" => ["purchases"]
+        )
+      end
+
+      it "re-raises for an AudienceMember that exists but is invisible to a lagging replica read" do
+        member = create(:audience_member)
+        allow(AudienceMember).to receive(:find).and_raise(ActiveRecord::RecordNotFound)
+
+        expect do
+          described_class.new.perform(
+            "index",
+            "class_name" => "AudienceMember",
+            "record_id" => member.id
+          )
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it "re-raises for models outside the hard-deleted allowlist" do
+        record = @model.create!(name: "Drawing")
+        record.destroy!
+
+        expect do
+          described_class.new.perform(
+            "index",
+            "class_name" => @model.name,
+            "record_id" => record.id
+          )
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
     context "when updating" do
       before do
         @record = @model.create!(name: "Drawing", country: "France")


### PR DESCRIPTION
## What

`ElasticsearchIndexerWorker` treats a missing database row as a successful no-op instead of raising — but only for models in a new `HARD_DELETED_CLASSES` allowlist (currently just `AudienceMember`), and only after confirming against the **primary** that the row is truly gone. Any other `RecordNotFound` — other models, or a row that exists on the primary but wasn't yet visible to a lagging replica read — re-raises and keeps the existing retry behavior unchanged.

## Why

`AudienceMember` is the first hard-deleted model in the indexing pipeline; every other indexed model (Purchase, Link, Balance, Installment) soft-deletes, so the worker's `klass.find` at execution time always succeeds for them. Audience members race their own jobs in a common flow: a buyer with several purchases unsubscribes, each purchase's callback updates the member (enqueuing update jobs at +4s and +3min), and the last one destroys it. Every queued update job then raises `ActiveRecord::RecordNotFound`, burns through all ten retries over hours, and lands in the dead set — pure noise, since the destroy's own `after_commit` already enqueued the delete that removes the document, so the retried jobs can never succeed. These failures accumulate in the retry set in production today.

Two deliberate constraints shape the fix:

- **Primary re-check before swallowing.** The worker's generous retry count doubles as the replica-lag buffer (the +3-minute re-enqueue exists for the same reason): a freshly written row can be invisible to a replica read, and those jobs must keep retrying until the replica catches up. `stick_to_primary!` + `exists?` distinguishes "deleted" from "not replicated yet", so lag can never masquerade as a deletion and silently drop a document.
- **Allowlist instead of blanket rescue.** For soft-deleted models a missing row always indicates lag or a bug, and their behavior stays byte-identical — the new code is unreachable for them. The constant documents the invariant a future class must satisfy to join: its destroy path must reliably enqueue the document delete.

Existing failed jobs self-heal on deploy: their next Sidekiq retry hits the primary check, confirms the row is gone, and completes as a no-op — no manual retry-set cleanup.

Follow-up to #5449.

## Before/After

Non-user-facing. Before: destroying an audience member with queued index/update jobs produced hours of `RecordNotFound` retries per job before dead-setting. After: those jobs complete as no-ops once the primary confirms the deletion, while replica-lag scenarios retain the full retry ladder.

_Draft — walkthrough video and staging QA steps to be added before marking ready for review._

## Test Results

```
spec/sidekiq/elasticsearch_indexer_worker_spec.rb   16 examples, 0 failures
```

Covers all three branches: hard-deleted member → no-op with no ES calls; member present on primary but invisible to the replica read → re-raises; deleted row of a non-allowlisted model → re-raises.

---

AI disclosure: implemented with Claude Code using the Claude Fable 5 model.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5458"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783797169&installation_id=134400930&pr_number=5458&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5458&signature=0708e7beeb9f01ef07e2ba3583df6ceb266257891faff56f3413903bae82d764"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes background indexing behavior for a hard-deleted model; primary re-check limits risk of silently dropping documents, but misclassification on the allowlist could affect search consistency.
> 
> **Overview**
> **`ElasticsearchIndexerWorker`** now rescues **`ActiveRecord::RecordNotFound`** on index/update and, for classes in **`HARD_DELETED_CLASSES`** (currently **`AudienceMember`** only), no-ops after **`stick_to_primary!`** and an **`exists?`** check confirm the row is really gone—so stale jobs after destroy stop retrying and hitting the dead set without touching Elasticsearch.
> 
> All other models and replica-lag cases (row still on primary) **re-raise** and keep the existing Sidekiq retry behavior. Specs cover no-op for destroyed audience members, re-raise when the row exists on primary, and re-raise for non-allowlisted models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b08df092217cff81bd89362c99a9292a8f27bce8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->