### PR TITLE
Show "Purchase again" only after a paid purchase

### DIFF
--- a/app/javascript/components/Product/CtaButton.tsx
+++ b/app/javascript/components/Product/CtaButton.tsx
@@ -155,7 +155,7 @@ export const CtaButton = React.forwardRef<HTMLAnchorElement, Props>(
           {...buttonCommonProps}
         >
           {label ??
-            (purchase?.was_paid
+            (purchase && (purchase.was_paid || product.recurrences)
               ? "Purchase again"
               : product.recurrences
                 ? "Subscribe"

--- a/app/javascript/components/Product/CtaButton.tsx
+++ b/app/javascript/components/Product/CtaButton.tsx
@@ -155,7 +155,7 @@ export const CtaButton = React.forwardRef<HTMLAnchorElement, Props>(
           {...buttonCommonProps}
         >
           {label ??
-            (purchase
+            (purchase?.was_paid
               ? "Purchase again"
               : product.recurrences
                 ? "Subscribe"

--- a/app/javascript/components/Product/index.tsx
+++ b/app/javascript/components/Product/index.tsx
@@ -172,6 +172,7 @@ export type Purchase = {
   created_at: string;
   review: FormReview | null;
   should_show_receipt: boolean;
+  was_paid: boolean;
   is_gift_receiver_purchase: boolean;
   content_url: string | null;
   show_view_content_button_on_product_page: boolean;

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -1142,6 +1142,7 @@ class Purchase < ApplicationRecord
     json = {
       created_at: purchase.created_at,
       should_show_receipt: !purchase.is_test_purchase? && purchase.successful_and_not_reversed?(include_gift: true),
+      was_paid: purchase.present? && purchase.paid?,
       show_view_content_button_on_product_page: purchase.show_view_content_button_on_product_page?,
       is_recurring_billing: link.is_recurring_billing,
       is_physical: link.is_physical,

--- a/app/presenters/product_presenter/product_props.rb
+++ b/app/presenters/product_presenter/product_props.rb
@@ -108,6 +108,7 @@ class ProductPresenter::ProductProps
         created_at: purchase_info[:created_at],
         review: purchase_info[:review],
         should_show_receipt: purchase_info[:should_show_receipt],
+        was_paid: purchase_info[:was_paid],
         is_gift_receiver_purchase: purchase_info[:is_gift_receiver_purchase],
         show_view_content_button_on_product_page: purchase_info[:show_view_content_button_on_product_page],
         total_price_including_tax_and_shipping: purchase_info[:total_price_including_tax_and_shipping],

--- a/spec/controllers/customers_controller_spec.rb
+++ b/spec/controllers/customers_controller_spec.rb
@@ -453,9 +453,10 @@ describe CustomersController, :vcr, type: :controller, inertia: true do
   describe "GET missed_posts" do
     before do
       @product = create(:product, user: seller)
-      @post1 = create(:installment, link: @product, published_at: Time.current)
-      @post2 = create(:installment, link: @product, published_at: Time.current)
-      @post3 = create(:installment, link: @product, published_at: Time.current)
+      published_at = Time.current
+      @post1 = create(:installment, link: @product, published_at:)
+      @post2 = create(:installment, link: @product, published_at:)
+      @post3 = create(:installment, link: @product, published_at:)
       @unpublished_post = create(:installment, link: @product)
       @purchase = create(:purchase, link: @product)
       create(:creator_contacting_customers_email_info_delivered, installment: @post1, purchase: @purchase)

--- a/spec/controllers/customers_controller_spec.rb
+++ b/spec/controllers/customers_controller_spec.rb
@@ -453,10 +453,9 @@ describe CustomersController, :vcr, type: :controller, inertia: true do
   describe "GET missed_posts" do
     before do
       @product = create(:product, user: seller)
-      published_at = Time.current
-      @post1 = create(:installment, link: @product, published_at:)
-      @post2 = create(:installment, link: @product, published_at:)
-      @post3 = create(:installment, link: @product, published_at:)
+      @post1 = create(:installment, link: @product, published_at: Time.current)
+      @post2 = create(:installment, link: @product, published_at: Time.current)
+      @post3 = create(:installment, link: @product, published_at: Time.current)
       @unpublished_post = create(:installment, link: @product)
       @purchase = create(:purchase, link: @product)
       create(:creator_contacting_customers_email_info_delivered, installment: @post1, purchase: @purchase)

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -4279,6 +4279,18 @@ describe Link, :vcr do
           it "returns purchase_info" do
             expect(product.purchase_info_for_product_page(user, nil)).to eq(purchase.purchase_info)
           end
+
+          it "marks the purchase as paid" do
+            expect(product.purchase_info_for_product_page(user, nil)[:was_paid]).to eq(true)
+          end
+        end
+
+        context "when the user's previous purchase was free" do
+          let!(:purchase) { create(:free_purchase, link: product, purchaser: user) }
+
+          it "marks the purchase as not paid" do
+            expect(product.purchase_info_for_product_page(user, nil)[:was_paid]).to eq(false)
+          end
         end
 
         context "when the user has a previous gift sender purchase" do

--- a/spec/presenters/product_presenter_spec.rb
+++ b/spec/presenters/product_presenter_spec.rb
@@ -186,6 +186,7 @@ describe ProductPresenter do
             membership: nil,
             review: nil,
             should_show_receipt: true,
+            was_paid: true,
             is_gift_receiver_purchase: false,
             show_view_content_button_on_product_page: false,
             subscription_has_lapsed: false,

--- a/spec/requests/products/show/cta_button_spec.rb
+++ b/spec/requests/products/show/cta_button_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Product page CTA button for a returning buyer", :js, type: :system do
+  let(:seller) { create(:named_user) }
+  let(:buyer) { create(:user) }
+
+  context "when the buyer's only prior purchase of the product was free" do
+    let(:product) { create(:product, user: seller, price_cents: 0) }
+
+    before do
+      create(:free_purchase, link: product, purchaser: buyer, email: buyer.email)
+      login_as buyer
+    end
+
+    it "shows the regular CTA instead of 'Purchase again'" do
+      visit short_link_path(product)
+
+      expect(page).to have_link("I want this!")
+      expect(page).to have_no_link("Purchase again")
+    end
+  end
+
+  context "when the buyer previously paid for the product" do
+    let(:product) { create(:product, user: seller, price_cents: 500) }
+
+    before do
+      create(:purchase, link: product, purchaser: buyer, email: buyer.email)
+      login_as buyer
+    end
+
+    it "shows 'Purchase again'" do
+      visit short_link_path(product)
+
+      expect(page).to have_link("Purchase again")
+    end
+  end
+end

--- a/spec/support/checkout_helpers.rb
+++ b/spec/support/checkout_helpers.rb
@@ -11,7 +11,7 @@ module CheckoutHelpers
 
     fill_in "Name a fair price", with: pwyw_price if pwyw_price.present?
 
-    if product.purchase_info_for_product_page(logged_in_user, Capybara.current_session.driver.browser.manage.all_cookies.find { |cookie| cookie[:name] == "_gumroad_guid" }&.[](:value)).present?
+    if product.purchase_info_for_product_page(logged_in_user, Capybara.current_session.driver.browser.manage.all_cookies.find { |cookie| cookie[:name] == "_gumroad_guid" }&.[](:value))&.dig(:was_paid)
       buy_text = "Purchase again"
     elsif cart
       buy_text = "Add to cart"

--- a/spec/support/checkout_helpers.rb
+++ b/spec/support/checkout_helpers.rb
@@ -11,7 +11,8 @@ module CheckoutHelpers
 
     fill_in "Name a fair price", with: pwyw_price if pwyw_price.present?
 
-    if product.purchase_info_for_product_page(logged_in_user, Capybara.current_session.driver.browser.manage.all_cookies.find { |cookie| cookie[:name] == "_gumroad_guid" }&.[](:value))&.dig(:was_paid)
+    purchase_info = product.purchase_info_for_product_page(logged_in_user, Capybara.current_session.driver.browser.manage.all_cookies.find { |cookie| cookie[:name] == "_gumroad_guid" }&.[](:value))
+    if purchase_info && (purchase_info[:was_paid] || product.is_recurring_billing)
       buy_text = "Purchase again"
     elsif cart
       buy_text = "Add to cart"


### PR DESCRIPTION
## What

On the product page, the CTA button showed **"Purchase again"** whenever the buyer had any prior purchase of the product — including a *free* acquisition. This changes it so "Purchase again" only appears when the buyer's prior purchase actually involved payment. A free prior purchase now falls through to the regular CTA ("I want this!" / "Subscribe" / "Rent" / custom text).

- `Purchase.purchase_info` / the product-page purchase prop now expose `was_paid` (backed by `Purchase#paid?`, i.e. `price_cents > 0`).
- `CtaButton` gates the "Purchase again" label on `purchase?.was_paid` instead of mere presence of a purchase.
- The shared `add_to_cart` spec helper mirrors the same rule.

Closes #5478

## Why

Sellers who offer a free version of a product reported the button as confusing: a buyer who only ever got the free version never purchased anything, so "Purchase again" is inaccurate and misleading. The original label is more appropriate when no money changed hands.

The paid/free decision is computed on the backend (`Purchase#paid?`) and passed to the frontend as a boolean, per the project convention that business logic (pricing) lives in Rails and the frontend renders backend-provided state.

## Before/After

### Before
<img width="1280" height="906" alt="pr-5520-free-before-desktop-light" src="https://github.com/user-attachments/assets/1b0994b6-4650-4dd8-8944-4ad9ce66da8c" />

### After
<img width="1280" height="906" alt="pr-5520-free-after-desktop-light" src="https://github.com/user-attachments/assets/5e3040b5-f3b5-447f-b742-35df4d3222c9" />

### Paid product not changed
<img width="1280" height="906" alt="pr-5520-paid-after-desktop-light" src="https://github.com/user-attachments/assets/c06ec7b5-21a3-4d56-8dea-138f6e56054f" />

---

🤖 Written with Claude Opus 4.8 (1M context)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784438127&installation_id=134400930&pr_number=5520&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5520&signature=aba8aeb922ad3983ef53f97b3539b6501f572c5ec8474c9d73642b579dad44ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow product-page CTA and test-helper behavior change with backend-sourced pricing flag; no auth or payment flow changes.
> 
> **Overview**
> The product page CTA no longer shows **"Purchase again"** just because the buyer has any prior purchase. It now requires a **paid** prior purchase (`was_paid` from Rails via `Purchase#paid?`, i.e. `price_cents > 0`). Buyers who only claimed a free copy see the normal label ("I want this!", Subscribe, Rent, or custom text).
> 
> `Purchase.purchase_info`, `ProductPresenter`, and the frontend `Purchase` type thread **`was_paid`** through. **`CtaButton`** and the **`add_to_cart`** test helper use the same rule (subscriptions still treat recurring products like returning buyers via `product.recurrences`).
> 
> Specs cover paid vs free purchase info, presenter props, a new system spec for the button text, and updated checkout helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfb393809d7133d2c05936ff7615b1559296af5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->