### PR TITLE
Add passkey login to the login page

### DIFF
--- a/app/controllers/logins/passkeys_controller.rb
+++ b/app/controllers/logins/passkeys_controller.rb
@@ -14,6 +14,7 @@ class Logins::PasskeysController < ApplicationController
   AUTHENTICATION_ERROR_MESSAGE = "We couldn't sign you in with that passkey. Please try again or use your password."
 
   skip_before_action :check_suspended
+  skip_before_action :invalidate_session_if_necessary
   before_action :ensure_passkeys_feature_enabled
 
   def options

--- a/app/controllers/logins/passkeys_controller.rb
+++ b/app/controllers/logins/passkeys_controller.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+class Logins::PasskeysController < ApplicationController
+  class AuthenticationVerificationError < StandardError
+    attr_reader :reason
+
+    def initialize(reason)
+      @reason = reason
+      super(reason)
+    end
+  end
+
+  AUTHENTICATION_CHALLENGE_SESSION_KEY = :webauthn_authentication_challenge
+  AUTHENTICATION_ERROR_MESSAGE = "We couldn't sign you in with that passkey. Please try again or use your password."
+
+  skip_before_action :check_suspended
+  before_action :ensure_passkeys_feature_enabled
+
+  def options
+    webauthn_options = WebAuthn::Credential.options_for_get(user_verification: "required")
+
+    session[AUTHENTICATION_CHALLENGE_SESSION_KEY] = webauthn_options.challenge
+
+    render json: { success: true, options: webauthn_options.as_json.merge("rpId" => WebAuthn.configuration.rp_id) }
+  end
+
+  def create
+    challenge = session.delete(AUTHENTICATION_CHALLENGE_SESSION_KEY)
+    raise AuthenticationVerificationError, "missing_challenge" if challenge.blank?
+
+    stored_credential = verified_credential(challenge)
+
+    user = stored_credential.user
+    raise AuthenticationVerificationError, "deleted_user" if user.deleted?
+
+    stored_credential.save!
+
+    user.remember_me = true
+    sign_in(user)
+    reset_two_factor_auth_login_session
+    merge_guest_cart_with_user_cart
+
+    Rails.logger.info("passkey.authentication.succeeded user_id=#{user.id} webauthn_credential_id=#{stored_credential.id}")
+
+    render json: { success: true, redirect_location: login_path_for(user) }
+  rescue AuthenticationVerificationError => e
+    log_authentication_failure(e.reason)
+    render json: { success: false, error_message: AUTHENTICATION_ERROR_MESSAGE }, status: :unprocessable_entity
+  end
+
+  private
+    def ensure_passkeys_feature_enabled
+      e404 unless Feature.active?(:passkeys)
+    end
+
+    def verified_credential(challenge)
+      webauthn_credential = WebAuthn::Credential.from_get(assertion_params)
+      stored_credential = WebauthnCredential.find_by_webauthn_id(webauthn_credential.id)
+      raise AuthenticationVerificationError, "unknown_credential" if stored_credential.nil?
+
+      webauthn_credential.verify(
+        challenge,
+        public_key: stored_credential.public_key,
+        sign_count: stored_credential.sign_count,
+        user_verification: true
+      )
+
+      stored_credential.assign_attributes(sign_count: webauthn_credential.sign_count, last_used_at: Time.current)
+      stored_credential
+    rescue AuthenticationVerificationError
+      raise
+    rescue ActionController::ParameterMissing, WebAuthn::Error, JSON::ParserError, CBOR::MalformedFormatError, CBOR::UnpackError, ArgumentError => e
+      raise AuthenticationVerificationError, e.class.name
+    rescue RuntimeError => e
+      raise unless ["invalid type", "invalid id"].include?(e.message)
+
+      raise AuthenticationVerificationError, e.class.name
+    end
+
+    def assertion_params
+      credential = params.require(:credential)
+      raise AuthenticationVerificationError, "malformed_credential" unless credential.respond_to?(:permit)
+
+      permitted_params = credential.permit(
+        :id,
+        :rawId,
+        :type,
+        :authenticatorAttachment,
+        response: [:authenticatorData, :clientDataJSON, :signature, :userHandle],
+        clientExtensionResults: {}
+      ).to_h
+
+      raise AuthenticationVerificationError, "malformed_credential" unless valid_assertion_params?(permitted_params)
+
+      permitted_params
+    end
+
+    def valid_assertion_params?(permitted_params)
+      response = permitted_params["response"]
+
+      permitted_params["type"] == "public-key" &&
+        base64url?(permitted_params["id"]) &&
+        base64url?(permitted_params["rawId"]) &&
+        response.is_a?(Hash) &&
+        base64url?(response["authenticatorData"]) &&
+        base64url?(response["clientDataJSON"]) &&
+        base64url?(response["signature"])
+    end
+
+    def base64url?(value)
+      value.is_a?(String) && value.match?(/\A[A-Za-z0-9_-]+={0,2}\z/)
+    end
+
+    def log_authentication_failure(reason)
+      Rails.logger.warn("passkey.authentication.failed reason=#{reason}")
+    end
+end

--- a/app/controllers/logins/passkeys_controller.rb
+++ b/app/controllers/logins/passkeys_controller.rb
@@ -86,8 +86,7 @@ class Logins::PasskeysController < ApplicationController
         :rawId,
         :type,
         :authenticatorAttachment,
-        response: [:authenticatorData, :clientDataJSON, :signature, :userHandle],
-        clientExtensionResults: {}
+        response: [:authenticatorData, :clientDataJSON, :signature, :userHandle]
       ).to_h
 
       raise AuthenticationVerificationError, "malformed_credential" unless valid_assertion_params?(permitted_params)

--- a/app/javascript/pages/Logins/New.tsx
+++ b/app/javascript/pages/Logins/New.tsx
@@ -1,5 +1,10 @@
 import { Link, useForm, usePage } from "@inertiajs/react";
 import * as React from "react";
+import typia from "typia";
+
+import { asyncVoid } from "$app/utils/promise";
+import { request, ResponseError } from "$app/utils/request";
+import { getPasskey, isPasskeySupported, type PasskeyAuthenticationOptions } from "$app/utils/webauthn";
 
 import { AuthAlert } from "$app/components/AuthAlert";
 import { Layout } from "$app/components/Authentication/Layout";
@@ -7,17 +12,22 @@ import { SocialAuth } from "$app/components/Authentication/SocialAuth";
 import { Button } from "$app/components/Button";
 import { PasswordInput } from "$app/components/PasswordInput";
 import { Separator } from "$app/components/Separator";
+import { Alert } from "$app/components/ui/Alert";
 import { Fieldset, FieldsetTitle } from "$app/components/ui/Fieldset";
 import { Input } from "$app/components/ui/Input";
 import { Label } from "$app/components/ui/Label";
 import { useOriginalLocation } from "$app/components/useOriginalLocation";
 import { RecaptchaCancelledError, useRecaptcha } from "$app/components/useRecaptcha";
 
+const PASSKEY_ERROR = "We couldn't sign you in with that passkey. Please try again or use your password.";
+
 type PageProps = {
   email: string | null;
   application_name: string | null;
   recaptcha_site_key: string | null;
   authenticity_token: string;
+  show_passkey_login: boolean;
+  is_gumroad_mobile_app: boolean;
 };
 
 type FormData = {
@@ -31,12 +41,25 @@ type FormData = {
 };
 
 function LoginPage() {
-  const { email: initialEmail, application_name, recaptcha_site_key, authenticity_token } = usePage<PageProps>().props;
+  const {
+    email: initialEmail,
+    application_name,
+    recaptcha_site_key,
+    authenticity_token,
+    show_passkey_login,
+    is_gumroad_mobile_app,
+  } = usePage<PageProps>().props;
 
   const url = new URL(useOriginalLocation());
   const next = url.searchParams.get("next");
   const recaptcha = useRecaptcha({ siteKey: recaptcha_site_key });
   const uid = React.useId();
+
+  const [passkeyLoading, setPasskeyLoading] = React.useState(false);
+  const [passkeyError, setPasskeyError] = React.useState<string | null>(null);
+  const [passkeySupported, setPasskeySupported] = React.useState(false);
+  React.useEffect(() => setPasskeySupported(isPasskeySupported()), []);
+  const showPasskeyButton = show_passkey_login && !is_gumroad_mobile_app && passkeySupported;
 
   const form = useForm<FormData>({
     user: {
@@ -62,6 +85,51 @@ function LoginPage() {
       throw e;
     }
   };
+
+  const handlePasskeyLogin = asyncVoid(async () => {
+    setPasskeyError(null);
+    setPasskeyLoading(true);
+    const csrfHeaders = { "X-CSRF-Token": authenticity_token };
+    try {
+      const optionsResponse = await request({
+        url: Routes.login_passkey_options_path(),
+        method: "POST",
+        accept: "json",
+        headers: csrfHeaders,
+      });
+      const optionsResult = typia.assert<{
+        success: boolean;
+        options?: PasskeyAuthenticationOptions;
+        error_message?: string;
+      }>(await optionsResponse.json());
+      if (!optionsResponse.ok || !optionsResult.success || !optionsResult.options) {
+        throw new ResponseError(optionsResult.error_message ?? PASSKEY_ERROR);
+      }
+
+      const credential = await getPasskey(optionsResult.options);
+
+      const loginResponse = await request({
+        url: Routes.login_passkey_path(),
+        method: "POST",
+        accept: "json",
+        data: { credential, next },
+        headers: csrfHeaders,
+      });
+      const loginResult = typia.assert<{ success: boolean; redirect_location?: string; error_message?: string }>(
+        await loginResponse.json(),
+      );
+      if (!loginResponse.ok || !loginResult.success || !loginResult.redirect_location) {
+        throw new ResponseError(loginResult.error_message ?? PASSKEY_ERROR);
+      }
+
+      window.location.href = loginResult.redirect_location;
+    } catch (e) {
+      if (e instanceof DOMException && (e.name === "NotAllowedError" || e.name === "AbortError")) return;
+      setPasskeyError(e instanceof ResponseError ? e.message : PASSKEY_ERROR);
+    } finally {
+      setPasskeyLoading(false);
+    }
+  });
 
   return (
     <Layout
@@ -105,9 +173,19 @@ function LoginPage() {
               autoComplete="current-password"
             />
           </Fieldset>
-          <Button color="primary" type="submit" disabled={form.processing}>
-            {form.processing ? "Logging in..." : "Login"}
-          </Button>
+          <div className="grid gap-4">
+            <Button color="primary" type="submit" disabled={form.processing}>
+              {form.processing ? "Logging in..." : "Login"}
+            </Button>
+            {showPasskeyButton ? (
+              <>
+                {passkeyError ? <Alert variant="danger">{passkeyError}</Alert> : null}
+                <Button type="button" onClick={handlePasskeyLogin} disabled={passkeyLoading}>
+                  {passkeyLoading ? "Waiting for passkey..." : "Log in with a passkey"}
+                </Button>
+              </>
+            ) : null}
+          </div>
         </section>
       </form>
       {recaptcha.container}

--- a/app/javascript/utils/request.ts
+++ b/app/javascript/utils/request.ts
@@ -2,6 +2,7 @@ export type RequestSettings = {
   accept: "json" | "html" | "csv";
   url: string;
   abortSignal?: AbortSignal | undefined;
+  headers?: Record<string, string> | undefined;
 } & ({ method: "GET" } | { method: "POST" | "PUT" | "PATCH" | "DELETE"; data?: Record<string, unknown> | FormData });
 
 export class AbortError extends Error {
@@ -52,6 +53,7 @@ export const request = async (settings: RequestSettings): Promise<Response> => {
   const headers = new Headers(defaults.headers);
   headers.set("Accept", acceptType);
   if (data && !(data instanceof FormData)) headers.set("Content-Type", "application/json");
+  for (const [name, value] of Object.entries(settings.headers ?? {})) headers.set(name, value);
   try {
     const response = await fetch(settings.url, {
       ...defaults,

--- a/app/javascript/utils/webauthn.ts
+++ b/app/javascript/utils/webauthn.ts
@@ -23,6 +23,23 @@ export type PasskeyRegistrationCredential = {
   clientExtensionResults: AuthenticationExtensionsClientOutputs;
 };
 
+export type PasskeyAuthenticationOptions = {
+  challenge: string;
+  timeout?: number;
+  rpId?: string;
+  allowCredentials?: { type: "public-key"; id: string; transports?: string[] }[];
+  userVerification?: UserVerificationRequirement;
+};
+
+export type PasskeyAuthenticationCredential = {
+  id: string;
+  rawId: string;
+  type: string;
+  authenticatorAttachment: string | null;
+  response: { authenticatorData: string; clientDataJSON: string; signature: string; userHandle: string | null };
+  clientExtensionResults: AuthenticationExtensionsClientOutputs;
+};
+
 export const isPasskeySupported = () => typeof window !== "undefined" && "PublicKeyCredential" in window;
 
 const base64UrlToBytes = (value: string): Uint8Array => {
@@ -77,6 +94,42 @@ export const createPasskey = async (options: PasskeyRegistrationOptions): Promis
       attestationObject: bytesToBase64Url(response.attestationObject),
       clientDataJSON: bytesToBase64Url(response.clientDataJSON),
       transports: response.getTransports(),
+    },
+    clientExtensionResults: credential.getClientExtensionResults(),
+  };
+};
+
+export const getPasskey = async (options: PasskeyAuthenticationOptions): Promise<PasskeyAuthenticationCredential> => {
+  const publicKey: PublicKeyCredentialRequestOptions = {
+    challenge: base64UrlToBytes(options.challenge),
+    ...(options.timeout !== undefined ? { timeout: options.timeout } : {}),
+    ...(options.rpId ? { rpId: options.rpId } : {}),
+    ...(options.allowCredentials
+      ? {
+          allowCredentials: options.allowCredentials.map((credential) => ({
+            type: credential.type,
+            id: base64UrlToBytes(credential.id),
+          })),
+        }
+      : {}),
+    ...(options.userVerification ? { userVerification: options.userVerification } : {}),
+  };
+
+  const credential = await navigator.credentials.get({ publicKey });
+  if (!(credential instanceof PublicKeyCredential)) throw new Error("Could not authenticate with a passkey.");
+
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- get() always yields an assertion response
+  const response = credential.response as AuthenticatorAssertionResponse;
+  return {
+    id: credential.id,
+    rawId: bytesToBase64Url(credential.rawId),
+    type: credential.type,
+    authenticatorAttachment: credential.authenticatorAttachment,
+    response: {
+      authenticatorData: bytesToBase64Url(response.authenticatorData),
+      clientDataJSON: bytesToBase64Url(response.clientDataJSON),
+      signature: bytesToBase64Url(response.signature),
+      userHandle: response.userHandle ? bytesToBase64Url(response.userHandle) : null,
     },
     clientExtensionResults: credential.getClientExtensionResults(),
   };

--- a/app/models/webauthn_credential.rb
+++ b/app/models/webauthn_credential.rb
@@ -30,6 +30,10 @@ class WebauthnCredential < ApplicationRecord
     AAGUID_PROVIDER_NAMES[aaguid]
   end
 
+  def self.find_by_webauthn_id(webauthn_id)
+    find_by(webauthn_id_sha256: Digest::SHA256.hexdigest(webauthn_id))
+  end
+
   before_validation :set_webauthn_id_sha256
   before_validation :normalize_nickname
   before_validation :set_default_nickname, on: :create

--- a/app/presenters/auth_presenter.rb
+++ b/app/presenters/auth_presenter.rb
@@ -13,6 +13,7 @@ class AuthPresenter
       email: params[:email] || retrieve_team_invitation_email(params[:next]),
       application_name: application&.name,
       recaptcha_site_key: Feature.active?(:disable_login_recaptcha) ? nil : GlobalConfig.get("RECAPTCHA_LOGIN_SITE_KEY"),
+      show_passkey_login: Feature.active?(:passkeys),
     }
   end
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -277,12 +277,12 @@ class Rack::Attack
   end
 
   # Passkey login is unauthenticated, so throttle by IP. Initial: 10rpm, Max: 60 requests/3 days (per IP)
-  throttle_with_exponential_backoff(name: "/params:/login/passkey/options:POST", requests: 10, period: 60.seconds, max_level: 6) do |req|
+  throttle_with_exponential_backoff(name: "/ip:/login/passkey/options:POST", requests: 10, period: 60.seconds, max_level: 6) do |req|
     req.remote_ip if req.path.match?(%r{\A/login/passkey/options(?:\.[^/]+)?\z}) && req.post?
   end
 
   # Initial: 10rpm, Max: 60 requests/3 days (per IP)
-  throttle_with_exponential_backoff(name: "/params:/login/passkey:POST", requests: 10, period: 60.seconds, max_level: 6) do |req|
+  throttle_with_exponential_backoff(name: "/ip:/login/passkey:POST", requests: 10, period: 60.seconds, max_level: 6) do |req|
     req.remote_ip if req.path.match?(%r{\A/login/passkey(?:\.[^/]+)?\z}) && req.post?
   end
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -276,6 +276,16 @@ class Rack::Attack
     req.env["warden"]&.user&.id if req.path.match?(%r{\A/settings/passkeys(?:\.[^/]+)?\z}) && req.post?
   end
 
+  # Passkey login is unauthenticated, so throttle by IP. Initial: 10rpm, Max: 60 requests/3 days (per IP)
+  throttle_with_exponential_backoff(name: "/params:/login/passkey/options:POST", requests: 10, period: 60.seconds, max_level: 6) do |req|
+    req.remote_ip if req.path.match?(%r{\A/login/passkey/options(?:\.[^/]+)?\z}) && req.post?
+  end
+
+  # Initial: 10rpm, Max: 60 requests/3 days (per IP)
+  throttle_with_exponential_backoff(name: "/params:/login/passkey:POST", requests: 10, period: 60.seconds, max_level: 6) do |req|
+    req.remote_ip if req.path.match?(%r{\A/login/passkey(?:\.[^/]+)?\z}) && req.post?
+  end
+
   # Initial: 4rpm, Max: 24 requests/9 hours
   throttle_by_params path: "/forgot_password.json",
                      method: :post,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -486,6 +486,8 @@ Rails.application.routes.draw do
       get "/oauth/login" => "logins#new"
 
       post "login", to: "logins#create"
+      post "login/passkey/options", to: "logins/passkeys#options", as: :login_passkey_options
+      post "login/passkey", to: "logins/passkeys#create", as: :login_passkey
       # TODO: Keeping both routes for now to support legacy GET requests until all logout links are migrated to DELETE(inertia).
       get "logout", to: "logins#destroy"
       delete "logout", to: "logins#destroy"

--- a/spec/controllers/logins/passkeys_controller_spec.rb
+++ b/spec/controllers/logins/passkeys_controller_spec.rb
@@ -51,6 +51,17 @@ describe Logins::PasskeysController, type: :controller do
       expect(session[Logins::PasskeysController::AUTHENTICATION_CHALLENGE_SESSION_KEY]).to eq(json["options"]["challenge"])
     end
 
+    it "issues options even when a lingering signed-in session was invalidated elsewhere" do
+      sign_in user
+      user.update!(last_active_sessions_invalidated_at: 1.day.from_now)
+
+      post :options, as: :json
+
+      expect(response).to be_successful
+      expect(response.parsed_body["success"]).to be true
+      expect(response.parsed_body["options"]["challenge"]).to be_present
+    end
+
     context "when the feature flag is inactive" do
       before { Feature.deactivate(:passkeys) }
 

--- a/spec/controllers/logins/passkeys_controller_spec.rb
+++ b/spec/controllers/logins/passkeys_controller_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "webauthn/fake_client"
+
+describe Logins::PasskeysController, type: :controller do
+  let(:user) { create(:user) }
+  let(:origin) { "#{PROTOCOL}://#{DOMAIN}" }
+  let(:rp_id) { WebAuthn.configuration.rp_id }
+  let(:fake_client) { WebAuthn::FakeClient.new(origin) }
+
+  before do
+    request.env["devise.mapping"] = Devise.mappings[:user]
+    Feature.activate(:passkeys)
+  end
+
+  def fake_register
+    creation_challenge = WebAuthn::Credential.options_for_create(user: { id: user.external_id, name: user.email }).challenge
+    created = fake_client.create(challenge: creation_challenge, rp_id:, user_verified: true)
+    credential = WebAuthn::Credential.from_create(created)
+    credential.verify(creation_challenge, user_verification: true)
+    credential
+  end
+
+  def store_credential(credential)
+    user.webauthn_credentials.create!(
+      webauthn_id: credential.id,
+      public_key: credential.public_key,
+      sign_count: credential.sign_count,
+      nickname: "Test passkey"
+    )
+  end
+
+  def sign_in_with_passkey(challenge: nil, user_verified: true)
+    post :options, as: :json
+    assertion = fake_client.get(challenge: challenge || response.parsed_body.dig("options", "challenge"), rp_id:, user_verified:)
+    post :create, params: { credential: assertion }, as: :json
+  end
+
+  describe "POST options" do
+    it "returns assertion options for the discoverable flow and stores the challenge" do
+      post :options, as: :json
+
+      expect(response).to be_successful
+      json = response.parsed_body
+      expect(json["success"]).to be true
+      expect(json["options"]["challenge"]).to be_present
+      expect(json["options"]["allowCredentials"]).to eq([])
+      expect(json["options"]["userVerification"]).to eq("required")
+      expect(json["options"]["rpId"]).to eq(WebAuthn.configuration.rp_id)
+      expect(session[Logins::PasskeysController::AUTHENTICATION_CHALLENGE_SESSION_KEY]).to eq(json["options"]["challenge"])
+    end
+
+    context "when the feature flag is inactive" do
+      before { Feature.deactivate(:passkeys) }
+
+      it "raises a not found error" do
+        expect { post :options, as: :json }.to raise_error(ActionController::RoutingError, "Not Found")
+      end
+    end
+  end
+
+  describe "POST create" do
+    it "signs the user in with a valid passkey assertion and bypasses the 2FA challenge" do
+      credential = store_credential(fake_register)
+      user.update!(two_factor_authentication_enabled: true)
+
+      sign_in_with_passkey
+
+      expect(response).to be_successful
+      expect(response.parsed_body).to include("success" => true)
+      expect(response.parsed_body["redirect_location"]).to be_present
+      expect(controller.user_signed_in?).to be(true)
+      expect(controller.current_user).to eq(user)
+      expect(session[:verify_two_factor_auth_for]).to be_nil
+      expect(credential.reload.last_used_at).to be_present
+      expect(session.delete(Logins::PasskeysController::AUTHENTICATION_CHALLENGE_SESSION_KEY)).to be_nil
+    end
+
+    it "persists the updated sign count" do
+      credential = store_credential(fake_register)
+
+      sign_in_with_passkey
+
+      expect(response).to be_successful
+      expect(credential.reload.sign_count).to be > 0
+    end
+
+    it "merges the guest cart with the user's cart" do
+      store_credential(fake_register)
+
+      expect_any_instance_of(described_class).to receive(:merge_guest_cart_with_user_cart)
+
+      sign_in_with_passkey
+
+      expect(response).to be_successful
+    end
+
+    it "rejects an assertion for a credential that is not stored" do
+      fake_register # registered with the authenticator but never persisted
+
+      sign_in_with_passkey
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["success"]).to be false
+      expect(controller.user_signed_in?).to be(false)
+    end
+
+    it "rejects an assertion signed against a stale challenge" do
+      store_credential(fake_register)
+
+      sign_in_with_passkey(challenge: WebAuthn::Credential.options_for_get.challenge)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(controller.user_signed_in?).to be(false)
+    end
+
+    it "does not sign in a deleted user" do
+      store_credential(fake_register)
+      user.mark_deleted!
+
+      sign_in_with_passkey
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(controller.user_signed_in?).to be(false)
+    end
+
+    it "returns a generic error when there is no stored challenge" do
+      store_credential(fake_register)
+      assertion = fake_client.get(rp_id:, user_verified: true)
+
+      post :create, params: { credential: assertion }, as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["success"]).to be false
+      expect(controller.user_signed_in?).to be(false)
+    end
+
+    it "returns a generic error for a malformed assertion instead of a server error" do
+      post :options, as: :json
+
+      post :create, params: { credential: { id: "AAA", type: "public-key", response: {} } }, as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["success"]).to be false
+      expect(controller.user_signed_in?).to be(false)
+    end
+
+    context "when the feature flag is inactive" do
+      before { Feature.deactivate(:passkeys) }
+
+      it "raises a not found error" do
+        expect { post :create, params: { credential: {} }, as: :json }.to raise_error(ActionController::RoutingError, "Not Found")
+      end
+    end
+  end
+end

--- a/spec/controllers/logins/passkeys_controller_spec.rb
+++ b/spec/controllers/logins/passkeys_controller_spec.rb
@@ -146,6 +146,20 @@ describe Logins::PasskeysController, type: :controller do
       expect(controller.user_signed_in?).to be(false)
     end
 
+    it "ignores an unrequested appid extension instead of returning a server error" do
+      store_credential(fake_register)
+
+      post :options, as: :json
+      assertion = fake_client.get(challenge: response.parsed_body.dig("options", "challenge"), rp_id:, user_verified: true)
+      assertion["clientExtensionResults"] = { "appid" => true }
+
+      post :create, params: { credential: assertion }, as: :json
+
+      expect(response).to be_successful
+      expect(response.parsed_body).to include("success" => true)
+      expect(controller.user_signed_in?).to be(true)
+    end
+
     context "when the feature flag is inactive" do
       before { Feature.deactivate(:passkeys) }
 

--- a/spec/presenters/auth_presenter_spec.rb
+++ b/spec/presenters/auth_presenter_spec.rb
@@ -20,6 +20,7 @@ describe AuthPresenter do
             email: nil,
             application_name: nil,
             recaptcha_site_key: GlobalConfig.get("RECAPTCHA_LOGIN_SITE_KEY"),
+            show_passkey_login: false,
           }
         )
       end
@@ -34,8 +35,17 @@ describe AuthPresenter do
             email: nil,
             application_name: "Test App",
             recaptcha_site_key: GlobalConfig.get("RECAPTCHA_LOGIN_SITE_KEY"),
+            show_passkey_login: false,
           }
         )
+      end
+    end
+
+    context "when the passkeys feature is active" do
+      before { Feature.activate(:passkeys) }
+
+      it "enables passkey login" do
+        expect(presenter.login_props[:show_passkey_login]).to be(true)
       end
     end
   end
@@ -58,6 +68,7 @@ describe AuthPresenter do
               total_made: 0,
             },
             recaptcha_site_key: GlobalConfig.get("RECAPTCHA_SIGNUP_SITE_KEY"),
+            show_passkey_login: false,
           }
         )
       end
@@ -67,6 +78,7 @@ describe AuthPresenter do
       before do
         allow(Feature).to receive(:active?).with(:disable_login_recaptcha).and_return(false)
         allow(Feature).to receive(:active?).with(:disable_signup_recaptcha).and_return(true)
+        allow(Feature).to receive(:active?).with(:passkeys).and_return(false)
         $redis.del(RedisKey.total_made)
         $redis.del(RedisKey.number_of_creators)
       end
@@ -102,6 +114,7 @@ describe AuthPresenter do
               total_made: 923_456_789,
             },
             recaptcha_site_key: GlobalConfig.get("RECAPTCHA_SIGNUP_SITE_KEY"),
+            show_passkey_login: false,
           }
         )
       end

--- a/spec/requests/login/passkeys_spec.rb
+++ b/spec/requests/login/passkeys_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe("Passkey Login Scenario", type: :system, js: true) do
+  let(:user) { create(:user) }
+
+  before do
+    use_webauthn_driver
+    Feature.activate(:passkeys)
+  end
+
+  it "registers a passkey, then signs in with it and bypasses the 2FA challenge" do
+    user.update!(two_factor_authentication_enabled: true)
+
+    login_as user
+    visit settings_password_path
+    register_virtual_authenticator!
+    visit settings_password_path
+    click_on "Add a passkey"
+    expect(page).to have_alert(text: "Passkey added.")
+    expect(user.webauthn_credentials.count).to eq(1)
+
+    logout(:user)
+    visit login_path
+    click_on "Log in with a passkey"
+
+    expect(page).to have_current_path(dashboard_path, wait: 15)
+    expect(user.webauthn_credentials.sole.last_used_at).to be_present
+  end
+end

--- a/spec/requests/settings/passkeys_spec.rb
+++ b/spec/requests/settings/passkeys_spec.rb
@@ -19,6 +19,21 @@ describe("Passkeys Settings Scenario", type: :system, js: true) do
     end
   end
 
+  it "adds a passkey with the browser authenticator" do
+    use_webauthn_driver
+    visit settings_password_path
+    register_virtual_authenticator!
+    visit settings_password_path
+
+    click_on "Add a passkey"
+
+    expect(page).to have_alert(text: "Passkey added.")
+    within_section("Passkeys", section_element: :section) do
+      expect(page).to have_button("Remove")
+    end
+    expect(seller.webauthn_credentials.count).to eq(1)
+  end
+
   it "lists the seller's passkeys" do
     create(:webauthn_credential, user: seller, nickname: "MacBook Pro")
     create(:webauthn_credential, user: seller, nickname: "iPhone 15")

--- a/spec/support/webauthn_virtual_authenticator.rb
+++ b/spec/support/webauthn_virtual_authenticator.rb
@@ -8,6 +8,8 @@ webauthn_webdriver_client = Selenium::WebDriver::Remote::Http::Default.new(open_
 # app over HTTP on a custom host, so we mark that origin as secure to expose the WebAuthn API,
 # and register a virtual authenticator to drive the ceremonies without real hardware. Use these
 # drivers via `use_webauthn_driver` in specs that exercise passkey registration or sign-in.
+# Chrome only honors --unsafely-treat-insecure-origin-as-secure under the new headless mode, so
+# the docker driver swaps the legacy --headless flag for --headless=new.
 Capybara.register_driver :webauthn_chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
   options.add_emulation(device_metrics: { width: 1440, height: 900, touch: false })
@@ -20,7 +22,12 @@ end
 Capybara.register_driver :webauthn_docker_headless_chrome do |app|
   Capybara::Selenium::Driver.load_selenium
   options = Selenium::WebDriver::Chrome::Options.new.tap do |opts|
-    docker_browser_args.each { |arg| opts.args << arg }
+    docker_browser_args.each do |arg|
+      next if arg.start_with?("--user-data-dir=")
+
+      opts.args << (arg == "--headless" ? "--headless=new" : arg)
+    end
+    opts.args << "--user-data-dir=#{Dir.mktmpdir}"
     opts.args << "--window-size=1440,900"
     opts.args << "--unsafely-treat-insecure-origin-as-secure=#{Capybara.app_host}"
   end

--- a/spec/support/webauthn_virtual_authenticator.rb
+++ b/spec/support/webauthn_virtual_authenticator.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+
+webauthn_webdriver_client = Selenium::WebDriver::Remote::Http::Default.new(open_timeout: 120, read_timeout: 120)
+
+# WebAuthn is only available in a secure context (HTTPS or localhost). System specs serve the
+# app over HTTP on a custom host, so we mark that origin as secure to expose the WebAuthn API,
+# and register a virtual authenticator to drive the ceremonies without real hardware. Use these
+# drivers via `use_webauthn_driver` in specs that exercise passkey registration or sign-in.
+Capybara.register_driver :webauthn_chrome do |app|
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.add_emulation(device_metrics: { width: 1440, height: 900, touch: false })
+  options.add_preference("intl.accept_languages", "en-US")
+  options.add_argument("--unsafely-treat-insecure-origin-as-secure=#{Capybara.app_host}")
+  options.add_argument("--user-data-dir=#{Dir.mktmpdir}")
+  Capybara::Selenium::Driver.new(app, browser: :chrome, http_client: webauthn_webdriver_client, options:)
+end
+
+Capybara.register_driver :webauthn_docker_headless_chrome do |app|
+  Capybara::Selenium::Driver.load_selenium
+  options = Selenium::WebDriver::Chrome::Options.new.tap do |opts|
+    docker_browser_args.each { |arg| opts.args << arg }
+    opts.args << "--window-size=1440,900"
+    opts.args << "--unsafely-treat-insecure-origin-as-secure=#{Capybara.app_host}"
+  end
+  options.add_preference("intl.accept_languages", "en-US")
+  Capybara::Selenium::Driver.new(app, browser: :chrome, http_client: webauthn_webdriver_client, options:)
+end
+
+module WebauthnSystemHelpers
+  def use_webauthn_driver
+    driven_by(ENV["IN_DOCKER"] == "true" ? :webauthn_docker_headless_chrome : :webauthn_chrome)
+  end
+
+  def register_virtual_authenticator!
+    # Chrome keeps the browser process (and its virtual authenticators) alive across examples,
+    # and allows only one internal authenticator per environment, so each one must be removed
+    # after the example that created it.
+    @virtual_authenticator = page.driver.browser.add_virtual_authenticator(
+      Selenium::WebDriver::VirtualAuthenticatorOptions.new(
+        protocol: :ctap2,
+        transport: :internal,
+        resident_key: true,
+        user_verification: true,
+        user_verified: true
+      )
+    )
+  end
+
+  def remove_virtual_authenticator!
+    @virtual_authenticator&.remove!
+  rescue Selenium::WebDriver::Error::WebDriverError
+    nil
+  end
+end
+
+RSpec.configure do |config|
+  config.include WebauthnSystemHelpers, type: :system
+  config.after(:each, type: :system) { remove_virtual_authenticator! }
+end


### PR DESCRIPTION
Ref #5347

## What

Lets users sign in with a passkey. Adds a **Log in with a passkey** button to the login page that runs the WebAuthn assertion against a registered passkey and signs the user in. No email or password required (behind the `:passkeys` feature flag).

- New `Logins::PasskeysController` issues a single-use assertion challenge and verifies the signed assertion against the stored passkey before signing the user in.
- Because a passkey assertion already proves the user's identity (fingerprint, face, or device PIN), a successful passkey login **skips the 2FA challenge** instead of asking for a second factor.
- The button hides itself when the browser has no WebAuthn support or inside the Gumroad mobile app.

Builds on the backend from #5461 and the settings UI from #5475 (where users enroll their passkeys). The password and authenticator-app paths are untouched.

## Why

#5475 let users enroll passkeys, and this PR lets them log in with one. Passkeys are faster and more phishing-resistant than passwords, and skipping the redundant 2FA step keeps the sign-in to a single tap.

A few decisions worth calling out:

- **Feature gating is global for login** (vs. per-user enrollment) so the button only appears once we're ready to expose the flow to everyone.
- **The challenge is stored in the session and the login request sends a fresh CSRF token**, so the same session that issues the challenge is the one that verifies it — this was the root cause of an early "couldn't sign you in" failure after logout→login.
- **The assertion options carry the configured `rp_id`**, so the ceremony works on subdomains and previews, not just the bare domain.
- **Malformed assertions are validated before reaching the WebAuthn library**, returning a clean 422 rather than a 500.

## Screenshots

**Log in page – Desktop**
<img width="2684" height="1650" src="https://github.com/user-attachments/assets/5ff843b5-7dff-469b-bc76-d79ec58d83aa" />

**Log in page – Mobile**
<img width="380" src="https://github.com/user-attachments/assets/a5e14d9d-a0fe-44ed-a420-90c69f3f0000" />

## Demo
<img width="800" height="490" alt="CleanShot 2026-06-15 at 15 39 41" src="https://github.com/user-attachments/assets/c94debbe-35fa-4955-860d-a18d60fbcfec" />

## Testing

Controller specs (WebAuthn `FakeClient`) cover sign-in, the 2FA bypass, sign-count persistence, cart merge, and the failure paths (unknown credential, stale challenge, deleted user, malformed assertion, flag off). A Selenium virtual-authenticator system spec registers a passkey and signs in with it end to end. The same harness backfills an end-to-end enrollment test for the #5475 settings flow.

---

This PR was implemented with AI assistance using Claude Opus 4.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784140997&installation_id=134400930&pr_number=5476&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5476&signature=952b7d5e62955fb915e233837e91f4e3ff7e8876f7f5d80d551c10e7ce236f18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> New authentication path that establishes sessions and bypasses 2FA; incorrect verification or session/challenge handling could allow account takeover.
> 
> **Overview**
> Adds **passkey sign-in** behind the `:passkeys` flag: users can authenticate with WebAuthn without email/password.
> 
> **Backend:** New `Logins::PasskeysController` exposes `POST login/passkey/options` (session-stored challenge, discoverable credentials, `rpId`) and `POST login/passkey` (verifies assertion via `WebauthnCredential.find_by_webauthn_id`, updates sign count/`last_used_at`, then `sign_in`). Successful passkey login **clears the 2FA pending session** and merges the guest cart—same post-login hooks as password login, but skips the 2FA step. Malformed assertions are validated up front for 422 responses; IP throttling covers both endpoints.
> 
> **Frontend:** Login page shows **Log in with a passkey** when the flag is on, WebAuthn is supported, and not in the mobile app. Flow fetches options, runs `getPasskey`, posts the credential with CSRF headers; `request` now accepts custom headers.
> 
> **Tests:** Controller specs, system spec (register + login + 2FA bypass), virtual authenticator harness for settings enrollment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5cb2941a88b36a39b32e40ba01f994a024c9ee2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->