### PR TITLE
Honor the cross-border payout delay for scheduled payouts

### DIFF
--- a/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
+++ b/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
@@ -15,6 +15,13 @@ class StripePayoutProcessor
   # the floor stay `unpaid` and roll forward to the next cycle.
   GUMROAD_HELD_USD_MIN_TRANSFER_CENTS = 1_00
 
+  # Money transferred into a cross-border-payouts Stripe Connect account becomes payable ~24h later
+  # (the funds land in the destination's `pending` balance and settle on the account's schedule).
+  # Attempting the bank payout before then fails with `balance_insufficient` and reverses the
+  # transfer, losing the FX spread. So those payouts are scheduled this far out instead of run
+  # immediately.
+  CROSS_BORDER_PAYOUT_DELAY = 25.hours
+
   # Public: Determines if it's possible for this processor to payout
   # the user by checking that the user has provided us with the
   # information we need to be able to payout with this processor.
@@ -306,6 +313,22 @@ class StripePayoutProcessor
     payments.each do |payment|
       perform_payment(payment)
     end
+  end
+
+  # Public: A payout to a Gumroad-managed Stripe account in a country that only supports cross-border
+  # payouts. For these, funds transferred into the connected account settle ~24h later, so the bank
+  # payout must be deferred (see CROSS_BORDER_PAYOUT_DELAY) rather than run in the same job as the
+  # transfer. Used to route both automated payouts and admin-scheduled payouts the same way.
+  def self.cross_border_payout?(payment)
+    return false unless payment.processor == PayoutProcessorType::STRIPE
+
+    merchant_account = payment.user.merchant_accounts.find_by(charge_processor_merchant_id: payment.stripe_connect_account_id)
+    return false if merchant_account&.is_a_stripe_connect_account?
+
+    compliance_info = payment.user.alive_user_compliance_info
+    return false if compliance_info.blank?
+
+    Country.new(compliance_info.legal_entity_country_code).supports_stripe_cross_border_payouts?
   end
 
   # Public: Actually sends the money.

--- a/app/models/scheduled_payout.rb
+++ b/app/models/scheduled_payout.rb
@@ -83,11 +83,17 @@ class ScheduledPayout < ApplicationRecord
           raise "Payout failed: #{error_detail}"
         end
 
-        payout_processor = PayoutProcessorType.get(payout_processor_type)
-        payout_processor.process_payments([payment])
+        if StripePayoutProcessor.cross_border_payout?(payment)
+          # Funds transferred into a cross-border Connect account settle ~24h later. Defer the bank
+          # payout (matching the automated payout path) instead of running it now — otherwise it
+          # fails with balance_insufficient and reverses the transfer, losing the FX spread.
+          ProcessPaymentWorker.perform_in(StripePayoutProcessor::CROSS_BORDER_PAYOUT_DELAY, payment.id)
+        else
+          PayoutProcessorType.get(payout_processor_type).process_payments([payment])
 
-        if payment.reload.failed?
-          raise "Payout failed: #{payment.errors.full_messages.first || "Payment processing failed"}"
+          if payment.reload.failed?
+            raise "Payout failed: #{payment.errors.full_messages.first || "Payment processing failed"}"
+          end
         end
       rescue => e
         update!(status: "pending", executed_at: nil)

--- a/app/services/payout_users_service.rb
+++ b/app/services/payout_users_service.rb
@@ -15,7 +15,7 @@ class PayoutUsersService
 
     PayoutProcessorType.get(processor_type).process_payments(payments) if payments.present?
     cross_border_payments.each do |payment|
-      ProcessPaymentWorker.perform_in(25.hours, payment.id)
+      ProcessPaymentWorker.perform_in(StripePayoutProcessor::CROSS_BORDER_PAYOUT_DELAY, payment.id)
     end
 
     payments + cross_border_payments
@@ -38,11 +38,8 @@ class PayoutUsersService
 
       if payment_errors.blank? && payment.present?
         # Money transferred to a cross-border-payouts Stripe Connect a/c becomes payable after 24 hours,
-        # so schedule those payouts for 25 hours from now instead of processing them immediately.
-        cross_border_payout = payment.processor == PayoutProcessorType::STRIPE &&
-            !payment.user.merchant_accounts.find_by(charge_processor_merchant_id: payment.stripe_connect_account_id)&.is_a_stripe_connect_account? &&
-            Country.new(user.alive_user_compliance_info.legal_entity_country_code).supports_stripe_cross_border_payouts?
-        if cross_border_payout
+        # so schedule those payouts later instead of processing them immediately.
+        if StripePayoutProcessor.cross_border_payout?(payment)
           cross_border_payments << payment
         else
           payments << payment

--- a/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
@@ -4176,4 +4176,29 @@ describe StripePayoutProcessor, :vcr do
       end
     end
   end
+
+  describe ".cross_border_payout?" do
+    let(:user) { create(:user) }
+    let!(:merchant_account) { create(:merchant_account, user:, charge_processor_merchant_id: "acct_cbp_test") }
+    let(:payment) do
+      create(:payment, user:, processor: PayoutProcessorType::STRIPE, state: "processing", correlation_id: nil,
+                       stripe_connect_account_id: merchant_account.charge_processor_merchant_id)
+    end
+
+    it "is true for a Gumroad-managed account in a cross-border-payouts country" do
+      create(:user_compliance_info, user:, country: "Thailand")
+      expect(described_class.cross_border_payout?(payment)).to eq(true)
+    end
+
+    it "is false for a country that does not require cross-border payouts" do
+      create(:user_compliance_info, user:, country: "United States")
+      expect(described_class.cross_border_payout?(payment)).to eq(false)
+    end
+
+    it "is false for non-Stripe payouts" do
+      create(:user_compliance_info, user:, country: "Thailand")
+      paypal_payment = create(:payment, user:, processor: PayoutProcessorType::PAYPAL, state: "processing")
+      expect(described_class.cross_border_payout?(paypal_payment)).to eq(false)
+    end
+  end
 end

--- a/spec/models/scheduled_payout_spec.rb
+++ b/spec/models/scheduled_payout_spec.rb
@@ -180,6 +180,10 @@ describe ScheduledPayout do
     context "when action is payout" do
       let(:scheduled_payout) { create(:scheduled_payout, user: user, action: "payout", scheduled_at: 1.day.ago) }
 
+      before do
+        allow(StripePayoutProcessor).to receive(:cross_border_payout?).and_return(false)
+      end
+
       it "creates a payment via Payouts.create_payment and marks as executed" do
         payment = instance_double(Payment, failed?: false, reload: nil)
         allow(payment).to receive(:reload).and_return(payment)
@@ -257,6 +261,25 @@ describe ScheduledPayout do
 
         expect { scheduled_payout.execute! }.to raise_error(RuntimeError, /Payout failed: Stripe account not connected/)
         expect(scheduled_payout.reload.status).to eq("pending")
+      end
+    end
+
+    context "when action is payout to a cross-border account" do
+      let(:scheduled_payout) { create(:scheduled_payout, user: user, action: "payout", scheduled_at: 1.day.ago) }
+
+      it "defers the bank payout instead of processing it immediately" do
+        payment = instance_double(Payment, id: 9876, blank?: false)
+        allow(Payouts).to receive(:create_payment)
+          .with(Date.yesterday.to_s, user.current_payout_processor, user)
+          .and_return([payment, nil])
+        allow(StripePayoutProcessor).to receive(:cross_border_payout?).with(payment).and_return(true)
+        expect(StripePayoutProcessor).not_to receive(:process_payments)
+        expect(ProcessPaymentWorker).to receive(:perform_in).with(StripePayoutProcessor::CROSS_BORDER_PAYOUT_DELAY, 9876)
+
+        scheduled_payout.execute!
+
+        expect(scheduled_payout.reload.status).to eq("executed")
+        expect(scheduled_payout.executed_at).to be_present
       end
     end
 

--- a/spec/models/scheduled_payout_spec.rb
+++ b/spec/models/scheduled_payout_spec.rb
@@ -268,12 +268,15 @@ describe ScheduledPayout do
       let(:scheduled_payout) { create(:scheduled_payout, user: user, action: "payout", scheduled_at: 1.day.ago) }
 
       it "defers the bank payout instead of processing it immediately" do
+        scheduled_payout.update!(processor: PayoutProcessorType::STRIPE)
         payment = instance_double(Payment, id: 9876, blank?: false)
         allow(Payouts).to receive(:create_payment)
-          .with(Date.yesterday.to_s, user.current_payout_processor, user)
+          .with(Date.yesterday.to_s, PayoutProcessorType::STRIPE, user)
           .and_return([payment, nil])
         allow(StripePayoutProcessor).to receive(:cross_border_payout?).with(payment).and_return(true)
-        expect(StripePayoutProcessor).not_to receive(:process_payments)
+        processor = class_double(StripePayoutProcessor)
+        allow(PayoutProcessorType).to receive(:get).and_return(processor)
+        expect(processor).not_to receive(:process_payments)
         expect(ProcessPaymentWorker).to receive(:perform_in).with(StripePayoutProcessor::CROSS_BORDER_PAYOUT_DELAY, 9876)
 
         scheduled_payout.execute!


### PR DESCRIPTION
## What

Make `ScheduledPayout#execute!` honor the **cross-border payout delay** that the automated payout path already applies. Payouts to a Gumroad-managed Stripe account in a cross-border-payouts country now defer the bank payout (`ProcessPaymentWorker.perform_in(CROSS_BORDER_PAYOUT_DELAY, …)`) instead of attempting it in the same job as the funding transfer.

- New `StripePayoutProcessor.cross_border_payout?(payment)` — the cross-border detection, extracted from `PayoutUsersService` so both paths share one definition.
- New `StripePayoutProcessor::CROSS_BORDER_PAYOUT_DELAY = 25.hours` constant (replaces the inline `25.hours`).
- `PayoutUsersService` refactored to use both (behavior unchanged).
- `ScheduledPayout#execute!` defers cross-border payouts.

## Why

For a Gumroad-managed account in a cross-border-payouts country, funds transferred (USD → the connected account) settle on the destination's schedule ~25h later — they land in the `pending` balance and aren't payable immediately. Paying out before then fails with `balance_insufficient`, and the failure path reverses the internal transfer, losing the FX spread on the round trip.

`PayoutUsersService` (automated payouts) already handles this — it defers cross-border payments by 25h via `ProcessPaymentWorker`. But `ScheduledPayout#execute!` (suspension hold releases and admin-triggered payouts) did **not**: it called `Payouts.create_payment` then `process_payments([payment])` immediately. So a scheduled payout to such an account transferred and paid out in the same job, hit `balance_insufficient`, reversed the transfer, and — because `execute!` resets the scheduled payout to `pending` on failure — repeated every single day, eroding the balance via the FX spread each cycle. (Observed in production on a TH managed account whose 21-day hold release looped daily. Context: antiwork/gumroad-private#524, internal.)

This closes that gap by routing both payout paths through the same cross-border logic.


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AI disclosure: drafted with Claude Opus 4.8 (1M context).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5481"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784193876&installation_id=134400930&pr_number=5481&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5481&signature=fa923dac4160a7a5f6eecefe4158ea940d259e62a1023d4ddfb57bc708d1e0a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live payout orchestration and Stripe transfer/payout timing; the change fixes a production failure loop but defers failure detection for scheduled cross-border payouts until the delayed job runs.
> 
> **Overview**
> **Scheduled payouts** to Gumroad-managed Stripe accounts in cross-border countries now **defer the bank payout** by `CROSS_BORDER_PAYOUT_DELAY` (25 hours) via `ProcessPaymentWorker`, matching automated payouts. Previously `ScheduledPayout#execute!` ran `process_payments` immediately after `create_payment`, which could hit `balance_insufficient`, reverse the internal transfer, and leave the scheduled payout **pending** to retry daily.
> 
> Shared **`StripePayoutProcessor.cross_border_payout?(payment)`** and **`CROSS_BORDER_PAYOUT_DELAY`** replace duplicated inline logic in `PayoutUsersService` (behavior unchanged there). For cross-border cases, `execute!` still marks the scheduled payout **executed** once deferral is enqueued rather than waiting for synchronous payout success.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 717ad2d1be0658700fafbf0c305a68c15e56eceb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

