### PR TITLE
Remove the minimum balance buffer from the Stripe balance check

### DIFF
--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -52,7 +52,6 @@ class RedisKey
     def unreviewed_users_cutoff_date = "admin:unreviewed_users_cutoff_date"
     def paypal_topup_needed = "paypal:topup_needed"
     def stripe_balance_topup_needed = "stripe:balance_topup_needed"
-    def stripe_minimum_balance_cents = "stripe:minimum_balance_cents"
     def min_successful_purchases_in_last_10_minutes = "healthcheck:min_successful_purchases_in_last_10_minutes"
     def email_router_fallback(user_id) = "email_router_fallback:#{user_id}"
     def mobile_minimum_version = "mobile:minimum_version"

--- a/app/services/stripe_balance_check_service.rb
+++ b/app/services/stripe_balance_check_service.rb
@@ -6,24 +6,16 @@
 # account transfers) draw from the same balance, so the balance can be
 # starved before a payout cycle runs. This service powers a proactive alert
 # so the balance can be topped up before any seller payout fails.
-#
-# The minimum balance kept on top of the estimated upcoming payouts is
-# configured at runtime via Redis (RedisKey.stripe_minimum_balance_cents).
 class StripeBalanceCheckService
   def initialize
     @upcoming_payouts_cents = calculate_upcoming_payouts_cents
-    @minimum_balance_cents = $redis.get(RedisKey.stripe_minimum_balance_cents).to_i
     @current_balance_cents = StripeTransferExternallyToGumroad.available_balances["usd"].to_i
   end
 
-  attr_reader :upcoming_payouts_cents, :minimum_balance_cents, :current_balance_cents
-
-  def required_balance_cents
-    upcoming_payouts_cents + minimum_balance_cents
-  end
+  attr_reader :upcoming_payouts_cents, :current_balance_cents
 
   def topup_amount_cents
-    @topup_amount_cents ||= required_balance_cents - current_balance_cents
+    @topup_amount_cents ||= upcoming_payouts_cents - current_balance_cents
   end
 
   def topup_needed?

--- a/app/sidekiq/send_stripe_balance_check_notification_job.rb
+++ b/app/sidekiq/send_stripe_balance_check_notification_job.rb
@@ -15,10 +15,8 @@ class SendStripeBalanceCheckNotificationJob
 
     return unless balance_check.topup_needed?
 
-    notification_msg = "Stripe balance needs to be #{formatted_dollar_amount(balance_check.required_balance_cents)} " \
-                       "(#{formatted_dollar_amount(balance_check.upcoming_payouts_cents)} for upcoming payouts + " \
-                       "#{formatted_dollar_amount(balance_check.minimum_balance_cents)} Stripe minimum balance) " \
-                       "to pay out all creators.\n" \
+    notification_msg = "Stripe balance needs to be #{formatted_dollar_amount(balance_check.upcoming_payouts_cents)} " \
+                       "to cover upcoming payouts.\n" \
                        "Current Stripe balance is #{formatted_dollar_amount(balance_check.current_balance_cents)}.\n" \
                        "A top-up of #{formatted_dollar_amount(balance_check.topup_amount_cents)} is needed."
 

--- a/spec/services/stripe_balance_check_service_spec.rb
+++ b/spec/services/stripe_balance_check_service_spec.rb
@@ -8,44 +8,27 @@ describe StripeBalanceCheckService do
       .with(User::PayoutSchedule.next_scheduled_payout_end_date)
       .and_return(300_000_00)
     allow(StripeTransferExternallyToGumroad).to receive(:available_balances).and_return({ "usd" => 1_000_000_00 })
-    $redis.set(RedisKey.stripe_minimum_balance_cents, 100_000_00)
   end
 
   it "uses the Gumroad-held Stripe estimate as the upcoming payout amount" do
     expect(described_class.new.upcoming_payouts_cents).to eq(300_000_00)
   end
 
-  it "reads the minimum balance from redis" do
-    expect(described_class.new.minimum_balance_cents).to eq(100_000_00)
-  end
-
-  it "adds the minimum balance on top of the upcoming payouts" do
-    expect(described_class.new.required_balance_cents).to eq(400_000_00)
-  end
-
   it "reads the available USD balance from Stripe" do
     expect(described_class.new.current_balance_cents).to eq(1_000_000_00)
   end
 
-  context "when the minimum balance is not configured" do
-    before { $redis.del(RedisKey.stripe_minimum_balance_cents) }
-
-    it "treats the minimum balance as zero" do
-      expect(described_class.new.minimum_balance_cents).to eq(0)
-    end
-  end
-
-  context "when the balance covers the upcoming payouts plus the minimum" do
+  context "when the balance covers the upcoming payouts" do
     it "does not need a top-up" do
       service = described_class.new
       expect(service.topup_needed?).to eq(false)
-      expect(service.topup_amount_cents).to eq(-600_000_00)
+      expect(service.topup_amount_cents).to eq(-700_000_00)
     end
   end
 
-  context "when the balance is below the upcoming payouts plus the minimum" do
+  context "when the balance is below the upcoming payouts" do
     before do
-      allow(StripeTransferExternallyToGumroad).to receive(:available_balances).and_return({ "usd" => 300_000_00 })
+      allow(StripeTransferExternallyToGumroad).to receive(:available_balances).and_return({ "usd" => 200_000_00 })
     end
 
     it "needs a top-up of the shortfall" do

--- a/spec/sidekiq/send_stripe_balance_check_notification_job_spec.rb
+++ b/spec/sidekiq/send_stripe_balance_check_notification_job_spec.rb
@@ -7,17 +7,16 @@ describe SendStripeBalanceCheckNotificationJob do
     before do
       allow(Rails.env).to receive(:production?).and_return(true)
       allow(PayoutEstimates).to receive(:estimate_gumroad_held_stripe_cents).and_return(300_000_00)
-      $redis.set(RedisKey.stripe_minimum_balance_cents, 100_000_00)
     end
 
     context "when the balance is insufficient" do
       before do
-        allow(StripeTransferExternallyToGumroad).to receive(:available_balances).and_return({ "usd" => 300_000_00 })
+        allow(StripeTransferExternallyToGumroad).to receive(:available_balances).and_return({ "usd" => 200_000_00 })
       end
 
       it "sends a notification with the required top-up and sets the redis key to true" do
-        notification_msg = "Stripe balance needs to be $400,000 ($300,000 for upcoming payouts + $100,000 Stripe minimum balance) to pay out all creators.\n"\
-                           "Current Stripe balance is $300,000.\n"\
+        notification_msg = "Stripe balance needs to be $300,000 to cover upcoming payouts.\n"\
+                           "Current Stripe balance is $200,000.\n"\
                            "A top-up of $100,000 is needed."
 
         described_class.new.perform
@@ -50,7 +49,7 @@ describe SendStripeBalanceCheckNotificationJob do
 
     context "when the disable_stripe_balance_check_notification flag is active" do
       before do
-        allow(StripeTransferExternallyToGumroad).to receive(:available_balances).and_return({ "usd" => 300_000_00 })
+        allow(StripeTransferExternallyToGumroad).to receive(:available_balances).and_return({ "usd" => 200_000_00 })
         Feature.activate(:disable_stripe_balance_check_notification)
       end
 


### PR DESCRIPTION
## What

Removes the fixed minimum balance buffer from the daily Stripe balance check (`SendStripeBalanceCheckNotificationJob` / `StripeBalanceCheckService`).

- `StripeBalanceCheckService` no longer adds a minimum balance on top of the estimated upcoming payouts. A top-up is flagged only when the current Stripe platform balance cannot cover the upcoming payouts (`topup_amount_cents = upcoming_payouts_cents - current_balance_cents`).
- Removes the now-unused `required_balance_cents` and `minimum_balance_cents` accessors and the `stripe:minimum_balance_cents` Redis key.
- Simplifies the alert copy to `"Stripe balance needs to be <X> to cover upcoming payouts."`.

## Why

The check previously required `upcoming_payouts + minimum_balance`, where the minimum balance was a fixed runtime-configured buffer. The buffer dominated the threshold and caused the alert to fire on a recurring basis even when the balance comfortably covered every upcoming seller payout — so the alert no longer signalled a real risk of a payout failing. Dropping the buffer makes the alert fire only on a genuine shortfall against upcoming payouts, which is the condition the alert exists to catch.

## Before / After

_Video to be added._

## Test Results

`spec/services/stripe_balance_check_service_spec.rb` and `spec/sidekiq/send_stripe_balance_check_notification_job_spec.rb` updated to drop the minimum-balance cases and assert the new shortfall math and copy — 9 examples, 0 failures locally. `rubocop` clean on all changed files. (`bin/test-confidence` was unavailable in this environment — no `ANTHROPIC_API_KEY` — so the affected specs were run directly.)

---

🤖 AI disclosure: this PR was written by Claude Opus 4.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784386451&installation_id=134400930&pr_number=5516&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5516&signature=dbd9f32ce1fc0d81dcc062a7e6d633fc641b9317a2d9b114f97c5c88d5406870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when internal Stripe top-up alerts fire for seller payouts; a genuine shortfall could be noticed later if payout estimates are wrong, though the check becomes less noisy.
> 
> **Overview**
> Removes the Redis-configured **minimum balance buffer** from the Stripe platform balance check so alerts only fire when the balance cannot cover **estimated upcoming seller payouts**.
> 
> `StripeBalanceCheckService` now compares current USD balance directly to upcoming payouts (`topup_amount_cents = upcoming_payouts_cents - current_balance_cents`) and drops `required_balance_cents`, `minimum_balance_cents`, and the `stripe:minimum_balance_cents` Redis key. `SendStripeBalanceCheckNotificationJob` alert copy is simplified to state the payout coverage target only. Specs are updated for the new threshold math and messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 727f9b593e54959020b0beafd392ec5c99d3d994. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->