### PR TITLE
Add Reset license uses button to the customer detail page

### DIFF
--- a/app/controllers/licenses_controller.rb
+++ b/app/controllers/licenses_controller.rb
@@ -5,7 +5,9 @@ class LicensesController < Sellers::BaseController
     license = License.find_by_external_id!(params[:id])
     authorize [:audience, license.purchase], :manage_license?
 
-    if ActiveModel::Type::Boolean.new.cast(params[:enabled])
+    if params.key?(:reset_uses)
+      license.reset_uses!
+    elsif ActiveModel::Type::Boolean.new.cast(params[:enabled])
       license.enable!
     else
       license.disable!

--- a/app/controllers/licenses_controller.rb
+++ b/app/controllers/licenses_controller.rb
@@ -2,7 +2,11 @@
 
 class LicensesController < Sellers::BaseController
   def update
-    license = License.find_by_external_id!(params[:id])
+    license = License.find_by_secure_external_id(params[:id], scope: License::MANAGE_SECURE_ID_SCOPE)
+    unless license
+      skip_authorization
+      return e404_json
+    end
     authorize [:audience, license.purchase], :manage_license?
 
     if params.key?(:reset_uses)

--- a/app/javascript/components/Audience/CustomerDetailPage.tsx
+++ b/app/javascript/components/Audience/CustomerDetailPage.tsx
@@ -30,6 +30,7 @@ import {
   resendPing,
   resendPost,
   resendReceipt,
+  resetLicenseUses,
   revokeAccess,
   undoRevokeAccess,
   updateCallUrl,
@@ -551,6 +552,18 @@ const CustomerDetailPage = ({
                   () => {
                     showAlert("Changes saved!", "success");
                     updateCustomer({ license: { ...license, enabled } });
+                  },
+                  (e: unknown) => {
+                    assertResponseError(e);
+                    showAlert(e.message, "error");
+                  },
+                )
+              }
+              onReset={() =>
+                resetLicenseUses(license.id).then(
+                  () => {
+                    showAlert("License uses reset", "success");
+                    updateCustomer({ license: { ...license, uses: 0 } });
                   },
                   (e: unknown) => {
                     assertResponseError(e);
@@ -1471,12 +1484,26 @@ const OptionSection = ({
   );
 };
 
-const LicenseSection = ({ license, onSave }: { license: License; onSave: (enabled: boolean) => Promise<void> }) => {
+const LicenseSection = ({
+  license,
+  onSave,
+  onReset,
+}: {
+  license: License;
+  onSave: (enabled: boolean) => Promise<void>;
+  onReset: () => Promise<void>;
+}) => {
   const [isLoading, setIsLoading] = React.useState(false);
 
   const handleSave = async (enabled: boolean) => {
     setIsLoading(true);
     await onSave(enabled);
+    setIsLoading(false);
+  };
+
+  const handleReset = async () => {
+    setIsLoading(true);
+    await onReset();
     setIsLoading(false);
   };
 
@@ -1496,6 +1523,17 @@ const LicenseSection = ({ license, onSave }: { license: License; onSave: (enable
         <CardContent>
           <h5 className="grow font-bold">Uses</h5>
           {license.uses}
+          {license.uses > 0 ? (
+            <Button
+              outline
+              disabled={isLoading}
+              onClick={() => void handleReset()}
+              aria-label="Reset uses"
+              title="Reset uses to 0"
+            >
+              Reset
+            </Button>
+          ) : null}
         </CardContent>
         <CardContent>
           {license.enabled ? (

--- a/app/javascript/components/Audience/CustomerDetailPage.tsx
+++ b/app/javascript/components/Audience/CustomerDetailPage.tsx
@@ -1494,6 +1494,7 @@ const LicenseSection = ({
   onReset: () => Promise<void>;
 }) => {
   const [isLoading, setIsLoading] = React.useState(false);
+  const [confirmingReset, setConfirmingReset] = React.useState(false);
 
   const handleSave = async (enabled: boolean) => {
     setIsLoading(true);
@@ -1505,6 +1506,7 @@ const LicenseSection = ({
     setIsLoading(true);
     await onReset();
     setIsLoading(false);
+    setConfirmingReset(false);
   };
 
   return (
@@ -1527,13 +1529,30 @@ const LicenseSection = ({
             <Button
               outline
               disabled={isLoading}
-              onClick={() => void handleReset()}
+              onClick={() => setConfirmingReset(true)}
               aria-label="Reset uses"
               title="Reset uses to 0"
             >
               Reset
             </Button>
           ) : null}
+          <Modal
+            open={confirmingReset}
+            onClose={() => setConfirmingReset(false)}
+            title="Reset license uses?"
+            footer={
+              <>
+                <Button disabled={isLoading} onClick={() => setConfirmingReset(false)}>
+                  Cancel
+                </Button>
+                <Button color="primary" disabled={isLoading} onClick={() => void handleReset()}>
+                  Reset
+                </Button>
+              </>
+            }
+          >
+            <p>This sets the usage count for this license back to 0.</p>
+          </Modal>
         </CardContent>
         <CardContent>
           {license.enabled ? (

--- a/app/javascript/data/customers.ts
+++ b/app/javascript/data/customers.ts
@@ -282,6 +282,13 @@ export const updateLicense = (licenseId: string, enabled: boolean) =>
     if (!response.ok) throw new ResponseError();
   });
 
+export const resetLicenseUses = (licenseId: string) =>
+  request({ method: "PUT", accept: "json", url: Routes.license_path(licenseId, { reset_uses: true }) }).then(
+    (response) => {
+      if (!response.ok) throw new ResponseError();
+    },
+  );
+
 export const markShipped = (purchaseId: string, trackingUrl: string) =>
   request({
     method: "POST",

--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
 class License < ApplicationRecord
+  MANAGE_SECURE_ID_SCOPE = "manage_license"
+
   has_paper_trail only: %i[disabled_at serial]
 
   include FlagShihTzu
   include ExternalId
+  include SecureExternalId
 
   validates_numericality_of :uses, greater_than_or_equal_to: 0
   validates_presence_of :serial

--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -41,6 +41,10 @@ class License < ApplicationRecord
     save!
   end
 
+  def reset_uses!
+    update!(uses: 0)
+  end
+
   def rotate!
     self.serial = nil
     generate_serial

--- a/app/presenters/customer_presenter.rb
+++ b/app/presenters/customer_presenter.rb
@@ -92,7 +92,7 @@ class CustomerPresenter
         } : nil,
       license: purchase.linked_license.present? ?
         {
-          id: purchase.linked_license.external_id,
+          id: purchase.linked_license.secure_external_id(scope: License::MANAGE_SECURE_ID_SCOPE),
           key: purchase.linked_license.serial,
           enabled: !purchase.linked_license.disabled?,
           uses: purchase.linked_license.uses,

--- a/spec/controllers/licenses_controller_spec.rb
+++ b/spec/controllers/licenses_controller_spec.rb
@@ -31,5 +31,21 @@ describe LicensesController do
       expect(response).to be_successful
       expect(license.reload.disabled_at).to be_nil
     end
+
+    it "resets the license uses when reset_uses is passed" do
+      license.update!(uses: 7)
+      put :update, format: :json, params: { id: license.external_id, reset_uses: true }
+      expect(response).to be_successful
+      expect(license.reload.uses).to eq 0
+    end
+
+    it "does not change the enabled status when resetting uses" do
+      license.update!(uses: 3)
+      expect(license.disabled_at).to be_nil
+      put :update, format: :json, params: { id: license.external_id, reset_uses: true }
+      expect(response).to be_successful
+      expect(license.reload.disabled_at).to be_nil
+      expect(license.uses).to eq 0
+    end
   end
 end

--- a/spec/controllers/licenses_controller_spec.rb
+++ b/spec/controllers/licenses_controller_spec.rb
@@ -11,30 +11,31 @@ describe LicensesController do
 
   let(:seller) { create(:named_seller) }
   let(:license) { create(:license) }
+  let(:secure_id) { license.secure_external_id(scope: License::MANAGE_SECURE_ID_SCOPE) }
 
   include_context "with user signed in as admin for seller"
 
   it_behaves_like "authorize called for controller", Audience::PurchasePolicy do
     let(:record) { license.purchase }
     let(:policy_method) { :manage_license? }
-    let(:request_params) { { id: license.external_id } }
+    let(:request_params) { { id: secure_id } }
   end
 
   describe "PUT update" do
     it "updates the enabled status of the license" do
       expect(license.disabled_at).to be_nil
-      put :update, format: :json, params: { id: license.external_id, enabled: false }
+      put :update, format: :json, params: { id: secure_id, enabled: false }
       expect(response).to be_successful
       expect(license.reload.disabled_at).to_not be_nil
 
-      put :update, format: :json, params: { id: license.external_id, enabled: true }
+      put :update, format: :json, params: { id: secure_id, enabled: true }
       expect(response).to be_successful
       expect(license.reload.disabled_at).to be_nil
     end
 
     it "resets the license uses when reset_uses is passed" do
       license.update!(uses: 7)
-      put :update, format: :json, params: { id: license.external_id, reset_uses: true }
+      put :update, format: :json, params: { id: secure_id, reset_uses: true }
       expect(response).to be_successful
       expect(license.reload.uses).to eq 0
     end
@@ -42,10 +43,33 @@ describe LicensesController do
     it "does not change the enabled status when resetting uses" do
       license.update!(uses: 3)
       expect(license.disabled_at).to be_nil
-      put :update, format: :json, params: { id: license.external_id, reset_uses: true }
+      put :update, format: :json, params: { id: secure_id, reset_uses: true }
       expect(response).to be_successful
       expect(license.reload.disabled_at).to be_nil
       expect(license.uses).to eq 0
+    end
+
+    context "when the id is not a valid management token" do
+      before { license.update!(uses: 9) }
+
+      it "rejects the plain external id that leaks via the license API" do
+        put :update, format: :json, params: { id: license.external_id, reset_uses: true }
+        expect(response).to have_http_status(:not_found)
+        expect(license.reload.uses).to eq 9
+      end
+
+      it "rejects a token minted for a different scope" do
+        wrong_scope_id = license.secure_external_id(scope: "some_other_scope")
+        put :update, format: :json, params: { id: wrong_scope_id, enabled: false }
+        expect(response).to have_http_status(:not_found)
+        expect(license.reload.disabled_at).to be_nil
+      end
+
+      it "rejects a forged token" do
+        put :update, format: :json, params: { id: "not-a-real-token", reset_uses: true }
+        expect(response).to have_http_status(:not_found)
+        expect(license.reload.uses).to eq 9
+      end
     end
   end
 end

--- a/spec/models/license_spec.rb
+++ b/spec/models/license_spec.rb
@@ -80,6 +80,21 @@ describe License do
     end
   end
 
+  describe "#reset_uses!" do
+    let(:license) { create(:license, uses: 5) }
+
+    it "resets the uses count to zero" do
+      expect(license.reset_uses!).to be(true)
+      expect(license.reload.uses).to eq 0
+    end
+
+    it "is a no-op result-wise when uses is already zero" do
+      license.update!(uses: 0)
+      expect(license.reset_uses!).to be(true)
+      expect(license.reload.uses).to eq 0
+    end
+  end
+
   describe "search index callbacks" do
     let!(:purchase) { create(:purchase, :with_license) }
     let!(:license) { purchase.license }

--- a/spec/presenters/customer_presenter_spec.rb
+++ b/spec/presenters/customer_presenter_spec.rb
@@ -70,6 +70,7 @@ describe CustomerPresenter do
     end
 
     it "returns the correct props for each customer" do
+      allow_any_instance_of(License).to receive(:secure_external_id).with(scope: License::MANAGE_SECURE_ID_SCOPE).and_return("secure-license-id")
       allow(purchase1).to receive(:transaction_url_for_seller).and_return("https://google.com")
       allow(purchase1).to receive(:stripe_partially_refunded?).and_return(true)
       allow(purchase1).to receive(:stripe_refunded?).and_return(true)
@@ -183,7 +184,7 @@ describe CustomerPresenter do
             type: "DirectAffiliate",
           },
           license: {
-            id: purchase2.license.external_id,
+            id: "secure-license-id",
             enabled: true,
             key: purchase2.license.serial,
             uses: purchase2.license.uses,


### PR DESCRIPTION
## What

Resolves #5498. Adds a **Reset** button to reset a license's usage count from the customer detail (Sales) page, next to the existing Disable/Enable toggle. Resetting is gated behind a confirmation dialog.

This also closes a pre-existing cross-tenant authorization gap in the license-management endpoint — see below.

## Why

Today the only way to decrement/reset license uses is via a script, which is tedious for sellers administering seat-limited licenses. This surfaces it in the dashboard where the license already shows its key, uses, and enable/disable control.

### Security: authorize by scoped secure external ID

`LicensesController#update` — which also backs the existing Disable/Enable toggle — authorized only the seller's *role* against the current seller context; it never checked that the license belonged to that seller. Because the license was addressed by its plain external ID, and that ID legitimately circulates (it's returned by the license-verification API and embedded in delivered license keys), any authenticated seller could enable, disable, or reset **any** license, including ones on other sellers' products.

The fix mints a `manage_license`-scoped `SecureExternalId` token for the license in `CustomerPresenter` — which only ever runs for the current seller's own sales — so a valid token is only ever generated into the owning seller's dashboard payload. The controller resolves the license via `find_by_secure_external_id` with that scope. The plain external ID, a token minted for a different scope, and forged tokens all return 404.

## Changes

- **`License#reset_uses!`** — sets `uses` to `0`. The existing `after_commit` re-index on `uses` keeps the purchase search index consistent.
- **`License` includes `SecureExternalId`** with a `MANAGE_SECURE_ID_SCOPE` constant shared between minting and lookup.
- **`CustomerPresenter`** — sends the license's scoped secure external ID as its `id` instead of the plain external ID.
- **`LicensesController#update`** — resolves the license via the scoped secure external ID (404 otherwise) and handles a `reset_uses` param (mutually exclusive with the existing `enabled` toggle), leaving the license's enabled status untouched.
- **`resetLicenseUses`** data helper + **`onReset`** wiring in `LicenseSection`. The Reset button renders next to the Uses count, only appears when `uses > 0`, and opens a confirmation dialog before resetting.
- Model, controller, and presenter specs — including cases asserting the plain external ID, a wrong-scope token, and a forged token are each rejected with 404.

## Testing

Run locally against the test DB:

- `bundle exec rspec spec/models/license_spec.rb spec/controllers/licenses_controller_spec.rb spec/presenters/customer_presenter_spec.rb spec/presenters/customers_presenter_spec.rb spec/controllers/customers_controller_spec.rb` → all green.
- `bundle exec rubocop` on the touched Ruby files → no offenses.
- `npx eslint` on `CustomerDetailPage.tsx` → clean.

The end-to-end Capybara spec (`spec/requests/customers/customers_spec.rb` "allows management of licenses") exercises the real presenter → frontend → controller token flow and should be relied on in CI; it could not run in my local sandbox (browser host resolution). The frontend uses `license.id` only as an opaque route param, so the token switch is transparent to the UI.

## Screenshots

Captured from the live app (real DOM): booted this branch, seeded a license-bearing purchase with `uses: 7`, opened the customer detail page, and exercised Reset end-to-end. The button flips uses **7 → 0**, then hides itself (it only renders when `uses > 0`), with a "License uses reset" toast. Verified the side-effect in the DB (`License#uses == 0`), not just the toast.

> Note: the Reset button now opens a confirmation dialog ("Reset license uses?") before applying. Updated media showing the confirmation step is to be captured.

**Before** — Uses 7, Reset button shown next to the count:

![before reset — uses 7](https://raw.githubusercontent.com/gumclaw/gumroad/pr5498-assets/docs/pr-5498/01-before-uses-7.png)

**After** — Uses 0, Reset button gone:

![after reset — uses 0](https://raw.githubusercontent.com/gumclaw/gumroad/pr5498-assets/docs/pr-5498/02-after-uses-0.png)

Closes #5498

---

🤖 AI disclosure: implemented with the assistance of Claude Opus 4.8.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication/authorization for license management (scoped tokens) and mutates license usage counts, which affects entitlement enforcement and cross-tenant access if misconfigured.
> 
> **Overview**
> Adds a **Reset** control on the customer detail license section so sellers can set usage back to **0** (with confirmation), wired through a new `reset_uses` path on `LicensesController#update` and `License#reset_uses!`.
> 
> **Security fix:** license enable/disable (and reset) no longer accept the plain license external ID. The dashboard now receives a `manage_license`-scoped secure external ID from `CustomerPresenter`, and the controller resolves licenses only via that scope—invalid, wrong-scope, or forged IDs return **404**.
> 
> The customer detail UI shows Reset only when `uses > 0` and updates local state after a successful reset; existing enable/disable behavior uses the same opaque `license.id` token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf28847a3b6823a2301b35340d95acb8cbde71c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->