### PR TITLE
Hide Teams nav link for users with no team memberships (#529)

### DIFF
--- a/app/javascript/components/client-components/Nav/footer.tsx
+++ b/app/javascript/components/client-components/Nav/footer.tsx
@@ -51,12 +51,14 @@ function NavbarFooter() {
             href={Routes.settings_main_url(routeParams)}
             component={Link}
           />
-          <NavLinkDropdownItem
-            text="Teams"
-            icon={<Group pack="filled" className="mx-1 size-5" />}
-            href={Routes.settings_team_url(routeParams)}
-            component={Link}
-          />
+          {teamMemberships != null && teamMemberships.length > 0 ? (
+            <NavLinkDropdownItem
+              text="Teams"
+              icon={<Group pack="filled" className="mx-1 size-5" />}
+              href={Routes.settings_team_url(routeParams)}
+              component={Link}
+            />
+          ) : null}
           <MenuItem asChild>
             <Link href={Routes.logout_url(routeParams)} method="delete" className="all-unset">
               <ArrowOutRightSquareHalf pack="filled" className="mx-1 size-5" />

--- a/spec/requests/main_navigation_spec.rb
+++ b/spec/requests/main_navigation_spec.rb
@@ -36,7 +36,7 @@ describe "Main Navigation", type: :system, js: true do
           expect(page).not_to have_text(user.display_name)
           expect(page).to have_menuitem("Profile")
           expect(page).to have_menuitem("Settings")
-          expect(page).to have_menuitem("Teams")
+          expect(page).not_to have_menuitem("Teams")
           expect(page).not_to have_menuitem("Affiliates")
           expect(page).to have_menuitem("Logout")
         end
@@ -99,6 +99,7 @@ describe "Main Navigation", type: :system, js: true do
           within "div[role='menu']" do
             expect(page).to have_text(user.display_name)
             expect(page).to have_text(seller.display_name)
+            expect(page).to have_menuitem("Teams")
           end
         end
       end


### PR DESCRIPTION
Addresses antiwork/gumroad-private#529.

Most users aren't members of multiple teams, so the always-visible **Teams** entry in the dashboard profile dropdown (`Nav/footer.tsx`) is noise. This shows it only when the user has ≥1 team membership — reusing the same `teamMemberships?.length > 0` condition the dropdown already uses to list memberships.

- The Teams feature, controllers, and `/settings/team` route are unchanged and still reachable directly.
- Pure nav-visibility change, no backend/data impact.

Marked against #529, which was filed as an *investigation* — opening this as the concrete, low-risk implementation for review (hide-when-solo rather than full removal, so team users keep the link). Easy to flip to full removal if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784221271&installation_id=134400930&pr_number=5489&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5489&signature=df77f2149424f797f62e9e7f1cf322b64d53c52e05a8904155dcaa13e1959162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Nav-only visibility change with no backend or data impact; team settings remain reachable by URL.
> 
> **Overview**
> The dashboard profile dropdown **Teams** link is now shown only when `loggedInUser.teamMemberships` has at least one entry—the same guard already used for listing team memberships in `footer.tsx`.
> 
> Solo sellers no longer see a Teams menu item; users with team memberships still get the link to `/settings/team`. Backend routes and team settings are unchanged.
> 
> Request specs were updated so the default logged-in user expects no **Teams** item, and the existing team-membership example asserts **Teams** is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adfbcae5cef8f7ccabffdd42e0878d579928a4e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->