### PR TITLE
Add opt-in grace period for old single chargebacks at checkout

### DIFF
--- a/app/modules/purchase/risk.rb
+++ b/app/modules/purchase/risk.rb
@@ -77,7 +77,9 @@ module Purchase::Risk
     def chargebacks_within_grace_period?(chargebacked_purchases)
       return false if Feature.inactive?(:chargeback_grace_period)
 
-      unique_chargebacked_purchases = chargebacked_purchases.uniq(&:id)
+      unique_chargebacked_purchases = chargebacked_purchases.uniq do |purchase|
+        purchase.bundle_purchase&.id || purchase.id
+      end
       return false if unique_chargebacked_purchases.count > CHARGEBACK_GRACE_LIMIT
 
       unique_chargebacked_purchases.all? { _1.chargeback_date < CHARGEBACK_GRACE_PERIOD.ago }

--- a/app/modules/purchase/risk.rb
+++ b/app/modules/purchase/risk.rb
@@ -3,6 +3,8 @@
 module Purchase::Risk
   IP_PROXY_THRESHOLD = 2
   CHECK_FOR_FRAUD_TIMEOUT_SECONDS = 4
+  CHARGEBACK_GRACE_PERIOD = 1.year
+  CHARGEBACK_GRACE_LIMIT = 1
 
   def check_for_fraud
     Timeout.timeout(CHECK_FOR_FRAUD_TIMEOUT_SECONDS) do
@@ -64,10 +66,21 @@ module Purchase::Risk
     end
 
     def check_for_past_chargebacks
-      return if find_past_chargebacked_purchases.none?
+      chargebacked_purchases = find_past_chargebacked_purchases
+      return if chargebacked_purchases.none?
+      return if chargebacks_within_grace_period?(chargebacked_purchases)
 
       self.error_code = PurchaseErrorCode::BUYER_CHARGED_BACK
       errors.add :base, "There's an active chargeback on one of your past Gumroad purchases. Please withdraw it by contacting your charge processor and try again later."
+    end
+
+    def chargebacks_within_grace_period?(chargebacked_purchases)
+      return false if Feature.inactive?(:chargeback_grace_period)
+
+      unique_chargebacked_purchases = chargebacked_purchases.uniq(&:id)
+      return false if unique_chargebacked_purchases.count > CHARGEBACK_GRACE_LIMIT
+
+      unique_chargebacked_purchases.all? { _1.chargeback_date < CHARGEBACK_GRACE_PERIOD.ago }
     end
 
     def check_for_past_fraudulent_buyers

--- a/spec/modules/purchase/risk_spec.rb
+++ b/spec/modules/purchase/risk_spec.rb
@@ -84,6 +84,20 @@ describe Purchase::Risk do
       end
     end
 
+    context "when the chargeback grace period feature is inactive" do
+      before do
+        Feature.deactivate(:chargeback_grace_period)
+      end
+
+      it "adds the chargeback error for exactly one unreversed chargeback older than one year" do
+        create(:purchase, link: product, email: "test@example.com", chargeback_date: 2.years.ago)
+
+        expect { new_purchase.send(:check_for_past_chargebacks) }
+          .to change { new_purchase.error_code }.from(nil).to(PurchaseErrorCode::BUYER_CHARGED_BACK)
+          .and change { new_purchase.errors.count }.by(1)
+      end
+    end
+
     context "when the chargeback grace period feature is active" do
       before do
         Feature.activate(:chargeback_grace_period)
@@ -128,6 +142,19 @@ describe Purchase::Risk do
 
       it "counts the same old chargeback once when it matches by both email and browser_guid" do
         create(:purchase, link: product, email: "test@example.com", browser_guid: "test-guid-123", chargeback_date: 2.years.ago)
+
+        expect { new_purchase.send(:check_for_past_chargebacks) }.not_to change { new_purchase.errors.count }
+        expect(new_purchase.error_code).to be_nil
+      end
+
+      it "counts one old bundle chargeback once when bundle product purchases also match" do
+        bundle = create(:product, :bundle)
+        bundle_purchase = create(:purchase, link: bundle, email: "test@example.com",
+                                            browser_guid: "test-guid-123", is_bundle_purchase: true,
+                                            chargeback_date: 2.years.ago)
+
+        Purchase::CreateBundleProductPurchaseService.new(bundle_purchase, bundle.bundle_products.first).perform
+        bundle_purchase.product_purchases.first.update!(chargeback_date: bundle_purchase.chargeback_date)
 
         expect { new_purchase.send(:check_for_past_chargebacks) }.not_to change { new_purchase.errors.count }
         expect(new_purchase.error_code).to be_nil

--- a/spec/modules/purchase/risk_spec.rb
+++ b/spec/modules/purchase/risk_spec.rb
@@ -84,6 +84,56 @@ describe Purchase::Risk do
       end
     end
 
+    context "when the chargeback grace period feature is active" do
+      before do
+        Feature.activate(:chargeback_grace_period)
+      end
+
+      after do
+        Feature.deactivate(:chargeback_grace_period)
+      end
+
+      it "does not add errors for exactly one unreversed chargeback older than one year" do
+        create(:purchase, link: product, email: "test@example.com", chargeback_date: 1.year.ago - 1.day)
+
+        expect { new_purchase.send(:check_for_past_chargebacks) }.not_to change { new_purchase.errors.count }
+        expect(new_purchase.error_code).to be_nil
+      end
+
+      it "still adds the chargeback error for one unreversed chargeback within the last year" do
+        create(:purchase, link: product, email: "test@example.com", chargeback_date: 1.year.ago + 1.day)
+
+        expect { new_purchase.send(:check_for_past_chargebacks) }
+          .to change { new_purchase.error_code }.from(nil).to(PurchaseErrorCode::BUYER_CHARGED_BACK)
+          .and change { new_purchase.errors.count }.by(1)
+      end
+
+      it "still adds the chargeback error for multiple old unreversed chargebacks" do
+        create(:purchase, link: product, email: "test@example.com", chargeback_date: 2.years.ago)
+        create(:purchase, link: product, email: "test@example.com", chargeback_date: 3.years.ago)
+
+        expect { new_purchase.send(:check_for_past_chargebacks) }
+          .to change { new_purchase.error_code }.from(nil).to(PurchaseErrorCode::BUYER_CHARGED_BACK)
+          .and change { new_purchase.errors.count }.by(1)
+      end
+
+      it "still adds the chargeback error when an old chargeback is accompanied by a recent chargeback" do
+        create(:purchase, link: product, email: "test@example.com", chargeback_date: 2.years.ago)
+        create(:purchase, link: product, email: "test@example.com", chargeback_date: 1.month.ago)
+
+        expect { new_purchase.send(:check_for_past_chargebacks) }
+          .to change { new_purchase.error_code }.from(nil).to(PurchaseErrorCode::BUYER_CHARGED_BACK)
+          .and change { new_purchase.errors.count }.by(1)
+      end
+
+      it "counts the same old chargeback once when it matches by both email and browser_guid" do
+        create(:purchase, link: product, email: "test@example.com", browser_guid: "test-guid-123", chargeback_date: 2.years.ago)
+
+        expect { new_purchase.send(:check_for_past_chargebacks) }.not_to change { new_purchase.errors.count }
+        expect(new_purchase.error_code).to be_nil
+      end
+    end
+
     context "when there is a past chargeback by browser_guid" do
       before do
         create(:purchase, link: product, browser_guid: "test-guid-123", chargeback_date: Time.current)


### PR DESCRIPTION
## What

Adds an **opt-in grace period** to the past-chargeback check in `Purchase::Risk` so that a single, old, unreversed chargeback no longer permanently blocks an otherwise-legitimate buyer from checking out.

Today, `check_for_past_chargebacks` blocks **any** buyer with an unreversed chargeback on a matching email or browser GUID — regardless of how old it is or how many there are. A buyer with one dispute from years ago is treated identically to an active serial abuser. We routinely see support tickets from real, long-history customers blocked by a single chargeback from 5+ years ago, where the only remediation is a manual Rails console flag flip.

## Behavior

A past chargeback is **forgiven** only when **both** conditions hold:

1. It is the buyer's **only** unreversed chargeback (`CHARGEBACK_GRACE_LIMIT = 1`), and
2. It is **older than the grace window** (`CHARGEBACK_GRACE_PERIOD = 1.year`).

| Scenario | Result |
|---|---|
| Recent chargeback (≤ 1yr), any count | **blocks** (unchanged) |
| 1 old chargeback (> 1yr) | forgiven → allowed |
| 2+ old chargebacks | **blocks** |
| old + recent mixed | **blocks** |
| reversed chargeback | allowed (unchanged) |

The intersection of *count* and *age* is deliberate: pure count-based grace would hand every active fraudster one free chargeback, and a recent dispute keeps its full predictive value. Only a single, stale dispute — which has near-zero correlation with current fraud — is waved through.

## Zero blast radius on merge

The whole path is gated behind `Feature.active?(:chargeback_grace_period)`. **Flag OFF (default) = today's exact behavior.** This ships dark; the team flips the flag on after review, and the threshold/limit constants are easy to tune from one place.

## Edge case handled

`find_past_chargebacked_purchases` concatenates email-matched and GUID-matched purchases, so a purchase matching both would appear twice. The grace check de-dupes by `id` (`uniq(&:id)`) before counting, so one chargeback that matches on both vectors is correctly counted once. Covered by a test.

## Tests

`spec/modules/purchase/risk_spec.rb` — 5 new examples covering: default-off preserves blocking; one old chargeback forgiven; recent / multiple / mixed still block; double-match counted once. Full file green locally:

```
39 examples, 0 failures
```

(Fast specs only; no system specs touched.)

Generated by Gumclaw.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784225117&installation_id=134400930&pr_number=5493&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5493&signature=4800210beab6583acf4aa49c5fed441a48ad87792691ad873a68dd1bdbe0a380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches purchase fraud/chargeback gating at checkout; risk is mitigated by a default-off feature flag and narrow count+age rules, but enabling the flag weakens blocking for some buyers with chargeback history.
> 
> **Overview**
> Adds an **opt-in** path in `Purchase::Risk` so checkout no longer blocks buyers who have exactly **one** unreversed chargeback **older than one year**, when `:chargeback_grace_period` is enabled.
> 
> `check_for_past_chargebacks` now bails out via `chargebacks_within_grace_period?` instead of always setting `BUYER_CHARGED_BACK`. Grace requires the feature flag, at most `CHARGEBACK_GRACE_LIMIT` unique chargebacks (deduped by bundle parent or purchase id), and every such chargeback before `CHARGEBACK_GRACE_PERIOD.ago`. Recent chargebacks, multiple old ones, or old+recent mixes still block.
> 
> **Default behavior is unchanged** while the flag is off. Specs cover flag-off parity, forgiven single stale chargeback, continued blocking for recent/multiple/mixed cases, email+GUID double-count, and bundle chargeback dedupe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ccc6dcf0a753cdb7ba91b75ac01cb33a800c8ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->