### PR TITLE
Clarify Stripe postal-code rejection message for valid-but-unrecognized addresses

### DIFF
--- a/app/controllers/settings/payments_controller.rb
+++ b/app/controllers/settings/payments_controller.rb
@@ -103,7 +103,7 @@ class Settings::PaymentsController < Settings::BaseController
       rescue Stripe::StripeError, MerchantRegistrationUserNotReadyError => e
         if e.is_a?(Stripe::InvalidRequestError) && e.code == "postal_code_invalid"
           country = current_seller.fetch_or_build_user_compliance_info.legal_entity_country
-          return redirect_with_error("The postal code you entered is not valid for #{country}.")
+          return redirect_with_error("We couldn't verify the postal code you entered for #{country}. If you're sure it's correct, such as a newly built address, contact support and we'll look into it.")
         end
         if e.is_a?(MerchantRegistrationUserNotReadyError)
           return redirect_with_error("Bank payouts are not supported in your country yet. Please use PayPal instead.")

--- a/app/services/update_user_compliance_info.rb
+++ b/app/services/update_user_compliance_info.rb
@@ -100,7 +100,7 @@ class UpdateUserComplianceInfo
       rescue Stripe::InvalidRequestError => e
         if e.code == "postal_code_invalid"
           country = new_compliance_info.legal_entity_country
-          return { success: false, error_message: "The postal code you entered is not valid for #{country}." }
+          return { success: false, error_message: "We couldn't verify the postal code you entered for #{country}. If you're sure it's correct, such as a newly built address, contact support and we'll look into it." }
         end
         return { success: false, error_message: e.message.split("Please contact us").first.strip }
       end

--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -1412,7 +1412,7 @@ describe("Payments Settings Scenario", type: :system, js: true) do
         expect(page).to have_content("Payouts will be made in EUR.")
 
         click_on("Update settings")
-        expect(page).to have_content("The postal code you entered is not valid for Germany.")
+        expect(page).to have_content("We couldn't verify the postal code you entered for Germany. If you're sure it's correct, such as a newly built address, contact support and we'll look into it.")
 
         fill_in("Postal code", with: "01067")
         click_on("Update settings")


### PR DESCRIPTION
Issue https://github.com/antiwork/gumroad-private/issues/432

## What

Reword the error shown when Stripe rejects a postal code with `postal_code_invalid` during account onboarding.

Before:
> The postal code you entered is not valid for {country}.

After:
> We couldn't verify the postal code you entered for {country}. If you're sure it's correct, such as a newly built address, contact support and we'll look into it.

Both call sites are updated:
- `Settings::PaymentsController#update` — the `StripeMerchantAccountManager.create_account` path
- `UpdateUserComplianceInfo` — the compliance-update path

## Why

`Stripe::Account.create` (and the compliance update) can reject a postal code with `postal_code_invalid` even when the postcode is real. Newly built addresses are assigned postcodes before they propagate into the address databases Stripe verifies against, so a correct entry is rejected. The old copy asserts the seller made a mistake, which sends them into a loop of reformatting the postcode, switching their account country, and retrying in incognito — none of which can fix an address-database gap on Stripe's side.

Stripe returns the same `postal_code_invalid` code for genuinely malformed postcodes and for valid-but-unrecognized ones, so we can't reliably auto-distinguish them in code. The reworded message stops asserting the entry is wrong and points sellers who believe it's correct to support, where the address can be escalated to Stripe.


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AI disclosure: drafted with Claude Opus 4.8

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784092463&installation_id=134400930&pr_number=5473&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5473&signature=c5831cdf4a33977d2a820951077b46cf3fd136fefb81286b366238926b6d8272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change on two existing error branches plus a spec assertion; no change to Stripe handling or validation logic.
> 
> **Overview**
> When Stripe returns **`postal_code_invalid`** during merchant account creation (`Settings::PaymentsController#update`) or compliance sync (`UpdateUserComplianceInfo`), the user-facing error no longer says the postal code is invalid for the country.
> 
> The new copy explains that Gumroad **couldn’t verify** the postcode, notes cases like **newly built addresses**, and directs users who believe it’s correct to **contact support**. The payments request spec expectation for the Germany EU-creator flow is updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b251fddce7ac44f3db832f2b79de8f7403de5e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->