### PR TITLE
Expose Stripe Connect / payout / bank fields in internal admin API (#530)

### DIFF
--- a/app/controllers/api/internal/admin/base_controller.rb
+++ b/app/controllers/api/internal/admin/base_controller.rb
@@ -380,13 +380,14 @@ class Api::Internal::Admin::BaseController < Api::Internal::BaseController
         bank_account_visual: bank_account&.account_number_visual,
         paypal_email: payment.payment_address,
         trace_id: nil,
-        stripe_payout_id: payment.stripe_transfer_id,
+        stripe_transfer_id: payment.stripe_transfer_id,
         bank_account: serialize_payout_bank_account(bank_account)
       }
     end
 
     def serialize_payout_bank_account(bank_account)
       return nil if bank_account.nil?
+      return nil if bank_account.is_a?(CardBankAccount)
 
       {
         bank_number: bank_account.routing_number,

--- a/app/controllers/api/internal/admin/base_controller.rb
+++ b/app/controllers/api/internal/admin/base_controller.rb
@@ -369,6 +369,7 @@ class Api::Internal::Admin::BaseController < Api::Internal::BaseController
     end
 
     def serialize_payout(payment)
+      bank_account = payment.bank_account
       {
         external_id: payment.external_id,
         amount_cents: payment.amount_cents,
@@ -376,8 +377,22 @@ class Api::Internal::Admin::BaseController < Api::Internal::BaseController
         state: payment.state,
         created_at: payment.created_at.as_json,
         processor: payment.processor,
-        bank_account_visual: payment.bank_account&.account_number_visual,
-        paypal_email: payment.payment_address
+        bank_account_visual: bank_account&.account_number_visual,
+        paypal_email: payment.payment_address,
+        trace_id: nil,
+        stripe_payout_id: payment.stripe_transfer_id,
+        bank_account: serialize_payout_bank_account(bank_account)
+      }
+    end
+
+    def serialize_payout_bank_account(bank_account)
+      return nil if bank_account.nil?
+
+      {
+        bank_number: bank_account.routing_number,
+        account_holder_full_name: bank_account.account_holder_full_name,
+        account_type: bank_account.account_type,
+        currency: bank_account.currency
       }
     end
 

--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -790,8 +790,53 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
           total_earnings_formatted: Money.from_cents(user.sales_cents_total).format,
           unpaid_balance_formatted: Money.from_cents(user.unpaid_balance_cents).format,
           comments_count: user.comments.size
-        }
+        },
+        stripe: serialize_stripe_connect(user),
+        admin_links: serialize_admin_links(user)
       }
+    end
+
+    def serialize_stripe_connect(user)
+      merchant_account = user.merchant_accounts.alive.stripe.first
+      account_id = merchant_account&.charge_processor_merchant_id
+      return { connected: false } if account_id.blank?
+
+      {
+        connected: true,
+        stripe_connect_account_id: account_id,
+        stripe_dashboard_url: "https://dashboard.stripe.com/connect/accounts/#{account_id}",
+        verification: serialize_stripe_verification(account_id)
+      }
+    end
+
+    def serialize_stripe_verification(account_id)
+      stripe_account = Stripe::Account.retrieve(account_id)
+      requirements = stripe_account.requirements
+      {
+        charges_enabled: stripe_account.charges_enabled,
+        payouts_enabled: stripe_account.payouts_enabled,
+        details_submitted: stripe_account.details_submitted,
+        disabled_reason: requirements&.disabled_reason,
+        currently_due_count: Array(requirements&.currently_due).size,
+        past_due_count: Array(requirements&.past_due).size,
+        pending_verification_count: Array(requirements&.pending_verification).size
+      }
+    rescue Stripe::StripeError, *INTERNET_EXCEPTIONS => e
+      { error: e.message }
+    end
+
+    def serialize_admin_links(user)
+      links = {
+        impersonate: admin_impersonate_helper_action_url(user_external_id: user.external_id, host: UrlService.domain_with_protocol),
+        admin_user: admin_user_url(user, host: UrlService.domain_with_protocol),
+        admin_purchases: admin_search_purchases_url(query: user.email, host: UrlService.domain_with_protocol)
+      }
+
+      if user.merchant_accounts.alive.stripe.first&.charge_processor_merchant_id
+        links[:stripe_dashboard] = admin_stripe_dashboard_helper_action_url(user_external_id: user.external_id, host: UrlService.domain_with_protocol)
+      end
+
+      links
     end
 
     def serialize_sign_in(user)

--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -760,6 +760,7 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
 
     def serialize_user_info(user)
       compliance_info = user.alive_user_compliance_info
+      stripe_merchant_account = user.merchant_accounts.alive.stripe.first
 
       {
         id: user.external_id,
@@ -791,13 +792,12 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
           unpaid_balance_formatted: Money.from_cents(user.unpaid_balance_cents).format,
           comments_count: user.comments.size
         },
-        stripe: serialize_stripe_connect(user),
-        admin_links: serialize_admin_links(user)
+        stripe: serialize_stripe_connect(stripe_merchant_account),
+        admin_links: serialize_admin_links(user, stripe_merchant_account)
       }
     end
 
-    def serialize_stripe_connect(user)
-      merchant_account = user.merchant_accounts.alive.stripe.first
+    def serialize_stripe_connect(merchant_account)
       account_id = merchant_account&.charge_processor_merchant_id
       return { connected: false } if account_id.blank?
 
@@ -825,14 +825,14 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
       { error: e.message }
     end
 
-    def serialize_admin_links(user)
+    def serialize_admin_links(user, merchant_account)
       links = {
         impersonate: admin_impersonate_helper_action_url(user_external_id: user.external_id, host: UrlService.domain_with_protocol),
         admin_user: admin_user_url(user, host: UrlService.domain_with_protocol),
         admin_purchases: admin_search_purchases_url(query: user.email, host: UrlService.domain_with_protocol)
       }
 
-      if user.merchant_accounts.alive.stripe.first&.charge_processor_merchant_id
+      if merchant_account&.charge_processor_merchant_id
         links[:stripe_dashboard] = admin_stripe_dashboard_helper_action_url(user_external_id: user.external_id, host: UrlService.domain_with_protocol)
       end
 

--- a/spec/controllers/api/internal/admin/payouts_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/payouts_controller_spec.rb
@@ -63,13 +63,47 @@ describe Api::Internal::Admin::PayoutsController do
         "state" => payment1.state,
         "processor" => payment1.processor,
         "bank_account_visual" => "******6789",
-        "paypal_email" => nil
+        "paypal_email" => nil,
+        "trace_id" => nil,
+        "stripe_payout_id" => payment1.stripe_transfer_id,
+        "bank_account" => {
+          "bank_number" => "110000000",
+          "account_holder_full_name" => "Stripe Test Account",
+          "account_type" => "checking",
+          "currency" => "usd"
+        }
       )
       expect(payouts.last).to include(
         "external_id" => payment5.external_id,
         "processor" => payment5.processor,
         "bank_account_visual" => nil,
-        "paypal_email" => "payme@example.com"
+        "paypal_email" => "payme@example.com",
+        "trace_id" => nil,
+        "stripe_payout_id" => nil,
+        "bank_account" => nil
+      )
+    end
+
+    it "surfaces the Stripe payout id from stripe_transfer_id and leaves trace_id nil" do
+      stripe_payment = create(:payment_completed,
+                              user:,
+                              processor: PayoutProcessorType::STRIPE,
+                              stripe_transfer_id: "po_1Test",
+                              stripe_connect_account_id: "acct_1Test",
+                              bank_account: create(:ach_account_stripe_succeed, user:))
+
+      get :index, params: { user_id: user.external_id }
+
+      expect(response).to have_http_status(:ok)
+      payout = response.parsed_body["recent_payouts"].find { _1["external_id"] == stripe_payment.external_id }
+      expect(payout["processor"]).to eq(PayoutProcessorType::STRIPE)
+      expect(payout["stripe_payout_id"]).to eq("po_1Test")
+      expect(payout["trace_id"]).to be_nil
+      expect(payout["bank_account"]).to include(
+        "bank_number" => "110000000",
+        "account_holder_full_name" => "Stripe Test Account",
+        "account_type" => "checking",
+        "currency" => "usd"
       )
     end
 

--- a/spec/controllers/api/internal/admin/payouts_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/payouts_controller_spec.rb
@@ -65,7 +65,7 @@ describe Api::Internal::Admin::PayoutsController do
         "bank_account_visual" => "******6789",
         "paypal_email" => nil,
         "trace_id" => nil,
-        "stripe_payout_id" => payment1.stripe_transfer_id,
+        "stripe_transfer_id" => payment1.stripe_transfer_id,
         "bank_account" => {
           "bank_number" => "110000000",
           "account_holder_full_name" => "Stripe Test Account",
@@ -79,12 +79,12 @@ describe Api::Internal::Admin::PayoutsController do
         "bank_account_visual" => nil,
         "paypal_email" => "payme@example.com",
         "trace_id" => nil,
-        "stripe_payout_id" => nil,
+        "stripe_transfer_id" => nil,
         "bank_account" => nil
       )
     end
 
-    it "surfaces the Stripe payout id from stripe_transfer_id and leaves trace_id nil" do
+    it "surfaces the stored Stripe transfer id and leaves trace_id nil" do
       stripe_payment = create(:payment_completed,
                               user:,
                               processor: PayoutProcessorType::STRIPE,
@@ -97,7 +97,7 @@ describe Api::Internal::Admin::PayoutsController do
       expect(response).to have_http_status(:ok)
       payout = response.parsed_body["recent_payouts"].find { _1["external_id"] == stripe_payment.external_id }
       expect(payout["processor"]).to eq(PayoutProcessorType::STRIPE)
-      expect(payout["stripe_payout_id"]).to eq("po_1Test")
+      expect(payout["stripe_transfer_id"]).to eq("po_1Test")
       expect(payout["trace_id"]).to be_nil
       expect(payout["bank_account"]).to include(
         "bank_number" => "110000000",
@@ -105,6 +105,10 @@ describe Api::Internal::Admin::PayoutsController do
         "account_type" => "checking",
         "currency" => "usd"
       )
+    end
+
+    it "omits the bank_account block for card payouts whose routing fields are card metadata, not real bank data" do
+      expect(controller.send(:serialize_payout_bank_account, CardBankAccount.new)).to be_nil
     end
 
     it "excludes soft-deleted payout notes from payout_note" do

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -420,6 +420,97 @@ describe Api::Internal::Admin::UsersController do
         "last_synced_at" => watched_user.last_synced_at.iso8601
       )
     end
+
+    it "reports an unconnected Stripe account when the user has no alive Stripe merchant account" do
+      user = create(:compliant_user, email: "no-stripe@example.com")
+
+      expect(Stripe::Account).not_to receive(:retrieve)
+
+      get :info, params: { email: user.email }
+
+      expect(response.parsed_body["user"]["stripe"]).to eq("connected" => false)
+    end
+
+    it "surfaces the Stripe Connect account id, dashboard url, and live verification state" do
+      user = create(:compliant_user, email: "stripe-connected@example.com")
+      create(:merchant_account, user:, charge_processor_merchant_id: "acct_123abc")
+
+      allow(Stripe::Account).to receive(:retrieve).with("acct_123abc").and_return(
+        double(:account,
+               charges_enabled: true,
+               payouts_enabled: false,
+               details_submitted: true,
+               requirements: double(:requirements,
+                                    disabled_reason: "requirements.past_due",
+                                    currently_due: %w[individual.id_number],
+                                    past_due: %w[external_account],
+                                    pending_verification: []))
+      )
+
+      get :info, params: { email: user.email }
+
+      expect(response.parsed_body["user"]["stripe"]).to eq(
+        "connected" => true,
+        "stripe_connect_account_id" => "acct_123abc",
+        "stripe_dashboard_url" => "https://dashboard.stripe.com/connect/accounts/acct_123abc",
+        "verification" => {
+          "charges_enabled" => true,
+          "payouts_enabled" => false,
+          "details_submitted" => true,
+          "disabled_reason" => "requirements.past_due",
+          "currently_due_count" => 1,
+          "past_due_count" => 1,
+          "pending_verification_count" => 0
+        }
+      )
+    end
+
+    it "makes at most one Stripe call and degrades to an error subfield when Stripe raises" do
+      user = create(:compliant_user, email: "stripe-error@example.com")
+      create(:merchant_account, user:, charge_processor_merchant_id: "acct_revoked")
+
+      expect(Stripe::Account).to receive(:retrieve).with("acct_revoked").once.and_raise(
+        Stripe::PermissionError.new("access revoked")
+      )
+
+      get :info, params: { email: user.email }
+
+      expect(response).to have_http_status(:ok)
+      stripe = response.parsed_body["user"]["stripe"]
+      expect(stripe).to include(
+        "connected" => true,
+        "stripe_connect_account_id" => "acct_revoked",
+        "stripe_dashboard_url" => "https://dashboard.stripe.com/connect/accounts/acct_revoked"
+      )
+      expect(stripe["verification"]).to eq("error" => "access revoked")
+    end
+
+    it "includes admin helper links keyed on the user external id and email" do
+      user = create(:compliant_user, email: "links@example.com")
+
+      get :info, params: { email: user.email }
+
+      links = response.parsed_body["user"]["admin_links"]
+      expect(links["impersonate"]).to include("/admin/helper_actions/impersonate/#{user.external_id}")
+      expect(links["admin_user"]).to include("/admin/users/#{user.id}")
+      expect(links["admin_purchases"]).to include("query=#{CGI.escape(user.email)}")
+      expect(links).not_to have_key("stripe_dashboard")
+    end
+
+    it "adds the View Stripe account link only when an alive Stripe merchant account exists" do
+      user = create(:compliant_user, email: "stripe-link@example.com")
+      create(:merchant_account, user:, charge_processor_merchant_id: "acct_link")
+      allow(Stripe::Account).to receive(:retrieve).and_return(
+        double(:account, charges_enabled: true, payouts_enabled: true, details_submitted: true,
+                         requirements: double(:requirements, disabled_reason: nil, currently_due: [], past_due: [], pending_verification: []))
+      )
+
+      get :info, params: { email: user.email }
+
+      expect(response.parsed_body["user"]["admin_links"]["stripe_dashboard"]).to include(
+        "/admin/helper_actions/stripe_dashboard/#{user.external_id}"
+      )
+    end
   end
 
   describe "GET affiliates" do


### PR DESCRIPTION
Addresses antiwork/gumroad-private#530 — surface in the internal admin API the data the admin web page already renders, so CLI/agent support stops round-tripping to Helper tRPC, Metabase, and the Stripe dashboard.

## `users info` (`serialize_user_info`)
- **`stripe`** block: `connected`, `stripe_connect_account_id` (`acct_…`, = `charge_processor_merchant_id`), `stripe_dashboard_url` (mirrors the `helper_actions/stripe_dashboard` link), and a **`verification`** readout — `charges_enabled`, `payouts_enabled`, `details_submitted`, `disabled_reason`, and `currently_due`/`past_due`/`pending_verification` counts (mirrors `Admin::MerchantAccountPresenter#live_attributes`).
- **`admin_links`**: `impersonate`, `admin_user`, `admin_purchases`, and `stripe_dashboard` (when a Stripe account exists) — same route helpers the Helper sidebar uses.

## `payouts list` (`serialize_payout`)
- **`stripe_payout_id`** (`po_…`) — from the stored `stripe_transfer_id` column (no Stripe call).
- **`bank_account`** block — `bank_number` (the real BIC/SWIFT/routing via `routing_number`, **not** the `******5995` visual), `account_holder_full_name`, `account_type`, `currency`.
- **`trace_id`** — ⚠️ see note below.

## ⚠️ On the `GUMROAD-…` trace ID
The issue asks for the customer-facing `GUMROAD-…` trace ID. **It isn't produced or stored anywhere in our codebase** (grepped all of `app/`/`lib/` and the admin payment presenter) — it's a bank/Stripe-side reconciliation reference that only appears in the Stripe dashboard / on the settled payout. So `trace_id` is returned as **`null`** rather than fabricated or guessed from `external_id` (which is *not* the trace ID). What we *can* expose is **`stripe_payout_id`** (`po_…`) — the actionable Stripe handle support can use to pull the trace in Stripe. If you want the human trace surfaced too, that's a follow-up that fetches the `po_…` payout from Stripe per row (an extra Stripe call) — flagging the tradeoff rather than baking in an N+1.

## Safety / perf
One **rescue-guarded** `Stripe::Account.retrieve` per `users info` request (degrades to `{ error: … }`, never 500s); payout rows read stored columns only — no per-row Stripe call, no new N+1 (index keeps `includes(:bank_account)`).

## Tests
Request specs cover: unconnected (`{connected:false}`, asserts Stripe is **not** called), connected (acct + dashboard + verification), Stripe-error degradation (200 + `{error}`, called once), and payouts for PayPal vs Stripe-processor rows. All green.

How this was built: parallel source-mapping of the 5 data points against the admin web page's own code, then implementation, then an adversarial review pass (correctness / security-PII / performance / tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784229316&installation_id=134400930&pr_number=5496&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5496&signature=e539300f1f5829be778b2c1f1e6c7542be7f3a87c844304707aa2afc643207d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds sensitive bank routing and holder fields to an admin-only API and one live Stripe call per user info request; payout rows stay DB-only with guarded error handling.
> 
> **Overview**
> Extends the **internal admin API** so CLI/agents can read Stripe Connect, payout, and navigation data that the admin UI already shows, without extra dashboard hops.
> 
> **`users info`** adds a **`stripe`** object (`connected`, Connect account id, dashboard URL, and live **verification** flags/counts from one `Stripe::Account.retrieve`, with `{ error: … }` on failure) and **`admin_links`** (impersonate, admin user, purchase search, optional Stripe dashboard helper).
> 
> **Payout list** serialization now includes **`stripe_transfer_id`**, **`trace_id`** (always `null`—not stored in-app), and a **`bank_account`** block with routing and holder metadata from the DB; **`CardBankAccount`** rows omit that block so card metadata is not exposed as bank data.
> 
> Request specs cover unconnected users, connected verification, Stripe error degradation, payout shapes, and conditional admin links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25b1f08eb14431414767d6d734791f4691e00d2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->