### PR TITLE
Fix license key overflowing its card on the customer detail page

### DIFF
--- a/app/javascript/components/Audience/CustomerDetailPage.tsx
+++ b/app/javascript/components/Audience/CustomerDetailPage.tsx
@@ -1489,7 +1489,7 @@ const LicenseSection = ({ license, onSave }: { license: License; onSave: (enable
           </header>
         </CardContent>
         <CardContent>
-          <pre className="grow">
+          <pre className="grow whitespace-pre-wrap break-all">
             <code>{license.key}</code>
           </pre>
         </CardContent>


### PR DESCRIPTION
## What

On the customer detail (Sales) page, a license key longer than the License key card clips at the card's right edge — the final character(s) are cut off. This makes the key un-copyable and looks broken.

The key is rendered in a `<pre>`, which preserves whitespace and does not wrap, so it overflows its column. This adds `whitespace-pre-wrap break-all` so the key wraps within the card instead of clipping.

## Changes

- `app/javascript/components/Audience/CustomerDetailPage.tsx` — one class change on the License key `<pre>`: `grow` → `grow whitespace-pre-wrap break-all`.

## Screenshots

Captured from the live app (real DOM): booted this branch, seeded a license-bearing purchase, opened the customer detail page, and toggled the class in place to capture both states on the same branch.

**Before** — key clips at the right edge (final `F` cut off):

![before — license key clipped](https://raw.githubusercontent.com/gumclaw/gumroad/licwrap-assets/docs/license-key-wrap/01-before-clipped.png)

**After** — key wraps and is fully visible:

![after — license key wraps](https://raw.githubusercontent.com/gumclaw/gumroad/licwrap-assets/docs/license-key-wrap/02-after-wrapped.png)

## Notes

Pre-existing on `main` (not a regression from another PR). Spotted while reviewing the customer detail card for #5500 (the Reset-license-uses button); kept separate to keep that PR scoped to the feature.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784287564&installation_id=134400930&pr_number=5501&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5501&signature=9cd9690af8b70b69d231d78b49a3be765b5f89d3e28f441689482c960a9698c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single presentational class change on the customer detail page with no logic, API, or data impact.
> 
> **Overview**
> Long license keys on the Sales customer detail page were clipped at the right edge of the **License key** card because the key sits in a `<pre>` that does not wrap by default.
> 
> The PR adds Tailwind classes **`whitespace-pre-wrap break-all`** on that `<pre>` in `LicenseSection` so the full key stays inside the card and remains selectable/copyable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b80aea53d41afc0b589f01a94981ead72246b19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->