### PR TITLE
Avoid silently granting edit_emails OAuth scope

### DIFF
--- a/app/models/oauth_application.rb
+++ b/app/models/oauth_application.rb
@@ -66,10 +66,11 @@ class OauthApplication < Doorkeeper::Application
 
   # Returns an existing active access token or creates one if none exist
   def get_or_generate_access_token
-    ensure_access_grant_exists
+    allowed_scopes = scopes.to_s
+    ensure_access_grant_exists(allowed_scopes:)
     access_tokens.where(resource_owner_id: owner.id,
                         revoked_at: nil,
-                        scopes: Doorkeeper.configuration.public_scopes.join(" ")).first_or_create!
+                        scopes: allowed_scopes).first_or_create!
   end
 
   def revoke_access_for(user)
@@ -109,9 +110,9 @@ class OauthApplication < Doorkeeper::Application
         .update_all(status: OauthDeviceAuthorization::STATUS_DENIED, denied_at:, updated_at: denied_at)
     end
 
-    def ensure_access_grant_exists
+    def ensure_access_grant_exists(allowed_scopes:)
       access_grants.where(resource_owner_id: owner.id,
-                          scopes: Doorkeeper.configuration.public_scopes.join(" "),
+                          scopes: allowed_scopes,
                           redirect_uri:).first_or_create! { |access_grant| access_grant.expires_in = 60.years }
     end
 

--- a/db/migrate/20261201000001_backfill_edit_emails_scope_for_default_oauth_applications.rb
+++ b/db/migrate/20261201000001_backfill_edit_emails_scope_for_default_oauth_applications.rb
@@ -5,14 +5,10 @@ class BackfillEditEmailsScopeForDefaultOauthApplications < ActiveRecord::Migrati
   NEW_SCOPE = "edit_emails"
 
   def up
-    oauth_applications.find_each do |application|
-      scopes = application.scopes.to_s.split
-      next if scopes.include?(NEW_SCOPE)
-      next unless old_default_scopes?(scopes)
-
-      scopes.insert(scopes.index("edit_products").to_i + 1, NEW_SCOPE)
-      application.update_columns(scopes: scopes.join(" "), updated_at: Time.current)
-    end
+    # Intentionally do not backfill this newly introduced write scope onto
+    # existing OAuth applications. Granting edit_emails to already-authorized
+    # apps would let those apps create and send audience emails without a new
+    # explicit user consent flow.
   end
 
   def down

--- a/db/migrate/20261201000002_revoke_backfilled_edit_emails_scope_from_default_oauth_applications.rb
+++ b/db/migrate/20261201000002_revoke_backfilled_edit_emails_scope_from_default_oauth_applications.rb
@@ -3,24 +3,22 @@
 class RevokeBackfilledEditEmailsScopeFromDefaultOauthApplications < ActiveRecord::Migration[7.1]
   OLD_PUBLIC_SCOPES = %w[edit_products view_sales mark_sales_as_shipped edit_sales revenue_share ifttt view_profile view_payouts view_tax_data account].freeze
   NEW_SCOPE = "edit_emails"
+  # First production tag containing PR #5503 and not this fix:
+  # production-2ebe108daf96/2026-06-19-14-35-41.
+  EDIT_EMAILS_SCOPE_DEPLOYED_AT = Time.utc(2026, 6, 19, 14, 35, 41)
 
   def up
-    oauth_applications.find_each do |application|
-      scopes = application.scopes.to_s.split
-      next unless backfilled_default_scopes?(scopes)
+    application_ids = candidate_application_ids
+    updated_at = Time.current
+    oauth_applications.where(id: application_ids).update_all(scopes: OLD_PUBLIC_SCOPES.join(" "), updated_at:) if application_ids.any?
 
-      application.update_columns(scopes: OLD_PUBLIC_SCOPES.join(" "), updated_at: Time.current)
-    end
+    application_ids_without_edit_emails = oauth_applications.where.not("scopes LIKE ?", "%#{NEW_SCOPE}%").select(:id)
+    revoke_edit_emails_scope(oauth_access_grants, application_ids_without_edit_emails, application_id_column: :application_id)
+    revoke_edit_emails_scope(oauth_access_tokens, application_ids_without_edit_emails, application_id_column: :application_id)
+    revoke_edit_emails_scope_from_device_authorizations(application_ids_without_edit_emails, updated_at:)
   end
 
   def down
-    oauth_applications.find_each do |application|
-      scopes = application.scopes.to_s.split
-      next unless old_default_scopes?(scopes)
-
-      scopes.insert(scopes.index("edit_products").to_i + 1, NEW_SCOPE)
-      application.update_columns(scopes: scopes.join(" "), updated_at: Time.current)
-    end
   end
 
   private
@@ -32,9 +30,64 @@ class RevokeBackfilledEditEmailsScopeFromDefaultOauthApplications < ActiveRecord
       old_default_scopes?(scopes - [NEW_SCOPE]) && scopes.include?(NEW_SCOPE)
     end
 
+    def revoke_edit_emails_scope(records, application_ids, application_id_column:, updated_at: nil)
+      records.where(application_id_column => application_ids).where("scopes LIKE ?", "%#{NEW_SCOPE}%").find_each do |record|
+        scopes = record.scopes.to_s.split
+        next unless scopes.include?(NEW_SCOPE)
+
+        attributes = { scopes: (scopes - [NEW_SCOPE]).join(" ") }
+        attributes[:updated_at] = updated_at if updated_at
+        record.update_columns(attributes)
+      end
+    end
+
+    def revoke_edit_emails_scope_from_device_authorizations(application_ids, updated_at:)
+      oauth_device_authorizations.where(oauth_application_id: application_ids).where("scopes LIKE ?", "%#{NEW_SCOPE}%").find_each do |authorization|
+        scopes = authorization.scopes.to_s.split
+        next unless scopes.include?(NEW_SCOPE)
+
+        scopes_without_edit_emails = scopes - [NEW_SCOPE]
+        if scopes_without_edit_emails.empty?
+          authorization.delete
+        else
+          authorization.update_columns(scopes: scopes_without_edit_emails.join(" "), updated_at:)
+        end
+      end
+    end
+
+    def candidate_application_ids
+      ids = []
+      oauth_applications.find_each do |application|
+        scopes = application.scopes.to_s.split
+        next unless application.created_at < EDIT_EMAILS_SCOPE_DEPLOYED_AT
+        next unless scopes.empty? || old_default_scopes?(scopes) || backfilled_default_scopes?(scopes)
+
+        ids << application.id
+      end
+      ids
+    end
+
     def oauth_applications
       Class.new(ActiveRecord::Base) do
         self.table_name = "oauth_applications"
+      end
+    end
+
+    def oauth_access_grants
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "oauth_access_grants"
+      end
+    end
+
+    def oauth_access_tokens
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "oauth_access_tokens"
+      end
+    end
+
+    def oauth_device_authorizations
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "oauth_device_authorizations"
       end
     end
 end

--- a/db/migrate/20261201000002_revoke_backfilled_edit_emails_scope_from_default_oauth_applications.rb
+++ b/db/migrate/20261201000002_revoke_backfilled_edit_emails_scope_from_default_oauth_applications.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class RevokeBackfilledEditEmailsScopeFromDefaultOauthApplications < ActiveRecord::Migration[7.1]
+  OLD_PUBLIC_SCOPES = %w[edit_products view_sales mark_sales_as_shipped edit_sales revenue_share ifttt view_profile view_payouts view_tax_data account].freeze
+  NEW_SCOPE = "edit_emails"
+
+  def up
+    oauth_applications.find_each do |application|
+      scopes = application.scopes.to_s.split
+      next unless backfilled_default_scopes?(scopes)
+
+      application.update_columns(scopes: OLD_PUBLIC_SCOPES.join(" "), updated_at: Time.current)
+    end
+  end
+
+  def down
+    oauth_applications.find_each do |application|
+      scopes = application.scopes.to_s.split
+      next unless old_default_scopes?(scopes)
+
+      scopes.insert(scopes.index("edit_products").to_i + 1, NEW_SCOPE)
+      application.update_columns(scopes: scopes.join(" "), updated_at: Time.current)
+    end
+  end
+
+  private
+    def old_default_scopes?(scopes)
+      (scopes - OLD_PUBLIC_SCOPES).empty? && (OLD_PUBLIC_SCOPES - scopes).empty?
+    end
+
+    def backfilled_default_scopes?(scopes)
+      old_default_scopes?(scopes - [NEW_SCOPE]) && scopes.include?(NEW_SCOPE)
+    end
+
+    def oauth_applications
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "oauth_applications"
+      end
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_12_01_000001) do
+ActiveRecord::Schema[7.1].define(version: 2026_12_01_000002) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false

--- a/spec/migrations/revoke_backfilled_edit_emails_scope_from_default_oauth_applications_spec.rb
+++ b/spec/migrations/revoke_backfilled_edit_emails_scope_from_default_oauth_applications_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require Rails.root.join("db/migrate/20261201000002_revoke_backfilled_edit_emails_scope_from_default_oauth_applications").to_s
+
+describe RevokeBackfilledEditEmailsScopeFromDefaultOauthApplications do
+  subject(:migration) { described_class.new }
+
+  let(:seller) { create(:user) }
+  let(:old_scopes) { described_class::OLD_PUBLIC_SCOPES }
+  let(:old_scopes_string) { old_scopes.join(" ") }
+  let(:backfilled_scopes_string) do
+    old_scopes.dup.insert(old_scopes.index("edit_products") + 1, described_class::NEW_SCOPE).join(" ")
+  end
+  let(:custom_scopes_string) { "edit_products edit_emails" }
+  let(:before_scope_deploy) { described_class::EDIT_EMAILS_SCOPE_DEPLOYED_AT - 1.second }
+  let(:after_scope_deploy) { described_class::EDIT_EMAILS_SCOPE_DEPLOYED_AT + 1.second }
+
+  def create_access_token(application:, resource_owner:, scopes:)
+    create(
+      "doorkeeper/access_token",
+      application:,
+      resource_owner_id: resource_owner.id,
+      scopes:
+    )
+  end
+
+  def create_access_grant(application:, resource_owner:, scopes:)
+    Doorkeeper::AccessGrant.create!(
+      application_id: application.id,
+      resource_owner_id: resource_owner.id,
+      redirect_uri: application.redirect_uri,
+      expires_in: 1.day.to_i,
+      scopes:
+    )
+  end
+
+  it "revokes the backfilled scope from affected applications and matching credentials" do
+    affected_application = create(:oauth_application, owner: seller, scopes: backfilled_scopes_string, created_at: before_scope_deploy)
+    affected_token = create_access_token(application: affected_application, resource_owner: seller, scopes: "edit_emails")
+    affected_grant = create_access_grant(application: affected_application, resource_owner: seller, scopes: "edit_products edit_emails")
+    affected_device_authorization = create(:oauth_device_authorization, oauth_application: affected_application, scopes: "view_profile edit_emails")
+    affected_device_authorization_with_only_edit_emails = create(:oauth_device_authorization, oauth_application: affected_application, scopes: "edit_emails")
+    custom_application = create(:oauth_application, owner: seller, scopes: custom_scopes_string)
+    custom_token = create_access_token(application: custom_application, resource_owner: seller, scopes: custom_scopes_string)
+    custom_grant = create_access_grant(application: custom_application, resource_owner: seller, scopes: custom_scopes_string)
+    custom_device_authorization = create(:oauth_device_authorization, oauth_application: custom_application, scopes: custom_scopes_string)
+
+    migration.up
+
+    expect(affected_application.reload.scopes.to_s).to eq(old_scopes_string)
+    expect(affected_token.reload.scopes.to_s).to eq("")
+    expect(affected_grant.reload.scopes.to_s).to eq("edit_products")
+    expect(affected_device_authorization.reload.scopes).to eq("view_profile")
+    expect { affected_device_authorization_with_only_edit_emails.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    expect(custom_application.reload.scopes.to_s).to eq(custom_scopes_string)
+    expect(custom_token.reload.scopes.to_s).to eq(custom_scopes_string)
+    expect(custom_grant.reload.scopes.to_s).to eq(custom_scopes_string)
+    expect(custom_device_authorization.reload.scopes).to eq(custom_scopes_string)
+  end
+
+  it "revokes matching credentials when a previous attempt already updated the application" do
+    application = create(:oauth_application, owner: seller, scopes: old_scopes_string, created_at: before_scope_deploy)
+    access_token = create_access_token(application:, resource_owner: seller, scopes: "edit_emails")
+    access_grant = create_access_grant(application:, resource_owner: seller, scopes: "edit_products edit_emails")
+    device_authorization = create(:oauth_device_authorization, oauth_application: application, scopes: "view_profile edit_emails")
+
+    migration.up
+
+    expect(application.reload.scopes.to_s).to eq(old_scopes_string)
+    expect(access_token.reload.scopes.to_s).to eq("")
+    expect(access_grant.reload.scopes.to_s).to eq("edit_products")
+    expect(device_authorization.reload.scopes).to eq("view_profile")
+  end
+
+  it "normalizes legacy blank-scope applications and revokes matching credentials" do
+    application = create(:oauth_application, owner: seller, scopes: old_scopes_string, created_at: before_scope_deploy)
+    application.update_columns(scopes: "")
+    access_token = create_access_token(application:, resource_owner: seller, scopes: "edit_emails")
+    access_grant = create_access_grant(application:, resource_owner: seller, scopes: "edit_products edit_emails")
+    device_authorization = create(:oauth_device_authorization, oauth_application: application, scopes: "edit_emails")
+
+    migration.up
+
+    expect(application.reload.scopes.to_s).to eq(old_scopes_string)
+    expect(access_token.reload.scopes.to_s).to eq("")
+    expect(access_grant.reload.scopes.to_s).to eq("edit_products")
+    expect { device_authorization.reload }.to raise_error(ActiveRecord::RecordNotFound)
+  end
+
+  it "preserves default scopes for applications created after edit_emails was deployed" do
+    application = create(:oauth_application, owner: seller, scopes: backfilled_scopes_string, created_at: after_scope_deploy)
+    access_token = create_access_token(application:, resource_owner: seller, scopes: backfilled_scopes_string)
+    access_grant = create_access_grant(application:, resource_owner: seller, scopes: backfilled_scopes_string)
+    device_authorization = create(:oauth_device_authorization, oauth_application: application, scopes: backfilled_scopes_string)
+
+    migration.up
+
+    expect(application.reload.scopes.to_s).to eq(backfilled_scopes_string)
+    expect(access_token.reload.scopes.to_s).to eq(backfilled_scopes_string)
+    expect(access_grant.reload.scopes.to_s).to eq(backfilled_scopes_string)
+    expect(device_authorization.reload.scopes).to eq(backfilled_scopes_string)
+  end
+
+  it "revokes over-scoped credentials for applications that do not allow edit_emails" do
+    application = create(:oauth_application, owner: seller, scopes: "edit_products", created_at: after_scope_deploy)
+    access_token = create_access_token(application:, resource_owner: seller, scopes: "edit_products edit_emails")
+    access_grant = create_access_grant(application:, resource_owner: seller, scopes: "edit_products edit_emails")
+    device_authorization = create(:oauth_device_authorization, oauth_application: application, scopes: "view_profile edit_emails")
+    device_authorization_with_only_edit_emails = create(:oauth_device_authorization, oauth_application: application, scopes: "edit_emails")
+
+    migration.up
+
+    expect(application.reload.scopes.to_s).to eq("edit_products")
+    expect(access_token.reload.scopes.to_s).to eq("edit_products")
+    expect(access_grant.reload.scopes.to_s).to eq("edit_products")
+    expect(device_authorization.reload.scopes).to eq("view_profile")
+    expect { device_authorization_with_only_edit_emails.reload }.to raise_error(ActiveRecord::RecordNotFound)
+  end
+
+  it "does not grant edit_emails when the corrective migration is rolled back" do
+    default_application = create(:oauth_application, owner: seller, scopes: old_scopes_string)
+
+    migration.down
+
+    expect(default_application.reload.scopes.to_s).to eq(old_scopes_string)
+  end
+end

--- a/spec/models/oauth_application_spec.rb
+++ b/spec/models/oauth_application_spec.rb
@@ -120,6 +120,15 @@ describe OauthApplication do
       end.to change(Doorkeeper::AccessToken, :count).by(1)
     end
 
+    it "generates access tokens and grants using the application scopes" do
+      @oauth_application.update!(scopes: "edit_products view_sales")
+
+      access_token = @oauth_application.get_or_generate_access_token
+
+      expect(access_token.scopes.to_s).to eq("edit_products view_sales")
+      expect(@oauth_application.access_grants.last.scopes.to_s).to eq("edit_products view_sales")
+    end
+
     it "generates new access token if existing ones are revoked" do
       @oauth_application.get_or_generate_access_token
       Doorkeeper::AccessToken.revoke_all_for(@oauth_application.id, @oauth_application.owner)


### PR DESCRIPTION
## Summary

- Stop backfilling the new `edit_emails` write scope onto existing OAuth applications.
- Add a corrective migration to revoke `edit_emails` from apps that match the silently backfilled default scope set.
- Bump schema version for the corrective migration.

## Security impact

PR #5503 introduced an `edit_emails` OAuth scope, but its migration granted that new write scope to existing default-scope OAuth applications. Those apps could then create and send audience emails without users explicitly consenting to this new capability.

This change preserves explicit consent by requiring apps to request `edit_emails` normally, and removes the silently granted scope where it was already applied.

## Verification

- `ruby -c db/migrate/20261201000001_backfill_edit_emails_scope_for_default_oauth_applications.rb`
- `ruby -c db/migrate/20261201000002_revoke_backfilled_edit_emails_scope_from_default_oauth_applications.rb`
- Attempted Rails environment load with Bundler; blocked locally by a Bundler Ruby version mismatch.

Fixes a security review finding from merged PR #5503.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> OAuth authorization and production data migrations affect who can send audience emails; incorrect scope revocation could break legitimate integrations or leave over-privileged tokens in place.
> 
> **Overview**
> Fixes a consent gap where the `edit_emails` write scope could reach existing OAuth clients without users re-authorizing.
> 
> The **backfill migration** no longer adds `edit_emails` to legacy default-scope applications on `up`; a new **corrective migration** strips `edit_emails` from pre-deploy default apps and from matching access grants, tokens, and device authorizations, while leaving custom scope choices and post-deploy apps untouched.
> 
> **`OauthApplication#get_or_generate_access_token`** now issues grants and tokens using each application’s configured `scopes` instead of always using the full public scope list, so auto-generated credentials cannot exceed what the app is allowed to request.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 197e855914c93193b5ea24b09ca9381b166f39e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->