### PR TITLE
Add conditional UI (autofill) for passkey login

### DIFF
--- a/app/controllers/concerns/webauthn_ceremony_verification.rb
+++ b/app/controllers/concerns/webauthn_ceremony_verification.rb
@@ -15,8 +15,15 @@ module WebauthnCeremonyVerification
   end
 
   MALFORMED_CREDENTIAL_RUNTIME_MESSAGES = ["invalid type", "invalid id"].freeze
+  AUTHENTICATION_CHALLENGE_SESSION_KEY = :webauthn_authentication_challenge
 
   private
+    def build_webauthn_authentication_options
+      webauthn_options = WebAuthn::Credential.options_for_get(user_verification: "required")
+      session[AUTHENTICATION_CHALLENGE_SESSION_KEY] = webauthn_options.challenge
+      webauthn_options.as_json.merge("rpId" => WebAuthn.configuration.rp_id)
+    end
+
     def permitted_credential_params(**nested_filters)
       credential = params.require(:credential)
       raise VerificationError, "malformed_credential" unless credential.respond_to?(:permit)

--- a/app/controllers/logins/passkeys_controller.rb
+++ b/app/controllers/logins/passkeys_controller.rb
@@ -3,7 +3,6 @@
 class Logins::PasskeysController < ApplicationController
   include WebauthnCeremonyVerification
 
-  AUTHENTICATION_CHALLENGE_SESSION_KEY = :webauthn_authentication_challenge
   AUTHENTICATION_ERROR_MESSAGE = "We couldn't sign you in with that passkey. Please try again or use your password."
 
   skip_before_action :check_suspended
@@ -11,11 +10,7 @@ class Logins::PasskeysController < ApplicationController
   before_action :ensure_passkeys_feature_enabled
 
   def options
-    webauthn_options = WebAuthn::Credential.options_for_get(user_verification: "required")
-
-    session[AUTHENTICATION_CHALLENGE_SESSION_KEY] = webauthn_options.challenge
-
-    render json: { success: true, options: webauthn_options.as_json.merge("rpId" => WebAuthn.configuration.rp_id) }
+    render json: { success: true, options: build_webauthn_authentication_options }
   end
 
   def create

--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class LoginsController < Devise::SessionsController
-  include OauthApplicationConfig, ValidateRecaptcha, InertiaRendering, SilentAlreadySignedInRedirect
+  include OauthApplicationConfig, ValidateRecaptcha, InertiaRendering, SilentAlreadySignedInRedirect, WebauthnCeremonyVerification
 
   include PageMeta::Base
 
@@ -22,7 +22,10 @@ class LoginsController < Devise::SessionsController
 
     set_meta_tag(title: "Log In")
     auth_presenter = AuthPresenter.new(params:, application: @application)
-    render inertia: "Logins/New", props: auth_presenter.login_props.merge(is_gumroad_mobile_app: cookies[:is_gumroad_mobile_app].present?)
+    render inertia: "Logins/New", props: auth_presenter.login_props.merge(
+      is_gumroad_mobile_app: cookies[:is_gumroad_mobile_app].present?,
+      passkey_login_options: Feature.active?(:passkeys) ? build_webauthn_authentication_options : nil,
+    )
   end
 
   def create

--- a/app/javascript/pages/Logins/New.tsx
+++ b/app/javascript/pages/Logins/New.tsx
@@ -3,8 +3,13 @@ import * as React from "react";
 import typia from "typia";
 
 import { asyncVoid } from "$app/utils/promise";
-import { request, ResponseError } from "$app/utils/request";
-import { getPasskey, isPasskeySupported, type PasskeyAuthenticationOptions } from "$app/utils/webauthn";
+import { AbortError, request, ResponseError } from "$app/utils/request";
+import {
+  getPasskey,
+  isConditionalMediationSupported,
+  isPasskeySupported,
+  type PasskeyAuthenticationOptions,
+} from "$app/utils/webauthn";
 
 import { AuthAlert } from "$app/components/AuthAlert";
 import { Layout } from "$app/components/Authentication/Layout";
@@ -27,6 +32,7 @@ type PageProps = {
   recaptcha_site_key: string | null;
   authenticity_token: string;
   show_passkey_login: boolean;
+  passkey_login_options: PasskeyAuthenticationOptions | null;
   is_gumroad_mobile_app: boolean;
 };
 
@@ -47,6 +53,7 @@ function LoginPage() {
     recaptcha_site_key,
     authenticity_token,
     show_passkey_login,
+    passkey_login_options,
     is_gumroad_mobile_app,
   } = usePage<PageProps>().props;
 
@@ -59,7 +66,8 @@ function LoginPage() {
   const [passkeyError, setPasskeyError] = React.useState<string | null>(null);
   const [passkeySupported, setPasskeySupported] = React.useState(false);
   React.useEffect(() => setPasskeySupported(isPasskeySupported()), []);
-  const showPasskeyButton = show_passkey_login && !is_gumroad_mobile_app && passkeySupported;
+  const passkeyLoginEnabled = show_passkey_login && !is_gumroad_mobile_app && passkeySupported;
+  const conditionalRequest = React.useRef<AbortController | null>(null);
 
   const form = useForm<FormData>({
     user: {
@@ -86,50 +94,92 @@ function LoginPage() {
     }
   };
 
+  const runPasskeyLogin = React.useCallback(
+    async ({
+      embeddedOptions,
+      mediation,
+      signal,
+      surfaceErrors,
+    }: {
+      embeddedOptions?: PasskeyAuthenticationOptions;
+      mediation?: CredentialMediationRequirement;
+      signal?: AbortSignal;
+      surfaceErrors: boolean;
+    }) => {
+      const csrfHeaders = { "X-CSRF-Token": authenticity_token };
+      try {
+        let options = embeddedOptions;
+        if (!options) {
+          const optionsResponse = await request({
+            url: Routes.login_passkey_options_path(),
+            method: "POST",
+            accept: "json",
+            headers: csrfHeaders,
+            abortSignal: signal,
+          });
+          const optionsResult = typia.assert<{
+            success: boolean;
+            options?: PasskeyAuthenticationOptions;
+            error_message?: string;
+          }>(await optionsResponse.json());
+          if (!optionsResponse.ok || !optionsResult.success || !optionsResult.options) {
+            throw new ResponseError(optionsResult.error_message ?? PASSKEY_ERROR);
+          }
+          options = optionsResult.options;
+        }
+
+        const credential = await getPasskey(options, { mediation, signal });
+
+        setPasskeyLoading(true);
+
+        const loginResponse = await request({
+          url: Routes.login_passkey_path(),
+          method: "POST",
+          accept: "json",
+          data: { credential, next },
+          headers: csrfHeaders,
+          abortSignal: signal,
+        });
+        const loginResult = typia.assert<{ success: boolean; redirect_location?: string; error_message?: string }>(
+          await loginResponse.json(),
+        );
+        if (!loginResponse.ok || !loginResult.success || !loginResult.redirect_location) {
+          throw new ResponseError(loginResult.error_message ?? PASSKEY_ERROR);
+        }
+
+        window.location.href = loginResult.redirect_location;
+      } catch (e) {
+        if (!signal?.aborted) setPasskeyLoading(false);
+        if (e instanceof AbortError) return;
+        if (e instanceof DOMException && (e.name === "NotAllowedError" || e.name === "AbortError")) return;
+        if (surfaceErrors) setPasskeyError(e instanceof ResponseError ? e.message : PASSKEY_ERROR);
+      }
+    },
+    [authenticity_token, next],
+  );
+
   const handlePasskeyLogin = asyncVoid(async () => {
+    conditionalRequest.current?.abort();
     setPasskeyError(null);
     setPasskeyLoading(true);
-    const csrfHeaders = { "X-CSRF-Token": authenticity_token };
-    try {
-      const optionsResponse = await request({
-        url: Routes.login_passkey_options_path(),
-        method: "POST",
-        accept: "json",
-        headers: csrfHeaders,
-      });
-      const optionsResult = typia.assert<{
-        success: boolean;
-        options?: PasskeyAuthenticationOptions;
-        error_message?: string;
-      }>(await optionsResponse.json());
-      if (!optionsResponse.ok || !optionsResult.success || !optionsResult.options) {
-        throw new ResponseError(optionsResult.error_message ?? PASSKEY_ERROR);
-      }
-
-      const credential = await getPasskey(optionsResult.options);
-
-      const loginResponse = await request({
-        url: Routes.login_passkey_path(),
-        method: "POST",
-        accept: "json",
-        data: { credential, next },
-        headers: csrfHeaders,
-      });
-      const loginResult = typia.assert<{ success: boolean; redirect_location?: string; error_message?: string }>(
-        await loginResponse.json(),
-      );
-      if (!loginResponse.ok || !loginResult.success || !loginResult.redirect_location) {
-        throw new ResponseError(loginResult.error_message ?? PASSKEY_ERROR);
-      }
-
-      window.location.href = loginResult.redirect_location;
-    } catch (e) {
-      if (e instanceof DOMException && (e.name === "NotAllowedError" || e.name === "AbortError")) return;
-      setPasskeyError(e instanceof ResponseError ? e.message : PASSKEY_ERROR);
-    } finally {
-      setPasskeyLoading(false);
-    }
+    await runPasskeyLogin({ surfaceErrors: true });
   });
+
+  React.useEffect(() => {
+    if (!passkeyLoginEnabled || !passkey_login_options) return;
+    const controller = new AbortController();
+    conditionalRequest.current = controller;
+    asyncVoid(async () => {
+      if (!(await isConditionalMediationSupported()) || controller.signal.aborted) return;
+      await runPasskeyLogin({
+        embeddedOptions: passkey_login_options,
+        mediation: "conditional",
+        signal: controller.signal,
+        surfaceErrors: false,
+      });
+    })();
+    return () => controller.abort();
+  }, [passkeyLoginEnabled, passkey_login_options, runPasskeyLogin]);
 
   return (
     <Layout
@@ -154,7 +204,7 @@ function LoginPage() {
               onChange={(e) => form.setData("user.login_identifier", e.target.value)}
               required
               tabIndex={1}
-              autoComplete="email"
+              autoComplete={passkeyLoginEnabled ? "email webauthn" : "email"}
             />
           </Fieldset>
           <Fieldset>
@@ -177,7 +227,7 @@ function LoginPage() {
             <Button color="primary" type="submit" disabled={form.processing}>
               {form.processing ? "Logging in..." : "Login"}
             </Button>
-            {showPasskeyButton ? (
+            {passkeyLoginEnabled ? (
               <>
                 {passkeyError ? <Alert variant="danger">{passkeyError}</Alert> : null}
                 <Button type="button" onClick={handlePasskeyLogin} disabled={passkeyLoading}>

--- a/app/javascript/utils/webauthn.ts
+++ b/app/javascript/utils/webauthn.ts
@@ -42,6 +42,15 @@ export type PasskeyAuthenticationCredential = {
 
 export const isPasskeySupported = () => typeof window !== "undefined" && "PublicKeyCredential" in window;
 
+export const isConditionalMediationSupported = async (): Promise<boolean> => {
+  if (!isPasskeySupported() || typeof PublicKeyCredential.isConditionalMediationAvailable !== "function") return false;
+  try {
+    return await PublicKeyCredential.isConditionalMediationAvailable();
+  } catch {
+    return false;
+  }
+};
+
 const base64UrlToBytes = (value: string): Uint8Array => {
   const base64 = value.replace(/-/gu, "+").replace(/_/gu, "/");
   const binary = atob(base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), "="));
@@ -99,7 +108,10 @@ export const createPasskey = async (options: PasskeyRegistrationOptions): Promis
   };
 };
 
-export const getPasskey = async (options: PasskeyAuthenticationOptions): Promise<PasskeyAuthenticationCredential> => {
+export const getPasskey = async (
+  options: PasskeyAuthenticationOptions,
+  { mediation, signal }: { mediation?: CredentialMediationRequirement; signal?: AbortSignal } = {},
+): Promise<PasskeyAuthenticationCredential> => {
   const publicKey: PublicKeyCredentialRequestOptions = {
     challenge: base64UrlToBytes(options.challenge),
     ...(options.timeout !== undefined ? { timeout: options.timeout } : {}),
@@ -115,7 +127,11 @@ export const getPasskey = async (options: PasskeyAuthenticationOptions): Promise
     ...(options.userVerification ? { userVerification: options.userVerification } : {}),
   };
 
-  const credential = await navigator.credentials.get({ publicKey });
+  const credential = await navigator.credentials.get({
+    publicKey,
+    ...(mediation ? { mediation } : {}),
+    ...(signal ? { signal } : {}),
+  });
   if (!(credential instanceof PublicKeyCredential)) throw new Error("Could not authenticate with a passkey.");
 
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- get() always yields an assertion response

--- a/spec/controllers/logins_controller_spec.rb
+++ b/spec/controllers/logins_controller_spec.rb
@@ -35,6 +35,31 @@ describe LoginsController, type: :controller, inertia: true do
       end
     end
 
+    context "when the passkeys feature is active" do
+      before { Feature.activate(:passkeys) }
+      after { Feature.deactivate(:passkeys) }
+
+      it "embeds passkey login options and stores the challenge in the session" do
+        get :new
+
+        expect(inertia.props[:show_passkey_login]).to be(true)
+        options = inertia.props[:passkey_login_options].with_indifferent_access
+        expect(options[:challenge]).to be_present
+        expect(options[:rpId]).to eq(WebAuthn.configuration.rp_id)
+        expect(session[:webauthn_authentication_challenge]).to eq(options[:challenge])
+      end
+    end
+
+    context "when the passkeys feature is inactive" do
+      it "does not embed passkey login options or store a challenge" do
+        get :new
+
+        expect(inertia.props[:show_passkey_login]).to be(false)
+        expect(inertia.props[:passkey_login_options]).to be_nil
+        expect(session[:webauthn_authentication_challenge]).to be_nil
+      end
+    end
+
     context "with an email in the query parameters" do
       it "renders successfully" do
         get :new, params: { email: "test@example.com" }

--- a/spec/requests/login/passkeys_spec.rb
+++ b/spec/requests/login/passkeys_spec.rb
@@ -23,8 +23,10 @@ describe("Passkey Login Scenario", type: :system, js: true) do
 
     logout(:user)
     visit login_path
-    click_on "Log in with a passkey"
 
+    # Conditional UI arms a discoverable passkey request on load; the virtual
+    # authenticator auto-consents, signing the user in and bypassing 2FA without
+    # the fallback "Log in with a passkey" button.
     expect(page).to have_current_path(dashboard_path, wait: 15)
     expect(user.webauthn_credentials.sole.last_used_at).to be_present
   end


### PR DESCRIPTION
Ref #5347

## What

Passkeys now appear directly in the login form's autofill dropdown. This uses WebAuthn **conditional mediation**: the login page arms a background `get()` on load, and the email field (`autocomplete="email webauthn"`) surfaces any passkey for the site alongside saved logins. The existing "Log in with a passkey" button stays as a fallback for browsers without conditional support.

To arm the autofill prompt without an extra request, the login page embeds the WebAuthn challenge in its render (`passkey_login_options`) instead of fetching it. The explicit button still fetches a fresh challenge on click. A shared `build_webauthn_authentication_options` keeps the embedded options and the `/login/passkey/options` endpoint identical.

## Why

The parent issue originally scoped **email-first** passkey login (type your email, then authenticate). Conditional UI is the better path:

- **Fewer steps.** Passkeys show up where users already look — the autofill dropdown — with no identifier typed first. This is the primary sign-in pattern FIDO, Google, and Apple recommend; the explicit button is the documented *fallback*.
- **More private.** Email-first can reveal whether an account (or passkey) exists; usernameless autofill doesn't.
- **One form for both.** Password users type their password; passkey users tap the suggestion. Same flow.

**Why embed the challenge instead of fetching it:** conditional UI must arm a challenge before the user interacts. Fetching it would POST the IP-throttled `/login/passkey/options` on every login-page view, so passive page loads on a shared IP could exhaust the rate limit the explicit login flow needs. Embedding the challenge in the page render avoids that entirely. The button fetches fresh so it can never sign a challenge the session has since replaced.

Builds on the shipped passkey login (#5476).

## Demo

**Apple Passwords**

https://github.com/user-attachments/assets/22820ad7-9de1-4903-b211-48eb6ee584d8

**1Password**

https://github.com/user-attachments/assets/43af3881-22a5-4f3d-aee0-6fa732ea88ac

If you have the **1Password** extension installed, it surfaces the conditional request eagerly and may prompt on page load (before you focus the field). That's 1Password's own handling of conditional WebAuthn. Chrome's native passkeys, Safari/iCloud Keychain, and Android stay silent until the email field is focused. We arm on load deliberately so the passkey is ready in the autofill dropdown before focus; the eager prompt is a 1Password-specific tradeoff, not a bug.

---

This PR was implemented with AI assistance using Claude Opus 4.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784307859&installation_id=134400930&pr_number=5509&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5509&signature=f3b353aed9775bde75fcc918529bfa3e806324606b9a14d2af69c83fc8c1c80d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches login and WebAuthn session challenges (embedded vs button), so wrong challenge reuse or race handling could break passkey sign-in; changes are gated behind `:passkeys` and reuse existing verification paths.
> 
> **Overview**
> Adds **WebAuthn conditional mediation** so passkeys can appear in the login email field’s autofill dropdown, while keeping the explicit “Log in with a passkey” button as a fallback.
> 
> **Server:** WebAuthn get-options and session challenge setup move into shared `build_webauthn_authentication_options` on `WebauthnCeremonyVerification`. The login `new` action embeds those options in Inertia props when `:passkeys` is on (avoids an extra options POST on every page view); `/login/passkey/options` uses the same helper for a fresh challenge when the button is used.
> 
> **Client:** On load, supported browsers arm a background `navigator.credentials.get` with `mediation: "conditional"` using embedded options; the email input uses `autocomplete="email webauthn"`. Passkey login is refactored into `runPasskeyLogin` with abort handling so conditional and button flows don’t race. `getPasskey` accepts optional `mediation` and `signal`; `isConditionalMediationAvailable` is wrapped for feature detection.
> 
> Specs cover embedded options/session challenge on login render and update the system test for auto sign-in via conditional UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c803bb7f099522496f5c0789c78fa2b587048c94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->