### PR TITLE
Fix infinite product search requests on profile pages

### DIFF
--- a/app/javascript/components/Profile/SectionsForm.tsx
+++ b/app/javascript/components/Profile/SectionsForm.tsx
@@ -13,6 +13,7 @@ import { SORT_BY_LABELS } from "$app/components/Product/CardGrid";
 import { TabWithId, tabsWithoutIds, useTabs } from "$app/components/Profile";
 import type { ProfileEditorProps, ProfileEditorState } from "$app/components/Profile/EditPage";
 import { Section, useSectionImageUploadSettings } from "$app/components/Profile/EditSections";
+import { reorderShownIds } from "$app/components/Profile/reorderShownIds";
 import { ImageUploadSettingsContext, RichTextEditorToolbar, useRichTextEditor } from "$app/components/RichTextEditor";
 import { showAlert } from "$app/components/server-components/Alert";
 import { Drawer, ReorderingHandle, SortableList } from "$app/components/SortableList";
@@ -310,8 +311,10 @@ const ProductsSectionFields = ({
     });
 
   const reorderProducts = (newOrder: string[]) => {
+    if (isEqual(newOrder, orderedProductIds)) return;
     setOrderedProductIds(newOrder);
-    update({ ...section, shown_products: sortBy(section.shown_products, (id) => newOrder.indexOf(id)) });
+    const reordered = reorderShownIds(section.shown_products, newOrder);
+    if (!isEqual(reordered, section.shown_products)) update({ ...section, shown_products: reordered });
   };
 
   return (
@@ -528,8 +531,10 @@ const WishlistsSectionFields = ({
     });
 
   const reorderWishlists = (newOrder: string[]) => {
+    if (isEqual(newOrder, orderedWishlistIds)) return;
     setOrderedWishlistIds(newOrder);
-    update({ ...section, shown_wishlists: sortBy(section.shown_wishlists, (id) => newOrder.indexOf(id)) });
+    const reordered = reorderShownIds(section.shown_wishlists, newOrder);
+    if (!isEqual(reordered, section.shown_wishlists)) update({ ...section, shown_wishlists: reordered });
   };
 
   return (

--- a/app/javascript/components/Profile/reorderShownIds.test.ts
+++ b/app/javascript/components/Profile/reorderShownIds.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+
+import { reorderShownIds } from "$app/components/Profile/reorderShownIds";
+
+describe("reorderShownIds", () => {
+  it("keeps ids missing from the new order at the end instead of moving them to the front", () => {
+    expect(reorderShownIds(["a", "b", "c", "x", "y"], ["c", "a", "b"])).toEqual(["c", "a", "b", "x", "y"]);
+  });
+
+  it("returns an unchanged order when the available ids already match the new order", () => {
+    const shown = ["a", "b", "c", "x", "y"];
+    expect(reorderShownIds(shown, ["a", "b", "c"])).toEqual(shown);
+  });
+
+  it("preserves the relative order of missing ids", () => {
+    expect(reorderShownIds(["x", "a", "y", "b"], ["b", "a"])).toEqual(["b", "a", "x", "y"]);
+  });
+});

--- a/app/javascript/components/Profile/reorderShownIds.ts
+++ b/app/javascript/components/Profile/reorderShownIds.ts
@@ -1,0 +1,7 @@
+import { sortBy } from "lodash-es";
+
+export const reorderShownIds = (shownIds: string[], newOrder: string[]): string[] =>
+  sortBy(shownIds, (id) => {
+    const index = newOrder.indexOf(id);
+    return index < 0 ? Infinity : index;
+  });


### PR DESCRIPTION
Fixes #5526

## What

Opening the profile editor by clicking through the app (rather than loading the page directly) could fire the product search endpoint in an endless loop, hitting the rate limit and blocking sellers from saving their profile.

This makes the editor's product and wishlist reordering stable, so it stops re-triggering the search.

## Why

When you reorder the products in a profile section, the editor re-sorts the section's saved product list to match the new order. It did that by looking up each saved product's position in the list of the seller's *available* products.

If a section still references a product that was later deleted or archived, that product isn't in the available list, so the lookup returned "-1" and the sort moved it to the **front** — a different order than it started with. The drag-and-drop list re-syncs itself on every re-render and calls the reorder handler again, so each pass kept rewriting the order, which re-rendered the editor and re-ran the search, never settling.

The fix keeps products that are no longer available at the **end** of the list (the same rule the editor already uses elsewhere) so reordering produces a stable result, and skips the update entirely when nothing actually moved. The same handling is applied to wishlist sections, which had the same issue.

## Before/After

Before:

https://github.com/user-attachments/assets/cce7231b-e83a-4f8d-8472-9c9ebc99c7ea

After:

https://github.com/user-attachments/assets/dc639e78-194b-4e36-a0c5-8326b95a865e

---

This PR was implemented with AI assistance using Claude Opus 4.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5529"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784502520&installation_id=134400930&pr_number=5529&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5529&signature=2a8c368847331db00a1cf929e96535a662d11acb6c153aef131874fe6bd19288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI fix in profile section forms with unit tests; no auth, API, or persistence contract changes beyond stable reorder behavior.
> 
> **Overview**
> Fixes an **infinite product-search loop** in the profile editor when navigating in-app (not on direct load). Reordering a section’s products or wishlists could keep rewriting `shown_products` / `shown_wishlists` because IDs missing from the available list were sorted with `indexOf` **-1** (front) instead of at the **end**, so the sortable list never settled and kept re-firing search.
> 
> Introduces **`reorderShownIds`**, matching the editor’s existing `optionOrder` rule: reorder by the drag list, leave unavailable IDs at the end in their relative order. **Product and wishlist** reorder handlers now use it, **no-op** when the drag order is unchanged, and **skip `update`** when the reordered shown list is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfcb3f5b6d784e89b6be6fd6c9c5cbf234223a12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->