### PR TITLE
Remove Teams from account popover, promote Settings to top-level nav

### DIFF
--- a/app/javascript/components/ProfilePopover.tsx
+++ b/app/javascript/components/ProfilePopover.tsx
@@ -17,7 +17,7 @@ export const DashboardNavProfilePopover = ({ children, user }: { children: React
     </PopoverTrigger>
     <PopoverContent
       side="top"
-      className="border-0 px-2 pb-1 shadow-none"
+      className="border-0 px-2 py-1 shadow-none"
       arrowClassName="fill-white"
       collisionPadding={0}
       matchTriggerWidth

--- a/app/javascript/components/ProfilePopover.tsx
+++ b/app/javascript/components/ProfilePopover.tsx
@@ -17,7 +17,7 @@ export const DashboardNavProfilePopover = ({ children, user }: { children: React
     </PopoverTrigger>
     <PopoverContent
       side="top"
-      className="border-0 p-0 shadow-none"
+      className="border-0 px-2 pb-1 shadow-none"
       arrowClassName="fill-white"
       collisionPadding={0}
       matchTriggerWidth

--- a/app/javascript/components/client-components/Nav/footer.tsx
+++ b/app/javascript/components/client-components/Nav/footer.tsx
@@ -30,11 +30,10 @@ function NavbarFooter() {
         icon={<Book pack="filled" className="size-5" />}
         href={Routes.help_center_root_url(routeParams)}
       />
-      <NavLink
+      <ClientNavLink
         text="Settings"
         icon={<Cog pack="filled" className="size-5" />}
         href={Routes.settings_main_url(routeParams)}
-        component={Link}
       />
       <DashboardNavProfilePopover user={currentSeller}>
         <Menu className="flex flex-col border-0! shadow-none! dark:border!">

--- a/app/javascript/components/client-components/Nav/footer.tsx
+++ b/app/javascript/components/client-components/Nav/footer.tsx
@@ -1,4 +1,4 @@
-import { ArrowOutRightSquareHalf, Book, Cog, Group, Store } from "@boxicons/react";
+import { ArrowOutRightSquareHalf, Book, Cog, Store } from "@boxicons/react";
 import { Link } from "@inertiajs/react";
 import React from "react";
 
@@ -30,6 +30,12 @@ function NavbarFooter() {
         icon={<Book pack="filled" className="size-5" />}
         href={Routes.help_center_root_url(routeParams)}
       />
+      <NavLink
+        text="Settings"
+        icon={<Cog pack="filled" className="size-5" />}
+        href={Routes.settings_main_url(routeParams)}
+        component={Link}
+      />
       <DashboardNavProfilePopover user={currentSeller}>
         <Menu className="flex flex-col border-0! shadow-none! dark:border!">
           {teamMemberships != null && teamMemberships.length > 0 ? (
@@ -45,20 +51,6 @@ function NavbarFooter() {
             icon={<Store pack="filled" className="mx-1 size-5" />}
             href={Routes.root_url({ ...routeParams, host: currentSeller?.subdomain ?? routeParams.host })}
           />
-          <NavLinkDropdownItem
-            text="Settings"
-            icon={<Cog pack="filled" className="mx-1 size-5" />}
-            href={Routes.settings_main_url(routeParams)}
-            component={Link}
-          />
-          {teamMemberships != null && teamMemberships.length > 0 ? (
-            <NavLinkDropdownItem
-              text="Teams"
-              icon={<Group pack="filled" className="mx-1 size-5" />}
-              href={Routes.settings_team_url(routeParams)}
-              component={Link}
-            />
-          ) : null}
           <MenuItem asChild>
             <Link href={Routes.logout_url(routeParams)} method="delete" className="all-unset">
               <ArrowOutRightSquareHalf pack="filled" className="mx-1 size-5" />

--- a/spec/requests/main_navigation_spec.rb
+++ b/spec/requests/main_navigation_spec.rb
@@ -29,13 +29,13 @@ describe "Main Navigation", type: :system, js: true do
         expect(page).to have_link("Collaborators")
 
         expect(page).not_to have_link("Community")
-        expect(page).not_to have_link("Settings")
+        expect(page).to have_link("Settings")
 
         toggle_disclosure("Gum")
         within "div[role='menu']" do
           expect(page).not_to have_text(user.display_name)
           expect(page).to have_menuitem("Profile")
-          expect(page).to have_menuitem("Settings")
+          expect(page).not_to have_menuitem("Settings")
           expect(page).not_to have_menuitem("Teams")
           expect(page).not_to have_menuitem("Affiliates")
           expect(page).to have_menuitem("Logout")
@@ -99,7 +99,6 @@ describe "Main Navigation", type: :system, js: true do
           within "div[role='menu']" do
             expect(page).to have_text(user.display_name)
             expect(page).to have_text(seller.display_name)
-            expect(page).to have_menuitem("Teams")
           end
         end
       end


### PR DESCRIPTION
## What

Cleans up the dashboard nav account popover:

- **Removes the "Teams" item** from the account popover. Most users aren't members of multiple teams, so it added clutter for the majority.
- **Promotes "Settings" to a top-level nav item** — it now sits directly after Help and above the account-name popover, instead of being buried inside the popover. This keeps Settings one click away now that it's no longer in the dropdown.
- The popover is now just **Profile** and **Logout** (plus team-membership switching and the impersonation "unbecome" item when applicable, unchanged).
- **Fixes the popover width** so it's no longer flush against the sidebar edges — it was rendered at the exact nav width with zero side padding (`p-0` + `matchTriggerWidth` + `collisionPadding={0}`), which looked cramped. Added a small horizontal inset (`px-2`) so the menu has breathing room from the nav sides.

## Why

The "Teams" entry in the account popover is irrelevant to most sellers (planning issue: investigate removing it since most users aren't in multiple teams). Rather than just deleting it, this also moves Settings out to the top level so it stays easily reachable, and tidies the popover's odd flush-to-the-edges appearance.

## Test plan

- Open the dashboard sidebar account popover → confirm it shows **Profile** and **Logout** only (no "Teams"); team-membership switch items still appear for users with team memberships.
- Confirm **Settings** appears as a top-level nav link after **Help** and above the account-name popover trigger, and routes to settings.
- Confirm the popover is inset from the sidebar edges (not flush) in both light and dark mode.
- `npx tsc --noEmit` passes; `pnpm format`/prettier clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5487"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784216872&installation_id=134400930&pr_number=5487&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5487&signature=c87c1ccf14514022fd55f8bfad2f9272bc06cc497d1c95e41ba470c34c1dd669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation-only UI and spec updates with no auth, data, or API changes.
> 
> **Overview**
> **Settings** moves out of the account popover into the main sidebar footer (after **Help**), so it stays one click away. The popover drops **Settings** and **Teams**; it now focuses on **Profile**, **Logout**, and unchanged team-membership switching / impersonation items when those apply.
> 
> **Profile popover** content gets light horizontal padding (`px-2 py-1`) so the menu isn’t flush against the sidebar when `matchTriggerWidth` is used.
> 
> Request specs are updated to expect **Settings** in the main nav and not inside the popover menu.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7404d4689e999e7eac35da04b3851fe5ed0d8066. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->