### PR TITLE
Make Stripe onboarding self-healing and remediate wedged accounts

### DIFF
--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -374,7 +374,6 @@ module StripeMerchantAccountManager
     end
   end
 
-  private_class_method
   def self.cleanup_failed_merchant_account(merchant_account)
     if merchant_account.charge_processor_merchant_id.present?
       begin

--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -116,7 +116,7 @@ module StripeMerchantAccountManager
 
     merchant_account
   rescue => e
-    if merchant_account.present?
+    if merchant_account.present? && merchant_account.charge_processor_alive_at.nil?
       cleanup_failed_merchant_account(merchant_account)
       ErrorNotifier.notify(e)
     end

--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -115,9 +115,11 @@ module StripeMerchantAccountManager
     end
 
     merchant_account
-  rescue Stripe::StripeError => e
-    cleanup_failed_merchant_account(merchant_account) if merchant_account.present?
-    ErrorNotifier.notify(e)
+  rescue => e
+    if merchant_account.present?
+      cleanup_failed_merchant_account(merchant_account)
+      ErrorNotifier.notify(e)
+    end
     raise
   end
 

--- a/app/services/onetime/cleanup_wedged_stripe_merchant_accounts.rb
+++ b/app/services/onetime/cleanup_wedged_stripe_merchant_accounts.rb
@@ -14,9 +14,11 @@
 # correctly set up".
 #
 # The forward fix broadens that rescue so new failures clean up after themselves.
-# This task remediates the rows stranded before that shipped: it soft-deletes each
-# wedged row whose owner has no other alive Stripe account, so the seller can
-# onboard again from scratch via the normal flow.
+# This task remediates the rows stranded before that shipped: for each wedged row
+# whose owner has no other alive Stripe account it runs the same cleanup the
+# forward fix uses — StripeMerchantAccountManager.cleanup_failed_merchant_account —
+# which deletes the orphaned half-provisioned Stripe account and soft-deletes the
+# row, so the seller can onboard again from scratch via the normal flow.
 #
 # It does NOT re-provision accounts or move money. Owners with a stranded balance
 # are logged so support can prompt them to re-enter their payout details.
@@ -65,7 +67,7 @@ module Onetime
             next
           end
 
-          merchant_account.mark_deleted!
+          StripeMerchantAccountManager.cleanup_failed_merchant_account(merchant_account)
           stats[:cleaned] += 1
           puts "cleaned merchant_account #{merchant_account.id} user #{user.id}"
         end

--- a/app/services/onetime/cleanup_wedged_stripe_merchant_accounts.rb
+++ b/app/services/onetime/cleanup_wedged_stripe_merchant_accounts.rb
@@ -36,6 +36,7 @@ module Onetime
 
     def process(dry_run: true, merchant_account_ids: nil)
       stats = Hash.new(0)
+      ActiveRecord::Base.connection.stick_to_primary! unless dry_run
 
       candidates(merchant_account_ids).find_in_batches(batch_size: BATCH_SIZE) do |batch|
         ReplicaLagWatcher.watch
@@ -49,8 +50,6 @@ module Onetime
             next
           end
 
-          # Re-validate on the primary at write time: a user with a working Stripe
-          # account is not wedged, and the stranded row is harmless for them.
           if user.merchant_accounts.alive.stripe.charge_processor_alive.exists?
             stats[:skipped_has_alive_account] += 1
             next
@@ -64,6 +63,12 @@ module Onetime
           if dry_run
             stats[:would_clean] += 1
             puts "DRY-RUN clean merchant_account #{merchant_account.id} user #{user.id}"
+            next
+          end
+
+          merchant_account.reload
+          unless merchant_account.alive? && merchant_account.charge_processor_alive_at.nil?
+            stats[:skipped_no_longer_wedged] += 1
             next
           end
 

--- a/app/services/onetime/cleanup_wedged_stripe_merchant_accounts.rb
+++ b/app/services/onetime/cleanup_wedged_stripe_merchant_accounts.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+# Cleans up half-provisioned Stripe merchant accounts that permanently wedge a
+# seller's payout onboarding. See issue #487.
+#
+# StripeMerchantAccountManager.create_account is non-atomic: between
+# Stripe::Account.create (which saves charge_processor_merchant_id) and the line
+# that sets charge_processor_alive_at, a non-Stripe interruption (deploy, DB blip,
+# timeout) used to escape the rescue — which only caught Stripe::StripeError — and
+# leave a MerchantAccount with a merchant id, no charge_processor_alive_at, and no
+# charge_processor_deleted_at. The self-serve form guard
+# (merchant_accounts.stripe.alive.empty?) then sees that row and never lets the
+# seller retry, so payouts skip forever with "the payout bank account was not
+# correctly set up".
+#
+# The forward fix broadens that rescue so new failures clean up after themselves.
+# This task remediates the rows stranded before that shipped: it soft-deletes each
+# wedged row whose owner has no other alive Stripe account, so the seller can
+# onboard again from scratch via the normal flow.
+#
+# It does NOT re-provision accounts or move money. Owners with a stranded balance
+# are logged so support can prompt them to re-enter their payout details.
+module Onetime
+  class CleanupWedgedStripeMerchantAccounts
+    BATCH_SIZE = 100
+
+    # Skip rows young enough that they might be a live onboarding still in flight
+    # rather than a stranded one.
+    MIN_AGE = 7.days
+
+    def self.process(dry_run: true, merchant_account_ids: nil)
+      new.process(dry_run:, merchant_account_ids:)
+    end
+
+    def process(dry_run: true, merchant_account_ids: nil)
+      stats = Hash.new(0)
+
+      candidates(merchant_account_ids).find_in_batches(batch_size: BATCH_SIZE) do |batch|
+        ReplicaLagWatcher.watch
+
+        batch.each do |merchant_account|
+          stats[:scanned] += 1
+
+          user = merchant_account.user
+          if user.nil?
+            stats[:skipped_no_user] += 1
+            next
+          end
+
+          # Re-validate on the primary at write time: a user with a working Stripe
+          # account is not wedged, and the stranded row is harmless for them.
+          if user.merchant_accounts.stripe.charge_processor_alive.exists?
+            stats[:skipped_has_alive_account] += 1
+            next
+          end
+
+          if user.unpaid_balance_cents > 0
+            stats[:wedged_with_balance] += 1
+            puts "balance: user #{user.id} merchant_account #{merchant_account.id} balance #{user.unpaid_balance_cents}c"
+          end
+
+          if dry_run
+            stats[:would_clean] += 1
+            puts "DRY-RUN clean merchant_account #{merchant_account.id} user #{user.id}"
+            next
+          end
+
+          merchant_account.mark_deleted!
+          stats[:cleaned] += 1
+          puts "cleaned merchant_account #{merchant_account.id} user #{user.id}"
+        end
+      end
+
+      puts "done: #{stats.to_h}"
+      stats.to_h
+    end
+
+    private
+      def candidates(merchant_account_ids)
+        scope = MerchantAccount
+                  .where(charge_processor_id: StripeChargeProcessor.charge_processor_id)
+                  .where(charge_processor_alive_at: nil, charge_processor_deleted_at: nil, deleted_at: nil)
+                  .where.not(charge_processor_merchant_id: nil)
+                  .where("created_at < ?", MIN_AGE.ago)
+        scope = scope.where(id: merchant_account_ids) if merchant_account_ids.present?
+        scope
+      end
+  end
+end

--- a/app/services/onetime/cleanup_wedged_stripe_merchant_accounts.rb
+++ b/app/services/onetime/cleanup_wedged_stripe_merchant_accounts.rb
@@ -49,7 +49,7 @@ module Onetime
 
           # Re-validate on the primary at write time: a user with a working Stripe
           # account is not wedged, and the stranded row is harmless for them.
-          if user.merchant_accounts.stripe.charge_processor_alive.exists?
+          if user.merchant_accounts.alive.stripe.charge_processor_alive.exists?
             stats[:skipped_has_alive_account] += 1
             next
           end

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -139,6 +139,18 @@ describe StripeMerchantAccountManager, :vcr do
         expect(merchant_account.alive?).to be(false)
       end
 
+      it "keeps an already-alive account when a later step fails" do
+        allow(described_class).to receive(:save_stripe_bank_account_info).and_raise(StandardError.new("bank sync failed"))
+        expect do
+          subject.create_account(user, passphrase: "1234")
+        end.to raise_error(StandardError, "bank sync failed")
+
+        merchant_account = user.merchant_accounts.stripe.last
+        expect(merchant_account.charge_processor_alive_at).to be_present
+        expect(merchant_account.alive?).to be(true)
+        expect(merchant_account.charge_processor_merchant_id).to be_present
+      end
+
       context "when user compliance info contains whitespaces" do
         let(:user_compliance_info) do
           create(:user_compliance_info,

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -502,6 +502,19 @@ describe StripeMerchantAccountManager, :vcr do
         expect(merchant_account.charge_processor_id).to eq(StripeChargeProcessor.charge_processor_id)
         expect(merchant_account.charge_processor_merchant_id).to be_present
       end
+
+      it "deletes the half-provisioned Stripe account when interrupted after it is created" do
+        allow(Stripe::Account).to receive(:create_person).and_raise(StandardError.new("interrupted"))
+        expect(Stripe::Account).to receive(:delete).with(/\Aacct_/).and_call_original
+
+        expect do
+          subject.create_account(user, passphrase: "1234")
+        end.to raise_error(StandardError, "interrupted")
+
+        merchant_account = user.merchant_accounts.stripe.last
+        expect(merchant_account.charge_processor_merchant_id).to be_present
+        expect(merchant_account.alive?).to be(false)
+      end
     end
 
     describe "US business with a foreign-resident representative (person_hash)" do

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -128,6 +128,17 @@ describe StripeMerchantAccountManager, :vcr do
         end.to raise_error(Stripe::InvalidRequestError)
       end
 
+      it "cleans up the merchant account when onboarding is interrupted by a non-Stripe error" do
+        allow(Stripe::Account).to receive(:create).and_raise(Timeout::Error.new("execution expired"))
+        expect do
+          subject.create_account(user, passphrase: "1234")
+        end.to raise_error(Timeout::Error)
+
+        merchant_account = user.merchant_accounts.stripe.last
+        expect(merchant_account).to be_present
+        expect(merchant_account.alive?).to be(false)
+      end
+
       context "when user compliance info contains whitespaces" do
         let(:user_compliance_info) do
           create(:user_compliance_info,

--- a/spec/services/onetime/cleanup_wedged_stripe_merchant_accounts_spec.rb
+++ b/spec/services/onetime/cleanup_wedged_stripe_merchant_accounts_spec.rb
@@ -39,6 +39,16 @@ describe Onetime::CleanupWedgedStripeMerchantAccounts do
       expect(wedged.reload.alive?).to be(true)
     end
 
+    it "still cleans a wedged row when the only alive-flagged account is soft-deleted" do
+      user = create(:user)
+      create(:merchant_account, user:).mark_deleted!
+      wedged = wedged_account(user:)
+
+      described_class.process(dry_run: false)
+
+      expect(wedged.reload.alive?).to be(false)
+    end
+
     it "ignores rows recent enough to be a live onboarding" do
       user = create(:user)
       recent = wedged_account(user:, created_at: 1.day.ago)

--- a/spec/services/onetime/cleanup_wedged_stripe_merchant_accounts_spec.rb
+++ b/spec/services/onetime/cleanup_wedged_stripe_merchant_accounts_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Onetime::CleanupWedgedStripeMerchantAccounts do
+  def wedged_account(user:, created_at: 8.days.ago)
+    create(:merchant_account, user:, charge_processor_alive_at: nil, created_at:)
+  end
+
+  describe ".process" do
+    it "soft-deletes a wedged Stripe merchant account so the seller can onboard again" do
+      user = create(:user)
+      merchant_account = wedged_account(user:)
+
+      result = described_class.process(dry_run: false)
+
+      expect(merchant_account.reload.alive?).to be(false)
+      expect(result[:cleaned]).to eq(1)
+    end
+
+    it "does not modify anything on a dry run" do
+      user = create(:user)
+      merchant_account = wedged_account(user:)
+
+      result = described_class.process(dry_run: true)
+
+      expect(merchant_account.reload.alive?).to be(true)
+      expect(result[:would_clean]).to eq(1)
+      expect(result[:cleaned]).to eq(0)
+    end
+
+    it "leaves users who have a working Stripe account untouched" do
+      user = create(:user)
+      create(:merchant_account, user:)
+      wedged = wedged_account(user:)
+
+      described_class.process(dry_run: false)
+
+      expect(wedged.reload.alive?).to be(true)
+    end
+
+    it "ignores rows recent enough to be a live onboarding" do
+      user = create(:user)
+      recent = wedged_account(user:, created_at: 1.day.ago)
+
+      result = described_class.process(dry_run: false)
+
+      expect(recent.reload.alive?).to be(true)
+      expect(result[:scanned]).to eq(0)
+    end
+
+    it "flags wedged owners that still have an unpaid balance" do
+      user = create(:user)
+      merchant_account = wedged_account(user:)
+      create(:balance, user:, merchant_account:, amount_cents: 5_00)
+
+      result = described_class.process(dry_run: false)
+
+      expect(result[:wedged_with_balance]).to eq(1)
+    end
+  end
+end

--- a/spec/services/onetime/cleanup_wedged_stripe_merchant_accounts_spec.rb
+++ b/spec/services/onetime/cleanup_wedged_stripe_merchant_accounts_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 describe Onetime::CleanupWedgedStripeMerchantAccounts do
+  before { allow(Stripe::Account).to receive(:delete) }
+
   def wedged_account(user:, created_at: 8.days.ago)
     create(:merchant_account, user:, charge_processor_alive_at: nil, created_at:)
   end
@@ -18,6 +20,15 @@ describe Onetime::CleanupWedgedStripeMerchantAccounts do
       expect(result[:cleaned]).to eq(1)
     end
 
+    it "deletes the orphaned half-provisioned Stripe account" do
+      user = create(:user)
+      merchant_account = wedged_account(user:)
+
+      described_class.process(dry_run: false)
+
+      expect(Stripe::Account).to have_received(:delete).with(merchant_account.charge_processor_merchant_id)
+    end
+
     it "does not modify anything on a dry run" do
       user = create(:user)
       merchant_account = wedged_account(user:)
@@ -27,6 +38,7 @@ describe Onetime::CleanupWedgedStripeMerchantAccounts do
       expect(merchant_account.reload.alive?).to be(true)
       expect(result[:would_clean]).to eq(1)
       expect(result[:cleaned]).to eq(0)
+      expect(Stripe::Account).not_to have_received(:delete)
     end
 
     it "leaves users who have a working Stripe account untouched" do

--- a/spec/services/onetime/cleanup_wedged_stripe_merchant_accounts_spec.rb
+++ b/spec/services/onetime/cleanup_wedged_stripe_merchant_accounts_spec.rb
@@ -61,6 +61,23 @@ describe Onetime::CleanupWedgedStripeMerchantAccounts do
       expect(wedged.reload.alive?).to be(false)
     end
 
+    it "skips a candidate that is no longer wedged when re-checked on the primary" do
+      user = create(:user)
+      merchant_account = wedged_account(user:)
+      allow_any_instance_of(MerchantAccount).to receive(:reload).and_wrap_original do |original|
+        record = original.call
+        record.charge_processor_alive_at = Time.current
+        record
+      end
+
+      result = described_class.process(dry_run: false)
+
+      expect(result[:skipped_no_longer_wedged]).to eq(1)
+      expect(result[:cleaned]).to eq(0)
+      expect(Stripe::Account).not_to have_received(:delete)
+      expect(MerchantAccount.find(merchant_account.id).alive?).to be(true)
+    end
+
     it "ignores rows recent enough to be a live onboarding" do
       user = create(:user)
       recent = wedged_account(user:, created_at: 1.day.ago)

--- a/spec/support/fixtures/vcr_cassettes/StripeMerchantAccountManager/_create_account/all_info_provided_of_a_business/deletes_the_half-provisioned_Stripe_account_when_interrupted_after_it_is_created.yml
+++ b/spec/support/fixtures/vcr_cassettes/StripeMerchantAccountManager/_create_account/all_info_provided_of_a_business/deletes_the_half-provisioned_Stripe_account_when_interrupted_after_it_is_created.yml
@@ -1,0 +1,451 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts
+    body:
+      encoding: UTF-8
+      string: type=custom&requested_capabilities[0]=card_payments&requested_capabilities[1]=transfers&country=US&default_currency=usd&metadata[user_id]=1466882108919&metadata[tos_agreement_id]=CX1DxoG-YVYCvLoCWsko5A%3D%3D&metadata[user_compliance_info_id]=Iaxx4yaUtfY_WFAOnOO4Tg%3D%3D&metadata[bank_account_id]=CX1DxoG-YVYCvLoCWsko5A%3D%3D&tos_acceptance[date]=1427846400&tos_acceptance[ip]=54.234.242.13&business_type=company&business_profile[name]=Buy+More%2C+LLC&business_profile[url]=https%3A%2F%2Fvipul.gumroad.com%2F&business_profile[product_description]=Buy+More%2C+LLC&company[name]=Buy+More%2C+LLC&company[address][line1]=address_full_match&company[address][city]=Burbank&company[address][state]=California&company[address][postal_code]=91506&company[address][country]=US&company[tax_id]=000000000&company[phone]=0000000000&company[directors_provided]=true&company[executives_provided]=true&bank_account[country]=US&bank_account[currency]=usd&bank_account[account_number]=000<STRONGBOX_GENERAL_PASSWORD>56789&bank_account[routing_number]=110000000&settings[payouts][schedule][interval]=manual&settings[payouts][debit_negative_balances]=true
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Idempotency-Key:
+      - 9e004beb-51bb-4c94-8f43-babfcfcbe941
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 15 Jun 2026 05:50:11 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '6923'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=NHUYGhi2kjFAofS7UV99pD_R0XOutoepOnwiSJAExToaUuud7-BaG7bpU-hqliNAZfXHpFsf-Nxf24kq;
+        report-to csp
+      Idempotency-Key:
+      - 9e004beb-51bb-4c94-8f43-babfcfcbe941
+      Original-Request:
+      - req_JjYG8pGJhWdXRq
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=NHUYGhi2kjFAofS7UV99pD_R0XOutoepOnwiSJAExToaUuud7-BaG7bpU-hqliNAZfXHpFsf-Nxf24kq&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=NHUYGhi2kjFAofS7UV99pD_R0XOutoepOnwiSJAExToaUuud7-BaG7bpU-hqliNAZfXHpFsf-Nxf24kq&t=1"
+      Request-Id:
+      - req_JjYG8pGJhWdXRq
+      Stripe-Notice:
+      - '2 notices for this request: (1) You are using an outdated API version (2023-10-16).
+        We recommend upgrading to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+        (2) We recommend building your integration using Accounts v2. See https://docs.stripe.com/api/v2/core/accounts'
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1TiTPPRSo64AENd3",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "minority_owned_business_designation": null,
+            "name": "Buy More, LLC",
+            "product_description": "Buy More, LLC",
+            "specified_commercial_transactions_act_url": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": "https://vipul.gumroad.com/"
+          },
+          "business_type": "company",
+          "capabilities": {
+            "card_payments": "inactive",
+            "transfers": "active"
+          },
+          "charges_enabled": false,
+          "company": {
+            "address": {
+              "city": "Burbank",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "91506",
+              "state": "California"
+            },
+            "directors_provided": true,
+            "executives_provided": true,
+            "name": "Buy More, LLC",
+            "owners_provided": false,
+            "phone": "0000000000",
+            "tax_id_provided": true,
+            "verification": {
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              }
+            }
+          },
+          "controller": {
+            "fees": {
+              "payer": "application_custom"
+            },
+            "is_controller": true,
+            "losses": {
+              "payments": "application"
+            },
+            "requirement_collection": "application",
+            "stripe_dashboard": {
+              "type": "none"
+            },
+            "type": "application"
+          },
+          "country": "US",
+          "created": 1781502609,
+          "default_currency": "usd",
+          "details_submitted": true,
+          "email": null,
+          "external_accounts": {
+            "object": "list",
+            "data": [
+              {
+                "id": "ba_1TiTPQRSo64AENd3qeoQE1eL",
+                "object": "bank_account",
+                "account": "acct_1TiTPPRSo64AENd3",
+                "account_holder_name": null,
+                "account_holder_type": null,
+                "account_type": null,
+                "available_payout_methods": [
+                  "standard",
+                  "instant"
+                ],
+                "bank_name": "STRIPE TEST BANK",
+                "country": "US",
+                "currency": "usd",
+                "default_for_currency": true,
+                "fingerprint": "l0OxwqZbI4t8wVSU",
+                "future_requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "last4": "6789",
+                "metadata": {},
+                "requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "routing_number": "110000000",
+                "status": "new"
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/accounts/acct_1TiTPPRSo64AENd3/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "metadata": {
+            "bank_account_id": "CX1DxoG-YVYCvLoCWsko5A==",
+            "tos_agreement_id": "CX1DxoG-YVYCvLoCWsko5A==",
+            "user_compliance_info_id": "Iaxx4yaUtfY_WFAOnOO4Tg==",
+            "user_id": "1466882108919"
+          },
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.mcc",
+              "company.owners_provided",
+              "owners.email",
+              "owners.first_name",
+              "owners.last_name",
+              "representative.address.city",
+              "representative.address.line1",
+              "representative.address.postal_code",
+              "representative.address.state",
+              "representative.dob.day",
+              "representative.dob.month",
+              "representative.dob.year",
+              "representative.email",
+              "representative.first_name",
+              "representative.last_name",
+              "representative.phone",
+              "representative.relationship.title",
+              "representative.ssn_last_4"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.mcc",
+              "company.owners_provided",
+              "owners.address.city",
+              "owners.address.line1",
+              "owners.address.postal_code",
+              "owners.address.state",
+              "owners.dob.day",
+              "owners.dob.month",
+              "owners.dob.year",
+              "owners.email",
+              "owners.first_name",
+              "owners.last_name",
+              "owners.phone",
+              "representative.address.city",
+              "representative.address.line1",
+              "representative.address.postal_code",
+              "representative.address.state",
+              "representative.dob.day",
+              "representative.dob.month",
+              "representative.dob.year",
+              "representative.email",
+              "representative.first_name",
+              "representative.last_name",
+              "representative.phone",
+              "representative.relationship.title",
+              "representative.ssn_last_4"
+            ],
+            "past_due": [
+              "business_profile.mcc",
+              "company.owners_provided",
+              "owners.email",
+              "owners.first_name",
+              "owners.last_name",
+              "representative.address.city",
+              "representative.address.line1",
+              "representative.address.postal_code",
+              "representative.address.state",
+              "representative.dob.day",
+              "representative.dob.month",
+              "representative.dob.year",
+              "representative.email",
+              "representative.first_name",
+              "representative.last_name",
+              "representative.phone",
+              "representative.relationship.title",
+              "representative.ssn_last_4"
+            ],
+            "pending_verification": [
+              "company.address.city",
+              "company.address.line1",
+              "company.address.postal_code",
+              "company.address.state",
+              "company.tax_id"
+            ]
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": "BUY MORE,",
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": "Buy More, LLC",
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null,
+              "hosted_payment_method_save": "offer"
+            },
+            "payments": {
+              "statement_descriptor": "BUY MORE, LLC",
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": true,
+              "schedule": {
+                "delay_days": 2,
+                "interval": "manual"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": 1427846400,
+            "ip": "54.234.242.13",
+            "user_agent": null
+          },
+          "type": "custom"
+        }
+  recorded_at: Mon, 15 Jun 2026 05:50:11 GMT
+- request:
+    method: delete
+    uri: https://api.stripe.com/v1/accounts/acct_1TiTPPRSo64AENd3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_JjYG8pGJhWdXRq","request_duration_ms":4102}}'
+      Idempotency-Key:
+      - 7e028a20-ac7d-42a3-bd28-254eccfcfb0b
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 15 Jun 2026 05:50:14 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '77'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=LIJwTavIP0ijWXfeosPZkFJgKIVKt3_NFN1iZgRl5qczTvxC1Sqprz3HmqzCFf_qi1-IKBNyJvsgeZOi;
+        report-to csp
+      Idempotency-Key:
+      - 7e028a20-ac7d-42a3-bd28-254eccfcfb0b
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=LIJwTavIP0ijWXfeosPZkFJgKIVKt3_NFN1iZgRl5qczTvxC1Sqprz3HmqzCFf_qi1-IKBNyJvsgeZOi&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=LIJwTavIP0ijWXfeosPZkFJgKIVKt3_NFN1iZgRl5qczTvxC1Sqprz3HmqzCFf_qi1-IKBNyJvsgeZOi&t=1"
+      Request-Id:
+      - req_jP2BAhhpaaihnr
+      Stripe-Account:
+      - acct_1TiTPPRSo64AENd3
+      Stripe-Notice:
+      - '2 notices for this request: (1) You are using an outdated API version (2023-10-16).
+        We recommend upgrading to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+        (2) We recommend building your integration using Accounts v2. See https://docs.stripe.com/api/v2/core/accounts'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1TiTPPRSo64AENd3",
+          "object": "account",
+          "deleted": true
+        }
+  recorded_at: Mon, 15 Jun 2026 05:50:13 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/StripeMerchantAccountManager/_create_account/all_info_provided_of_an_individual/keeps_an_already-alive_account_when_a_later_step_fails.yml
+++ b/spec/support/fixtures/vcr_cassettes/StripeMerchantAccountManager/_create_account/all_info_provided_of_an_individual/keeps_an_already-alive_account_when_a_later_step_fails.yml
@@ -1,0 +1,373 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts
+    body:
+      encoding: UTF-8
+      string: type=custom&requested_capabilities[0]=card_payments&requested_capabilities[1]=transfers&country=US&default_currency=usd&metadata[user_id]=3671342086212&metadata[tos_agreement_id]=b_NJLhN90jIu60dX4luuxg%3D%3D&metadata[user_compliance_info_id]=u6kvqOkqswz8UaR_UROu8A%3D%3D&metadata[bank_account_id]=b_NJLhN90jIu60dX4luuxg%3D%3D&tos_acceptance[date]=1427846400&tos_acceptance[ip]=54.234.242.13&business_type=individual&business_profile[name]=Chuck+Bartowski&business_profile[url]=https%3A%2F%2Fvipul.gumroad.com%2F&business_profile[product_description]=Chuck+Bartowski&individual[first_name]=Chuck&individual[last_name]=Bartowski&individual[email]=chuck%40gum.com&individual[phone]=0000000000&individual[dob][day]=1&individual[dob][month]=1&individual[dob][year]=1901&individual[address][line1]=address_full_match&individual[address][city]=San+Francisco&individual[address][state]=California&individual[address][postal_code]=94107&individual[address][country]=US&individual[id_number]=000000000&bank_account[country]=US&bank_account[currency]=usd&bank_account[account_number]=000<STRONGBOX_GENERAL_PASSWORD>56789&bank_account[routing_number]=110000000&settings[payouts][schedule][interval]=manual&settings[payouts][debit_negative_balances]=true
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Idempotency-Key:
+      - 3f573132-f675-40de-9219-6370ee5f140d
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 15 Jun 2026 05:42:34 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '6841'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=MtcDH06N9iE_pExPkHgfQKkH_dQrknkLtuAYnNk9XJvzy_oIb9xvjgrL7rLSV7Z6iGE04H6xXFeXYNZH;
+        report-to csp
+      Idempotency-Key:
+      - 3f573132-f675-40de-9219-6370ee5f140d
+      Original-Request:
+      - req_G3m2iPGIvfxI13
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=MtcDH06N9iE_pExPkHgfQKkH_dQrknkLtuAYnNk9XJvzy_oIb9xvjgrL7rLSV7Z6iGE04H6xXFeXYNZH&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=MtcDH06N9iE_pExPkHgfQKkH_dQrknkLtuAYnNk9XJvzy_oIb9xvjgrL7rLSV7Z6iGE04H6xXFeXYNZH&t=1"
+      Request-Id:
+      - req_G3m2iPGIvfxI13
+      Stripe-Notice:
+      - '2 notices for this request: (1) You are using an outdated API version (2023-10-16).
+        We recommend upgrading to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+        (2) We recommend building your integration using Accounts v2. See https://docs.stripe.com/api/v2/core/accounts'
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1TiTI3EbC2zWOCEE",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "minority_owned_business_designation": null,
+            "name": "Chuck Bartowski",
+            "product_description": "Chuck Bartowski",
+            "specified_commercial_transactions_act_url": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": "https://vipul.gumroad.com/"
+          },
+          "business_type": "individual",
+          "capabilities": {
+            "card_payments": "inactive",
+            "transfers": "active"
+          },
+          "charges_enabled": false,
+          "company": {
+            "address": {
+              "city": "San Francisco",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "directors_provided": true,
+            "executives_provided": true,
+            "name": null,
+            "owners_provided": true,
+            "phone": "+10000000000",
+            "tax_id_provided": false,
+            "verification": {
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              }
+            }
+          },
+          "controller": {
+            "fees": {
+              "payer": "application_custom"
+            },
+            "is_controller": true,
+            "losses": {
+              "payments": "application"
+            },
+            "requirement_collection": "application",
+            "stripe_dashboard": {
+              "type": "none"
+            },
+            "type": "application"
+          },
+          "country": "US",
+          "created": 1781502152,
+          "default_currency": "usd",
+          "details_submitted": true,
+          "email": null,
+          "external_accounts": {
+            "object": "list",
+            "data": [
+              {
+                "id": "ba_1TiTI3EbC2zWOCEE61UDnK8E",
+                "object": "bank_account",
+                "account": "acct_1TiTI3EbC2zWOCEE",
+                "account_holder_name": null,
+                "account_holder_type": null,
+                "account_type": null,
+                "available_payout_methods": [
+                  "standard",
+                  "instant"
+                ],
+                "bank_name": "STRIPE TEST BANK",
+                "country": "US",
+                "currency": "usd",
+                "default_for_currency": true,
+                "fingerprint": "l0OxwqZbI4t8wVSU",
+                "future_requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "last4": "6789",
+                "metadata": {},
+                "requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "routing_number": "110000000",
+                "status": "new"
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/accounts/acct_1TiTI3EbC2zWOCEE/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "individual": {
+            "id": "person_1TiTI3EbC2zWOCEEO201RM8C",
+            "object": "person",
+            "account": "acct_1TiTI3EbC2zWOCEE",
+            "address": {
+              "city": "San Francisco",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "created": 1781502151,
+            "dob": {
+              "day": 1,
+              "month": 1,
+              "year": 1901
+            },
+            "email": "chuck@gum.com",
+            "first_name": "Chuck",
+            "future_requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "id_number_provided": true,
+            "last_name": "Bartowski",
+            "metadata": {},
+            "phone": "+10000000000",
+            "relationship": {
+              "authorizer": false,
+              "director": false,
+              "executive": false,
+              "legal_guardian": false,
+              "owner": false,
+              "percent_ownership": null,
+              "representative": true,
+              "title": null
+            },
+            "requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": [
+                "address.city",
+                "address.line1",
+                "address.postal_code",
+                "address.state",
+                "id_number",
+                "verification.document"
+              ]
+            },
+            "ssn_last_4_provided": true,
+            "verification": {
+              "additional_document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "details": null,
+              "details_code": null,
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "status": "pending"
+            }
+          },
+          "metadata": {
+            "bank_account_id": "b_NJLhN90jIu60dX4luuxg==",
+            "tos_agreement_id": "b_NJLhN90jIu60dX4luuxg==",
+            "user_compliance_info_id": "u6kvqOkqswz8UaR_UROu8A==",
+            "user_id": "3671342086212"
+          },
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.mcc"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.mcc"
+            ],
+            "past_due": [
+              "business_profile.mcc"
+            ],
+            "pending_verification": [
+              "individual.address.city",
+              "individual.address.line1",
+              "individual.address.postal_code",
+              "individual.address.state",
+              "individual.id_number",
+              "individual.verification.document"
+            ]
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": "CHUCK BART",
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": "Chuck Bartowski",
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null,
+              "hosted_payment_method_save": "offer"
+            },
+            "payments": {
+              "statement_descriptor": "CHUCK BARTOWSKI",
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": true,
+              "schedule": {
+                "delay_days": 2,
+                "interval": "manual"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": 1427846400,
+            "ip": "54.234.242.13",
+            "user_agent": null
+          },
+          "type": "custom"
+        }
+  recorded_at: Mon, 15 Jun 2026 05:42:34 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## What

Two changes that fix and clean up a payout-onboarding deadlock:

1. **Self-healing onboarding.** `StripeMerchantAccountManager.create_account` is non-atomic. After `Stripe::Account.create` succeeds and saves `charge_processor_merchant_id`, several more steps run (person creation, the SGP person update, the save that sets `charge_processor_alive_at`, the bank sync) before the account is usable. The rescue around all of this only caught `Stripe::StripeError`, so a non-Stripe interruption in that window — a deploy/SIGTERM, a DB blip, a Sidekiq timeout — escaped cleanup and left a `MerchantAccount` with a merchant id but no `charge_processor_alive_at` and no `charge_processor_deleted_at`. The rescue now catches any exception, cleans up the half-provisioned row, and re-raises.

2. **`Onetime::CleanupWedgedStripeMerchantAccounts`** to remediate rows stranded before the fix.

## Why

The half-provisioned row permanently wedges the seller. The self-serve form guard (`merchant_accounts.stripe.alive.empty?`) sees the row and never lets them retry, and `user.stripe_account` returns nil because it requires the `charge_processor_alive` scope — so payouts skip every cycle with "the payout bank account was not correctly set up". A read-replica scan put this state at hundreds of sellers, dozens sitting on a balance they can't withdraw.

The narrowest correct fix is to make onboarding clean up after itself on *any* failure, not just Stripe errors. `cleanup_failed_merchant_account` already deletes the Stripe account when one exists and soft-deletes the row; the `ErrorNotifier.notify` stays scoped to the case where a row was actually created, so expected validation errors raised earlier (TOS/country checks, before any row exists) don't add noise.

The Onetime task heals the existing victims under supervision rather than via a callback or auto-job (per the repo's guidance against mass backfill jobs): it soft-deletes each wedged row whose owner has no other alive Stripe account so they can onboard again from scratch, skips rows younger than a week to avoid racing a live onboarding, runs in batches with `ReplicaLagWatcher`, and logs owners with a stranded balance for support to follow up. It does not re-provision accounts or move money. Run dry first: `Onetime::CleanupWedgedStripeMerchantAccounts.process(dry_run: true)`.

This is a follow-up to the investigation behind gumroad-private#487, where a Malaysian seller hit the same stuck-non-alive state.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AI disclosure: written with Claude Opus 4.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784093766&installation_id=134400930&pr_number=5474&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5474&signature=dc5a9e051f11409e28b39848ebdf9259e8a8a34512e3a706d638f6cb74c178c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes Stripe Connect onboarding failure handling and runs a one-time cleanup that deletes Stripe accounts and soft-deletes merchant rows, which can affect payout eligibility and sellers with stranded balances.
> 
> **Overview**
> Fixes sellers stuck in payout onboarding when Stripe account creation partially succeeds but never reaches **`charge_processor_alive_at`**.
> 
> **`StripeMerchantAccountManager.create_account`** now rescues **any** exception (not only `Stripe::StripeError`). Cleanup runs only when a row exists and is still half-provisioned (`charge_processor_alive_at` nil): it deletes the orphaned Stripe account and soft-deletes the row, then re-raises. Failures **after** the account is marked alive are left intact.
> 
> Adds **`Onetime::CleanupWedgedStripeMerchantAccounts`** to remediate existing wedged rows (Stripe id present, not alive/deleted, older than 7 days), skipping users who already have a charge-processor-alive Stripe account, with dry-run, batching, and logging for sellers who still have an unpaid balance.
> 
> **`cleanup_failed_merchant_account`** is exposed for the onetime task; specs cover non-Stripe interruptions, post-alive failures, and cleanup behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 180ea040781c834eccbec55c681a177d9891816d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->