### PR TITLE
Alert when custom-domain SSL renewal exhausts retries (#488)

### DIFF
--- a/app/sidekiq/generate_ssl_certificate.rb
+++ b/app/sidekiq/generate_ssl_certificate.rb
@@ -4,6 +4,22 @@ class GenerateSslCertificate
   include Sidekiq::Job
   sidekiq_options retry: 5, queue: :low
 
+  # #488: surface silently-stuck SSL renewals. Once retries are exhausted the
+  # ACME order has failed and `ssl_certificate_issued_at` stays NULL with no
+  # other signal — report it so a stuck domain is caught without a support
+  # ticket (one such domain was down over HTTPS for ~4 months unnoticed).
+  sidekiq_retries_exhausted do |msg, exception|
+    custom_domain_id = msg["args"].first
+    domain = CustomDomain.find_by(id: custom_domain_id)&.domain
+    ErrorNotifier.notify(
+      "GenerateSslCertificate exhausted retries — SSL certificate not provisioned (ssl_certificate_issued_at remains unset)",
+      custom_domain_id:,
+      domain:,
+      exception_class: exception&.class&.name,
+      exception_message: exception&.message
+    )
+  end
+
   def perform(id)
     if SslCertificates::Generate.supported_environment?
       custom_domain = CustomDomain.find(id)


### PR DESCRIPTION
Addresses ask #3 of antiwork/gumroad-private#488.

`GenerateSslCertificate` is `retry: 5` then silently gives up — no failure flag on the record, no alert — so a domain whose Let's Encrypt ACME order keeps failing stays on an expired cert (`ssl_certificate_issued_at` NULL) until a customer files a ticket. Per the issue, one domain (`resellingguide.ai`) was down over HTTPS for **~4 months** unnoticed.

This adds a `sidekiq_retries_exhausted` hook that reports to Sentry via the existing `ErrorNotifier` (same pattern as `HandleNewBankAccountWorker`), with `custom_domain_id`, `domain`, and the underlying exception — so stuck renewals surface proactively. No happy-path change, no migration.

Out of scope here (need production access): ask #1 (pull Sidekiq/Sentry logs for domain 36820) and ask #2 (force re-provision that domain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784221600&installation_id=134400930&pr_number=5491&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5491&signature=c9a67239e0d25e95d33cb910eb99b507b1b40c8ab8202ad5be9c3914bb216de3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change on failure after retries; no change to SSL provisioning logic or data migrations.
> 
> **Overview**
> **`GenerateSslCertificate`** previously stopped retrying after five failures with no record flag or alert, so ACME failures could leave **`ssl_certificate_issued_at`** unset and HTTPS broken until someone noticed.
> 
> This PR adds a **`sidekiq_retries_exhausted`** hook that calls **`ErrorNotifier.notify`** (same pattern as other Sidekiq workers) with **`custom_domain_id`**, hostname, and the underlying exception. The **`perform`** path and retry count are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4651a5b0f3f9bbdd9f027e21e4d07d4bde58233d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->