### PR TITLE
Restore balances stranded in processing by pre-#5177 PayPal reversals

### DIFF
--- a/app/services/onetime/restore_stranded_paypal_reversal_balances.rb
+++ b/app/services/onetime/restore_stranded_paypal_reversal_balances.rb
@@ -21,11 +21,10 @@ module Onetime
   class RestoreStrandedPaypalReversalBalances
     BATCH_SIZE = 100
 
-    # A balance still owed to a live payout must not be reverted. These are the
-    # payment states in which a balance is rightfully held in `processing`.
-    HOLDING_PAYMENT_STATES = [
-      Payment::CREATING, Payment::PROCESSING, Payment::UNCLAIMED, Payment::COMPLETED
-    ].freeze
+    # A balance still owed to a live payout must not be reverted. A balance is
+    # rightfully held in `processing` while any of its payments is still in a
+    # non-terminal state, so delegate to the model's own constant to stay in sync.
+    HOLDING_PAYMENT_STATES = Payment::NON_TERMINAL_STATES
 
     def self.process(dry_run: true, payment_ids: nil)
       new.process(dry_run:, payment_ids:)
@@ -34,31 +33,34 @@ module Onetime
     def process(dry_run: true, payment_ids: nil)
       stats = Hash.new(0)
 
-      candidate_payments(payment_ids).find_each(batch_size: BATCH_SIZE) do |payment|
+      candidate_payments(payment_ids).find_in_batches(batch_size: BATCH_SIZE) do |batch|
         ReplicaLagWatcher.watch
-        stats[:payments_scanned] += 1
 
-        stuck_balances = payment.balances.processing.to_a
-        next if stuck_balances.empty?
+        batch.each do |payment|
+          stats[:payments_scanned] += 1
 
-        stats[:payments_with_stuck_balances] += 1
+          stuck_balances = payment.balances.processing.to_a
+          next if stuck_balances.empty?
 
-        stuck_balances.each do |balance|
-          unless restorable?(balance)
-            stats[:balances_skipped_still_held] += 1
-            puts "skip balance #{balance.id} (payment #{payment.id}): still held by an active payout"
-            next
+          stats[:payments_with_stuck_balances] += 1
+
+          stuck_balances.each do |balance|
+            unless restorable?(balance)
+              stats[:balances_skipped_still_held] += 1
+              puts "skip balance #{balance.id} (payment #{payment.id}): still held by an active payout"
+              next
+            end
+
+            if dry_run
+              stats[:balances_would_restore] += 1
+              puts "DRY-RUN restore balance #{balance.id} (#{balance.amount_cents}c) payment #{payment.id} user #{payment.user_id}"
+              next
+            end
+
+            balance.mark_unpaid!
+            stats[:balances_restored] += 1
+            puts "restored balance #{balance.id} (#{balance.amount_cents}c) payment #{payment.id} user #{payment.user_id}"
           end
-
-          if dry_run
-            stats[:balances_would_restore] += 1
-            puts "DRY-RUN restore balance #{balance.id} (#{balance.amount_cents}c) payment #{payment.id} user #{payment.user_id}"
-            next
-          end
-
-          balance.mark_unpaid!
-          stats[:balances_restored] += 1
-          puts "restored balance #{balance.id} (#{balance.amount_cents}c) payment #{payment.id} user #{payment.user_id}"
         end
       end
 

--- a/app/services/onetime/restore_stranded_paypal_reversal_balances.rb
+++ b/app/services/onetime/restore_stranded_paypal_reversal_balances.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+# Restores balances stranded in `processing` by PayPal payouts that reversed (or
+# returned) directly from the `processing` state before PR #5177 shipped. See
+# issue #486.
+#
+# Before #5177 the only balance-restoring callback for a reversal was
+# `after_transition unclaimed: [... reversed returned ...]`, so a payout that
+# reversed straight from `processing` (never going `unclaimed`) left its balances
+# stuck in `processing` — the funds never re-entered the payout queue and the
+# seller's unpaid balance showed $0.00. The forward fix added
+# `after_transition processing: [reversed returned] => mark_balances_as_unpaid`
+# (app/models/payment.rb), but it did not backfill balances stranded earlier.
+#
+# This task re-finds every PayPal payment in a `reversed`/`returned` state whose
+# balances are still `processing` and flips those balances back to `unpaid`,
+# matching what the forward fix would have done. Each balance is re-validated at
+# write time and skipped if it is still held by any active or completed payout, so
+# a balance legitimately in-flight on a newer payment is never touched.
+module Onetime
+  class RestoreStrandedPaypalReversalBalances
+    BATCH_SIZE = 100
+
+    # A balance still owed to a live payout must not be reverted. These are the
+    # payment states in which a balance is rightfully held in `processing`.
+    HOLDING_PAYMENT_STATES = [
+      Payment::CREATING, Payment::PROCESSING, Payment::UNCLAIMED, Payment::COMPLETED
+    ].freeze
+
+    def self.process(dry_run: true, payment_ids: nil)
+      new.process(dry_run:, payment_ids:)
+    end
+
+    def process(dry_run: true, payment_ids: nil)
+      stats = Hash.new(0)
+
+      candidate_payments(payment_ids).find_each(batch_size: BATCH_SIZE) do |payment|
+        ReplicaLagWatcher.watch
+        stats[:payments_scanned] += 1
+
+        stuck_balances = payment.balances.processing.to_a
+        next if stuck_balances.empty?
+
+        stats[:payments_with_stuck_balances] += 1
+
+        stuck_balances.each do |balance|
+          unless restorable?(balance)
+            stats[:balances_skipped_still_held] += 1
+            puts "skip balance #{balance.id} (payment #{payment.id}): still held by an active payout"
+            next
+          end
+
+          if dry_run
+            stats[:balances_would_restore] += 1
+            puts "DRY-RUN restore balance #{balance.id} (#{balance.amount_cents}c) payment #{payment.id} user #{payment.user_id}"
+            next
+          end
+
+          balance.mark_unpaid!
+          stats[:balances_restored] += 1
+          puts "restored balance #{balance.id} (#{balance.amount_cents}c) payment #{payment.id} user #{payment.user_id}"
+        end
+      end
+
+      puts "done: #{stats.to_h}"
+      stats.to_h
+    end
+
+    private
+      def candidate_payments(payment_ids)
+        scope = Payment.processed_by(PayoutProcessorType::PAYPAL)
+                       .where(state: [Payment::REVERSED, Payment::RETURNED])
+        scope = scope.where(id: payment_ids) if payment_ids.present?
+        scope
+      end
+
+      def restorable?(balance)
+        balance.processing? &&
+          balance.payments.where(state: HOLDING_PAYMENT_STATES).none?
+      end
+  end
+end

--- a/spec/services/onetime/restore_stranded_paypal_reversal_balances_spec.rb
+++ b/spec/services/onetime/restore_stranded_paypal_reversal_balances_spec.rb
@@ -61,14 +61,14 @@ describe Onetime::RestoreStrandedPaypalReversalBalances do
     end
 
     it "leaves balances held by a completed payout untouched" do
-      balance = build_balance(state: "paid")
+      balance = build_balance
       build_payment(:payment_reversed, balances: [balance])
       build_payment(:payment_completed, balances: [balance])
 
       result = described_class.process(dry_run: false)
 
-      expect(balance.reload.state).to eq("paid")
-      expect(result[:payments_with_stuck_balances]).to eq(0)
+      expect(balance.reload.state).to eq("processing")
+      expect(result[:balances_skipped_still_held]).to eq(1)
       expect(result[:balances_restored]).to eq(0)
     end
 

--- a/spec/services/onetime/restore_stranded_paypal_reversal_balances_spec.rb
+++ b/spec/services/onetime/restore_stranded_paypal_reversal_balances_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Onetime::RestoreStrandedPaypalReversalBalances do
+  let(:seller) { create(:user) }
+  let(:merchant_account) { create(:merchant_account_paypal, user: seller) }
+
+  def build_balance(state: "processing", **overrides)
+    create(:balance, user: seller, merchant_account:, state:, **overrides)
+  end
+
+  def build_payment(factory, balances:)
+    payment = create(factory, user: seller)
+    payment.balances << balances
+    payment
+  end
+
+  describe ".process" do
+    it "restores balances stranded in processing by a reversed PayPal payout" do
+      balance = build_balance
+      build_payment(:payment_reversed, balances: [balance])
+
+      result = described_class.process(dry_run: false)
+
+      expect(balance.reload.state).to eq("unpaid")
+      expect(result[:balances_restored]).to eq(1)
+    end
+
+    it "restores balances stranded by a returned PayPal payout" do
+      balance = build_balance
+      build_payment(:payment_returned, balances: [balance])
+
+      result = described_class.process(dry_run: false)
+
+      expect(balance.reload.state).to eq("unpaid")
+      expect(result[:balances_restored]).to eq(1)
+    end
+
+    it "does not change balances during a dry run" do
+      balance = build_balance
+      build_payment(:payment_reversed, balances: [balance])
+
+      result = described_class.process(dry_run: true)
+
+      expect(balance.reload.state).to eq("processing")
+      expect(result[:balances_would_restore]).to eq(1)
+      expect(result[:balances_restored]).to eq(0)
+    end
+
+    it "leaves balances that are still held by an active payout untouched" do
+      balance = build_balance
+      build_payment(:payment_reversed, balances: [balance])
+      build_payment(:payment, balances: [balance])
+
+      result = described_class.process(dry_run: false)
+
+      expect(balance.reload.state).to eq("processing")
+      expect(result[:balances_skipped_still_held]).to eq(1)
+      expect(result[:balances_restored]).to eq(0)
+    end
+
+    it "leaves balances held by a completed payout untouched" do
+      balance = build_balance(state: "paid")
+      build_payment(:payment_reversed, balances: [balance])
+      build_payment(:payment_completed, balances: [balance])
+
+      result = described_class.process(dry_run: false)
+
+      expect(balance.reload.state).to eq("paid")
+      expect(result[:payments_with_stuck_balances]).to eq(0)
+      expect(result[:balances_restored]).to eq(0)
+    end
+
+    it "ignores Stripe payouts" do
+      balance = build_balance
+      build_payment(:payment_reversed, balances: [balance]).update_columns(processor: PayoutProcessorType::STRIPE)
+
+      result = described_class.process(dry_run: false)
+
+      expect(balance.reload.state).to eq("processing")
+      expect(result[:payments_scanned]).to eq(0)
+    end
+
+    it "ignores reversed payouts whose balances already reverted to unpaid" do
+      balance = build_balance(state: "unpaid")
+      build_payment(:payment_reversed, balances: [balance])
+
+      result = described_class.process(dry_run: false)
+
+      expect(result[:payments_with_stuck_balances]).to eq(0)
+      expect(result[:balances_restored]).to eq(0)
+    end
+
+    it "limits the sweep to the given payment_ids" do
+      stuck_balance = build_balance
+      target = build_payment(:payment_reversed, balances: [stuck_balance])
+
+      other_balance = build_balance
+      build_payment(:payment_reversed, balances: [other_balance])
+
+      result = described_class.process(dry_run: false, payment_ids: [target.id])
+
+      expect(stuck_balance.reload.state).to eq("unpaid")
+      expect(other_balance.reload.state).to eq("processing")
+      expect(result[:balances_restored]).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds a one-time task (`Onetime::RestoreStrandedPaypalReversalBalances`) that finds PayPal payments in a `reversed`/`returned` state whose associated `balances` rows are still `processing`, and flips those balances back to `unpaid` so the funds re-enter the payout queue.

Each balance is re-validated at write time and **skipped if it is still held by any active or completed payout** (a payment in `creating`/`processing`/`unclaimed`/`completed`), so a balance legitimately in-flight on a newer payout is never touched. The task defaults to `dry_run: true` and accepts an optional `payment_ids:` list to scope the run.

## Why

Balances revert `processing → unpaid` via `after_transition` callbacks on `Payment`. Before #5177, the only reversal-restoring callback was `after_transition unclaimed: %i[cancelled reversed returned failed]` — it fired **only** when a payout reversed from the `unclaimed` state. A payout that reversed **directly from `processing`** (never going `unclaimed`) had no callback, so its balance rows stayed stuck in `processing`: the seller's funds were stranded outside the payout queue and their unpaid balance showed $0.00.

#5177 closed the gap going forward by adding `after_transition processing: %i[reversed returned], do: :mark_balances_as_unpaid`, but it shipped **no backfill** for balances already stranded before it merged. This task is that backfill. It is query-driven rather than a hardcoded ID list so it also surfaces any other sellers stranded the same way, not just the originally reported account.

Per the contributing guidelines, backfills run as a `app/services/onetime` task (never via ActiveRecord callbacks), with a `dry_run` preview and `ReplicaLagWatcher` between batches.

Reference: private issue #486.

---

AI disclosure: drafted with Claude Opus 4.8

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783834599&installation_id=134400930&pr_number=5459&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5459&signature=103aa61ef73b5bdff2cb7a56fe3478b1b9f66aecfa408d77464951287fffddf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Directly mutates seller balance state for payout eligibility; mitigated by dry-run default, per-balance holding checks, and PayPal-only scoped query.
> 
> **Overview**
> Adds **`Onetime::RestoreStrandedPaypalReversalBalances`**, a query-driven one-time backfill for PayPal payouts that reversed/returned while their balance rows stayed in `processing` (the gap fixed forward in #5177 but never backfilled).
> 
> The task scans reversed/returned PayPal payments in batches (with **`ReplicaLagWatcher`**), finds still-`processing` balances, and calls **`mark_unpaid!`** so funds re-enter the payout queue. It defaults to **`dry_run: true`**, supports optional **`payment_ids:`** scoping, and skips any balance still tied to a payment in **`Payment::NON_TERMINAL_STATES`** (or otherwise held by an active/completed payout). Specs cover dry run, restore paths, skip rules, processor filter, and scoped runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80bd91da0583286aee930b98ebd656d1cf7eca6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->