### PR TITLE
Add lint and typecheck CI gates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,38 @@ jobs:
     steps:
       - run: true
 
+  lint_js:
+    name: Lint JS/TS
+    runs-on: ubicloud-standard-4
+    needs: ci_gate
+    if: ${{ github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name != github.repository }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: npm
+      - run: npm ci
+      - run: npm run lint-fast
+
+  lint_ruby:
+    name: Lint Ruby
+    runs-on: ubicloud-standard-4
+    needs: ci_gate
+    if: ${{ github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name != github.repository }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - run: bundle exec rubocop --format github
+
   build:
     name: Build images${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository && ' (internal PR noop)' || '' }}
     runs-on: blacksmith-8vcpu-ubuntu-2204

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,7 @@ Also lint before committing:
 ```bash
 bundle exec rubocop -a              # Ruby lint + auto-correct
 DISABLE_TYPE_CHECKED=1 npx eslint   # JS/TS lint
+npm run typecheck                   # TS type check
 ```
 
 Do not push code with failing tests. CI is not a substitute for local verification. Fix any issues before committing.

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ bin/rake task_name
 
 ### Linting
 
-We use ESLint for JS, and Rubocop for Ruby. Your editor should support displaying and fixing issues reported by these inline, and CI will automatically check and fix (if possible) these.
+We use ESLint for JS, and Rubocop for Ruby. Your editor should support displaying and fixing issues reported by these inline, and CI checks these on every push.
 
 If you'd like, you can run `git config --local core.hooksPath .githooks` to check for these locally when committing.
 

--- a/app/controllers/api/v2/walks/synthesis_controller.rb
+++ b/app/controllers/api/v2/walks/synthesis_controller.rb
@@ -127,5 +127,4 @@ class Api::V2::Walks::SynthesisController < Api::V2::BaseController
       Rails.logger.warn("Anthropic synthesis returned non-JSON: #{e.message} — raw: #{cleaned.truncate(500)}")
       nil
     end
-
 end

--- a/app/controllers/bundles/product_controller.rb
+++ b/app/controllers/bundles/product_controller.rb
@@ -53,7 +53,6 @@ class Bundles::ProductController < Bundles::BaseController
   rescue ActiveRecord::RecordNotSaved, ActiveRecord::RecordInvalid, Link::LinkInvalid => e
     error_message = @bundle.errors.full_messages.first || e.message
     redirect_to edit_bundle_product_path(@bundle.external_id), alert: error_message
-
   end
 
   private

--- a/app/javascript/components/Admin/Users/PermissionRisk/FlagForFraud.tsx
+++ b/app/javascript/components/Admin/Users/PermissionRisk/FlagForFraud.tsx
@@ -17,7 +17,9 @@ const FlagForFraud = ({ user }: FlagForFraudProps) => {
       <Button
         size="sm"
         color="danger"
-        onClick={() => { window.location.href = suspendUrl; }}
+        onClick={() => {
+          window.location.href = suspendUrl;
+        }}
       >
         Suspend for fraud
       </Button>

--- a/app/javascript/components/ApiDocumentation/Endpoints/Earnings.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/Earnings.tsx
@@ -23,11 +23,19 @@ export const GetEarnings = () => (
         { name: "success", type: "boolean", description: "Whether the request succeeded" },
         { name: "year", type: "integer", description: "The tax year the earnings cover" },
         { name: "currency", type: "string", description: 'Always "usd"' },
-        { name: "gross_cents", type: "integer", description: "Gross earnings in cents, summed across all successful non-refunded sales" },
+        {
+          name: "gross_cents",
+          type: "integer",
+          description: "Gross earnings in cents, summed across all successful non-refunded sales",
+        },
         { name: "fees_cents", type: "integer", description: "Gumroad fees in cents" },
         { name: "taxes_cents", type: "integer", description: "Gumroad-collected and seller-collected taxes in cents" },
         { name: "affiliate_credit_cents", type: "integer", description: "Affiliate credit in cents" },
-        { name: "net_cents", type: "integer", description: "gross_cents - fees_cents - taxes_cents - affiliate_credit_cents" },
+        {
+          name: "net_cents",
+          type: "integer",
+          description: "gross_cents - fees_cents - taxes_cents - affiliate_credit_cents",
+        },
       ])}
     </ApiResponseFields>
     <CodeSnippet caption="cURL example">

--- a/app/javascript/components/ApiDocumentation/Scopes.tsx
+++ b/app/javascript/components/ApiDocumentation/Scopes.tsx
@@ -13,8 +13,7 @@ const SCOPES = [
   },
   {
     name: "edit_products",
-    description:
-      "read/write access to the user's products and their variants, offer codes, custom fields, and files.",
+    description: "read/write access to the user's products and their variants, offer codes, custom fields, and files.",
   },
   {
     name: "view_sales",

--- a/app/javascript/components/Audience/CustomerDetailPage.tsx
+++ b/app/javascript/components/Audience/CustomerDetailPage.tsx
@@ -1152,7 +1152,14 @@ const EmailSection = ({
                 className="grow"
               />
               <div className="flex w-full gap-2">
-                <Button onClick={() => { setEmail(currentEmail); setIsEditing(false); }} disabled={isLoading} className="flex-1">
+                <Button
+                  onClick={() => {
+                    setEmail(currentEmail);
+                    setIsEditing(false);
+                  }}
+                  disabled={isLoading}
+                  className="flex-1"
+                >
                   Cancel
                 </Button>
                 <Button color="primary" onClick={() => void handleSave()} disabled={isLoading} className="flex-1">

--- a/app/javascript/components/CheckoutDashboard/DiscountsPage.tsx
+++ b/app/javascript/components/CheckoutDashboard/DiscountsPage.tsx
@@ -869,7 +869,7 @@ const Form = ({
 
   const [existingCustomersOnly, setExistingCustomersOnly] = React.useState(!!offerCode?.existing_customers_only);
   const [ownershipProductIds, setOwnershipProductIds] = React.useState<{ value: string[]; error?: boolean }>({
-    value: offerCode?.ownership_products?.map(({ id }) => id) ?? [],
+    value: offerCode?.ownership_products.map(({ id }) => id) ?? [],
   });
   const ownershipProductsFieldRef = React.useRef<SelectInstance<Option, true, GroupBase<Option>>>(null);
   const ownershipProducts = products.filter(({ id }) => ownershipProductIds.value.includes(id));

--- a/app/javascript/components/Download/RichContent.tsx
+++ b/app/javascript/components/Download/RichContent.tsx
@@ -122,7 +122,11 @@ const Link = Mark.create<BaseLinkOptions & { saleInfo: SaleInfo | null; rootDoma
       "a",
       {
         ...HTMLAttributes,
-        href: addSaleInfoQueryParams(typia.assert<string>(HTMLAttributes.href), this.options.saleInfo, this.options.rootDomain),
+        href: addSaleInfoQueryParams(
+          typia.assert<string>(HTMLAttributes.href),
+          this.options.saleInfo,
+          this.options.rootDomain,
+        ),
         target: "_blank",
       },
       0,
@@ -143,7 +147,11 @@ const TiptapLink = TiptapNode.create<{ saleInfo: SaleInfo | null; rootDomain: st
         ...HTMLAttributes,
         target: "_blank",
         rel: "noopener noreferrer nofollow",
-        href: addSaleInfoQueryParams(typia.assert<string>(HTMLAttributes.href), this.options.saleInfo, this.options.rootDomain),
+        href: addSaleInfoQueryParams(
+          typia.assert<string>(HTMLAttributes.href),
+          this.options.saleInfo,
+          this.options.rootDomain,
+        ),
       },
       0,
     ];

--- a/app/javascript/components/Product/Thumbnail.tsx
+++ b/app/javascript/components/Product/Thumbnail.tsx
@@ -3,11 +3,11 @@ import * as React from "react";
 import useLazyLoadingProps from "$app/hooks/useLazyLoadingProps";
 import { ProductNativeType } from "$app/parsers/product";
 
-const rawThumbnails = import.meta.glob("$assets/images/native_types/thumbnails/*", {
+const rawThumbnails = import.meta.glob<string>("$assets/images/native_types/thumbnails/*", {
   eager: true,
   query: "?url",
   import: "default",
-}) as Record<string, string>;
+});
 const nativeTypeThumbnails = Object.fromEntries(
   Object.entries(rawThumbnails).map(([key, value]) => [`./${key.split("/").pop()}`, value]),
 );

--- a/app/javascript/components/ProductEdit/ContentTab/FileEmbed.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/FileEmbed.tsx
@@ -315,7 +315,9 @@ const FileEmbedNodeView = ({ node, editor, getPos, updateAttributes }: NodeViewP
       <>
         {parentNode?.childCount === 1 ? null : (
           <MenuItem
-            onClick={() => editor.commands.moveFileEmbedToGroup({ fileUid: typia.assert<string>(node.attrs.uid), groupUid: null })}
+            onClick={() =>
+              editor.commands.moveFileEmbedToGroup({ fileUid: typia.assert<string>(node.attrs.uid), groupUid: null })
+            }
           >
             <FolderPlus className="size-5" />
             <span>New folder</span>

--- a/app/javascript/components/ProductEdit/ContentTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.tsx
@@ -1196,7 +1196,9 @@ export const ContentTab = () => {
         accept: "json",
       });
       if (!response.ok) throw new ResponseError();
-      const parsedResponse = typia.assert<{ posts: Post[]; total: number; next_page: number | null }>(await response.json());
+      const parsedResponse = typia.assert<{ posts: Post[]; total: number; next_page: number | null }>(
+        await response.json(),
+      );
       loadedPostsData.current.set(
         selectedVariantId,
         refresh

--- a/app/javascript/components/ProductEdit/ProductTab/CustomSummaryInput.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/CustomSummaryInput.tsx
@@ -15,12 +15,7 @@ export const CustomSummaryInput = ({
   return (
     <Fieldset>
       <Label htmlFor={uid}>Summary</Label>
-      <Input
-        id={uid}
-        type="text"
-        value={value ?? ""}
-        onChange={(evt) => onChange(evt.target.value)}
-      />
+      <Input id={uid} type="text" value={value ?? ""} onChange={(evt) => onChange(evt.target.value)} />
     </Fieldset>
   );
 };

--- a/app/javascript/components/ProductEdit/ProductTab/PriceChecker/DistributionChart.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/PriceChecker/DistributionChart.tsx
@@ -145,7 +145,7 @@ const RefLineLabel: React.FC<RefLineLabelProps> = ({
   xShift = 0,
   padX = PAD_X_TIGHT,
 }) => {
-  if (!viewBox || viewBox.x === undefined || viewBox.y === undefined) return null;
+  if (viewBox?.x === undefined || viewBox.y === undefined) return null;
   const lines = value !== undefined ? [title, value] : [title];
   const width = approxLabelWidth(lines, padX);
   const height = labelHeight(lines.length);
@@ -193,7 +193,7 @@ const PartialDashedLine: React.FC<PartialDashedLineProps> = ({
   labelHeightPx,
   fromBottom = false,
 }) => {
-  if (!viewBox || viewBox.x === undefined || viewBox.y === undefined) return null;
+  if (viewBox?.x === undefined || viewBox.y === undefined) return null;
   const top = viewBox.y - labelHeightPx + yOffset;
   const startY = fromBottom ? top + labelHeightPx : top + labelHeightPx / 2;
   const plotBottom = viewBox.y + (viewBox.height ?? 0);

--- a/app/javascript/components/ProductEdit/ProductTab/PriceChecker/index.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/PriceChecker/index.tsx
@@ -57,7 +57,7 @@ const buildPriceMarkers = (product: Product): PriceMarker[] => {
     { id: "base", label: "Base price", valueCents: product.price_cents },
     ...paidVariants.map((variant) => ({
       id: variant.id ?? variant.name ?? `variant-${variant.price_difference_cents ?? 0}`,
-      label: truncateLabel(variant.name?.trim() || "Variant"),
+      label: truncateLabel(variant.name.trim() || "Variant"),
       valueCents: product.price_cents + (variant.price_difference_cents ?? 0),
     })),
   ];
@@ -203,7 +203,7 @@ export const PriceCheckerCard = () => {
         </Alert>
       ) : null}
 
-      {isInsufficient && data?.status === "insufficient_data" ? (
+      {isInsufficient && data.status === "insufficient_data" ? (
         <div className="grid min-h-64 content-between gap-3 rounded-sm border border-dashed border-border bg-background p-4 xl:min-h-80">
           <div className="flex items-start justify-between gap-2">
             <div className="grid min-w-0 flex-1 gap-1 text-sm">
@@ -226,7 +226,7 @@ export const PriceCheckerCard = () => {
             productTypeLabel={productTypeLabel}
           />
         </div>
-      ) : hasOk && data?.status === "ok" ? (
+      ) : hasOk && data.status === "ok" ? (
         <div className="grid min-h-64 grid-rows-[auto_1fr_auto] gap-3 rounded-sm border border-border bg-background p-4 xl:min-h-80">
           {chartHeaderRow}
           <DistributionChart

--- a/app/javascript/components/ProductEdit/ProductTab/ThumbnailEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/ThumbnailEditor.tsx
@@ -10,11 +10,11 @@ import { assertResponseError } from "$app/utils/request";
 import { ImageUploader } from "$app/components/ImageUploader";
 import { showAlert } from "$app/components/server-components/Alert";
 
-const rawThumbnails = import.meta.glob("$assets/images/native_types/thumbnails/*", {
+const rawThumbnails = import.meta.glob<string>("$assets/images/native_types/thumbnails/*", {
   eager: true,
   query: "?url",
   import: "default",
-}) as Record<string, string>;
+});
 const nativeTypeThumbnails = Object.fromEntries(
   Object.entries(rawThumbnails).map(([key, value]) => [`./${key.split("/").pop()}`, value]),
 );

--- a/app/javascript/components/ProductEdit/ShareTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ShareTab/index.tsx
@@ -1,5 +1,4 @@
 import { Link } from "@boxicons/react";
-import hands from "$assets/images/illustrations/hands.png";
 import * as React from "react";
 
 import { Button } from "$app/components/Button";
@@ -19,6 +18,8 @@ import { Alert } from "$app/components/ui/Alert";
 import { Fieldset } from "$app/components/ui/Fieldset";
 import { Switch } from "$app/components/ui/Switch";
 import { useRunOnce } from "$app/components/useRunOnce";
+
+import hands from "$assets/images/illustrations/hands.png";
 
 export const ShareTab = () => {
   const currentSeller = useCurrentSeller();

--- a/app/javascript/components/Settings/AdvancedPage/ApplicationForm.tsx
+++ b/app/javascript/components/Settings/AdvancedPage/ApplicationForm.tsx
@@ -1,7 +1,6 @@
 import { Trash } from "@boxicons/react";
 import { router } from "@inertiajs/react";
 import { DirectUpload } from "@rails/activestorage";
-import placeholderAppIcon from "$assets/images/gumroad_app.png";
 import * as React from "react";
 import typia from "typia";
 
@@ -16,6 +15,8 @@ import { Fieldset, FieldsetTitle } from "$app/components/ui/Fieldset";
 import { Input } from "$app/components/ui/Input";
 import { Label } from "$app/components/ui/Label";
 import { WithTooltip } from "$app/components/WithTooltip";
+
+import placeholderAppIcon from "$assets/images/gumroad_app.png";
 
 export type Application = {
   id: string;
@@ -239,9 +240,9 @@ const ApplicationForm = ({ application }: { application?: Application }) => {
                       method: "POST",
                       accept: "json",
                     });
-                    const responseData = typia.assert<{ success: true; token: string } | { success: false; message: string }>(
-                      await response.json(),
-                    );
+                    const responseData = typia.assert<
+                      { success: true; token: string } | { success: false; message: string }
+                    >(await response.json());
                     if (!responseData.success) throw new ResponseError(responseData.message);
                     setToken(responseData.token);
                   } catch (e) {

--- a/app/javascript/components/Settings/AdvancedPage/ApplicationsSection.tsx
+++ b/app/javascript/components/Settings/AdvancedPage/ApplicationsSection.tsx
@@ -1,5 +1,4 @@
 import { Link, router } from "@inertiajs/react";
-import placeholderAppIcon from "$assets/images/gumroad_app.png";
 import * as React from "react";
 
 import { Button } from "$app/components/Button";
@@ -7,6 +6,8 @@ import { showAlert } from "$app/components/server-components/Alert";
 import ApplicationForm from "$app/components/Settings/AdvancedPage/ApplicationForm";
 import { FormSection } from "$app/components/ui/FormSection";
 import { Row, RowActions, RowContent, Rows } from "$app/components/ui/Rows";
+
+import placeholderAppIcon from "$assets/images/gumroad_app.png";
 
 export type Application = {
   id: string;

--- a/app/javascript/components/Settings/AdvancedPage/NotificationEndpointSection.tsx
+++ b/app/javascript/components/Settings/AdvancedPage/NotificationEndpointSection.tsx
@@ -68,12 +68,7 @@ const NotificationEndpointSection = ({
           <Label htmlFor={uid}>Ping endpoint</Label>
         </FieldsetTitle>
         <InputGroup>
-          <Input
-            type="url"
-            id={uid}
-            value={pingEndpoint}
-            onChange={(e) => setPingEndpoint(e.target.value)}
-          />
+          <Input type="url" id={uid} value={pingEndpoint} onChange={(e) => setPingEndpoint(e.target.value)} />
           <WithTooltip tip={isSendingPing ? null : "Send your most recent sale's JSON, with 'test' set to 'true'"}>
             <Pill asChild>
               <Button className="rounded-full! px-3! py-2!" onClick={sendTestPing} disabled={isSendingPing}>

--- a/app/javascript/components/Settings/PasswordPage/AuthenticatorSetup.tsx
+++ b/app/javascript/components/Settings/PasswordPage/AuthenticatorSetup.tsx
@@ -67,7 +67,9 @@ export const AuthenticatorSetup = ({ onCancel }: { onCancel: () => void }) => {
         accept: "json",
         data: { code },
       });
-      const json = typia.assert<{ success: boolean; recovery_codes?: string[]; error_message?: string }>(await response.json());
+      const json = typia.assert<{ success: boolean; recovery_codes?: string[]; error_message?: string }>(
+        await response.json(),
+      );
       if (json.success && json.recovery_codes) {
         setRecoveryCodes(json.recovery_codes);
         setStep("recovery");

--- a/app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx
@@ -396,7 +396,7 @@ const AccountDetailsSection = ({
   };
 
   const getMaskedValue = (placeholder: string, lastFour: string | null, showLastFour: boolean): string => {
-    const fullyMasked = placeholder.replace(/[a-zA-Z0-9]/g, "\u2022");
+    const fullyMasked = placeholder.replace(/[a-zA-Z0-9]/gu, "\u2022");
     if (!showLastFour || !lastFour) return fullyMasked;
     const maskPrefix = fullyMasked.slice(0, -lastFour.length);
     return maskPrefix + lastFour;

--- a/app/javascript/components/TiptapExtensions/Link.tsx
+++ b/app/javascript/components/TiptapExtensions/Link.tsx
@@ -13,10 +13,10 @@ import { Button, buttonVariants } from "$app/components/Button";
 import { Modal } from "$app/components/Modal";
 import { Popover, PopoverContent, PopoverTrigger } from "$app/components/Popover";
 import { MenuItem, validateUrl } from "$app/components/RichTextEditor";
-import { MenuItem as MenuListItem } from "$app/components/ui/Menu";
 import { showAlert } from "$app/components/server-components/Alert";
 import { Fieldset } from "$app/components/ui/Fieldset";
 import { Input } from "$app/components/ui/Input";
+import { MenuItem as MenuListItem } from "$app/components/ui/Menu";
 
 export const LinkDialog = ({
   editor,

--- a/app/javascript/components/TiptapExtensions/MediaEmbed.tsx
+++ b/app/javascript/components/TiptapExtensions/MediaEmbed.tsx
@@ -11,12 +11,12 @@ import { sanitizeHtml } from "$app/utils/sanitize";
 
 import { Button } from "$app/components/Button";
 import { MenuItem } from "$app/components/RichTextEditor";
-import { MenuItem as MenuListItem } from "$app/components/ui/Menu";
 import { showAlert } from "$app/components/server-components/Alert";
 import { createInsertCommand } from "$app/components/TiptapExtensions/utils";
 import { Fieldset, FieldsetTitle } from "$app/components/ui/Fieldset";
 import { Input } from "$app/components/ui/Input";
 import { Label } from "$app/components/ui/Label";
+import { MenuItem as MenuListItem } from "$app/components/ui/Menu";
 import { Row, RowActions, RowContent, RowDetails } from "$app/components/ui/Rows";
 
 declare module "@tiptap/core" {
@@ -211,7 +211,10 @@ export const ExternalMediaFileEmbed = TiptapNode.create({
     return ReactNodeViewRenderer(({ editor, node, deleteNode }: NodeViewProps) => (
       <NodeViewWrapper>
         <Row className="embed">
-          <RowDetails className="preview" dangerouslySetInnerHTML={{ __html: sanitizeHtml(typia.assert<string>(node.attrs.html)) }} />
+          <RowDetails
+            className="preview"
+            dangerouslySetInnerHTML={{ __html: sanitizeHtml(typia.assert<string>(node.attrs.html)) }}
+          />
           <RowContent className="content">
             <PlayCircle pack="filled" className="type-icon size-5" />
             <div>

--- a/app/javascript/components/UtmLinks/UtmLinkForm.tsx
+++ b/app/javascript/components/UtmLinks/UtmLinkForm.tsx
@@ -185,7 +185,9 @@ export const UtmLinkForm = (pageProps: UtmLinkFormProps | UtmLinkEditProps) => {
     router.reload({
       only: ["additional_metadata"],
       onSuccess: (page) => {
-        const additionalMetadata = typia.assert<UtmLinkFormAdditionalMetadata | undefined>(page.props.additional_metadata);
+        const additionalMetadata = typia.assert<UtmLinkFormAdditionalMetadata | undefined>(
+          page.props.additional_metadata,
+        );
         const newPermalink = additionalMetadata?.new_permalink;
         if (newPermalink) {
           setShortUrl((shortUrl) => ({ ...shortUrl, permalink: newPermalink }));

--- a/app/javascript/components/Wishlist/Card.tsx
+++ b/app/javascript/components/Wishlist/Card.tsx
@@ -14,11 +14,11 @@ import { ProductCard, ProductCardFigure, ProductCardHeader } from "$app/componen
 import { StretchedLink } from "$app/components/ui/StretchedLink";
 import { useFollowWishlist } from "$app/components/Wishlist/FollowButton";
 
-const rawThumbnails = import.meta.glob("$assets/images/native_types/thumbnails/*", {
+const rawThumbnails = import.meta.glob<string>("$assets/images/native_types/thumbnails/*", {
   eager: true,
   query: "?url",
   import: "default",
-}) as Record<string, string>;
+});
 const nativeTypeThumbnails = Object.fromEntries(
   Object.entries(rawThumbnails).map(([key, value]) => [`./${key.split("/").pop()}`, value]),
 );

--- a/app/javascript/components/WorkflowsPage/WorkflowEmails.tsx
+++ b/app/javascript/components/WorkflowsPage/WorkflowEmails.tsx
@@ -518,7 +518,11 @@ const EmailRow = ({
                 <Select
                   value={email.delayed_delivery_time_period}
                   aria-label="Period"
-                  onChange={(e) => onChange({ delayed_delivery_time_period: typia.assert<InstallmentDeliveryTimePeriod>(e.target.value) })}
+                  onChange={(e) =>
+                    onChange({
+                      delayed_delivery_time_period: typia.assert<InstallmentDeliveryTimePeriod>(e.target.value),
+                    })
+                  }
                   onFocus={() => onFocus("delayed_delivery_time_period")}
                 >
                   {INSTALLMENT_DELIVERY_TIME_PERIODS.map((period) => (

--- a/app/javascript/data/account.ts
+++ b/app/javascript/data/account.ts
@@ -37,9 +37,9 @@ export const createAccount = async (data: CreateAccountPayload): Promise<CreateA
       ...("recaptchaResponse" in data ? { "g-recaptcha-response": data.recaptchaResponse } : {}),
     },
   });
-  const responseData = typia.assert<{ success: true; redirect_location: string } | { success: false; error_message: string }>(
-    await response.json(),
-  );
+  const responseData = typia.assert<
+    { success: true; redirect_location: string } | { success: false; error_message: string }
+  >(await response.json());
   if (!responseData.success) throw new ResponseError(responseData.error_message);
   return { redirectLocation: responseData.redirect_location };
 };
@@ -57,7 +57,9 @@ export const addPurchaseToLibrary = async (data: {
     data: { user: { purchase_id: data.purchaseId, purchase_email: data.purchaseEmail } },
   });
 
-  const responseData = typia.assert<{ success: true; redirect_location: string } | { success: false }>(await response.json());
+  const responseData = typia.assert<{ success: true; redirect_location: string } | { success: false }>(
+    await response.json(),
+  );
   if (!responseData.success) throw new ResponseError();
   return { redirectLocation: responseData.redirect_location };
 };

--- a/app/javascript/data/circle_integration.ts
+++ b/app/javascript/data/circle_integration.ts
@@ -20,7 +20,9 @@ export const fetchCommunities = async (apiKey: string) => {
     url: Routes.communities_integrations_circle_index_path({ format: "json", api_key: apiKey }),
     accept: "json",
   });
-  const responseData = typia.assert<FetchCommunitiesSuccessResponse | FetchCommunitiesErrorResponse>(await response.json());
+  const responseData = typia.assert<FetchCommunitiesSuccessResponse | FetchCommunitiesErrorResponse>(
+    await response.json(),
+  );
   if (!responseData.success) throw new ResponseError();
   return { communities: responseData.communities };
 };
@@ -35,7 +37,9 @@ export const fetchSpaceGroups = async (apiKey: string, communityId: number) => {
     }),
     accept: "json",
   });
-  const responseData = typia.assert<FetchSpaceGroupsSuccessResponse | FetchSpaceGroupsErrorResponse>(await response.json());
+  const responseData = typia.assert<FetchSpaceGroupsSuccessResponse | FetchSpaceGroupsErrorResponse>(
+    await response.json(),
+  );
   if (!responseData.success) throw new ResponseError();
   return { spaceGroups: responseData.space_groups };
 };

--- a/app/javascript/data/covers.ts
+++ b/app/javascript/data/covers.ts
@@ -17,9 +17,9 @@ export const createCover = async (permalink: string, coverPayload: CoverPayload)
   });
 
   if (response.ok) {
-    const responseData = typia.assert<{ success: true; asset_previews: AssetPreview[] } | { success: false; error: string }>(
-      await response.json(),
-    );
+    const responseData = typia.assert<
+      { success: true; asset_previews: AssetPreview[] } | { success: false; error: string }
+    >(await response.json());
     if (responseData.success) return responseData.asset_previews;
     throw new ResponseError(responseData.error);
   }

--- a/app/javascript/data/discord_integration.ts
+++ b/app/javascript/data/discord_integration.ts
@@ -36,7 +36,9 @@ export const joinServer = async (
     accept: "json",
   });
   if (response.ok) {
-    const responseData = typia.assert<{ success: true; server_name: string } | { success: false }>(await response.json());
+    const responseData = typia.assert<{ success: true; server_name: string } | { success: false }>(
+      await response.json(),
+    );
     if (responseData.success) {
       return { ok: true, serverName: responseData.server_name };
     }
@@ -52,7 +54,9 @@ export const leaveServer = async (purchaseId: string): Promise<{ ok: true; serve
     accept: "json",
   });
   if (response.ok) {
-    const responseData = typia.assert<{ success: true; server_name: string } | { success: false }>(await response.json());
+    const responseData = typia.assert<{ success: true; server_name: string } | { success: false }>(
+      await response.json(),
+    );
     if (responseData.success) {
       return { ok: true, serverName: responseData.server_name };
     }

--- a/app/javascript/data/dropbox_upload.ts
+++ b/app/javascript/data/dropbox_upload.ts
@@ -29,7 +29,9 @@ export async function cancelDropboxFileUpload(id: string) {
     url: Routes.cancel_dropbox_file_upload_path(id),
   });
   if (!response.ok) throw new ResponseError();
-  const json = typia.assert<{ success: false } | { dropbox_file: ResponseDropboxFile; success: true }>(await response.json());
+  const json = typia.assert<{ success: false } | { dropbox_file: ResponseDropboxFile; success: true }>(
+    await response.json(),
+  );
   if (!json.success) throw new ResponseError();
   return json.dropbox_file;
 }

--- a/app/javascript/data/google_calendar_integration.ts
+++ b/app/javascript/data/google_calendar_integration.ts
@@ -38,9 +38,9 @@ export const fetchCalendarList = async (accessToken: string, refreshToken: strin
     }),
     accept: "json",
   });
-  const responseData = typia.assert<{ success: true; calendar_list: { id: string; summary: string }[] } | { success: false }>(
-    await response.json(),
-  );
+  const responseData = typia.assert<
+    { success: true; calendar_list: { id: string; summary: string }[] } | { success: false }
+  >(await response.json());
   if (!responseData.success) throw new ResponseError();
   return responseData.calendar_list;
 };

--- a/app/javascript/data/thumbnails.ts
+++ b/app/javascript/data/thumbnails.ts
@@ -35,7 +35,9 @@ export const deleteThumbnail = async (permalink: string, thumbnailId: string) =>
   });
 
   if (response.ok) {
-    const responseData = typia.assert<{ success: true; thumbnail: Thumbnail } | { success: false }>(await response.json());
+    const responseData = typia.assert<{ success: true; thumbnail: Thumbnail } | { success: false }>(
+      await response.json(),
+    );
     if (responseData.success) return;
   }
 

--- a/app/javascript/entrypoints/inertia.js
+++ b/app/javascript/entrypoints/inertia.js
@@ -96,8 +96,8 @@ function assignLayout(page) {
   return page;
 }
 
-const pages = import.meta.glob('../pages/**/*.tsx');
-const jsxPages = import.meta.glob('../pages/**/*.jsx');
+const pages = import.meta.glob("../pages/**/*.tsx");
+const jsxPages = import.meta.glob("../pages/**/*.jsx");
 
 async function resolvePageComponent(name) {
   const tsxPath = `../pages/${name}.tsx`;

--- a/app/javascript/pages/Admin/Search/Purchases/Index.tsx
+++ b/app/javascript/pages/Admin/Search/Purchases/Index.tsx
@@ -113,9 +113,9 @@ export default function Purchases() {
                       <ArrowUpRightSquare className="size-5" />
                     </a>{" "}
                     <PurchaseStates purchase={purchase} />
-                    {((purchase.stripe_risk_level && purchase.stripe_risk_level !== "normal") ||
-                      purchase.early_fraud_warning ||
-                      purchase.disputes.length > 0) && (
+                    {(purchase.stripe_risk_level && purchase.stripe_risk_level !== "normal") ||
+                    purchase.early_fraud_warning ||
+                    purchase.disputes.length > 0 ? (
                       <span className="inline-flex flex-wrap gap-1">
                         {purchase.stripe_risk_level && purchase.stripe_risk_level !== "normal" ? (
                           <Pill size="small" color={purchase.stripe_risk_level === "highest" ? "danger" : "warning"}>
@@ -140,7 +140,7 @@ export default function Purchases() {
                           </Pill>
                         ))}
                       </span>
-                    )}
+                    ) : null}
                     <div className="text-sm">
                       <InlineList>
                         {purchase.refund_policy ? (

--- a/app/javascript/pages/Admin/SuspendUsers/Show.tsx
+++ b/app/javascript/pages/Admin/SuspendUsers/Show.tsx
@@ -130,12 +130,12 @@ const SuspendUsers = () => {
         </Select>
 
         <Label htmlFor="additionalNotes">Notes</Label>
-        <div className="flex flex-wrap gap-1 mb-2">
+        <div className="mb-2 flex flex-wrap gap-1">
           {NOTES_SUGGESTIONS.map((suggestion) => (
             <button
               key={suggestion}
               type="button"
-              className="rounded-full border px-2.5 py-0.5 text-xs hover:bg-black hover:text-white transition-colors"
+              className="rounded-full border px-2.5 py-0.5 text-xs transition-colors hover:bg-black hover:text-white"
               onClick={() => {
                 const current = form.data.suspend_users.additional_notes;
                 const sep = current && !current.endsWith("\n") ? "\n" : "";

--- a/app/javascript/pages/AffiliateRequests/New.tsx
+++ b/app/javascript/pages/AffiliateRequests/New.tsx
@@ -24,7 +24,9 @@ type Props = {
 };
 
 const AffiliateRequestsNew = () => {
-  const { creator_profile, success, requester_has_existing_account, email_param } = typia.assert<Props>(usePage().props);
+  const { creator_profile, success, requester_has_existing_account, email_param } = typia.assert<Props>(
+    usePage().props,
+  );
 
   const appDomain = useAppDomain();
   const loggedInUser = useLoggedInUser();

--- a/app/javascript/pages/Collaborators/Incomings/Index.tsx
+++ b/app/javascript/pages/Collaborators/Incomings/Index.tsx
@@ -172,9 +172,8 @@ type IncomingCollaboratorsPageProps = {
 const IncomingCollaboratorsPage = () => {
   const loggedInUser = useLoggedInUser();
 
-  const { collaborators: incomingCollaborators, collaborators_disabled_reason } = typia.assert<IncomingCollaboratorsPageProps>(
-    usePage().props,
-  );
+  const { collaborators: incomingCollaborators, collaborators_disabled_reason } =
+    typia.assert<IncomingCollaboratorsPageProps>(usePage().props);
 
   const [selected, setSelected] = React.useState<IncomingCollaborator | null>(null);
 

--- a/app/javascript/pages/Collaborators/Index.tsx
+++ b/app/javascript/pages/Collaborators/Index.tsx
@@ -27,9 +27,8 @@ type CollaboratorsPageProps = {
 const CollaboratorsPage = () => {
   const loggedInUser = useLoggedInUser();
 
-  const { collaborators, collaborators_disabled_reason, has_incoming_collaborators } = typia.assert<CollaboratorsPageProps>(
-    usePage().props,
-  );
+  const { collaborators, collaborators_disabled_reason, has_incoming_collaborators } =
+    typia.assert<CollaboratorsPageProps>(usePage().props);
   const [selectedCollaborator, setSelectedCollaborator] = React.useState<Collaborator | null>(null);
 
   const deleteForm = useForm({});

--- a/app/javascript/pages/Emails/Edit.tsx
+++ b/app/javascript/pages/Emails/Edit.tsx
@@ -7,7 +7,9 @@ import { Installment, InstallmentFormContext } from "$app/data/installments";
 import { EmailForm } from "$app/components/EmailsPage/EmailForm";
 
 export default function EmailsEdit() {
-  const { installment, context } = typia.assert<{ installment: Installment; context: InstallmentFormContext }>(usePage().props);
+  const { installment, context } = typia.assert<{ installment: Installment; context: InstallmentFormContext }>(
+    usePage().props,
+  );
 
   return <EmailForm context={context} installment={installment} />;
 }

--- a/app/javascript/pages/Payouts/Index.tsx
+++ b/app/javascript/pages/Payouts/Index.tsx
@@ -567,7 +567,7 @@ export default function PayoutsIndex() {
                 )
               ) : (
                 <>
-                  Your balance is on hold. Please <a href={"mailto:support@gumroad.com"}>contact support</a> for details.
+                  Your balance is on hold. Please <a href="mailto:support@gumroad.com">contact support</a> for details.
                 </>
               )}
             </p>
@@ -602,7 +602,7 @@ export default function PayoutsIndex() {
                 {instant_payout.payable_balances.some(
                   (balance) => balance.amount_cents > MAXIMUM_INSTANT_PAYOUT_AMOUNT_CENTS,
                 ) ? (
-                  <a href={"mailto:support@gumroad.com"}>Contact us for an instant payout</a>
+                  <a href="mailto:support@gumroad.com">Contact us for an instant payout</a>
                 ) : (
                   <Button
                     size="sm"

--- a/app/javascript/pages/Products/New.tsx
+++ b/app/javascript/pages/Products/New.tsx
@@ -1,6 +1,5 @@
 import { ChevronDown, Sparkle } from "@boxicons/react";
 import { Link, useForm, usePage } from "@inertiajs/react";
-import hands from "$assets/images/illustrations/hands.png";
 import * as React from "react";
 import { useState } from "react";
 import typia from "typia";
@@ -33,11 +32,13 @@ import { Tab, Tabs } from "$app/components/ui/Tabs";
 import { Textarea } from "$app/components/ui/Textarea";
 import { WithTooltip } from "$app/components/WithTooltip";
 
-const rawIcons = import.meta.glob("$assets/images/native_types/*", {
+import hands from "$assets/images/illustrations/hands.png";
+
+const rawIcons = import.meta.glob<string>("$assets/images/native_types/*", {
   eager: true,
   query: "?url",
   import: "default",
-}) as Record<string, string>;
+});
 const nativeTypeIcons = Object.fromEntries(
   Object.entries(rawIcons).map(([key, value]) => [`./${key.split("/").pop()}`, value]),
 );
@@ -433,8 +434,7 @@ const NewProductPage = () => {
                       const firstDotIndex = newValue.indexOf(".");
                       if (firstDotIndex !== -1) {
                         newValue =
-                          newValue.slice(0, firstDotIndex + 1) +
-                          newValue.slice(firstDotIndex + 1).replace(/\./gu, "");
+                          newValue.slice(0, firstDotIndex + 1) + newValue.slice(firstDotIndex + 1).replace(/\./gu, "");
                       }
                       form.setData("link.price_range", newValue);
                       form.clearErrors("link.price_range");

--- a/app/javascript/pages/Purchases/DisputeEvidence/Show.tsx
+++ b/app/javascript/pages/Purchases/DisputeEvidence/Show.tsx
@@ -278,7 +278,9 @@ export default function Show() {
                 <Radio
                   name="cancellationRebuttal"
                   value={option}
-                  onChange={(evt) => setCancellationRebuttalOption(typia.assert<CancellationRebuttalOption>(evt.target.value))}
+                  onChange={(evt) =>
+                    setCancellationRebuttalOption(typia.assert<CancellationRebuttalOption>(evt.target.value))
+                  }
                 />
                 {message}
               </Label>

--- a/app/javascript/pages/Purchases/Invoices/New.tsx
+++ b/app/javascript/pages/Purchases/Invoices/New.tsx
@@ -65,7 +65,7 @@ const PurchaseNewInvoicePage = () => {
     form_metadata.display_vat_id && form.data.address_fields.country_code === initialCountryCode
       ? form_metadata.vat_id_label
       : (form_metadata.business_id_labels[form.data.address_fields.country_code] ?? form_metadata.vat_id_label);
-  const businessIdLabel = /\bID\b|Registration/i.test(rawBusinessIdLabel)
+  const businessIdLabel = /\bID\b|Registration/iu.test(rawBusinessIdLabel)
     ? rawBusinessIdLabel
     : `${rawBusinessIdLabel} ID`;
 

--- a/app/javascript/pages/Reviews/Index.tsx
+++ b/app/javascript/pages/Reviews/Index.tsx
@@ -20,11 +20,11 @@ import { WithTooltip } from "$app/components/WithTooltip";
 
 import placeholderImage from "$assets/images/placeholders/reviews.png";
 
-const rawThumbnails = import.meta.glob("$assets/images/native_types/thumbnails/*", {
+const rawThumbnails = import.meta.glob<string>("$assets/images/native_types/thumbnails/*", {
   eager: true,
   query: "?url",
   import: "default",
-}) as Record<string, string>;
+});
 const nativeTypeThumbnails = Object.fromEntries(
   Object.entries(rawThumbnails).map(([key, value]) => [`./${key.split("/").pop()}`, value]),
 );

--- a/app/javascript/pages/SecureRedirect/New.tsx
+++ b/app/javascript/pages/SecureRedirect/New.tsx
@@ -24,7 +24,9 @@ type SecureRedirectFormData = {
 };
 
 const New = () => {
-  const { message, field_name, encrypted_payload, error_message } = typia.assert<SecureRedirectPageProps>(usePage().props);
+  const { message, field_name, encrypted_payload, error_message } = typia.assert<SecureRedirectPageProps>(
+    usePage().props,
+  );
 
   const form = useForm<SecureRedirectFormData>({
     confirmation_text: "",

--- a/app/javascript/pages/Settings/ThirdPartyAnalytics/Show.tsx
+++ b/app/javascript/pages/Settings/ThirdPartyAnalytics/Show.tsx
@@ -114,7 +114,11 @@ export default function ThirdPartyAnalyticsPage() {
               <Fieldset>
                 <FieldsetTitle>
                   <Label htmlFor={`${uid}googleAnalyticsId`}>Google Analytics Property ID</Label>
-                  <a href="/help/article/174-third-party-analytics#Google-Analytics-Ib1dB" target="_blank" rel="noreferrer">
+                  <a
+                    href="/help/article/174-third-party-analytics#Google-Analytics-Ib1dB"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
                     Learn more
                   </a>
                 </FieldsetTitle>

--- a/app/javascript/pages/Subscriptions/MagicLinks/New.tsx
+++ b/app/javascript/pages/Subscriptions/MagicLinks/New.tsx
@@ -21,7 +21,9 @@ type Props = {
 };
 
 function SubscriptionsMagicLink() {
-  const { product_name, subscription_id, is_installment_plan, user_emails, email_sent } = typia.assert<Props>(usePage().props);
+  const { product_name, subscription_id, is_installment_plan, user_emails, email_sent } = typia.assert<Props>(
+    usePage().props,
+  );
 
   const hasSentEmail = email_sent !== null;
   const defaultEmailSource = email_sent ?? user_emails[0].source;

--- a/app/javascript/pages/TaxCenter/Index.tsx
+++ b/app/javascript/pages/TaxCenter/Index.tsx
@@ -1,6 +1,5 @@
 import { Cog } from "@boxicons/react";
 import { Link, router, usePage } from "@inertiajs/react";
-import taxesPlaceholder from "$assets/images/placeholders/taxes.png";
 import * as React from "react";
 import typia from "typia";
 
@@ -16,6 +15,8 @@ import { Placeholder, PlaceholderImage } from "$app/components/ui/Placeholder";
 import { Select } from "$app/components/ui/Select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "$app/components/ui/Table";
 import { Tab, Tabs } from "$app/components/ui/Tabs";
+
+import taxesPlaceholder from "$assets/images/placeholders/taxes.png";
 
 type TaxDocument = {
   document: string;

--- a/app/javascript/utils/discover.ts
+++ b/app/javascript/utils/discover.ts
@@ -2,11 +2,11 @@ import typia from "typia";
 
 import { SearchRequest } from "$app/data/search";
 
-const rawCategoryImages = import.meta.glob("$assets/images/discover/*", {
+const rawCategoryImages = import.meta.glob<string>("$assets/images/discover/*", {
   eager: true,
   query: "?url",
   import: "default",
-}) as Record<string, string>;
+});
 const categoryImages = Object.fromEntries(
   Object.entries(rawCategoryImages).map(([key, value]) => [`./${key.split("/").pop()}`, value]),
 );

--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -65,9 +65,9 @@ class License < ApplicationRecord
       return if purchase_id.blank? || fields.blank?
 
       ElasticsearchIndexerWorker.perform_in(2.seconds, "update", {
-        "record_id" => purchase_id,
-        "class_name" => "Purchase",
-        "fields" => fields
-      })
+                                              "record_id" => purchase_id,
+                                              "class_name" => "Purchase",
+                                              "fields" => fields
+                                            })
     end
 end

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -2389,7 +2389,7 @@ class Purchase < ApplicationRecord
       existing_redirects = UrlRedirect.where(purchase_id: purchase_ids, installment_id: installment_ids)
                                       .order(:id)
                                       .reverse_each
-                                      .each_with_object({}) { |ur, h| h[[ur.purchase_id, ur.installment_id]] = ur }
+                                      .index_by { |ur| [ur.purchase_id, ur.installment_id] }
 
       # Key email_infos on original_purchase.id to match action_at_for_purchase's
       # behavior — otherwise renewal purchases get post.published_at instead of the
@@ -2398,7 +2398,7 @@ class Purchase < ApplicationRecord
       email_infos = CreatorContactingCustomersEmailInfo
                       .where(installment_id: installment_ids, purchase_id: original_purchase_ids)
                       .order(:id)
-                      .each_with_object({}) { |ei, h| h[[ei.installment_id, ei.purchase_id]] = ei }
+                      .index_by { |ei| [ei.installment_id, ei.purchase_id] }
     else
       existing_redirects = {}
       email_infos = {}

--- a/app/models/walks_free_trial.rb
+++ b/app/models/walks_free_trial.rb
@@ -35,9 +35,9 @@ class WalksFreeTrial < ApplicationRecord
       .where(id: id)
       .where("synthesis_attempts < ?", MAX_SYNTHESIS_ATTEMPTS)
       .update_all([
-        "synthesis_attempts = synthesis_attempts + 1, updated_at = ?",
-        Time.current,
-      ])
+                    "synthesis_attempts = synthesis_attempts + 1, updated_at = ?",
+                    Time.current,
+                  ])
     if n == 1
       self.synthesis_attempts += 1
       true

--- a/app/services/content_moderation/strategies/blocklist_strategy.rb
+++ b/app/services/content_moderation/strategies/blocklist_strategy.rb
@@ -26,9 +26,7 @@ class ContentModeration::Strategies::BlocklistStrategy
   end
 
   def self.yaml_words
-    @yaml_words ||= begin
-      File.exist?(YAML_PATH) ? Array(YAML.load_file(YAML_PATH).fetch("blocklist", [])) : []
-    end
+    @yaml_words ||= File.exist?(YAML_PATH) ? Array(YAML.load_file(YAML_PATH).fetch("blocklist", [])) : []
   end
 
   def self.reset_yaml_cache!

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "build:pages-tailwind": "node scripts/build_pages_tailwind.mjs",
     "build:widget": "WIDGET_TARGET=gumroad npx vite build --config vite.config.widget.ts && WIDGET_TARGET=gumroad-embed npx vite build --config vite.config.widget.ts",
     "lint-fast": "DISABLE_TYPE_CHECKED=1 npx eslint",
+    "typecheck": "tsc --noEmit",
     "setup": "bundle exec rails js:export && npm run build:pages-tailwind",
     "postinstall": "patch-package && ts-patch install -s"
   },

--- a/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
@@ -293,8 +293,8 @@ describe StripePayoutProcessor, :vcr do
       before do
         allow(Stripe::Balance).to receive(:retrieve).and_return(
           Stripe::Balance.construct_from(object: "balance",
-                                          available: [{ amount: 1_096_45, currency: "eur" }],
-                                          pending: [{ amount: 0, currency: "eur" }])
+                                         available: [{ amount: 1_096_45, currency: "eur" }],
+                                         pending: [{ amount: 0, currency: "eur" }])
         )
       end
 
@@ -321,8 +321,8 @@ describe StripePayoutProcessor, :vcr do
       before do
         allow(Stripe::Balance).to receive(:retrieve).and_return(
           Stripe::Balance.construct_from(object: "balance",
-                                          available: [{ amount: 1_096_45, currency: "eur" }],
-                                          pending: [{ amount: 26_000, currency: "eur" }])
+                                         available: [{ amount: 1_096_45, currency: "eur" }],
+                                         pending: [{ amount: 26_000, currency: "eur" }])
         )
       end
 
@@ -338,8 +338,8 @@ describe StripePayoutProcessor, :vcr do
       before do
         allow(Stripe::Balance).to receive(:retrieve).and_return(
           Stripe::Balance.construct_from(object: "balance",
-                                          available: [{ amount: 1_500_00, currency: "eur" }],
-                                          pending: [{ amount: -50_000, currency: "eur" }])
+                                         available: [{ amount: 1_500_00, currency: "eur" }],
+                                         pending: [{ amount: -50_000, currency: "eur" }])
         )
       end
 
@@ -355,8 +355,8 @@ describe StripePayoutProcessor, :vcr do
       before do
         allow(Stripe::Balance).to receive(:retrieve).and_return(
           Stripe::Balance.construct_from(object: "balance",
-                                          available: [{ amount: 1_400_00, currency: "eur" }],
-                                          pending: [{ amount: 0, currency: "eur" }])
+                                         available: [{ amount: 1_400_00, currency: "eur" }],
+                                         pending: [{ amount: 0, currency: "eur" }])
         )
       end
 
@@ -373,8 +373,8 @@ describe StripePayoutProcessor, :vcr do
       before do
         allow(Stripe::Balance).to receive(:retrieve).and_return(
           Stripe::Balance.construct_from(object: "balance",
-                                          available: [{ amount: 1_400_00, currency: "usd" }],
-                                          pending: [{ amount: 50_000, currency: "usd" }])
+                                         available: [{ amount: 1_400_00, currency: "usd" }],
+                                         pending: [{ amount: 50_000, currency: "usd" }])
         )
       end
 

--- a/spec/controllers/admin/comments_controller_spec.rb
+++ b/spec/controllers/admin/comments_controller_spec.rb
@@ -33,6 +33,5 @@ describe Admin::CommentsController do
         end.to raise_error(ActiveRecord::RecordInvalid)
       end
     end
-
   end
 end

--- a/spec/controllers/api/mobile/purchases_controller_spec.rb
+++ b/spec/controllers/api/mobile/purchases_controller_spec.rb
@@ -718,7 +718,7 @@ describe Api::Mobile::PurchasesController do
         expect(response.parsed_body[:success]).to be true
         expect(response.parsed_body[:purchases].size).to eq(3)
         expect(per_row_queries).to be_empty,
-          "Expected zero per-row SELECTs for sellers/products, got:\n#{per_row_queries.join("\n")}"
+                                   "Expected zero per-row SELECTs for sellers/products, got:\n#{per_row_queries.join("\n")}"
       end
     end
 

--- a/spec/controllers/api/v2/subscribers_controller_spec.rb
+++ b/spec/controllers/api/v2/subscribers_controller_spec.rb
@@ -123,7 +123,7 @@ describe Api::V2::SubscribersController do
           per_row_patterns.each do |pattern, label|
             hits = queries.grep(pattern)
             expect(hits).to be_empty,
-              "Expected no per-row queries matching #{label}, got #{hits.size}:\n#{hits.join("\n")}"
+                            "Expected no per-row queries matching #{label}, got #{hits.size}:\n#{hits.join("\n")}"
           end
         end
       end

--- a/spec/controllers/api/v2/tax_forms_controller_spec.rb
+++ b/spec/controllers/api/v2/tax_forms_controller_spec.rb
@@ -80,12 +80,12 @@ describe Api::V2::TaxFormsController do
 
         expect(response).to be_successful
         expect(response.parsed_body["tax_forms"]).to eq([
-          {
-            tax_year: form_2025.tax_year,
-            tax_form_type: form_2025.tax_form_type,
-            filed_at: nil
-          }.as_json
-        ])
+                                                          {
+                                                            tax_year: form_2025.tax_year,
+                                                            tax_form_type: form_2025.tax_form_type,
+                                                            filed_at: nil
+                                                          }.as_json
+                                                        ])
       end
 
       it "returns filed_at as ISO-8601 when the form has been filed" do

--- a/spec/controllers/api/v2/variants_controller_spec.rb
+++ b/spec/controllers/api/v2/variants_controller_spec.rb
@@ -32,9 +32,9 @@ describe Api::V2::VariantsController do
       it "returns error for nonexistent variant_category_id" do
         get @action, params: @params.merge(variant_category_id: "nonexistent")
         expect(response.parsed_body).to eq({
-          "success" => false,
-          "message" => "The variant_category was not found."
-        })
+                                             "success" => false,
+                                             "message" => "The variant_category was not found."
+                                           })
       end
 
       it "shows the 0 variants in that variant category" do
@@ -85,9 +85,9 @@ describe Api::V2::VariantsController do
       it "returns error for nonexistent variant_category_id" do
         post @action, params: @params.merge(variant_category_id: "nonexistent")
         expect(response.parsed_body).to eq({
-          "success" => false,
-          "message" => "The variant_category was not found."
-        })
+                                             "success" => false,
+                                             "message" => "The variant_category was not found."
+                                           })
       end
 
       describe "usd" do
@@ -173,9 +173,9 @@ describe Api::V2::VariantsController do
       it "returns error for nonexistent variant_category_id" do
         get @action, params: @params.merge(variant_category_id: "nonexistent")
         expect(response.parsed_body).to eq({
-          "success" => false,
-          "message" => "The variant_category was not found."
-        })
+                                             "success" => false,
+                                             "message" => "The variant_category was not found."
+                                           })
       end
 
       it "returns the right response" do
@@ -260,9 +260,9 @@ describe Api::V2::VariantsController do
         it "returns error for nonexistent variant_category_id" do
           put @action, params: @params.merge(variant_category_id: "nonexistent")
           expect(response.parsed_body).to eq({
-            "success" => false,
-            "message" => "The variant_category was not found."
-          })
+                                               "success" => false,
+                                               "message" => "The variant_category was not found."
+                                             })
         end
       end
 
@@ -557,9 +557,9 @@ describe Api::V2::VariantsController do
       it "returns error for nonexistent variant_category_id" do
         delete @action, params: @params.merge(variant_category_id: "nonexistent")
         expect(response.parsed_body).to eq({
-          "success" => false,
-          "message" => "The variant_category was not found."
-        })
+                                             "success" => false,
+                                             "message" => "The variant_category was not found."
+                                           })
       end
 
       describe "usd" do

--- a/spec/controllers/api/v2/walks/realtime_tokens_controller_spec.rb
+++ b/spec/controllers/api/v2/walks/realtime_tokens_controller_spec.rb
@@ -31,9 +31,9 @@ describe Api::V2::Walks::RealtimeTokensController do
         .with(headers: { "Authorization" => "Bearer sk-test-openai" })
         .to_return(status: 200, body: openai_response.to_json, headers: { "Content-Type" => "application/json" })
 
-      expect {
+      expect do
         post :create, params: { topic: "How I built my SaaS" }
-      }.to change(WalksFreeTrial, :count).by(1)
+      end.to change(WalksFreeTrial, :count).by(1)
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["value"]).to eq("ek_proj_xyz")
@@ -74,9 +74,9 @@ describe Api::V2::Walks::RealtimeTokensController do
       stub_request(:post, "https://api.openai.com/v1/realtime/client_secrets")
         .to_return(status: 200, body: { "value" => "ek_x" }.to_json, headers: { "Content-Type" => "application/json" })
 
-      expect {
+      expect do
         post :create, params: { topic: "x" }
-      }.not_to change(WalksFreeTrial, :count)
+      end.not_to change(WalksFreeTrial, :count)
 
       expect(response).to have_http_status(:ok)
     end

--- a/spec/controllers/api/v2/walks/synthesis_controller_spec.rb
+++ b/spec/controllers/api/v2/walks/synthesis_controller_spec.rb
@@ -249,9 +249,9 @@ describe Api::V2::Walks::SynthesisController do
       stub_request(:post, "https://api.anthropic.com/v1/messages")
         .to_return(status: 200, body: { "content" => [{ "type" => "text", "text" => "{}" }] }.to_json, headers: { "Content-Type" => "application/json" })
 
-      expect {
+      expect do
         post :create, params: { topic: "x", exchanges: exchanges }
-      }.not_to change(WalksFreeTrial, :count)
+      end.not_to change(WalksFreeTrial, :count)
 
       expect(response).to have_http_status(:payment_required)
     end
@@ -280,9 +280,9 @@ describe Api::V2::Walks::SynthesisController do
       stub_request(:post, "https://api.anthropic.com/v1/messages")
         .to_return(status: 200, body: { "content" => [{ "type" => "text", "text" => "{}" }] }.to_json, headers: { "Content-Type" => "application/json" })
 
-      expect {
+      expect do
         post :create, params: { topic: "x", exchanges: exchanges }
-      }.not_to change { trial.reload.synthesis_attempts }
+      end.not_to change { trial.reload.synthesis_attempts }
     end
   end
 end

--- a/spec/controllers/balance_controller_spec.rb
+++ b/spec/controllers/balance_controller_spec.rb
@@ -60,11 +60,11 @@ describe BalanceController, type: :controller, inertia: true do
           get :index
 
           expect(inertia.props[:scheduled_payout]).to eq({
-            action: "payout",
-            status: "pending",
-            scheduled_at: sp.scheduled_at,
-            payout_amount_cents: 50_000
-          })
+                                                           action: "payout",
+                                                           status: "pending",
+                                                           scheduled_at: sp.scheduled_at,
+                                                           payout_amount_cents: 50_000
+                                                         })
         end
 
         it "returns executed payout props" do
@@ -73,11 +73,11 @@ describe BalanceController, type: :controller, inertia: true do
           get :index
 
           expect(inertia.props[:scheduled_payout]).to eq({
-            action: "refund",
-            status: "executed",
-            scheduled_at: sp.scheduled_at,
-            payout_amount_cents: 30_000
-          })
+                                                           action: "refund",
+                                                           status: "executed",
+                                                           scheduled_at: sp.scheduled_at,
+                                                           payout_amount_cents: 30_000
+                                                         })
         end
 
         it "returns the most recent scheduled payout" do

--- a/spec/controllers/checkout/upsells/products_controller_spec.rb
+++ b/spec/controllers/checkout/upsells/products_controller_spec.rb
@@ -223,7 +223,7 @@ describe Checkout::Upsells::ProductsController do
       ].each do |per_row_pattern|
         per_row = queries.grep(per_row_pattern)
         expect(per_row).to be_empty,
-          "Expected no per-row queries matching #{per_row_pattern.inspect}, got #{per_row.size}:\n#{per_row.join("\n")}"
+                           "Expected no per-row queries matching #{per_row_pattern.inspect}, got #{per_row.size}:\n#{per_row.join("\n")}"
       end
     end
   end

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -519,7 +519,7 @@ describe CheckoutController, type: :controller, inertia: true do
       end
 
       it "acquires a row lock on the cart to prevent deadlocks" do
-        cart = create(:cart, user: seller)
+        create(:cart, user: seller)
 
         expect_any_instance_of(Cart).to receive(:lock!).and_call_original
 

--- a/spec/controllers/purchases_controller_spec.rb
+++ b/spec/controllers/purchases_controller_spec.rb
@@ -670,7 +670,7 @@ describe PurchasesController, :vcr do
         str = value.to_s
         return value if str.empty?
         first = str[0]
-        if first == '+' || first == '-'
+        if first == "+" || first == "-"
           return value if str[1..]&.match?(/\A\d+\.?\d*\z/)
         end
         %w[= @ | % \r \t + -].include?(first) ? "'#{value}" : value

--- a/spec/helpers/products_helper_spec.rb
+++ b/spec/helpers/products_helper_spec.rb
@@ -243,7 +243,7 @@ describe ProductsHelper do
       per_row_patterns.each do |pattern, label|
         hits = queries.grep(pattern)
         expect(hits).to be_empty,
-          "Expected no per-row queries matching #{label}, got #{hits.size}:\n#{hits.join("\n")}"
+                        "Expected no per-row queries matching #{label}, got #{hits.size}:\n#{hits.join("\n")}"
       end
     end
   end

--- a/spec/lib/elasticsearch_setup_spec.rb
+++ b/spec/lib/elasticsearch_setup_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe ElasticsearchSetup do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -49,7 +49,6 @@ describe Comment do
             expect(comment).to be_valid
           end
         end
-
       end
 
       context "when content does not contain adult keywords" do

--- a/spec/models/purchase/purchase_installments_spec.rb
+++ b/spec/models/purchase/purchase_installments_spec.rb
@@ -499,10 +499,10 @@ describe "PurchaseInstallments", :vcr do
     end
 
     context "Purchase.preload_product_updates_data!" do
-      def capture_queries
+      def capture_queries(&block)
         queries = []
         callback = ->(*, payload) { queries << payload[:sql] if payload[:sql].present? && !payload[:sql].start_with?("EXPLAIN", "SAVEPOINT", "RELEASE", "ROLLBACK", "BEGIN", "COMMIT") }
-        ActiveSupport::Notifications.subscribed(callback, "sql.active_record") { yield }
+        ActiveSupport::Notifications.subscribed(callback, "sql.active_record", &block)
         queries
       end
 

--- a/spec/modules/product/prices_spec.rb
+++ b/spec/modules/product/prices_spec.rb
@@ -257,7 +257,7 @@ describe Product::Prices do
 
           per_row_alive_variants = queries.grep(/FROM `base_variants`.*`variant_category_id` = \d+/)
           expect(per_row_alive_variants).to be_empty,
-            "Expected no per-row alive_variants queries when associations are not preloaded, got:\n#{per_row_alive_variants.join("\n")}"
+                                            "Expected no per-row alive_variants queries when associations are not preloaded, got:\n#{per_row_alive_variants.join("\n")}"
         end
       end
     end

--- a/spec/modules/shipping_destination/destinations_spec.rb
+++ b/spec/modules/shipping_destination/destinations_spec.rb
@@ -46,38 +46,37 @@ describe ShippingDestination::Destinations do
   end
 
   private
+    def shipping_countries_expected
+      first_countries = {
+        "US" => "United States",
+        ShippingDestination::Destinations::ASIA => "Asia",
+        ShippingDestination::Destinations::EUROPE => "Europe",
+        ShippingDestination::Destinations::NORTH_AMERICA => "North America",
+        ShippingDestination::Destinations::ELSEWHERE => "Elsewhere"
+      }
+      first_countries.merge!(
+        Compliance::Countries.for_select.reject { |c| Compliance::Countries.blocked?(c[0]) }.to_h
+      )
+    end
 
-  def shipping_countries_expected
-    first_countries = {
-      "US" => "United States",
-      ShippingDestination::Destinations::ASIA => "Asia",
-      ShippingDestination::Destinations::EUROPE => "Europe",
-      ShippingDestination::Destinations::NORTH_AMERICA => "North America",
-      ShippingDestination::Destinations::ELSEWHERE => "Elsewhere"
-    }
-    first_countries.merge!(
-      Compliance::Countries.for_select.reject { |c| Compliance::Countries.blocked?(c[0]) }.to_h
-    )
-  end
+    def continent_expected(continent_name)
+      ISO3166::Country.all
+        .select { |c| c.continent == continent_name }
+        .reject { |c| Compliance::Countries.blocked?(c.alpha2) || Compliance::Countries.risk_physical_blocked?(c.alpha2) }
+        .map { |c| [c.alpha2, c.common_name] }
+        .sort_by { |pair| pair.last }
+        .to_h
+    end
 
-  def continent_expected(continent_name)
-    ISO3166::Country.all
-      .select { |c| c.continent == continent_name }
-      .reject { |c| Compliance::Countries.blocked?(c.alpha2) || Compliance::Countries.risk_physical_blocked?(c.alpha2) }
-      .map { |c| [c.alpha2, c.common_name] }
-      .sort_by { |pair| pair.last }
-      .to_h
-  end
+    def europe_shipping_countries_expected
+      continent_expected("Europe")
+    end
 
-  def europe_shipping_countries_expected
-    continent_expected("Europe")
-  end
+    def asia_shipping_countries_expected
+      continent_expected("Asia")
+    end
 
-  def asia_shipping_countries_expected
-    continent_expected("Asia")
-  end
-
-  def north_america_shipping_countries_expected
-    continent_expected("North America")
-  end
+    def north_america_shipping_countries_expected
+      continent_expected("North America")
+    end
 end

--- a/spec/modules/user/posts_spec.rb
+++ b/spec/modules/user/posts_spec.rb
@@ -265,7 +265,7 @@ describe User::Posts, :freeze_time do
         # most ONE links-by-permalink lookup, regardless of post count.
         links_by_permalink = queries.grep(/FROM `links`.*WHERE.*`unique_permalink`/)
         expect(links_by_permalink.size).to be <= 1,
-          "Expected at most 1 Link.find_by(unique_permalink:) lookup, got #{links_by_permalink.size}:\n#{links_by_permalink.join("\n")}"
+                                           "Expected at most 1 Link.find_by(unique_permalink:) lookup, got #{links_by_permalink.size}:\n#{links_by_permalink.join("\n")}"
 
         # Direct probe of the filter cache: call seller_post_passes_filters
         # twice on the same post with the same cache; the second call must
@@ -307,7 +307,7 @@ describe User::Posts, :freeze_time do
         end
         not_bought_hits = cache_hit_queries.grep(/FROM `purchases`.*`link_id`.*`email` = /)
         expect(not_bought_hits).to be_empty,
-          "Second call with shared cache must issue 0 not_bought_products lookups, got #{not_bought_hits.size}:\n#{not_bought_hits.join("\n")}"
+                                   "Second call with shared cache must issue 0 not_bought_products lookups, got #{not_bought_hits.size}:\n#{not_bought_hits.join("\n")}"
       end
     end
   end

--- a/spec/modules/user/risk_spec.rb
+++ b/spec/modules/user/risk_spec.rb
@@ -91,7 +91,6 @@ describe User::Risk do
         end.to change(SuspendAccountsWithPaymentAddressWorker.jobs, :size).from(1).to(0)
       end
     end
-
   end
 
   describe "#unblock_seller_ip!" do
@@ -112,6 +111,5 @@ describe User::Risk do
       expect(ip_block.reload.blocked_at).to be_nil
       expect(email_block.reload.blocked_at).to be_present
     end
-
   end
 end

--- a/spec/presenters/paginated_installments_presenter_spec.rb
+++ b/spec/presenters/paginated_installments_presenter_spec.rb
@@ -194,7 +194,7 @@ describe PaginatedInstallmentsPresenter do
         per_row_patterns.each do |pattern, label, max|
           hits = queries.grep(pattern)
           expect(hits.size).to be <= max,
-            "Expected at most #{max} per-row queries matching #{label}, got #{hits.size}:\n#{hits.join("\n")}"
+                               "Expected at most #{max} per-row queries matching #{label}, got #{hits.size}:\n#{hits.join("\n")}"
         end
       end
     end

--- a/spec/presenters/settings_presenter_spec.rb
+++ b/spec/presenters/settings_presenter_spec.rb
@@ -273,21 +273,21 @@ describe SettingsPresenter do
 
     it "returns the correct props" do
       expect(presenter.third_party_analytics_props).to eq({
-        disable_third_party_analytics: false,
-        google_analytics_id: "",
-        facebook_pixel_id: "",
-        tiktok_pixel_id: "",
-        skip_free_sale_analytics: false,
-        facebook_meta_tag: "",
-        enable_verify_domain_third_party_services: false,
-        snippets: [{
-          id: third_party_analytic.external_id,
-          name: third_party_analytic.name,
-          location: third_party_analytic.location,
-          code: third_party_analytic.analytics_code,
-          product: third_party_analytic.link.unique_permalink,
-        }]
-      })
+                                                            disable_third_party_analytics: false,
+                                                            google_analytics_id: "",
+                                                            facebook_pixel_id: "",
+                                                            tiktok_pixel_id: "",
+                                                            skip_free_sale_analytics: false,
+                                                            facebook_meta_tag: "",
+                                                            enable_verify_domain_third_party_services: false,
+                                                            snippets: [{
+                                                              id: third_party_analytic.external_id,
+                                                              name: third_party_analytic.name,
+                                                              location: third_party_analytic.location,
+                                                              code: third_party_analytic.analytics_code,
+                                                              product: third_party_analytic.link.unique_permalink,
+                                                            }]
+                                                          })
     end
 
     context "when attributes are set" do

--- a/spec/presenters/wishlist_presenter_spec.rb
+++ b/spec/presenters/wishlist_presenter_spec.rb
@@ -407,7 +407,7 @@ describe WishlistPresenter do
       ].each do |per_row_pattern|
         per_row = queries.grep(per_row_pattern)
         expect(per_row).to be_empty,
-          "Expected no per-row queries matching #{per_row_pattern.inspect}, got #{per_row.size}:\n#{per_row.join("\n")}"
+                           "Expected no per-row queries matching #{per_row_pattern.inspect}, got #{per_row.size}:\n#{per_row.join("\n")}"
       end
     end
   end

--- a/spec/requests/products/collabs_spec.rb
+++ b/spec/requests/products/collabs_spec.rb
@@ -79,13 +79,11 @@ describe "Collabs", type: :system, js: true do
       end
 
       [Purchase, Link, Balance].each do |model|
-        begin
-          index_model_records(model)
-        rescue Elasticsearch::Transport::Transport::Errors::BadRequest => e
-          raise unless e.message.include?("resource_already_exists_exception")
-          sleep 0.5
-          index_model_records(model)
-        end
+        index_model_records(model)
+      rescue Elasticsearch::Transport::Transport::Errors::BadRequest => e
+        raise unless e.message.include?("resource_already_exists_exception")
+        sleep 0.5
+        index_model_records(model)
       end
     end
 

--- a/spec/services/app_store_walks_jws_verifier_spec.rb
+++ b/spec/services/app_store_walks_jws_verifier_spec.rb
@@ -135,12 +135,12 @@ describe AppStoreWalksJwsVerifier do
 
       it "returns valid?: true for a current ProSub subscription" do
         result = described_class.verify(make_jws({
-          productId: "ProSub",
-          bundleId: "com.gumroad.walks",
-          environment: "Sandbox",
-          expiresDate: (Time.current.to_i + 86_400) * 1000,
-          originalTransactionId: "1000000123",
-        }))
+                                                   productId: "ProSub",
+                                                   bundleId: "com.gumroad.walks",
+                                                   environment: "Sandbox",
+                                                   expiresDate: (Time.current.to_i + 86_400) * 1000,
+                                                   originalTransactionId: "1000000123",
+                                                 }))
         expect(result.valid?).to be(true)
         expect(result.product_id).to eq("ProSub")
         expect(result.original_transaction_id).to eq("1000000123")
@@ -148,63 +148,63 @@ describe AppStoreWalksJwsVerifier do
 
       it "rejects an expired subscription" do
         result = described_class.verify(make_jws({
-          productId: "ProSub",
-          bundleId: "com.gumroad.walks",
-          environment: "Sandbox",
-          expiresDate: (Time.current.to_i - 86_400) * 1000,
-        }))
+                                                   productId: "ProSub",
+                                                   bundleId: "com.gumroad.walks",
+                                                   environment: "Sandbox",
+                                                   expiresDate: (Time.current.to_i - 86_400) * 1000,
+                                                 }))
         expect(result.valid?).to be(false)
         expect(result.error).to eq("not_entitled")
       end
 
       it "rejects a revoked subscription" do
         result = described_class.verify(make_jws({
-          productId: "ProSub",
-          bundleId: "com.gumroad.walks",
-          environment: "Sandbox",
-          expiresDate: (Time.current.to_i + 86_400) * 1000,
-          revocationDate: (Time.current.to_i - 60) * 1000,
-        }))
+                                                   productId: "ProSub",
+                                                   bundleId: "com.gumroad.walks",
+                                                   environment: "Sandbox",
+                                                   expiresDate: (Time.current.to_i + 86_400) * 1000,
+                                                   revocationDate: (Time.current.to_i - 60) * 1000,
+                                                 }))
         expect(result.valid?).to be(false)
       end
 
       it "rejects a subscription for a different product id" do
         result = described_class.verify(make_jws({
-          productId: "OtherSub",
-          bundleId: "com.gumroad.walks",
-          environment: "Sandbox",
-          expiresDate: (Time.current.to_i + 86_400) * 1000,
-        }))
+                                                   productId: "OtherSub",
+                                                   bundleId: "com.gumroad.walks",
+                                                   environment: "Sandbox",
+                                                   expiresDate: (Time.current.to_i + 86_400) * 1000,
+                                                 }))
         expect(result.valid?).to be(false)
       end
 
       it "rejects a subscription from the wrong bundle" do
         result = described_class.verify(make_jws({
-          productId: "ProSub",
-          bundleId: "com.other.app",
-          environment: "Sandbox",
-          expiresDate: (Time.current.to_i + 86_400) * 1000,
-        }))
+                                                   productId: "ProSub",
+                                                   bundleId: "com.other.app",
+                                                   environment: "Sandbox",
+                                                   expiresDate: (Time.current.to_i + 86_400) * 1000,
+                                                 }))
         expect(result.valid?).to be(false)
       end
 
       it "rejects a Production-signed subscription in a non-production env (test env accepts only Sandbox)" do
         result = described_class.verify(make_jws({
-          productId: "ProSub",
-          bundleId: "com.gumroad.walks",
-          environment: "Production",
-          expiresDate: (Time.current.to_i + 86_400) * 1000,
-        }))
+                                                   productId: "ProSub",
+                                                   bundleId: "com.gumroad.walks",
+                                                   environment: "Production",
+                                                   expiresDate: (Time.current.to_i + 86_400) * 1000,
+                                                 }))
         expect(result.valid?).to be(false)
       end
 
       it "rejects an unknown environment value" do
         result = described_class.verify(make_jws({
-          productId: "ProSub",
-          bundleId: "com.gumroad.walks",
-          environment: "Xcode",
-          expiresDate: (Time.current.to_i + 86_400) * 1000,
-        }))
+                                                   productId: "ProSub",
+                                                   bundleId: "com.gumroad.walks",
+                                                   environment: "Xcode",
+                                                   expiresDate: (Time.current.to_i + 86_400) * 1000,
+                                                 }))
         expect(result.valid?).to be(false)
       end
 
@@ -213,31 +213,31 @@ describe AppStoreWalksJwsVerifier do
 
         it "accepts a Production-signed ProSub subscription" do
           result = described_class.verify(make_jws({
-            productId: "ProSub",
-            bundleId: "com.gumroad.walks",
-            environment: "Production",
-            expiresDate: (Time.current.to_i + 86_400) * 1000,
-          }))
+                                                     productId: "ProSub",
+                                                     bundleId: "com.gumroad.walks",
+                                                     environment: "Production",
+                                                     expiresDate: (Time.current.to_i + 86_400) * 1000,
+                                                   }))
           expect(result.valid?).to be(true)
         end
 
         it "accepts a Sandbox-signed ProSub subscription (TestFlight / sandbox tester on prod)" do
           result = described_class.verify(make_jws({
-            productId: "ProSub",
-            bundleId: "com.gumroad.walks",
-            environment: "Sandbox",
-            expiresDate: (Time.current.to_i + 86_400) * 1000,
-          }))
+                                                     productId: "ProSub",
+                                                     bundleId: "com.gumroad.walks",
+                                                     environment: "Sandbox",
+                                                     expiresDate: (Time.current.to_i + 86_400) * 1000,
+                                                   }))
           expect(result.valid?).to be(true)
         end
 
         it "still rejects an unknown environment value" do
           result = described_class.verify(make_jws({
-            productId: "ProSub",
-            bundleId: "com.gumroad.walks",
-            environment: "Xcode",
-            expiresDate: (Time.current.to_i + 86_400) * 1000,
-          }))
+                                                     productId: "ProSub",
+                                                     bundleId: "com.gumroad.walks",
+                                                     environment: "Xcode",
+                                                     expiresDate: (Time.current.to_i + 86_400) * 1000,
+                                                   }))
           expect(result.valid?).to be(false)
         end
       end

--- a/spec/services/content_moderation/strategies/prompt_strategy_spec.rb
+++ b/spec/services/content_moderation/strategies/prompt_strategy_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe ContentModeration::Strategies::PromptStrategy, :vcr do
         image_urls: ["https://cdn.example.com/photo.png", "https://cdn.example.com/design.psd", "https://cdn.example.com/logo.svg"]
       ).perform
 
-      adult_call = client.as_null_object
+      client.as_null_object
       expect(client).to have_received(:chat).with(
         parameters: hash_including(
           messages: [

--- a/spec/services/exports/payouts/annual_spec.rb
+++ b/spec/services/exports/payouts/annual_spec.rb
@@ -88,7 +88,7 @@ describe Exports::Payouts::Annual, :vcr do
       str = value.to_s
       return value if str.empty?
       first = str[0]
-      if first == '+' || first == '-'
+      if first == "+" || first == "-"
         return value if str[1..]&.match?(/\A\d+\.?\d*\z/)
       end
       %w[= @ | % \r \t + -].include?(first) ? "'#{value}" : value

--- a/spec/services/exports/payouts/csv_spec.rb
+++ b/spec/services/exports/payouts/csv_spec.rb
@@ -229,7 +229,7 @@ describe Exports::Payouts::Csv, :vcr do
     str = value.to_s
     return value if str.empty?
     first = str[0]
-    if first == '+' || first == '-'
+    if first == "+" || first == "-"
       return value if str[1..]&.match?(/\A\d+\.?\d*\z/)
     end
     %w[= @ | % \r \t + -].include?(first) ? "'#{value}" : value

--- a/spec/services/update_user_country_spec.rb
+++ b/spec/services/update_user_country_spec.rb
@@ -87,9 +87,9 @@ describe UpdateUserCountry do
         old_compliance_info = @user.alive_user_compliance_info
         expect(old_compliance_info.country).to eq("Japan")
 
-        expect {
+        expect do
           UpdateUserCountry.new(new_country_code: "GB", user: @user).process
-        }.not_to raise_error
+        end.not_to raise_error
 
         expect(old_compliance_info.reload.deleted?).to eq(true)
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -256,14 +256,14 @@ RSpec.configure do |config|
     [
       Thread.new { prepare_mysql },
       Thread.new { ElasticsearchSetup.prepare_test_environment },
-      Thread.new {
+      Thread.new do
         routes_dir = Rails.root.join("app", "javascript", "utils")
         routes_file = routes_dir.join("routes.js")
         unless routes_file.exist?
           JsRoutes.generate!(routes_file)
           JsRoutes.definitions!(routes_dir.join("routes.d.ts"))
         end
-      }
+      end
     ].each(&:join)
 
     # Build Vite assets up front so :js system specs don't race autoBuild

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,11 @@
-import { fileURLToPath } from "node:url";
-import path from "path";
-
 import UnpluginTypia from "@typia/unplugin/vite";
 import react from "@vitejs/plugin-react";
+import { fileURLToPath } from "node:url";
+import path from "path";
+import { visualizer } from "rollup-plugin-visualizer";
 import AutoImport from "unplugin-auto-import/vite";
 import { defineConfig } from "vite";
 import RubyPlugin from "vite-plugin-ruby";
-import { visualizer } from "rollup-plugin-visualizer";
 
 const rootPath = path.dirname(fileURLToPath(import.meta.url));
 
@@ -15,7 +14,7 @@ function stripCjsExportsPlugin() {
     name: "strip-cjs-exports",
     transform(code: string, id: string) {
       if (id.endsWith("routes.js")) {
-        return code.replace(/^Object\.defineProperty\(exports.*$/m, "").replace(/^exports\.\w+\s*=.*$/gm, "");
+        return code.replace(/^Object\.defineProperty\(exports.*$/mu, "").replace(/^exports\.\w+\s*=.*$/gmu, "");
       }
     },
   };
@@ -67,7 +66,12 @@ export default defineConfig(({ mode }) => ({
     AutoImport({
       imports: [
         { "$app/utils/routes": [["*", "Routes"]] },
-        { jquery: [["default", "$"], ["default", "jQuery"]] },
+        {
+          jquery: [
+            ["default", "$"],
+            ["default", "jQuery"],
+          ],
+        },
       ],
     }),
     stripCjsExportsPlugin(),


### PR DESCRIPTION
## What

Enables enforcing CI lint gates: adds `lint_js` and `lint_ruby` jobs to `.github/workflows/tests.yml`, a `typecheck` npm script, and corrects the README's linting claim.

**Stacked on #5465** (the lint baseline cleanup) — must merge after that, otherwise these gates fail on pre-existing violations.

## Why

CI ran only RSpec — no RuboCop, no ESLint — yet the README claimed "CI will automatically check and fix these." Style and type regressions could merge silently. These two cheap jobs make the documented contract real.

## How

- **`lint_js`** — `npm ci` + `npm run lint-fast` (`DISABLE_TYPE_CHECKED=1 eslint`). Fast path; the type-checked rules need the Rails-generated TS artifacts (`rails js:export`) and a DB, so full `tsc` stays a local command, not a CI job.
- **`lint_ruby`** — `ruby/setup-ruby` (reads `.ruby-version` 3.4.3, `bundler-cache: true`) + `bundle exec rubocop --format github`. Check-only, no `-a`/`--fix` in CI.
- Both jobs `needs: ci_gate` and copy the **exact fork-PR `if:` guard** from the `build` job — preserving the `pull_request_target` security boundary.
- Added `"typecheck": "tsc --noEmit"` to package.json and documented it in CONTRIBUTING's "Before pushing" block.
- README: "CI will automatically check and fix (if possible) these" → "CI checks these on every push."

## Verification

- `.github/workflows/tests.yml` parses as valid YAML; contains `lint_js` + `lint_ruby`.
- On the clean base (after #5465): `bundle exec rubocop` → no offenses; `npm run lint-fast` → exit 0. Both gates will be green.
- No `-a`/`--fix` runs in CI (check-only, as intended).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783903242&installation_id=134400930&pr_number=5466&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5466&signature=7a1f6a2cba0b27c43b0d866f25374f30af11a74bb7f3c1353e7909bf64668e53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions workflow and contributor docs; no runtime application code. Main risk is CI noise or red builds until the lint baseline PR merges.
> 
> **Overview**
> Adds **CI enforcement** for the linters the repo already documents: new **`lint_js`** (`npm ci` + `npm run lint-fast`) and **`lint_ruby`** (`bundle exec rubocop --format github`) jobs in `tests.yml`, both gated on `ci_gate` with the same fork-PR `if:` guard as **`build`**. They run in parallel with image build rather than blocking RSpec.
> 
> Introduces **`npm run typecheck`** (`tsc --noEmit`) for local use only; CONTRIBUTING’s pre-push section now lists it alongside RuboCop and ESLint. README no longer claims CI auto-fixes lint—**check-only on every push**.
> 
> **Note:** These gates expect a clean lint baseline (stacked on #5465); until that lands, new jobs may fail on existing offenses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e148e5575731d9a4a6498547594682b83b656340. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->