### PR TITLE
Classify Stripe balance_insufficient payout failures as INSUFFICIENT_FUNDS

### DIFF
--- a/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
+++ b/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
@@ -383,12 +383,14 @@ class StripePayoutProcessor
   end
 
   def self.stripe_invalid_request_error_failure_reason(error)
+    return Payment::FailureReason::INSUFFICIENT_FUNDS if error.code.to_s == "balance_insufficient"
+
     case error.message.to_s
     when /Cannot create live transfers/, /Cannot create payouts/
       Payment::FailureReason::CANNOT_PAY
     when /Debit card transfers are only supported for amounts less/
       Payment::FailureReason::DEBIT_CARD_LIMIT
-    when /Insufficient funds in Stripe account/
+    when /insufficient funds in (your )?Stripe account/i
       Payment::FailureReason::INSUFFICIENT_FUNDS
     when /has been deleted and can no longer be used/
       Payment::FailureReason::BANK_ACCOUNT_NOT_FOUND_AT_STRIPE

--- a/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
@@ -1243,6 +1243,7 @@ describe StripePayoutProcessor, :vcr do
         errors = described_class.perform_payment(payment)
         expect(errors).to be_present
         expect(errors.first).to match(/You have insufficient funds in your Stripe account for this transfer/)
+        expect(payment.reload.failure_reason).to eq(Payment::FailureReason::INSUFFICIENT_FUNDS)
       end
     end
   end
@@ -1669,6 +1670,7 @@ describe StripePayoutProcessor, :vcr do
         errors = described_class.perform_payment(payment)
         expect(errors).to be_present
         expect(errors.first).to match(/You have insufficient funds in your Stripe account for this transfer/)
+        expect(payment.reload.failure_reason).to eq(Payment::FailureReason::INSUFFICIENT_FUNDS)
       end
     end
   end


### PR DESCRIPTION
## What

Classify Stripe payout failures that return the `balance_insufficient` error code as `Payment::FailureReason::INSUFFICIENT_FUNDS`, instead of leaving `failure_reason` NULL.

## Why

When a `Stripe::Payout.create` (or transfer) is rejected for insufficient available balance, Stripe returns:

- `error.code = "balance_insufficient"`
- `error.message = "You have insufficient funds in your Stripe account for this transfer. Your card balance is too low. ..."`

The classifier only matched `/Insufficient funds in Stripe account/`. The real message is "insufficient funds in **your** Stripe account" — different casing plus an extra "your" — so it never matched. The result: `failure_reason` was set to `nil`, support/admin tooling showed no reason, and the real cause survived only in `error_message` (which isn't surfaced), making these failures hard to diagnose.

This change matches on the Stripe **error code** as the primary, robust signal, with a case-insensitive message fallback for safety. Matching the structured code is resilient to Stripe wording changes; the message fallback covers cases where a code isn't present.

This is a non-user-facing backend change (failure-reason classification only). No behavior change to the payout/transfer flow itself.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AI disclosure: drafted with Claude Opus 4.8 (1M context).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5479"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784189757&installation_id=134400930&pr_number=5479&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5479&signature=85c82d831c740cca5efbcc6b952f6c9a3edcc77fb197ed54b9bdc40b9ecb182c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Classification-only change in Stripe error handling; payout behavior is unchanged and covered by existing VCR specs plus new failure_reason assertions.
> 
> **Overview**
> Stripe payout/transfer rejections for low Connect balance were leaving `failure_reason` unset because classification only matched an outdated message pattern, not Stripe’s `balance_insufficient` error code.
> 
> `stripe_invalid_request_error_failure_reason` now maps **`balance_insufficient`** to `Payment::FailureReason::INSUFFICIENT_FUNDS` first, with a looser case-insensitive message fallback (`insufficient funds in (your )?Stripe account`). Failed payments should show the correct reason in admin/support tooling without changing payout execution.
> 
> Specs for standard and instant “amount over balance” flows now assert `failure_reason == INSUFFICIENT_FUNDS` against existing VCR cassettes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22c8d7e9002f4bda01a04d004abfd80eb73353e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->