### PR TITLE
Add passkey management UI to password settings

### DIFF
--- a/app/controllers/settings/passkeys_controller.rb
+++ b/app/controllers/settings/passkeys_controller.rb
@@ -58,7 +58,7 @@ class Settings::PasskeysController < Settings::BaseController
         webauthn_id: webauthn_credential.id,
         public_key: webauthn_credential.public_key,
         sign_count: webauthn_credential.sign_count,
-        nickname: params[:nickname]
+        nickname: params[:nickname].presence || detected_provider_name(webauthn_credential)
       )
     end
 
@@ -140,6 +140,10 @@ class Settings::PasskeysController < Settings::BaseController
       raise unless ["invalid type", "invalid id"].include?(e.message)
 
       raise RegistrationVerificationError, e.class.name
+    end
+
+    def detected_provider_name(webauthn_credential)
+      WebauthnCredential.provider_name_for_aaguid(webauthn_credential.response&.authenticator_data&.aaguid)
     end
 
     def passkey_props(credential)

--- a/app/javascript/components/Settings/PasswordPage/PasskeysSection.tsx
+++ b/app/javascript/components/Settings/PasswordPage/PasskeysSection.tsx
@@ -1,0 +1,250 @@
+import { parseISO } from "date-fns";
+import * as React from "react";
+import typia from "typia";
+
+import { formatDate } from "$app/utils/date";
+import { asyncVoid } from "$app/utils/promise";
+import { request, ResponseError } from "$app/utils/request";
+import { createPasskey, isPasskeySupported, type PasskeyRegistrationOptions } from "$app/utils/webauthn";
+
+import { Button } from "$app/components/Button";
+import { Modal } from "$app/components/Modal";
+import { showAlert } from "$app/components/server-components/Alert";
+import { Alert } from "$app/components/ui/Alert";
+import { FieldsetDescription } from "$app/components/ui/Fieldset";
+import { Input } from "$app/components/ui/Input";
+import { Row, RowActions, RowContent, Rows } from "$app/components/ui/Rows";
+
+const MAX_PASSKEYS = 10;
+const MAX_NICKNAME_LENGTH = 100;
+const GENERIC_ERROR = "Sorry, something went wrong. Please try again.";
+const ADD_ERROR = "Could not add this passkey. Please try again.";
+
+export type Passkey = {
+  id: string;
+  nickname: string;
+  created_at: string;
+  last_used_at: string | null;
+};
+
+const formatPasskeyDate = (value: string) => formatDate(parseISO(value), { dateStyle: "medium" });
+
+export const PasskeysSection = ({ passkeys: initialPasskeys }: { passkeys: Passkey[] }) => {
+  const [passkeys, setPasskeys] = React.useState(initialPasskeys);
+  const [adding, setAdding] = React.useState(false);
+  const [editingId, setEditingId] = React.useState<string | null>(null);
+  const [editingNickname, setEditingNickname] = React.useState("");
+  const [savingRename, setSavingRename] = React.useState(false);
+  const [pendingDeletion, setPendingDeletion] = React.useState<Passkey | null>(null);
+  const [deleting, setDeleting] = React.useState(false);
+  const supported = isPasskeySupported();
+  const reachedLimit = passkeys.length >= MAX_PASSKEYS;
+
+  const handleAdd = asyncVoid(async () => {
+    setAdding(true);
+    try {
+      const optionsResponse = await request({
+        url: Routes.registration_options_settings_passkeys_path(),
+        method: "POST",
+        accept: "json",
+      });
+      const optionsResult = typia.assert<{
+        success: boolean;
+        options?: PasskeyRegistrationOptions;
+        error_message?: string;
+      }>(await optionsResponse.json());
+      if (!optionsResponse.ok || !optionsResult.success || !optionsResult.options) {
+        throw new ResponseError(optionsResult.error_message ?? ADD_ERROR);
+      }
+
+      const credential = await createPasskey(optionsResult.options);
+
+      const createResponse = await request({
+        url: Routes.settings_passkeys_path(),
+        method: "POST",
+        accept: "json",
+        data: { credential },
+      });
+      const createResult = typia.assert<{ success: boolean; passkey?: Passkey; error_message?: string }>(
+        await createResponse.json(),
+      );
+      if (!createResponse.ok || !createResult.success || !createResult.passkey) {
+        throw new ResponseError(createResult.error_message ?? ADD_ERROR);
+      }
+
+      const added = createResult.passkey;
+      setPasskeys((current) => [...current, added]);
+      showAlert("Passkey added.", "success");
+    } catch (e) {
+      if (e instanceof DOMException && (e.name === "NotAllowedError" || e.name === "AbortError")) return;
+      showAlert(e instanceof ResponseError ? e.message : ADD_ERROR, "error");
+    } finally {
+      setAdding(false);
+    }
+  });
+
+  const handleRename = asyncVoid(async (passkey: Passkey) => {
+    const nickname = editingNickname.trim();
+    if (!nickname || nickname === passkey.nickname) {
+      setEditingId(null);
+      return;
+    }
+
+    setSavingRename(true);
+    try {
+      const response = await request({
+        url: Routes.settings_passkey_path(passkey.id),
+        method: "PATCH",
+        accept: "json",
+        data: { nickname },
+      });
+      const result = typia.assert<{ success: boolean; passkey?: Passkey; error_message?: string }>(
+        await response.json(),
+      );
+      if (!response.ok || !result.success || !result.passkey) {
+        throw new ResponseError(result.error_message ?? GENERIC_ERROR);
+      }
+
+      const updated = result.passkey;
+      setPasskeys((current) => current.map((item) => (item.id === updated.id ? updated : item)));
+      setEditingId(null);
+    } catch (e) {
+      showAlert(e instanceof ResponseError ? e.message : GENERIC_ERROR, "error");
+    } finally {
+      setSavingRename(false);
+    }
+  });
+
+  const handleConfirmDelete = asyncVoid(async () => {
+    if (!pendingDeletion) return;
+
+    setDeleting(true);
+    try {
+      const response = await request({
+        url: Routes.settings_passkey_path(pendingDeletion.id),
+        method: "DELETE",
+        accept: "json",
+      });
+      const result = typia.assert<{ success: boolean; error_message?: string }>(await response.json());
+      if (!response.ok || !result.success) {
+        throw new ResponseError(result.error_message ?? GENERIC_ERROR);
+      }
+
+      setPasskeys((current) => current.filter((item) => item.id !== pendingDeletion.id));
+      setPendingDeletion(null);
+      showAlert("Passkey removed.", "success");
+    } catch (e) {
+      showAlert(e instanceof ResponseError ? e.message : GENERIC_ERROR, "error");
+    } finally {
+      setDeleting(false);
+    }
+  });
+
+  return (
+    <>
+      {passkeys.length === 0 ? (
+        <Alert variant="info">
+          Passkeys are an easier, more secure alternative to passwords. Sign in with your fingerprint, face, or screen
+          lock.
+        </Alert>
+      ) : (
+        <Rows role="list">
+          {passkeys.map((passkey) =>
+            editingId === passkey.id ? (
+              <Row key={passkey.id} role="listitem">
+                <RowContent>
+                  <Input
+                    className="flex-1"
+                    value={editingNickname}
+                    onChange={(e) => setEditingNickname(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        e.preventDefault();
+                        handleRename(passkey);
+                      } else if (e.key === "Escape") {
+                        setEditingId(null);
+                      }
+                    }}
+                    aria-label="Passkey name"
+                    maxLength={MAX_NICKNAME_LENGTH}
+                    autoFocus
+                    disabled={savingRename}
+                  />
+                </RowContent>
+                <RowActions>
+                  <Button color="accent" onClick={() => handleRename(passkey)} disabled={savingRename}>
+                    {savingRename ? "Saving..." : "Save"}
+                  </Button>
+                  <Button onClick={() => setEditingId(null)} disabled={savingRename}>
+                    Cancel
+                  </Button>
+                </RowActions>
+              </Row>
+            ) : (
+              <Row key={passkey.id} role="listitem">
+                <RowContent>
+                  <div className="grid gap-1">
+                    <div className="font-bold">{passkey.nickname}</div>
+                    <FieldsetDescription>
+                      Added {formatPasskeyDate(passkey.created_at)} ·{" "}
+                      {passkey.last_used_at ? `last used ${formatPasskeyDate(passkey.last_used_at)}` : "never used"}
+                    </FieldsetDescription>
+                  </div>
+                </RowContent>
+                <RowActions>
+                  <Button
+                    onClick={() => {
+                      setEditingId(passkey.id);
+                      setEditingNickname(passkey.nickname);
+                    }}
+                  >
+                    Rename
+                  </Button>
+                  <Button color="danger" outline onClick={() => setPendingDeletion(passkey)}>
+                    Remove
+                  </Button>
+                </RowActions>
+              </Row>
+            ),
+          )}
+        </Rows>
+      )}
+
+      {supported ? (
+        reachedLimit ? (
+          <FieldsetDescription>You've reached the maximum of {MAX_PASSKEYS} passkeys.</FieldsetDescription>
+        ) : (
+          <div>
+            <Button color="accent" onClick={handleAdd} disabled={adding}>
+              {adding ? "Waiting for passkey..." : "Add a passkey"}
+            </Button>
+          </div>
+        )
+      ) : (
+        <FieldsetDescription>This browser doesn't support passkeys.</FieldsetDescription>
+      )}
+
+      {pendingDeletion ? (
+        <Modal
+          open
+          onClose={() => (deleting ? null : setPendingDeletion(null))}
+          title="Remove passkey"
+          footer={
+            <>
+              <Button onClick={() => setPendingDeletion(null)} disabled={deleting}>
+                Cancel
+              </Button>
+              <Button color="danger" onClick={handleConfirmDelete} disabled={deleting}>
+                {deleting ? "Removing..." : "Remove"}
+              </Button>
+            </>
+          }
+        >
+          <p>
+            Remove <strong>{pendingDeletion.nickname}</strong>? You won't be able to use it to sign in anymore.
+          </p>
+        </Modal>
+      ) : null}
+    </>
+  );
+};

--- a/app/javascript/components/Settings/PasswordPage/PasskeysSection.tsx
+++ b/app/javascript/components/Settings/PasswordPage/PasskeysSection.tsx
@@ -160,7 +160,7 @@ export const PasskeysSection = ({ passkeys: initialPasskeys }: { passkeys: Passk
                     onKeyDown={(e) => {
                       if (e.key === "Enter") {
                         e.preventDefault();
-                        handleRename(passkey);
+                        if (editingNickname.trim()) handleRename(passkey);
                       } else if (e.key === "Escape") {
                         setEditingId(null);
                       }
@@ -172,7 +172,11 @@ export const PasskeysSection = ({ passkeys: initialPasskeys }: { passkeys: Passk
                   />
                 </RowContent>
                 <RowActions>
-                  <Button color="accent" onClick={() => handleRename(passkey)} disabled={savingRename}>
+                  <Button
+                    color="accent"
+                    onClick={() => handleRename(passkey)}
+                    disabled={savingRename || !editingNickname.trim()}
+                  >
                     {savingRename ? "Saving..." : "Save"}
                   </Button>
                   <Button onClick={() => setEditingId(null)} disabled={savingRename}>

--- a/app/javascript/pages/Settings/Password/Show.tsx
+++ b/app/javascript/pages/Settings/Password/Show.tsx
@@ -11,6 +11,7 @@ import { PasswordInput } from "$app/components/PasswordInput";
 import { showAlert } from "$app/components/server-components/Alert";
 import { Layout as SettingsLayout } from "$app/components/Settings/Layout";
 import { AuthenticatorSetup } from "$app/components/Settings/PasswordPage/AuthenticatorSetup";
+import { PasskeysSection, type Passkey } from "$app/components/Settings/PasswordPage/PasskeysSection";
 import { RecoveryCodes } from "$app/components/Settings/PasswordPage/RecoveryCodes";
 import { Alert } from "$app/components/ui/Alert";
 import { Fieldset, FieldsetDescription, FieldsetTitle } from "$app/components/ui/Fieldset";
@@ -25,6 +26,8 @@ type PasswordPageProps = {
   require_old_password: boolean;
   show_authenticator_app_settings: boolean;
   authenticator_app_enabled: boolean;
+  show_passkeys_settings: boolean;
+  passkeys: Passkey[];
 };
 
 export default function PasswordPage() {
@@ -195,6 +198,11 @@ export default function PasswordPage() {
           {props.authenticator_app_enabled && regeneratedCodes ? (
             <RecoveryCodes codes={regeneratedCodes} onDone={() => setRegeneratedCodes(null)} />
           ) : null}
+        </FormSection>
+      ) : null}
+      {props.show_passkeys_settings ? (
+        <FormSection header={<h2>Passkeys</h2>}>
+          <PasskeysSection passkeys={props.passkeys} />
         </FormSection>
       ) : null}
     </SettingsLayout>

--- a/app/javascript/utils/webauthn.ts
+++ b/app/javascript/utils/webauthn.ts
@@ -1,0 +1,83 @@
+export type PasskeyRegistrationOptions = {
+  challenge: string;
+  timeout?: number;
+  rp: { id: string; name: string };
+  user: { id: string; name: string; displayName: string };
+  pubKeyCredParams: { type: "public-key"; alg: number }[];
+  excludeCredentials?: { type: "public-key"; id: string; transports?: string[] }[];
+  authenticatorSelection?: {
+    authenticatorAttachment?: "platform" | "cross-platform";
+    residentKey?: ResidentKeyRequirement;
+    requireResidentKey?: boolean;
+    userVerification?: UserVerificationRequirement;
+  };
+  attestation?: AttestationConveyancePreference;
+};
+
+export type PasskeyRegistrationCredential = {
+  id: string;
+  rawId: string;
+  type: string;
+  authenticatorAttachment: string | null;
+  response: { attestationObject: string; clientDataJSON: string; transports: string[] };
+  clientExtensionResults: AuthenticationExtensionsClientOutputs;
+};
+
+export const isPasskeySupported = () => typeof window !== "undefined" && "PublicKeyCredential" in window;
+
+const base64UrlToBytes = (value: string): Uint8Array => {
+  const base64 = value.replace(/-/gu, "+").replace(/_/gu, "/");
+  const binary = atob(base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), "="));
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+};
+
+const bytesToBase64Url = (buffer: ArrayBuffer): string => {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/gu, "-").replace(/\//gu, "_").replace(/=+$/u, "");
+};
+
+export const createPasskey = async (options: PasskeyRegistrationOptions): Promise<PasskeyRegistrationCredential> => {
+  const publicKey: PublicKeyCredentialCreationOptions = {
+    rp: options.rp,
+    user: {
+      id: new TextEncoder().encode(options.user.id),
+      name: options.user.name,
+      displayName: options.user.displayName,
+    },
+    challenge: base64UrlToBytes(options.challenge),
+    pubKeyCredParams: options.pubKeyCredParams,
+    ...(options.timeout !== undefined ? { timeout: options.timeout } : {}),
+    ...(options.excludeCredentials
+      ? {
+          excludeCredentials: options.excludeCredentials.map((credential) => ({
+            type: credential.type,
+            id: base64UrlToBytes(credential.id),
+          })),
+        }
+      : {}),
+    ...(options.authenticatorSelection ? { authenticatorSelection: options.authenticatorSelection } : {}),
+    ...(options.attestation ? { attestation: options.attestation } : {}),
+  };
+
+  const credential = await navigator.credentials.create({ publicKey });
+  if (!(credential instanceof PublicKeyCredential)) throw new Error("Could not create a passkey.");
+
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- create() always yields an attestation response
+  const response = credential.response as AuthenticatorAttestationResponse;
+  return {
+    id: credential.id,
+    rawId: bytesToBase64Url(credential.rawId),
+    type: credential.type,
+    authenticatorAttachment: credential.authenticatorAttachment,
+    response: {
+      attestationObject: bytesToBase64Url(response.attestationObject),
+      clientDataJSON: bytesToBase64Url(response.clientDataJSON),
+      transports: response.getTransports(),
+    },
+    clientExtensionResults: credential.getClientExtensionResults(),
+  };
+};

--- a/app/models/webauthn_credential.rb
+++ b/app/models/webauthn_credential.rb
@@ -11,7 +11,24 @@ class WebauthnCredential < ApplicationRecord
   MAX_NICKNAME_LENGTH = 100
   MAX_WEBAUTHN_ID_LENGTH = 1_364
 
+  AAGUID_PROVIDER_NAMES = {
+    "fbfc3007-154e-4ecc-8c0b-6e020557d7bd" => "iCloud Keychain",
+    "bada5566-a7aa-401f-bd96-45619a55120d" => "1Password",
+    "ea9b8d66-4d01-1d21-3ce4-b6b48cb575d4" => "Google Password Manager",
+    "adce0002-35bc-c60a-648b-0b25f1f05503" => "Chrome on Mac",
+    "08987058-cadc-4b81-b6e1-30de50dcbe96" => "Windows Hello",
+    "9ddd1817-af5a-4672-a2b9-3e3dd95000a9" => "Windows Hello",
+    "6028b017-b1d4-4c02-b4b3-afcdafc96bb2" => "Windows Hello",
+    "d548826e-79b4-db40-a3d8-11116f7e8349" => "Bitwarden",
+    "531126d6-e717-415c-9320-3d9aa6981239" => "Dashlane",
+    "fdb141b2-5d84-443e-8a35-4698c205a502" => "KeePassXC",
+  }.freeze
+
   belongs_to :user
+
+  def self.provider_name_for_aaguid(aaguid)
+    AAGUID_PROVIDER_NAMES[aaguid]
+  end
 
   before_validation :set_webauthn_id_sha256
   before_validation :normalize_nickname

--- a/app/presenters/settings_presenter.rb
+++ b/app/presenters/settings_presenter.rb
@@ -182,11 +182,27 @@ class SettingsPresenter
   end
 
   def password_props
+    passkeys_enabled = Feature.active?(:passkeys, seller)
+    passkeys = if passkeys_enabled
+      seller.webauthn_credentials.order(:created_at).map do |credential|
+        {
+          id: credential.external_id,
+          nickname: credential.nickname,
+          created_at: credential.created_at.iso8601,
+          last_used_at: credential.last_used_at&.iso8601,
+        }
+      end
+    else
+      []
+    end
+
     {
       require_old_password: seller.provider.blank?,
       settings_pages: pages,
       show_authenticator_app_settings: Feature.active?(:authenticator_2fa, seller),
       authenticator_app_enabled: seller.totp_enabled?,
+      show_passkeys_settings: passkeys_enabled,
+      passkeys:,
     }
   end
 

--- a/spec/controllers/settings/passkeys_controller_spec.rb
+++ b/spec/controllers/settings/passkeys_controller_spec.rb
@@ -132,6 +132,17 @@ describe Settings::PasskeysController, type: :controller do
       expect(user.reload.webauthn_credentials.sole.nickname).to eq("Passkey 1")
     end
 
+    it "names the passkey after the detected provider when no nickname is provided" do
+      expect(WebauthnCredential).to receive(:provider_name_for_aaguid).with(a_string_matching(/\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/)).and_return("1Password")
+
+      post :registration_options, as: :json
+
+      post :create, params: { credential: valid_credential_params }, as: :json
+
+      expect(response).to have_http_status(:created)
+      expect(user.reload.webauthn_credentials.sole.nickname).to eq("1Password")
+    end
+
     it "rejects a stale challenge" do
       post :registration_options, as: :json
       credential_params = fake_client.create(

--- a/spec/models/webauthn_credential_spec.rb
+++ b/spec/models/webauthn_credential_spec.rb
@@ -82,4 +82,16 @@ describe WebauthnCredential do
       expect(credential.nickname).to eq("MacBook Pro")
     end
   end
+
+  describe ".provider_name_for_aaguid" do
+    it "maps a known AAGUID to its provider name" do
+      expect(described_class.provider_name_for_aaguid("bada5566-a7aa-401f-bd96-45619a55120d")).to eq("1Password")
+      expect(described_class.provider_name_for_aaguid("fbfc3007-154e-4ecc-8c0b-6e020557d7bd")).to eq("iCloud Keychain")
+    end
+
+    it "returns nil for an unknown or missing AAGUID" do
+      expect(described_class.provider_name_for_aaguid("00000000-0000-0000-0000-000000000000")).to be_nil
+      expect(described_class.provider_name_for_aaguid(nil)).to be_nil
+    end
+  end
 end

--- a/spec/presenters/settings_presenter_spec.rb
+++ b/spec/presenters/settings_presenter_spec.rb
@@ -334,13 +334,31 @@ describe SettingsPresenter do
       end
 
       it "returns the correct props" do
-        expect(presenter.password_props).to eq(require_old_password: false, settings_pages:, show_authenticator_app_settings: false, authenticator_app_enabled: false)
+        expect(presenter.password_props).to eq(require_old_password: false, settings_pages:, show_authenticator_app_settings: false, authenticator_app_enabled: false, show_passkeys_settings: false, passkeys: [])
       end
     end
 
     context "when seller is registered using email" do
       it "returns the correct props" do
-        expect(presenter.password_props).to eq(require_old_password: true, settings_pages:, show_authenticator_app_settings: false, authenticator_app_enabled: false)
+        expect(presenter.password_props).to eq(require_old_password: true, settings_pages:, show_authenticator_app_settings: false, authenticator_app_enabled: false, show_passkeys_settings: false, passkeys: [])
+      end
+    end
+
+    context "when the passkeys feature is active" do
+      before { Feature.activate_user(:passkeys, seller) }
+
+      it "enables the passkeys settings" do
+        expect(presenter.password_props).to include(show_passkeys_settings: true, passkeys: [])
+      end
+
+      it "returns the seller's passkeys ordered by creation date" do
+        older = create(:webauthn_credential, user: seller, nickname: "Laptop", created_at: 2.days.ago, last_used_at: 1.hour.ago)
+        newer = create(:webauthn_credential, user: seller, nickname: "Phone", created_at: 1.day.ago, last_used_at: nil)
+
+        expect(presenter.password_props[:passkeys]).to eq([
+                                                            { id: older.external_id, nickname: "Laptop", created_at: older.created_at.iso8601, last_used_at: older.last_used_at.iso8601 },
+                                                            { id: newer.external_id, nickname: "Phone", created_at: newer.created_at.iso8601, last_used_at: nil },
+                                                          ])
       end
     end
   end

--- a/spec/requests/settings/passkeys_spec.rb
+++ b/spec/requests/settings/passkeys_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe("Passkeys Settings Scenario", type: :system, js: true) do
+  let(:seller) { create(:user) }
+
+  before do
+    Feature.activate_user(:passkeys, seller)
+    login_as seller
+  end
+
+  it "shows the empty state when the seller has no passkeys" do
+    visit settings_password_path
+
+    within_section("Passkeys", section_element: :section) do
+      expect(page).to have_text("Passkeys are an easier, more secure alternative to passwords")
+      expect(page).to_not have_button("Rename")
+    end
+  end
+
+  it "lists the seller's passkeys" do
+    create(:webauthn_credential, user: seller, nickname: "MacBook Pro")
+    create(:webauthn_credential, user: seller, nickname: "iPhone 15")
+
+    visit settings_password_path
+
+    within_section("Passkeys", section_element: :section) do
+      expect(page).to have_text("MacBook Pro")
+      expect(page).to have_text("iPhone 15")
+    end
+  end
+
+  it "renames a passkey" do
+    create(:webauthn_credential, user: seller, nickname: "MacBook Pro")
+
+    visit settings_password_path
+
+    within_section("Passkeys", section_element: :section) do
+      click_on "Rename"
+      fill_in "Passkey name", with: "Work laptop"
+      click_on "Save"
+
+      expect(page).to have_text("Work laptop")
+      expect(page).to_not have_text("MacBook Pro")
+    end
+
+    expect(seller.webauthn_credentials.sole.nickname).to eq("Work laptop")
+  end
+
+  it "disables saving a rename when the name is blank" do
+    create(:webauthn_credential, user: seller, nickname: "MacBook Pro")
+
+    visit settings_password_path
+
+    within_section("Passkeys", section_element: :section) do
+      click_on "Rename"
+      fill_in "Passkey name", with: ""
+
+      expect(page).to have_button("Save", disabled: true)
+    end
+
+    expect(seller.webauthn_credentials.sole.nickname).to eq("MacBook Pro")
+  end
+
+  it "removes a passkey after confirmation" do
+    create(:webauthn_credential, user: seller, nickname: "MacBook Pro")
+
+    visit settings_password_path
+
+    within_section("Passkeys", section_element: :section) do
+      click_on "Remove"
+    end
+
+    within_modal "Remove passkey" do
+      click_on "Remove"
+    end
+
+    expect(page).to have_alert(text: "Passkey removed.")
+    expect(seller.webauthn_credentials).to be_empty
+  end
+
+  context "when the passkeys feature is disabled" do
+    before { Feature.deactivate_user(:passkeys, seller) }
+
+    it "does not show the passkeys section" do
+      visit settings_password_path
+
+      expect(page).to have_text("Change password")
+      expect(page).to_not have_text("Passkeys are an easier, more secure alternative to passwords")
+    end
+  end
+end


### PR DESCRIPTION
Ref #5347

## What

Adds the **Passkeys** section to **Settings → Password and authentication**, giving sellers a full management surface (behind the `:passkeys` feature flag):

- Add a passkey, with an empty-state explainer and CTA
- See each passkey's name, when it was added, and when it was last used
- Rename inline, and remove with a confirmation
- A 10-per-account limit and a graceful notice on browsers that don't support passkeys

New passkeys are **auto-named after the provider that created them**. They're detected from the authenticator's AAGUID (e.g. *1Password*, *iCloud Keychain*, *Google Password Manager*, *Windows Hello*). So a passkey shows up as "1Password" instead of a generic "Passkey 1"; unknown providers fall back to "Passkey N".

Builds on the backend from #5461 and sits next to the existing two-factor (authenticator app) section, which is unchanged.

## Why

Passkeys are an easier, more phishing-resistant alternative to passwords. This PR delivers the management half of that experience so sellers can enroll and curate their passkeys. Auto-naming by provider removes the friction of fixing a generic label and makes the list self-explanatory — matching how Google, Apple, and GitHub present passkeys.

Signing in with a passkey is a deliberate follow-up so each piece can be reviewed and rolled out on its own. The password and 2FA paths are untouched.

## Screenshots

**Empty state**
|Desktop|Mobile|
|-|-|
|<img width="2678" height="1648" alt="CleanShot 2026-06-15 at 12 50 19@2x" src="https://github.com/user-attachments/assets/71ac3aed-7742-47e0-b240-589ce0ef3848" />|<img width="978" height="1650" alt="CleanShot 2026-06-15 at 12 50 34@2x" src="https://github.com/user-attachments/assets/e754d5c7-9edb-4b1e-a4ec-710b4fa2c139" />|

**Passkeys list view**
|Desktop|Mobile|
|-|-|
|<img width="2684" height="1652" alt="CleanShot 2026-06-15 at 12 53 17@2x" src="https://github.com/user-attachments/assets/c89155ee-f122-48b5-88f9-95ec11037b11" />|<img width="978" height="1654" alt="CleanShot 2026-06-15 at 12 53 27@2x" src="https://github.com/user-attachments/assets/7f9aab28-4f4a-4eee-9cde-3be67d9fac4c" />|

**Delete confirmation dialog**
<img width="480" src="https://github.com/user-attachments/assets/3a91328d-33fa-41c4-986d-14cf27de033e" />

## Demo
https://github.com/user-attachments/assets/10263912-d76e-4023-b96a-62a4ab0c2dea

---

This PR was implemented with AI assistance using Claude Opus 4.8.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential enrollment and WebAuthn registration in account settings (security-sensitive), but changes are scoped to management UI and nickname defaults behind a feature flag; sign-in with passkeys is explicitly out of scope.
> 
> **Overview**
> Adds a **Passkeys** section to **Settings → Password** (gated by the `:passkeys` feature flag) so sellers can add, list, rename, and remove passkeys via the existing settings API, with a 10-passkey cap and browser capability messaging.
> 
> Introduces client-side WebAuthn registration (`webauthn.ts` + `PasskeysSection`) and wires `password_props` to expose `show_passkeys_settings` and the seller’s passkeys. **New passkeys without a client-supplied nickname** are labeled from the authenticator **AAGUID** (e.g. 1Password, iCloud Keychain); unknown providers still get the existing **Passkey N** default via model validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32cb74687dc8d9ce2e49d94dcdbe2d8ffafeaffb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->