### PR TITLE
Defer Stripe bank payout until the funding internal transfer settles

### DIFF
--- a/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
+++ b/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
@@ -15,6 +15,17 @@ class StripePayoutProcessor
   # the floor stay `unpaid` and roll forward to the next cycle.
   GUMROAD_HELD_USD_MIN_TRANSFER_CENTS = 1_00
 
+  # When funds held by Gumroad are paid out, they are first transferred (USD) into the creator's
+  # Connect account and then paid to the bank. On accounts with a settlement delay (e.g. cross-border
+  # accounts with `delay_days > 0`), that internal transfer lands in the destination's `pending`
+  # balance and only becomes `available` a day or more later. Creating the bank payout in the same run
+  # fails with `balance_insufficient`, and the failure path reverses the transfer — losing the FX
+  # spread each cycle and never settling. Instead we defer the bank payout until the transferred funds
+  # are `available`, reusing the same Payment (no re-transfer). Capped so total deferral stays well
+  # under SyncStuckPayoutsJob's 3-day `processing` cutoff.
+  MAX_PAYOUT_SETTLEMENT_RETRIES = 2
+  SETTLEMENT_RETRY_BUFFER = 1.hour
+
   # Public: Determines if it's possible for this processor to payout
   # the user by checking that the user has provided us with the
   # information we need to be able to payout with this processor.
@@ -323,6 +334,21 @@ class StripePayoutProcessor
       return
     end
 
+    # Guard against re-paying a payment that already has a bank payout (e.g. a settlement retry that
+    # races a prior success).
+    return if payment.stripe_transfer_id.present?
+
+    # If the internal transfer that funded this payout is still settling, the destination's `available`
+    # balance can't cover the payout yet. Defer to a later run rather than attempting (and reversing)
+    # the payout now. `perform_payment` never re-transfers, so retrying the same Payment is safe.
+    if (settlement_time = pending_internal_transfer_settlement_time(payment)) &&
+       payment.payout_settlement_retry_count.to_i < MAX_PAYOUT_SETTLEMENT_RETRIES
+      payment.increment_payout_settlement_retry_count!
+      RetryStripePayoutForSettlingTransferJob.perform_at(settlement_time + SETTLEMENT_RETRY_BUFFER, payment.id)
+      Rails.logger.info("Payouts: deferring payout for payment #{payment.id} until internal transfer settles at #{settlement_time}")
+      return []
+    end
+
     amount_cents = if payment.currency == Currency::KRW
       # Our currencies.yml assumes KRW to have 100 subunits, and that's how we store them in the database.
       # However, Stripe treats KRW as a single-unit currency. So we convert the value here.
@@ -553,6 +579,32 @@ class StripePayoutProcessor
       payment.send_payout_failure_email
     end
   end
+
+  # Returns the Time at which the internal transfer's funds become `available` on the destination
+  # account, but only while they are still `pending` (i.e. not yet spendable). Returns nil when there
+  # is no internal transfer, the funds have already settled, or the state can't be determined — in all
+  # of which cases the caller should proceed with the payout as normal.
+  def self.pending_internal_transfer_settlement_time(payment)
+    return nil if payment.stripe_internal_transfer_id.blank?
+
+    internal_transfer = Stripe::Transfer.retrieve(payment.stripe_internal_transfer_id)
+    return nil if internal_transfer.destination_payment.blank?
+
+    destination_payment = Stripe::Charge.retrieve(
+      { id: internal_transfer.destination_payment, expand: %w[balance_transaction] },
+      { stripe_account: internal_transfer.destination }
+    )
+    balance_transaction = destination_payment.balance_transaction
+    return nil if balance_transaction.blank?
+    return nil if balance_transaction.status != "pending"
+
+    available_on = Time.zone.at(balance_transaction.available_on)
+    available_on > Time.current ? available_on : nil
+  rescue Stripe::StripeError => e
+    Rails.logger.error("Payouts: could not determine internal transfer settlement time for payment #{payment.id}: #{e.message}")
+    nil
+  end
+  private_class_method :pending_internal_transfer_settlement_time
 
   def self.reverse_internal_transfer!(payment)
     return if payment.stripe_internal_transfer_id.nil?

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -36,6 +36,12 @@ class Payment < ApplicationRecord
   attr_json_data_accessor :payout_type
   attr_json_data_accessor :gumroad_fee_cents
   attr_json_data_accessor :error_message
+  attr_json_data_accessor :payout_settlement_retry_count
+
+  def increment_payout_settlement_retry_count!
+    self.payout_settlement_retry_count = payout_settlement_retry_count.to_i + 1
+    save!
+  end
 
   # Payment state transitions:
   #

--- a/app/sidekiq/retry_stripe_payout_for_settling_transfer_job.rb
+++ b/app/sidekiq/retry_stripe_payout_for_settling_transfer_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Retries the bank payout for a Stripe payment whose funding internal transfer was still settling when
+# the payout was first attempted. `StripePayoutProcessor.perform_payment` only creates the bank payout
+# (the internal transfer happens once, in `prepare_payment_and_set_amount`), so re-running it against
+# the same Payment never re-transfers funds.
+class RetryStripePayoutForSettlingTransferJob
+  include Sidekiq::Job
+  sidekiq_options retry: 3, queue: :low
+
+  def perform(payment_id)
+    payment = Payment.find(payment_id)
+    return unless payment.state == Payment::PROCESSING
+    return if payment.stripe_transfer_id.present?
+
+    StripePayoutProcessor.perform_payment(payment)
+  end
+end

--- a/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
@@ -4176,4 +4176,47 @@ describe StripePayoutProcessor, :vcr do
       end
     end
   end
+
+  describe "perform_payment when the internal transfer is still settling" do
+    let(:user) { create(:user) }
+    let!(:merchant_account) { create(:merchant_account, user:, charge_processor_merchant_id: "acct_test_settling") }
+    let(:bank_account) { create(:ach_account, user:) }
+    let(:balances) { [create(:balance, user:, merchant_account:, amount_cents: 100_00, state: "processing")] }
+    let(:payment) do
+      create(:payment, user:, processor: PayoutProcessorType::STRIPE, state: "processing",
+                       bank_account:, balances:, amount_cents: 100_00, correlation_id: nil,
+                       stripe_connect_account_id: merchant_account.charge_processor_merchant_id,
+                       stripe_internal_transfer_id: "tr_test")
+    end
+    let(:settlement_time) { 1.day.from_now.change(usec: 0) }
+
+    before do
+      allow(StripePayoutProcessor).to receive(:pending_internal_transfer_settlement_time).and_return(settlement_time)
+    end
+
+    it "defers the payout and schedules a retry instead of attempting or reversing it" do
+      expect(Stripe::Payout).not_to receive(:create)
+      expect(StripePayoutProcessor).not_to receive(:reverse_internal_transfer!)
+
+      StripePayoutProcessor.perform_payment(payment)
+
+      expect(RetryStripePayoutForSettlingTransferJob.jobs.size).to eq(1)
+      expect(RetryStripePayoutForSettlingTransferJob.jobs.first["args"]).to eq([payment.id])
+      expect(payment.reload.payout_settlement_retry_count.to_i).to eq(1)
+      expect(payment.reload.state).to eq("processing")
+      expect(payment.stripe_transfer_id).to be_nil
+    end
+
+    it "stops deferring and attempts the payout once the retry limit is reached" do
+      payment.payout_settlement_retry_count = StripePayoutProcessor::MAX_PAYOUT_SETTLEMENT_RETRIES
+      payment.save!
+      stripe_payout = double(id: "po_test", arrival_date: nil, application_fee_amount: nil)
+      expect(Stripe::Payout).to receive(:create).and_return(stripe_payout)
+
+      StripePayoutProcessor.perform_payment(payment)
+
+      expect(RetryStripePayoutForSettlingTransferJob.jobs.size).to eq(0)
+      expect(payment.reload.stripe_transfer_id).to eq("po_test")
+    end
+  end
 end

--- a/spec/sidekiq/retry_stripe_payout_for_settling_transfer_job_spec.rb
+++ b/spec/sidekiq/retry_stripe_payout_for_settling_transfer_job_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe RetryStripePayoutForSettlingTransferJob do
+  describe "#perform" do
+    it "re-attempts the bank payout for a processing payment with no payout yet" do
+      payment = create(:payment, processor: PayoutProcessorType::STRIPE, state: "processing")
+
+      expect(StripePayoutProcessor).to receive(:perform_payment) do |arg|
+        expect(arg.id).to eq(payment.id)
+      end
+
+      described_class.new.perform(payment.id)
+    end
+
+    it "does nothing when the payment is no longer processing" do
+      payment = create(:payment, processor: PayoutProcessorType::STRIPE, state: "cancelled")
+
+      expect(StripePayoutProcessor).not_to receive(:perform_payment)
+
+      described_class.new.perform(payment.id)
+    end
+
+    it "does nothing when a bank payout already exists" do
+      payment = create(:payment, processor: PayoutProcessorType::STRIPE, state: "processing", stripe_transfer_id: "po_existing")
+
+      expect(StripePayoutProcessor).not_to receive(:perform_payment)
+
+      described_class.new.perform(payment.id)
+    end
+  end
+end


### PR DESCRIPTION
> **Draft — needs payments review before merge.** This changes payout money-movement timing. See "Open questions" below.

## What

Before creating a Stripe **bank payout**, check whether the **internal transfer** that funded it (USD moved from Gumroad's platform into the creator's Connect account) is still settling. If the transferred funds are still `pending` (not yet `available`), defer the bank payout to a later run instead of attempting it now.

- New: `StripePayoutProcessor.pending_internal_transfer_settlement_time` — returns the funds' `available_on` while they're still `pending`, else `nil`.
- `perform_payment` defers (reschedules) when funds are still settling, capped by `MAX_PAYOUT_SETTLEMENT_RETRIES`.
- New `RetryStripePayoutForSettlingTransferJob` re-runs `perform_payment` for the same Payment after settlement.
- `Payment#payout_settlement_retry_count` (json_data, no migration) bounds the deferrals.

## Why

For funds held by Gumroad, payout is two steps: `Stripe::Transfer.create` (USD → Connect account) in `prepare_payment_and_set_amount`, then `Stripe::Payout.create` (→ bank) in `perform_payment`. On accounts with a settlement delay (cross-border, `delay_days > 0`), the transfer lands in the destination's **`pending`** balance with `available_on` a day or more out. Creating the bank payout in the **same run** fails with `balance_insufficient` because the `available` balance can't cover it yet.

The failure path then calls `reverse_internal_transfer!`, clawing the funds back before they can settle and **losing the FX spread** on the USD↔local round trip. The next scheduled run repeats the identical sequence, so the payout never settles and the residual loss compounds each cycle. (Observed in production: an account looping transfer→payout-fail→reverse daily, losing ~$2/day, payout never reaching the bank. Context: antiwork/gumroad-private#524, internal.)

Deferring is safe because `perform_payment` never re-transfers — the internal transfer is created once, and `payment.amount_cents` / `stripe_internal_transfer_id` are already persisted — so re-running it against the same Payment just retries the bank payout once the funds are `available`.

## How it behaves

- **Day T**: transfer funds (pending) → `perform_payment` sees funds still settling → schedules `RetryStripePayoutForSettlingTransferJob` at `available_on + 1h`, leaves the Payment `processing`, does **not** attempt or reverse the payout.
- **Day T+1**: retry job runs → funds now `available` → payout created normally.
- **Genuine insufficiency** (e.g. negative residual once funds have settled): `pending_internal_transfer_settlement_time` returns `nil`, so the existing attempt-then-reverse path runs unchanged. Capped at `MAX_PAYOUT_SETTLEMENT_RETRIES` (2) so a pathological case still falls through to the existing behavior.

## Test Results

- `spec/sidekiq/retry_stripe_payout_for_settling_transfer_job_spec.rb` — 3 examples, green.
- `stripe_payout_processor_spec.rb` "when the internal transfer is still settling" — 2 examples, green; verified to **fail** when the deferral branch is disabled (proceeds to `Stripe::Payout.create`).
- `rubocop` clean. (Tests are offline/unit — no live Stripe.)

## Open questions for payments review

1. **SyncStuckPayoutsJob interaction**: it reverses STRIPE payments stuck `processing` with no `arrival_date` after **3 days**. The deferral cap keeps total wait under that, but please confirm the margin is comfortable (and whether deferred payments should be explicitly excluded).
2. **Settlement signal**: is `balance_transaction.status == "pending"` + future `available_on` the right discriminator across all delayed-settlement account types, or should we also handle multi-day (`delay_days > 1`) windows explicitly?
3. **Retry cap / fallback**: on cap exhaustion we fall through to attempt-then-reverse. Is that the desired terminal behavior, or should it pause payouts (cf. `MAX_CONSECUTIVE_FAILED_PAYOUTS`) instead?
4. **Integration coverage**: VCR cassettes for the live delayed-settlement path should be recorded in an env with working Stripe test-account provisioning (it times out locally here).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AI disclosure: drafted with Claude Opus 4.8 (1M context). Prompt: after root-causing a production payout that failed/reversed daily, draft the fix that stops reversing a still-settling internal transfer and lets the payout succeed, as a separate PR for payments review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784192183&installation_id=134400930&pr_number=5480&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5480&signature=f85bcd1f59d79f3ff498872b16f2675de9943c6da8bdd455fc04ad2a18bf6a60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->