### PR TITLE
Allow admins to release a payout below the $100 minimum

### DIFF
--- a/app/business/payments/payouts/payouts.rb
+++ b/app/business/payments/payouts/payouts.rb
@@ -7,7 +7,7 @@ class Payouts
   PAYOUT_TYPE_STANDARD = "standard"
   PAYOUT_TYPE_INSTANT = "instant"
 
-  def self.is_user_payable(user, date, processor_type: nil, add_comment: false, from_admin: false, payout_type: Payouts::PAYOUT_TYPE_STANDARD)
+  def self.is_user_payable(user, date, processor_type: nil, add_comment: false, from_admin: false, bypass_minimum_payout: false, payout_type: Payouts::PAYOUT_TYPE_STANDARD)
     payout_date = Time.current.to_fs(:formatted_date_full_month)
 
     unless user.compliant? || from_admin
@@ -26,13 +26,17 @@ class Payouts
 
     account_balance = amount_payable + user.paid_payments_cents_for_date(date)
     if account_balance < user.minimum_payout_amount_cents
-      if add_comment && account_balance > 0
-        current_balance = user.formatted_dollar_amount(account_balance, with_currency: true)
-        minimum_balance = user.formatted_dollar_amount(user.minimum_payout_amount_cents, with_currency: true)
-        user.add_payout_note(content: "Payout on #{payout_date} was skipped because the account balance #{current_balance} was less than the minimum payout amount of #{minimum_balance}.") if add_comment
+      is_payable_from_admin = from_admin && account_balance > 0 &&
+        (bypass_minimum_payout || user.unpaid_balance_cents_up_to_date_held_by_gumroad(date) == account_balance)
+
+      unless is_payable_from_admin
+        if add_comment && account_balance > 0
+          current_balance = user.formatted_dollar_amount(account_balance, with_currency: true)
+          minimum_balance = user.formatted_dollar_amount(user.minimum_payout_amount_cents, with_currency: true)
+          user.add_payout_note(content: "Payout on #{payout_date} was skipped because the account balance #{current_balance} was less than the minimum payout amount of #{minimum_balance}.")
+        end
+        return false
       end
-      is_payable_from_admin = from_admin && account_balance > 0 && user.unpaid_balance_cents_up_to_date_held_by_gumroad(date) == account_balance
-      return false unless is_payable_from_admin
     end
 
     if payout_type == Payouts::PAYOUT_TYPE_INSTANT
@@ -83,7 +87,7 @@ class Payouts
     self.create_instant_payouts_for_balances_up_to_date_for_users(date, users, perform_async: true, add_comment: true)
   end
 
-  def self.create_payments_for_balances_up_to_date_for_users(date, processor_type, users, perform_async: false, retrying: false, bank_account_type: nil, from_admin: false)
+  def self.create_payments_for_balances_up_to_date_for_users(date, processor_type, users, perform_async: false, retrying: false, bank_account_type: nil, from_admin: false, bypass_minimum_payout: false)
     raise ArgumentError.new("Cannot payout for today or future balances.") if date >= Date.current
 
     user_ids_to_pay = []
@@ -93,7 +97,8 @@ class Payouts
         user, date,
         processor_type:,
         add_comment: true,
-        from_admin:
+        from_admin:,
+        bypass_minimum_payout:
       ) &&
       (
         from_admin ||

--- a/app/controllers/api/internal/admin/payouts_controller.rb
+++ b/app/controllers/api/internal/admin/payouts_controller.rb
@@ -105,12 +105,14 @@ class Api::Internal::Admin::PayoutsController < Api::Internal::Admin::BaseContro
       return render json: { success: false, message: "payout_period_end_date must be in the past" }, status: :bad_request
     end
 
+    bypass_minimum_payout = ActiveModel::Type::Boolean.new.cast(params[:bypass_minimum_payout]) || false
+
     record_admin_write(action: "payouts.issue", target: @user) do
       if processor_param == PayoutProcessorType::PAYPAL && ActiveModel::Type::Boolean.new.cast(params[:should_split_the_amount])
         @user.update!(should_paypal_payout_be_split: true)
       end
 
-      payments = Payouts.create_payments_for_balances_up_to_date_for_users(date, processor_param, [@user], from_admin: true)
+      payments = Payouts.create_payments_for_balances_up_to_date_for_users(date, processor_param, [@user], from_admin: true, bypass_minimum_payout:)
       payment = payments.first&.first
 
       if payment.blank? || payment.failed?

--- a/app/controllers/api/internal/admin/payouts_controller.rb
+++ b/app/controllers/api/internal/admin/payouts_controller.rb
@@ -105,7 +105,7 @@ class Api::Internal::Admin::PayoutsController < Api::Internal::Admin::BaseContro
       return render json: { success: false, message: "payout_period_end_date must be in the past" }, status: :bad_request
     end
 
-    bypass_minimum_payout = ActiveModel::Type::Boolean.new.cast(params[:bypass_minimum_payout]) || false
+    bypass_minimum_payout = ActiveModel::Type::Boolean.new.cast(params[:bypass_minimum_payout]) == true
 
     record_admin_write(action: "payouts.issue", target: @user) do
       if processor_param == PayoutProcessorType::PAYPAL && ActiveModel::Type::Boolean.new.cast(params[:should_split_the_amount])

--- a/spec/business/payments/payouts/payouts_spec.rb
+++ b/spec/business/payments/payouts/payouts_spec.rb
@@ -143,6 +143,42 @@ describe Payouts do
       end
     end
 
+    describe "below the minimum payout amount held by a processor" do
+      let(:payout_date) { Date.today }
+      let(:seller) { create(:singaporean_user_with_compliance_info, user_risk_state: "compliant", payment_address: "bob1@example.com") }
+
+      before do
+        create(:balance, user: seller, amount_cents: 50_00, date: payout_date - 2)
+        allow(PaypalPayoutProcessor).to receive(:is_user_payable).and_return(true)
+        allow(StripePayoutProcessor).to receive(:is_user_payable).and_return(true)
+        allow_any_instance_of(User).to receive(:unpaid_balance_cents_up_to_date_held_by_gumroad).and_return(0)
+      end
+
+      it "considers the user NOT payable from admin without bypass_minimum_payout" do
+        expect(described_class.is_user_payable(seller, payout_date, from_admin: true)).to eq(false)
+      end
+
+      it "considers the user payable from admin with bypass_minimum_payout" do
+        expect(described_class.is_user_payable(seller, payout_date, from_admin: true, bypass_minimum_payout: true)).to eq(true)
+      end
+
+      it "ignores bypass_minimum_payout when the request is not from admin" do
+        expect(described_class.is_user_payable(seller, payout_date, bypass_minimum_payout: true)).to eq(false)
+      end
+
+      it "does not add a skipped-below-minimum note when the payout is forced from admin" do
+        expect do
+          described_class.is_user_payable(seller, payout_date, from_admin: true, bypass_minimum_payout: true, add_comment: true)
+        end.not_to change { seller.comments.with_type_payout_note.count }
+      end
+
+      it "still rejects a forced payout when the balance is not positive" do
+        allow_any_instance_of(User).to receive(:unpaid_balance_cents_up_to_date).and_return(0)
+        allow_any_instance_of(User).to receive(:paid_payments_cents_for_date).and_return(0)
+        expect(described_class.is_user_payable(seller, payout_date, from_admin: true, bypass_minimum_payout: true)).to eq(false)
+      end
+    end
+
     describe "instant payouts" do
       let(:seller) { create(:compliant_user) }
 

--- a/spec/controllers/api/internal/admin/payouts_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/payouts_controller_spec.rb
@@ -461,7 +461,7 @@ describe Api::Internal::Admin::PayoutsController do
       date = 1.day.ago.to_date
 
       expect(Payouts).to receive(:create_payments_for_balances_up_to_date_for_users).with(
-        date, PayoutProcessorType::STRIPE, [user], from_admin: true
+        date, PayoutProcessorType::STRIPE, [user], from_admin: true, bypass_minimum_payout: false
       ).and_return([[payment]])
 
       post :issue, params: { user_id: user.external_id, payout_processor: "stripe", payout_period_end_date: date.to_s }
@@ -472,6 +472,20 @@ describe Api::Internal::Admin::PayoutsController do
         "user_id" => user.external_id,
         "payout" => hash_including("external_id" => payment.external_id, "state" => "completed")
       )
+    end
+
+    it "forwards bypass_minimum_payout to release a balance below the payout minimum" do
+      payment = create(:payment_completed, user:)
+      date = 1.day.ago.to_date
+
+      expect(Payouts).to receive(:create_payments_for_balances_up_to_date_for_users).with(
+        date, PayoutProcessorType::STRIPE, [user], from_admin: true, bypass_minimum_payout: true
+      ).and_return([[payment]])
+
+      post :issue, params: { user_id: user.external_id, payout_processor: "stripe", payout_period_end_date: date.to_s, bypass_minimum_payout: "true" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["success"]).to be(true)
     end
 
     it "sets should_paypal_payout_be_split when paypal split is requested" do


### PR DESCRIPTION
## What

Adds a `bypass_minimum_payout` option to the admin payout endpoint (`POST /internal/admin/payouts/issue`) so an admin can release a creator's balance that sits **below the $100 payout minimum**.

- `Payouts.is_user_payable` and `create_payments_for_balances_up_to_date_for_users` take a new `bypass_minimum_payout:` keyword (default `false`).
- The controller reads `params[:bypass_minimum_payout]` and passes it through (`from_admin: true` is already hard-coded there).
- When set, a **positive** sub-minimum balance is payable from admin regardless of holder of funds. Every other guard — compliance, paused payouts, processor setup, positive-balance — is unchanged.
- The default path (no param) still rejects below-minimum payouts, unchanged.
- The "skipped because below the minimum" payout note now only records when the payout is actually skipped, so a forced payout no longer leaves a misleading "skipped" note in the audit trail.

This is the backend half of the gumroad-cli feature in antiwork/gumroad-cli#161. The CLI `--force` flag (separate PR) sends this param.

## Why

The endpoint already had a below-minimum escape hatch for admins, but it required the **entire** balance to be Gumroad-held:

```ruby
is_payable_from_admin = from_admin && account_balance > 0 && user.unpaid_balance_cents_up_to_date_held_by_gumroad(date) == account_balance
```

A compliant creator winding down a product whose remaining balance is on a Stripe Connect account therefore failed with `Payment was not sent.`, and the only workaround was a Rails console call:

```ruby
PayoutUsersService.new(date_string: "<date>", processor_type: "STRIPE", user_ids: <id>).process
```

That console path works because it calls `Payouts.create_payment` directly, skipping `is_user_payable` (and thus the minimum) entirely. Rather than expose that unconditional bypass, this widens the existing, scoped admin bypass with an explicit, opt-in flag — mirroring the `--force` precedent on `purchases refund` (relax one specific guard, keep the rest).

**Why not reuse scheduled payouts?** `ScheduledPayout#execute!` does pay below the minimum (it also calls `create_payment` directly), but `scheduled_payouts#create` is hard-gated to suspended users (`"User is not suspended."`). This issue targets compliant, non-suspended creators, so that path would require loosening the suspended-only guard — a bigger, riskier change.

## Before/After

Backend-only change. Behavior is exercised by specs below; a console walkthrough on staging will be attached.

- Before: admin issue for a sub-$100 Stripe-held balance → `Payment was not sent.`
- After: same call with `bypass_minimum_payout: true` → payout is created; without the param → still rejected.

## Test Results

```
spec/business/payments/payouts/payouts_spec.rb            55 examples, 0 failures
spec/controllers/api/internal/admin/payouts_controller_spec.rb   …POST issue 16 examples, 0 failures
rubocop (4 changed files)                                no offenses detected
```

New specs:
- `is_user_payable` below-minimum, processor-held: not payable from admin without the flag, payable with it, ignored when not from admin, no skipped-note when forced, still rejected when balance is not positive.
- Controller: forwards `bypass_minimum_payout` (true and the default false).

## QA steps

On a preview/staging env, with a compliant seller holding a sub-$100 Stripe-held balance:
1. `POST /internal/admin/payouts/issue` with `payout_processor=stripe`, a past `payout_period_end_date` → expect 422 `Payment was not sent.`
2. Same request with `bypass_minimum_payout=true` → expect 200 and a created payout.
3. Confirm no `Payout … was skipped because the account balance … was less than the minimum` note is added in case 2.

---

🤖 AI disclosure: drafted with the help of Claude Opus 4.8.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes money-movement eligibility for admin-issued payouts; the bypass is scoped to admin + explicit flag but still relaxes a core payout guard.
> 
> **Overview**
> Adds an opt-in **`bypass_minimum_payout`** path on the internal admin payout issue flow so admins can release a **positive balance below the payout minimum**, including when funds are held by Stripe/processors (not only Gumroad-held balances).
> 
> **`Payouts.is_user_payable`** and **`create_payments_for_balances_up_to_date_for_users`** accept the new keyword (default `false`). Admin bypass now allows either the existing Gumroad-held escape hatch **or** `bypass_minimum_payout` when `from_admin` is true; the flag is ignored outside admin. The below-minimum “skipped” payout note is only written when the payout is actually rejected, so a forced admin payout does not leave a misleading audit note.
> 
> **`POST /internal/admin/payouts/issue`** reads `params[:bypass_minimum_payout]` and passes it through with `from_admin: true`. Scheduled and estimate paths are unchanged (they do not pass the flag).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53289f002cf9422a56c118c2e4f4992849cb4678. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784403919&installation_id=134400930&pr_number=5518&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5518&signature=7ab1d35a9d60cd8415aa1868f3a3dcb063143d1ecd99d03ab590a03665947cd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->