### PR TITLE
Send email to filtered customer list from Sales page

### DIFF
--- a/app/javascript/components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/Audience/CustomersPage.tsx
@@ -1,4 +1,4 @@
-import { ArrowInDownSquareHalf, MenuFilter, Truck } from "@boxicons/react";
+import { ArrowInDownSquareHalf, Envelope, MenuFilter, Truck } from "@boxicons/react";
 import { router, useRemember } from "@inertiajs/react";
 import cx from "classnames";
 import { lightFormat, subMonths } from "date-fns";
@@ -40,7 +40,7 @@ import { WithTooltip } from "$app/components/WithTooltip";
 
 import placeholder from "$assets/images/placeholders/customers.png";
 
-type Product = { id: string; name: string; variants: { id: string; name: string }[] };
+type Product = { id: string; permalink: string; name: string; variants: { id: string; name: string }[] };
 
 export type CustomerPageProps = {
   customers: Customer[];
@@ -53,6 +53,7 @@ export type CustomerPageProps = {
   can_ping: boolean;
   show_refund_fee_notice: boolean;
   license_uses_filter_enabled: boolean;
+  can_send_emails: boolean;
 };
 
 const year = new Date().getFullYear();
@@ -70,6 +71,7 @@ const CustomersPage = ({
   can_ping,
   show_refund_fee_notice,
   license_uses_filter_enabled,
+  can_send_emails,
   ...initialState
 }: CustomerPageProps) => {
   const currentSeller = useCurrentSeller();
@@ -187,6 +189,29 @@ const CustomersPage = ({
         : null,
     [includedItems, products],
   );
+
+  const emailFilterParams = React.useMemo(() => {
+    const boughtPermalinks = includedItems.flatMap((item) => {
+      if (item.type === "variant") return [item.id];
+      const product = products.find(({ id }) => id === item.id);
+      return product ? [product.permalink] : [];
+    });
+    const notBoughtPermalinks = excludedItems.flatMap((item) => {
+      if (item.type === "variant") return [item.id];
+      const product = products.find(({ id }) => id === item.id);
+      return product ? [product.permalink] : [];
+    });
+    return {
+      template: "filtered_customers" as const,
+      bought: boughtPermalinks.length > 0 ? boughtPermalinks : undefined,
+      not_bought: notBoughtPermalinks.length > 0 ? notBoughtPermalinks : undefined,
+      paid_more_than: minimumAmount != null ? String(minimumAmount) : undefined,
+      paid_less_than: maximumAmount != null ? String(maximumAmount) : undefined,
+      created_after: createdAfter || undefined,
+      created_before: createdBefore || undefined,
+      from_country: country || undefined,
+    };
+  }, [includedItems, excludedItems, products, minimumAmount, maximumAmount, createdAfter, createdBefore, country]);
 
   if (!currentSeller) return null;
   const timeZoneAbbreviation = format(new Date(), "z", { timeZone: currentSeller.timeZone.name });
@@ -393,6 +418,12 @@ const CustomersPage = ({
                 </div>
               </PopoverContent>
             </Popover>
+            {can_send_emails ? (
+              <NavigationButton href={Routes.new_email_path(emailFilterParams)}>
+                <Envelope aria-hidden="true" className="size-5" />
+                Send email to these customers
+              </NavigationButton>
+            ) : null}
           </div>
         }
       />

--- a/app/javascript/components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/Audience/CustomersPage.tsx
@@ -428,7 +428,7 @@ const CustomersPage = ({
               </PopoverContent>
             </Popover>
             {can_send_emails && hasActiveFilters ? (
-              <NavigationButton href={Routes.new_email_path(emailFilterParams)}>
+              <NavigationButton color="accent" href={Routes.new_email_path(emailFilterParams)}>
                 <Envelope aria-hidden="true" className="size-5" />
                 Send email to these customers
               </NavigationButton>

--- a/app/javascript/components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/Audience/CustomersPage.tsx
@@ -190,6 +190,15 @@ const CustomersPage = ({
     [includedItems, products],
   );
 
+  const hasActiveFilters =
+    includedItems.length > 0 ||
+    excludedItems.length > 0 ||
+    minimumAmount != null ||
+    maximumAmount != null ||
+    createdAfter != null ||
+    createdBefore != null ||
+    country != null;
+
   const emailFilterParams = React.useMemo(() => {
     const boughtPermalinks = includedItems.flatMap((item) => {
       if (item.type === "variant") return [item.id];
@@ -207,8 +216,8 @@ const CustomersPage = ({
       not_bought: notBoughtPermalinks.length > 0 ? notBoughtPermalinks : undefined,
       paid_more_than: minimumAmount != null ? String(minimumAmount) : undefined,
       paid_less_than: maximumAmount != null ? String(maximumAmount) : undefined,
-      created_after: createdAfter || undefined,
-      created_before: createdBefore || undefined,
+      created_after: createdAfter ? lightFormat(createdAfter, "yyyy-MM-dd") : undefined,
+      created_before: createdBefore ? lightFormat(createdBefore, "yyyy-MM-dd") : undefined,
       from_country: country || undefined,
     };
   }, [includedItems, excludedItems, products, minimumAmount, maximumAmount, createdAfter, createdBefore, country]);
@@ -418,7 +427,7 @@ const CustomersPage = ({
                 </div>
               </PopoverContent>
             </Popover>
-            {can_send_emails ? (
+            {can_send_emails && hasActiveFilters ? (
               <NavigationButton href={Routes.new_email_path(emailFilterParams)}>
                 <Envelope aria-hidden="true" className="size-5" />
                 Send email to these customers

--- a/app/javascript/components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/Audience/CustomersPage.tsx
@@ -430,7 +430,7 @@ const CustomersPage = ({
             {can_send_emails && hasActiveFilters ? (
               <NavigationButton color="accent" href={Routes.new_email_path(emailFilterParams)}>
                 <Envelope aria-hidden="true" className="size-5" />
-                Send email to these customers
+                Email these customers
               </NavigationButton>
             ) : null}
           </div>

--- a/app/javascript/components/EmailsPage/EmailForm.tsx
+++ b/app/javascript/components/EmailsPage/EmailForm.tsx
@@ -393,8 +393,14 @@ export const EmailForm = ({ context, installment }: EmailFormProps) => {
 
         const paidMoreThan = searchParams.get("paid_more_than");
         const paidLessThan = searchParams.get("paid_less_than");
-        if (paidMoreThan !== null && paidMoreThan !== "") setPaidMoreThanCents(Number.parseInt(paidMoreThan, 10));
-        if (paidLessThan !== null && paidLessThan !== "") setPaidLessThanCents(Number.parseInt(paidLessThan, 10));
+        if (paidMoreThan !== null && paidMoreThan !== "") {
+          const parsed = Number.parseInt(paidMoreThan, 10);
+          if (!Number.isNaN(parsed)) setPaidMoreThanCents(parsed);
+        }
+        if (paidLessThan !== null && paidLessThan !== "") {
+          const parsed = Number.parseInt(paidLessThan, 10);
+          if (!Number.isNaN(parsed)) setPaidLessThanCents(parsed);
+        }
 
         const createdAfter = searchParams.get("created_after");
         const createdBefore = searchParams.get("created_before");

--- a/app/javascript/components/EmailsPage/EmailForm.tsx
+++ b/app/javascript/components/EmailsPage/EmailForm.tsx
@@ -379,6 +379,36 @@ export const EmailForm = ({ context, installment }: EmailFormProps) => {
     const template = searchParams.get("template");
     const isBundleMarketing = template === "bundle_marketing";
 
+    if (template === "filtered_customers") {
+      if (canSendToCustomers) {
+        setAudienceType("customers");
+        const boughtIds = searchParams
+          .getAll("bought[]")
+          .filter((id) => productOptions.findIndex((option) => option.id === id) !== -1);
+        const notBoughtIds = searchParams
+          .getAll("not_bought[]")
+          .filter((id) => productOptions.findIndex((option) => option.id === id) !== -1);
+        if (boughtIds.length > 0) setBought(boughtIds);
+        if (notBoughtIds.length > 0) setNotBought(notBoughtIds);
+
+        const paidMoreThan = searchParams.get("paid_more_than");
+        const paidLessThan = searchParams.get("paid_less_than");
+        if (paidMoreThan !== null && paidMoreThan !== "") setPaidMoreThanCents(Number.parseInt(paidMoreThan, 10));
+        if (paidLessThan !== null && paidLessThan !== "") setPaidLessThanCents(Number.parseInt(paidLessThan, 10));
+
+        const createdAfter = searchParams.get("created_after");
+        const createdBefore = searchParams.get("created_before");
+        if (createdAfter) setAfterDate(createdAfter);
+        if (createdBefore) setBeforeDate(createdBefore);
+
+        const fromCountry = searchParams.get("from_country");
+        if (fromCountry && context.countries.includes(fromCountry)) setFromCountry(fromCountry);
+
+        setChannel({ profile: false, email: true });
+      }
+      return;
+    }
+
     if (template === "content_updates" && permalink) {
       const bought = searchParams.getAll("bought[]");
       form.setData("installment.name", `New content added to ${productName}`);

--- a/app/javascript/components/EmailsPage/EmailForm.tsx
+++ b/app/javascript/components/EmailsPage/EmailForm.tsx
@@ -395,17 +395,18 @@ export const EmailForm = ({ context, installment }: EmailFormProps) => {
         const paidLessThan = searchParams.get("paid_less_than");
         if (paidMoreThan !== null && paidMoreThan !== "") {
           const parsed = Number.parseInt(paidMoreThan, 10);
-          if (!Number.isNaN(parsed)) setPaidMoreThanCents(parsed);
+          if (!Number.isNaN(parsed) && parsed >= 0) setPaidMoreThanCents(parsed);
         }
         if (paidLessThan !== null && paidLessThan !== "") {
           const parsed = Number.parseInt(paidLessThan, 10);
-          if (!Number.isNaN(parsed)) setPaidLessThanCents(parsed);
+          if (!Number.isNaN(parsed) && parsed >= 0) setPaidLessThanCents(parsed);
         }
 
+        const isValidDate = (value: string) => /^\d{4}-\d{2}-\d{2}$/u.test(value);
         const createdAfter = searchParams.get("created_after");
         const createdBefore = searchParams.get("created_before");
-        if (createdAfter) setAfterDate(createdAfter);
-        if (createdBefore) setBeforeDate(createdBefore);
+        if (createdAfter && isValidDate(createdAfter)) setAfterDate(createdAfter);
+        if (createdBefore && isValidDate(createdBefore)) setBeforeDate(createdBefore);
 
         const fromCountry = searchParams.get("from_country");
         if (fromCountry && context.countries.includes(fromCountry)) setFromCountry(fromCountry);

--- a/app/presenters/customers_presenter.rb
+++ b/app/presenters/customers_presenter.rb
@@ -12,14 +12,16 @@ class CustomersPresenter
   end
 
   def customers_props
+    user_presenter = UserPresenter.new(user: pundit_user.seller)
     {
       pagination:,
       product_id: product&.external_id,
       customers: customers.map { CustomerPresenter.new(purchase: _1).customer(pundit_user:) },
       count:,
-      products: UserPresenter.new(user: pundit_user.seller).products_for_filter_box.map do |product|
+      products: user_presenter.products_for_filter_box.map do |product|
         {
           id: product.external_id,
+          permalink: product.unique_permalink,
           name: product.name,
           variants: (product.is_physical? ? product.skus_alive_not_default : product.variant_categories_alive.first&.alive_variants || []).map do |variant|
             { id: variant.external_id, name: variant.name || "" }
@@ -31,6 +33,7 @@ class CustomersPresenter
       can_ping: pundit_user.seller.urls_for_ping_notification(ResourceSubscription::SALE_RESOURCE_NAME).size > 0,
       show_refund_fee_notice: pundit_user.seller.show_refund_fee_notice?,
       license_uses_filter_enabled: Feature.active?(:license_uses_sales_filter, pundit_user.seller),
+      can_send_emails: user_presenter.audience_types.include?(:customers),
     }
   end
 end

--- a/spec/presenters/customers_presenter_spec.rb
+++ b/spec/presenters/customers_presenter_spec.rb
@@ -31,11 +31,13 @@ describe CustomersPresenter do
           products: [
             {
               id: product.external_id,
+              permalink: product.unique_permalink,
               name: "Product",
               variants: [],
             },
             {
               id: membership.external_id,
+              permalink: membership.unique_permalink,
               name: "Membership",
               variants: [
                 {
@@ -50,6 +52,7 @@ describe CustomersPresenter do
             },
             {
               id: coffee.external_id,
+              permalink: coffee.unique_permalink,
               name: "Coffee",
               variants: [
                 {
@@ -68,6 +71,7 @@ describe CustomersPresenter do
           can_ping: true,
           show_refund_fee_notice: false,
           license_uses_filter_enabled: false,
+          can_send_emails: true,
         }
       )
     end

--- a/spec/presenters/customers_presenter_spec.rb
+++ b/spec/presenters/customers_presenter_spec.rb
@@ -71,7 +71,7 @@ describe CustomersPresenter do
           can_ping: true,
           show_refund_fee_notice: false,
           license_uses_filter_enabled: false,
-          can_send_emails: true,
+          can_send_emails: false,
         }
       )
     end
@@ -81,6 +81,22 @@ describe CustomersPresenter do
 
       it "returns license_uses_filter_enabled as true" do
         expect(presenter.customers_props[:license_uses_filter_enabled]).to eq(true)
+      end
+    end
+
+    describe "can_send_emails" do
+      context "when the seller has a customers audience" do
+        before { create(:purchase, link: product, seller:, email: "contactable@gumroad.com", can_contact: true) }
+
+        it "returns true" do
+          expect(presenter.customers_props[:can_send_emails]).to eq(true)
+        end
+      end
+
+      context "when the seller has no customers audience" do
+        it "returns false" do
+          expect(presenter.customers_props[:can_send_emails]).to eq(false)
+        end
       end
     end
   end


### PR DESCRIPTION
## What

Adds a **Send email to these customers** button to the Sales (Customers) page. When a seller applies filters on the Sales page (products bought / not bought, paid more/less than, purchase date range, country), the button opens the email composer at `/emails/new` with those same filters pre-applied as the email's audience.

- `CustomersPresenter#customers_props` now exposes each product's `permalink` (the email audience keys products by permalink, not external id) and a `can_send_emails` flag (true when the seller has a customers audience).
- `CustomersPage` renders the button (gated on `can_send_emails`) and builds a `new_email_path` deep-link carrying `bought[]`, `not_bought[]`, `paid_more_than`, `paid_less_than`, `created_after`, `created_before`, and `from_country` under a `template=filtered_customers` marker.
- `EmailForm` parses the `filtered_customers` template params on `/emails/new` and pre-applies the Customers audience type plus each forwarded filter.

Filters that have no equivalent on the email-audience side (`active_customers_only`, `minimum_license_uses`) are intentionally not forwarded, so the composed audience only reflects filters the email side can honor.

## Why

Resolves #5472. Sellers frequently want to email a targeted subset of customers (e.g. everyone who bought product X but not Y, or who paid over $50). Previously they had to re-create the same filter by hand on the Emails page. This wires the existing Sales-page filter directly into the email composer, and surfaces the recipient set so the seller can review who they're about to email.

## Test plan

- `spec/presenters/customers_presenter_spec.rb` updated to assert the new `permalink` and `can_send_emails` keys; CI runs the presenter spec.
- Manual: on the Sales page, apply a product / amount / date / country filter → click **Send email to these customers** → composer opens with the Customers audience and matching filters populated; recipient count reflects the filtered set.
- Manual: a seller with no customers audience does not see the button.
- Type-checked locally (no new `tsc` errors in the changed files).

Closes #5472

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784470347&installation_id=134400930&pr_number=5522&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5522&signature=f3e54df814b0b233055f25ab8aacaab2277f109d6c7390f5c514fb4f4b9a78e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes who can be targeted for outbound email from Sales filters; behavior relies on URL param parsing and permalink mapping, but reuses existing email audience logic with basic validation.
> 
> **Overview**
> Sellers on the **Sales** page can jump straight into the email composer with the same audience filters they already applied, instead of rebuilding them on **Emails**.
> 
> When at least one supported filter is active and the seller has a customers audience (`can_send_emails`), a new **Email these customers** control links to `/emails/new` with `template=filtered_customers` plus bought/not bought, amount, date, and country query params. Product selections are sent as **permalinks** (variants still use variant ids), matching how the email audience UI keys products.
> 
> `CustomersPresenter` now includes each product’s `permalink` and `can_send_emails`. `EmailForm` handles the `filtered_customers` template on load: sets Customers audience, applies validated filters, and defaults the channel to email-only. Sales-only filters (`active_customers_only`, `minimum_license_uses`) are not forwarded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf212d3a1601ee14f718f3ebf1e03d6ea9a2fca1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->