### PR TITLE
Add auto-merge-gate: deterministic safe-lane eligibility check

### DIFF
--- a/.github/workflows/auto-merge-gate.yml
+++ b/.github/workflows/auto-merge-gate.yml
@@ -79,9 +79,16 @@ jobs:
           # `.author.login` is GitHub's resolved identity for the signing key, so
           # a different collaborator's verified commit yields THEIR login, not the
           # bot's, and the Ruby gate then blocks it.
+          #
+          # SECURITY: authenticate the COMMITTER, not the author. GitHub binds the
+          # verifying key to the committer email, so `.committer.login` is the
+          # identity cryptographically tied to the signature. `.author.login` is
+          # spoofable — an attacker can set author email to the bot's noreply
+          # address (resolving .author.login -> bot) while signing with their own
+          # key (verification.verified == true). Reading the committer closes that.
           signers=$(echo "$commits" | jq -r \
-            '[.[] | if (.commit.verification.verified == true) and (.author.login != null)
-                    then .author.login else "unverified" end] | join(",")')
+            '[.[] | if (.commit.verification.verified == true) and (.committer.login != null)
+                    then .committer.login else "unverified" end] | join(",")')
 
           if [ "$total" = "0" ] || [ -z "$signers" ]; then
             signers="unverified"

--- a/.github/workflows/auto-merge-gate.yml
+++ b/.github/workflows/auto-merge-gate.yml
@@ -2,44 +2,115 @@ name: auto-merge-gate
 
 # Deterministic eligibility check for the support→ship safe lane.
 #
-# GREEN  => PR is a small, bot-authored, ticket-scoped fix in non-sensitive
-#           code and is eligible for unattended auto-merge.
+# GREEN  => PR is a small, bot-signed, ticket-scoped fix touching ONLY
+#           allowlisted safe paths; eligible for unattended auto-merge.
 # RED    => PR is complex or sensitive; auto-merge will NOT run and the change
 #           routes to the human one-tap approval lane.
 #
-# This check is advisory unless added as a REQUIRED status check in branch
-# protection. The merge itself is performed by GitHub native auto-merge, which
-# only fires when every required check (including this one) is green — so this
-# job never merges anything itself.
+# SECURITY (finding #1 — self-refuting check):
+#   This job MUST evaluate using TRUSTED code, never the PR's checkout, or a
+#   malicious PR could rewrite the gate to pass. We therefore:
+#     * trigger on `pull_request_target` (runs in the BASE repo context), and
+#     * explicitly run the gate script + allowlist FROM THE BASE REF
+#       (github.event.pull_request.base.sha), not from the PR head.
+#   We never check out or execute PR-authored code in this job.
+#
+#   Authorization (finding #4) comes from VERIFIED per-commit signatures pulled
+#   from the API — not the mutable PR author field. The label is read from the
+#   API too. The job has read-only permissions and no build/test of PR code.
+#
+# This check is advisory until added as a REQUIRED status check in branch
+# protection. The merge itself is GitHub native auto-merge, which only fires
+# when every required check (including this) is green — this job never merges.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
 permissions:
   contents: read
+  pull-requests: read
+  statuses: write
 
 jobs:
   gate:
     runs-on: ubuntu-latest
     steps:
+      # Check out the BASE ref explicitly — this is trusted code from the
+      # protected branch, NOT the PR's contents.
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
+
+      # Make the PR head commits available to diff against, without merging
+      # or executing them.
+      - name: Fetch PR head for diffing
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: git fetch --no-tags origin "$HEAD_SHA"
 
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.4.3"
 
-      - name: Evaluate auto-merge eligibility
+      # Pull VERIFIED commit signers + label from the API (trusted metadata),
+      # not from PR-mutable fields.
+      - name: Resolve verified commit signers and label
+        id: meta
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          signers=$(gh api "repos/$REPO/pulls/$PR_NUMBER/commits" \
+            --jq '[.[] | select(.commit.verification.verified == true) | "gumclaw"] | join(",")' \
+            2>/dev/null || echo "")
+          # If ANY commit is unverified, surface a sentinel so the gate blocks.
+          total=$(gh api "repos/$REPO/pulls/$PR_NUMBER/commits" --jq 'length')
+          verified=$(gh api "repos/$REPO/pulls/$PR_NUMBER/commits" \
+            --jq '[.[] | select(.commit.verification.verified == true)] | length')
+          if [ "$total" != "$verified" ] || [ "$total" = "0" ]; then
+            signers="unverified"
+          fi
+          label=$(gh api "repos/$REPO/pulls/$PR_NUMBER" \
+            --jq '[.labels[].name] | index("support-fix") != null')
+          echo "signers=$signers" >> "$GITHUB_OUTPUT"
+          echo "label=$label" >> "$GITHUB_OUTPUT"
+
+      - name: Evaluate auto-merge eligibility (from trusted base script)
+        id: gate
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          SIGNERS: ${{ steps.meta.outputs.signers }}
+          LABEL: ${{ steps.meta.outputs.label }}
         run: |
+          set +e
           ruby scripts/auto_merge_gate.rb \
             --base-sha "$BASE_SHA" \
             --head-sha "$HEAD_SHA" \
-            --author "$PR_AUTHOR" \
-            --labels "$PR_LABELS"
+            --commit-signers "$SIGNERS" \
+            --label-verified "$LABEL"
+          echo "result=$?" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      # Publish an explicit commit status so branch protection can require it
+      # and the merge automation can read a stable context name.
+      - name: Publish commit status
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          RESULT: ${{ steps.gate.outputs.result }}
+        run: |
+          if [ "$RESULT" = "0" ]; then
+            state=success; desc="Eligible for safe-lane auto-merge"
+          else
+            state=failure; desc="Blocked — routes to human approval"
+          fi
+          gh api -X POST "repos/$REPO/statuses/$HEAD_SHA" \
+            -f state="$state" \
+            -f context="auto-merge-gate" \
+            -f description="$desc" >/dev/null
+          [ "$RESULT" = "0" ]

--- a/.github/workflows/auto-merge-gate.yml
+++ b/.github/workflows/auto-merge-gate.yml
@@ -1,0 +1,45 @@
+name: auto-merge-gate
+
+# Deterministic eligibility check for the support→ship safe lane.
+#
+# GREEN  => PR is a small, bot-authored, ticket-scoped fix in non-sensitive
+#           code and is eligible for unattended auto-merge.
+# RED    => PR is complex or sensitive; auto-merge will NOT run and the change
+#           routes to the human one-tap approval lane.
+#
+# This check is advisory unless added as a REQUIRED status check in branch
+# protection. The merge itself is performed by GitHub native auto-merge, which
+# only fires when every required check (including this one) is green — so this
+# job never merges anything itself.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4.3"
+
+      - name: Evaluate auto-merge eligibility
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          ruby scripts/auto_merge_gate.rb \
+            --base-sha "$BASE_SHA" \
+            --head-sha "$HEAD_SHA" \
+            --author "$PR_AUTHOR" \
+            --labels "$PR_LABELS"

--- a/.github/workflows/auto-merge-gate.yml
+++ b/.github/workflows/auto-merge-gate.yml
@@ -63,16 +63,30 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
-          signers=$(gh api "repos/$REPO/pulls/$PR_NUMBER/commits" \
-            --jq '[.[] | select(.commit.verification.verified == true) | "gumclaw"] | join(",")' \
-            2>/dev/null || echo "")
-          # If ANY commit is unverified, surface a sentinel so the gate blocks.
-          total=$(gh api "repos/$REPO/pulls/$PR_NUMBER/commits" --jq 'length')
-          verified=$(gh api "repos/$REPO/pulls/$PR_NUMBER/commits" \
-            --jq '[.[] | select(.commit.verification.verified == true)] | length')
-          if [ "$total" != "$verified" ] || [ "$total" = "0" ]; then
+          set -euo pipefail
+          # --paginate walks ALL commit pages (finding: signer check ignored
+          # pages past the first 30). We collect every commit into one JSON array.
+          commits=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/commits" \
+            --jq '.[]' | jq -s '.')
+
+          total=$(echo "$commits" | jq 'length')
+
+          # Extract the ACTUAL verified signer identity per commit, not a literal
+          # constant (finding: verified commits were all misattributed to the bot).
+          # A commit counts as bot-signed ONLY if BOTH:
+          #   * cryptographic signature verified by GitHub, AND
+          #   * GitHub-resolved author login == the bot account.
+          # `.author.login` is GitHub's resolved identity for the signing key, so
+          # a different collaborator's verified commit yields THEIR login, not the
+          # bot's, and the Ruby gate then blocks it.
+          signers=$(echo "$commits" | jq -r \
+            '[.[] | if (.commit.verification.verified == true) and (.author.login != null)
+                    then .author.login else "unverified" end] | join(",")')
+
+          if [ "$total" = "0" ] || [ -z "$signers" ]; then
             signers="unverified"
           fi
+
           label=$(gh api "repos/$REPO/pulls/$PR_NUMBER" \
             --jq '[.labels[].name] | index("support-fix") != null')
           echo "signers=$signers" >> "$GITHUB_OUTPUT"

--- a/scripts/auto_merge_gate.rb
+++ b/scripts/auto_merge_gate.rb
@@ -42,7 +42,7 @@ require "open3"
 # ---- Tunables (start conservative; loosen only with evidence) ----
 MAX_LINES_CHANGED = 40
 MAX_FILES_CHANGED = 5
-SHA_RE = /\A[0-9a-f]{7,40}\z/.freeze
+SHA_RE = /\A[0-9a-f]{7,40}\z/
 # The bot account whose VERIFIED signature authorizes the safe lane. Compared
 # against each commit's GitHub-resolved signer login (.author.login on a
 # verified commit), supplied by the trusted caller — never the PR author field.
@@ -86,8 +86,8 @@ end.parse!
 
 base = options[:base].to_s
 head = options[:head].to_s
-block!("missing/invalid --base-sha") unless base =~ SHA_RE
-block!("missing/invalid --head-sha") unless head =~ SHA_RE
+block!("missing/invalid --base-sha") unless SHA_RE.match?(base)
+block!("missing/invalid --head-sha") unless SHA_RE.match?(head)
 
 # (4) Authorization comes from VERIFIED commit signatures supplied by the trusted
 # caller (from the GitHub API `verification.verified` + signer), not from the

--- a/scripts/auto_merge_gate.rb
+++ b/scripts/auto_merge_gate.rb
@@ -43,6 +43,10 @@ require "open3"
 MAX_LINES_CHANGED = 40
 MAX_FILES_CHANGED = 5
 SHA_RE = /\A[0-9a-f]{7,40}\z/.freeze
+# The bot account whose VERIFIED signature authorizes the safe lane. Compared
+# against each commit's GitHub-resolved signer login (.author.login on a
+# verified commit), supplied by the trusted caller — never the PR author field.
+BOT_IDENTITY = "gumclaw"
 
 # ALLOWLIST (default-deny): a PR is eligible ONLY if EVERY changed path matches
 # one of these safe prefixes. Anything outside the allowlist => block. This is
@@ -90,7 +94,7 @@ block!("missing/invalid --head-sha") unless head =~ SHA_RE
 # mutable PR author field. Every commit must be bot-signed.
 signers = options[:signers].to_s.split(",").map(&:strip)
 block!("no verified commit signers provided") if signers.empty?
-unless signers.all? { |s| s == "gumclaw" }
+unless signers.all? { |s| s == BOT_IDENTITY }
   block!("not all commits verified-signed by bot (signers=#{signers.uniq.join(',')})")
 end
 # Label is a SECONDARY scoping signal, verified by the trusted caller via API.

--- a/scripts/auto_merge_gate.rb
+++ b/scripts/auto_merge_gate.rb
@@ -1,0 +1,111 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# auto_merge_gate.rb
+#
+# Decides whether a PR is ELIGIBLE for unattended auto-merge on the "safe lane".
+#
+# Deterministic by design: an AI agent may DRAFT the fix, but the merge
+# decision itself is made by inspectable rules here — there is no model
+# judgment anywhere in the merge path. A PR only becomes a candidate when it
+# is a small, bot-authored, ticket-scoped fix that touches no sensitive code.
+#
+#   Exit 0 (GREEN) => eligible for safe-lane auto-merge.
+#   Exit 1 (RED)   => blocked; routes to the human one-tap approval lane.
+#
+# Usage (CI):
+#   ruby scripts/auto_merge_gate.rb \
+#     --base-sha "$BASE_SHA" --head-sha "$HEAD_SHA" \
+#     --author "$PR_AUTHOR" --labels "$PR_LABELS"
+#
+# Reads the diff via `git diff --numstat base...head`, so the workflow must
+# check out with enough history to resolve both SHAs (fetch-depth: 0).
+
+require "optparse"
+
+# ---- Tunables (intentionally conservative; loosen only with evidence) ----
+MAX_LINES_CHANGED = 40
+MAX_FILES_CHANGED = 5
+BOT_AUTHOR        = "gumclaw"
+REQUIRED_LABEL    = "support-fix"
+
+# Any changed file matching ANY of these patterns blocks the merge.
+# Covers money, auth, fraud/risk, schema/data migrations, infra/CI, deps —
+# anything where an unattended change could move money or break checkout.
+SENSITIVE_PATTERNS = [
+  %r{\Aapp/models/(charge|purchase|payment|subscription|balance|refund|credit|payout)}i,
+  %r{\Aapp/services/.*(payment|payout|charge|risk|fraud|stripe|paypal|tax)}i,
+  %r{\Aapp/services/risk}i,
+  %r{payments?/}i,
+  %r{stripe}i,
+  %r{paypal}i,
+  %r{webhook}i,
+  %r{\Adb/migrate/},
+  %r{\Adb/schema\.rb\z},
+  %r{\Aconfig/},
+  %r{devise}i,
+  %r{\Aapp/controllers/.*(session|auth|login|oauth|admin)}i,
+  %r{\AGemfile(\.lock)?\z},
+  %r{package(-lock)?\.json\z},
+  %r{yarn\.lock\z},
+  %r{\A\.github/},                 # never let the loop edit its own CI
+  %r{\Ascripts/auto_merge_gate},   # never let it edit the gate itself
+].freeze
+
+def block!(reason)
+  puts "🔴 auto-merge-gate: BLOCKED"
+  puts "   reason: #{reason}"
+  puts "   → routing to human one-tap approval lane"
+  exit 1
+end
+
+def allow!(files:, lines:, author:)
+  puts "🟢 auto-merge-gate: ELIGIBLE for safe-lane auto-merge"
+  puts "   files=#{files} lines=#{lines} author=#{author}"
+  exit 0
+end
+
+options = {}
+OptionParser.new do |o|
+  o.on("--base-sha SHA") { |v| options[:base] = v }
+  o.on("--head-sha SHA") { |v| options[:head] = v }
+  o.on("--author A")     { |v| options[:author] = v }
+  o.on("--labels L")     { |v| options[:labels] = v.to_s }
+end.parse!
+
+base   = options[:base]  || abort("--base-sha required")
+head   = options[:head]  || abort("--head-sha required")
+author = options[:author].to_s
+labels = options[:labels].to_s.split(/[,\s]+/).map(&:strip).reject(&:empty?)
+
+# 1) Provenance — only bot-authored, ticket-scoped fixes are candidates.
+block!("author '#{author}' is not the bot (#{BOT_AUTHOR})") unless author == BOT_AUTHOR
+block!("missing required label '#{REQUIRED_LABEL}'")        unless labels.include?(REQUIRED_LABEL)
+
+# 2) Diff analysis.
+numstat = `git diff --numstat #{base}...#{head}`.strip
+block!("empty or unreadable diff") if numstat.empty?
+
+files = []
+total_lines = 0
+numstat.each_line do |line|
+  added, deleted, path = line.strip.split("\t", 3)
+  next if path.nil?
+  # binary files report "-" for added/deleted counts.
+  block!("binary file change: #{path}") if added == "-" || deleted == "-"
+  files << path
+  total_lines += added.to_i + deleted.to_i
+end
+
+# 3) Sensitive-path veto.
+files.each do |path|
+  SENSITIVE_PATTERNS.each do |re|
+    block!("touches sensitive path: #{path}") if path =~ re
+  end
+end
+
+# 4) Size ceilings.
+block!("too many files (#{files.size} > #{MAX_FILES_CHANGED})")   if files.size > MAX_FILES_CHANGED
+block!("too many lines (#{total_lines} > #{MAX_LINES_CHANGED})")  if total_lines > MAX_LINES_CHANGED
+
+allow!(files: files.size, lines: total_lines, author: author)

--- a/scripts/auto_merge_gate.rb
+++ b/scripts/auto_merge_gate.rb
@@ -52,13 +52,7 @@ BOT_IDENTITY = "gumclaw"
 # one of these safe prefixes. Anything outside the allowlist => block. This is
 # the inverse of a denylist and fails closed on unknown/new code areas.
 SAFE_PATH_ALLOWLIST = [
-  %r{\Aapp/services/support/},
-  %r{\Aapp/views/support/},
-  %r{\Aapp/javascript/components/support/}i,
-  %r{\Aapp/helpers/support/},
-  %r{\Aspec/services/support/},
-  %r{\Aspec/views/support/},
-  %r{\Aconfig/locales/support\.[a-z-]+\.yml\z},
+  %r{\Aapp/views/help_center/articles/contents/},
   %r{\A(README|CHANGELOG)\.md\z},
   %r{\Adocs/},
 ].freeze

--- a/scripts/auto_merge_gate.rb
+++ b/scripts/auto_merge_gate.rb
@@ -57,6 +57,46 @@ SAFE_PATH_ALLOWLIST = [
   %r{\Adocs/},
 ].freeze
 
+# DENYLIST (hard block): critical paths with real production blast radius —
+# money movement, auth, data shape, config, secrets, dependencies, CI, and the
+# gate itself. Evaluated BEFORE the allowlist so a deny ALWAYS wins. Today this
+# is redundant with the default-deny allowlist, but it is a durable tripwire: if
+# the allowlist is ever broadened, none of these can reach unattended merge.
+SENSITIVE_PATH_DENYLIST = [
+  # Payments core: charging, payouts, transfers, refunds, disputes, merchant
+  # registration, sales tax, raw card data.
+  %r{\Aapp/business/payments/},
+  %r{\Aapp/business/sales_tax/},
+  %r{\Aapp/business/card_data_handling/},
+  # Money/auth models (charge, refund, dispute, payout, balance, payment,
+  # purchase, credit, subscription, bank account, merchant, fraud, tax).
+  %r{\Aapp/models/concerns/(balance|charge|payment)/},
+  %r{\Aapp/models/.*(charge|refund|dispute|chargeback|payout|balance|payment|purchase|credit|subscription|bank|merchant|fraud|recurring_service|tax)},
+  # Payment/fraud/subscription services and money exports.
+  %r{\Aapp/services/(charge|dispute_evidence|early_fraud_warning|subscription)/},
+  %r{\Aapp/services/exports/(payouts|tax_summary)/},
+  # Legacy payment/subscription modules.
+  %r{\Aapp/modules/(payment|subscription)/},
+  # Money/auth/admin/webhook controllers.
+  %r{\Aapp/controllers/(admin|oauth|payouts|subscriptions|stripe|settings)/},
+  %r{\Aapp/controllers/api/internal/admin/},
+  %r{\Aapp/controllers/.*(webhook|paypal|stripe|ipn|events_controller|sessions_controller|users_controller|application_controller)},
+  # Authorization policies for money/admin/settings.
+  %r{\Aapp/policies/(admin|settings)/},
+  # Admin & payment frontend (server enforces logic, but block the surface too).
+  %r{\Aapp/javascript/(components|pages)/Admin/},
+  %r{\Aapp/javascript/(components|pages)/(Settings/Payments|Payout|Subscriptions)},
+  # Database schema, migrations, seeds.
+  %r{\Adb/},
+  # Application config, secrets, certs, routes, initializers, credentials.
+  %r{\Aconfig/},
+  # Dependency manifests / lockfiles.
+  %r{\A(Gemfile(\.lock)?|package(-lock)?\.json|yarn\.lock)\z},
+  # CI / automation / the gate itself — no self-widening of authority.
+  %r{\A\.github/},
+  %r{\Ascripts/auto_merge_gate},
+].freeze
+
 def block!(reason)
   puts "🔴 auto-merge-gate: BLOCKED"
   puts "   reason: #{reason}"
@@ -117,8 +157,13 @@ out.split("\0").each do |rec|
 end
 block!("no file changes parsed") if files.empty?
 
-# (3) Default-deny: every path must be inside the safe allowlist.
+# (3) Deny wins over allow: any critical path hard-blocks the PR, even if a
+# future allowlist change would match it. Then default-deny: every remaining
+# path must be inside the safe allowlist.
 files.each do |path|
+  if SENSITIVE_PATH_DENYLIST.any? { |re| path =~ re }
+    block!("critical path blocked by denylist: #{path}")
+  end
   unless SAFE_PATH_ALLOWLIST.any? { |re| path =~ re }
     block!("path outside safe allowlist: #{path}")
   end

--- a/scripts/auto_merge_gate.rb
+++ b/scripts/auto_merge_gate.rb
@@ -22,6 +22,7 @@
 # check out with enough history to resolve both SHAs (fetch-depth: 0).
 
 require "optparse"
+require "open3"
 
 # ---- Tunables (intentionally conservative; loosen only with evidence) ----
 MAX_LINES_CHANGED = 40
@@ -73,8 +74,8 @@ OptionParser.new do |o|
   o.on("--labels L")     { |v| options[:labels] = v.to_s }
 end.parse!
 
-base   = options[:base]  || abort("--base-sha required")
-head   = options[:head]  || abort("--head-sha required")
+base   = options[:base]  || block!("--base-sha argument is required")
+head   = options[:head]  || block!("--head-sha argument is required")
 author = options[:author].to_s
 labels = options[:labels].to_s.split(/[,\s]+/).map(&:strip).reject(&:empty?)
 
@@ -83,7 +84,20 @@ block!("author '#{author}' is not the bot (#{BOT_AUTHOR})") unless author == BOT
 block!("missing required label '#{REQUIRED_LABEL}'")        unless labels.include?(REQUIRED_LABEL)
 
 # 2) Diff analysis.
-numstat = `git diff --numstat #{base}...#{head}`.strip
+#
+# Use Open3 (no shell) so the SHA range can never be interpreted by /bin/sh —
+# this script is the security boundary, so it must not build shell strings.
+# Validate the SHA shape as defense-in-depth even though CI always supplies
+# 40-char hex. `--no-renames` forces git to emit renames as separate
+# delete/add rows (instead of the `dir/{old => new}` inline form), so a renamed
+# sensitive file is still checked against SENSITIVE_PATTERNS on both paths.
+[base, head].each do |sha|
+  block!("invalid SHA format: #{sha.inspect}") unless sha =~ /\A[0-9a-fA-F]{7,40}\z/
+end
+
+numstat, status = Open3.capture2("git", "diff", "--numstat", "--no-renames", "#{base}...#{head}")
+block!("git diff failed (exit #{status.exitstatus})") unless status.success?
+numstat = numstat.strip
 block!("empty or unreadable diff") if numstat.empty?
 
 files = []

--- a/scripts/auto_merge_gate.rb
+++ b/scripts/auto_merge_gate.rb
@@ -1,125 +1,132 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# auto_merge_gate.rb
+# auto-merge-gate
 #
 # Decides whether a PR is ELIGIBLE for unattended auto-merge on the "safe lane".
+# Deterministic by design: a model drafts the fix, but the merge decision is
+# inspectable rules — no LLM judgment in the merge path.
 #
-# Deterministic by design: an AI agent may DRAFT the fix, but the merge
-# decision itself is made by inspectable rules here — there is no model
-# judgment anywhere in the merge path. A PR only becomes a candidate when it
-# is a small, bot-authored, ticket-scoped fix that touches no sensitive code.
+# ─────────────────────────────────────────────────────────────────────────────
+# SECURITY MODEL (read before changing the wiring)
 #
-#   Exit 0 (GREEN) => eligible for safe-lane auto-merge.
-#   Exit 1 (RED)   => blocked; routes to the human one-tap approval lane.
+#   This script is a SECURITY BOUNDARY. It MUST be executed from TRUSTED code —
+#   i.e. the copy of this file on the protected base branch (main) — and NEVER
+#   from the PR's own checkout. If it runs from the PR checkout, the PR under
+#   judgment can rewrite the gate to always pass, which defeats the entire
+#   purpose (self-refuting check).
 #
-# Usage (CI):
-#   ruby scripts/auto_merge_gate.rb \
-#     --base-sha "$BASE_SHA" --head-sha "$HEAD_SHA" \
-#     --author "$PR_AUTHOR" --labels "$PR_LABELS"
+#   Enforced by the caller (the trusted support-to-ship cron OR a
+#   `workflow_run`-triggered job that checks out `main`), which:
+#     1. checks out THIS script from the base/main ref,
+#     2. fetches the PR's verified metadata via the API (not from PR files),
+#     3. runs the diff against the PR head,
+#     4. posts the commit status.
 #
-# Reads the diff via `git diff --numstat base...head`, so the workflow must
-# check out with enough history to resolve both SHAs (fetch-depth: 0).
+#   The gate also requires per-commit verification: every commit on the PR must
+#   be verified-signed by the bot identity. The PR "author" field and labels are
+#   NOT treated as authorization (both are spoofable / mutable by the PR).
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Exit 0 (GREEN) => eligible: small, signed-by-bot, ticket-scoped fix touching
+#                   ONLY allowlisted safe paths.
+# Exit 1 (RED)   => blocked: routes to the one-tap human-approval lane.
+#
+# Usage (from trusted context only):
+#   ruby auto_merge_gate.rb --base-sha SHA --head-sha SHA \
+#     --commit-signers "gumclaw,gumclaw" --label-verified true
 
 require "optparse"
 require "open3"
 
-# ---- Tunables (intentionally conservative; loosen only with evidence) ----
+# ---- Tunables (start conservative; loosen only with evidence) ----
 MAX_LINES_CHANGED = 40
 MAX_FILES_CHANGED = 5
-BOT_AUTHOR        = "gumclaw"
-REQUIRED_LABEL    = "support-fix"
+SHA_RE = /\A[0-9a-f]{7,40}\z/.freeze
 
-# Any changed file matching ANY of these patterns blocks the merge.
-# Covers money, auth, fraud/risk, schema/data migrations, infra/CI, deps —
-# anything where an unattended change could move money or break checkout.
-SENSITIVE_PATTERNS = [
-  %r{\Aapp/models/(charge|purchase|payment|subscription|balance|refund|credit|payout)}i,
-  %r{\Aapp/services/.*(payment|payout|charge|risk|fraud|stripe|paypal|tax)}i,
-  %r{\Aapp/services/risk}i,
-  %r{payments?/}i,
-  %r{stripe}i,
-  %r{paypal}i,
-  %r{webhook}i,
-  %r{\Adb/migrate/},
-  %r{\Adb/schema\.rb\z},
-  %r{\Aconfig/},
-  %r{devise}i,
-  %r{\Aapp/controllers/.*(session|auth|login|oauth|admin)}i,
-  %r{\AGemfile(\.lock)?\z},
-  %r{package(-lock)?\.json\z},
-  %r{yarn\.lock\z},
-  %r{\A\.github/},                 # never let the loop edit its own CI
-  %r{\Ascripts/auto_merge_gate},   # never let it edit the gate itself
+# ALLOWLIST (default-deny): a PR is eligible ONLY if EVERY changed path matches
+# one of these safe prefixes. Anything outside the allowlist => block. This is
+# the inverse of a denylist and fails closed on unknown/new code areas.
+SAFE_PATH_ALLOWLIST = [
+  %r{\Aapp/services/support/},
+  %r{\Aapp/views/support/},
+  %r{\Aapp/javascript/components/support/}i,
+  %r{\Aapp/helpers/support/},
+  %r{\Aspec/services/support/},
+  %r{\Aspec/views/support/},
+  %r{\Aconfig/locales/support\.[a-z-]+\.yml\z},
+  %r{\A(README|CHANGELOG)\.md\z},
+  %r{\Adocs/},
 ].freeze
 
 def block!(reason)
   puts "🔴 auto-merge-gate: BLOCKED"
   puts "   reason: #{reason}"
-  puts "   → routing to human one-tap approval lane"
+  puts "   → routing to human-approval lane"
   exit 1
 end
 
-def allow!(files:, lines:, author:)
+def pass!(stats)
   puts "🟢 auto-merge-gate: ELIGIBLE for safe-lane auto-merge"
-  puts "   files=#{files} lines=#{lines} author=#{author}"
+  puts "   files=#{stats[:files]} lines=#{stats[:lines]} signed_by=#{stats[:signer]}"
   exit 0
 end
 
 options = {}
 OptionParser.new do |o|
-  o.on("--base-sha SHA") { |v| options[:base] = v }
-  o.on("--head-sha SHA") { |v| options[:head] = v }
-  o.on("--author A")     { |v| options[:author] = v }
-  o.on("--labels L")     { |v| options[:labels] = v.to_s }
+  o.on("--base-sha SHA")        { |v| options[:base] = v }
+  o.on("--head-sha SHA")        { |v| options[:head] = v }
+  o.on("--commit-signers LIST") { |v| options[:signers] = v.to_s }
+  o.on("--label-verified BOOL") { |v| options[:label] = (v == "true") }
 end.parse!
 
-base   = options[:base]  || block!("--base-sha argument is required")
-head   = options[:head]  || block!("--head-sha argument is required")
-author = options[:author].to_s
-labels = options[:labels].to_s.split(/[,\s]+/).map(&:strip).reject(&:empty?)
+base = options[:base].to_s
+head = options[:head].to_s
+block!("missing/invalid --base-sha") unless base =~ SHA_RE
+block!("missing/invalid --head-sha") unless head =~ SHA_RE
 
-# 1) Provenance — only bot-authored, ticket-scoped fixes are candidates.
-block!("author '#{author}' is not the bot (#{BOT_AUTHOR})") unless author == BOT_AUTHOR
-block!("missing required label '#{REQUIRED_LABEL}'")        unless labels.include?(REQUIRED_LABEL)
-
-# 2) Diff analysis.
-#
-# Use Open3 (no shell) so the SHA range can never be interpreted by /bin/sh —
-# this script is the security boundary, so it must not build shell strings.
-# Validate the SHA shape as defense-in-depth even though CI always supplies
-# 40-char hex. `--no-renames` forces git to emit renames as separate
-# delete/add rows (instead of the `dir/{old => new}` inline form), so a renamed
-# sensitive file is still checked against SENSITIVE_PATTERNS on both paths.
-[base, head].each do |sha|
-  block!("invalid SHA format: #{sha.inspect}") unless sha =~ /\A[0-9a-fA-F]{7,40}\z/
+# (4) Authorization comes from VERIFIED commit signatures supplied by the trusted
+# caller (from the GitHub API `verification.verified` + signer), not from the
+# mutable PR author field. Every commit must be bot-signed.
+signers = options[:signers].to_s.split(",").map(&:strip)
+block!("no verified commit signers provided") if signers.empty?
+unless signers.all? { |s| s == "gumclaw" }
+  block!("not all commits verified-signed by bot (signers=#{signers.uniq.join(',')})")
 end
+# Label is a SECONDARY scoping signal, verified by the trusted caller via API.
+block!("support-fix label not present/verified") unless options[:label]
 
-numstat, status = Open3.capture2("git", "diff", "--numstat", "--no-renames", "#{base}...#{head}")
-block!("git diff failed (exit #{status.exitstatus})") unless status.success?
-numstat = numstat.strip
-block!("empty or unreadable diff") if numstat.empty?
+# (2) Parse the diff with quoting disabled and NUL separators so no path can
+# dodge the matchers via git's octal/quote escaping or embedded whitespace.
+# (1) The caller guarantees this runs against trusted git state.
+out, status = Open3.capture2(
+  "git", "-c", "core.quotePath=false",
+  "diff", "--numstat", "-z", "--no-renames", "#{base}...#{head}"
+)
+block!("git diff failed (#{status.exitstatus})") unless status.success?
+block!("empty or unreadable diff") if out.strip.empty?
 
+# numstat -z format: "added\tdeleted\tpath\0" repeated.
 files = []
-total_lines = 0
-numstat.each_line do |line|
-  added, deleted, path = line.strip.split("\t", 3)
-  next if path.nil?
-  # binary files report "-" for added/deleted counts.
+total = 0
+out.split("\0").each do |rec|
+  next if rec.empty?
+  added, deleted, path = rec.split("\t", 3)
+  next if path.nil? || path.empty?
   block!("binary file change: #{path}") if added == "-" || deleted == "-"
   files << path
-  total_lines += added.to_i + deleted.to_i
+  total += added.to_i + deleted.to_i
 end
+block!("no file changes parsed") if files.empty?
 
-# 3) Sensitive-path veto.
+# (3) Default-deny: every path must be inside the safe allowlist.
 files.each do |path|
-  SENSITIVE_PATTERNS.each do |re|
-    block!("touches sensitive path: #{path}") if path =~ re
+  unless SAFE_PATH_ALLOWLIST.any? { |re| path =~ re }
+    block!("path outside safe allowlist: #{path}")
   end
 end
 
-# 4) Size ceilings.
-block!("too many files (#{files.size} > #{MAX_FILES_CHANGED})")   if files.size > MAX_FILES_CHANGED
-block!("too many lines (#{total_lines} > #{MAX_LINES_CHANGED})")  if total_lines > MAX_LINES_CHANGED
+block!("too many files (#{files.size} > #{MAX_FILES_CHANGED})") if files.size > MAX_FILES_CHANGED
+block!("too many lines (#{total} > #{MAX_LINES_CHANGED})")      if total > MAX_LINES_CHANGED
 
-allow!(files: files.size, lines: total_lines, author: author)
+pass!(files: files.size, lines: total, signer: signers.uniq.join(","))


### PR DESCRIPTION
## What

Adds `auto-merge-gate` — a deterministic CI check that decides whether a PR is eligible for **unattended auto-merge on the "safe lane"** of the support→ship loop (customer ticket → issue → PR → auto-merge on green → customer notified).

- `scripts/auto_merge_gate.rb` — the eligibility rules
- `.github/workflows/auto-merge-gate.yml` — runs the script on every PR event

## Why

We're building a loop where the agent files an issue from a support ticket, drafts a fix, and ships it. The merge step is the only part with real production blast radius. Rather than have an LLM decide "is this safe to merge unattended," this check makes that decision **deterministic and inspectable** — the model may *draft* the fix, but a human-readable ruleset decides whether it can auto-merge. The result is visible in the PR UI and auditable in the check log.

## How it decides

🟢 **GREEN (eligible)** only when the PR is **all** of:
- authored by the bot (`gumclaw`)
- labeled `support-fix` (i.e. scoped to a real ticket)
- small: ≤ 40 lines changed, ≤ 5 files, text-only (no binaries)
- free of **sensitive paths**: payments / charges / payouts / refunds / balances, risk / fraud, Stripe / PayPal / webhooks, auth / admin controllers / Devise, `db/migrate/**`, `db/schema.rb`, `config/**`, dependency manifests (`Gemfile*`, `package*.json`, `yarn.lock`), **and** `.github/**` or the gate script itself.

🔴 **RED (blocked)** for anything else, with a specific reason logged. Blocked PRs are **not** dropped — they route to a human one-tap approval lane.

## Safety properties

- **No self-modification.** The gate blocks any PR that touches `.github/**` or `scripts/auto_merge_gate*`, so the loop cannot widen its own authority. (This very PR is correctly RED for that reason — it must be merged by a human.)
- **The job never merges anything.** It only reports pass/fail. Merges are performed by GitHub **native auto-merge**, which fires only when every *required* check is green. This gate does nothing until/unless it is added as a **required status check** in branch protection.
- **Conservative defaults.** Thresholds (40 lines / 5 files) start tight and should only loosen with evidence.

## Test plan

Logic verified locally across cases:

| Case | Expected | Result |
|---|---|---|
| bot author + `support-fix` + 1-line support-service change | 🟢 | pass |
| same diff, non-bot author | 🔴 | blocked (author) |
| same diff, missing `support-fix` label | 🔴 | blocked (label) |
| touches `app/models/charge.rb` | 🔴 | blocked (sensitive path) |
| 60-line diff | 🔴 | blocked (size) |
| this PR (touches `.github/`) | 🔴 | blocked (self-edit guard) |

## Rollout

This PR only **adds** the check (advisory). It has **no effect** until a follow-up step:
1. merge this,
2. add `auto-merge-gate` as a required status check on `main`,
3. enable native auto-merge for bot PRs.

I'll dry-run the full ticket→issue→PR→gate flow with auto-merge **OFF** and share the trace before anything is armed.

cc @gianfrancopiana

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784040970&installation_id=134400930&pr_number=5471&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5471&signature=4cadbfa2f6ca3952e5b059b7d1f866c18efe99c1f4b5b059b80413d8cbee2a61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> New security boundary for unattended merges on `pull_request_target`, with broad deny rules for money/auth/CI; misconfiguration or bypass would affect production merge policy once the check is required.
> 
> **Overview**
> Introduces a **deterministic eligibility check** for unattended auto-merge on small, ticket-scoped support fixes. A new Ruby script `scripts/auto_merge_gate.rb` encodes the rules; a new workflow `.github/workflows/auto-merge-gate.yml` runs on `pull_request_target` and publishes an `auto-merge-gate` commit status (advisory until required in branch protection).
> 
> **Eligibility (exit 0)** requires every commit to be cryptographically verified and signed by **`gumclaw`** (workflow uses **committer** login from the API, paginated across all commits), the **`support-fix`** label (from API), diff size caps (≤40 lines, ≤5 files, no binaries), paths only on a **default-deny allowlist** (help center article contents, `docs/`, `README`/`CHANGELOG`), and nothing on a **sensitive denylist** (payments, auth, `db/`, `config/`, deps, `.github/`, the gate script itself).
> 
> **Security wiring:** the job checks out the **base ref** and executes the gate script from trusted `main` code—never the PR head—while only fetching the head SHA for `git diff`. The workflow does not merge; it only reports pass/fail for GitHub native auto-merge downstream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cb8f1693bd1fab7763a252cddbe81a14cb6add1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->