### PR TITLE
Improve Bangladesh payout account-number error with format guidance

### DIFF
--- a/app/models/bangladesh_bank_account.rb
+++ b/app/models/bangladesh_bank_account.rb
@@ -50,6 +50,6 @@ class BangladeshBankAccount < BankAccount
 
     def validate_account_number
       return if ACCOUNT_NUMBER_FORMAT_REGEX.match?(account_number_decrypted)
-      errors.add :base, "The account number is invalid."
+      errors.add :base, "Bangladesh account numbers are 13 to 17 digits. If yours is shorter, your bank's full-length format usually adds leading zeros (for example, 12345678901 becomes 0012345678901)."
     end
 end

--- a/spec/models/bangladesh_bank_account_spec.rb
+++ b/spec/models/bangladesh_bank_account_spec.rb
@@ -41,19 +41,19 @@ describe BangladeshBankAccount do
 
       bd_bank_account = build(:bangladesh_bank_account, account_number: "000012345678")
       expect(bd_bank_account).to_not be_valid
-      expect(bd_bank_account.errors.full_messages.to_sentence).to eq("The account number is invalid.")
+      expect(bd_bank_account.errors.full_messages.to_sentence).to eq("Bangladesh account numbers are 13 to 17 digits. If yours is shorter, your bank's full-length format usually adds leading zeros (for example, 12345678901 becomes 0012345678901).")
 
       bd_bank_account = build(:bangladesh_bank_account, account_number: "0000123456789101112")
       expect(bd_bank_account).to_not be_valid
-      expect(bd_bank_account.errors.full_messages.to_sentence).to eq("The account number is invalid.")
+      expect(bd_bank_account.errors.full_messages.to_sentence).to eq("Bangladesh account numbers are 13 to 17 digits. If yours is shorter, your bank's full-length format usually adds leading zeros (for example, 12345678901 becomes 0012345678901).")
 
       bd_bank_account = build(:bangladesh_bank_account, account_number: "BD00123456789101112")
       expect(bd_bank_account).to_not be_valid
-      expect(bd_bank_account.errors.full_messages.to_sentence).to eq("The account number is invalid.")
+      expect(bd_bank_account.errors.full_messages.to_sentence).to eq("Bangladesh account numbers are 13 to 17 digits. If yours is shorter, your bank's full-length format usually adds leading zeros (for example, 12345678901 becomes 0012345678901).")
 
       bd_bank_account = build(:bangladesh_bank_account, account_number: "BDABC")
       expect(bd_bank_account).to_not be_valid
-      expect(bd_bank_account.errors.full_messages.to_sentence).to eq("The account number is invalid.")
+      expect(bd_bank_account.errors.full_messages.to_sentence).to eq("Bangladesh account numbers are 13 to 17 digits. If yours is shorter, your bank's full-length format usually adds leading zeros (for example, 12345678901 becomes 0012345678901).")
     end
   end
 end


### PR DESCRIPTION
## What

Bangladesh sellers whose bank account number is shorter than the required 13–17 digits hit a generic "The account number is invalid." error with no indication of how to fix it. This replaces that message with actionable guidance: the expected 13–17 digit length and the leading-zero padding banks commonly use for shorter numbers.

## Why

The validation itself is correct — Bangladesh account numbers are canonically 13–17 digits, which is also what the downstream payout processor expects. The problem was purely the dead-end error message, which pushed sellers into a multi-day support round-trip just to learn they needed to zero-pad a short number. Surfacing the format at the point of failure lets them self-correct.

This intentionally does **not** loosen the length validation: accepting shorter numbers would only move the rejection downstream to the payment processor.

Closes antiwork/gumroad-private#537

---

AI disclosure: drafted with Claude Opus 4.8

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784361479&installation_id=134400930&pr_number=5514&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5514&signature=05d953c1b95359066261618da08e7c145dc53a48325b5f15ed54b339e6ce1e05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit af39e987f0dc085053d417c9012796e9d2b24a44. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->