### PR TITLE
Send all 2FA emails via SendGrid; retire the Resend auth fallback (#506)

### DIFF
--- a/app/services/email_router_fallback_service.rb
+++ b/app/services/email_router_fallback_service.rb
@@ -5,10 +5,10 @@ class EmailRouterFallbackService
 
   class << self
     def email_provider_for_two_factor(user:)
-      return nil unless Feature.active?(:resend_fallback_for_auth_emails)
-      return nil unless $redis.exists?(RedisKey.email_router_fallback(user.id))
-
-      MailerInfo::EMAIL_PROVIDER_RESEND
+      # #506: all 2FA emails go through SendGrid (speed + deliverability).
+      # The Resend fallback for auth emails is retired — always use the
+      # default provider (SendGrid) by returning nil here.
+      nil
     end
 
     def record_email_sent(user:)


### PR DESCRIPTION
Addresses antiwork/gumroad-private#506.

2FA emails already **default to SendGrid** (`MailerInfo.default_delivery_method_options` → SendGrid). The only Resend path was `EmailRouterFallbackService.email_provider_for_two_factor`, which returned Resend for a within-5-min **resend** when the `resend_fallback_for_auth_emails` feature flag was active. Per #506 (SendGrid = speed + deliverability — and the 2FA mailer already carried a `TODO(ershad): remove once the Resend issue is resolved`), this retires that fallback so **every** 2FA email, including resends, uses SendGrid.

- One-line behavioral change: `email_provider_for_two_factor` now always returns `nil` (→ SendGrid default).
- The `resend_fallback_for_auth_emails` flag becomes a no-op; `record_email_sent`/`clear` are now harmless dead code — left in place to keep the diff minimal, can be removed in a follow-up.
- No template/recipient changes; SendGrid was already the primary, so this only removes the rare Resend resend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784221471&installation_id=134400930&pr_number=5490&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5490&signature=c8b206279d633d16a8173e0e5939bd5e462ecd761880cb4f2994cee825a5bc6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-method behavior change on auth email routing with SendGrid already the primary path; no template or recipient changes.
> 
> **Overview**
> **Retires the Resend fallback for two-factor authentication emails** so every 2FA send—including quick resends—uses the default provider (SendGrid) instead of occasionally switching to Resend.
> 
> `EmailRouterFallbackService.email_provider_for_two_factor` no longer checks the `resend_fallback_for_auth_emails` feature flag or the per-user Redis “recently sent” key; it **always returns `nil`**, which keeps the existing mailer default (SendGrid). `record_email_sent` and `clear` are unchanged but no longer affect routing; they can be removed in a follow-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50ef7fde5bfe9dba1eff71f2042c8bafd264dec0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->