### PR TITLE
API v2: support minimum_amount_cents on offer code create

### DIFF
--- a/app/controllers/api/v2/offer_codes_controller.rb
+++ b/app/controllers/api/v2/offer_codes_controller.rb
@@ -17,12 +17,14 @@ class Api::V2::OfferCodesController < Api::V2::BaseController
       OfferCode.new(code: params[:name],
                     universal: params[:universal] == "true",
                     amount_percentage: params[:amount_off].to_i,
-                    max_purchase_count: params[:max_purchase_count])
+                    max_purchase_count: params[:max_purchase_count],
+                    minimum_amount_cents: params[:minimum_amount_cents].presence)
     else
       OfferCode.new(code: params[:name],
                     universal: params[:universal] == "true",
                     amount_cents: params[:amount_cents].presence || params[:amount_off].presence,
                     max_purchase_count: params[:max_purchase_count],
+                    minimum_amount_cents: params[:minimum_amount_cents].presence,
                     currency_type: @product.price_currency_type)
     end
 
@@ -59,7 +61,7 @@ class Api::V2::OfferCodesController < Api::V2::BaseController
 
   private
     def permitted_params
-      params.permit(:max_purchase_count)
+      params.permit(:max_purchase_count, :minimum_amount_cents)
     end
 
     def check_offer_code_params

--- a/app/javascript/components/ApiDocumentation/Endpoints/OfferCodes.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/OfferCodes.tsx
@@ -111,6 +111,10 @@ export const CreateOfferCode = () => (
       <ApiParameter name="amount_off" />
       <ApiParameter name="offer_type" description='(optional, "cents" or "percent") Default: "cents"' />
       <ApiParameter name="max_purchase_count" description="(optional)" />
+      <ApiParameter
+        name="minimum_amount_cents"
+        description="(optional) Minimum order total in cents required for the offer code to apply"
+      />
       <ApiParameter name="universal" description="(optional, true or false) Default: false" />
     </ApiParameters>
     <OfferCodeResponseFields />
@@ -135,6 +139,7 @@ export const CreateOfferCode = () => (
     "name": "1OFF",
     "amount_cents": 100,
     "max_purchase_count": null,
+    "minimum_amount_cents": null,
     "times_used": 1
   }
 }`}
@@ -151,6 +156,10 @@ export const UpdateOfferCode = () => (
     <ApiParameters>
       <ApiParameter name="offer_code" />
       <ApiParameter name="max_purchase_count" />
+      <ApiParameter
+        name="minimum_amount_cents"
+        description="(optional) Minimum order total in cents required for the offer code to apply"
+      />
     </ApiParameters>
     <OfferCodeResponseFields />
     <CodeSnippet caption="cURL example">

--- a/app/javascript/components/ApiDocumentation/responseFieldDefinitions.ts
+++ b/app/javascript/components/ApiDocumentation/responseFieldDefinitions.ts
@@ -682,6 +682,11 @@ export const OFFER_CODE_FIELDS: FieldDefinition[] = [
     condition: "present for percentage offer codes",
   },
   { name: "max_purchase_count", type: "number | null", description: "Maximum number of times this code can be used" },
+  {
+    name: "minimum_amount_cents",
+    type: "number | null",
+    description: "Minimum order total in cents required for the offer code to apply. null when there is no minimum.",
+  },
   { name: "universal", type: "boolean", description: "Whether this code applies to all products" },
   { name: "times_used", type: "number", description: "Number of times this code has been redeemed" },
 ];

--- a/app/models/offer_code.rb
+++ b/app/models/offer_code.rb
@@ -128,6 +128,7 @@ class OfferCode < ApplicationRecord
         universal: universal?,
         times_used:
       }
+      json[:minimum_amount_cents] = minimum_amount_cents if minimum_amount_cents.present?
 
       if is_percent?
         json[:percent_off] = amount_percentage
@@ -148,6 +149,7 @@ class OfferCode < ApplicationRecord
       universal: universal?,
       times_used:
     }
+    json[:minimum_amount_cents] = minimum_amount_cents if minimum_amount_cents.present?
 
     if is_percent?
       json[:percent_off] = amount_percentage

--- a/app/models/offer_code.rb
+++ b/app/models/offer_code.rb
@@ -125,10 +125,10 @@ class OfferCode < ApplicationRecord
         id: external_id,
         code:,
         max_purchase_count:,
+        minimum_amount_cents:,
         universal: universal?,
         times_used:
       }
-      json[:minimum_amount_cents] = minimum_amount_cents if minimum_amount_cents.present?
 
       if is_percent?
         json[:percent_off] = amount_percentage
@@ -146,10 +146,10 @@ class OfferCode < ApplicationRecord
       # The `code` is returned as `name` for backwards compatibility of the API
       name: code,
       max_purchase_count:,
+      minimum_amount_cents:,
       universal: universal?,
       times_used:
     }
-    json[:minimum_amount_cents] = minimum_amount_cents if minimum_amount_cents.present?
 
     if is_percent?
       json[:percent_off] = amount_percentage

--- a/spec/controllers/api/v2/offer_codes_controller_spec.rb
+++ b/spec/controllers/api/v2/offer_codes_controller_spec.rb
@@ -273,6 +273,13 @@ describe Api::V2::OfferCodesController do
         expect(@product.offer_codes.alive.first.max_purchase_count).to eq(@new_offer_code_params[:max_purchase_count])
       end
 
+      it "updates offer code minimum_amount_cents" do
+        put @action, params: @params.merge(minimum_amount_cents: 5000)
+
+        expect(@product.reload.offer_codes.alive.count).to eq(1)
+        expect(@product.offer_codes.alive.first.minimum_amount_cents).to eq(5000)
+      end
+
       it "returns the right response" do
         put @action, params: @params
 

--- a/spec/controllers/api/v2/offer_codes_controller_spec.rb
+++ b/spec/controllers/api/v2/offer_codes_controller_spec.rb
@@ -118,6 +118,37 @@ describe Api::V2::OfferCodesController do
         expect(@product.offer_codes.alive.first.currency_type).to eq @product.price_currency_type
       end
 
+      it "creates a cents offer code with a minimum_amount_cents threshold" do
+        post @action, params: @params.merge(offer_type: "cents", minimum_amount_cents: 5000)
+
+        expect(@product.reload.offer_codes.alive.count).to eq 1
+        offer_code = @product.offer_codes.alive.first
+        expect(offer_code.amount_cents).to eq @new_offer_code_params[:amount_off]
+        expect(offer_code.minimum_amount_cents).to eq 5000
+      end
+
+      it "creates a percent offer code with a minimum_amount_cents threshold" do
+        post @action, params: @params.merge(offer_type: "percent", minimum_amount_cents: 5000)
+
+        expect(@product.reload.offer_codes.alive.count).to eq 1
+        offer_code = @product.offer_codes.alive.first
+        expect(offer_code.amount_percentage).to eq @new_offer_code_params[:amount_off]
+        expect(offer_code.minimum_amount_cents).to eq 5000
+      end
+
+      it "leaves minimum_amount_cents nil when not provided" do
+        post @action, params: @params.merge(offer_type: "cents")
+
+        expect(@product.reload.offer_codes.alive.first.minimum_amount_cents).to be(nil)
+      end
+
+      it "returns minimum_amount_cents in the response when set" do
+        post @action, params: @params.merge(offer_type: "cents", minimum_amount_cents: 5000)
+
+        result = response.parsed_body.deep_symbolize_keys
+        expect(result[:offer_code][:minimum_amount_cents]).to eq(5000)
+      end
+
       it "creates a percent offer code by ignoring amount_cents and using amount_off" do
         post @action, params: @params.merge(offer_type: "percent", amount_cents: 50)
 


### PR DESCRIPTION
## What

Make the **minimum-spend threshold** (`minimum_amount_cents`) reachable through the public offer-codes API.

- `POST /v2/products/:id/offer_codes` now reads `minimum_amount_cents` for both percent and cents discounts and passes it to `OfferCode.new`.
- `PUT` permits `minimum_amount_cents`.
- `as_json` / `as_json_for_api` include `minimum_amount_cents` when present, so the value round-trips and a client can confirm it actually persisted.

## Why

The `offer_codes` model and DB column already support `minimum_amount_cents` (added in `20230629014321_add_minimum_amount_cents_to_offer_codes`), and the web Discounts editor (`Checkout::DiscountsController`) sets it. But the **API v2** `OfferCodesController#create` built `OfferCode.new(...)` with a hardcoded attribute list that omitted it, and the API serializer never returned it.

The result was a silent-drop bug: an API client (or the CLI) could pass `minimum_amount_cents` and the value was discarded with no error — the request "succeeded" but produced a discount with no minimum. This is the root cause blocking gumroad-cli #152 ("spend over $100 → 10% off"). Exposing the existing model capability through the API is the minimal fix; no schema or model change needed.

I scoped this to the API surface only (controller + serializer) to mirror how `max_purchase_count` is already threaded, rather than touching the web editor or model, which already handle this field.

## Before / After

This is a non-user-facing (API) change. Walkthrough via the controller spec, which now covers the gap:

- **Before:** `minimum_amount_cents` passed to the API was silently dropped; not returned in the response.
- **After:** it persists for both percent and cents codes, stays `nil` when omitted, and is echoed back in the JSON.

## Test Results

`spec/controllers/api/v2/offer_codes_controller_spec.rb` — **34 examples, 0 failures** (4 new specs added for the threshold: cents code, percent code, nil-when-omitted, returned-in-response). Each new spec fails if the controller change is reverted (the value falls back to `nil`).

```
Finished in 6.99 seconds (files took 3.03 seconds to load)
34 examples, 0 failures
```

> Note: ran locally against the test DB with the healthy Redis port (`:6379` is wedged in this environment; `SIDEKIQ_REDIS_HOST=localhost:6380/11`). No screen recording — headless environment — so test output stands in for the walkthrough video.

---

🤖 AI disclosure: authored by Gumclaw (an autonomous agent operating the Gumroad/Antiwork stack) using **Claude Opus 4.8**. Prompt: "Do this: github.com/antiwork/gumroad-cli/issues/152" (add a CLI `--minimum-amount` flag for offer codes) — which on inspection required first unblocking the API here, since the field wasn't reachable through `/v2`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783949258&installation_id=134400930&pr_number=5469&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5469&signature=335cb3fce89db8a67e61dd3d809d92f082ab1d1487aa4479e08feb78c5666f8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow API surface change reusing an existing model column; no schema or checkout logic changes in this PR.
> 
> **Overview**
> API v2 offer codes now accept and return **`minimum_amount_cents`**, fixing a silent-drop bug where clients could send a minimum spend threshold but it was never persisted.
> 
> **Create** passes `minimum_amount_cents` into `OfferCode.new` for both cents and percent codes; **update** permits it alongside `max_purchase_count`. **`OfferCode#as_json` / `as_json_for_api`** include the field so responses round-trip. Public API docs and `OFFER_CODE_FIELDS` document the optional parameter; controller specs cover create, update, nil-when-omitted, and response shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af30d6a20da2ede5b849db9d63385f60cce8cfa0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->