### PR TITLE
Add passkey funnel analytics

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -191,6 +191,7 @@ class ApplicationController < ActionController::Base
     def refresh_passkey_setup_prompt(user)
       if cookies[:is_gumroad_mobile_app].blank? && user.passkeys_setup_pending?
         session[PROMPT_PASSKEY_SETUP_SESSION_KEY] = user.id
+        Rails.logger.info("passkey.prompt.eligible user_id=#{user.id}")
       else
         session.delete(PROMPT_PASSKEY_SETUP_SESSION_KEY)
       end

--- a/app/controllers/logins/passkeys_controller.rb
+++ b/app/controllers/logins/passkeys_controller.rb
@@ -14,6 +14,8 @@ class Logins::PasskeysController < ApplicationController
   end
 
   def create
+    Rails.logger.info("passkey.authentication.started")
+
     challenge = session.delete(AUTHENTICATION_CHALLENGE_SESSION_KEY)
     raise VerificationError, "missing_challenge" if challenge.blank?
 

--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -48,6 +48,10 @@ class LoginsController < Devise::SessionsController
 
     return redirect_with_login_error("You cannot log in because your account was permanently deleted. Please sign up for a new account to start selling!") if @user.deleted?
 
+    if @user.passkeys_enabled?
+      Rails.logger.info("passkey.password_fallback user_id=#{@user.id}")
+    end
+
     @user.remember_me = true # Always "remember" user sessions
 
     sign_in_or_prepare_for_two_factor_auth(@user)

--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -48,13 +48,13 @@ class LoginsController < Devise::SessionsController
 
     return redirect_with_login_error("You cannot log in because your account was permanently deleted. Please sign up for a new account to start selling!") if @user.deleted?
 
-    if @user.passkeys_enabled?
-      Rails.logger.info("passkey.password_fallback user_id=#{@user.id}")
-    end
-
     @user.remember_me = true # Always "remember" user sessions
 
     sign_in_or_prepare_for_two_factor_auth(@user)
+
+    if user_signed_in? && @user.passkeys_enabled?
+      Rails.logger.info("passkey.password_fallback user_id=#{@user.id}")
+    end
 
     if @user.respond_to?(:pwned?) && @user.pwned?
       flash[:warning] = "Your password has previously appeared in a data breach as per haveibeenpwned.com and should never be used. We strongly recommend you change your password everywhere you have used it."

--- a/app/controllers/settings/passkeys_controller.rb
+++ b/app/controllers/settings/passkeys_controller.rb
@@ -32,6 +32,8 @@ class Settings::PasskeysController < Settings::BaseController
 
     session[REGISTRATION_CHALLENGE_SESSION_KEY] = options.challenge
 
+    Rails.logger.info("passkey.registration.started user_id=#{@user.id}")
+
     render json: { success: true, options: options.as_json }
   end
 

--- a/spec/controllers/logins/passkeys_controller_spec.rb
+++ b/spec/controllers/logins/passkeys_controller_spec.rb
@@ -88,6 +88,14 @@ describe Logins::PasskeysController, type: :controller do
       expect(session.delete(Logins::PasskeysController::AUTHENTICATION_CHALLENGE_SESSION_KEY)).to be_nil
     end
 
+    it "logs the login-started analytics event when an assertion is submitted" do
+      allow(Rails.logger).to receive(:info)
+
+      post :create, as: :json
+
+      expect(Rails.logger).to have_received(:info).with("passkey.authentication.started")
+    end
+
     it "persists the updated sign count" do
       credential = store_credential(fake_register)
 

--- a/spec/controllers/logins_controller_spec.rb
+++ b/spec/controllers/logins_controller_spec.rb
@@ -144,6 +144,14 @@ describe LoginsController, type: :controller, inertia: true do
         expect(session[:prompt_passkey_setup]).to eq(@user.id)
       end
 
+      it "logs the prompt-eligible analytics event after an eligible login" do
+        allow(Rails.logger).to receive(:info)
+
+        post "create", params: { user: { login_identifier: @user.email, password: "password" } }
+
+        expect(Rails.logger).to have_received(:info).with("passkey.prompt.eligible user_id=#{@user.id}")
+      end
+
       it "does not flag the prompt when the user already has a passkey" do
         create(:webauthn_credential, user: @user)
 
@@ -175,6 +183,28 @@ describe LoginsController, type: :controller, inertia: true do
         post "create", params: { user: { login_identifier: @user.email, password: "password" } }
 
         expect(session[:prompt_passkey_setup]).to be_nil
+      end
+    end
+
+    describe "passkey password fallback" do
+      before { Feature.activate(:passkeys) }
+      after { Feature.deactivate(:passkeys) }
+
+      it "logs the password-fallback analytics event when a passkey user signs in with a password" do
+        create(:webauthn_credential, user: @user)
+        allow(Rails.logger).to receive(:info)
+
+        post "create", params: { user: { login_identifier: @user.email, password: "password" } }
+
+        expect(Rails.logger).to have_received(:info).with("passkey.password_fallback user_id=#{@user.id}")
+      end
+
+      it "does not log the fallback event for a user without a passkey" do
+        allow(Rails.logger).to receive(:info)
+
+        post "create", params: { user: { login_identifier: @user.email, password: "password" } }
+
+        expect(Rails.logger).not_to have_received(:info).with("passkey.password_fallback user_id=#{@user.id}")
       end
     end
 

--- a/spec/controllers/logins_controller_spec.rb
+++ b/spec/controllers/logins_controller_spec.rb
@@ -206,6 +206,17 @@ describe LoginsController, type: :controller, inertia: true do
 
         expect(Rails.logger).not_to have_received(:info).with("passkey.password_fallback user_id=#{@user.id}")
       end
+
+      it "does not log the fallback event while the login is still pending 2FA" do
+        create(:webauthn_credential, user: @user)
+        @user.update!(two_factor_authentication_enabled: true)
+        allow(Rails.logger).to receive(:info)
+
+        post "create", params: { user: { login_identifier: @user.email, password: "password" } }
+
+        expect(controller.user_signed_in?).to be(false)
+        expect(Rails.logger).not_to have_received(:info).with("passkey.password_fallback user_id=#{@user.id}")
+      end
     end
 
     it "logs in if user already exists" do

--- a/spec/controllers/settings/passkeys_controller_spec.rb
+++ b/spec/controllers/settings/passkeys_controller_spec.rb
@@ -47,6 +47,14 @@ describe Settings::PasskeysController, type: :controller do
       expect(options["excludeCredentials"]).to contain_exactly("type" => "public-key", "id" => credential.webauthn_id)
     end
 
+    it "logs the enrollment-started analytics event" do
+      allow(Rails.logger).to receive(:info)
+
+      post :registration_options, as: :json
+
+      expect(Rails.logger).to have_received(:info).with("passkey.registration.started user_id=#{user.id}")
+    end
+
     it "returns an error when the user already has the maximum number of passkeys" do
       create_list(:webauthn_credential, WebauthnCredential::MAX_PER_USER, user:)
 


### PR DESCRIPTION
Ref #5347

## What

Wires the analytics for the passkey funnel — the last open item on #5347. The full funnel is now tracked as structured `passkey.*` log events:

- `passkey.registration.started` / `.succeeded` / `.failed`
- `passkey.authentication.started` / `.succeeded` / `.failed`
- `passkey.prompt.eligible` — the post-login enrollment prompt being offered
- `passkey.password_fallback` — a user who has a passkey signing in with a password instead

These flow to Elasticsearch for funnel and error/fallback-rate monitoring. The durable adoption metrics aren't logged — they're already rows in `webauthn_credentials` and are queried directly in Metabase. No migration, no new table.

## Why

Two-tier by data lifetime:

- **Outcomes / adoption** (creation rate, % of users with a passkey, recency, repeat-login) are permanent rows in `webauthn_credentials` → query in **Metabase** indefinitely, without scanning the huge `users` table.
- **Funnel / rate events** (started, prompt-eligible, fallback, failures) are ephemeral → emit as logs → **Elasticsearch/Kibana** for near-term funnel and error-rate monitoring.

A dedicated events table was considered and deferred: the metrics worth trending long-term (outcomes) are already durable in the DB, and the funnel events are operational, so persisting them would add a migration + write path for little gain.

## Analytics strategy — how to query

**Tier 1 · Metabase (adoption & outcomes, from `webauthn_credentials`):**
- Passkeys created over time: `select date(created_at), count(*) from webauthn_credentials group by 1`
- Users with ≥1 passkey: `select count(distinct user_id) from webauthn_credentials`
- Active passkeys: filter on `last_used_at`
- Adoption %: the count above ÷ a cached total-users figure (avoid `count(*)` on `users`)
- Password-reset rate, passkey vs non-passkey users: cohort = `user_id`s in `webauthn_credentials`, compared against the baseline

**Tier 2 · Kibana/ES (funnel & rates, from the `passkey.*` logs):**
- Enrollment funnel: `passkey.registration.started` → `.succeeded` / `.failed`
- Login success / error rate: `passkey.authentication.succeeded` vs `.failed` (with `reason=`)
- Fallback rate: `passkey.password_fallback`
- Prompt reach: `passkey.prompt.eligible`

---

This PR was implemented with AI assistance using Claude Opus 4.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5511"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784315668&installation_id=134400930&pr_number=5511&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5511&signature=f7a000f28812e58aff0f0f8d4ffad1f648345f7911c024a60507773043c16ac4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only: info-level logs on existing auth paths with no behavior or data-model changes.
> 
> **Overview**
> Adds structured **`passkey.*`** `Rails.logger.info` events at key funnel steps so enrollment, login, prompt reach, and password fallback can be monitored in Elasticsearch/Kibana (complementing durable adoption data in `webauthn_credentials`).
> 
> **New events in this diff:** `passkey.registration.started` when registration options are issued; `passkey.authentication.started` when a passkey login assertion is submitted; `passkey.prompt.eligible` when the post-login setup prompt session flag is set; `passkey.password_fallback` when a fully signed-in user who already has passkeys completes password login (skipped while 2FA is still pending).
> 
> Controller specs assert each new log line (and that password fallback is not logged without a passkey or before sign-in).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44c26cc35bab67f0f27fbf25f03b47663bb59446. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->