### PR TITLE
Add ProductOwnershipTransferService for moving a product between sellers

### DIFF
--- a/app/services/product_ownership_transfer_service.rb
+++ b/app/services/product_ownership_transfer_service.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+# Moves a product (Link) from one seller to another, repointing every record that
+# carries a denormalized owner reference while leaving historical/financial data with
+# the origin account. See the "Product ownership transfer between accounts" issue for
+# the full rationale.
+#
+# What moves:
+#   - Link.user_id -> new seller
+#   - Owner-keyed records that belong to the product: product/variant installments and
+#     their workflows, product-scoped offer codes, UTM links, and the product's spot in
+#     the origin seller's profile layout.
+#
+# What does NOT move (forward-only, by design):
+#   - Purchases, refunds, balances, payouts, subscription events, 1099/tax attribution.
+#     These stay with the origin account that actually received the money. As a result,
+#     historical purchases keep seller_id = origin while link.user is now the new seller;
+#     future purchases of the product are attributed to the new seller and stay
+#     consistent. Followers are per-creator, not per-product, and also stay.
+#
+# What is detached rather than moved:
+#   - Affiliate / collaborator / self-service-affiliate relationships are agreements
+#     between an affiliate and the origin seller. They are detached from the product
+#     instead of silently re-homed under the new seller, who can re-enroll the product.
+#
+# The repointing and the audit comments run in a single transaction so the move either
+# happens completely or not at all. Cache invalidation and search reindexing run after
+# commit.
+class ProductOwnershipTransferService
+  class TransferError < StandardError; end
+
+  def initialize(product:, new_seller:, performed_by: nil, move_subscriptions: false)
+    @product = product
+    @new_seller = new_seller
+    @previous_seller = product.user
+    @performed_by = performed_by
+    @move_subscriptions = move_subscriptions
+  end
+
+  def process
+    validate_preconditions!
+
+    ApplicationRecord.connection.stick_to_primary!
+    ApplicationRecord.transaction do
+      move_installments_and_workflows
+      move_offer_codes
+      move_utm_links
+      move_subscriptions! if @move_subscriptions
+      detach_affiliate_relationships
+      move_product_page_sections
+      remove_from_origin_profile
+      repoint_product
+      leave_audit_comments
+    end
+
+    rebuild_derived_data
+
+    @product.reload
+  end
+
+  private
+    attr_reader :product, :new_seller, :previous_seller, :performed_by
+
+    def validate_preconditions!
+      raise TransferError, "Product is required" if product.blank?
+      raise TransferError, "New seller is required" if new_seller.blank?
+      raise TransferError, "Product already belongs to the new seller" if previous_seller == new_seller
+      raise TransferError, "New seller account is not in good standing" unless seller_in_good_standing?(new_seller)
+
+      if custom_permalink_collides?
+        raise TransferError, "New seller already has a product with the custom permalink \"#{product.custom_permalink}\""
+      end
+    end
+
+    def seller_in_good_standing?(user)
+      !user.deleted? && !user.suspended?
+    end
+
+    def custom_permalink_collides?
+      return false if product.custom_permalink.blank?
+
+      new_seller.links.where(custom_permalink: product.custom_permalink).where.not(id: product.id).exists?
+    end
+
+    # Product and variant installments (and the workflows that own them) are scoped to a
+    # single product via link_id. Seller-wide posts (no link_id) stay with the origin.
+    def move_installments_and_workflows
+      product.workflows.update_all(seller_id: new_seller.id)
+      product.installments
+             .where(installment_type: [Installment::PRODUCT_TYPE, Installment::VARIANT_TYPE])
+             .update_all(seller_id: new_seller.id)
+    end
+
+    # Offer codes that exist only for this product move with it. Universal codes and codes
+    # shared with other products of the origin seller stay put; the moved product is just
+    # detached from the shared ones so it no longer carries the origin seller's discount.
+    def move_offer_codes
+      product.offer_codes.to_a.each do |offer_code|
+        if exclusive_to_product?(offer_code)
+          offer_code.update!(user_id: new_seller.id)
+        else
+          product.offer_codes.delete(offer_code)
+        end
+      end
+    end
+
+    def exclusive_to_product?(offer_code)
+      !offer_code.universal? && offer_code.product_ids.uniq == [product.id]
+    end
+
+    def move_utm_links
+      UtmLink.where(seller_id: previous_seller.id, target_resource_type: "product_page", target_resource_id: product.id)
+             .update_all(seller_id: new_seller.id)
+    end
+
+    def move_subscriptions!
+      product.subscriptions.update_all(seller_id: new_seller.id)
+    end
+
+    # Affiliate, collaborator, and self-service-affiliate relationships are agreements
+    # between an affiliate and the origin seller, not properties of the product, so we
+    # detach the product from them instead of silently re-homing them under the new
+    # seller. Destroying each ProductAffiliate triggers its own callbacks, which clear the
+    # product's collab flag and remove the product from the affiliate's audience entry.
+    def detach_affiliate_relationships
+      product.product_affiliates.each(&:destroy!)
+      SelfServiceAffiliateProduct.where(product_id: product.id).destroy_all
+    end
+
+    # Sections scoped to the product (its own page layout) belong to the product and
+    # travel with it; only their denormalized seller_id needs to follow the new owner.
+    def move_product_page_sections
+      product.seller_profile_sections.update_all(seller_id: new_seller.id)
+    end
+
+    # The origin seller's profile-level sections stay with them, but they must stop
+    # referencing a product they no longer own: drop it from "products" sections and
+    # delete any "featured product" section that featured it.
+    def remove_from_origin_profile
+      SellerProfileProductsSection.on_profile.where(seller_id: previous_seller.id).find_each do |section|
+        next unless section.shown_products.include?(product.id)
+
+        section.update!(shown_products: section.shown_products - [product.id])
+      end
+
+      SellerProfileFeaturedProductSection.on_profile.where(seller_id: previous_seller.id).find_each do |section|
+        section.destroy! if section.featured_product_id == product.id
+      end
+    end
+
+    def repoint_product
+      product.user = new_seller
+      product.save!
+    end
+
+    def leave_audit_comments
+      previous_seller.comments.create!(
+        author_id:,
+        author_name:,
+        comment_type: Comment::COMMENT_TYPE_NOTE,
+        content: "Product \"#{product.name}\" (ID #{product.id}, /#{product.general_permalink}) transferred to " \
+                 "#{seller_label(new_seller)}#{performed_by_suffix}.",
+        idempotency_key: "product_transfer_out_#{product.id}_to_#{new_seller.id}"
+      )
+
+      new_seller.comments.create!(
+        author_id:,
+        author_name:,
+        comment_type: Comment::COMMENT_TYPE_NOTE,
+        content: "Product \"#{product.name}\" (ID #{product.id}, /#{product.general_permalink}) received from " \
+                 "#{seller_label(previous_seller)}#{performed_by_suffix}.",
+        idempotency_key: "product_transfer_in_#{product.id}_from_#{previous_seller.id}"
+      )
+    end
+
+    def author_id
+      performed_by&.id || GUMROAD_ADMIN_ID
+    end
+
+    def author_name
+      performed_by&.name
+    end
+
+    def performed_by_suffix
+      performed_by.present? ? " by #{seller_label(performed_by)}" : ""
+    end
+
+    def seller_label(user)
+      "#{user.display_name} (ID #{user.id})"
+    end
+
+    # The product's row-level data (prices, variants, rich content, files, reviews,
+    # co-purchase graph, etc.) is keyed on link_id and travels automatically. Changing the
+    # owner already busts the product's caches through Link's after_update callback, so the
+    # only derived data left to fix is its search document: the owner fields aren't in the
+    # auto-reindexed set, so reindex it explicitly for the new seller.
+    #
+    # Audience members need no rebuild here: detaching the product's ProductAffiliates
+    # already updated the origin seller's audience via callbacks, and the new seller
+    # inherits no audience because purchases and followers stay with the origin (§6).
+    # Likewise, ProductPageView analytics stay attributed to the origin seller.
+    def rebuild_derived_data
+      ProductIndexingService.perform(product:, action: "index", on_failure: :async)
+    end
+end

--- a/spec/services/product_ownership_transfer_service_spec.rb
+++ b/spec/services/product_ownership_transfer_service_spec.rb
@@ -1,0 +1,219 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ProductOwnershipTransferService do
+  let(:previous_seller) { create(:user, name: "Origin Seller") }
+  let(:new_seller) { create(:user, name: "Destination Seller") }
+  let(:product) { create(:product, user: previous_seller, name: "The Premium Course") }
+
+  before do
+    allow(ProductIndexingService).to receive(:perform)
+  end
+
+  def transfer(**options)
+    described_class.new(product:, new_seller:, **options).process
+  end
+
+  describe "ownership pointer" do
+    it "repoints the product to the new seller" do
+      transfer
+
+      expect(product.reload.user).to eq(new_seller)
+    end
+
+    it "keeps the new owner consistent with the product's user for future sales" do
+      transfer
+
+      purchase = build(:purchase, link: product.reload)
+      purchase.valid?
+      expect(purchase.seller).to eq(new_seller)
+      expect(purchase.errors[:base]).not_to include("link does not belong to user")
+    end
+
+    it "raises when the product already belongs to the new seller" do
+      expect do
+        described_class.new(product:, new_seller: previous_seller).process
+      end.to raise_error(described_class::TransferError, /already belongs/)
+    end
+
+    it "raises when the new seller is suspended" do
+      allow(new_seller).to receive(:suspended?).and_return(true)
+
+      expect { transfer }.to raise_error(described_class::TransferError, /good standing/)
+      expect(product.reload.user).to eq(previous_seller)
+    end
+
+    it "raises when the custom permalink collides in the new seller's namespace" do
+      product.update!(custom_permalink: "small-bets")
+      create(:product, user: new_seller, custom_permalink: "small-bets")
+
+      expect { transfer }.to raise_error(described_class::TransferError, /custom permalink/)
+      expect(product.reload.user).to eq(previous_seller)
+    end
+  end
+
+  describe "installments and workflows" do
+    it "moves product and variant installments to the new seller" do
+      product_installment = create(:installment, link: product, seller: previous_seller, installment_type: Installment::PRODUCT_TYPE)
+      seller_wide_installment = create(:seller_installment, seller: previous_seller)
+
+      transfer
+
+      expect(product_installment.reload.seller).to eq(new_seller)
+      expect(seller_wide_installment.reload.seller).to eq(previous_seller)
+    end
+
+    it "moves the product's workflows to the new seller" do
+      workflow = create(:workflow, seller: previous_seller, link: product)
+
+      transfer
+
+      expect(workflow.reload.seller).to eq(new_seller)
+    end
+  end
+
+  describe "offer codes" do
+    it "moves an offer code that is exclusive to the product" do
+      offer_code = create(:offer_code, user: previous_seller, products: [product])
+
+      transfer
+
+      expect(offer_code.reload.user).to eq(new_seller)
+      expect(product.reload.offer_codes).to include(offer_code)
+    end
+
+    it "detaches the product from an offer code shared with another product" do
+      other_product = create(:product, user: previous_seller)
+      offer_code = create(:offer_code, user: previous_seller, products: [product, other_product])
+
+      transfer
+
+      expect(offer_code.reload.user).to eq(previous_seller)
+      expect(offer_code.products).to match_array([other_product])
+    end
+
+    it "leaves universal offer codes with the origin seller" do
+      universal = create(:universal_offer_code, user: previous_seller)
+
+      transfer
+
+      expect(universal.reload.user).to eq(previous_seller)
+    end
+  end
+
+  describe "UTM links" do
+    it "moves UTM links that target the product" do
+      utm_link = create(:utm_link, seller: previous_seller, target_resource_type: :product_page, target_resource_id: product.id)
+      other_utm_link = create(:utm_link, seller: previous_seller, target_resource_type: :profile_page)
+
+      transfer
+
+      expect(utm_link.reload.seller).to eq(new_seller)
+      expect(other_utm_link.reload.seller).to eq(previous_seller)
+    end
+  end
+
+  describe "affiliates and collaborators" do
+    it "detaches the product's affiliates and self-service enrollment" do
+      affiliate = create(:direct_affiliate, seller: previous_seller)
+      create(:product_affiliate, product:, affiliate:)
+      create(:self_service_affiliate_product, seller: previous_seller, product:)
+
+      transfer
+
+      expect(product.reload.product_affiliates).to be_empty
+      expect(SelfServiceAffiliateProduct.where(product_id: product.id)).to be_empty
+    end
+
+    it "clears the collab flag when a collaborator is detached" do
+      collaborator = create(:collaborator, seller: previous_seller, apply_to_all_products: false)
+      create(:product_affiliate, product:, affiliate: collaborator)
+      expect(product.reload.is_collab).to be(true)
+
+      transfer
+
+      expect(product.reload.is_collab).to be(false)
+    end
+  end
+
+  describe "seller profile" do
+    it "repoints the product's own page sections to the new seller" do
+      section = create(:seller_profile_products_section, seller: previous_seller, product:)
+
+      transfer
+
+      expect(section.reload.seller).to eq(new_seller)
+    end
+
+    it "removes the product from the origin seller's profile-level sections" do
+      products_section = create(:seller_profile_products_section, seller: previous_seller, shown_products: [product.id])
+      featured_section = create(:seller_profile_featured_product_section, seller: previous_seller)
+      featured_section.update!(featured_product_id: product.id)
+
+      transfer
+
+      expect(products_section.reload.shown_products).to be_empty
+      expect(SellerProfileSection.where(id: featured_section.id)).to be_empty
+    end
+  end
+
+  describe "audit comments" do
+    it "records a note on the origin and destination accounts" do
+      transfer
+
+      origin_comment = previous_seller.comments.last
+      expect(origin_comment.comment_type).to eq(Comment::COMMENT_TYPE_NOTE)
+      expect(origin_comment.content).to include("transferred to", new_seller.display_name, "The Premium Course")
+
+      destination_comment = new_seller.comments.last
+      expect(destination_comment.content).to include("received from", previous_seller.display_name, "The Premium Course")
+    end
+
+    it "attributes the note to the admin who performed the transfer" do
+      admin = create(:admin_user, name: "Support Admin")
+
+      described_class.new(product:, new_seller:, performed_by: admin).process
+
+      comment = previous_seller.comments.last
+      expect(comment.author_id).to eq(admin.id)
+      expect(comment.content).to include("by Support Admin")
+    end
+  end
+
+  describe "historical and financial records" do
+    it "leaves existing purchases attributed to the origin seller" do
+      purchase = create(:free_purchase, link: product, seller: previous_seller)
+
+      transfer
+
+      expect(purchase.reload.seller).to eq(previous_seller)
+    end
+  end
+
+  describe "derived data" do
+    it "busts the product cache when the owner changes" do
+      expect(product).to receive(:invalidate_cache).at_least(:once).and_call_original
+
+      transfer
+    end
+
+    it "reindexes the product for search under the new owner" do
+      expect(ProductIndexingService).to receive(:perform).with(product:, action: "index", on_failure: :async)
+
+      transfer
+    end
+  end
+
+  describe "atomicity" do
+    it "rolls the whole move back when a step fails" do
+      installment = create(:installment, link: product, seller: previous_seller, installment_type: Installment::PRODUCT_TYPE)
+      allow_any_instance_of(described_class).to receive(:leave_audit_comments).and_raise(StandardError, "boom")
+
+      expect { transfer }.to raise_error(StandardError, "boom")
+
+      expect(product.reload.user).to eq(previous_seller)
+      expect(installment.reload.seller).to eq(previous_seller)
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds `ProductOwnershipTransferService` — a single entry point for moving a product (`Link`) from one seller account to another. A product isn't owned by one column: records are keyed on the product (`link_id`/`product_id`), on the owning user (`seller_id`/`user_id`), and some ownership is denormalized. An unguarded `Link.user_id` update therefore breaks the `seller_is_link_user` invariant and leaves stale aggregates behind. This service does the whole move atomically.

```ruby
ProductOwnershipTransferService.new(
  product:,
  new_seller:,
  performed_by: admin,        # optional; attributed in the audit comments
  move_subscriptions: false,  # opt-in; live subscriptions stay with the origin by default
).process
```

**Moves to the new seller (in one transaction):**
- `Link.user_id`
- The product's own profile-page sections (`SellerProfileSection` scoped by `product_id`) — their denormalized `seller_id` follows the new owner
- Product and variant `Installment`s and the `Workflow`s that own them (seller-wide posts stay)
- Offer codes that exist *only* for this product (universal and shared codes stay; the product is just detached from shared ones)
- `UtmLink`s that target the product

**Detached rather than re-homed across accounts:**
- Affiliate / collaborator / self-service-affiliate relationships are agreements with the *origin* seller, so the product is detached from them instead of silently moving them under the new seller. Destroying each `ProductAffiliate` reuses the model's existing callbacks, which clear the `is_collab` flag and reconcile the origin seller's `AudienceMember` entries.
- The product is removed from the origin seller's profile-level layout (`shown_products` lists and any "featured product" section).

**Stays with the origin account (forward-only, by design):**
- `Purchase`, `Refund`, `ScheduledPayout`, `Balance`, `SubscriptionEvent`, payout routing, and 1099/tax attribution — these followed the money and can't cross accounts/TINs.
- `Follower`s (per-creator, not per-product) and `ProductPageView` analytics.

**After commit:** the search index is refreshed for the new owner (owner fields aren't in the auto-reindexed set; cache busting already happens via `Link`'s `after_update` callback), and an audit comment is written to **both** accounts (`"… transferred to …"` on the origin, `"… received from …"` on the destination).

**Preconditions enforced before anything changes:** distinct seller, new seller in good standing (not deleted/suspended), and no `custom_permalink` collision in the new seller's namespace.

## Why

There's currently no supported way to move a product between accounts — only unsafe manual DB edits that break `seller_is_link_user`, leave `AudienceMember`/caches/search stale, and misattribute revenue. This centralizes the move into one auditable, transactional operation.

The key design decision is **forward-only**: historical revenue, payouts, and tax can't be reassigned across accounts, so purchases and balances stay with the origin. A consequence worth calling out for review: existing purchases keep `seller_id = origin` while `link.user` becomes the new seller, so the `seller_is_link_user` check (validated on `Purchase` at save time) no longer holds for those historical rows — future purchases of the moved product are attributed to the new seller and stay consistent. Affiliate relationships are detached rather than moved for the same reason: they're agreements with the origin seller, and recreating them under the new seller would fabricate consent that doesn't exist.

Related: antiwork/gumroad-private#522.

## Out of scope / follow-ups

- **URL continuity for the origin's subdomain.** The product keeps its permalink, so it still resolves at the apex and redirects to the new seller's subdomain. The old `<origin>.gumroad.com/l/<permalink>` URL still 404s, because subdomain lookups are scoped to the resolved seller and `LegacyPermalink` is only consulted when no seller is in context. A redirect for the origin's subdomain URL needs a routing change and is left as a follow-up.
- **Wiring.** This adds the service only; an admin action/console runbook to invoke it is a follow-up.
- **Authorization.** A real transfer is gated on the product owner's consent / proper authorization — a precondition handled outside this service.

## Before / After

Non-user-facing backend service; no UI change. Video pending per the contributing guide — I'll attach a short console walkthrough of a transfer (records repointed, comments written, purchases left in place) before marking ready for review.

## Test Results

New spec `spec/services/product_ownership_transfer_service_spec.rb` covers the ownership pointer and invariant, each repointed/detached record type, the audit comments, that purchases stay with the origin, cache busting + reindex, precondition failures, and transactional rollback.

```
21 examples, 0 failures
```

`bundle exec rubocop` clean on both files.

---

AI disclosure: this PR was written with Claude Opus 4.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784208453&installation_id=134400930&pr_number=5483&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5483&signature=4c6a92a09ff6c028d69b09019b6827a0b5f29326301660187fb951e3169f7b85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->