### PR TITLE
Fix stale CSRF token for request() on Inertia pages

### DIFF
--- a/app/javascript/components/PasskeySetupPrompt.tsx
+++ b/app/javascript/components/PasskeySetupPrompt.tsx
@@ -15,10 +15,7 @@ const SNOOZE_KEY_PREFIX = "passkeySetupPromptSnoozedUntil";
 const SNOOZE_MS = 90 * 24 * 60 * 60 * 1000;
 
 export const PasskeySetupPrompt = () => {
-  const { authenticity_token, prompt_passkey_setup } = usePage<{
-    authenticity_token: string;
-    prompt_passkey_setup?: boolean;
-  }>().props;
+  const { prompt_passkey_setup } = usePage<{ prompt_passkey_setup?: boolean }>().props;
   const currentSeller = useCurrentSeller();
   const snoozeKey = `${SNOOZE_KEY_PREFIX}:${currentSeller?.id}`;
   const [supported, setSupported] = React.useState(false);
@@ -47,7 +44,7 @@ export const PasskeySetupPrompt = () => {
   const handleSetup = asyncVoid(async () => {
     setAdding(true);
     try {
-      await registerPasskey(authenticity_token);
+      await registerPasskey();
       setDismissed(true);
       showAlert("You're set — next time, sign in with your passkey.", "success");
     } catch (e) {

--- a/app/javascript/entrypoints/inertia.js
+++ b/app/javascript/entrypoints/inertia.js
@@ -4,6 +4,15 @@ import { createRoot } from "react-dom/client";
 
 import AppWrapper from "../inertia/app_wrapper.tsx";
 import Layout, { PublicLayout, LoggedInUserLayout } from "../inertia/layout.tsx";
+import { defaults as requestDefaults } from "../utils/request";
+
+// Keep the `request()` util's CSRF token current for Inertia pages. `base_page.ts` only
+// sets `requestDefaults.headers` on legacy react-on-rails pages, so without this a `request()`
+// POST after a client-side navigation (e.g. right after login) sends a stale/missing token and
+// fails CSRF verification. `authenticity_token` is a shared Inertia prop, fresh on every visit.
+function syncRequestCsrfToken(token) {
+  if (token) requestDefaults.headers = { ...requestDefaults.headers, "X-CSRF-Token": token };
+}
 
 // Prevent "Failed to execute 'removeChild' on 'Node'" errors caused by
 // browser translation extensions (e.g. Google Translate) relocating DOM nodes.
@@ -59,6 +68,10 @@ router.on("before", (event) => {
       sessionStorage.setItem("inertia_previous_route", currentUrl.pathname);
     }
   }
+});
+
+router.on("success", (event) => {
+  syncRequestCsrfToken(event.detail.page.props.authenticity_token);
 });
 
 // Handle non-Inertia responses (e.g., redirects to non-Inertia pages after login)
@@ -124,6 +137,7 @@ createInertiaApp({
     if (!el) return;
 
     const global = props.initialPage.props;
+    syncRequestCsrfToken(global.authenticity_token);
 
     const root = createRoot(el);
     root.render(createElement(AppWrapper, { global }, createElement(App, props)));

--- a/app/javascript/pages/Logins/New.tsx
+++ b/app/javascript/pages/Logins/New.tsx
@@ -106,7 +106,6 @@ function LoginPage() {
       signal?: AbortSignal;
       surfaceErrors: boolean;
     }) => {
-      const csrfHeaders = { "X-CSRF-Token": authenticity_token };
       try {
         let options = embeddedOptions;
         if (!options) {
@@ -114,7 +113,6 @@ function LoginPage() {
             url: Routes.login_passkey_options_path(),
             method: "POST",
             accept: "json",
-            headers: csrfHeaders,
             abortSignal: signal,
           });
           const optionsResult = typia.assert<{
@@ -137,7 +135,6 @@ function LoginPage() {
           method: "POST",
           accept: "json",
           data: { credential, next },
-          headers: csrfHeaders,
           abortSignal: signal,
         });
         const loginResult = typia.assert<{ success: boolean; redirect_location?: string; error_message?: string }>(
@@ -155,7 +152,7 @@ function LoginPage() {
         if (surfaceErrors) setPasskeyError(e instanceof ResponseError ? e.message : PASSKEY_ERROR);
       }
     },
-    [authenticity_token, next],
+    [next],
   );
 
   const handlePasskeyLogin = asyncVoid(async () => {

--- a/app/javascript/utils/passkeyRegistration.ts
+++ b/app/javascript/utils/passkeyRegistration.ts
@@ -12,14 +12,11 @@ export type Passkey = {
 
 export const PASSKEY_ADD_ERROR = "Could not add this passkey. Please try again.";
 
-export const registerPasskey = async (csrfToken?: string): Promise<Passkey> => {
-  const headers = csrfToken ? { "X-CSRF-Token": csrfToken } : undefined;
-
+export const registerPasskey = async (): Promise<Passkey> => {
   const optionsResponse = await request({
     url: Routes.registration_options_settings_passkeys_path(),
     method: "POST",
     accept: "json",
-    headers,
   });
   const optionsResult = typia.assert<{
     success: boolean;
@@ -37,7 +34,6 @@ export const registerPasskey = async (csrfToken?: string): Promise<Passkey> => {
     method: "POST",
     accept: "json",
     data: { credential },
-    headers,
   });
   const createResult = typia.assert<{ success: boolean; passkey?: Passkey; error_message?: string }>(
     await createResponse.json(),


### PR DESCRIPTION
## What

The `request()` util sends its CSRF token only from the module-level `defaults.headers`, which `base_page.ts` populates from the `<meta name=csrf-token>` tag. `base_page.ts` runs on legacy react-on-rails pages but never on Inertia pages. So after a client-side Inertia navigation (most visibly right after login, which has no full page reload) `request()` had a stale or missing token, and any POST failed CSRF verification and surfaced as a 404.

The Inertia entrypoint now keeps `requestDefaults.headers` in sync with the `authenticity_token` shared prop — which is fresh on every Inertia response — at initial load (`setup()`) and on every navigation (`router.on("success")`).

With the default now correct on Inertia pages, the per-caller `X-CSRF-Token` workarounds are removed from passkey login (`New.tsx`), the passkey registration helper, and the passkey setup prompt.

## Why

The token was being patched per-caller every time this bit someone (twice for passkeys). Fixing it once in the entrypoint means every `request()` call on an Inertia page gets a valid token automatically, and new callers don't have to know about the gap. The `authenticity_token` shared prop is the right source because it's rendered fresh on every response, unlike the static `<meta>` tag which isn't refreshed across client-side navigations.

---

This PR was implemented with AI assistance using Claude Opus 4.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784313304&installation_id=134400930&pr_number=5510&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5510&signature=280ff02c894ff204625c54367545894cd3a33bf9940c2072c37e1e7389b7e4f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how CSRF tokens are attached for all `request()` calls on Inertia pages, including passkey login and registration, but aligns tokens with server-issued values rather than omitting protection.
> 
> **Overview**
> **Fixes `request()` POSTs failing CSRF on Inertia after client-side navigations** (e.g. right after login) by updating the shared `request()` default `X-CSRF-Token` from Inertia’s `authenticity_token` on initial app setup and on every `router` success visit. Legacy pages already set this via `base_page.ts` and the static meta tag; Inertia never refreshed the util’s defaults.
> 
> With that centralized behavior, **per-call CSRF header workarounds are removed** from passkey login (`Logins/New.tsx`), `registerPasskey`, and `PasskeySetupPrompt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f32c090c1c26e57baae95c9115ca88e19faccf8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->