### PR TITLE
Add 60s cooldown to 2FA resend token button

### DIFF
--- a/app/controllers/concerns/two_factor_authentication_validator.rb
+++ b/app/controllers/concerns/two_factor_authentication_validator.rb
@@ -5,7 +5,10 @@ module TwoFactorAuthenticationValidator
 
   TWO_FACTOR_AUTH_USER_ID_SESSION_NAME = :verify_two_factor_auth_for
   TWO_FACTOR_AUTH_METHOD_SESSION_NAME = :two_factor_auth_method
-  private_constant :TWO_FACTOR_AUTH_USER_ID_SESSION_NAME, :TWO_FACTOR_AUTH_METHOD_SESSION_NAME
+  TWO_FACTOR_AUTH_TOKEN_SENT_AT_SESSION_NAME = :two_factor_auth_token_sent_at
+  RESEND_AUTHENTICATION_TOKEN_COOLDOWN = 60.seconds
+  private_constant :TWO_FACTOR_AUTH_USER_ID_SESSION_NAME, :TWO_FACTOR_AUTH_METHOD_SESSION_NAME,
+                   :TWO_FACTOR_AUTH_TOKEN_SENT_AT_SESSION_NAME, :RESEND_AUTHENTICATION_TOKEN_COOLDOWN
 
   def skip_two_factor_authentication?(user)
     # Skip 2FA if it's not enabled for the user
@@ -36,7 +39,23 @@ module TwoFactorAuthenticationValidator
       return if params[:next] && params[:next].include?(verify_two_factor_authentication_path(format: :html))
 
       user.send_authentication_token!
+      mark_authentication_token_sent
     end
+  end
+
+  def mark_authentication_token_sent
+    session[TWO_FACTOR_AUTH_TOKEN_SENT_AT_SESSION_NAME] = Time.current.to_i
+  end
+
+  def authentication_token_sent_at
+    session[TWO_FACTOR_AUTH_TOKEN_SENT_AT_SESSION_NAME]
+  end
+
+  def resend_authentication_token_cooldown_seconds
+    sent_at = authentication_token_sent_at
+    return 0 if sent_at.blank?
+
+    [RESEND_AUTHENTICATION_TOKEN_COOLDOWN.to_i - (Time.current.to_i - sent_at), 0].max
   end
 
   def two_factor_auth_method
@@ -56,6 +75,7 @@ module TwoFactorAuthenticationValidator
   def reset_two_factor_auth_login_session
     session.delete(TWO_FACTOR_AUTH_USER_ID_SESSION_NAME)
     session.delete(TWO_FACTOR_AUTH_METHOD_SESSION_NAME)
+    session.delete(TWO_FACTOR_AUTH_TOKEN_SENT_AT_SESSION_NAME)
   end
 
   def set_two_factor_auth_cookie(user)

--- a/app/controllers/two_factor_authentication_controller.rb
+++ b/app/controllers/two_factor_authentication_controller.rb
@@ -16,7 +16,9 @@ class TwoFactorAuthenticationController < ApplicationController
       user_id: @user.encrypted_external_id,
       email: @user.email,
       token: (User::DEFAULT_AUTH_TOKEN unless Rails.env.production?),
-      two_factor_method: two_factor_auth_method
+      two_factor_method: two_factor_auth_method,
+      token_sent_at: authentication_token_sent_at,
+      resend_cooldown_seconds: resend_authentication_token_cooldown_seconds
     }
   end
 
@@ -35,6 +37,7 @@ class TwoFactorAuthenticationController < ApplicationController
     end
 
     @user.send_authentication_token!
+    mark_authentication_token_sent
 
     redirect_to two_factor_authentication_path, notice: "Resent the authentication token, please check your inbox.", status: :see_other
   end
@@ -42,6 +45,7 @@ class TwoFactorAuthenticationController < ApplicationController
   def switch_to_email
     self.two_factor_auth_method = "email"
     @user.send_authentication_token!
+    mark_authentication_token_sent
 
     redirect_to two_factor_authentication_path, notice: "Authentication token sent to #{@user.email}.", status: :see_other
   end

--- a/app/javascript/pages/TwoFactorAuthentication/Show.tsx
+++ b/app/javascript/pages/TwoFactorAuthentication/Show.tsx
@@ -17,10 +17,20 @@ type PageProps = {
   token: string | null;
   authenticity_token: string;
   two_factor_method: TwoFactorMethod;
+  token_sent_at: number | null;
+  resend_cooldown_seconds: number;
 };
 
 function TwoFactorAuthentication() {
-  const { user_id, email, token: initialToken, authenticity_token, two_factor_method } = usePage<PageProps>().props;
+  const {
+    user_id,
+    email,
+    token: initialToken,
+    authenticity_token,
+    two_factor_method,
+    token_sent_at,
+    resend_cooldown_seconds,
+  } = usePage<PageProps>().props;
   const next = new URL(useOriginalLocation()).searchParams.get("next");
   const uid = React.useId();
 
@@ -30,6 +40,22 @@ function TwoFactorAuthentication() {
 
   const [token, setToken] = React.useState(initialToken ?? "");
   const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const [resendCooldown, setResendCooldown] = React.useState(resend_cooldown_seconds);
+
+  React.useEffect(() => {
+    setResendCooldown(resend_cooldown_seconds);
+  }, [token_sent_at, resend_cooldown_seconds]);
+
+  React.useEffect(() => {
+    if (resendCooldown <= 0) return;
+    const timer = setTimeout(() => setResendCooldown((seconds) => seconds - 1), 1000);
+    return () => clearTimeout(timer);
+  }, [resendCooldown]);
+
+  const resendToken = () => {
+    if (switchForm.processing || resendCooldown > 0) return;
+    switchForm.post(Routes.resend_authentication_token_path({ user_id }));
+  };
 
   const submitCode = (token: string) => {
     if (isSubmitting) return;
@@ -102,11 +128,10 @@ function TwoFactorAuthentication() {
             switch (two_factor_method) {
               case "email":
                 return (
-                  <Button
-                    disabled={switchForm.processing}
-                    onClick={() => switchForm.post(Routes.resend_authentication_token_path({ user_id }))}
-                  >
-                    Resend Authentication Token
+                  <Button disabled={switchForm.processing || resendCooldown > 0} onClick={resendToken}>
+                    {resendCooldown > 0
+                      ? `Resend Authentication Token in ${resendCooldown}s`
+                      : "Resend Authentication Token"}
                   </Button>
                 );
               case "totp":

--- a/spec/controllers/concerns/two_factor_authentication_validator_spec.rb
+++ b/spec/controllers/concerns/two_factor_authentication_validator_spec.rb
@@ -150,6 +150,14 @@ describe TwoFactorAuthenticationValidator, type: :controller do
           controller.prepare_for_two_factor_authentication(@user)
         end.to have_enqueued_mail(TwoFactorAuthenticationMailer, :authentication_token).with(@user.id, email_provider: nil)
       end
+
+      it "records when the authentication token was sent in the session" do
+        freeze_time do
+          controller.prepare_for_two_factor_authentication(@user)
+
+          expect(session[:two_factor_auth_token_sent_at]).to eq(Time.current.to_i)
+        end
+      end
     end
 
     context "when user has TOTP enabled" do
@@ -173,6 +181,12 @@ describe TwoFactorAuthenticationValidator, type: :controller do
             controller.prepare_for_two_factor_authentication(@user)
           end.not_to have_enqueued_mail(TwoFactorAuthenticationMailer, :authentication_token)
         end
+
+        it "does not record a token-sent time" do
+          controller.prepare_for_two_factor_authentication(@user)
+
+          expect(session[:two_factor_auth_token_sent_at]).to be_nil
+        end
       end
 
       context "when authenticator_2fa flag is not active for the user" do
@@ -195,6 +209,32 @@ describe TwoFactorAuthenticationValidator, type: :controller do
         controller.prepare_for_two_factor_authentication(@user)
 
         expect(controller.two_factor_auth_method).to eq("email")
+      end
+    end
+  end
+
+  describe "#resend_authentication_token_cooldown_seconds" do
+    it "returns 0 when no token has been sent" do
+      expect(controller.resend_authentication_token_cooldown_seconds).to eq(0)
+    end
+
+    it "returns the full cooldown immediately after a token is sent" do
+      freeze_time do
+        controller.prepare_for_two_factor_authentication(@user)
+
+        expect(controller.resend_authentication_token_cooldown_seconds).to eq(60)
+      end
+    end
+
+    it "decreases as time passes and reaches 0 after the cooldown elapses" do
+      travel_to(Time.current) do
+        controller.prepare_for_two_factor_authentication(@user)
+
+        travel 25.seconds
+        expect(controller.resend_authentication_token_cooldown_seconds).to eq(35)
+
+        travel 36.seconds
+        expect(controller.resend_authentication_token_cooldown_seconds).to eq(0)
       end
     end
   end
@@ -224,11 +264,12 @@ describe TwoFactorAuthenticationValidator, type: :controller do
       controller.prepare_for_two_factor_authentication(@user)
     end
 
-    it "removes the user_id and method from session" do
+    it "removes the user_id, method, and token-sent time from session" do
       controller.reset_two_factor_auth_login_session
 
       expect(session[:verify_two_factor_auth_for]).to be_nil
       expect(session[:two_factor_auth_method]).to be_nil
+      expect(session[:two_factor_auth_token_sent_at]).to be_nil
     end
   end
 end

--- a/spec/controllers/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication_controller_spec.rb
@@ -116,6 +116,17 @@ describe TwoFactorAuthenticationController, type: :controller, inertia: true do
       expect(inertia.props[:token]).to eq(User::DEFAULT_AUTH_TOKEN)
     end
 
+    it "exposes the resend cooldown derived from when the token was sent" do
+      freeze_time do
+        controller.prepare_for_two_factor_authentication(@user)
+
+        get :show
+
+        expect(inertia.props[:token_sent_at]).to eq(Time.current.to_i)
+        expect(inertia.props[:resend_cooldown_seconds]).to eq(60)
+      end
+    end
+
     it "sets the page title" do
       get :show
 
@@ -152,6 +163,12 @@ describe TwoFactorAuthenticationController, type: :controller, inertia: true do
 
         expect(flash[:notice]).to eq "Successfully logged in!"
         expect(response).to redirect_to(controller.send(:login_path_for, @user))
+      end
+
+      it "clears the token-sent time from the session" do
+        post :create, params: { token: @user.otp_code, user_id: @user.encrypted_external_id }
+
+        expect(session[:two_factor_auth_token_sent_at]).to be_nil
       end
 
       it_behaves_like "merge guest cart with user cart" do
@@ -246,6 +263,14 @@ describe TwoFactorAuthenticationController, type: :controller, inertia: true do
       expect(flash[:notice]).to eq "Resent the authentication token, please check your inbox."
     end
 
+    it "records the token-sent time so the cooldown restarts" do
+      freeze_time do
+        post :resend_authentication_token, params: { user_id: @user.encrypted_external_id }
+
+        expect(session[:two_factor_auth_token_sent_at]).to eq(Time.current.to_i)
+      end
+    end
+
     context "when user has TOTP enabled" do
       before do
         Feature.activate_user(:authenticator_2fa, @user)
@@ -301,6 +326,14 @@ describe TwoFactorAuthenticationController, type: :controller, inertia: true do
       expect(controller.send(:two_factor_auth_method)).to eq("email")
       expect(response).to redirect_to(two_factor_authentication_path)
       expect(flash[:notice]).to eq "Authentication token sent to #{@user.email}."
+    end
+
+    it "records the token-sent time so the cooldown starts" do
+      freeze_time do
+        post :switch_to_email, params: { user_id: @user.encrypted_external_id }
+
+        expect(session[:two_factor_auth_token_sent_at]).to eq(Time.current.to_i)
+      end
     end
   end
 

--- a/spec/requests/two_factor_authentication_spec.rb
+++ b/spec/requests/two_factor_authentication_spec.rb
@@ -109,14 +109,22 @@ describe "Two-Factor Authentication", js: true, type: :system do
   end
 
   describe "Resend authentication token" do
-    it "resends the authentication token" do
+    it "disables the resend button during the cooldown after login" do
+      login_to_app
+      expect(page).to have_content "Two-Factor Authentication"
+
+      expect(page).to have_button("Resend Authentication Token", disabled: true)
+    end
+
+    it "resends the authentication token once the cooldown allows it" do
+      stub_const("TwoFactorAuthenticationValidator::RESEND_AUTHENTICATION_TOKEN_COOLDOWN", 0.seconds)
+
       expect do
         login_to_app
         expect(page).to have_content "Two-Factor Authentication"
 
         click_on "Resend Authentication Token"
 
-        # Wait for the success message to appear (flash notice from the redirect)
         expect(page).to have_content "Resent the authentication token"
       end.to have_enqueued_mail(TwoFactorAuthenticationMailer, :authentication_token).twice.with(user.id, email_provider: nil)
     end
@@ -151,7 +159,7 @@ describe "Two-Factor Authentication", js: true, type: :system do
 
         expect(page).to have_content "Authentication token sent to #{user.email}."
         expect(page).to have_content "Authentication Token"
-        expect(page).to have_button "Resend Authentication Token"
+        expect(page).to have_button("Resend Authentication Token", disabled: true)
         expect(page).not_to have_button "Use email instead"
       end.to have_enqueued_mail(TwoFactorAuthenticationMailer, :authentication_token).once.with(user.id, email_provider: nil)
 


### PR DESCRIPTION
## What

Adds a 60-second cooldown to the **Resend Authentication Token** button on the email two-factor login screen. While the cooldown is active the button is disabled and its label counts down the remaining time (`Resend Authentication Token in 59s` → … → `Resend Authentication Token`).

## Why

Nothing stopped a user from clicking resend repeatedly and triggering a burst of authentication-token emails. This throttles that in the UI.

The cooldown is anchored to a **server-side timestamp** rather than ephemeral client state. That keeps the behavior correct across the cases that matter:

- It survives a page reload — reloading mid-cooldown shows the correct remaining time instead of resetting to 60.
- It resets exactly on a successful login.
- It can't be casually bypassed by re-rendering the component.

This remains a UX gate. Abuse of the endpoint itself is still guarded server-side by the existing Rack::Attack throttle on `POST /two-factor/resend_authentication_token`.

## Implementation

- The send time is stored in the session whenever the email token is sent — initial login (`prepare_for_two_factor_authentication`), `resend_authentication_token`, and `switch_to_email`.
- `resend_authentication_token_cooldown_seconds` computes the remaining seconds (`60 - elapsed`, floored at 0); the two-factor page renders it as an Inertia prop.
- The frontend initializes its countdown from that prop, ticks it down once per second, and disables resend until it reaches 0. After a resend, the page reloads with a fresh value and the countdown restarts.
- The timestamp is cleared in `reset_two_factor_auth_login_session`, so it's removed once the user signs in.

## Before/After

_Video to be added._

## Test Results

Controller and concern specs pass locally; Rubocop and ESLint are clean on the changed files.

_Screenshot to be added._

---

🤖 AI disclosure: Implemented with Claude Opus 4.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784229186&installation_id=134400930&pr_number=5495&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5495&signature=d76a59706dc8addeb24955838c8e185367d3580dd9e6bfcf3adc41d58b016b31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the 2FA login flow and session state, but only gates the resend UX; endpoint abuse still relies on existing Rack::Attack throttling rather than a new server-side resend cooldown check.
> 
> **Overview**
> Adds a **60-second resend cooldown** for email two-factor login so users cannot spam **Resend Authentication Token** from the UI.
> 
> The server records `two_factor_auth_token_sent_at` in the session whenever an email token is sent (initial 2FA prep, resend, and switch-to-email), exposes remaining seconds via Inertia (`resend_cooldown_seconds`), and clears that timestamp when the 2FA login session resets. The **TwoFactorAuthentication/Show** page disables resend while cooldown is active, shows a per-second countdown label, and restarts from server props after reload or redirect.
> 
> Specs cover cooldown math, session lifecycle, controller props, and system tests for the disabled button (with cooldown stubbed to 0 for the happy-path resend).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ae9dbd12350c52f9e33e6e0bd8ee4dd91c4d1dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->