### PR TITLE
Add Api::V2 emails endpoints for audience emails (gumroad-cli#158)

### DIFF
--- a/app/controllers/api/v2/categories_controller.rb
+++ b/app/controllers/api/v2/categories_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V2::CategoriesController < Api::V2::BaseController
-  before_action -> { doorkeeper_authorize!(*Doorkeeper.configuration.public_scopes.concat([:view_public])) }
+  before_action -> { doorkeeper_authorize!(*Doorkeeper.configuration.public_api_read_scopes.concat([:view_public])) }
 
   def index
     expires_in 1.hour

--- a/app/controllers/api/v2/custom_fields_controller.rb
+++ b/app/controllers/api/v2/custom_fields_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V2::CustomFieldsController < Api::V2::BaseController
-  before_action(only: [:index]) { doorkeeper_authorize!(*Doorkeeper.configuration.public_scopes.concat([:view_public])) }
+  before_action(only: [:index]) { doorkeeper_authorize!(*Doorkeeper.configuration.public_api_read_scopes.concat([:view_public])) }
   before_action(only: [:create, :update, :destroy]) { doorkeeper_authorize! :edit_products }
   before_action :fetch_product
   before_action :fetch_custom_fields

--- a/app/controllers/api/v2/emails_controller.rb
+++ b/app/controllers/api/v2/emails_controller.rb
@@ -66,7 +66,7 @@ class Api::V2::EmailsController < Api::V2::BaseController
   end
 
   def preview
-    @installment.seller ||= current_seller
+    ensure_installment_seller
     @installment.send_preview_email(current_seller)
     render_response(
       true,
@@ -76,13 +76,17 @@ class Api::V2::EmailsController < Api::V2::BaseController
     )
   rescue Installment::PreviewEmailError => e
     render_response(false, message: e.message)
+  rescue => e
+    ErrorNotifier.notify(e)
+    render_response(false, message: e.message)
   end
 
   def send_email
     return render_response(false, message: "The email has already been sent.") if @installment.has_been_blasted?
     return render_response(false, message: "The email is scheduled to be sent at its scheduled time.") if !@installment.published? && @installment.ready_to_publish?
 
-    @installment.seller ||= current_seller
+    ensure_installment_seller
+    ensure_implicit_purchase_filters
     service = SaveInstallmentService.new(
       seller: current_seller,
       params: service_params_for_publish(@installment),
@@ -135,6 +139,18 @@ class Api::V2::EmailsController < Api::V2::BaseController
     def fetch_installment
       @installment = scoped_installments.find_by_external_id(params[:id])
       error_with_email if @installment.nil?
+    end
+
+    def ensure_installment_seller
+      return if @installment.seller_id.present?
+
+      @installment.update_column(:seller_id, current_seller.id)
+      @installment.seller = current_seller
+    end
+
+    def ensure_implicit_purchase_filters
+      @installment.bought_products = bought_products_for_publish(@installment)
+      @installment.bought_variants = bought_variants_for_publish(@installment)
     end
 
     def installment_type_from_audience_param
@@ -199,14 +215,30 @@ class Api::V2::EmailsController < Api::V2::BaseController
         shown_on_profile: installment.shown_on_profile?,
         send_emails: true,
         allow_comments: installment.allow_comments?,
-        bought_products: installment.bought_products,
-        bought_variants: installment.bought_variants,
+        bought_products: bought_products_for_publish(installment),
+        bought_variants: bought_variants_for_publish(installment),
         affiliate_products: installment.affiliate_products,
         not_bought_products: installment.not_bought_products,
         not_bought_variants: installment.not_bought_variants,
         shown_in_profile_sections: shown_in_profile_sections_for(installment),
         files: existing_files_for(installment),
       }
+    end
+
+    def bought_products_for_publish(installment)
+      return installment.bought_products if has_purchase_filter?(installment) || !installment.product_type?
+
+      Array(installment.link&.unique_permalink).compact
+    end
+
+    def bought_variants_for_publish(installment)
+      return installment.bought_variants if has_purchase_filter?(installment) || !installment.variant_type?
+
+      Array(installment.base_variant&.external_id).compact
+    end
+
+    def has_purchase_filter?(installment)
+      installment.bought_products.present? || installment.bought_variants.present?
     end
 
     def existing_files_for(installment)

--- a/app/controllers/api/v2/emails_controller.rb
+++ b/app/controllers/api/v2/emails_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Api::V2::InstallmentsController < Api::V2::BaseController
+class Api::V2::EmailsController < Api::V2::BaseController
   before_action(only: [:index, :show]) do
     doorkeeper_authorize!(*Doorkeeper.configuration.public_scopes.concat([:view_public]))
   end
@@ -40,11 +40,11 @@ class Api::V2::InstallmentsController < Api::V2::BaseController
     paginated_installments = paginated_installments.first(RESULTS_PER_PAGE)
     additional_response = has_next_page ? pagination_info(paginated_installments.last) : {}
 
-    success_with_object(:installments, paginated_installments, additional_response)
+    success_with_object(:emails, paginated_installments, additional_response)
   end
 
   def show
-    success_with_installment(@installment)
+    success_with_email(@installment)
   end
 
   def create
@@ -62,7 +62,7 @@ class Api::V2::InstallmentsController < Api::V2::BaseController
     )
 
     if service.process
-      success_with_installment(service.installment)
+      success_with_email(service.installment)
     else
       render_response(false, message: service.error)
     end
@@ -72,7 +72,7 @@ class Api::V2::InstallmentsController < Api::V2::BaseController
     @installment.send_preview_email(current_seller)
     render_response(
       true,
-      installment: @installment,
+      email: @installment,
       preview_url: preview_url_for(@installment),
       message: "A preview has been sent to your email."
     )
@@ -81,7 +81,7 @@ class Api::V2::InstallmentsController < Api::V2::BaseController
   end
 
   def send_email
-    return render_response(false, message: "The installment has already been sent.") if @installment.published?
+    return render_response(false, message: "The email has already been sent.") if @installment.published?
 
     service = SaveInstallmentService.new(
       seller: current_seller,
@@ -91,7 +91,7 @@ class Api::V2::InstallmentsController < Api::V2::BaseController
     )
 
     if service.process
-      success_with_installment(service.installment)
+      success_with_email(service.installment)
     else
       render_response(false, message: service.error)
     end
@@ -99,9 +99,9 @@ class Api::V2::InstallmentsController < Api::V2::BaseController
 
   def destroy
     if @installment.update(deleted_at: Time.current)
-      success_with_installment
+      success_with_email
     else
-      error_with_installment(@installment)
+      error_with_email(@installment)
     end
   end
 
@@ -134,7 +134,7 @@ class Api::V2::InstallmentsController < Api::V2::BaseController
 
     def fetch_installment
       @installment = scoped_installments.find_by_external_id(params[:id])
-      error_with_installment if @installment.nil?
+      error_with_email if @installment.nil?
     end
 
     def installment_type_from_audience_param
@@ -234,15 +234,15 @@ class Api::V2::InstallmentsController < Api::V2::BaseController
     def installment_creation_error(message)
       installment = Installment.new
       installment.errors.add(:base, message)
-      error_with_creating_object(:installment, installment)
+      error_with_creating_object(:email, installment)
       nil
     end
 
-    def success_with_installment(installment = nil)
-      success_with_object(:installment, installment)
+    def success_with_email(installment = nil)
+      success_with_object(:email, installment)
     end
 
-    def error_with_installment(installment = nil)
-      error_with_object(:installment, installment)
+    def error_with_email(installment = nil)
+      error_with_object(:email, installment)
     end
 end

--- a/app/controllers/api/v2/emails_controller.rb
+++ b/app/controllers/api/v2/emails_controller.rb
@@ -79,6 +79,7 @@ class Api::V2::EmailsController < Api::V2::BaseController
 
   def send_email
     return render_response(false, message: "The email has already been sent.") if @installment.published?
+    return render_response(false, message: "The email is scheduled to be sent at its scheduled time.") if @installment.ready_to_publish?
 
     service = SaveInstallmentService.new(
       seller: current_seller,

--- a/app/controllers/api/v2/emails_controller.rb
+++ b/app/controllers/api/v2/emails_controller.rb
@@ -226,7 +226,7 @@ class Api::V2::EmailsController < Api::V2::BaseController
     end
 
     def publish_requested?
-      boolean_param(:publish)
+      boolean_param(:publish) || boolean_param(:draft) == false
     end
 
     def boolean_param(key)

--- a/app/controllers/api/v2/emails_controller.rb
+++ b/app/controllers/api/v2/emails_controller.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V2::EmailsController < Api::V2::BaseController
-  before_action(only: [:index, :show]) do
-    doorkeeper_authorize!(*Doorkeeper.configuration.public_scopes.concat([:view_public]))
-  end
-  before_action(only: [:create, :preview, :send_email, :destroy]) { doorkeeper_authorize! :edit_products }
+  before_action { doorkeeper_authorize! :edit_products }
   before_action :fetch_installment, only: %i[show preview send_email destroy]
 
   RESULTS_PER_PAGE = 10
@@ -28,7 +25,7 @@ class Api::V2::EmailsController < Api::V2::BaseController
       rescue ArgumentError
         return error_400("Invalid page_key.")
       end
-      installments = installments.where("created_at <= ? and id < ?", last_installment_created_at, last_installment_id)
+      installments = installments.where("(created_at < ?) OR (created_at = ? AND id < ?)", last_installment_created_at, last_installment_created_at, last_installment_id)
     end
 
     paginated_installments = installments
@@ -165,7 +162,8 @@ class Api::V2::EmailsController < Api::V2::BaseController
           message: params[:body],
           installment_type:,
           link_id: product_link_id,
-          send_emails: send_emails_param,
+          bought_products: (installment_type == Installment::PRODUCT_TYPE ? [product_link_id] : []),
+          send_emails: true,
           shown_on_profile: false,
           shown_in_profile_sections: [],
         },
@@ -204,7 +202,20 @@ class Api::V2::EmailsController < Api::V2::BaseController
         not_bought_products: installment.not_bought_products,
         not_bought_variants: installment.not_bought_variants,
         shown_in_profile_sections: shown_in_profile_sections_for(installment),
+        files: existing_files_for(installment),
       }
+    end
+
+    def existing_files_for(installment)
+      installment.alive_product_files.map do |file|
+        {
+          external_id: file.external_id,
+          url: file.url,
+          position: file.position,
+          stream_only: file.stream_only?,
+          subtitle_files: file.alive_subtitle_files.map { |subtitle| { url: subtitle.url, language: subtitle.language } },
+        }
+      end
     end
 
     def shown_in_profile_sections_for(installment)
@@ -213,14 +224,8 @@ class Api::V2::EmailsController < Api::V2::BaseController
       end
     end
 
-    def send_emails_param
-      return true unless params.key?(:send_emails)
-
-      boolean_param(:send_emails)
-    end
-
     def publish_requested?
-      boolean_param(:publish) || (params.key?(:draft) && !boolean_param(:draft))
+      boolean_param(:publish)
     end
 
     def boolean_param(key)
@@ -228,7 +233,9 @@ class Api::V2::EmailsController < Api::V2::BaseController
     end
 
     def preview_url_for(installment)
-      installment.published? ? installment.full_url : edit_email_path(installment.external_id, preview_post: true)
+      return installment.full_url if installment.published?
+
+      edit_email_url(installment.external_id, preview_post: true, host: UrlService.domain_with_protocol)
     end
 
     def installment_creation_error(message)

--- a/app/controllers/api/v2/emails_controller.rb
+++ b/app/controllers/api/v2/emails_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V2::EmailsController < Api::V2::BaseController
-  before_action { doorkeeper_authorize! :edit_products }
+  before_action { doorkeeper_authorize! :edit_emails }
   before_action :fetch_installment, only: %i[show preview send_email destroy]
 
   RESULTS_PER_PAGE = 10
@@ -66,6 +66,7 @@ class Api::V2::EmailsController < Api::V2::BaseController
   end
 
   def preview
+    @installment.seller ||= current_seller
     @installment.send_preview_email(current_seller)
     render_response(
       true,
@@ -78,9 +79,10 @@ class Api::V2::EmailsController < Api::V2::BaseController
   end
 
   def send_email
-    return render_response(false, message: "The email has already been sent.") if @installment.published?
-    return render_response(false, message: "The email is scheduled to be sent at its scheduled time.") if @installment.ready_to_publish?
+    return render_response(false, message: "The email has already been sent.") if @installment.has_been_blasted?
+    return render_response(false, message: "The email is scheduled to be sent at its scheduled time.") if !@installment.published? && @installment.ready_to_publish?
 
+    @installment.seller ||= current_seller
     service = SaveInstallmentService.new(
       seller: current_seller,
       params: service_params_for_publish(@installment),
@@ -109,7 +111,7 @@ class Api::V2::EmailsController < Api::V2::BaseController
     end
 
     def scoped_installments
-      current_seller.installments.alive.not_workflow_installment
+      Installment.ordered_updates(current_seller, nil).reorder(nil)
     end
 
     def filter_installments_by_type(installments)
@@ -195,7 +197,7 @@ class Api::V2::EmailsController < Api::V2::BaseController
         created_before: installment.created_before,
         bought_from: installment.bought_from,
         shown_on_profile: installment.shown_on_profile?,
-        send_emails: installment.send_emails?,
+        send_emails: true,
         allow_comments: installment.allow_comments?,
         bought_products: installment.bought_products,
         bought_variants: installment.bought_variants,
@@ -234,7 +236,7 @@ class Api::V2::EmailsController < Api::V2::BaseController
     end
 
     def preview_url_for(installment)
-      return installment.full_url if installment.published?
+      return installment.public_page_location if installment.published?
 
       edit_email_url(installment.external_id, preview_post: true, host: UrlService.domain_with_protocol)
     end

--- a/app/controllers/api/v2/installments_controller.rb
+++ b/app/controllers/api/v2/installments_controller.rb
@@ -1,0 +1,248 @@
+# frozen_string_literal: true
+
+class Api::V2::InstallmentsController < Api::V2::BaseController
+  before_action(only: [:index, :show]) do
+    doorkeeper_authorize!(*Doorkeeper.configuration.public_scopes.concat([:view_public]))
+  end
+  before_action(only: [:create, :preview, :send_email, :destroy]) { doorkeeper_authorize! :edit_products }
+  before_action :fetch_installment, only: %i[show preview send_email destroy]
+
+  RESULTS_PER_PAGE = 10
+  AUDIENCE_TYPES_BY_PARAM = {
+    "all" => Installment::AUDIENCE_TYPE,
+    "audience" => Installment::AUDIENCE_TYPE,
+    "customers" => Installment::SELLER_TYPE,
+    "seller" => Installment::SELLER_TYPE,
+    "followers" => Installment::FOLLOWER_TYPE,
+    "follower" => Installment::FOLLOWER_TYPE,
+    "product" => Installment::PRODUCT_TYPE,
+  }.freeze
+
+  def index
+    installments = filter_installments_by_type(scoped_installments)
+    return if performed?
+
+    if params[:page_key].present?
+      begin
+        last_installment_created_at, last_installment_id = decode_page_key(params[:page_key])
+      rescue ArgumentError
+        return error_400("Invalid page_key.")
+      end
+      installments = installments.where("created_at <= ? and id < ?", last_installment_created_at, last_installment_id)
+    end
+
+    paginated_installments = installments
+                             .includes(:installment_rule, :link)
+                             .order(created_at: :desc, id: :desc)
+                             .limit(RESULTS_PER_PAGE + 1)
+                             .to_a
+    has_next_page = paginated_installments.size > RESULTS_PER_PAGE
+    paginated_installments = paginated_installments.first(RESULTS_PER_PAGE)
+    additional_response = has_next_page ? pagination_info(paginated_installments.last) : {}
+
+    success_with_object(:installments, paginated_installments, additional_response)
+  end
+
+  def show
+    success_with_installment(@installment)
+  end
+
+  def create
+    installment_type = installment_type_from_audience_param
+    return if performed?
+
+    product_link_id = product_link_id_for(installment_type)
+    return if performed?
+
+    service = SaveInstallmentService.new(
+      seller: current_seller,
+      params: service_params_for_create(installment_type:, product_link_id:),
+      installment: nil,
+      preview_email_recipient: current_seller
+    )
+
+    if service.process
+      success_with_installment(service.installment)
+    else
+      render_response(false, message: service.error)
+    end
+  end
+
+  def preview
+    @installment.send_preview_email(current_seller)
+    render_response(
+      true,
+      installment: @installment,
+      preview_url: preview_url_for(@installment),
+      message: "A preview has been sent to your email."
+    )
+  rescue Installment::PreviewEmailError => e
+    render_response(false, message: e.message)
+  end
+
+  def send_email
+    return render_response(false, message: "The installment has already been sent.") if @installment.published?
+
+    service = SaveInstallmentService.new(
+      seller: current_seller,
+      params: service_params_for_publish(@installment),
+      installment: @installment,
+      preview_email_recipient: current_seller
+    )
+
+    if service.process
+      success_with_installment(service.installment)
+    else
+      render_response(false, message: service.error)
+    end
+  end
+
+  def destroy
+    if @installment.update(deleted_at: Time.current)
+      success_with_installment
+    else
+      error_with_installment(@installment)
+    end
+  end
+
+  private
+    def current_seller
+      current_resource_owner
+    end
+
+    def scoped_installments
+      current_seller.installments.alive.not_workflow_installment
+    end
+
+    def filter_installments_by_type(installments)
+      case params[:type].presence
+      when nil
+        installments
+      when Installment::PUBLISHED
+        installments.published
+      when Installment::SCHEDULED
+        installments.scheduled
+      when Installment::DRAFT
+        installments.draft
+      else
+        error_400(
+          "Invalid type. Valid values are: " \
+          "#{[Installment::PUBLISHED, Installment::SCHEDULED, Installment::DRAFT].join(', ')}."
+        )
+      end
+    end
+
+    def fetch_installment
+      @installment = scoped_installments.find_by_external_id(params[:id])
+      error_with_installment if @installment.nil?
+    end
+
+    def installment_type_from_audience_param
+      audience = params[:audience].presence || Installment::AUDIENCE_TYPE
+      AUDIENCE_TYPES_BY_PARAM[audience.to_s.downcase] ||
+        installment_creation_error("Invalid audience. Valid values are: #{AUDIENCE_TYPES_BY_PARAM.keys.join(', ')}.")
+    end
+
+    def product_link_id_for(installment_type)
+      return unless installment_type == Installment::PRODUCT_TYPE
+
+      product_identifier = params[:product_id].presence || params[:link_id].presence
+      if product_identifier.blank?
+        return installment_creation_error("Product audience requires a product_id or link_id.")
+      end
+
+      product = current_seller.links.visible.find_by_external_id(product_identifier) ||
+                current_seller.links.visible.find_by(unique_permalink: product_identifier)
+      return installment_creation_error("Product not found.") unless product
+
+      product.unique_permalink
+    end
+
+    def service_params_for_create(installment_type:, product_link_id:)
+      ActionController::Parameters.new(
+        installment: {
+          name: params[:subject],
+          message: params[:body],
+          installment_type:,
+          link_id: product_link_id,
+          send_emails: send_emails_param,
+          shown_on_profile: false,
+          shown_in_profile_sections: [],
+        },
+        publish: ("true" if publish_requested?)
+      )
+    end
+
+    def service_params_for_publish(installment)
+      service_params = {
+        installment: installment_service_attributes(installment),
+        publish: "true",
+      }
+      if installment.variant_type? && installment.base_variant.present?
+        service_params[:variant_external_id] = installment.base_variant.external_id
+      end
+      ActionController::Parameters.new(service_params)
+    end
+
+    def installment_service_attributes(installment)
+      {
+        name: installment.name,
+        message: installment.message,
+        installment_type: installment.installment_type,
+        link_id: installment.link&.unique_permalink,
+        paid_more_than_cents: installment.paid_more_than_cents,
+        paid_less_than_cents: installment.paid_less_than_cents,
+        created_after: installment.created_after,
+        created_before: installment.created_before,
+        bought_from: installment.bought_from,
+        shown_on_profile: installment.shown_on_profile?,
+        send_emails: installment.send_emails?,
+        allow_comments: installment.allow_comments?,
+        bought_products: installment.bought_products,
+        bought_variants: installment.bought_variants,
+        affiliate_products: installment.affiliate_products,
+        not_bought_products: installment.not_bought_products,
+        not_bought_variants: installment.not_bought_variants,
+        shown_in_profile_sections: shown_in_profile_sections_for(installment),
+      }
+    end
+
+    def shown_in_profile_sections_for(installment)
+      current_seller.seller_profile_posts_sections.filter_map do |section|
+        section.external_id if section.shown_posts.include?(installment.id)
+      end
+    end
+
+    def send_emails_param
+      return true unless params.key?(:send_emails)
+
+      boolean_param(:send_emails)
+    end
+
+    def publish_requested?
+      boolean_param(:publish) || (params.key?(:draft) && !boolean_param(:draft))
+    end
+
+    def boolean_param(key)
+      ActiveModel::Type::Boolean.new.cast(params[key])
+    end
+
+    def preview_url_for(installment)
+      installment.published? ? installment.full_url : edit_email_path(installment.external_id, preview_post: true)
+    end
+
+    def installment_creation_error(message)
+      installment = Installment.new
+      installment.errors.add(:base, message)
+      error_with_creating_object(:installment, installment)
+      nil
+    end
+
+    def success_with_installment(installment = nil)
+      success_with_object(:installment, installment)
+    end
+
+    def error_with_installment(installment = nil)
+      error_with_object(:installment, installment)
+    end
+end

--- a/app/controllers/api/v2/links_controller.rb
+++ b/app/controllers/api/v2/links_controller.rb
@@ -23,7 +23,7 @@ class Api::V2::LinksController < Api::V2::BaseController
     { variant_categories_alive: [{ alive_variants: :alive_rich_contents }] },
   ]).freeze
 
-  before_action(only: [:show, :index]) { doorkeeper_authorize!(*Doorkeeper.configuration.public_scopes.concat([:view_public])) }
+  before_action(only: [:show, :index]) { doorkeeper_authorize!(*Doorkeeper.configuration.public_api_read_scopes.concat([:view_public])) }
   before_action(only: [:create, :update, :disable, :enable, :destroy, :preview_custom_html]) { doorkeeper_authorize! :edit_products }
   before_action :reject_unsupported_upload_fields, only: [:update, :create]
   before_action :resolve_category_param, only: [:update, :create]

--- a/app/controllers/api/v2/offer_codes_controller.rb
+++ b/app/controllers/api/v2/offer_codes_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V2::OfferCodesController < Api::V2::BaseController
-  before_action(only: [:index, :show]) { doorkeeper_authorize!(*Doorkeeper.configuration.public_scopes.concat([:view_public])) }
+  before_action(only: [:index, :show]) { doorkeeper_authorize!(*Doorkeeper.configuration.public_api_read_scopes.concat([:view_public])) }
   before_action(only: [:create, :update, :destroy]) { doorkeeper_authorize! :edit_products }
   before_action :check_offer_code_params, only: [:create]
   before_action :fetch_product

--- a/app/controllers/api/v2/refund_policies_controller.rb
+++ b/app/controllers/api/v2/refund_policies_controller.rb
@@ -11,7 +11,7 @@ class Api::V2::RefundPoliciesController < Api::V2::BaseController
   }.freeze
   ACCOUNT_LEVEL_REFUND_POLICY_NOT_IN_EFFECT_MESSAGE = "The account-level refund policy is not in effect for this seller."
 
-  before_action(only: [:show]) { doorkeeper_authorize!(*Doorkeeper.configuration.public_scopes.concat([:view_public])) }
+  before_action(only: [:show]) { doorkeeper_authorize!(*Doorkeeper.configuration.public_api_read_scopes.concat([:view_public])) }
   before_action(only: [:update]) { doorkeeper_authorize! :edit_products }
 
   def show

--- a/app/controllers/api/v2/skus_controller.rb
+++ b/app/controllers/api/v2/skus_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V2::SkusController < Api::V2::BaseController
-  before_action -> { doorkeeper_authorize!(*Doorkeeper.configuration.public_scopes.concat([:view_public])) }
+  before_action -> { doorkeeper_authorize!(*Doorkeeper.configuration.public_api_read_scopes.concat([:view_public])) }
   before_action :fetch_product
 
   def index

--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V2::UsersController < Api::V2::BaseController
-  before_action -> { doorkeeper_authorize!(*Doorkeeper.configuration.public_scopes.concat([:view_public])) }, only: [:show, :ifttt_sale_trigger]
+  before_action -> { doorkeeper_authorize!(*Doorkeeper.configuration.public_api_read_scopes.concat([:view_public])) }, only: [:show, :ifttt_sale_trigger]
 
   def show
     if params[:is_ifttt]

--- a/app/controllers/api/v2/variant_categories_controller.rb
+++ b/app/controllers/api/v2/variant_categories_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V2::VariantCategoriesController < Api::V2::BaseController
-  before_action(only: [:index, :show]) { doorkeeper_authorize!(*Doorkeeper.configuration.public_scopes.concat([:view_public])) }
+  before_action(only: [:index, :show]) { doorkeeper_authorize!(*Doorkeeper.configuration.public_api_read_scopes.concat([:view_public])) }
   before_action(only: [:create, :update, :destroy]) { doorkeeper_authorize! :edit_products }
   before_action :fetch_product
   before_action :fetch_variant_category, only: [:show, :update, :destroy]

--- a/app/controllers/api/v2/variants_controller.rb
+++ b/app/controllers/api/v2/variants_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V2::VariantsController < Api::V2::BaseController
-  before_action(only: [:index, :show]) { doorkeeper_authorize!(*Doorkeeper.configuration.public_scopes.concat([:view_public])) }
+  before_action(only: [:index, :show]) { doorkeeper_authorize!(*Doorkeeper.configuration.public_api_read_scopes.concat([:view_public])) }
   before_action(only: [:create, :update, :destroy]) { doorkeeper_authorize! :edit_products }
   before_action :fetch_product
   before_action :fetch_variant_category, only: [:index, :create, :show, :update, :destroy]

--- a/app/controllers/oauth/device_authorizations_controller.rb
+++ b/app/controllers/oauth/device_authorizations_controller.rb
@@ -173,6 +173,7 @@ class Oauth::DeviceAuthorizationsController < ApplicationController
     def oauth_scope_description(scope)
       case scope
       when "creator_api" then "Creator API"
+      when "edit_emails" then "Create and manage your audience emails."
       when "edit_products" then "Create new products and edit your existing products."
       when "ifttt" then "See your sales data."
       when "mark_sales_as_shipped" then "Mark your sales as shipped."

--- a/app/javascript/components/ApiDocumentation/Endpoints/Emails.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/Emails.tsx
@@ -89,7 +89,7 @@ export const GetEmails = () => (
   -d "type=draft" \\
   -X GET`}
     </CodeSnippet>
-    <CodeSnippet caption="Gumroad CLI">gumroad email list --type draft</CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">gumroad emails list --type draft</CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
@@ -123,7 +123,7 @@ export const GetEmail = () => (
   -d "access_token=ACCESS_TOKEN" \\
   -X GET`}
     </CodeSnippet>
-    <CodeSnippet caption="Gumroad CLI">gumroad email view bfi_30HLgGWL8H2wo_Gzlg==</CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">gumroad emails view bfi_30HLgGWL8H2wo_Gzlg==</CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
@@ -153,7 +153,7 @@ export const CreateEmail = () => (
   <ApiEndpoint
     method="post"
     path="/emails"
-    description="Create a draft audience email, or send it immediately by passing publish=true or draft=false."
+    description="Create a draft audience email, or send it immediately by passing publish=true. Scheduled emails can only be created in the Emails web editor."
   >
     <ApiParameters>
       <ApiParameter name="subject" description="Email subject line" />
@@ -161,9 +161,7 @@ export const CreateEmail = () => (
       <ApiParameter name="audience" description={AUDIENCE_PARAMETER_DESCRIPTION} />
       <ApiParameter name="product_id" description="Required when audience is product" />
       <ApiParameter name="link_id" description="Product permalink accepted when audience is product" />
-      <ApiParameter name="send_emails" description="(optional, true or false) Default: true" />
       <ApiParameter name="publish" description="(optional, true to send immediately)" />
-      <ApiParameter name="draft" description="(optional, false to send immediately)" />
     </ApiParameters>
     <EmailResponseFields />
     <CodeSnippet caption="cURL example">
@@ -171,14 +169,14 @@ export const CreateEmail = () => (
   -d "access_token=ACCESS_TOKEN" \\
   -d "subject=Launch update" \\
   -d "body=<p>Hello, world!</p>" \\
-  -d "audience=audience" \\
+  -d "audience=all" \\
   -X POST`}
     </CodeSnippet>
     <CodeSnippet caption="Gumroad CLI">
-      {`gumroad email create \\
+      {`gumroad emails create \\
   --subject "Launch update" \\
-  --body "<p>Hello, world!</p>" \\
-  --audience audience`}
+  --body ./email.html \\
+  --audience all`}
     </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
@@ -217,7 +215,7 @@ export const PreviewEmail = () => (
   -d "access_token=ACCESS_TOKEN" \\
   -X POST`}
     </CodeSnippet>
-    <CodeSnippet caption="Gumroad CLI">gumroad email preview bfi_30HLgGWL8H2wo_Gzlg==</CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">gumroad emails send-preview bfi_30HLgGWL8H2wo_Gzlg==</CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
@@ -238,7 +236,7 @@ export const PreviewEmail = () => (
     "created_at": "2026-06-17T12:00:00.000Z",
     "updated_at": "2026-06-17T12:00:00.000Z"
   },
-  "preview_url": "/emails/bfi_30HLgGWL8H2wo_Gzlg==/edit?preview_post=true",
+  "preview_url": "https://gumroad.com/emails/bfi_30HLgGWL8H2wo_Gzlg==/edit?preview_post=true",
   "message": "A preview has been sent to your email."
 }`}
     </CodeSnippet>
@@ -257,7 +255,7 @@ export const SendEmail = () => (
   -d "access_token=ACCESS_TOKEN" \\
   -X POST`}
     </CodeSnippet>
-    <CodeSnippet caption="Gumroad CLI">gumroad email send bfi_30HLgGWL8H2wo_Gzlg==</CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">gumroad emails send bfi_30HLgGWL8H2wo_Gzlg==</CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
@@ -296,7 +294,7 @@ export const DeleteEmail = () => (
   -d "access_token=ACCESS_TOKEN" \\
   -X DELETE`}
     </CodeSnippet>
-    <CodeSnippet caption="Gumroad CLI">gumroad email delete bfi_30HLgGWL8H2wo_Gzlg==</CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">gumroad emails delete bfi_30HLgGWL8H2wo_Gzlg==</CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,

--- a/app/javascript/components/ApiDocumentation/Endpoints/Emails.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/Emails.tsx
@@ -12,12 +12,12 @@ const AUDIENCE_PARAMETER_DESCRIPTION = [
   'Default: "audience"',
 ].join(" ");
 
-const InstallmentResponseFields = () => (
+const EmailResponseFields = () => (
   <ApiResponseFields>
     {renderFields([
       { name: "success", type: "boolean", description: "Whether the request succeeded" },
       {
-        name: "installment",
+        name: "email",
         type: "object",
         description: "The email object",
         children: INSTALLMENT_FIELDS,
@@ -26,12 +26,12 @@ const InstallmentResponseFields = () => (
   </ApiResponseFields>
 );
 
-const InstallmentsResponseFields = () => (
+const EmailsResponseFields = () => (
   <ApiResponseFields>
     {renderFields([
       { name: "success", type: "boolean", description: "Whether the request succeeded" },
       {
-        name: "installments",
+        name: "emails",
         type: "array",
         description: "Array of email objects",
         children: INSTALLMENT_FIELDS,
@@ -57,7 +57,7 @@ const PreviewResponseFields = () => (
     {renderFields([
       { name: "success", type: "boolean", description: "Whether the request succeeded" },
       {
-        name: "installment",
+        name: "email",
         type: "object",
         description: "The email object",
         children: INSTALLMENT_FIELDS,
@@ -75,16 +75,16 @@ const PreviewResponseFields = () => (
 export const GetEmails = () => (
   <ApiEndpoint
     method="get"
-    path="/installments"
+    path="/emails"
     description="Retrieve the seller's audience emails. Use type to filter by published, scheduled, or draft emails."
   >
     <ApiParameters>
       <ApiParameter name="type" description='(optional, "published", "scheduled", or "draft")' />
       <ApiParameter name="page_key" description="(optional) Cursor returned by the previous page" />
     </ApiParameters>
-    <InstallmentsResponseFields />
+    <EmailsResponseFields />
     <CodeSnippet caption="cURL example">
-      {`curl https://api.gumroad.com/v2/installments \\
+      {`curl https://api.gumroad.com/v2/emails \\
   -d "access_token=ACCESS_TOKEN" \\
   -d "type=draft" \\
   -X GET`}
@@ -93,7 +93,7 @@ export const GetEmails = () => (
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
-  "installments": [{
+  "emails": [{
     "id": "bfi_30HLgGWL8H2wo_Gzlg==",
     "subject": "Launch update",
     "message": "<p>Hello, world!</p>",
@@ -116,10 +116,10 @@ export const GetEmails = () => (
 );
 
 export const GetEmail = () => (
-  <ApiEndpoint method="get" path="/installments/:id" description="Retrieve the details of a specific audience email.">
-    <InstallmentResponseFields />
+  <ApiEndpoint method="get" path="/emails/:id" description="Retrieve the details of a specific audience email.">
+    <EmailResponseFields />
     <CodeSnippet caption="cURL example">
-      {`curl https://api.gumroad.com/v2/installments/bfi_30HLgGWL8H2wo_Gzlg== \\
+      {`curl https://api.gumroad.com/v2/emails/bfi_30HLgGWL8H2wo_Gzlg== \\
   -d "access_token=ACCESS_TOKEN" \\
   -X GET`}
     </CodeSnippet>
@@ -127,7 +127,7 @@ export const GetEmail = () => (
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
-  "installment": {
+  "email": {
     "id": "bfi_30HLgGWL8H2wo_Gzlg==",
     "subject": "Launch update",
     "message": "<p>Hello, world!</p>",
@@ -152,7 +152,7 @@ export const GetEmail = () => (
 export const CreateEmail = () => (
   <ApiEndpoint
     method="post"
-    path="/installments"
+    path="/emails"
     description="Create a draft audience email, or send it immediately by passing publish=true or draft=false."
   >
     <ApiParameters>
@@ -165,9 +165,9 @@ export const CreateEmail = () => (
       <ApiParameter name="publish" description="(optional, true to send immediately)" />
       <ApiParameter name="draft" description="(optional, false to send immediately)" />
     </ApiParameters>
-    <InstallmentResponseFields />
+    <EmailResponseFields />
     <CodeSnippet caption="cURL example">
-      {`curl https://api.gumroad.com/v2/installments \\
+      {`curl https://api.gumroad.com/v2/emails \\
   -d "access_token=ACCESS_TOKEN" \\
   -d "subject=Launch update" \\
   -d "body=<p>Hello, world!</p>" \\
@@ -183,7 +183,7 @@ export const CreateEmail = () => (
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
-  "installment": {
+  "email": {
     "id": "bfi_30HLgGWL8H2wo_Gzlg==",
     "subject": "Launch update",
     "message": "<p>Hello, world!</p>",
@@ -208,12 +208,12 @@ export const CreateEmail = () => (
 export const PreviewEmail = () => (
   <ApiEndpoint
     method="post"
-    path="/installments/:id/preview"
+    path="/emails/:id/preview"
     description="Send a preview of an audience email to the seller's email address."
   >
     <PreviewResponseFields />
     <CodeSnippet caption="cURL example">
-      {`curl https://api.gumroad.com/v2/installments/bfi_30HLgGWL8H2wo_Gzlg==/preview \\
+      {`curl https://api.gumroad.com/v2/emails/bfi_30HLgGWL8H2wo_Gzlg==/preview \\
   -d "access_token=ACCESS_TOKEN" \\
   -X POST`}
     </CodeSnippet>
@@ -221,7 +221,7 @@ export const PreviewEmail = () => (
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
-  "installment": {
+  "email": {
     "id": "bfi_30HLgGWL8H2wo_Gzlg==",
     "subject": "Launch update",
     "message": "<p>Hello, world!</p>",
@@ -248,12 +248,12 @@ export const PreviewEmail = () => (
 export const SendEmail = () => (
   <ApiEndpoint
     method="post"
-    path="/installments/:id/send"
+    path="/emails/:id/send"
     description="Publish a draft audience email and send it to its audience."
   >
-    <InstallmentResponseFields />
+    <EmailResponseFields />
     <CodeSnippet caption="cURL example">
-      {`curl https://api.gumroad.com/v2/installments/bfi_30HLgGWL8H2wo_Gzlg==/send \\
+      {`curl https://api.gumroad.com/v2/emails/bfi_30HLgGWL8H2wo_Gzlg==/send \\
   -d "access_token=ACCESS_TOKEN" \\
   -X POST`}
     </CodeSnippet>
@@ -261,7 +261,7 @@ export const SendEmail = () => (
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
-  "installment": {
+  "email": {
     "id": "bfi_30HLgGWL8H2wo_Gzlg==",
     "subject": "Launch update",
     "message": "<p>Hello, world!</p>",
@@ -284,7 +284,7 @@ export const SendEmail = () => (
 );
 
 export const DeleteEmail = () => (
-  <ApiEndpoint method="delete" path="/installments/:id" description="Delete an audience email.">
+  <ApiEndpoint method="delete" path="/emails/:id" description="Delete an audience email.">
     <ApiResponseFields>
       {renderFields([
         { name: "success", type: "boolean", description: "Whether the request succeeded" },
@@ -292,7 +292,7 @@ export const DeleteEmail = () => (
       ])}
     </ApiResponseFields>
     <CodeSnippet caption="cURL example">
-      {`curl https://api.gumroad.com/v2/installments/bfi_30HLgGWL8H2wo_Gzlg== \\
+      {`curl https://api.gumroad.com/v2/emails/bfi_30HLgGWL8H2wo_Gzlg== \\
   -d "access_token=ACCESS_TOKEN" \\
   -X DELETE`}
     </CodeSnippet>
@@ -300,7 +300,7 @@ export const DeleteEmail = () => (
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
-  "message": "The installment was deleted successfully."
+  "message": "The email was deleted successfully."
 }`}
     </CodeSnippet>
   </ApiEndpoint>

--- a/app/javascript/components/ApiDocumentation/Endpoints/Emails.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/Emails.tsx
@@ -153,7 +153,7 @@ export const CreateEmail = () => (
   <ApiEndpoint
     method="post"
     path="/emails"
-    description="Create a draft audience email, or send it immediately by passing publish=true. Scheduled emails can only be created in the Emails web editor."
+    description="Create a draft audience email, or send it immediately by passing publish=true (or draft=false). Scheduled emails can only be created in the Emails web editor."
   >
     <ApiParameters>
       <ApiParameter name="subject" description="Email subject line" />
@@ -162,6 +162,7 @@ export const CreateEmail = () => (
       <ApiParameter name="product_id" description="Required when audience is product" />
       <ApiParameter name="link_id" description="Product permalink accepted when audience is product" />
       <ApiParameter name="publish" description="(optional, true to send immediately)" />
+      <ApiParameter name="draft" description="(optional, false to send immediately)" />
     </ApiParameters>
     <EmailResponseFields />
     <CodeSnippet caption="cURL example">

--- a/app/javascript/components/ApiDocumentation/Endpoints/Emails.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/Emails.tsx
@@ -76,7 +76,7 @@ export const GetEmails = () => (
   <ApiEndpoint
     method="get"
     path="/emails"
-    description="Retrieve the seller's audience emails. Use type to filter by published, scheduled, or draft emails."
+    description="Retrieve the seller's audience emails. Use type to filter by published, scheduled, or draft emails. Requires the edit_emails or account scope."
   >
     <ApiParameters>
       <ApiParameter name="type" description='(optional, "published", "scheduled", or "draft")' />
@@ -116,7 +116,11 @@ export const GetEmails = () => (
 );
 
 export const GetEmail = () => (
-  <ApiEndpoint method="get" path="/emails/:id" description="Retrieve the details of a specific audience email.">
+  <ApiEndpoint
+    method="get"
+    path="/emails/:id"
+    description="Retrieve the details of a specific audience email. Requires the edit_emails or account scope."
+  >
     <EmailResponseFields />
     <CodeSnippet caption="cURL example">
       {`curl https://api.gumroad.com/v2/emails/bfi_30HLgGWL8H2wo_Gzlg== \\
@@ -153,7 +157,7 @@ export const CreateEmail = () => (
   <ApiEndpoint
     method="post"
     path="/emails"
-    description="Create a draft audience email, or send it immediately by passing publish=true (or draft=false). Scheduled emails can only be created in the Emails web editor."
+    description="Create a draft audience email, or send it immediately by passing publish=true (or draft=false). Scheduled emails can only be created in the Emails web editor. Requires the edit_emails or account scope."
   >
     <ApiParameters>
       <ApiParameter name="subject" description="Email subject line" />
@@ -208,7 +212,7 @@ export const PreviewEmail = () => (
   <ApiEndpoint
     method="post"
     path="/emails/:id/preview"
-    description="Send a preview of an audience email to the seller's email address."
+    description="Send a preview of an audience email to the seller's email address. Requires the edit_emails or account scope."
   >
     <PreviewResponseFields />
     <CodeSnippet caption="cURL example">
@@ -248,7 +252,7 @@ export const SendEmail = () => (
   <ApiEndpoint
     method="post"
     path="/emails/:id/send"
-    description="Publish a draft audience email and send it to its audience."
+    description="Publish a draft audience email and send it to its audience. Requires the edit_emails or account scope."
   >
     <EmailResponseFields />
     <CodeSnippet caption="cURL example">
@@ -273,7 +277,7 @@ export const SendEmail = () => (
     "shown_on_profile": false,
     "audience_count": null,
     "recipients_count": 0,
-    "url": "/seller/p/launch-update",
+    "url": "https://seller.gumroad.com/p/launch-update",
     "created_at": "2026-06-17T12:00:00.000Z",
     "updated_at": "2026-06-17T12:15:00.000Z"
   }
@@ -283,7 +287,11 @@ export const SendEmail = () => (
 );
 
 export const DeleteEmail = () => (
-  <ApiEndpoint method="delete" path="/emails/:id" description="Delete an audience email.">
+  <ApiEndpoint
+    method="delete"
+    path="/emails/:id"
+    description="Delete an audience email. Requires the edit_emails or account scope."
+  >
     <ApiResponseFields>
       {renderFields([
         { name: "success", type: "boolean", description: "Whether the request succeeded" },

--- a/app/javascript/components/ApiDocumentation/Endpoints/Emails.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/Emails.tsx
@@ -1,0 +1,307 @@
+import React from "react";
+
+import CodeSnippet from "$app/components/ui/CodeSnippet";
+
+import { ApiEndpoint } from "../ApiEndpoint";
+import { ApiParameter, ApiParameters } from "../ApiParameters";
+import { ApiResponseFields, renderFields } from "../ApiResponseFields";
+import { INSTALLMENT_FIELDS } from "../responseFieldDefinitions";
+
+const AUDIENCE_PARAMETER_DESCRIPTION = [
+  '(optional, "all", "audience", "customers", "seller", "followers", "follower", or "product")',
+  'Default: "audience"',
+].join(" ");
+
+const InstallmentResponseFields = () => (
+  <ApiResponseFields>
+    {renderFields([
+      { name: "success", type: "boolean", description: "Whether the request succeeded" },
+      {
+        name: "installment",
+        type: "object",
+        description: "The email object",
+        children: INSTALLMENT_FIELDS,
+      },
+    ])}
+  </ApiResponseFields>
+);
+
+const InstallmentsResponseFields = () => (
+  <ApiResponseFields>
+    {renderFields([
+      { name: "success", type: "boolean", description: "Whether the request succeeded" },
+      {
+        name: "installments",
+        type: "array",
+        description: "Array of email objects",
+        children: INSTALLMENT_FIELDS,
+      },
+      {
+        name: "next_page_key",
+        type: "string",
+        description: "Cursor for the next page",
+        condition: "present when more results exist",
+      },
+      {
+        name: "next_page_url",
+        type: "string",
+        description: "URL for the next page",
+        condition: "present when more results exist",
+      },
+    ])}
+  </ApiResponseFields>
+);
+
+const PreviewResponseFields = () => (
+  <ApiResponseFields>
+    {renderFields([
+      { name: "success", type: "boolean", description: "Whether the request succeeded" },
+      {
+        name: "installment",
+        type: "object",
+        description: "The email object",
+        children: INSTALLMENT_FIELDS,
+      },
+      {
+        name: "preview_url",
+        type: "string | null",
+        description: "Public post URL when published, otherwise the seller edit URL",
+      },
+      { name: "message", type: "string", description: "Preview delivery message" },
+    ])}
+  </ApiResponseFields>
+);
+
+export const GetEmails = () => (
+  <ApiEndpoint
+    method="get"
+    path="/installments"
+    description="Retrieve the seller's audience emails. Use type to filter by published, scheduled, or draft emails."
+  >
+    <ApiParameters>
+      <ApiParameter name="type" description='(optional, "published", "scheduled", or "draft")' />
+      <ApiParameter name="page_key" description="(optional) Cursor returned by the previous page" />
+    </ApiParameters>
+    <InstallmentsResponseFields />
+    <CodeSnippet caption="cURL example">
+      {`curl https://api.gumroad.com/v2/installments \\
+  -d "access_token=ACCESS_TOKEN" \\
+  -d "type=draft" \\
+  -X GET`}
+    </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">gumroad email list --type draft</CodeSnippet>
+    <CodeSnippet caption="Example response:">
+      {`{
+  "success": true,
+  "installments": [{
+    "id": "bfi_30HLgGWL8H2wo_Gzlg==",
+    "subject": "Launch update",
+    "message": "<p>Hello, world!</p>",
+    "audience_type": "audience",
+    "product_id": null,
+    "state": "draft",
+    "published_at": null,
+    "scheduled_at": null,
+    "send_emails": true,
+    "shown_on_profile": false,
+    "audience_count": null,
+    "recipients_count": null,
+    "url": null,
+    "created_at": "2026-06-17T12:00:00.000Z",
+    "updated_at": "2026-06-17T12:00:00.000Z"
+  }]
+}`}
+    </CodeSnippet>
+  </ApiEndpoint>
+);
+
+export const GetEmail = () => (
+  <ApiEndpoint method="get" path="/installments/:id" description="Retrieve the details of a specific audience email.">
+    <InstallmentResponseFields />
+    <CodeSnippet caption="cURL example">
+      {`curl https://api.gumroad.com/v2/installments/bfi_30HLgGWL8H2wo_Gzlg== \\
+  -d "access_token=ACCESS_TOKEN" \\
+  -X GET`}
+    </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">gumroad email view bfi_30HLgGWL8H2wo_Gzlg==</CodeSnippet>
+    <CodeSnippet caption="Example response:">
+      {`{
+  "success": true,
+  "installment": {
+    "id": "bfi_30HLgGWL8H2wo_Gzlg==",
+    "subject": "Launch update",
+    "message": "<p>Hello, world!</p>",
+    "audience_type": "audience",
+    "product_id": null,
+    "state": "draft",
+    "published_at": null,
+    "scheduled_at": null,
+    "send_emails": true,
+    "shown_on_profile": false,
+    "audience_count": null,
+    "recipients_count": null,
+    "url": null,
+    "created_at": "2026-06-17T12:00:00.000Z",
+    "updated_at": "2026-06-17T12:00:00.000Z"
+  }
+}`}
+    </CodeSnippet>
+  </ApiEndpoint>
+);
+
+export const CreateEmail = () => (
+  <ApiEndpoint
+    method="post"
+    path="/installments"
+    description="Create a draft audience email, or send it immediately by passing publish=true or draft=false."
+  >
+    <ApiParameters>
+      <ApiParameter name="subject" description="Email subject line" />
+      <ApiParameter name="body" description="HTML email body" />
+      <ApiParameter name="audience" description={AUDIENCE_PARAMETER_DESCRIPTION} />
+      <ApiParameter name="product_id" description="Required when audience is product" />
+      <ApiParameter name="link_id" description="Product permalink accepted when audience is product" />
+      <ApiParameter name="send_emails" description="(optional, true or false) Default: true" />
+      <ApiParameter name="publish" description="(optional, true to send immediately)" />
+      <ApiParameter name="draft" description="(optional, false to send immediately)" />
+    </ApiParameters>
+    <InstallmentResponseFields />
+    <CodeSnippet caption="cURL example">
+      {`curl https://api.gumroad.com/v2/installments \\
+  -d "access_token=ACCESS_TOKEN" \\
+  -d "subject=Launch update" \\
+  -d "body=<p>Hello, world!</p>" \\
+  -d "audience=audience" \\
+  -X POST`}
+    </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">
+      {`gumroad email create \\
+  --subject "Launch update" \\
+  --body "<p>Hello, world!</p>" \\
+  --audience audience`}
+    </CodeSnippet>
+    <CodeSnippet caption="Example response:">
+      {`{
+  "success": true,
+  "installment": {
+    "id": "bfi_30HLgGWL8H2wo_Gzlg==",
+    "subject": "Launch update",
+    "message": "<p>Hello, world!</p>",
+    "audience_type": "audience",
+    "product_id": null,
+    "state": "draft",
+    "published_at": null,
+    "scheduled_at": null,
+    "send_emails": true,
+    "shown_on_profile": false,
+    "audience_count": null,
+    "recipients_count": null,
+    "url": null,
+    "created_at": "2026-06-17T12:00:00.000Z",
+    "updated_at": "2026-06-17T12:00:00.000Z"
+  }
+}`}
+    </CodeSnippet>
+  </ApiEndpoint>
+);
+
+export const PreviewEmail = () => (
+  <ApiEndpoint
+    method="post"
+    path="/installments/:id/preview"
+    description="Send a preview of an audience email to the seller's email address."
+  >
+    <PreviewResponseFields />
+    <CodeSnippet caption="cURL example">
+      {`curl https://api.gumroad.com/v2/installments/bfi_30HLgGWL8H2wo_Gzlg==/preview \\
+  -d "access_token=ACCESS_TOKEN" \\
+  -X POST`}
+    </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">gumroad email preview bfi_30HLgGWL8H2wo_Gzlg==</CodeSnippet>
+    <CodeSnippet caption="Example response:">
+      {`{
+  "success": true,
+  "installment": {
+    "id": "bfi_30HLgGWL8H2wo_Gzlg==",
+    "subject": "Launch update",
+    "message": "<p>Hello, world!</p>",
+    "audience_type": "audience",
+    "product_id": null,
+    "state": "draft",
+    "published_at": null,
+    "scheduled_at": null,
+    "send_emails": true,
+    "shown_on_profile": false,
+    "audience_count": null,
+    "recipients_count": null,
+    "url": null,
+    "created_at": "2026-06-17T12:00:00.000Z",
+    "updated_at": "2026-06-17T12:00:00.000Z"
+  },
+  "preview_url": "/emails/bfi_30HLgGWL8H2wo_Gzlg==/edit?preview_post=true",
+  "message": "A preview has been sent to your email."
+}`}
+    </CodeSnippet>
+  </ApiEndpoint>
+);
+
+export const SendEmail = () => (
+  <ApiEndpoint
+    method="post"
+    path="/installments/:id/send"
+    description="Publish a draft audience email and send it to its audience."
+  >
+    <InstallmentResponseFields />
+    <CodeSnippet caption="cURL example">
+      {`curl https://api.gumroad.com/v2/installments/bfi_30HLgGWL8H2wo_Gzlg==/send \\
+  -d "access_token=ACCESS_TOKEN" \\
+  -X POST`}
+    </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">gumroad email send bfi_30HLgGWL8H2wo_Gzlg==</CodeSnippet>
+    <CodeSnippet caption="Example response:">
+      {`{
+  "success": true,
+  "installment": {
+    "id": "bfi_30HLgGWL8H2wo_Gzlg==",
+    "subject": "Launch update",
+    "message": "<p>Hello, world!</p>",
+    "audience_type": "audience",
+    "product_id": null,
+    "state": "published",
+    "published_at": "2026-06-17T12:15:00.000Z",
+    "scheduled_at": null,
+    "send_emails": true,
+    "shown_on_profile": false,
+    "audience_count": null,
+    "recipients_count": 0,
+    "url": "/seller/p/launch-update",
+    "created_at": "2026-06-17T12:00:00.000Z",
+    "updated_at": "2026-06-17T12:15:00.000Z"
+  }
+}`}
+    </CodeSnippet>
+  </ApiEndpoint>
+);
+
+export const DeleteEmail = () => (
+  <ApiEndpoint method="delete" path="/installments/:id" description="Delete an audience email.">
+    <ApiResponseFields>
+      {renderFields([
+        { name: "success", type: "boolean", description: "Whether the request succeeded" },
+        { name: "message", type: "string", description: "Deletion confirmation message" },
+      ])}
+    </ApiResponseFields>
+    <CodeSnippet caption="cURL example">
+      {`curl https://api.gumroad.com/v2/installments/bfi_30HLgGWL8H2wo_Gzlg== \\
+  -d "access_token=ACCESS_TOKEN" \\
+  -X DELETE`}
+    </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">gumroad email delete bfi_30HLgGWL8H2wo_Gzlg==</CodeSnippet>
+    <CodeSnippet caption="Example response:">
+      {`{
+  "success": true,
+  "message": "The installment was deleted successfully."
+}`}
+    </CodeSnippet>
+  </ApiEndpoint>
+);

--- a/app/javascript/components/ApiDocumentation/Navigation.tsx
+++ b/app/javascript/components/ApiDocumentation/Navigation.tsx
@@ -50,6 +50,9 @@ export const Navigation = () => (
             <a href="#offer-codes">Offer codes</a>
           </li>
           <li>
+            <a href="#emails">Emails</a>
+          </li>
+          <li>
             <a href="#custom-fields">Custom fields</a>
           </li>
           <li>

--- a/app/javascript/components/ApiDocumentation/Scopes.tsx
+++ b/app/javascript/components/ApiDocumentation/Scopes.tsx
@@ -16,6 +16,10 @@ const SCOPES = [
     description: "read/write access to the user's products and their variants, offer codes, custom fields, and files.",
   },
   {
+    name: "edit_emails",
+    description: "read/write access to the user's audience emails.",
+  },
+  {
     name: "view_sales",
     description:
       "read access to the user's products' sales information, including sales counts. This scope is also required in order to subscribe to the user's sales.",

--- a/app/javascript/components/ApiDocumentation/responseFieldDefinitions.ts
+++ b/app/javascript/components/ApiDocumentation/responseFieldDefinitions.ts
@@ -666,6 +666,40 @@ export const USER_FIELDS: FieldDefinition[] = [
   { name: "profile_picture_url", type: "string", description: "URL of the user's profile picture" },
 ];
 
+export const INSTALLMENT_FIELDS: FieldDefinition[] = [
+  { name: "id", type: "string", description: "Unique identifier for the email" },
+  { name: "subject", type: "string | null", description: "Subject line" },
+  { name: "message", type: "string | null", description: "HTML body" },
+  {
+    name: "audience_type",
+    type: "string",
+    description: 'Audience type, one of "audience", "seller", "follower", or "product"',
+  },
+  {
+    name: "product_id",
+    type: "string | null",
+    description: "Product ID for product-targeted emails, null otherwise",
+  },
+  { name: "state", type: "string", description: 'Current state, one of "draft", "scheduled", or "published"' },
+  { name: "published_at", type: "string | null", description: "Timestamp when the email was published" },
+  { name: "scheduled_at", type: "string | null", description: "Timestamp when the email is scheduled to publish" },
+  { name: "send_emails", type: "boolean", description: "Whether this post sends emails to its audience" },
+  { name: "shown_on_profile", type: "boolean", description: "Whether this post is shown on the seller profile" },
+  {
+    name: "audience_count",
+    type: "number | null",
+    description: "Estimated audience size when available, null when not computed",
+  },
+  {
+    name: "recipients_count",
+    type: "number | null",
+    description: "Delivered recipient count when available, null before publishing",
+  },
+  { name: "url", type: "string | null", description: "Public post URL when published, null otherwise" },
+  { name: "created_at", type: "string", description: "ISO 8601 timestamp of when the email was created" },
+  { name: "updated_at", type: "string", description: "ISO 8601 timestamp of when the email was last updated" },
+];
+
 export const OFFER_CODE_FIELDS: FieldDefinition[] = [
   { name: "id", type: "string", description: "Unique identifier for the offer code" },
   { name: "name", type: "string", description: "Coupon code used at checkout" },

--- a/app/javascript/pages/Public/Api.tsx
+++ b/app/javascript/pages/Public/Api.tsx
@@ -12,6 +12,14 @@ import {
 } from "$app/components/ApiDocumentation/Endpoints/CustomFields";
 import { GetEarnings } from "$app/components/ApiDocumentation/Endpoints/Earnings";
 import {
+  CreateEmail,
+  DeleteEmail,
+  GetEmail,
+  GetEmails,
+  PreviewEmail,
+  SendEmail,
+} from "$app/components/ApiDocumentation/Endpoints/Emails";
+import {
   AbortFile,
   AttachFile,
   CompleteFile,
@@ -178,6 +186,15 @@ export default function Api() {
                 <CreateOfferCode />
                 <UpdateOfferCode />
                 <DeleteOfferCode />
+              </ApiResource>
+
+              <ApiResource name="Emails" id="emails">
+                <GetEmails />
+                <GetEmail />
+                <CreateEmail />
+                <PreviewEmail />
+                <SendEmail />
+                <DeleteEmail />
               </ApiResource>
 
               <ApiResource name="Custom fields" id="custom-fields">

--- a/app/javascript/pages/Settings/AuthorizedApplications/Index.tsx
+++ b/app/javascript/pages/Settings/AuthorizedApplications/Index.tsx
@@ -27,6 +27,7 @@ type AuthorizedApplication = {
 
 type Scope =
   | "account"
+  | "edit_emails"
   | "edit_products"
   | "ifttt"
   | "mark_sales_as_shipped"
@@ -44,6 +45,7 @@ type Scope =
 
 const SCOPE_DESCRIPTIONS: Record<Scope, string> = {
   account: "Full access to your account.",
+  edit_emails: "Create and manage your audience emails.",
   edit_products: "Create new products and edit your existing products.",
   ifttt: "See your sales data.",
   mark_sales_as_shipped: "Mark your sales as shipped.",

--- a/app/models/installment.rb
+++ b/app/models/installment.rb
@@ -522,6 +522,24 @@ class Installment < ApplicationRecord
     end
   end
 
+  def public_page_location(purchase_id: nil)
+    return unless slug.present?
+    if user.subdomain_with_protocol.present?
+      custom_domain_view_post_url(
+        host: user.subdomain_with_protocol,
+        slug:,
+        purchase_id: purchase_id.presence
+      )
+    else
+      view_post_url(
+        host: UrlService.domain_with_protocol,
+        username: user.username.presence || user.external_id,
+        slug:,
+        purchase_id: purchase_id.presence
+      )
+    end
+  end
+
   def generate_url_redirect_for_imported_customer(imported_customer, product: nil)
     return unless imported_customer
     product ||= imported_customer.link
@@ -620,20 +638,21 @@ class Installment < ApplicationRecord
   end
 
   def as_json_for_api(include_audience_count: false)
+    state = display_type
     {
       id: external_id,
       subject: name,
       message:,
       audience_type: installment_type,
       product_id: link&.external_id,
-      state: display_type,
+      state:,
       published_at:,
-      scheduled_at: installment_rule&.to_be_published_at,
+      scheduled_at: state == SCHEDULED && installment_rule&.alive? ? installment_rule.to_be_published_at : nil,
       send_emails: send_emails?,
       shown_on_profile: shown_on_profile?,
       audience_count: include_audience_count ? api_audience_members_count : nil,
       recipients_count: published? ? customer_count : nil,
-      url: published? ? full_url : nil,
+      url: published? ? public_page_location : nil,
       created_at:,
       updated_at:,
     }

--- a/app/models/installment.rb
+++ b/app/models/installment.rb
@@ -613,6 +613,32 @@ class Installment < ApplicationRecord
     ready_to_publish? ? "scheduled" : "draft"
   end
 
+  def as_json(options = {})
+    return as_json_for_api if options[:api_scopes].present?
+
+    super
+  end
+
+  def as_json_for_api(include_audience_count: false)
+    {
+      id: external_id,
+      subject: name,
+      message:,
+      audience_type: installment_type,
+      product_id: link&.external_id,
+      state: display_type,
+      published_at:,
+      scheduled_at: installment_rule&.to_be_published_at,
+      send_emails: send_emails?,
+      shown_on_profile: shown_on_profile?,
+      audience_count: include_audience_count ? api_audience_members_count : nil,
+      recipients_count: published? ? customer_count : nil,
+      url: published? ? full_url : nil,
+      created_at:,
+      updated_at:,
+    }
+  end
+
   def publish!(published_at: nil)
     enforce_user_email_confirmation!
     transcode_videos!
@@ -855,6 +881,12 @@ class Installment < ApplicationRecord
     else
       AudienceMember.filter(seller_id:, params: audience_members_filter_params).limit(limit).count
     end
+  end
+
+  def api_audience_members_count
+    audience_members_count
+  rescue StandardError
+    nil
   end
 
   def self.receivable_by_customers_of_product(product:, variant_external_id:)

--- a/app/views/doorkeeper/authorizations/new.html.erb
+++ b/app/views/doorkeeper/authorizations/new.html.erb
@@ -18,6 +18,7 @@
             <%=
             case scope
               when "creator_api" then "Creator API"
+              when "edit_emails" then "Create and manage your audience emails."
               when "edit_products" then "Create new products and edit your existing products."
               when "ifttt" then "See your sales data."
               when "mark_sales_as_shipped" then "Mark your sales as shipped."

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -7,7 +7,7 @@ module VisibleScopes
   # These are the scopes that the public should be aware of. Update this list when adding scopes to Doorkeeper.
   # Mobile Api scope is not included because we don't want the public to have knowledge of that scope.
   def public_scopes
-    %i[edit_products view_sales mark_sales_as_shipped edit_sales revenue_share ifttt view_profile view_payouts view_tax_data account]
+    %i[edit_products edit_emails view_sales mark_sales_as_shipped edit_sales revenue_share ifttt view_profile view_payouts view_tax_data account]
   end
 end
 
@@ -35,7 +35,7 @@ Doorkeeper.configure do
 
   # access token scopes for providers
   default_scopes :view_public
-  optional_scopes :edit_products, :view_sales, :view_payouts, :mark_sales_as_shipped, :refund_sales, :edit_sales, :revenue_share, :ifttt, :mobile_api,
+  optional_scopes :edit_products, :edit_emails, :view_sales, :view_payouts, :mark_sales_as_shipped, :refund_sales, :edit_sales, :revenue_share, :ifttt, :mobile_api,
                   :creator_api, :view_profile, :unfurl, :helper_api, :view_tax_data, :account
 
   use_refresh_token

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -9,6 +9,10 @@ module VisibleScopes
   def public_scopes
     %i[edit_products edit_emails view_sales mark_sales_as_shipped edit_sales revenue_share ifttt view_profile view_payouts view_tax_data account]
   end
+
+  def public_api_read_scopes
+    public_scopes - %i[edit_emails]
+  end
 end
 
 Doorkeeper.configure do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,7 +82,7 @@ Rails.application.routes.draw do
           post "preview_custom_html"
         end
       end
-      resources :installments, only: [:index, :show, :create, :destroy] do
+      resources :emails, only: [:index, :show, :create, :destroy] do
         member do
           post :preview
           post :send, action: :send_email

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,12 @@ Rails.application.routes.draw do
           post "preview_custom_html"
         end
       end
+      resources :installments, only: [:index, :show, :create, :destroy] do
+        member do
+          post :preview
+          post :send, action: :send_email
+        end
+      end
       post "sales/exports", to: "sales#export"
       get "sales/summary", to: "sales#summary"
       resources :sales, only: [:index, :show] do

--- a/db/migrate/20261201000001_backfill_edit_emails_scope_for_default_oauth_applications.rb
+++ b/db/migrate/20261201000001_backfill_edit_emails_scope_for_default_oauth_applications.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class BackfillEditEmailsScopeForDefaultOauthApplications < ActiveRecord::Migration[7.1]
+  OLD_PUBLIC_SCOPES = %w[edit_products view_sales mark_sales_as_shipped edit_sales revenue_share ifttt view_profile view_payouts view_tax_data account].freeze
+  NEW_SCOPE = "edit_emails"
+
+  def up
+    oauth_applications.find_each do |application|
+      scopes = application.scopes.to_s.split
+      next if scopes.include?(NEW_SCOPE)
+      next unless old_default_scopes?(scopes)
+
+      scopes.insert(scopes.index("edit_products").to_i + 1, NEW_SCOPE)
+      application.update_columns(scopes: scopes.join(" "), updated_at: Time.current)
+    end
+  end
+
+  def down
+    oauth_applications.find_each do |application|
+      scopes = application.scopes.to_s.split
+      next unless scopes.include?(NEW_SCOPE)
+      next unless new_default_scopes?(scopes)
+
+      application.update_columns(scopes: (scopes - [NEW_SCOPE]).join(" "), updated_at: Time.current)
+    end
+  end
+
+  private
+    def old_default_scopes?(scopes)
+      (scopes - OLD_PUBLIC_SCOPES).empty? && (OLD_PUBLIC_SCOPES - scopes).empty?
+    end
+
+    def new_default_scopes?(scopes)
+      old_default_scopes?(scopes - [NEW_SCOPE])
+    end
+
+    def oauth_applications
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "oauth_applications"
+      end
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_12_01_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_12_01_000001) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false

--- a/spec/controllers/api/v2/emails_controller_spec.rb
+++ b/spec/controllers/api/v2/emails_controller_spec.rb
@@ -399,6 +399,25 @@ describe Api::V2::EmailsController do
           message: "The email has already been sent."
         }.as_json)
       end
+
+      it "does not immediately send a scheduled email" do
+        scheduled = create(
+          :scheduled_installment,
+          seller: @user,
+          link: nil,
+          installment_type: Installment::AUDIENCE_TYPE
+        )
+
+        expect do
+          post @action, params: @params.merge(id: scheduled.external_id)
+        end.not_to change(PostEmailBlast, :count)
+
+        expect(response.parsed_body).to eq({
+          success: false,
+          message: "The email is scheduled to be sent at its scheduled time."
+        }.as_json)
+        expect(scheduled.reload.published?).to be(false)
+      end
     end
   end
 

--- a/spec/controllers/api/v2/emails_controller_spec.rb
+++ b/spec/controllers/api/v2/emails_controller_spec.rb
@@ -227,6 +227,17 @@ describe Api::V2::EmailsController do
         expect(SendPostBlastEmailsJob).to have_enqueued_sidekiq_job(PostEmailBlast.last.id)
       end
 
+      it "publishes when draft is false" do
+        allow_any_instance_of(User).to receive(:eligible_to_send_emails?).and_return(true)
+
+        expect do
+          post @action, params: @params.merge(draft: "false")
+        end.to change(PostEmailBlast, :count).by(1)
+
+        expect(@user.installments.alive.sole.published?).to be(true)
+        expect(response.parsed_body["email"]["state"]).to eq("published")
+      end
+
       it "does not publish from a blank draft parameter" do
         allow_any_instance_of(User).to receive(:eligible_to_send_emails?).and_return(true)
 

--- a/spec/controllers/api/v2/emails_controller_spec.rb
+++ b/spec/controllers/api/v2/emails_controller_spec.rb
@@ -410,7 +410,9 @@ describe Api::V2::EmailsController do
 
         expect(response.parsed_body["success"]).to be(true)
         expect(response.parsed_body["email"]["id"]).to eq(product_owned_installment.external_id)
-        expect(product_owned_installment.reload.seller).to be_nil
+        expect(response.parsed_body["preview_url"]).to eq(edit_email_url(product_owned_installment.external_id, preview_post: true, host: UrlService.domain_with_protocol))
+        expect(product_owned_installment.reload.seller).to eq(@user)
+        expect(@user.installments.alive.find_by_external_id(product_owned_installment.external_id)).to eq(product_owned_installment)
       end
 
       it "returns an absolute preview URL for a published email" do
@@ -437,6 +439,21 @@ describe Api::V2::EmailsController do
         expect(response.parsed_body).to eq({
           success: false,
           message: "Preview failed."
+        }.as_json)
+      end
+
+      it "returns a JSON error and notifies for unexpected preview failures" do
+        error = StandardError.new("Provider unavailable.")
+        allow_any_instance_of(Installment)
+          .to receive(:send_preview_email)
+          .and_raise(error)
+        expect(ErrorNotifier).to receive(:notify).with(error)
+
+        post @action, params: @params
+
+        expect(response.parsed_body).to eq({
+          success: false,
+          message: "Provider unavailable."
         }.as_json)
       end
     end
@@ -478,7 +495,31 @@ describe Api::V2::EmailsController do
 
         expect(product_owned_installment.reload).to be_published
         expect(product_owned_installment.seller).to eq(@user)
+        expect(product_owned_installment.bought_products).to eq([product_owned_installment.link.unique_permalink])
         expect(response.parsed_body["email"]["id"]).to eq(product_owned_installment.external_id)
+        expect(SendPostBlastEmailsJob).to have_enqueued_sidekiq_job(PostEmailBlast.last.id)
+      end
+
+      it "sends a variant-owned email to buyers of the variant" do
+        product = create(:product, user: @user)
+        variant = create(:variant, variant_category: create(:variant_category, link: product))
+        variant_owned_installment = create(
+          :variant_installment,
+          link: product,
+          seller: nil,
+          base_variant: variant,
+          bought_products: [],
+          bought_variants: []
+        )
+
+        expect do
+          post @action, params: @params.merge(id: variant_owned_installment.external_id)
+        end.to change(PostEmailBlast, :count).by(1)
+
+        expect(variant_owned_installment.reload).to be_published
+        expect(variant_owned_installment.seller).to eq(@user)
+        expect(variant_owned_installment.bought_products).to be_nil
+        expect(variant_owned_installment.bought_variants).to eq([variant.external_id])
         expect(SendPostBlastEmailsJob).to have_enqueued_sidekiq_job(PostEmailBlast.last.id)
       end
 
@@ -493,12 +534,31 @@ describe Api::V2::EmailsController do
 
         expect(product_owned_installment.reload.seller).to eq(@user)
         expect(PostEmailBlast.last.seller).to eq(@user)
+        expect(product_owned_installment.bought_products).to eq([product_owned_installment.link.unique_permalink])
         expect(response.parsed_body["email"]).to include(
           "id" => product_owned_installment.external_id,
           "send_emails" => true,
           "shown_on_profile" => true,
           "state" => "published"
         )
+        expect(SendPostBlastEmailsJob).to have_enqueued_sidekiq_job(PostEmailBlast.last.id)
+      end
+
+      it "sends a published variant-owned profile-only post to buyers of the variant" do
+        product = create(:product, user: @user)
+        variant = create(:variant, variant_category: create(:variant_category, link: product))
+        variant_owned_installment = create(:variant_installment, link: product, seller: nil, base_variant: variant, published_at: 1.hour.ago)
+        variant_owned_installment.assign_attributes(send_emails: false, shown_on_profile: true, bought_products: [], bought_variants: [])
+        variant_owned_installment.save!(validate: false)
+
+        expect do
+          post @action, params: @params.merge(id: variant_owned_installment.external_id)
+        end.to change(PostEmailBlast, :count).by(1)
+
+        expect(variant_owned_installment.reload.seller).to eq(@user)
+        expect(variant_owned_installment.bought_products).to be_nil
+        expect(variant_owned_installment.bought_variants).to eq([variant.external_id])
+        expect(PostEmailBlast.last.seller).to eq(@user)
         expect(SendPostBlastEmailsJob).to have_enqueued_sidekiq_job(PostEmailBlast.last.id)
       end
 

--- a/spec/controllers/api/v2/emails_controller_spec.rb
+++ b/spec/controllers/api/v2/emails_controller_spec.rb
@@ -13,6 +13,10 @@ describe Api::V2::EmailsController do
     create("doorkeeper/access_token", application: @app, resource_owner_id: @user.id, scopes:)
   end
 
+  def create_product_owned_installment(**attributes)
+    create(:product_installment, { link: create(:product, user: @user), seller: nil }.merge(attributes))
+  end
+
   describe "GET 'index'" do
     before do
       @action = :index
@@ -20,11 +24,11 @@ describe Api::V2::EmailsController do
     end
 
     it_behaves_like "authorized oauth v1 api method"
-    it_behaves_like "authorized oauth v1 api method only for edit_products scope"
+    it_behaves_like "authorized oauth v1 api method only for edit_emails scope"
 
-    describe "when logged in with edit_products scope" do
+    describe "when logged in with edit_emails scope" do
       before do
-        @token = create_access_token("edit_products")
+        @token = create_access_token("edit_emails")
         @params.merge!(access_token: @token.token)
       end
 
@@ -88,7 +92,7 @@ describe Api::V2::EmailsController do
 
         expect(response.parsed_body).to eq({
           success: true,
-          emails: expected_installments[per_page..].as_json(api_scopes: ["edit_products"])
+          emails: expected_installments[per_page..].as_json(api_scopes: ["edit_emails"])
         }.as_json)
       end
 
@@ -123,6 +127,21 @@ describe Api::V2::EmailsController do
           emails: []
         }.as_json)
       end
+
+      it "returns installments owned through the seller's products" do
+        product_owned_installment = create_product_owned_installment
+        other_seller_product_owned_installment = create(
+          :product_installment,
+          link: create(:product, user: create(:user)),
+          seller: nil
+        )
+
+        get @action, params: @params
+
+        email_ids = response.parsed_body["emails"].map { _1["id"] }
+        expect(email_ids).to include(product_owned_installment.external_id)
+        expect(email_ids).not_to include(other_seller_product_owned_installment.external_id)
+      end
     end
 
     it "grants access with the account scope" do
@@ -140,11 +159,11 @@ describe Api::V2::EmailsController do
     end
 
     it_behaves_like "authorized oauth v1 api method"
-    it_behaves_like "authorized oauth v1 api method only for edit_products scope"
+    it_behaves_like "authorized oauth v1 api method only for edit_emails scope"
 
-    describe "when logged in with edit_products scope" do
+    describe "when logged in with edit_emails scope" do
       before do
-        @token = create_access_token("edit_products")
+        @token = create_access_token("edit_emails")
         @params.merge!(access_token: @token.token)
       end
 
@@ -153,8 +172,16 @@ describe Api::V2::EmailsController do
 
         expect(response.parsed_body).to eq({
           success: true,
-          email: @installment.as_json(api_scopes: ["edit_products"])
+          email: @installment.as_json(api_scopes: ["edit_emails"])
         }.as_json)
+      end
+
+      it "returns an installment owned through one of the seller's products" do
+        product_owned_installment = create_product_owned_installment
+
+        get @action, params: @params.merge(id: product_owned_installment.external_id)
+
+        expect(response.parsed_body["email"]["id"]).to eq(product_owned_installment.external_id)
       end
 
       it "does not return another seller's installment" do
@@ -176,6 +203,19 @@ describe Api::V2::EmailsController do
           message: "The email was not found."
         }.as_json)
       end
+
+      it "returns an absolute URL for a published installment" do
+        @installment.update!(published_at: Time.current)
+        allow_any_instance_of(User).to receive(:subdomain_with_protocol).and_return(nil)
+
+        get @action, params: @params
+
+        expect(response.parsed_body["email"]["url"]).to eq(view_post_url(
+          host: UrlService.domain_with_protocol,
+          username: @installment.user.username,
+          slug: @installment.slug
+        ))
+      end
     end
   end
 
@@ -189,11 +229,11 @@ describe Api::V2::EmailsController do
     end
 
     it_behaves_like "authorized oauth v1 api method"
-    it_behaves_like "authorized oauth v1 api method only for edit_products scope"
+    it_behaves_like "authorized oauth v1 api method only for edit_emails scope"
 
-    describe "when logged in with edit_products scope" do
+    describe "when logged in with edit_emails scope" do
       before do
-        @token = create_access_token("edit_products")
+        @token = create_access_token("edit_emails")
         @params.merge!(access_token: @token.token)
       end
 
@@ -316,6 +356,15 @@ describe Api::V2::EmailsController do
         expect(installment.link).to eq(product)
       end
     end
+
+    it "grants create access with the account scope used by the CLI" do
+      token = create_access_token("account")
+
+      post @action, params: @params.merge(access_token: token.token)
+
+      expect(response.parsed_body["success"]).to be(true)
+      expect(@user.installments.alive.sole).not_to be_published
+    end
   end
 
   describe "POST 'preview'" do
@@ -326,11 +375,11 @@ describe Api::V2::EmailsController do
     end
 
     it_behaves_like "authorized oauth v1 api method"
-    it_behaves_like "authorized oauth v1 api method only for edit_products scope"
+    it_behaves_like "authorized oauth v1 api method only for edit_emails scope"
 
-    describe "when logged in with edit_products scope" do
+    describe "when logged in with edit_emails scope" do
       before do
-        @token = create_access_token("edit_products")
+        @token = create_access_token("edit_emails")
         @params.merge!(access_token: @token.token)
       end
 
@@ -346,6 +395,36 @@ describe Api::V2::EmailsController do
         )
         expect(response.parsed_body["preview_url"]).to start_with("http")
         expect(response.parsed_body["email"]["id"]).to eq(@installment.external_id)
+      end
+
+      it "sends a preview for an email owned through one of the seller's products" do
+        product_owned_installment = create_product_owned_installment
+        expect(PostEmailApi).to receive(:process) do |post:, recipients:, preview:|
+          expect(post).to eq(product_owned_installment)
+          expect(post.seller).to eq(@user)
+          expect(recipients).to eq([{ email: @user.email }])
+          expect(preview).to be(true)
+        end
+
+        post @action, params: @params.merge(id: product_owned_installment.external_id)
+
+        expect(response.parsed_body["success"]).to be(true)
+        expect(response.parsed_body["email"]["id"]).to eq(product_owned_installment.external_id)
+        expect(product_owned_installment.reload.seller).to be_nil
+      end
+
+      it "returns an absolute preview URL for a published email" do
+        @installment.update!(published_at: Time.current)
+        allow_any_instance_of(User).to receive(:subdomain_with_protocol).and_return(nil)
+        expect_any_instance_of(Installment).to receive(:send_preview_email).with(@user)
+
+        post @action, params: @params
+
+        expect(response.parsed_body["preview_url"]).to eq(view_post_url(
+          host: UrlService.domain_with_protocol,
+          username: @installment.user.username,
+          slug: @installment.slug
+        ))
       end
 
       it "returns preview email errors" do
@@ -371,11 +450,11 @@ describe Api::V2::EmailsController do
     end
 
     it_behaves_like "authorized oauth v1 api method"
-    it_behaves_like "authorized oauth v1 api method only for edit_products scope"
+    it_behaves_like "authorized oauth v1 api method only for edit_emails scope"
 
-    describe "when logged in with edit_products scope" do
+    describe "when logged in with edit_emails scope" do
       before do
-        @token = create_access_token("edit_products")
+        @token = create_access_token("edit_emails")
         @params.merge!(access_token: @token.token)
         allow_any_instance_of(User).to receive(:eligible_to_send_emails?).and_return(true)
       end
@@ -390,6 +469,99 @@ describe Api::V2::EmailsController do
         expect(SendPostBlastEmailsJob).to have_enqueued_sidekiq_job(PostEmailBlast.last.id)
       end
 
+      it "sends an email owned through one of the seller's products" do
+        product_owned_installment = create_product_owned_installment
+
+        expect do
+          post @action, params: @params.merge(id: product_owned_installment.external_id)
+        end.to change(PostEmailBlast, :count).by(1)
+
+        expect(product_owned_installment.reload).to be_published
+        expect(product_owned_installment.seller).to eq(@user)
+        expect(response.parsed_body["email"]["id"]).to eq(product_owned_installment.external_id)
+        expect(SendPostBlastEmailsJob).to have_enqueued_sidekiq_job(PostEmailBlast.last.id)
+      end
+
+      it "sends a published product-owned profile-only post that has not been blasted" do
+        product_owned_installment = create_product_owned_installment(published_at: 1.hour.ago)
+        product_owned_installment.assign_attributes(send_emails: false, shown_on_profile: true)
+        product_owned_installment.save!(validate: false)
+
+        expect do
+          post @action, params: @params.merge(id: product_owned_installment.external_id)
+        end.to change(PostEmailBlast, :count).by(1)
+
+        expect(product_owned_installment.reload.seller).to eq(@user)
+        expect(PostEmailBlast.last.seller).to eq(@user)
+        expect(response.parsed_body["email"]).to include(
+          "id" => product_owned_installment.external_id,
+          "send_emails" => true,
+          "shown_on_profile" => true,
+          "state" => "published"
+        )
+        expect(SendPostBlastEmailsJob).to have_enqueued_sidekiq_job(PostEmailBlast.last.id)
+      end
+
+      it "turns a profile-only draft into an email blast" do
+        @installment.update!(send_emails: false, shown_on_profile: true)
+
+        expect do
+          post @action, params: @params
+        end.to change(PostEmailBlast, :count).by(1)
+
+        expect(@installment.reload.send_emails?).to be(true)
+        expect(@installment.published?).to be(true)
+        expect(response.parsed_body["email"]).to include(
+          "send_emails" => true,
+          "shown_on_profile" => true,
+          "state" => "published"
+        )
+        expect(SendPostBlastEmailsJob).to have_enqueued_sidekiq_job(PostEmailBlast.last.id)
+      end
+
+      it "sends a published profile-only post that has not been blasted" do
+        @installment.update!(published_at: 1.hour.ago, send_emails: false, shown_on_profile: true)
+
+        expect do
+          post @action, params: @params
+        end.to change(PostEmailBlast, :count).by(1)
+
+        expect(@installment.reload.send_emails?).to be(true)
+        expect(@installment.published?).to be(true)
+        expect(response.parsed_body["email"]).to include(
+          "send_emails" => true,
+          "shown_on_profile" => true,
+          "state" => "published"
+        )
+        expect(SendPostBlastEmailsJob).to have_enqueued_sidekiq_job(PostEmailBlast.last.id)
+      end
+
+      it "sends a published scheduled profile-only post that has not been blasted" do
+        scheduled = create(
+          :scheduled_installment,
+          seller: @user,
+          link: nil,
+          installment_type: Installment::AUDIENCE_TYPE,
+          published_at: 1.hour.ago
+        )
+        scheduled.assign_attributes(send_emails: false, shown_on_profile: true)
+        scheduled.save!(validate: false)
+        scheduled.installment_rule.mark_deleted!
+
+        expect do
+          post @action, params: @params.merge(id: scheduled.external_id)
+        end.to change(PostEmailBlast, :count).by(1)
+
+        expect(scheduled.reload.send_emails?).to be(true)
+        expect(scheduled.published?).to be(true)
+        expect(response.parsed_body["email"]).to include(
+          "send_emails" => true,
+          "shown_on_profile" => true,
+          "state" => "published"
+        )
+        expect(SendPostBlastEmailsJob).to have_enqueued_sidekiq_job(PostEmailBlast.last.id)
+      end
+
       it "keeps attached files when publishing a draft" do
         file = create(:product_file, url: "#{AWS_S3_ENDPOINT}/#{S3_BUCKET}/specs/magic.mp3")
         @installment.product_files << file
@@ -400,8 +572,9 @@ describe Api::V2::EmailsController do
         expect(@installment.reload.alive_product_files.map(&:external_id)).to include(file.external_id)
       end
 
-      it "returns an error for an already-published installment" do
+      it "returns an error for an already-blasted email" do
         @installment.update!(published_at: Time.current)
+        create(:blast, post: @installment)
 
         post @action, params: @params
 
@@ -430,6 +603,18 @@ describe Api::V2::EmailsController do
         expect(scheduled.reload.published?).to be(false)
       end
     end
+
+    it "grants send access with the account scope used by the CLI" do
+      token = create_access_token("account")
+      allow_any_instance_of(User).to receive(:eligible_to_send_emails?).and_return(true)
+
+      expect do
+        post @action, params: @params.merge(access_token: token.token)
+      end.to change(PostEmailBlast, :count).by(1)
+
+      expect(@installment.reload).to be_published
+      expect(SendPostBlastEmailsJob).to have_enqueued_sidekiq_job(PostEmailBlast.last.id)
+    end
   end
 
   describe "DELETE 'destroy'" do
@@ -440,11 +625,11 @@ describe Api::V2::EmailsController do
     end
 
     it_behaves_like "authorized oauth v1 api method"
-    it_behaves_like "authorized oauth v1 api method only for edit_products scope"
+    it_behaves_like "authorized oauth v1 api method only for edit_emails scope"
 
-    describe "when logged in with edit_products scope" do
+    describe "when logged in with edit_emails scope" do
       before do
-        @token = create_access_token("edit_products")
+        @token = create_access_token("edit_emails")
         @params.merge!(access_token: @token.token)
       end
 
@@ -452,6 +637,14 @@ describe Api::V2::EmailsController do
         delete @action, params: @params
 
         expect(@installment.reload.deleted_at).to be_present
+      end
+
+      it "soft-deletes an email owned through one of the seller's products" do
+        product_owned_installment = create_product_owned_installment
+
+        delete @action, params: @params.merge(id: product_owned_installment.external_id)
+
+        expect(product_owned_installment.reload.deleted_at).to be_present
       end
 
       it "returns the deleted response" do

--- a/spec/controllers/api/v2/emails_controller_spec.rb
+++ b/spec/controllers/api/v2/emails_controller_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 require "shared_examples/authorized_oauth_v1_api_method"
 
-describe Api::V2::InstallmentsController do
+describe Api::V2::EmailsController do
   before do
     @user = create(:user, email: "seller@example.com")
     @app = create(:oauth_application, owner: create(:user))
@@ -44,7 +44,7 @@ describe Api::V2::InstallmentsController do
         get @action, params: @params
 
         expect(response.parsed_body["success"]).to eq(true)
-        expect(response.parsed_body["installments"].map { _1["id"] })
+        expect(response.parsed_body["emails"].map { _1["id"] })
           .to eq([scheduled, published, draft].map(&:external_id))
       end
 
@@ -60,17 +60,17 @@ describe Api::V2::InstallmentsController do
         )
 
         get @action, params: @params.merge(type: Installment::PUBLISHED)
-        expect(response.parsed_body["installments"].map { _1["id"] }).to eq([published.external_id])
+        expect(response.parsed_body["emails"].map { _1["id"] }).to eq([published.external_id])
 
         get @action, params: @params.merge(type: Installment::SCHEDULED)
-        expect(response.parsed_body["installments"].map { _1["id"] }).to eq([scheduled.external_id])
+        expect(response.parsed_body["emails"].map { _1["id"] }).to eq([scheduled.external_id])
 
         get @action, params: @params.merge(type: Installment::DRAFT)
-        expect(response.parsed_body["installments"].map { _1["id"] }).to eq([draft.external_id])
+        expect(response.parsed_body["emails"].map { _1["id"] }).to eq([draft.external_id])
       end
 
       it "paginates installments with a page key" do
-        per_page = Api::V2::InstallmentsController::RESULTS_PER_PAGE
+        per_page = Api::V2::EmailsController::RESULTS_PER_PAGE
         installments = (0..per_page).map do |index|
           create(:audience_installment, seller: @user, created_at: (per_page - index).minutes.ago)
         end
@@ -78,16 +78,16 @@ describe Api::V2::InstallmentsController do
 
         get @action, params: @params
 
-        expect(response.parsed_body["installments"].map { _1["id"] })
+        expect(response.parsed_body["emails"].map { _1["id"] })
           .to eq(expected_installments.first(per_page).map(&:external_id))
         expect(response.parsed_body["next_page_key"]).to be_present
-        expect(response.parsed_body["next_page_url"]).to include("/v2/installments")
+        expect(response.parsed_body["next_page_url"]).to include("/v2/emails")
 
         get @action, params: @params.merge(page_key: response.parsed_body["next_page_key"])
 
         expect(response.parsed_body).to eq({
           success: true,
-          installments: expected_installments[per_page..].as_json(api_scopes: ["view_public"])
+          emails: expected_installments[per_page..].as_json(api_scopes: ["view_public"])
         }.as_json)
       end
 
@@ -98,7 +98,7 @@ describe Api::V2::InstallmentsController do
 
         expect(response.parsed_body).to eq({
           success: true,
-          installments: []
+          emails: []
         }.as_json)
       end
     end
@@ -130,7 +130,7 @@ describe Api::V2::InstallmentsController do
 
         expect(response.parsed_body).to eq({
           success: true,
-          installment: @installment.as_json(api_scopes: ["view_public"])
+          email: @installment.as_json(api_scopes: ["view_public"])
         }.as_json)
       end
 
@@ -141,7 +141,7 @@ describe Api::V2::InstallmentsController do
 
         expect(response.parsed_body).to eq({
           success: false,
-          message: "The installment was not found."
+          message: "The email was not found."
         }.as_json)
       end
 
@@ -150,7 +150,7 @@ describe Api::V2::InstallmentsController do
 
         expect(response.parsed_body).to eq({
           success: false,
-          message: "The installment was not found."
+          message: "The email was not found."
         }.as_json)
       end
     end
@@ -183,7 +183,7 @@ describe Api::V2::InstallmentsController do
         expect(installment.installment_type).to eq(Installment::AUDIENCE_TYPE)
         expect(installment.send_emails?).to be(true)
         expect(installment.published?).to be(false)
-        expect(response.parsed_body["installment"]).to include(
+        expect(response.parsed_body["email"]).to include(
           "id" => installment.external_id,
           "subject" => "Launch update",
           "state" => "draft",
@@ -200,7 +200,7 @@ describe Api::V2::InstallmentsController do
 
         installment = @user.installments.alive.sole
         expect(installment.published?).to be(true)
-        expect(response.parsed_body["installment"]["state"]).to eq("published")
+        expect(response.parsed_body["email"]["state"]).to eq("published")
         expect(SendPostBlastEmailsJob).to have_enqueued_sidekiq_job(PostEmailBlast.last.id)
       end
 
@@ -255,7 +255,7 @@ describe Api::V2::InstallmentsController do
         installment = @user.installments.alive.sole
         expect(installment.installment_type).to eq(Installment::PRODUCT_TYPE)
         expect(installment.link).to eq(product)
-        expect(response.parsed_body["installment"]["product_id"]).to eq(product.external_id)
+        expect(response.parsed_body["email"]["product_id"]).to eq(product.external_id)
       end
 
       it "threads link_id to the installment" do
@@ -296,7 +296,7 @@ describe Api::V2::InstallmentsController do
           "preview_url" => edit_email_path(@installment.external_id, preview_post: true),
           "message" => "A preview has been sent to your email."
         )
-        expect(response.parsed_body["installment"]["id"]).to eq(@installment.external_id)
+        expect(response.parsed_body["email"]["id"]).to eq(@installment.external_id)
       end
 
       it "returns preview email errors" do
@@ -337,7 +337,7 @@ describe Api::V2::InstallmentsController do
         end.to change(PostEmailBlast, :count).by(1)
 
         expect(@installment.reload.published?).to be(true)
-        expect(response.parsed_body["installment"]["state"]).to eq("published")
+        expect(response.parsed_body["email"]["state"]).to eq("published")
         expect(SendPostBlastEmailsJob).to have_enqueued_sidekiq_job(PostEmailBlast.last.id)
       end
 
@@ -348,7 +348,7 @@ describe Api::V2::InstallmentsController do
 
         expect(response.parsed_body).to eq({
           success: false,
-          message: "The installment has already been sent."
+          message: "The email has already been sent."
         }.as_json)
       end
     end
@@ -381,7 +381,7 @@ describe Api::V2::InstallmentsController do
 
         expect(response.parsed_body).to eq({
           success: true,
-          message: "The installment was deleted successfully."
+          message: "The email was deleted successfully."
         }.as_json)
       end
     end

--- a/spec/controllers/api/v2/emails_controller_spec.rb
+++ b/spec/controllers/api/v2/emails_controller_spec.rb
@@ -20,10 +20,11 @@ describe Api::V2::EmailsController do
     end
 
     it_behaves_like "authorized oauth v1 api method"
+    it_behaves_like "authorized oauth v1 api method only for edit_products scope"
 
-    describe "when logged in with public scope" do
+    describe "when logged in with edit_products scope" do
       before do
-        @token = create_access_token("view_public")
+        @token = create_access_token("edit_products")
         @params.merge!(access_token: @token.token)
       end
 
@@ -87,8 +88,29 @@ describe Api::V2::EmailsController do
 
         expect(response.parsed_body).to eq({
           success: true,
-          emails: expected_installments[per_page..].as_json(api_scopes: ["view_public"])
+          emails: expected_installments[per_page..].as_json(api_scopes: ["edit_products"])
         }.as_json)
+      end
+
+      it "does not drop installments whose ids are not ordered by creation time" do
+        per_page = Api::V2::EmailsController::RESULTS_PER_PAGE
+        installments = (0..per_page).map do |index|
+          create(:audience_installment, seller: @user, created_at: index.minutes.ago)
+        end
+        expected_order = installments.sort_by { |installment| [installment.created_at, installment.id] }.reverse
+
+        get @action, params: @params
+        first_page_ids = response.parsed_body["emails"].map { _1["id"] }
+        expect(first_page_ids).to eq(expected_order.first(per_page).map(&:external_id))
+
+        next_page_key = response.parsed_body["next_page_key"]
+        expect(next_page_key).to be_present
+
+        get @action, params: @params.merge(page_key: next_page_key)
+        second_page_ids = response.parsed_body["emails"].map { _1["id"] }
+        expect(second_page_ids).to eq(expected_order[per_page..].map(&:external_id))
+
+        expect(first_page_ids + second_page_ids).to match_array(installments.map(&:external_id))
       end
 
       it "returns an empty list for another seller's installments" do
@@ -118,10 +140,11 @@ describe Api::V2::EmailsController do
     end
 
     it_behaves_like "authorized oauth v1 api method"
+    it_behaves_like "authorized oauth v1 api method only for edit_products scope"
 
-    describe "when logged in with public scope" do
+    describe "when logged in with edit_products scope" do
       before do
-        @token = create_access_token("view_public")
+        @token = create_access_token("edit_products")
         @params.merge!(access_token: @token.token)
       end
 
@@ -130,7 +153,7 @@ describe Api::V2::EmailsController do
 
         expect(response.parsed_body).to eq({
           success: true,
-          email: @installment.as_json(api_scopes: ["view_public"])
+          email: @installment.as_json(api_scopes: ["edit_products"])
         }.as_json)
       end
 
@@ -204,12 +227,15 @@ describe Api::V2::EmailsController do
         expect(SendPostBlastEmailsJob).to have_enqueued_sidekiq_job(PostEmailBlast.last.id)
       end
 
-      it "publishes when draft is false" do
+      it "does not publish from a blank draft parameter" do
         allow_any_instance_of(User).to receive(:eligible_to_send_emails?).and_return(true)
 
-        post @action, params: @params.merge(draft: "false")
+        expect do
+          post @action, params: @params.merge(draft: "")
+        end.not_to change(PostEmailBlast, :count)
 
-        expect(@user.installments.alive.sole).to be_published
+        expect(@user.installments.alive.sole.published?).to be(false)
+        expect(response.parsed_body["email"]["state"]).to eq("draft")
       end
 
       {
@@ -235,6 +261,17 @@ describe Api::V2::EmailsController do
           "Invalid audience. Valid values are: all, audience, customers, seller, followers, follower, product."
         )
         expect(@user.installments.alive.count).to eq(0)
+      end
+
+      it "targets a product audience to that product's buyers" do
+        product = create(:product, user: @user)
+
+        post @action, params: @params.merge(audience: "product", product_id: product.external_id)
+
+        installment = @user.installments.alive.sole
+        expect(installment.installment_type).to eq(Installment::PRODUCT_TYPE)
+        expect(installment.link).to eq(product)
+        expect(installment.bought_products).to eq([product.unique_permalink])
       end
 
       it "requires a product id for product audience emails" do
@@ -286,16 +323,17 @@ describe Api::V2::EmailsController do
         @params.merge!(access_token: @token.token)
       end
 
-      it "sends a preview email and returns the preview URL" do
+      it "sends a preview email and returns an absolute preview URL" do
         expect_any_instance_of(Installment).to receive(:send_preview_email).with(@user)
 
         post @action, params: @params
 
         expect(response.parsed_body).to include(
           "success" => true,
-          "preview_url" => edit_email_path(@installment.external_id, preview_post: true),
+          "preview_url" => edit_email_url(@installment.external_id, preview_post: true, host: UrlService.domain_with_protocol),
           "message" => "A preview has been sent to your email."
         )
+        expect(response.parsed_body["preview_url"]).to start_with("http")
         expect(response.parsed_body["email"]["id"]).to eq(@installment.external_id)
       end
 
@@ -339,6 +377,16 @@ describe Api::V2::EmailsController do
         expect(@installment.reload.published?).to be(true)
         expect(response.parsed_body["email"]["state"]).to eq("published")
         expect(SendPostBlastEmailsJob).to have_enqueued_sidekiq_job(PostEmailBlast.last.id)
+      end
+
+      it "keeps attached files when publishing a draft" do
+        file = create(:product_file, url: "#{AWS_S3_ENDPOINT}/#{S3_BUCKET}/specs/magic.mp3")
+        @installment.product_files << file
+
+        post @action, params: @params
+
+        expect(response.parsed_body["success"]).to be(true)
+        expect(@installment.reload.alive_product_files.map(&:external_id)).to include(file.external_id)
       end
 
       it "returns an error for an already-published installment" do

--- a/spec/controllers/api/v2/installments_controller_spec.rb
+++ b/spec/controllers/api/v2/installments_controller_spec.rb
@@ -1,0 +1,389 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "shared_examples/authorized_oauth_v1_api_method"
+
+describe Api::V2::InstallmentsController do
+  before do
+    @user = create(:user, email: "seller@example.com")
+    @app = create(:oauth_application, owner: create(:user))
+  end
+
+  def create_access_token(scopes)
+    create("doorkeeper/access_token", application: @app, resource_owner_id: @user.id, scopes:)
+  end
+
+  describe "GET 'index'" do
+    before do
+      @action = :index
+      @params = {}
+    end
+
+    it_behaves_like "authorized oauth v1 api method"
+
+    describe "when logged in with public scope" do
+      before do
+        @token = create_access_token("view_public")
+        @params.merge!(access_token: @token.token)
+      end
+
+      it "returns the seller's alive non-workflow installments" do
+        draft = create(:audience_installment, seller: @user, created_at: 3.minutes.ago)
+        published = create(:audience_installment, :published, seller: @user, created_at: 2.minutes.ago)
+        scheduled = create(
+          :scheduled_installment,
+          seller: @user,
+          link: nil,
+          installment_type: Installment::AUDIENCE_TYPE,
+          created_at: 1.minute.ago
+        )
+        create(:audience_installment, seller: @user, deleted_at: Time.current)
+        create(:workflow_installment, seller: @user, link: create(:product, user: @user))
+        create(:audience_installment, seller: create(:user))
+
+        get @action, params: @params
+
+        expect(response.parsed_body["success"]).to eq(true)
+        expect(response.parsed_body["installments"].map { _1["id"] })
+          .to eq([scheduled, published, draft].map(&:external_id))
+      end
+
+      it "filters installments by type" do
+        draft = create(:audience_installment, seller: @user, created_at: 3.minutes.ago)
+        published = create(:audience_installment, :published, seller: @user, created_at: 2.minutes.ago)
+        scheduled = create(
+          :scheduled_installment,
+          seller: @user,
+          link: nil,
+          installment_type: Installment::AUDIENCE_TYPE,
+          created_at: 1.minute.ago
+        )
+
+        get @action, params: @params.merge(type: Installment::PUBLISHED)
+        expect(response.parsed_body["installments"].map { _1["id"] }).to eq([published.external_id])
+
+        get @action, params: @params.merge(type: Installment::SCHEDULED)
+        expect(response.parsed_body["installments"].map { _1["id"] }).to eq([scheduled.external_id])
+
+        get @action, params: @params.merge(type: Installment::DRAFT)
+        expect(response.parsed_body["installments"].map { _1["id"] }).to eq([draft.external_id])
+      end
+
+      it "paginates installments with a page key" do
+        per_page = Api::V2::InstallmentsController::RESULTS_PER_PAGE
+        installments = (0..per_page).map do |index|
+          create(:audience_installment, seller: @user, created_at: (per_page - index).minutes.ago)
+        end
+        expected_installments = installments.sort_by { |installment| [installment.created_at, installment.id] }.reverse
+
+        get @action, params: @params
+
+        expect(response.parsed_body["installments"].map { _1["id"] })
+          .to eq(expected_installments.first(per_page).map(&:external_id))
+        expect(response.parsed_body["next_page_key"]).to be_present
+        expect(response.parsed_body["next_page_url"]).to include("/v2/installments")
+
+        get @action, params: @params.merge(page_key: response.parsed_body["next_page_key"])
+
+        expect(response.parsed_body).to eq({
+          success: true,
+          installments: expected_installments[per_page..].as_json(api_scopes: ["view_public"])
+        }.as_json)
+      end
+
+      it "returns an empty list for another seller's installments" do
+        create(:audience_installment, seller: create(:user))
+
+        get @action, params: @params
+
+        expect(response.parsed_body).to eq({
+          success: true,
+          installments: []
+        }.as_json)
+      end
+    end
+
+    it "grants access with the account scope" do
+      token = create_access_token("account")
+      get @action, params: @params.merge(access_token: token.token)
+      expect(response).to be_successful
+    end
+  end
+
+  describe "GET 'show'" do
+    before do
+      @installment = create(:audience_installment, seller: @user)
+      @action = :show
+      @params = { id: @installment.external_id }
+    end
+
+    it_behaves_like "authorized oauth v1 api method"
+
+    describe "when logged in with public scope" do
+      before do
+        @token = create_access_token("view_public")
+        @params.merge!(access_token: @token.token)
+      end
+
+      it "returns the installment" do
+        get @action, params: @params
+
+        expect(response.parsed_body).to eq({
+          success: true,
+          installment: @installment.as_json(api_scopes: ["view_public"])
+        }.as_json)
+      end
+
+      it "does not return another seller's installment" do
+        other_installment = create(:audience_installment, seller: create(:user))
+
+        get @action, params: @params.merge(id: other_installment.external_id)
+
+        expect(response.parsed_body).to eq({
+          success: false,
+          message: "The installment was not found."
+        }.as_json)
+      end
+
+      it "fails gracefully on an unknown id" do
+        get @action, params: @params.merge(id: "#{@installment.external_id}++")
+
+        expect(response.parsed_body).to eq({
+          success: false,
+          message: "The installment was not found."
+        }.as_json)
+      end
+    end
+  end
+
+  describe "POST 'create'" do
+    before do
+      @action = :create
+      @params = {
+        subject: "Launch update",
+        body: "<p>Hello, world!</p>",
+      }
+    end
+
+    it_behaves_like "authorized oauth v1 api method"
+    it_behaves_like "authorized oauth v1 api method only for edit_products scope"
+
+    describe "when logged in with edit_products scope" do
+      before do
+        @token = create_access_token("edit_products")
+        @params.merge!(access_token: @token.token)
+      end
+
+      it "creates a draft installment with email sending enabled by default" do
+        post @action, params: @params
+
+        installment = @user.installments.alive.sole
+        expect(installment.name).to eq("Launch update")
+        expect(installment.message).to eq("<p>Hello, world!</p>")
+        expect(installment.installment_type).to eq(Installment::AUDIENCE_TYPE)
+        expect(installment.send_emails?).to be(true)
+        expect(installment.published?).to be(false)
+        expect(response.parsed_body["installment"]).to include(
+          "id" => installment.external_id,
+          "subject" => "Launch update",
+          "state" => "draft",
+          "send_emails" => true
+        )
+      end
+
+      it "publishes and enqueues the blast when requested" do
+        allow_any_instance_of(User).to receive(:eligible_to_send_emails?).and_return(true)
+
+        expect do
+          post @action, params: @params.merge(publish: "true")
+        end.to change(PostEmailBlast, :count).by(1)
+
+        installment = @user.installments.alive.sole
+        expect(installment.published?).to be(true)
+        expect(response.parsed_body["installment"]["state"]).to eq("published")
+        expect(SendPostBlastEmailsJob).to have_enqueued_sidekiq_job(PostEmailBlast.last.id)
+      end
+
+      it "publishes when draft is false" do
+        allow_any_instance_of(User).to receive(:eligible_to_send_emails?).and_return(true)
+
+        post @action, params: @params.merge(draft: "false")
+
+        expect(@user.installments.alive.sole).to be_published
+      end
+
+      {
+        "all" => Installment::AUDIENCE_TYPE,
+        "audience" => Installment::AUDIENCE_TYPE,
+        "customers" => Installment::SELLER_TYPE,
+        "seller" => Installment::SELLER_TYPE,
+        "followers" => Installment::FOLLOWER_TYPE,
+        "follower" => Installment::FOLLOWER_TYPE,
+      }.each do |audience, installment_type|
+        it "maps audience #{audience} to #{installment_type}" do
+          post @action, params: @params.merge(audience:)
+
+          expect(@user.installments.alive.sole.installment_type).to eq(installment_type)
+        end
+      end
+
+      it "returns a helpful error for an invalid audience" do
+        post @action, params: @params.merge(audience: "invalid_audience")
+
+        expect(response.parsed_body["success"]).to eq(false)
+        expect(response.parsed_body["message"]).to eq(
+          "Invalid audience. Valid values are: all, audience, customers, seller, followers, follower, product."
+        )
+        expect(@user.installments.alive.count).to eq(0)
+      end
+
+      it "requires a product id for product audience emails" do
+        post @action, params: @params.merge(audience: "product")
+
+        expect(response.parsed_body).to eq({
+          success: false,
+          message: "Product audience requires a product_id or link_id."
+        }.as_json)
+        expect(@user.installments.alive.count).to eq(0)
+      end
+
+      it "threads product_id to the installment" do
+        product = create(:product, user: @user)
+
+        post @action, params: @params.merge(audience: "product", product_id: product.external_id)
+
+        installment = @user.installments.alive.sole
+        expect(installment.installment_type).to eq(Installment::PRODUCT_TYPE)
+        expect(installment.link).to eq(product)
+        expect(response.parsed_body["installment"]["product_id"]).to eq(product.external_id)
+      end
+
+      it "threads link_id to the installment" do
+        product = create(:product, user: @user)
+
+        post @action, params: @params.merge(audience: "product", link_id: product.unique_permalink)
+
+        installment = @user.installments.alive.sole
+        expect(installment.installment_type).to eq(Installment::PRODUCT_TYPE)
+        expect(installment.link).to eq(product)
+      end
+    end
+  end
+
+  describe "POST 'preview'" do
+    before do
+      @installment = create(:audience_installment, seller: @user)
+      @action = :preview
+      @params = { id: @installment.external_id }
+    end
+
+    it_behaves_like "authorized oauth v1 api method"
+    it_behaves_like "authorized oauth v1 api method only for edit_products scope"
+
+    describe "when logged in with edit_products scope" do
+      before do
+        @token = create_access_token("edit_products")
+        @params.merge!(access_token: @token.token)
+      end
+
+      it "sends a preview email and returns the preview URL" do
+        expect_any_instance_of(Installment).to receive(:send_preview_email).with(@user)
+
+        post @action, params: @params
+
+        expect(response.parsed_body).to include(
+          "success" => true,
+          "preview_url" => edit_email_path(@installment.external_id, preview_post: true),
+          "message" => "A preview has been sent to your email."
+        )
+        expect(response.parsed_body["installment"]["id"]).to eq(@installment.external_id)
+      end
+
+      it "returns preview email errors" do
+        allow_any_instance_of(Installment)
+          .to receive(:send_preview_email)
+          .and_raise(Installment::PreviewEmailError, "Preview failed.")
+
+        post @action, params: @params
+
+        expect(response.parsed_body).to eq({
+          success: false,
+          message: "Preview failed."
+        }.as_json)
+      end
+    end
+  end
+
+  describe "POST 'send_email'" do
+    before do
+      @installment = create(:audience_installment, seller: @user)
+      @action = :send_email
+      @params = { id: @installment.external_id }
+    end
+
+    it_behaves_like "authorized oauth v1 api method"
+    it_behaves_like "authorized oauth v1 api method only for edit_products scope"
+
+    describe "when logged in with edit_products scope" do
+      before do
+        @token = create_access_token("edit_products")
+        @params.merge!(access_token: @token.token)
+        allow_any_instance_of(User).to receive(:eligible_to_send_emails?).and_return(true)
+      end
+
+      it "publishes an existing draft and enqueues the blast" do
+        expect do
+          post @action, params: @params
+        end.to change(PostEmailBlast, :count).by(1)
+
+        expect(@installment.reload.published?).to be(true)
+        expect(response.parsed_body["installment"]["state"]).to eq("published")
+        expect(SendPostBlastEmailsJob).to have_enqueued_sidekiq_job(PostEmailBlast.last.id)
+      end
+
+      it "returns an error for an already-published installment" do
+        @installment.update!(published_at: Time.current)
+
+        post @action, params: @params
+
+        expect(response.parsed_body).to eq({
+          success: false,
+          message: "The installment has already been sent."
+        }.as_json)
+      end
+    end
+  end
+
+  describe "DELETE 'destroy'" do
+    before do
+      @installment = create(:audience_installment, seller: @user)
+      @action = :destroy
+      @params = { id: @installment.external_id }
+    end
+
+    it_behaves_like "authorized oauth v1 api method"
+    it_behaves_like "authorized oauth v1 api method only for edit_products scope"
+
+    describe "when logged in with edit_products scope" do
+      before do
+        @token = create_access_token("edit_products")
+        @params.merge!(access_token: @token.token)
+      end
+
+      it "soft-deletes the installment" do
+        delete @action, params: @params
+
+        expect(@installment.reload.deleted_at).to be_present
+      end
+
+      it "returns the deleted response" do
+        delete @action, params: @params
+
+        expect(response.parsed_body).to eq({
+          success: true,
+          message: "The installment was deleted successfully."
+        }.as_json)
+      end
+    end
+  end
+end

--- a/spec/controllers/api/v2/links_controller_spec.rb
+++ b/spec/controllers/api/v2/links_controller_spec.rb
@@ -153,6 +153,13 @@ describe Api::V2::LinksController do
       expect(response.parsed_body["products"]).to be_present
     end
 
+    it "does not grant product index access with only edit_emails scope" do
+      token = create("doorkeeper/access_token", application: @app, resource_owner_id: @user.id, scopes: "edit_emails")
+      get @action, params: { access_token: token.token }
+      expect(response.status).to eq(403)
+      expect(response.body.strip).to be_empty
+    end
+
     describe "query count" do
       def count_sql_queries(&block)
         count = 0
@@ -1162,6 +1169,13 @@ describe Api::V2::LinksController do
       get :show, params: { id: @product.external_id, access_token: token.token }
       expect(response).to be_successful
       expect(response.parsed_body["product"]).to have_key("sales_count")
+    end
+
+    it "does not grant product detail access with only edit_emails scope" do
+      token = create("doorkeeper/access_token", application: @app, resource_owner_id: @user.id, scopes: "edit_emails")
+      get :show, params: { id: @product.external_id, access_token: token.token }
+      expect(response.status).to eq(403)
+      expect(response.body.strip).to be_empty
     end
 
     context "when product is a tiered membership with no default tier" do

--- a/spec/models/installment_spec.rb
+++ b/spec/models/installment_spec.rb
@@ -24,6 +24,21 @@ describe Installment do
     end
   end
 
+  describe "#as_json_for_api" do
+    it "only returns scheduled_at while the post is scheduled with an alive rule" do
+      installment = create(:scheduled_installment, seller: @creator, link: nil, installment_type: Installment::AUDIENCE_TYPE)
+
+      expect(installment.as_json(api_scopes: ["edit_emails"])[:scheduled_at]).to eq(installment.installment_rule.to_be_published_at)
+
+      installment.update!(published_at: Time.current)
+      installment.installment_rule.mark_deleted!
+
+      serialized_installment = installment.reload.as_json(api_scopes: ["edit_emails"])
+      expect(serialized_installment[:state]).to eq("published")
+      expect(serialized_installment[:scheduled_at]).to be_nil
+    end
+  end
+
   describe "#is_downloadable?" do
     it "returns false if post has no files" do
       expect(@installment.is_downloadable?).to eq(false)

--- a/spec/models/oauth_application_spec.rb
+++ b/spec/models/oauth_application_spec.rb
@@ -63,6 +63,7 @@ describe OauthApplication do
     let(:doorkeeper_scopes) { Doorkeeper.configuration.scopes.map(&:to_sym) }
     let(:default_scopes) { Doorkeeper.configuration.default_scopes.map(&:to_sym) }
     let(:public_scopes) { Doorkeeper.configuration.public_scopes.map(&:to_sym) }
+    let(:public_api_read_scopes) { Doorkeeper.configuration.public_api_read_scopes.map(&:to_sym) }
     let(:private_scopes) { %i[refund_sales mobile_api creator_api helper_api unfurl] }
 
     it "all public scopes are included in Doorkeeper's scopes" do
@@ -79,6 +80,13 @@ describe OauthApplication do
 
     it "defines private scopes as neither public nor default" do
       expect(private_scopes).to match_array(doorkeeper_scopes - public_scopes - default_scopes)
+    end
+
+    it "does not include email management in shared public API read scopes" do
+      expect(public_scopes).to include(:edit_emails)
+      expect(public_api_read_scopes).to include(:edit_products)
+      expect(public_api_read_scopes).not_to include(:edit_emails)
+      expect(public_api_read_scopes - public_scopes).to be_empty
     end
 
     it "includes public scopes in user-created applications" do

--- a/spec/requests/oauth_applications_pages_spec.rb
+++ b/spec/requests/oauth_applications_pages_spec.rb
@@ -89,7 +89,7 @@ describe "OauthApplicationsPages", type: :system, js: true do
     expect(page).to have_field("Access Token", with: application.access_tokens.last.token)
     expect(application.access_grants.count).to eq 1
     expect(application.access_tokens.count).to eq 1
-    expect(application.access_tokens.last.scopes.to_a).to eq %w[edit_products view_sales mark_sales_as_shipped edit_sales revenue_share ifttt view_profile view_payouts view_tax_data account]
+    expect(application.access_tokens.last.scopes.to_a).to eq %w[edit_products edit_emails view_sales mark_sales_as_shipped edit_sales revenue_share ifttt view_profile view_payouts view_tax_data account]
   end
 
   it "doesn't list the application if there are no grants for it" do

--- a/spec/shared_examples/authorized_oauth_v1_api_method.rb
+++ b/spec/shared_examples/authorized_oauth_v1_api_method.rb
@@ -26,3 +26,17 @@ RSpec.shared_examples_for "authorized oauth v1 api method only for edit_products
     expect(response.body.strip).to be_empty
   end
 end
+
+RSpec.shared_examples_for "authorized oauth v1 api method only for edit_emails scope" do
+  it "errors out if you aren't authenticated" do
+    raise "no @action in before block of test" unless @action
+    raise "no @params in before block of test" unless @params
+    raise "no @app in before block of test" unless @app
+    raise "no @user in before block of test" unless @user
+
+    @token = create("doorkeeper/access_token", application: @app, resource_owner_id: @user.id, scopes: "view_public view_sales edit_products")
+    get @action, params: @params.merge(access_token: @token.token)
+    expect(response.status).to eq(403)
+    expect(response.body.strip).to be_empty
+  end
+end


### PR DESCRIPTION
Implements the API side of antiwork/gumroad-cli#158 — programmatic audience emails (a.k.a. "posts"/"installments" internally) so the CLI's `gumroad email` command has a public v2 surface to call.

## Naming

The seller UI calls these **Emails** (the nav label is "Emails", the route is `/emails`, and the legacy `/posts` route now redirects to `/emails`), and the CLI command is `gumroad email`. This API matches that vocabulary: the route is `/v2/emails`, the controller is `Api::V2::EmailsController`, and the JSON envelope keys are `email`/`emails`. `Installment` remains only as the internal backing model — no API consumer has to learn it.

## Endpoints (`/v2/emails`)

- `GET /v2/emails` — list audience emails, `type` filter (published/scheduled/draft), cursor pagination.
- `GET /v2/emails/:id` — fetch one.
- `POST /v2/emails` — create a draft by default; `publish=true` / `draft=false` sends immediately. `audience` maps to installment type (all/audience/customers/seller/followers/follower/product); product audiences take `product_id` or `link_id`.
- `POST /v2/emails/:id/preview` — send a preview to the seller, returns a shareable URL.
- `POST /v2/emails/:id/send` — publish a draft and blast it.
- `DELETE /v2/emails/:id` — soft-delete.

Read actions accept the public scope; writes require `edit_products`. The `send` route maps to a `send_email` action to avoid shadowing `Object#send`.

## Implementation notes

- Reuses the existing **`SaveInstallmentService`** — the same service the web editor uses — so audience filtering, the publish → `PostEmailBlast` → `SendPostBlastEmailsJob` path, and preview emails behave identically to the UI rather than being reimplemented.
- `Installment#as_json` gains an API serialization path keyed off `options[:api_scopes]`; existing callers don't pass that, so they fall through to `super` (behavior-preserving).
- API docs added (renders on gumroad.com/api).

## Verification

- `spec/controllers/api/v2/emails_controller_spec.rb`: **37 examples, 0 failures** (host, rbenv 3.4.3, Redis :6380).
- rubocop clean; routes resolve (`/v2/emails`, `/v2/emails/:id/preview`, `/v2/emails/:id/send`).

CLI counterpart: antiwork/gumroad-cli#160.

Closes part of antiwork/gumroad-cli#158.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> New OAuth scope and mass-email send/publish paths are security- and abuse-sensitive; scope split changes which tokens can read products.
> 
> **Overview**
> Adds **`/v2/emails`** for programmatic audience emails (list/show/create/preview/send/delete), backed by **`SaveInstallmentService`** and **`Installment`** with new **`as_json_for_api`** / **`public_page_location`** serialization.
> 
> Introduces the **`edit_emails`** OAuth scope (all email routes require **`edit_emails`** or **`account`**). Product and other public read endpoints now authorize with **`public_api_read_scopes`** instead of **`public_scopes`**, so **`edit_emails` alone cannot read products**. Default OAuth applications are backfilled with **`edit_emails`** via migration; docs, scope copy, and a large controller spec cover the surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f0cd77d20cc677a54687abfcf687118d8e1c817. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->