### PR TITLE
Fix ES index leak in backfill_audience_members_index_spec

### DIFF
--- a/spec/services/onetime/backfill_audience_members_index_spec.rb
+++ b/spec/services/onetime/backfill_audience_members_index_spec.rb
@@ -9,6 +9,14 @@ describe Onetime::BackfillAudienceMembersIndex do
     $redis.del(described_class::REDIS_FAILED_IDS_KEY)
   end
 
+  # Some examples delete the index to exercise the missing-index path. Without
+  # this, whichever index-deleting example runs last (order is randomized)
+  # leaves audiencemember-test deleted, breaking unrelated specs that share the
+  # Knapsack worker and assume the index exists (e.g. DevTools.reindex_all_for_user).
+  after do
+    recreate_model_index(AudienceMember)
+  end
+
   it "raises when the index does not exist" do
     AudienceMember.__elasticsearch__.delete_index!
 


### PR DESCRIPTION
## What

`spec/services/onetime/backfill_audience_members_index_spec.rb` deletes the `AudienceMember` Elasticsearch index in two examples to exercise the missing-index path (`:13` and `:178`), but never recreates it afterward. RSpec randomizes example order, so whichever delete-example runs **last** leaves `audiencemember-test` deleted when the file finishes.

When Knapsack shards this spec into the same CI worker as an unrelated spec that assumes the index exists, that spec fails. It surfaced as `DevTools.reindex_all_for_user`:

```
ArgumentError:
  audiencemember-test does not exist to be imported into. Use create_index! or the :force option to create it.
# ./lib/utilities/dev_tools.rb:143:in 'block in DevTools.es_import_with_time'
# ./lib/utilities/dev_tools.rb:44:in 'block in DevTools.reindex_all_for_user'
```

This is why it's intermittent and looked like a flake — it only fires when shard composition co-locates the two specs and the delete-example happens to sort last. Re-running reshuffles shards and "fixes" it, which is exactly why it shouldn't be dismissed as flaky.

Example red run: https://github.com/antiwork/gumroad/actions/runs/27687745781/job/81891903930 (Test Fast 12).

## Fix

Add an `after` hook that recreates the index after each example, symmetric with the existing `before` hook. The file now never leaks deleted ES state to its Knapsack sibling specs. Minimal and local to the offending spec.

## Testing

Reproduced deterministically by running both specs in one process with a delete-example sorted last:

```
bundle exec rspec spec/services/onetime/backfill_audience_members_index_spec.rb \
                  spec/lib/utilities/dev_tools_spec.rb --order defined
```

- **Before:** 18 examples, **2 failures** (`dev_tools_spec.rb:8` and `:15` — the exact CI failures)
- **After:** 18 examples, **0 failures**

Run on the host (rbenv 3.4.3, Redis :6380).

---

Implemented with AI assistance using Claude Opus 4.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784302566&installation_id=134400930&pr_number=5507&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5507&signature=bc270bfc1adcc1626f01dca137756482baf451695dea11d74fb20b0c47973b10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only teardown change with no production or runtime behavior impact.
> 
> **Overview**
> Adds an **`after` hook** in `backfill_audience_members_index_spec.rb` that calls `recreate_model_index(AudienceMember)`, matching the existing **`before` setup**.
> 
> Examples that call **`delete_index!`** to test the missing-index path no longer leave `audiencemember-test` deleted when they run last under randomized order. That leaked state was breaking **unrelated specs on the same Knapsack worker** (e.g. `DevTools.reindex_all_for_user`) with intermittent CI failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fd655a78567e10b9fc36c0768054287a0f9b993. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->