### PR TITLE
Fix Tailwind class order lint error on customer detail page

### DIFF
--- a/app/javascript/components/Audience/CustomerDetailPage.tsx
+++ b/app/javascript/components/Audience/CustomerDetailPage.tsx
@@ -1489,7 +1489,7 @@ const LicenseSection = ({ license, onSave }: { license: License; onSave: (enable
           </header>
         </CardContent>
         <CardContent>
-          <pre className="grow whitespace-pre-wrap break-all">
+          <pre className="grow break-all whitespace-pre-wrap">
             <code>{license.key}</code>
           </pre>
         </CardContent>


### PR DESCRIPTION
## What

Reorder the Tailwind classes on the license key `<pre>` in `CustomerDetailPage.tsx` from `whitespace-pre-wrap break-all` to `break-all whitespace-pre-wrap`, matching the canonical order `prettier-plugin-tailwindcss` enforces.

## Why

Commit d75c2ebf8 (#5501) landed these classes out of order, which turned the repo-wide "Lint JS/TS" check (`prettier/prettier`) red on `main` and blocked the Lint check on every open PR. Class order has no effect on rendering, so this is a pure lint fix with no behavior change.

Verified locally: `DISABLE_TYPE_CHECKED=1 npx eslint app/javascript/components/Audience/CustomerDetailPage.tsx` reports no offenses.

---

This PR was implemented with AI assistance using Claude Opus 4.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784301766&installation_id=134400930&pr_number=5506&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5506&signature=574fe3eaf4e85cb7706325de8b94424ece1e30db73afd52db5f858e1fca63232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line class reorder on a display element; no logic, data, or styling semantics change.
> 
> **Overview**
> Reorders Tailwind classes on the license key `<pre>` in `CustomerDetailPage` (`LicenseSection`) from `whitespace-pre-wrap break-all` to **`break-all whitespace-pre-wrap`**, matching the order enforced by `prettier-plugin-tailwindcss` / ESLint `prettier/prettier`.
> 
> This is a **lint-only** fix with no UI or behavior change; it clears a failing JS/TS lint check introduced when those classes were added out of order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d10d310f43f639ec80b54e5dce0f6e49e3f7c1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->