### PR TITLE
Don't auto-close stale issues/PRs a human reopened

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -46,6 +46,8 @@ jobs:
 
               let lastActivity = new Date(issue.created_at).getTime();
               let staleLabeledAt = null;
+              let humanReopenedAt = null;
+              let lastBotCloseAt = null;
 
               for (const event of events) {
                 if (event.event === "commented" && event.user?.type !== "Bot") {
@@ -63,7 +65,37 @@ jobs:
                 if (event.event === "labeled" && event.label?.name === "stale") {
                   staleLabeledAt = new Date(event.created_at).getTime();
                 }
+
+                // Track the last time the bot closed this issue
+                if (event.event === "closed" && event.actor?.type === "Bot") {
+                  lastBotCloseAt = new Date(event.created_at).getTime();
+                }
+
+                // A human reopening the issue is an explicit "keep this" signal.
+                // Count it as activity AND remember it so we never auto-close again.
+                if (event.event === "reopened" && event.actor?.type !== "Bot") {
+                  const ts = new Date(event.created_at).getTime();
+                  if (ts > lastActivity) lastActivity = ts;
+                  humanReopenedAt = ts;
+                }
               }
+
+              // A human reopened this issue AFTER the bot last closed it (or it was
+              // never bot-closed) — treat it as protected: strip any stale label and
+              // skip all stale processing so the bot can't re-close what a human revived.
+              const humanRevived = humanReopenedAt && (!lastBotCloseAt || humanReopenedAt > lastBotCloseAt);
+              if (humanRevived) {
+                if (issue.labels.some(l => l.name === "stale")) {
+                  await github.rest.issues.removeLabel({
+                    owner, repo, issue_number: issue.number, name: "stale"
+                  }).catch(() => {});
+                  core.info(`#${issue.number} — removed stale label (human reopened; protected from auto-close)`);
+                } else {
+                  core.info(`#${issue.number} — skipped (human reopened; protected from auto-close)`);
+                }
+                continue;
+              }
+
 
               const staleDays = (now - lastActivity) / MS_PER_DAY;
               const lastActivityDate = new Date(lastActivity).toISOString().split("T")[0];

--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -48,6 +48,8 @@ jobs:
 
               let lastActivity = new Date(pr.created_at).getTime();
               let staleLabeledAt = null;
+              let humanReopenedAt = null;
+              let lastBotCloseAt = null;
 
               for (const event of events) {
                 let ts = null;
@@ -70,10 +72,36 @@ jobs:
                       staleLabeledAt = new Date(event.created_at).getTime();
                     }
                     break;
+                  case "closed":
+                    if (event.actor?.type === "Bot") lastBotCloseAt = new Date(event.created_at).getTime();
+                    break;
+                  case "reopened":
+                    // A human reopening is an explicit "keep this" signal.
+                    if (event.actor?.type !== "Bot") {
+                      humanReopenedAt = new Date(event.created_at).getTime();
+                      ts = humanReopenedAt;
+                    }
+                    break;
                 }
 
                 if (ts && ts > lastActivity) lastActivity = ts;
               }
+
+              // A human reopened this PR after the bot last closed it (or it was never
+              // bot-closed) — protect it: strip any stale label and skip stale processing.
+              const humanRevived = humanReopenedAt && (!lastBotCloseAt || humanReopenedAt > lastBotCloseAt);
+              if (humanRevived) {
+                if (pr.labels.some(l => l.name === "stale")) {
+                  await github.rest.issues.removeLabel({
+                    owner, repo, issue_number: pr.number, name: "stale"
+                  }).catch(() => {});
+                  core.info(`#${pr.number} — removed stale label (human reopened; protected from auto-close)`);
+                } else {
+                  core.info(`#${pr.number} — skipped (human reopened; protected from auto-close)`);
+                }
+                continue;
+              }
+
 
               const staleDays = (now - lastActivity) / MS_PER_DAY;
               const lastActivityDate = new Date(lastActivity).toISOString().split("T")[0];


### PR DESCRIPTION
## What

Stop the stale-bot from auto-closing issues/PRs that a **human has reopened** after the bot previously closed them.

Both `close-stale-issues.yml` and `close-stale-prs.yml` now:
- Track `reopened` events by non-bot actors as activity, and record the timestamp.
- Track the last **bot** `closed` event.
- If a human reopened the item *after* the bot's last close (or it was never bot-closed), treat it as **protected**: strip any lingering `stale` label and `continue` past all stale processing — so the bot can never re-mark or re-close what a person deliberately revived.

## Why

The workflows only counted `commented` / `cross-referenced` / (for PRs) `committed`/`reviewed` as activity. A **reopen was invisible** to them. So the loop was:

1. Bot marks an inactive issue `stale`, then closes it 24h later.
2. A human reopens it (an explicit "this still matters" signal).
3. Next hourly run sees no *comment* activity, re-marks it `stale`, and closes it **again** — fighting the human.

Concrete case: **#5362** ("Maximize accepted payment methods via Stripe Payment Element") — Sahil reopened it and commented "Likely during onsite," yet it still carries the `stale` label and was on track to be auto-closed a third time. A human reopen is the strongest possible keep-alive signal and must win over inactivity.

## Behavior after this change

- Human-reopened item with a `stale` label → label removed, skipped (logged `protected from auto-close`).
- Human-reopened item without the label → skipped.
- A *bot* reopen (shouldn't happen, but guarded) does **not** grant protection.
- If the bot closes, a human reopens, and then it goes inactive again — it stays protected (the human's intent persists). This is intentional: deliberately-revived items should be closed by a human, not the scheduler.
- All other items: unchanged stale→warn→close behavior.

## Test plan

- `node --check` passes on both extracted `github-script` blocks.
- Both workflow YAMLs parse cleanly.
- Logic verified by hand against #5362's timeline (bot close → human reopen → would now be protected).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5527"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784496825&installation_id=134400930&pr_number=5527&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5527&signature=21029a602294128288e534ea62b68ebcd5d2bc2db5d34ebd20c94fdae611712c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped GitHub Actions script changes to stale automation only; no app runtime, auth, or data paths.
> 
> **Overview**
> The hourly **close-stale-issues** and **close-stale-prs** workflows now treat a **non-bot reopen** as a keep-alive signal instead of ignoring it.
> 
> Timeline parsing records the latest human `reopened` time and the latest bot `closed` time. When a human reopened after the bot’s last close (or the item was never bot-closed), the run **skips** all stale labeling and auto-close, removes an existing `stale` label if present, and logs that the item is protected. Human reopens also bump `lastActivity` where applicable. Bot reopens do not grant protection.
> 
> Everything else in the stale → warn → close flow is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52b38b1ecb689dc51cb6b723e143658cdb19bee9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->