### PR TITLE
Hide Name column on Sales page when no sale has a name

### DIFF
--- a/app/javascript/components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/Audience/CustomersPage.tsx
@@ -190,6 +190,7 @@ const CustomersPage = ({
 
   if (!currentSeller) return null;
   const timeZoneAbbreviation = format(new Date(), "z", { timeZone: currentSeller.timeZone.name });
+  const showNameColumn = customers.some((customer) => customer.name);
 
   return (
     <div className="h-full">
@@ -404,7 +405,7 @@ const CustomersPage = ({
               <TableHeader>
                 <TableRow>
                   <TableHead>Email</TableHead>
-                  <TableHead>Name</TableHead>
+                  {showNameColumn ? <TableHead>Name</TableHead> : null}
                   <TableHead>Product</TableHead>
                   <TableHead {...thProps("created_at")}>Purchase Date</TableHead>
                   <TableHead {...thProps("price_cents")}>Price</TableHead>
@@ -439,7 +440,7 @@ const CustomersPage = ({
                         ) : null}
                         {customer.email.length <= 30 ? customer.email : `${customer.email.slice(0, 27)}...`}
                       </TableCell>
-                      <TableCell>{customer.name}</TableCell>
+                      {showNameColumn ? <TableCell>{customer.name}</TableCell> : null}
                       <TableCell>
                         {customer.product.name}
                         {customer.subscription?.is_installment_plan ? (

--- a/spec/requests/customers/customers_spec.rb
+++ b/spec/requests/customers/customers_spec.rb
@@ -48,6 +48,27 @@ describe "Sales page", type: :system, js: true do
       expect(page).to have_table_row({ "Email" => "customer3hasaninsanelylonge...", "Name" => "Customer 3", "Product" => "Product 2Bundle", "Price" => "$3" })
     end
 
+    it "hides the Name column when no sale on the page has a name" do
+      Purchase.update_all(full_name: nil)
+      Purchase.all.find_each { |purchase| purchase.purchaser&.update(name: nil) }
+      index_model_records(Purchase)
+
+      login_as seller
+      visit customers_path
+
+      expect(page).to have_table("All sales (6)")
+      expect(page).not_to have_selector(:columnheader, "Name")
+      expect(page).to have_selector(:columnheader, "Email")
+      expect(page).to have_selector(:columnheader, "Product")
+    end
+
+    it "shows the Name column when at least one sale on the page has a name" do
+      login_as seller
+      visit customers_path
+
+      expect(page).to have_selector(:columnheader, "Name")
+    end
+
     it "sorts and paginates sales in the table" do
       login_as seller
       visit customers_path


### PR DESCRIPTION
## What

On the Sales page (`/customers`), the **Name** column previously always rendered — showing an empty header and blank cells when none of the sales on the current page had a buyer name. This hides both the column header and the per-row cell unless at least one customer on the page has a name.

## Why

Many sales have no associated buyer name (`full_name` is blank and there is no registered purchaser), so the column was often just dead whitespace. `CustomerPresenter` already resolves `name` to `""` in that case, so the page has the information it needs to decide.

## How

- Compute `showNameColumn = customers.some((customer) => customer.name)` once per render.
- Conditionally render the `Name` `<TableHead>` and the per-row `<TableCell>`.

## Test plan

- Added a system spec asserting the Name column is hidden when no sale on the page has a name, and shown when at least one does (`spec/requests/customers/customers_spec.rb`).
- Existing Sales-page table specs continue to pass (rows still match by Name where names are present).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784475664&installation_id=134400930&pr_number=5524&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5524&signature=929a9b82a9ddc83243e5b04afadb02b33092b2f038bb159d5f45643809f0fc6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change to the Sales table with no API or data-model changes; behavior is scoped to the current page of results.
> 
> **Overview**
> On the Sales page (`CustomersPage`), the **Name** column no longer always appears. It is shown only when at least one sale on the **current page** has a non-empty `customer.name`; otherwise the header and row cells are omitted.
> 
> Visibility is driven by `showNameColumn = customers.some((customer) => customer.name)` on each render, including after pagination, search, and filters.
> 
> System specs cover the hidden case (all names cleared on purchases/purchasers) and the visible case when names exist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88d8c1cc711a5a9cc265f28403632224b05a1690. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->