### PR TITLE
Surface Stripe payout pause reasons and widen seller notifications

### DIFF
--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -25,6 +25,25 @@ module StripeMerchantAccountManager
   end
   private_class_method :stripe_payouts_pause_email_type
 
+  # Sends at most one of each pause email per Stripe-disabled episode, surviving
+  # admin/payout-method resumes (the marker is cleared only when Stripe re-enables
+  # payouts). Action-required is sent on first notice or on escalation from
+  # under-review; under-review is sent only as the first notice.
+  def self.deliver_stripe_payouts_pause_email(user, merchant_account, pause_email_type)
+    case pause_email_type
+    when :action_required
+      return if merchant_account.stripe_payouts_pause_email_sent == "action_required"
+      MerchantRegistrationMailer.stripe_payouts_disabled(user.id).deliver_later
+    when :under_review
+      return unless merchant_account.stripe_payouts_pause_email_sent.nil?
+      MerchantRegistrationMailer.stripe_payouts_under_review(user.id).deliver_later
+    else
+      return
+    end
+    merchant_account.update!(stripe_payouts_pause_email_sent: pause_email_type.to_s)
+  end
+  private_class_method :deliver_stripe_payouts_pause_email
+
   def self.account_holder_name_synced_to_stripe?(user)
     country_code = user.alive_user_compliance_info&.legal_entity_country_code
     ACCOUNT_HOLDER_NAME_SYNC_COUNTRIES.include?(country_code)
@@ -889,7 +908,7 @@ module StripeMerchantAccountManager
           content: "Payouts automatically resumed: Stripe re-enabled payouts on the connected account."
         )
       end
-      merchant_account.update!(stripe_payouts_action_required_notified: false) if merchant_account.stripe_payouts_action_required_notified
+      merchant_account.update!(stripe_payouts_pause_email_sent: nil) if merchant_account.stripe_payouts_pause_email_sent
     elsif stripe_account["payouts_enabled"] == false && !user.payouts_paused_internally?
       ActiveRecord::Base.transaction do
         user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_STRIPE)
@@ -899,13 +918,7 @@ module StripeMerchantAccountManager
           content: merchant_account.stripe_payouts_paused_comment
         )
       end
-      case pause_email_type
-      when :action_required
-        MerchantRegistrationMailer.stripe_payouts_disabled(user.id).deliver_later
-        merchant_account.update!(stripe_payouts_action_required_notified: true)
-      when :under_review
-        MerchantRegistrationMailer.stripe_payouts_under_review(user.id).deliver_later
-      end
+      deliver_stripe_payouts_pause_email(user, merchant_account, pause_email_type)
     elsif stripe_account["payouts_enabled"] == false && user.payouts_paused_by_source == User::PAYOUT_PAUSE_SOURCE_STRIPE
       refreshed_comment = merchant_account.stripe_payouts_paused_comment
       if user.comments.with_type_payouts_paused.last&.content != refreshed_comment
@@ -915,10 +928,7 @@ module StripeMerchantAccountManager
           content: refreshed_comment
         )
       end
-      if pause_email_type == :action_required && !merchant_account.stripe_payouts_action_required_notified
-        MerchantRegistrationMailer.stripe_payouts_disabled(user.id).deliver_later
-        merchant_account.update!(stripe_payouts_action_required_notified: true)
-      end
+      deliver_stripe_payouts_pause_email(user, merchant_account, pause_email_type)
     end
 
     last_outstanding_request_at = user.user_compliance_info_requests.requested.last&.created_at

--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -902,6 +902,15 @@ module StripeMerchantAccountManager
       when :under_review
         MerchantRegistrationMailer.stripe_payouts_under_review(user.id).deliver_later
       end
+    elsif stripe_account["payouts_enabled"] == false && user.payouts_paused_by_source == User::PAYOUT_PAUSE_SOURCE_STRIPE
+      refreshed_comment = merchant_account.stripe_payouts_paused_comment
+      if user.comments.with_type_payouts_paused.last&.content != refreshed_comment
+        user.comments.create!(
+          author_name: STRIPE_PAYOUTS_SYNC_COMMENT_AUTHOR,
+          comment_type: Comment::COMMENT_TYPE_PAYOUTS_PAUSED,
+          content: refreshed_comment
+        )
+      end
     end
 
     last_outstanding_request_at = user.user_compliance_info_requests.requested.last&.created_at

--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -906,12 +906,18 @@ module StripeMerchantAccountManager
     # after the lock commits; the dedupe marker is claimed inside it.
     pause_email_to_send = nil
     user.with_lock do
+      # Refresh under the lock so the dedupe marker reflects commits from any
+      # concurrent webhook that ran just before us (with_lock reloads the user,
+      # but not merchant_account, where the marker lives).
+      merchant_account.reload
       if stripe_account["payouts_enabled"] && user.payouts_paused_by_source == User::PAYOUT_PAUSE_SOURCE_STRIPE
         user.update!(payouts_paused_internally: false, payouts_paused_by: nil)
         user.comments.create!(
           author_name: STRIPE_PAYOUTS_SYNC_COMMENT_AUTHOR,
           comment_type: Comment::COMMENT_TYPE_PAYOUTS_RESUMED,
-          content: "Payouts automatically resumed: Stripe re-enabled payouts on the connected account."
+          content: user.payouts_paused_by_user? ?
+            "Stripe re-enabled payouts on the connected account; payouts remain paused by the creator." :
+            "Payouts automatically resumed: Stripe re-enabled payouts on the connected account."
         )
         merchant_account.update!(stripe_payouts_pause_email_sent: nil) if merchant_account.stripe_payouts_pause_email_sent
       elsif stripe_account["payouts_enabled"] == false && !user.payouts_paused_internally?

--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -907,8 +907,8 @@ module StripeMerchantAccountManager
           comment_type: Comment::COMMENT_TYPE_PAYOUTS_RESUMED,
           content: "Payouts automatically resumed: Stripe re-enabled payouts on the connected account."
         )
+        merchant_account.update!(stripe_payouts_pause_email_sent: nil) if merchant_account.stripe_payouts_pause_email_sent
       end
-      merchant_account.update!(stripe_payouts_pause_email_sent: nil) if merchant_account.stripe_payouts_pause_email_sent
     elsif stripe_account["payouts_enabled"] == false && !user.payouts_paused_internally?
       ActiveRecord::Base.transaction do
         user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_STRIPE)

--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -25,24 +25,25 @@ module StripeMerchantAccountManager
   end
   private_class_method :stripe_payouts_pause_email_type
 
-  # Sends at most one of each pause email per Stripe-disabled episode, surviving
-  # admin/payout-method resumes (the marker is cleared only when Stripe re-enables
-  # payouts). Action-required is sent on first notice or on escalation from
-  # under-review; under-review is sent only as the first notice.
-  def self.deliver_stripe_payouts_pause_email(user, merchant_account, pause_email_type)
+  # Claims (at most one of each) pause email per Stripe-disabled episode,
+  # surviving admin/payout-method resumes (the marker is cleared only when
+  # Stripe re-enables payouts). Action-required is claimed on first notice or on
+  # escalation from under-review; under-review only as the first notice. Updates
+  # the marker (called inside the user lock) and returns the email type to
+  # enqueue after the lock commits, or nil.
+  def self.claim_stripe_payouts_pause_email(merchant_account, pause_email_type)
     case pause_email_type
     when :action_required
-      return if merchant_account.stripe_payouts_pause_email_sent == "action_required"
-      MerchantRegistrationMailer.stripe_payouts_disabled(user.id).deliver_later
+      return nil if merchant_account.stripe_payouts_pause_email_sent == "action_required"
     when :under_review
-      return unless merchant_account.stripe_payouts_pause_email_sent.nil?
-      MerchantRegistrationMailer.stripe_payouts_under_review(user.id).deliver_later
+      return nil unless merchant_account.stripe_payouts_pause_email_sent.nil?
     else
-      return
+      return nil
     end
     merchant_account.update!(stripe_payouts_pause_email_sent: pause_email_type.to_s)
+    pause_email_type
   end
-  private_class_method :deliver_stripe_payouts_pause_email
+  private_class_method :claim_stripe_payouts_pause_email
 
   def self.account_holder_name_synced_to_stripe?(user)
     country_code = user.alive_user_compliance_info&.legal_entity_country_code
@@ -899,8 +900,13 @@ module StripeMerchantAccountManager
                                       alternative_fields_due].compact.flatten.any?
     pause_email_type = stripe_payouts_pause_email_type(requirements["disabled_reason"], action_required_fields_present)
 
-    if stripe_account["payouts_enabled"] && user.payouts_paused_by_source == User::PAYOUT_PAUSE_SOURCE_STRIPE
-      ActiveRecord::Base.transaction do
+    # Serialize concurrent account.updated webhooks for the same user so two
+    # near-simultaneous events can't both pass the "not yet paused" check and
+    # write duplicate comments / send duplicate emails. The email is enqueued
+    # after the lock commits; the dedupe marker is claimed inside it.
+    pause_email_to_send = nil
+    user.with_lock do
+      if stripe_account["payouts_enabled"] && user.payouts_paused_by_source == User::PAYOUT_PAUSE_SOURCE_STRIPE
         user.update!(payouts_paused_internally: false, payouts_paused_by: nil)
         user.comments.create!(
           author_name: STRIPE_PAYOUTS_SYNC_COMMENT_AUTHOR,
@@ -908,27 +914,32 @@ module StripeMerchantAccountManager
           content: "Payouts automatically resumed: Stripe re-enabled payouts on the connected account."
         )
         merchant_account.update!(stripe_payouts_pause_email_sent: nil) if merchant_account.stripe_payouts_pause_email_sent
-      end
-    elsif stripe_account["payouts_enabled"] == false && !user.payouts_paused_internally?
-      ActiveRecord::Base.transaction do
+      elsif stripe_account["payouts_enabled"] == false && !user.payouts_paused_internally?
         user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_STRIPE)
         user.comments.create!(
           author_name: STRIPE_PAYOUTS_SYNC_COMMENT_AUTHOR,
           comment_type: Comment::COMMENT_TYPE_PAYOUTS_PAUSED,
           content: merchant_account.stripe_payouts_paused_comment
         )
+        pause_email_to_send = claim_stripe_payouts_pause_email(merchant_account, pause_email_type)
+      elsif stripe_account["payouts_enabled"] == false && user.payouts_paused_by_source == User::PAYOUT_PAUSE_SOURCE_STRIPE
+        refreshed_comment = merchant_account.stripe_payouts_paused_comment
+        if user.comments.with_type_payouts_paused.last&.content != refreshed_comment
+          user.comments.create!(
+            author_name: STRIPE_PAYOUTS_SYNC_COMMENT_AUTHOR,
+            comment_type: Comment::COMMENT_TYPE_PAYOUTS_PAUSED,
+            content: refreshed_comment
+          )
+        end
+        pause_email_to_send = claim_stripe_payouts_pause_email(merchant_account, pause_email_type)
       end
-      deliver_stripe_payouts_pause_email(user, merchant_account, pause_email_type)
-    elsif stripe_account["payouts_enabled"] == false && user.payouts_paused_by_source == User::PAYOUT_PAUSE_SOURCE_STRIPE
-      refreshed_comment = merchant_account.stripe_payouts_paused_comment
-      if user.comments.with_type_payouts_paused.last&.content != refreshed_comment
-        user.comments.create!(
-          author_name: STRIPE_PAYOUTS_SYNC_COMMENT_AUTHOR,
-          comment_type: Comment::COMMENT_TYPE_PAYOUTS_PAUSED,
-          content: refreshed_comment
-        )
-      end
-      deliver_stripe_payouts_pause_email(user, merchant_account, pause_email_type)
+    end
+
+    case pause_email_to_send
+    when :action_required
+      MerchantRegistrationMailer.stripe_payouts_disabled(user.id).deliver_later
+    when :under_review
+      MerchantRegistrationMailer.stripe_payouts_under_review(user.id).deliver_later
     end
 
     last_outstanding_request_at = user.user_compliance_info_requests.requested.last&.created_at

--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -875,6 +875,11 @@ module StripeMerchantAccountManager
       MerchantRegistrationMailer.stripe_charges_disabled(user.id).deliver_later(queue: "critical")
     end
 
+    action_required_fields_present = [requirements["currently_due"], requirements["past_due"],
+                                      future_requirements["currently_due"], future_requirements["past_due"],
+                                      alternative_fields_due].compact.flatten.any?
+    pause_email_type = stripe_payouts_pause_email_type(requirements["disabled_reason"], action_required_fields_present)
+
     if stripe_account["payouts_enabled"] && user.payouts_paused_by_source == User::PAYOUT_PAUSE_SOURCE_STRIPE
       ActiveRecord::Base.transaction do
         user.update!(payouts_paused_internally: false, payouts_paused_by: nil)
@@ -884,6 +889,7 @@ module StripeMerchantAccountManager
           content: "Payouts automatically resumed: Stripe re-enabled payouts on the connected account."
         )
       end
+      merchant_account.update!(stripe_payouts_action_required_notified: false) if merchant_account.stripe_payouts_action_required_notified
     elsif stripe_account["payouts_enabled"] == false && !user.payouts_paused_internally?
       ActiveRecord::Base.transaction do
         user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_STRIPE)
@@ -893,12 +899,10 @@ module StripeMerchantAccountManager
           content: merchant_account.stripe_payouts_paused_comment
         )
       end
-      action_required_fields_present = [requirements["currently_due"], requirements["past_due"],
-                                        future_requirements["currently_due"], future_requirements["past_due"],
-                                        alternative_fields_due].compact.flatten.any?
-      case stripe_payouts_pause_email_type(requirements["disabled_reason"], action_required_fields_present)
+      case pause_email_type
       when :action_required
         MerchantRegistrationMailer.stripe_payouts_disabled(user.id).deliver_later
+        merchant_account.update!(stripe_payouts_action_required_notified: true)
       when :under_review
         MerchantRegistrationMailer.stripe_payouts_under_review(user.id).deliver_later
       end
@@ -910,6 +914,10 @@ module StripeMerchantAccountManager
           comment_type: Comment::COMMENT_TYPE_PAYOUTS_PAUSED,
           content: refreshed_comment
         )
+      end
+      if pause_email_type == :action_required && !merchant_account.stripe_payouts_action_required_notified
+        MerchantRegistrationMailer.stripe_payouts_disabled(user.id).deliver_later
+        merchant_account.update!(stripe_payouts_action_required_notified: true)
       end
     end
 

--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -876,19 +876,23 @@ module StripeMerchantAccountManager
     end
 
     if stripe_account["payouts_enabled"] && user.payouts_paused_by_source == User::PAYOUT_PAUSE_SOURCE_STRIPE
-      user.update!(payouts_paused_internally: false, payouts_paused_by: nil)
-      user.comments.create!(
-        author_name: STRIPE_PAYOUTS_SYNC_COMMENT_AUTHOR,
-        comment_type: Comment::COMMENT_TYPE_PAYOUTS_RESUMED,
-        content: "Payouts automatically resumed: Stripe re-enabled payouts on the connected account."
-      )
+      ActiveRecord::Base.transaction do
+        user.update!(payouts_paused_internally: false, payouts_paused_by: nil)
+        user.comments.create!(
+          author_name: STRIPE_PAYOUTS_SYNC_COMMENT_AUTHOR,
+          comment_type: Comment::COMMENT_TYPE_PAYOUTS_RESUMED,
+          content: "Payouts automatically resumed: Stripe re-enabled payouts on the connected account."
+        )
+      end
     elsif stripe_account["payouts_enabled"] == false && !user.payouts_paused_internally?
-      user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_STRIPE)
-      user.comments.create!(
-        author_name: STRIPE_PAYOUTS_SYNC_COMMENT_AUTHOR,
-        comment_type: Comment::COMMENT_TYPE_PAYOUTS_PAUSED,
-        content: merchant_account.stripe_payouts_paused_comment
-      )
+      ActiveRecord::Base.transaction do
+        user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_STRIPE)
+        user.comments.create!(
+          author_name: STRIPE_PAYOUTS_SYNC_COMMENT_AUTHOR,
+          comment_type: Comment::COMMENT_TYPE_PAYOUTS_PAUSED,
+          content: merchant_account.stripe_payouts_paused_comment
+        )
+      end
       action_required_fields_present = [requirements["currently_due"], requirements["past_due"],
                                         future_requirements["currently_due"], future_requirements["past_due"],
                                         alternative_fields_due].compact.flatten.any?

--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -15,6 +15,16 @@ module StripeMerchantAccountManager
 
   NEW_ACCOUNT_CREATION_BLOCKED_COUNTRIES = [Compliance::Countries::IND.alpha2].freeze
 
+  STRIPE_PAYOUTS_SYNC_COMMENT_AUTHOR = "Stripe payouts sync"
+  private_constant :STRIPE_PAYOUTS_SYNC_COMMENT_AUTHOR
+
+  def self.stripe_payouts_pause_email_type(disabled_reason, fields_needed_present)
+    return nil if disabled_reason.to_s.start_with?("rejected.") || disabled_reason == "platform_paused"
+    return :action_required if fields_needed_present
+    :under_review
+  end
+  private_class_method :stripe_payouts_pause_email_type
+
   def self.account_holder_name_synced_to_stripe?(user)
     country_code = user.alive_user_compliance_info&.legal_entity_country_code
     ACCOUNT_HOLDER_NAME_SYNC_COUNTRIES.include?(country_code)
@@ -867,10 +877,26 @@ module StripeMerchantAccountManager
 
     if stripe_account["payouts_enabled"] && user.payouts_paused_by_source == User::PAYOUT_PAUSE_SOURCE_STRIPE
       user.update!(payouts_paused_internally: false, payouts_paused_by: nil)
+      user.comments.create!(
+        author_name: STRIPE_PAYOUTS_SYNC_COMMENT_AUTHOR,
+        comment_type: Comment::COMMENT_TYPE_PAYOUTS_RESUMED,
+        content: "Payouts automatically resumed: Stripe re-enabled payouts on the connected account."
+      )
     elsif stripe_account["payouts_enabled"] == false && !user.payouts_paused_internally?
       user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_STRIPE)
-      if stripe_fields_needed.present? && requirements["disabled_reason"].in?(%w(action_required.requested_capabilities requirements.past_due))
+      user.comments.create!(
+        author_name: STRIPE_PAYOUTS_SYNC_COMMENT_AUTHOR,
+        comment_type: Comment::COMMENT_TYPE_PAYOUTS_PAUSED,
+        content: merchant_account.stripe_payouts_paused_comment
+      )
+      action_required_fields_present = [requirements["currently_due"], requirements["past_due"],
+                                        future_requirements["currently_due"], future_requirements["past_due"],
+                                        alternative_fields_due].compact.flatten.any?
+      case stripe_payouts_pause_email_type(requirements["disabled_reason"], action_required_fields_present)
+      when :action_required
         MerchantRegistrationMailer.stripe_payouts_disabled(user.id).deliver_later
+      when :under_review
+        MerchantRegistrationMailer.stripe_payouts_under_review(user.id).deliver_later
       end
     end
 

--- a/app/javascript/components/Admin/Users/PayoutInfo/ResumePayoutsForm.tsx
+++ b/app/javascript/components/Admin/Users/PayoutInfo/ResumePayoutsForm.tsx
@@ -29,7 +29,7 @@ const AdminResumePayoutsForm = ({
           ) : payouts_paused_by === "system" ? (
             <p>Payouts are currently automatically paused by the system. See comments below for details.</p>
           ) : payouts_paused_by === "stripe" ? (
-            <p>Payouts are currently paused by Stripe because of pending verification requirements.</p>
+            <p>{reason || "Payouts are currently paused by Stripe."}</p>
           ) : payouts_paused_by === "user" ? (
             <p>Payouts are currently paused by the creator.</p>
           ) : null}

--- a/app/javascript/components/Admin/Users/PayoutInfo/ResumePayoutsForm.tsx
+++ b/app/javascript/components/Admin/Users/PayoutInfo/ResumePayoutsForm.tsx
@@ -27,7 +27,9 @@ const AdminResumePayoutsForm = ({
           {payouts_paused_by === "admin" ? (
             <p>Payouts are currently paused by Gumroad admin. Reason: {reason}</p>
           ) : payouts_paused_by === "system" ? (
-            <p>Payouts are currently automatically paused by the system. See comments below for details.</p>
+            <p>
+              {reason || "Payouts are currently automatically paused by the system. See comments below for details."}
+            </p>
           ) : payouts_paused_by === "stripe" ? (
             <p>{reason || "Payouts are currently paused by Stripe."}</p>
           ) : payouts_paused_by === "user" ? (

--- a/app/mailers/merchant_registration_mailer.rb
+++ b/app/mailers/merchant_registration_mailer.rb
@@ -43,4 +43,9 @@ class MerchantRegistrationMailer < ApplicationMailer
     user = User.find(user_id)
     mail(subject: "Action required: Your payouts are paused", from: NOREPLY_EMAIL_WITH_NAME, to: user.email)
   end
+
+  def stripe_payouts_under_review(user_id)
+    user = User.find(user_id)
+    mail(subject: "Your payouts are temporarily paused", from: NOREPLY_EMAIL_WITH_NAME, to: user.email)
+  end
 end

--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -131,7 +131,7 @@ module Purchase::Blockable
     seller.comments.create(
       content: "Payouts automatically paused due to chargeback rate (#{chargeback_volume_percentage}) exceeding #{User::MAX_CHARGEBACK_RATE_ALLOWED_FOR_PAYOUTS}% volume.",
       comment_type: Comment::COMMENT_TYPE_ON_PROBATION,
-      author_name: "pause_payouts_for_seller_based_on_chargeback_rate"
+      author_name: User::SYSTEM_PAYOUT_PAUSE_COMMENT_AUTHORS[:high_chargeback_rate]
     )
   end
 
@@ -236,7 +236,7 @@ module Purchase::Blockable
         seller.comments.create(
           content: "Payouts paused due to high volume of failed purchases (#{failed_price_amount} USD in #{failed_seller_purchases_watch_minutes} minutes).",
           comment_type: Comment::COMMENT_TYPE_ON_PROBATION,
-          author_name: "pause_payouts_for_seller_based_on_recent_failures"
+          author_name: User::SYSTEM_PAYOUT_PAUSE_COMMENT_AUTHORS[:recent_failed_purchases]
         )
       end
     end

--- a/app/models/merchant_account.rb
+++ b/app/models/merchant_account.rb
@@ -16,6 +16,7 @@ class MerchantAccount < ApplicationRecord
   attr_json_data_accessor :meta
   attr_json_data_accessor :unclaimed_balance_collection_transfer_id
   attr_json_data_accessor :stripe_disabled_reason
+  attr_json_data_accessor :stripe_payouts_action_required_notified
 
   validates :charge_processor_id, presence: true
   validates :charge_processor_merchant_id, presence: true, if: -> { user && charge_processor_alive? }

--- a/app/models/merchant_account.rb
+++ b/app/models/merchant_account.rb
@@ -134,6 +134,30 @@ class MerchantAccount < ApplicationRecord
     stripe_disabled_reason.to_s.start_with?("rejected.")
   end
 
+  STRIPE_DISABLED_REASON_DESCRIPTIONS = {
+    "requirements.past_due" => "Stripe requires additional verification information that is now past due.",
+    "requirements.pending_verification" => "Stripe is verifying the information already submitted; no action is needed right now.",
+    "action_required.requested_capabilities" => "Stripe has requested additional information or capabilities for this account.",
+    "listed" => "Stripe is reviewing the account against its restricted and prohibited business lists.",
+    "under_review" => "Stripe is reviewing the account.",
+    "platform_paused" => "Payouts were paused at the platform level.",
+    "rejected.fraud" => "Stripe rejected the account for suspected fraud.",
+    "rejected.listed" => "Stripe rejected the account because it matched a restricted or prohibited list.",
+    "rejected.terms_of_service" => "Stripe rejected the account for a terms of service violation.",
+    "rejected.other" => "Stripe rejected the account.",
+    "other" => "Stripe disabled payouts on the account."
+  }.freeze
+
+  def stripe_disabled_reason_description
+    return if stripe_disabled_reason.blank?
+    STRIPE_DISABLED_REASON_DESCRIPTIONS[stripe_disabled_reason] || "Stripe disabled payouts on the account."
+  end
+
+  def stripe_payouts_paused_comment
+    reason = stripe_disabled_reason.presence || "not specified"
+    ["Payouts automatically paused by Stripe (disabled reason: #{reason}).", stripe_disabled_reason_description].compact.join(" ")
+  end
+
   def paypal_account_details
     payment_integration_api = PaypalIntegrationRestApi.new(user, authorization_header: PaypalPartnerRestCredentials.new.auth_token)
     paypal_response = payment_integration_api.get_merchant_account_by_merchant_id(charge_processor_merchant_id)

--- a/app/models/merchant_account.rb
+++ b/app/models/merchant_account.rb
@@ -16,7 +16,7 @@ class MerchantAccount < ApplicationRecord
   attr_json_data_accessor :meta
   attr_json_data_accessor :unclaimed_balance_collection_transfer_id
   attr_json_data_accessor :stripe_disabled_reason
-  attr_json_data_accessor :stripe_payouts_action_required_notified
+  attr_json_data_accessor :stripe_payouts_pause_email_sent
 
   validates :charge_processor_id, presence: true
   validates :charge_processor_merchant_id, presence: true, if: -> { user && charge_processor_alive? }

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -285,7 +285,7 @@ class Payment < ApplicationRecord
       user.comments.create!(
         content: "Payouts paused automatically after #{failed_count} consecutive failed payouts to the same bank account. Verify the seller's payout details before resuming.",
         comment_type: Comment::COMMENT_TYPE_ON_PROBATION,
-        author_name: "pause_payouts_after_repeated_failures"
+        author_name: User::SYSTEM_PAYOUT_PAUSE_COMMENT_AUTHORS[:repeated_failed_payouts]
       )
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -963,8 +963,15 @@ class User < ApplicationRecord
 
   def payouts_paused_for_reason
     return nil unless payouts_paused?
-    return nil unless payouts_paused_by_source.in?([PAYOUT_PAUSE_SOURCE_ADMIN, PAYOUT_PAUSE_SOURCE_STRIPE])
-    comments.with_type_payouts_paused.last&.content
+
+    case payouts_paused_by_source
+    when PAYOUT_PAUSE_SOURCE_ADMIN, PAYOUT_PAUSE_SOURCE_STRIPE
+      comments.with_type_payouts_paused.last&.content
+    when PAYOUT_PAUSE_SOURCE_SYSTEM
+      comments.with_type_on_probation
+              .where(author_name: SYSTEM_PAYOUT_PAUSE_COMMENT_AUTHORS.values)
+              .last&.content
+    end
   end
 
   def made_a_successful_sale_with_a_stripe_connect_or_paypal_connect_account?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -962,7 +962,9 @@ class User < ApplicationRecord
   end
 
   def payouts_paused_for_reason
-    payouts_paused_by_source == PAYOUT_PAUSE_SOURCE_ADMIN ? comments.with_type_payouts_paused.last&.content : nil
+    return nil unless payouts_paused?
+    return nil unless payouts_paused_by_source.in?([PAYOUT_PAUSE_SOURCE_ADMIN, PAYOUT_PAUSE_SOURCE_STRIPE])
+    comments.with_type_payouts_paused.last&.content
   end
 
   def made_a_successful_sale_with_a_stripe_connect_or_paypal_connect_account?

--- a/app/modules/user/payout_info.rb
+++ b/app/modules/user/payout_info.rb
@@ -8,7 +8,7 @@ module User::PayoutInfo
       active_bank_account: active_bank_account&.as_json(only: %i[type account_holder_full_name], methods: %i[formatted_account]),
       payment_address:,
       payouts_paused_by_source:,
-      payouts_paused_for_reason: comments.with_type_payouts_paused.last&.content,
+      payouts_paused_for_reason:,
       manual_payout_info:
     }
   end

--- a/app/modules/user/risk.rb
+++ b/app/modules/user/risk.rb
@@ -234,6 +234,12 @@ module User::Risk
     self.const_set("PAYOUT_PAUSE_SOURCE_#{source.upcase}", source)
   end
 
+  SYSTEM_PAYOUT_PAUSE_COMMENT_AUTHORS = {
+    repeated_failed_payouts: "pause_payouts_after_repeated_failures",
+    high_chargeback_rate: "pause_payouts_for_seller_based_on_chargeback_rate",
+    recent_failed_purchases: "pause_payouts_for_seller_based_on_recent_failures",
+  }.freeze
+
   class_methods do
   end
 end

--- a/app/services/onetime/backfill_stripe_payout_pause_comments.rb
+++ b/app/services/onetime/backfill_stripe_payout_pause_comments.rb
@@ -26,6 +26,7 @@ module Onetime
 
         user = merchant_account.user
         return if user.nil?
+        return unless merchant_account == user.stripe_account
         return unless user.payouts_paused? && user.payouts_paused_by_source == User::PAYOUT_PAUSE_SOURCE_STRIPE
 
         comment = merchant_account.stripe_payouts_paused_comment

--- a/app/services/onetime/backfill_stripe_payout_pause_comments.rb
+++ b/app/services/onetime/backfill_stripe_payout_pause_comments.rb
@@ -16,7 +16,7 @@ module Onetime
 
       scope.in_batches(of: batch_size) do |batch|
         ReplicaLagWatcher.watch
-        batch.each { |merchant_account| backfill_comment(merchant_account) }
+        batch.includes(:user).each { |merchant_account| backfill_comment(merchant_account) }
       end
     end
 
@@ -26,8 +26,10 @@ module Onetime
 
         user = merchant_account.user
         return if user.nil?
-        return unless merchant_account == user.stripe_account
+        # Cheap flag checks first; the canonical-account query only runs for the
+        # small set of Stripe-paused users (vs. every alive Stripe account).
         return unless user.payouts_paused? && user.payouts_paused_by_source == User::PAYOUT_PAUSE_SOURCE_STRIPE
+        return unless merchant_account == user.stripe_account
 
         comment = merchant_account.stripe_payouts_paused_comment
         return if user.comments.with_type_payouts_paused.last&.content == comment

--- a/app/services/onetime/backfill_stripe_payout_pause_comments.rb
+++ b/app/services/onetime/backfill_stripe_payout_pause_comments.rb
@@ -27,12 +27,14 @@ module Onetime
         user = merchant_account.user
         return if user.nil?
         return unless user.payouts_paused? && user.payouts_paused_by_source == User::PAYOUT_PAUSE_SOURCE_STRIPE
-        return if user.comments.with_type_payouts_paused.exists?
+
+        comment = merchant_account.stripe_payouts_paused_comment
+        return if user.comments.with_type_payouts_paused.last&.content == comment
 
         user.comments.create!(
           author_name: COMMENT_AUTHOR_NAME,
           comment_type: Comment::COMMENT_TYPE_PAYOUTS_PAUSED,
-          content: merchant_account.stripe_payouts_paused_comment
+          content: comment
         )
         puts "Backfilled payout pause comment for User #{user.id} → #{merchant_account.stripe_disabled_reason.inspect}"
       end

--- a/app/services/onetime/backfill_stripe_payout_pause_comments.rb
+++ b/app/services/onetime/backfill_stripe_payout_pause_comments.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Onetime
+  class BackfillStripePayoutPauseComments
+    BATCH_SIZE = 500
+    COMMENT_AUTHOR_NAME = "Stripe payouts sync"
+
+    def self.process(batch_size: BATCH_SIZE)
+      new.process(batch_size:)
+    end
+
+    def process(batch_size: BATCH_SIZE)
+      scope = MerchantAccount.stripe
+        .charge_processor_alive
+        .where.not(charge_processor_merchant_id: nil)
+
+      scope.in_batches(of: batch_size) do |batch|
+        ReplicaLagWatcher.watch
+        batch.each { |merchant_account| backfill_comment(merchant_account) }
+      end
+    end
+
+    private
+      def backfill_comment(merchant_account)
+        return if merchant_account.is_a_stripe_connect_account?
+
+        user = merchant_account.user
+        return if user.nil?
+        return unless user.payouts_paused? && user.payouts_paused_by_source == User::PAYOUT_PAUSE_SOURCE_STRIPE
+        return if user.comments.with_type_payouts_paused.exists?
+
+        user.comments.create!(
+          author_name: COMMENT_AUTHOR_NAME,
+          comment_type: Comment::COMMENT_TYPE_PAYOUTS_PAUSED,
+          content: merchant_account.stripe_payouts_paused_comment
+        )
+        puts "Backfilled payout pause comment for User #{user.id} → #{merchant_account.stripe_disabled_reason.inspect}"
+      end
+  end
+end

--- a/app/views/merchant_registration_mailer/stripe_payouts_under_review.html.erb
+++ b/app/views/merchant_registration_mailer/stripe_payouts_under_review.html.erb
@@ -1,0 +1,7 @@
+<div>
+  <h2>Your payouts are temporarily paused</h2>
+  <p>Our payments processor has temporarily paused payouts on your account while it completes a review. There's nothing you need to do right now.</p>
+  <p>We'll let you know as soon as the review is complete and your payouts resume. If we need anything from you, we'll reach out.</p>
+  <p>You can check your current status anytime on your <%= link_to "payments settings page", settings_payments_url %>.</p>
+  <p>Thank you for your patience and understanding.</p>
+</div>

--- a/lib/mailer_previews/merchant_registration_mailer_preview.rb
+++ b/lib/mailer_previews/merchant_registration_mailer_preview.rb
@@ -12,4 +12,8 @@ class MerchantRegistrationMailerPreview < ActionMailer::Preview
   def stripe_payouts_disabled
     MerchantRegistrationMailer.stripe_payouts_disabled(User.last&.id)
   end
+
+  def stripe_payouts_under_review
+    MerchantRegistrationMailer.stripe_payouts_under_review(User.last&.id)
+  end
 end

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -10564,6 +10564,19 @@ describe StripeMerchantAccountManager, :vcr do
               expect(user.payouts_paused_by_source).to be nil
             end
 
+            it "rolls back the resume when clearing the pause-email marker fails, so a retry can recover" do
+              merchant_account.update!(stripe_payouts_pause_email_sent: "action_required")
+              user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_STRIPE)
+              allow_any_instance_of(MerchantAccount).to receive(:update!).and_raise(ActiveRecord::RecordInvalid)
+
+              expect do
+                described_class.handle_stripe_event(stripe_event)
+              end.to raise_error(ActiveRecord::RecordInvalid)
+
+              expect(user.reload.payouts_paused_internally?).to be true
+              expect(user.comments.with_type_payouts_resumed.count).to eq(0)
+            end
+
             it "does not resume payouts if payouts are paused internally by admin" do
               user.update!(payouts_paused_internally: true, payouts_paused_by: User.last.id)
               expect(user.reload.payouts_paused_internally?).to be true

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -10294,6 +10294,14 @@ describe StripeMerchantAccountManager, :vcr do
               expect(user.payouts_paused_for_reason).to eq(comment.content)
             end
 
+            it "applies the pause under a user lock so concurrent webhooks are serialized" do
+              expect_any_instance_of(User).to receive(:with_lock).and_call_original
+
+              expect do
+                described_class.handle_stripe_event(stripe_event)
+              end.to change { user.reload.payouts_paused_internally? }.from(false).to(true)
+            end
+
             it "rolls back the pause when the reason comment cannot be written, so a retry can recover" do
               allow_any_instance_of(MerchantAccount).to receive(:stripe_payouts_paused_comment).and_return("")
 

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -10294,6 +10294,17 @@ describe StripeMerchantAccountManager, :vcr do
               expect(user.payouts_paused_for_reason).to eq(comment.content)
             end
 
+            it "rolls back the pause when the reason comment cannot be written, so a retry can recover" do
+              allow_any_instance_of(MerchantAccount).to receive(:stripe_payouts_paused_comment).and_return("")
+
+              expect do
+                described_class.handle_stripe_event(stripe_event)
+              end.to raise_error(ActiveRecord::RecordInvalid)
+
+              expect(user.reload.payouts_paused_internally?).to be false
+              expect(user.comments.with_type_payouts_paused).to be_empty
+            end
+
             it "does not overwrite the payout pause source if payouts are already paused internally" do
               user.update!(payouts_paused_internally: true, payouts_paused_by: User.last.id)
               expect(user.reload.payouts_paused_internally?).to be true

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -9624,6 +9624,8 @@ describe StripeMerchantAccountManager, :vcr do
       allow(described_class).to receive(:update_bank_account).with(user, passphrase: GlobalConfig.get("STRONGBOX_GENERAL_PASSWORD")).and_return(:stripe_unknown_error)
       allow(active_bank_account).to receive(:is_a?) { |klass| klass == CardBankAccount }
       allow(user).to receive(:active_bank_account).and_return(active_bank_account, active_bank_account, active_bank_account, nil, nil)
+      allow(user).to receive(:with_lock).and_yield
+      allow(merchant_account).to receive(:reload).and_return(merchant_account)
     end
 
     it "captures the active bank once before enqueueing the retry worker" do

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -10279,7 +10279,7 @@ describe StripeMerchantAccountManager, :vcr do
               }
             end
 
-            it "pauses payouts on the account and notifies the creator by email if payouts are disabled due to info requirement" do
+            it "pauses payouts, records the Stripe reason as a comment, and notifies the creator by email if payouts are disabled due to info requirement" do
               expect(user.reload.payouts_paused_internally?).to be false
               stripe_event["data"]["object"]["requirements"]["disabled_reason"] = "requirements.past_due"
 
@@ -10288,6 +10288,10 @@ describe StripeMerchantAccountManager, :vcr do
               end.to have_enqueued_mail(MerchantRegistrationMailer, :stripe_payouts_disabled).with(user.id)
 
               expect(user.reload.payouts_paused_internally?).to be true
+              comment = user.comments.with_type_payouts_paused.last
+              expect(comment).to be_present
+              expect(comment.content).to include("requirements.past_due")
+              expect(user.payouts_paused_for_reason).to eq(comment.content)
             end
 
             it "does not overwrite the payout pause source if payouts are already paused internally" do
@@ -10316,19 +10320,67 @@ describe StripeMerchantAccountManager, :vcr do
               expect(user.reload.payouts_paused_internally?).to be true
             end
 
-            it "does not email the creator if payouts are disabled due to a reason other than info requirement" do
+            it "sends the action-required email for any disabled reason that still has outstanding requirements" do
               expect(user.reload.payouts_paused_internally?).to be false
+              stripe_event["data"]["object"]["requirements"]["disabled_reason"] = "listed"
+
               expect do
                 described_class.handle_stripe_event(stripe_event)
-              end.not_to have_enqueued_mail(MerchantRegistrationMailer, :stripe_payouts_disabled)
-              expect(user.reload.payouts_paused_internally?).to be true
+              end.to have_enqueued_mail(MerchantRegistrationMailer, :stripe_payouts_disabled).with(user.id)
 
+              expect(user.reload.payouts_paused_internally?).to be true
+              expect(user.payouts_paused_for_reason).to include("listed")
+            end
+
+            it "does not email the creator when the platform paused payouts" do
               stripe_event["data"]["object"]["requirements"]["disabled_reason"] = "platform_paused"
 
-              expect do
-                described_class.handle_stripe_event(stripe_event)
-              end.not_to have_enqueued_mail(MerchantRegistrationMailer, :stripe_payouts_disabled)
+              expect(MerchantRegistrationMailer).not_to receive(:stripe_payouts_disabled)
+              expect(MerchantRegistrationMailer).not_to receive(:stripe_payouts_under_review)
+
+              described_class.handle_stripe_event(stripe_event)
+
               expect(user.reload.payouts_paused_internally?).to be true
+              expect(user.payouts_paused_for_reason).to include("platform_paused")
+            end
+
+            it "does not email the creator when Stripe rejected the account" do
+              stripe_event["data"]["object"]["requirements"]["disabled_reason"] = "rejected.listed"
+
+              expect(MerchantRegistrationMailer).not_to receive(:stripe_payouts_disabled)
+              expect(MerchantRegistrationMailer).not_to receive(:stripe_payouts_under_review)
+
+              described_class.handle_stripe_event(stripe_event)
+
+              expect(user.reload.payouts_paused_internally?).to be true
+              expect(user.payouts_paused_for_reason).to include("rejected.listed")
+            end
+
+            context "when Stripe is not requesting any fields" do
+              before do
+                stripe_event["data"]["object"]["requirements"]["past_due"] = []
+              end
+
+              it "sends the under-review email for a non-rejected reason with no outstanding requirements" do
+                stripe_event["data"]["object"]["requirements"]["disabled_reason"] = "requirements.pending_verification"
+
+                expect do
+                  described_class.handle_stripe_event(stripe_event)
+                end.to have_enqueued_mail(MerchantRegistrationMailer, :stripe_payouts_under_review).with(user.id)
+
+                expect(user.reload.payouts_paused_internally?).to be true
+              end
+
+              it "sends the under-review email when only eventually-due (not yet required) fields exist" do
+                stripe_event["data"]["object"]["requirements"]["disabled_reason"] = "requirements.pending_verification"
+                stripe_event["data"]["object"]["requirements"]["eventually_due"] = ["individual.id_number"]
+
+                expect do
+                  described_class.handle_stripe_event(stripe_event)
+                end.to have_enqueued_mail(MerchantRegistrationMailer, :stripe_payouts_under_review).with(user.id)
+
+                expect(user.reload.payouts_paused_internally?).to be true
+              end
             end
           end
 
@@ -10413,12 +10465,14 @@ describe StripeMerchantAccountManager, :vcr do
               }
             end
 
-            it "resumes payouts on the account if payouts are paused internally by stripe" do
+            it "resumes payouts on the account and records a resume comment if payouts are paused internally by stripe" do
               user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_STRIPE)
               expect(user.reload.payouts_paused_internally?).to be true
               expect(user.payouts_paused_by_source).to eq(User::PAYOUT_PAUSE_SOURCE_STRIPE)
 
-              described_class.handle_stripe_event(stripe_event)
+              expect do
+                described_class.handle_stripe_event(stripe_event)
+              end.to change { user.comments.with_type_payouts_resumed.count }.by(1)
 
               expect(user.reload.payouts_paused_internally?).to be false
               expect(user.payouts_paused_by).to be nil

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -10331,6 +10331,33 @@ describe StripeMerchantAccountManager, :vcr do
               expect(user.reload.payouts_paused_internally?).to be true
             end
 
+            it "refreshes the pause reason comment when Stripe's disabled reason changes while already paused by Stripe" do
+              user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_STRIPE)
+              user.comments.create!(
+                author_name: "Stripe payouts sync",
+                comment_type: Comment::COMMENT_TYPE_PAYOUTS_PAUSED,
+                content: "Payouts automatically paused by Stripe (disabled reason: requirements.past_due)."
+              )
+              stripe_event["data"]["object"]["requirements"]["disabled_reason"] = "rejected.listed"
+
+              expect do
+                described_class.handle_stripe_event(stripe_event)
+              end.to change { user.comments.with_type_payouts_paused.count }.by(1)
+
+              expect(user.reload.payouts_paused_for_reason).to include("rejected.listed")
+            end
+
+            it "does not duplicate the pause reason comment when the Stripe reason is unchanged while already paused by Stripe" do
+              user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_STRIPE)
+              stripe_event["data"]["object"]["requirements"]["disabled_reason"] = "requirements.past_due"
+              described_class.handle_stripe_event(stripe_event)
+              expect(user.comments.with_type_payouts_paused.count).to eq(1)
+
+              expect do
+                described_class.handle_stripe_event(stripe_event)
+              end.not_to change { user.comments.with_type_payouts_paused.count }
+            end
+
             it "sends the action-required email for any disabled reason that still has outstanding requirements" do
               expect(user.reload.payouts_paused_internally?).to be false
               stripe_event["data"]["object"]["requirements"]["disabled_reason"] = "listed"

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -10358,6 +10358,37 @@ describe StripeMerchantAccountManager, :vcr do
               end.not_to change { user.comments.with_type_payouts_paused.count }
             end
 
+            it "sends the action-required email once when Stripe escalates an account already paused for review" do
+              user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_STRIPE)
+              stripe_event["data"]["object"]["requirements"]["disabled_reason"] = "requirements.pending_verification"
+              stripe_event["data"]["object"]["requirements"]["currently_due"] = []
+              stripe_event["data"]["object"]["requirements"]["past_due"] = []
+
+              expect do
+                described_class.handle_stripe_event(stripe_event)
+              end.not_to have_enqueued_mail(MerchantRegistrationMailer, :stripe_payouts_disabled)
+
+              stripe_event["data"]["object"]["requirements"]["currently_due"] = ["individual.id_number"]
+
+              expect do
+                described_class.handle_stripe_event(stripe_event)
+              end.to have_enqueued_mail(MerchantRegistrationMailer, :stripe_payouts_disabled).with(user.id)
+
+              expect do
+                described_class.handle_stripe_event(stripe_event)
+              end.not_to have_enqueued_mail(MerchantRegistrationMailer, :stripe_payouts_disabled)
+            end
+
+            it "clears the action-required notification flag when Stripe re-enables payouts" do
+              merchant_account.update!(stripe_payouts_action_required_notified: true)
+              user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_STRIPE)
+              stripe_event["data"]["object"]["payouts_enabled"] = true
+
+              described_class.handle_stripe_event(stripe_event)
+
+              expect(merchant_account.reload.stripe_payouts_action_required_notified).to be_falsey
+            end
+
             it "sends the action-required email for any disabled reason that still has outstanding requirements" do
               expect(user.reload.payouts_paused_internally?).to be false
               stripe_event["data"]["object"]["requirements"]["disabled_reason"] = "listed"

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -10379,14 +10379,30 @@ describe StripeMerchantAccountManager, :vcr do
               end.not_to have_enqueued_mail(MerchantRegistrationMailer, :stripe_payouts_disabled)
             end
 
-            it "clears the action-required notification flag when Stripe re-enables payouts" do
-              merchant_account.update!(stripe_payouts_action_required_notified: true)
+            it "clears the pause-email marker when Stripe re-enables payouts" do
+              merchant_account.update!(stripe_payouts_pause_email_sent: "action_required")
               user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_STRIPE)
               stripe_event["data"]["object"]["payouts_enabled"] = true
 
               described_class.handle_stripe_event(stripe_event)
 
-              expect(merchant_account.reload.stripe_payouts_action_required_notified).to be_falsey
+              expect(merchant_account.reload.stripe_payouts_pause_email_sent).to be_nil
+            end
+
+            it "does not re-send the pause email when re-paused after a non-Stripe resume while Stripe stays disabled" do
+              stripe_event["data"]["object"]["requirements"]["disabled_reason"] = "requirements.past_due"
+
+              expect do
+                described_class.handle_stripe_event(stripe_event)
+              end.to have_enqueued_mail(MerchantRegistrationMailer, :stripe_payouts_disabled).with(user.id)
+
+              # an admin or update_payout_method resume clears the internal pause but not the marker
+              user.update!(payouts_paused_internally: false, payouts_paused_by: nil)
+
+              expect do
+                described_class.handle_stripe_event(stripe_event)
+              end.not_to have_enqueued_mail(MerchantRegistrationMailer, :stripe_payouts_disabled)
+              expect(user.reload.payouts_paused_internally?).to be true
             end
 
             it "sends the action-required email for any disabled reason that still has outstanding requirements" do

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -10294,8 +10294,9 @@ describe StripeMerchantAccountManager, :vcr do
               expect(user.payouts_paused_for_reason).to eq(comment.content)
             end
 
-            it "applies the pause under a user lock so concurrent webhooks are serialized" do
+            it "applies the pause under a user lock and refreshes the merchant account so concurrent webhooks are serialized" do
               expect_any_instance_of(User).to receive(:with_lock).and_call_original
+              expect_any_instance_of(MerchantAccount).to receive(:reload).and_call_original
 
               expect do
                 described_class.handle_stripe_event(stripe_event)
@@ -10570,6 +10571,18 @@ describe StripeMerchantAccountManager, :vcr do
               expect(user.reload.payouts_paused_internally?).to be false
               expect(user.payouts_paused_by).to be nil
               expect(user.payouts_paused_by_source).to be nil
+            end
+
+            it "notes that payouts remain creator-paused when Stripe re-enables an account the creator also paused" do
+              user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_STRIPE)
+              user.update!(payouts_paused_by_user: true)
+
+              described_class.handle_stripe_event(stripe_event)
+
+              user.reload
+              expect(user.payouts_paused_internally?).to be false
+              expect(user.payouts_paused?).to be true # still paused by the creator
+              expect(user.comments.with_type_payouts_resumed.last.content).to include("remain paused by the creator")
             end
 
             it "rolls back the resume when clearing the pause-email marker fails, so a retry can recover" do

--- a/spec/mailers/merchant_registration_mailer_spec.rb
+++ b/spec/mailers/merchant_registration_mailer_spec.rb
@@ -97,4 +97,18 @@ describe MerchantRegistrationMailer do
       expect(mail.body.encoded).to include("Thank you for your patience and understanding.")
     end
   end
+
+  describe "stripe_payouts_under_review" do
+    it "notifies the user that their payouts are paused while under review, with no action needed" do
+      user = create(:user)
+      mail = described_class.stripe_payouts_under_review(user.id)
+
+      expect(mail.subject).to eq("Your payouts are temporarily paused")
+      expect(mail.to).to include(user.email)
+      expect(mail.from).to eq([ApplicationMailer::NOREPLY_EMAIL])
+      expect(mail.body.encoded).to include("temporarily paused payouts on your account while it completes a review")
+      expect(mail.body.encoded).to include("There's nothing you need to do right now.")
+      expect(mail.body.encoded).to include("Thank you for your patience and understanding.")
+    end
+  end
 end

--- a/spec/models/merchant_account_spec.rb
+++ b/spec/models/merchant_account_spec.rb
@@ -130,6 +130,37 @@ describe MerchantAccount do
     end
   end
 
+  describe "#stripe_disabled_reason_description" do
+    it "returns a human-readable description for a known reason" do
+      merchant_account = create(:merchant_account, stripe_disabled_reason: "requirements.past_due")
+      expect(merchant_account.stripe_disabled_reason_description).to eq("Stripe requires additional verification information that is now past due.")
+    end
+
+    it "returns a generic description for an unknown reason" do
+      merchant_account = create(:merchant_account, stripe_disabled_reason: "some.new.reason")
+      expect(merchant_account.stripe_disabled_reason_description).to eq("Stripe disabled payouts on the account.")
+    end
+
+    it "returns nil when the reason is blank" do
+      merchant_account = create(:merchant_account, stripe_disabled_reason: nil)
+      expect(merchant_account.stripe_disabled_reason_description).to be_nil
+    end
+  end
+
+  describe "#stripe_payouts_paused_comment" do
+    it "includes the raw reason code and its description" do
+      merchant_account = create(:merchant_account, stripe_disabled_reason: "listed")
+      expect(merchant_account.stripe_payouts_paused_comment).to eq(
+        "Payouts automatically paused by Stripe (disabled reason: listed). Stripe is reviewing the account against its restricted and prohibited business lists."
+      )
+    end
+
+    it "falls back to 'not specified' when there is no reason" do
+      merchant_account = create(:merchant_account, stripe_disabled_reason: nil)
+      expect(merchant_account.stripe_payouts_paused_comment).to eq("Payouts automatically paused by Stripe (disabled reason: not specified).")
+    end
+  end
+
   describe "#holder_of_funds" do
     it "returns the holder of funds for a known charge processor" do
       merchant_account = create(:merchant_account, charge_processor_id: ChargeProcessor.charge_processor_ids.first)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3361,19 +3361,50 @@ describe User, :vcr do
       expect(seller.payouts_paused_for_reason).to eq("Chargeback rate too high.")
     end
 
-    it "returns nil if payouts are not paused by admin" do
+    it "returns the content of the last payouts_paused comment when payouts are paused by stripe" do
       seller.comments.create!(
-        author_id: User.last.id,
-        content: "Chargeback rate too high.",
+        author_name: "Stripe payouts sync",
+        content: "Payouts automatically paused by Stripe (disabled reason: requirements.past_due).",
         comment_type: Comment::COMMENT_TYPE_PAYOUTS_PAUSED
       )
 
       seller.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_STRIPE)
       expect(seller.reload.payouts_paused_by_source).to eq(User::PAYOUT_PAUSE_SOURCE_STRIPE)
-      expect(seller.payouts_paused_for_reason).to be nil
+      expect(seller.payouts_paused_for_reason).to eq("Payouts automatically paused by Stripe (disabled reason: requirements.past_due).")
+    end
+
+    it "returns nil for system pauses that only write an on_probation comment" do
+      seller.comments.create!(
+        author_name: "pause_payouts_for_seller_based_on_chargeback_rate",
+        content: "Payouts automatically paused due to chargeback rate.",
+        comment_type: Comment::COMMENT_TYPE_ON_PROBATION
+      )
 
       seller.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_SYSTEM)
       expect(seller.reload.payouts_paused_by_source).to eq(User::PAYOUT_PAUSE_SOURCE_SYSTEM)
+      expect(seller.payouts_paused_for_reason).to be nil
+    end
+
+    it "returns nil when the current pause is by the system even if a stale Stripe pause comment remains" do
+      seller.comments.create!(
+        author_name: "Stripe payouts sync",
+        content: "Payouts automatically paused by Stripe (disabled reason: listed).",
+        comment_type: Comment::COMMENT_TYPE_PAYOUTS_PAUSED
+      )
+
+      seller.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_SYSTEM)
+      expect(seller.reload.payouts_paused_by_source).to eq(User::PAYOUT_PAUSE_SOURCE_SYSTEM)
+      expect(seller.payouts_paused_for_reason).to be nil
+    end
+
+    it "returns nil once payouts are no longer paused even if a stale pause comment remains" do
+      seller.comments.create!(
+        author_name: "Stripe payouts sync",
+        content: "Payouts automatically paused by Stripe (disabled reason: requirements.past_due).",
+        comment_type: Comment::COMMENT_TYPE_PAYOUTS_PAUSED
+      )
+
+      expect(seller.payouts_paused?).to be false
       expect(seller.payouts_paused_for_reason).to be nil
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3373,15 +3373,26 @@ describe User, :vcr do
       expect(seller.payouts_paused_for_reason).to eq("Payouts automatically paused by Stripe (disabled reason: requirements.past_due).")
     end
 
-    it "returns nil for system pauses that only write an on_probation comment" do
+    it "returns the system pause reason from the on_probation comment for a system pause" do
       seller.comments.create!(
-        author_name: "pause_payouts_for_seller_based_on_chargeback_rate",
-        content: "Payouts automatically paused due to chargeback rate.",
+        author_name: User::SYSTEM_PAYOUT_PAUSE_COMMENT_AUTHORS[:high_chargeback_rate],
+        content: "Payouts automatically paused due to chargeback rate (5%) exceeding 3% volume.",
         comment_type: Comment::COMMENT_TYPE_ON_PROBATION
       )
 
       seller.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_SYSTEM)
       expect(seller.reload.payouts_paused_by_source).to eq(User::PAYOUT_PAUSE_SOURCE_SYSTEM)
+      expect(seller.payouts_paused_for_reason).to eq("Payouts automatically paused due to chargeback rate (5%) exceeding 3% volume.")
+    end
+
+    it "returns nil for a system pause whose only on_probation comment is unrelated to payouts" do
+      seller.comments.create!(
+        author_name: "some_other_probation_reason",
+        content: "On probation for an unrelated reason.",
+        comment_type: Comment::COMMENT_TYPE_ON_PROBATION
+      )
+
+      seller.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_SYSTEM)
       expect(seller.payouts_paused_for_reason).to be nil
     end
 

--- a/spec/services/onetime/backfill_stripe_payout_pause_comments_spec.rb
+++ b/spec/services/onetime/backfill_stripe_payout_pause_comments_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Onetime::BackfillStripePayoutPauseComments do
+  describe ".process" do
+    def stripe_paused_user
+      create(:user).tap do |user|
+        user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_STRIPE)
+      end
+    end
+
+    it "writes a payouts_paused comment with the stored Stripe reason for a Stripe-paused user that has none" do
+      user = stripe_paused_user
+      create(:merchant_account, user:, charge_processor_merchant_id: "acct_one", stripe_disabled_reason: "listed")
+
+      expect do
+        described_class.process
+      end.to change { user.comments.with_type_payouts_paused.count }.from(0).to(1)
+
+      comment = user.comments.with_type_payouts_paused.last
+      expect(comment.content).to include("listed")
+      expect(comment.author_name).to eq("Stripe payouts sync")
+      expect(user.reload.payouts_paused_for_reason).to include("listed")
+    end
+
+    it "is idempotent and does not write a second comment when one already exists" do
+      user = stripe_paused_user
+      create(:merchant_account, user:, charge_processor_merchant_id: "acct_two", stripe_disabled_reason: "listed")
+      user.comments.create!(
+        author_name: "Stripe payouts sync",
+        comment_type: Comment::COMMENT_TYPE_PAYOUTS_PAUSED,
+        content: "Payouts automatically paused by Stripe (disabled reason: requirements.past_due)."
+      )
+
+      expect do
+        described_class.process
+        described_class.process
+      end.not_to change { user.comments.with_type_payouts_paused.count }
+    end
+
+    it "skips users whose payouts are paused by the system, not Stripe" do
+      user = create(:user)
+      user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_SYSTEM)
+      create(:merchant_account, user:, charge_processor_merchant_id: "acct_three", stripe_disabled_reason: "listed")
+
+      expect { described_class.process }.not_to change { Comment.with_type_payouts_paused.count }
+    end
+
+    it "skips users whose payouts are not paused" do
+      user = create(:user)
+      create(:merchant_account, user:, charge_processor_merchant_id: "acct_four", stripe_disabled_reason: "listed")
+
+      expect { described_class.process }.not_to change { Comment.with_type_payouts_paused.count }
+    end
+
+    it "skips Stripe Connect accounts" do
+      user = stripe_paused_user
+      merchant_account = create(:merchant_account, user:, charge_processor_merchant_id: "acct_five", stripe_disabled_reason: "listed")
+      merchant_account.update!(json_data: merchant_account.json_data.deep_merge("meta" => { "stripe_connect" => "true" }))
+
+      expect { described_class.process }.not_to change { user.comments.with_type_payouts_paused.count }
+    end
+  end
+end

--- a/spec/services/onetime/backfill_stripe_payout_pause_comments_spec.rb
+++ b/spec/services/onetime/backfill_stripe_payout_pause_comments_spec.rb
@@ -77,5 +77,19 @@ describe Onetime::BackfillStripePayoutPauseComments do
 
       expect { described_class.process }.not_to change { user.comments.with_type_payouts_paused.count }
     end
+
+    it "writes one comment from the canonical account and stays idempotent when a user has multiple Stripe accounts" do
+      user = stripe_paused_user
+      create(:merchant_account, user:, charge_processor_merchant_id: "acct_a", stripe_disabled_reason: "requirements.past_due")
+      create(:merchant_account, user:, charge_processor_merchant_id: "acct_b", stripe_disabled_reason: "listed")
+      canonical_reason = user.stripe_account.stripe_payouts_paused_comment
+
+      expect do
+        described_class.process
+        described_class.process
+      end.to change { user.comments.with_type_payouts_paused.count }.from(0).to(1)
+
+      expect(user.reload.payouts_paused_for_reason).to eq(canonical_reason)
+    end
   end
 end

--- a/spec/services/onetime/backfill_stripe_payout_pause_comments_spec.rb
+++ b/spec/services/onetime/backfill_stripe_payout_pause_comments_spec.rb
@@ -24,19 +24,35 @@ describe Onetime::BackfillStripePayoutPauseComments do
       expect(user.reload.payouts_paused_for_reason).to include("listed")
     end
 
-    it "is idempotent and does not write a second comment when one already exists" do
+    it "is idempotent and does not write a second comment when the latest comment already matches" do
       user = stripe_paused_user
-      create(:merchant_account, user:, charge_processor_merchant_id: "acct_two", stripe_disabled_reason: "listed")
+      merchant_account = create(:merchant_account, user:, charge_processor_merchant_id: "acct_two", stripe_disabled_reason: "listed")
       user.comments.create!(
         author_name: "Stripe payouts sync",
         comment_type: Comment::COMMENT_TYPE_PAYOUTS_PAUSED,
-        content: "Payouts automatically paused by Stripe (disabled reason: requirements.past_due)."
+        content: merchant_account.stripe_payouts_paused_comment
       )
 
       expect do
         described_class.process
         described_class.process
       end.not_to change { user.comments.with_type_payouts_paused.count }
+    end
+
+    it "writes the Stripe reason even when an older, mismatched payouts_paused comment exists" do
+      user = stripe_paused_user
+      create(:merchant_account, user:, charge_processor_merchant_id: "acct_six", stripe_disabled_reason: "listed")
+      user.comments.create!(
+        author_name: "admin",
+        comment_type: Comment::COMMENT_TYPE_PAYOUTS_PAUSED,
+        content: "Payouts paused by an admin for an unrelated earlier reason."
+      )
+
+      expect do
+        described_class.process
+      end.to change { user.comments.with_type_payouts_paused.count }.by(1)
+
+      expect(user.reload.payouts_paused_for_reason).to include("listed")
     end
 
     it "skips users whose payouts are paused by the system, not Stripe" do


### PR DESCRIPTION
## What

When Gumroad pauses a seller's payouts, this makes the pause explain itself on the admin Payout Info panel and notifies the seller — across Stripe-mirrored pauses and Gumroad's own system pauses.

- **Stripe pauses:** on a Stripe-source pause, write a `payouts_paused` comment with the raw Stripe `disabled_reason` + a human-readable description; write a `payouts_resumed` comment on re-enable. The comment is refreshed if Stripe's reason changes while the account stays paused. Writes are atomic with the pause-state update.
- **Reason surfacing:** `User#payouts_paused_for_reason` returns the reason for the *current* pause source — the `payouts_paused` comment for admin/Stripe pauses, and the relevant `on_probation` comment for **system** pauses (repeated failed payouts / high chargeback rate / failed-purchase spike), matched by their known authors. The admin panel renders this for every source instead of the old hardcoded strings.
- **Notifications:** widened beyond the previous two-reason allow-list — action-required email whenever Stripe has *currently-actionable* requirements (excluding future `eventually_due`), a new "under review" email otherwise, nothing for rejected/platform-paused. Sellers are re-notified once if a pause **escalates** to action-required, deduped so re-pauses and admin/payout-method toggles don't spam (`MerchantAccount#stripe_payouts_pause_email_sent`).
- **Backfill:** a one-time task (`Onetime::BackfillStripePayoutPauseComments`) writes the reason comment for accounts already paused by Stripe, reading the persisted `stripe_disabled_reason` (no Stripe calls), batched, idempotent. System pauses need no backfill (their `on_probation` comment already exists). Run: `Onetime::BackfillStripePayoutPauseComments.process`.

## Why

Stripe-mirrored pauses were the dominant cause of "payouts paused, no explanation" tickets: the pause flipped silently, the panel showed a fixed generic string, and the seller email fired for only two `disabled_reason` values. Both the seller and the support agent were left in the dark. This records the reason durably, surfaces it accurately on the panel for every pause source, widens and escalates notification, and backfills existing paused accounts.


---

AI disclosure: implemented with Claude Opus 4.8.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes payout pause/resume side effects on Stripe webhooks (locking, comments, email dedupe) and seller-facing notifications; incorrect logic could miss alerts or duplicate emails, but scope is bounded to Stripe-synced payout state.
> 
> **Overview**
> Stripe `account.updated` handling now **records payout pause/resume in user comments** (with human-readable `disabled_reason` text), runs pause state updates **under a user lock** with a merchant-account email dedupe marker, and sends **action-required** vs **under-review** emails more broadly (excluding rejected/platform-paused), including one escalation to action-required per Stripe-disabled episode.
> 
> **`User#payouts_paused_for_reason`** and admin **Payout Info** now show the live pause explanation for Stripe and system pauses (via `payouts_paused` / known `on_probation` authors), not only admin pauses. A one-time **`Onetime::BackfillStripePayoutPauseComments`** backfills comments for accounts already Stripe-paused.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 865f29d6eb99ac18bc09e1d6daae15b09b01c2f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->