### PR TITLE
Add kill switch for SendStripeBalanceCheckNotificationJob

### DIFF
--- a/app/sidekiq/send_stripe_balance_check_notification_job.rb
+++ b/app/sidekiq/send_stripe_balance_check_notification_job.rb
@@ -7,6 +7,7 @@ class SendStripeBalanceCheckNotificationJob
 
   def perform
     return unless Rails.env.production?
+    return if Feature.active?(:disable_stripe_balance_check_notification)
 
     balance_check = StripeBalanceCheckService.new
 

--- a/spec/sidekiq/send_stripe_balance_check_notification_job_spec.rb
+++ b/spec/sidekiq/send_stripe_balance_check_notification_job_spec.rb
@@ -47,5 +47,21 @@ describe SendStripeBalanceCheckNotificationJob do
 
       expect(InternalNotificationWorker.jobs.size).to eq(0)
     end
+
+    context "when the disable_stripe_balance_check_notification flag is active" do
+      before do
+        allow(StripeTransferExternallyToGumroad).to receive(:available_balances).and_return({ "usd" => 300_000_00 })
+        Feature.activate(:disable_stripe_balance_check_notification)
+      end
+
+      it "does not check the balance, notify, or set the redis key" do
+        expect(StripeBalanceCheckService).not_to receive(:new)
+
+        described_class.new.perform
+
+        expect(InternalNotificationWorker.jobs.size).to eq(0)
+        expect($redis.get(RedisKey.stripe_balance_topup_needed)).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
## What

Adds a `disable_stripe_balance_check_notification` Flipper flag that, when active, makes `SendStripeBalanceCheckNotificationJob` no-op. It's checked as an early return at the top of `#perform`:

```ruby
def perform
  return unless Rails.env.production?
  return if Feature.active?(:disable_stripe_balance_check_notification)
  # ...
end
```

The flag is **inactive by default**, so normal behavior is unchanged. Activating it (`Feature.activate(:disable_stripe_balance_check_notification)`) stops the daily job from running the balance check, sending the internal "Stripe Balance Check" notification, or writing the `stripe:balance_topup_needed` redis cache key — all without a deploy.

## Why

The job runs daily via Sidekiq cron and previously had no off switch — the only guards were the `Rails.env.production?` check and the `topup_needed?` check. If the balance estimate ever misfires and floods the `#payments` channel with false top-up alerts, there was no way to silence it short of editing `config/sidekiq_schedule.yml` and shipping a deploy (or hand-editing the Sidekiq-Cron schedule in a console).

A runtime-toggleable kill switch is the lightest fix. This mirrors the existing `pause_audience_members_index_backfill` emergency-stop flag (`app/sidekiq/backfill_audience_members_index_job.rb`), so it follows an established pattern rather than introducing a new convention.

A Flipper flag (rather than a `$redis` key) was chosen because the codebase already standardizes on `Feature.active?` for this kind of operational toggle (`disable_braintree_sales`, `disable_paypal_sales`, `disable_stripe_signup`, etc.), and it's controllable from the Flipper UI.

## Before/After

Not user-facing — this gates an internal Slack/notification cron job. Behavior with the flag inactive (the default) is identical to before. Walkthrough video to be attached.

## Test Results

Added a spec asserting that with the flag active and an insufficient balance (a state that would otherwise notify), the job does not instantiate `StripeBalanceCheckService`, enqueues no `InternalNotificationWorker` job, and leaves the redis key unset. Verified the spec fails when the guard is reverted.

```
4 examples, 0 failures
```

---

AI disclosure: drafted with Claude Opus 4.8.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single early-return guard on an internal cron job; default-off flag leaves production behavior unchanged.
> 
> **Overview**
> Adds a runtime **kill switch** so the daily `SendStripeBalanceCheckNotificationJob` can be silenced without a deploy.
> 
> When Flipper flag `disable_stripe_balance_check_notification` is active, `#perform` returns immediately after the existing production guard—**no** `StripeBalanceCheckService` run, **no** internal “Stripe Balance Check” notification, and **no** `stripe:balance_topup_needed` Redis write. The flag is off by default, so behavior is unchanged until ops toggles it (same `Feature.active?` pattern as other payment disable flags).
> 
> Specs cover the active-flag path: insufficient balance would normally notify, but with the flag on the service is never instantiated and Redis stays unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f48419fab74f3715e5a6a3a903f1bc9682bf7070. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784209764&installation_id=134400930&pr_number=5484&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5484&signature=2571fe2b0f80756eaf54d76facce94706f64586bdc60ab138d4ca562f06a5165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->