### PR TITLE
Fix misspelled currency key in FlowOfFunds serialization

### DIFF
--- a/app/business/payments/charging/flow_of_funds.rb
+++ b/app/business/payments/charging/flow_of_funds.rb
@@ -11,7 +11,7 @@ class FlowOfFunds
 
     def to_h
       {
-        currenty: currency,
+        currency:,
         cents:
       }
     end

--- a/spec/business/payments/charging/flow_of_funds_spec.rb
+++ b/spec/business/payments/charging/flow_of_funds_spec.rb
@@ -32,4 +32,37 @@ describe FlowOfFunds do
       expect(flow_of_funds.merchant_account_net_amount).to be_nil
     end
   end
+
+  describe "#to_h" do
+    let(:currency) { Currency::USD }
+    let(:amount_cents) { 100_00 }
+    let(:flow_of_funds) { described_class.build_simple_flow_of_funds(currency, amount_cents) }
+
+    it "serializes each amount under the correct keys" do
+      expect(flow_of_funds.to_h).to eq(
+        issued_amount: { currency:, cents: amount_cents },
+        settled_amount: { currency:, cents: amount_cents },
+        gumroad_amount: { currency:, cents: amount_cents },
+        merchant_account_gross_amount: {},
+        merchant_account_net_amount: {}
+      )
+    end
+
+    it "serializes nil merchant account amounts as empty hashes" do
+      expect(flow_of_funds.to_h[:merchant_account_gross_amount]).to eq({})
+      expect(flow_of_funds.to_h[:merchant_account_net_amount]).to eq({})
+    end
+  end
+end
+
+describe FlowOfFunds::Amount do
+  describe "#to_h" do
+    let(:currency) { Currency::USD }
+    let(:cents) { 100_00 }
+    let(:amount) { described_class.new(currency:, cents:) }
+
+    it "serializes the currency under the :currency key" do
+      expect(amount.to_h).to eq(currency:, cents:)
+    end
+  end
 end


### PR DESCRIPTION
## What

`FlowOfFunds::Amount#to_h` serialized the currency under the **misspelled key `currenty`** instead of `currency`.

This hash is embedded in `ChargeEvent#to_h` and logged for **every charge event and every refund** on Gumroad's money path (`charge_events_handler.rb`, `refundable.rb`). Any consumer reading `currency` from these serialized hashes gets `nil`. The typo survived because the existing spec only exercised `.build_simple_flow_of_funds` and never asserted on `#to_h`.

## Fix

- One-word fix: `currenty: currency` → `currency:` (Ruby 3.1 shorthand, matching the adjacent `cents:`).
- Added exact-shape specs (`eq`, not `include`, so a future key rename fails the test):
  - `FlowOfFunds::Amount#to_h` serializes under `:currency`
  - `FlowOfFunds#to_h` full-shape assertion, pinning the existing behavior that nil merchant-account amounts serialize to `{}`.

## Verification

- `grep -rn "currenty" app lib spec config` → no matches.
- `bundle exec rspec spec/business/payments/charging/flow_of_funds_spec.rb` → **8 examples, 0 failures**.
- Guard check: reverting the key to `currenty` makes the 2 new `#to_h` specs fail (2 failures) → tests genuinely guard the fix.
- `bundle exec rubocop` → 0 offenses on both files.

No consumer reads the misspelled key (verified by grep), so the rename is safe.

🤖 Authored with AI assistance (claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783900258&installation_id=134400930&pr_number=5463&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5463&signature=7a89dd7fda000a436688e9eba7e031b88220f6bba8bf0c050f4a4fb39322ae6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small bug fix on payment event serialization with exact-shape tests; no auth or payout logic changes.
> 
> **Overview**
> **Fixes a serialization typo** in `FlowOfFunds::Amount#to_h`: amounts were emitted under `currenty` instead of `currency`. That hash is nested in `ChargeEvent#to_h` on charge/refund logging, so anything reading `currency` from those payloads would have seen `nil`.
> 
> The change is a one-line key rename (`currency:` shorthand). **Specs** now assert full `#to_h` shape for `FlowOfFunds` and `FlowOfFunds::Amount`, including nil merchant-account amounts serializing to `{}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa0545e018e51c9646ed2976d0ef1d9ad03bfa08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->