### PR TITLE
Reconcile combined-charge money splits to charge totals

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -44,11 +44,45 @@ class Charge < ApplicationRecord
     transaction do
       update!(processor_fee_cents:)
 
-      charged_purchases.each do |purchase|
-        purchase_processor_fee_cents = (processor_fee_cents * (purchase.total_transaction_cents.to_f / amount_cents)).round
-        purchase.update!(processor_fee_cents: purchase_processor_fee_cents)
+      purchases = charged_purchases.to_a
+      allocated_fees = self.class.allocate_by_largest_remainder(
+        processor_fee_cents,
+        purchases.map(&:total_transaction_cents),
+        amount_cents,
+      )
+
+      purchases.each_with_index do |purchase, index|
+        purchase.update!(processor_fee_cents: allocated_fees[index])
       end
     end
+  end
+
+  # Splits +total_cents+ into one integer-cent share per weight so that the
+  # shares always sum exactly to +total_cents+ (largest-remainder method).
+  # Each share is floor(total_cents * weight / weight_total); the leftover
+  # cents are handed out one at a time to the shares with the largest
+  # fractional remainders, tie-broken by position so the result is
+  # deterministic. Returns an array aligned with +weights+.
+  def self.allocate_by_largest_remainder(total_cents, weights, weight_total)
+    return weights.map { 0 } if weight_total.to_i == 0
+
+    exact_shares = weights.map { |weight| total_cents * weight.to_f / weight_total }
+    floors = exact_shares.map(&:floor)
+    residual = total_cents - floors.sum
+
+    if residual != 0
+      step = residual.positive? ? 1 : -1
+      ranked = (0...weights.size).sort_by do |index|
+        remainder = exact_shares[index] - floors[index]
+        # Largest remainder first when distributing positive cents; smallest
+        # (to reclaim) first when distributing negative cents. Tie-break by
+        # index for determinism.
+        [residual.positive? ? -remainder : remainder, index]
+      end
+      ranked.first(residual.abs).each { |index| floors[index] += step }
+    end
+
+    floors
   end
 
   def upload_invoice_pdf(pdf)

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -2938,29 +2938,41 @@ class Purchase < ApplicationRecord
   end
 
   def build_flow_of_funds_from_combined_charge(combined_flow_of_funds)
-    total_issued_amount_cents = combined_flow_of_funds.issued_amount.cents
-    purchase_portion = total_transaction_cents * 1.0 / charge.amount_cents
-    purchase_gumroad_amount_portion = if charge.gumroad_amount_cents == 0
+    charge_purchases = charge.purchases.to_a.sort_by(&:id)
+    purchase_index = charge_purchases.index { |purchase| purchase.id == id }
+    raise ArgumentError, "Purchase #{id} is not part of charge #{charge&.id}" if purchase_index.nil?
+
+    # The "portion" ratios use total_transaction_cents (whole charge), the
+    # gumroad amount, and the seller (complement) amount respectively. Each
+    # amount is split across all purchases in the charge with the
+    # largest-remainder method so the per-purchase shares always reconcile to
+    # the combined charge amount; this purchase takes its own share by index.
+    transaction_weights = charge_purchases.map(&:total_transaction_cents)
+    gumroad_weights = charge_purchases.map(&:total_transaction_amount_for_gumroad_cents)
+    seller_weights = charge_purchases.map { |purchase| purchase.total_transaction_cents - purchase.total_transaction_amount_for_gumroad_cents }
+
+    share = lambda do |total_cents, weights, weight_total|
+      Charge.allocate_by_largest_remainder(total_cents, weights, weight_total)[purchase_index]
+    end
+
+    issued_amount_cents = share.call(combined_flow_of_funds.issued_amount.cents, transaction_weights, charge.amount_cents)
+    settled_amount_cents = share.call(combined_flow_of_funds.settled_amount.cents, transaction_weights, charge.amount_cents)
+    gumroad_amount_cents = if charge.gumroad_amount_cents == 0
       0
     else
-      total_transaction_amount_for_gumroad_cents * 1.0 / charge.gumroad_amount_cents
+      share.call(combined_flow_of_funds.gumroad_amount.cents, gumroad_weights, charge.gumroad_amount_cents)
     end
-    purchase_seller_portion = (total_transaction_cents - total_transaction_amount_for_gumroad_cents) * 1.0 /
-        (charge.amount_cents - charge.gumroad_amount_cents)
-
-    issued_amount_cents = (total_issued_amount_cents * purchase_portion).floor
-    settled_amount_cents = (combined_flow_of_funds.settled_amount.cents * purchase_portion).floor
-    gumroad_amount_cents = (combined_flow_of_funds.gumroad_amount.cents * purchase_gumroad_amount_portion).floor
 
     issued_amount = FlowOfFunds::Amount.new(currency: combined_flow_of_funds.issued_amount.currency, cents: issued_amount_cents)
     settled_amount = FlowOfFunds::Amount.new(currency: combined_flow_of_funds.settled_amount.currency, cents: settled_amount_cents)
     gumroad_amount = FlowOfFunds::Amount.new(currency: combined_flow_of_funds.gumroad_amount.currency, cents: gumroad_amount_cents)
 
     if combined_flow_of_funds.merchant_account_gross_amount.present?
-      merchant_account_gross_amount_cents = (combined_flow_of_funds.merchant_account_gross_amount.cents * purchase_seller_portion).floor
+      seller_weight_total = charge.amount_cents - charge.gumroad_amount_cents
+      merchant_account_gross_amount_cents = share.call(combined_flow_of_funds.merchant_account_gross_amount.cents, seller_weights, seller_weight_total)
       merchant_account_gross_amount = FlowOfFunds::Amount.new(currency: combined_flow_of_funds.merchant_account_gross_amount.currency,
                                                               cents: merchant_account_gross_amount_cents)
-      merchant_account_net_amount_cents = (combined_flow_of_funds.merchant_account_net_amount.cents * purchase_seller_portion).floor
+      merchant_account_net_amount_cents = share.call(combined_flow_of_funds.merchant_account_net_amount.cents, seller_weights, seller_weight_total)
       merchant_account_net_amount = FlowOfFunds::Amount.new(currency: combined_flow_of_funds.merchant_account_net_amount.currency,
                                                             cents: merchant_account_net_amount_cents)
     end

--- a/spec/models/concerns/charge/chargeable_spec.rb
+++ b/spec/models/concerns/charge/chargeable_spec.rb
@@ -253,6 +253,22 @@ describe Charge::Chargeable do
         expect(purchase2.reload.processor_fee_cents).to eq 3_00
         expect(purchase3.reload.processor_fee_cents).to eq 5_00
       end
+
+      it "allocates a non-divisible fee so the per-purchase fees sum exactly to the charge fee" do
+        charge = create(:charge, amount_cents: 100_00)
+        purchase1 = create(:purchase, total_transaction_cents: 33_33)
+        purchase2 = create(:purchase, total_transaction_cents: 33_33)
+        purchase3 = create(:purchase, total_transaction_cents: 33_34)
+        charge.purchases << purchase1
+        charge.purchases << purchase2
+        charge.purchases << purchase3
+
+        charge.update_processor_fee_cents!(processor_fee_cents: 1_00)
+
+        expect(charge.reload.processor_fee_cents).to eq 1_00
+        per_purchase_fees = [purchase1, purchase2, purchase3].map { |purchase| purchase.reload.processor_fee_cents }
+        expect(per_purchase_fees.sum).to eq 1_00
+      end
     end
   end
 

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -5807,7 +5807,10 @@ describe Purchase, :vcr do
       expect(flow_of_funds.settled_amount.currency).to eq(Currency::CAD)
       expect(flow_of_funds.gumroad_amount.cents).to eq(-3_00)
       expect(flow_of_funds.gumroad_amount.currency).to eq(Currency::USD)
-      expect(flow_of_funds.merchant_account_gross_amount.cents).to eq(-52_74)
+      # p2's gross share is -52_73 (not -52_74): with the largest-remainder
+      # split, the three purchases' gross shares now sum to exactly -125_00
+      # (was -125_01 before the fix). p1 -23_44 + p2 -52_73 + p3 -48_83 = -125_00.
+      expect(flow_of_funds.merchant_account_gross_amount.cents).to eq(-52_73)
       expect(flow_of_funds.merchant_account_gross_amount.currency).to eq(Currency::CAD)
       expect(flow_of_funds.merchant_account_net_amount.cents).to eq(-33_75)
       expect(flow_of_funds.merchant_account_net_amount.currency).to eq(Currency::CAD)
@@ -5824,6 +5827,37 @@ describe Purchase, :vcr do
       expect(flow_of_funds.merchant_account_gross_amount.currency).to eq(Currency::CAD)
       expect(flow_of_funds.merchant_account_net_amount.cents).to eq(-31_25)
       expect(flow_of_funds.merchant_account_net_amount.currency).to eq(Currency::CAD)
+    end
+
+    it "splits each amount so the per-purchase shares sum exactly to the combined charge amounts" do
+      charge = create(:charge, amount_cents: 100_01, gumroad_amount_cents: 10_01)
+
+      purchase1 = create(:purchase, total_transaction_cents: 33_34)
+      purchase1.update!(fee_cents: 3_34)
+      purchase2 = create(:purchase, total_transaction_cents: 33_34)
+      purchase2.update!(fee_cents: 3_34)
+      purchase3 = create(:purchase, total_transaction_cents: 33_33)
+      purchase3.update!(fee_cents: 3_33)
+
+      charge.purchases << purchase1
+      charge.purchases << purchase2
+      charge.purchases << purchase3
+
+      combined_flow_of_funds = FlowOfFunds.new(
+        issued_amount: FlowOfFunds::Amount.new(currency: Currency::USD, cents: 100_01),
+        settled_amount: FlowOfFunds::Amount.new(currency: Currency::CAD, cents: 125_01),
+        gumroad_amount: FlowOfFunds::Amount.new(currency: Currency::USD, cents: 10_01),
+        merchant_account_gross_amount: FlowOfFunds::Amount.new(currency: Currency::CAD, cents: 125_01),
+        merchant_account_net_amount: FlowOfFunds::Amount.new(currency: Currency::CAD, cents: 112_51)
+      )
+
+      flows = [purchase1, purchase2, purchase3].map { |purchase| purchase.build_flow_of_funds_from_combined_charge(combined_flow_of_funds) }
+
+      expect(flows.sum { |flow| flow.issued_amount.cents }).to eq(100_01)
+      expect(flows.sum { |flow| flow.settled_amount.cents }).to eq(125_01)
+      expect(flows.sum { |flow| flow.gumroad_amount.cents }).to eq(10_01)
+      expect(flows.sum { |flow| flow.merchant_account_gross_amount.cents }).to eq(125_01)
+      expect(flows.sum { |flow| flow.merchant_account_net_amount.cents }).to eq(112_51)
     end
   end
 


### PR DESCRIPTION
## What

Fixes a money-split bug where combined-charge amounts allocated back to individual purchases don't reconcile to the charge total — each per-purchase share is independently floored/rounded, so the parts can come up a cent short (or over) relative to the whole.

Two methods, same root cause, same fix (largest-remainder allocation):
1. `Charge#update_processor_fee_cents!` — per-purchase processor fees
2. `Purchase#build_flow_of_funds_from_combined_charge` — the five flow-of-funds amounts (issued, settled, gumroad, merchant gross, merchant net)

## Why

When several purchases are charged together as one `Charge`, these splits feed balance transactions for refunds, disputes, and charge events. Independent `.floor`/`.round` per purchase means a 100¢ amount split three ways yields 33+33+33 = **99¢** — seller balance movements drift from what the processor actually settled. The existing specs only used cleanly divisible amounts (20/30/50 of 100), so the drift was invisible.

**Demonstrated drift (now covered by tests):**
- A 1_00¢ fee split across 33_33/33_33/33_34 summed to **99¢**, not 100¢.
- A combined settled amount of 125_01 split across 33_34/33_34/33_33 summed to **125_00**, not 125_01.

## How

New deterministic helper `Charge.allocate_by_largest_remainder(total_cents, weights, weight_total)`:
- floor each share, then distribute the leftover cents one at a time to the largest fractional remainders (tie-broken by index → deterministic).
- handles negative totals (refunds/disputes) by reclaiming cents from the smallest remainders.
- `weight_total == 0` guard preserves the existing gumroad-amount-zero branch.

`build_flow_of_funds_from_combined_charge` is still called **one purchase at a time** (5 caller sites unchanged) — each call ranks all purchases in the charge by `id` and takes its own share by index, so siblings never need to coordinate. The three ratio families (transaction / gumroad / seller-complement) are each allocated within their own family, preserving the original ratio definitions.

## Backward compatibility

- Divisible fixtures (20/30/50 splits) produce **byte-identical** values — largest-remainder reproduces 2_00/3_00/5_00 and the existing exact per-purchase flow-of-funds assertions are unchanged.
- One **non-divisible** fixture (the affiliate-fee case) changes by 1¢: p2 merchant-gross `-52_74 → -52_73`, which makes the three shares sum to exactly `-125_00` (was `-125_01`) — i.e. the bug being fixed. Annotated inline.

## Verification (local)

- `bin/rspec spec/models/concerns/charge/chargeable_spec.rb -e "update_processor_fee_cents!"` → **4 pass** (incl. new non-divisible sum-reconciliation case; divisible case still 2/3/5).
- `bin/rspec spec/models/purchase_spec.rb -e "build_flow_of_funds_from_combined_charge"` → **4 pass** (incl. new per-amount sum-reconciliation case).
- Revert-check: with the model changes stashed, both new tests fail (`99 ≠ 100`, settled `12500 ≠ 12501`) — they genuinely guard the fix.
- Pure arithmetic, no new HTTP — `:vcr` specs need no new cassettes.

*(One unrelated pre-existing failure in `charge_spec.rb`, `#upload_invoice_pdf`, is an S3 networking call that also fails on unmodified `main` in a sandboxed env — not touched by this change.)*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783904482&installation_id=134400930&pr_number=5468&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5468&signature=b2210d0b0d26f76216d68c9e4dc2ca53bd65a8e90c09839fd4fb42de8b67744c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payment allocation for combined charges (processor fees and flow-of-funds used in refunds/disputes/balance logic); behavior is deterministic and mostly unchanged for divisible amounts, but some real cent values may shift by 1¢ where rounding previously drifted.
> 
> **Overview**
> Fixes **off-by-cent drift** when a single `Charge` is split across multiple purchases: independent `.floor`/`.round` per line could leave totals short or long (e.g. 100¢ fee → 33+33+33 = 99¢).
> 
> Adds **`Charge.allocate_by_largest_remainder`** — floor proportional shares, then distribute leftover cents by largest fractional remainder (index tie-break; supports negative amounts for refunds). **`Charge#update_processor_fee_cents!`** now allocates processor fees through this helper so per-purchase fees **sum exactly** to the charge fee.
> 
> **`Purchase#build_flow_of_funds_from_combined_charge`** uses the same helper for issued, settled, Gumroad, and merchant gross/net amounts (sorted by purchase `id`, each call takes its index share). Cleanly divisible splits stay unchanged; one non-divisible spec expectation shifts by 1¢ so three merchant-gross shares reconcile to the combined total.
> 
> Specs add sum-reconciliation cases for fees and flow-of-funds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3aac0795766f849f71a46082fd7acdf64eb0cfe3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->