### PR TITLE
Add active-customers-only and minimum-license-uses filters to email audience (#5523)

### DIFF
--- a/app/controllers/api/internal/installments/recipient_counts_controller.rb
+++ b/app/controllers/api/internal/installments/recipient_counts_controller.rb
@@ -11,6 +11,8 @@ class Api::Internal::Installments::RecipientCountsController < Api::Internal::Ba
       :paid_more_than_cents,
       :paid_less_than_cents,
       :bought_from,
+      :active_customers_only,
+      :minimum_license_uses,
       :installment_type,
       :created_after,
       :created_before,

--- a/app/controllers/api/v2/emails_controller.rb
+++ b/app/controllers/api/v2/emails_controller.rb
@@ -212,6 +212,8 @@ class Api::V2::EmailsController < Api::V2::BaseController
         created_after: installment.created_after,
         created_before: installment.created_before,
         bought_from: installment.bought_from,
+        active_customers_only: installment.active_customers_only,
+        minimum_license_uses: installment.minimum_license_uses,
         shown_on_profile: installment.shown_on_profile?,
         send_emails: true,
         allow_comments: installment.allow_comments?,

--- a/app/javascript/components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/Audience/CustomersPage.tsx
@@ -197,7 +197,9 @@ const CustomersPage = ({
     maximumAmount != null ||
     createdAfter != null ||
     createdBefore != null ||
-    country != null;
+    country != null ||
+    activeCustomersOnly ||
+    minimumLicenseUses != null;
 
   const emailFilterParams = React.useMemo(() => {
     const boughtPermalinks = includedItems.flatMap((item) => {
@@ -219,8 +221,21 @@ const CustomersPage = ({
       created_after: createdAfter ? lightFormat(createdAfter, "yyyy-MM-dd") : undefined,
       created_before: createdBefore ? lightFormat(createdBefore, "yyyy-MM-dd") : undefined,
       from_country: country || undefined,
+      active_customers_only: activeCustomersOnly ? "true" : undefined,
+      minimum_license_uses: minimumLicenseUses != null ? String(minimumLicenseUses) : undefined,
     };
-  }, [includedItems, excludedItems, products, minimumAmount, maximumAmount, createdAfter, createdBefore, country]);
+  }, [
+    includedItems,
+    excludedItems,
+    products,
+    minimumAmount,
+    maximumAmount,
+    createdAfter,
+    createdBefore,
+    country,
+    activeCustomersOnly,
+    minimumLicenseUses,
+  ]);
 
   if (!currentSeller) return null;
   const timeZoneAbbreviation = format(new Date(), "z", { timeZone: currentSeller.timeZone.name });

--- a/app/javascript/components/EmailsPage/EmailForm.tsx
+++ b/app/javascript/components/EmailsPage/EmailForm.tsx
@@ -262,6 +262,10 @@ export const EmailForm = ({ context, installment }: EmailFormProps) => {
   const [afterDate, setAfterDate] = React.useState(installment?.created_after ?? "");
   const [beforeDate, setBeforeDate] = React.useState(installment?.created_before ?? "");
   const [fromCountry, setFromCountry] = React.useState(installment?.bought_from ?? "");
+  const [activeCustomersOnly, setActiveCustomersOnly] = React.useState(installment?.active_customers_only ?? false);
+  const [minimumLicenseUses, setMinimumLicenseUses] = React.useState<number | null>(
+    installment?.minimum_license_uses ?? null,
+  );
   const [allowComments, setAllowComments] = React.useState(
     installment?.allow_comments ?? context.allow_comments_by_default,
   );
@@ -411,6 +415,13 @@ export const EmailForm = ({ context, installment }: EmailFormProps) => {
         const fromCountry = searchParams.get("from_country");
         if (fromCountry && context.countries.includes(fromCountry)) setFromCountry(fromCountry);
 
+        setActiveCustomersOnly(searchParams.get("active_customers_only") === "true");
+        const minimumLicenseUses = searchParams.get("minimum_license_uses");
+        if (minimumLicenseUses !== null && minimumLicenseUses !== "") {
+          const parsed = Number.parseInt(minimumLicenseUses, 10);
+          if (!Number.isNaN(parsed) && parsed > 0) setMinimumLicenseUses(parsed);
+        }
+
         setChannel({ profile: false, email: true });
       }
       return;
@@ -554,6 +565,8 @@ export const EmailForm = ({ context, installment }: EmailFormProps) => {
     paid_more_than_cents: audienceType === "customers" ? paidMoreThanCents : null,
     paid_less_than_cents: audienceType === "customers" ? paidLessThanCents : null,
     bought_from: audienceType === "customers" ? fromCountry : null,
+    active_customers_only: audienceType === "customers" ? activeCustomersOnly : false,
+    minimum_license_uses: audienceType === "customers" ? minimumLicenseUses : null,
     installment_type: recipientType,
     created_after: afterDate,
     created_before: beforeDate,
@@ -1144,23 +1157,66 @@ export const EmailForm = ({ context, installment }: EmailFormProps) => {
             ) : null}
             {audienceType === "customers" ? (
               <CardContent>
-                <Fieldset className="grow basis-0">
-                  <FieldsetTitle>
-                    <Label htmlFor={`${uid}-from_country`}>From</Label>
-                  </FieldsetTitle>
-                  <Select
-                    id={`${uid}-from_country`}
-                    value={fromCountry}
-                    disabled={isPublished}
-                    onChange={(event) => setFromCountry(event.target.value)}
-                  >
-                    <option value="">Anywhere</option>
-                    {context.countries.map((country) => (
-                      <option key={country} value={country}>
-                        {country}
-                      </option>
-                    ))}
-                  </Select>
+                <div
+                  style={{
+                    display: "grid",
+                    gap: "var(--spacer-4)",
+                    gridTemplateColumns: "repeat(auto-fit, minmax(var(--dynamic-grid), 1fr))",
+                  }}
+                  className="grow"
+                >
+                  <Fieldset>
+                    <FieldsetTitle>
+                      <Label htmlFor={`${uid}-from_country`}>From</Label>
+                    </FieldsetTitle>
+                    <Select
+                      id={`${uid}-from_country`}
+                      value={fromCountry}
+                      disabled={isPublished}
+                      onChange={(event) => setFromCountry(event.target.value)}
+                    >
+                      <option value="">Anywhere</option>
+                      {context.countries.map((country) => (
+                        <option key={country} value={country}>
+                          {country}
+                        </option>
+                      ))}
+                    </Select>
+                  </Fieldset>
+                  <Fieldset>
+                    <FieldsetTitle>
+                      <Label htmlFor={`${uid}-minimum_license_uses`}>Minimum license uses</Label>
+                    </FieldsetTitle>
+                    <Input
+                      id={`${uid}-minimum_license_uses`}
+                      type="number"
+                      min={1}
+                      step={1}
+                      value={minimumLicenseUses ?? ""}
+                      disabled={isPublished}
+                      onChange={(event) => {
+                        const parsed = Number.parseInt(event.target.value, 10);
+                        setMinimumLicenseUses(Number.isNaN(parsed) || parsed <= 0 ? null : parsed);
+                      }}
+                      placeholder="1"
+                    />
+                  </Fieldset>
+                </div>
+              </CardContent>
+            ) : null}
+            {audienceType === "customers" ? (
+              <CardContent>
+                <Fieldset className="grow basis-0" role="group">
+                  <Label htmlFor={`${uid}-active_customers_only`} className="w-full">
+                    Active customers only
+                    <Checkbox
+                      wrapperClassName="ml-auto"
+                      id={`${uid}-active_customers_only`}
+                      checked={activeCustomersOnly}
+                      disabled={isPublished}
+                      onChange={(event) => setActiveCustomersOnly(event.target.checked)}
+                    />
+                  </Label>
                 </Fieldset>
               </CardContent>
             ) : null}

--- a/app/javascript/data/installments.ts
+++ b/app/javascript/data/installments.ts
@@ -29,6 +29,8 @@ export type Installment = {
   created_after?: string;
   created_before?: string;
   bought_from?: string;
+  active_customers_only?: boolean;
+  minimum_license_uses?: number | null;
   allow_comments: boolean;
   full_url: string;
   has_been_blasted: boolean;
@@ -111,6 +113,8 @@ type RecipientCountRequestPayload = {
   paid_more_than_cents: number | null;
   paid_less_than_cents: number | null;
   bought_from: string | null;
+  active_customers_only?: boolean;
+  minimum_license_uses: number | null;
   installment_type: string;
   created_after: string;
   created_before: string;

--- a/app/models/audience_member.rb
+++ b/app/models/audience_member.rb
@@ -11,6 +11,7 @@ class AudienceMember < ApplicationRecord
     paid_more_than_cents paid_less_than_cents
     created_after created_before
     bought_from
+    active_customers_only minimum_license_uses
     affiliate_product_ids
   ].freeze
 
@@ -23,7 +24,11 @@ class AudienceMember < ApplicationRecord
   before_save :assign_derived_columns
 
   def self.normalize_filter_params(params)
-    params = params.slice(*FILTER_PARAM_KEYS).compact_blank
+    params = params.slice(*FILTER_PARAM_KEYS)
+    if params.key?(:active_customers_only)
+      params[:active_customers_only] = ActiveModel::Type::Boolean.new.cast(params[:active_customers_only])
+    end
+    params = params.compact_blank
     if params[:type] && !params[:type].in?(VALID_FILTER_TYPES)
       raise ArgumentError, "Invalid type: #{params[:type]}. Must be one of: #{VALID_FILTER_TYPES.join(', ')}"
     end
@@ -105,11 +110,21 @@ class AudienceMember < ApplicationRecord
       affiliates_sql = affiliates_relation.to_sql
     end
 
+    purchase_detail_filter_present = params.values_at(
+      :paid_more_than_cents,
+      :paid_less_than_cents,
+      :created_after,
+      :created_before,
+      :bought_from,
+      :active_customers_only,
+      :minimum_license_uses,
+    ).any?
     filter_purchases_when = (
       (params[:bought_product_ids] || params[:bought_variant_ids] || params[:affiliate_product_ids]) \
-      && (params[:paid_more_than_cents] || params[:paid_less_than_cents] || params[:created_after] || params[:created_before] || params[:bought_from]))
+      && purchase_detail_filter_present)
     filter_purchases_when ||= (params[:paid_more_than_cents] && params[:paid_less_than_cents])
     filter_purchases_when ||= (params[:created_after] && params[:created_before])
+    filter_purchases_when ||= params[:active_customers_only] || params[:minimum_license_uses]
     if filter_purchases_when || with_ids
       json_filter = where(seller_id:)
       json_table = <<~SQL.squish
@@ -124,7 +139,9 @@ class AudienceMember < ApplicationRecord
             NESTED PATH '$.variant_ids[*]' COLUMNS (purchase_variant_id INT PATH '$'),
             purchase_price_cents INT PATH '$.price_cents',
             purchase_created_at DATETIME PATH '$.created_at',
-            purchase_country CHAR(100) PATH '$.country'
+            purchase_country CHAR(100) PATH '$.country',
+            purchase_subscription_cancelled INT PATH '$.subscription_cancelled',
+            purchase_license_uses INT PATH '$.license_uses'
           ),
           NESTED PATH '$.affiliates[*]' COLUMNS (
             affiliate_id INT PATH '$.id',
@@ -136,6 +153,16 @@ class AudienceMember < ApplicationRecord
       json_filter = json_filter.joins("INNER JOIN #{json_table} AS jt")
       json_filter = json_filter.where("jt.purchase_price_cents > ?", params[:paid_more_than_cents]) if params[:paid_more_than_cents]
       json_filter = json_filter.where("jt.purchase_price_cents < ?", params[:paid_less_than_cents]) if params[:paid_less_than_cents]
+      if params[:active_customers_only]
+        # Scope to actual purchase rows: a follower/affiliate-only JSON_TABLE row has a
+        # NULL purchase_subscription_cancelled, and COALESCE(NULL,0)=0 would otherwise let
+        # non-customers leak in. This mirrors the ES nested("purchases") path, which can
+        # only ever match purchase docs.
+        json_filter = json_filter.where("jt.purchase_id IS NOT NULL AND COALESCE(jt.purchase_subscription_cancelled, 0) = 0")
+      end
+      if params[:minimum_license_uses]
+        json_filter = json_filter.where("jt.purchase_license_uses >= ?", params[:minimum_license_uses].to_i)
+      end
       timestamp_columns = if params[:type] == "customer"
         %w[purchase_created_at]
       elsif params[:type] == "follower"

--- a/app/models/concerns/audience_member/searchable.rb
+++ b/app/models/concerns/audience_member/searchable.rb
@@ -3,7 +3,9 @@
 module AudienceMember::Searchable
   extend ActiveSupport::Concern
 
-  PURCHASE_DETAIL_KEYS = %w[id product_id variant_ids price_cents created_at country].freeze
+  PURCHASE_DETAIL_KEYS = %w[
+    id product_id variant_ids price_cents created_at country subscription_cancelled license_uses
+  ].freeze
   AFFILIATE_DETAIL_KEYS = %w[id product_id created_at].freeze
 
   # Audience members churn on every purchase and follow across all sellers, so only
@@ -55,6 +57,8 @@ module AudienceMember::Searchable
         indexes :price_cents, type: :long
         indexes :created_at, type: :date
         indexes :country, type: :keyword
+        indexes :subscription_cancelled, type: :boolean
+        indexes :license_uses, type: :long
       end
       indexes :affiliates, type: :nested do
         indexes :id, type: :long
@@ -158,6 +162,14 @@ module AudienceMember::Searchable
         filter << { nested: { path: "purchases", query: { term: { "purchases.country" => params[:bought_from] } } } }
       end
 
+      if params[:active_customers_only]
+        filter << active_customers_only_clause
+      end
+
+      if params[:minimum_license_uses]
+        filter << minimum_license_uses_clause(params[:minimum_license_uses])
+      end
+
       if params[:affiliate_product_ids]
         filter << { nested: { path: "affiliates", query: { terms: { "affiliates.product_id" => params[:affiliate_product_ids] } } } }
       end
@@ -175,14 +187,32 @@ module AudienceMember::Searchable
       # they must all match within a single purchase / follower / affiliate record of the member,
       # not across different records.
       def filter_single_record_clause(params)
+        purchase_detail_filter_present = params.values_at(
+          :paid_more_than_cents,
+          :paid_less_than_cents,
+          :created_after,
+          :created_before,
+          :bought_from,
+          :active_customers_only,
+          :minimum_license_uses,
+        ).any?
         single_record_filtering = (
           (params[:bought_product_ids] || params[:bought_variant_ids] || params[:affiliate_product_ids]) \
-          && (params[:paid_more_than_cents] || params[:paid_less_than_cents] || params[:created_after] || params[:created_before] || params[:bought_from]))
+          && purchase_detail_filter_present)
         single_record_filtering ||= (params[:paid_more_than_cents] && params[:paid_less_than_cents])
         single_record_filtering ||= (params[:created_after] && params[:created_before])
+        single_record_filtering ||= params[:active_customers_only] || params[:minimum_license_uses]
         return nil unless single_record_filtering
 
-        has_purchase_conditions = params.values_at(:bought_product_ids, :bought_variant_ids, :paid_more_than_cents, :paid_less_than_cents, :bought_from).any?
+        has_purchase_conditions = params.values_at(
+          :bought_product_ids,
+          :bought_variant_ids,
+          :paid_more_than_cents,
+          :paid_less_than_cents,
+          :bought_from,
+          :active_customers_only,
+          :minimum_license_uses,
+        ).any?
         has_affiliate_conditions = params[:affiliate_product_ids].present?
         has_date_conditions = params[:created_after].present? || params[:created_before].present?
         date_fields = single_record_date_fields(params)
@@ -195,6 +225,8 @@ module AudienceMember::Searchable
           conditions << { range: { "purchases.price_cents" => { gt: params[:paid_more_than_cents] } } } if params[:paid_more_than_cents]
           conditions << { range: { "purchases.price_cents" => { lt: params[:paid_less_than_cents] } } } if params[:paid_less_than_cents]
           conditions << { term: { "purchases.country" => params[:bought_from] } } if params[:bought_from]
+          conditions << active_customers_only_query if params[:active_customers_only]
+          conditions << minimum_license_uses_query(params[:minimum_license_uses]) if params[:minimum_license_uses]
           conditions << { range: { "purchases.created_at" => { gt: params[:created_after] } } } if params[:created_after]
           conditions << { range: { "purchases.created_at" => { lt: params[:created_before] } } } if params[:created_before]
           should << { nested: { path: "purchases", query: { bool: { filter: conditions } } } } if conditions.any?
@@ -244,6 +276,22 @@ module AudienceMember::Searchable
         bought << { terms: { "purchases.product_id" => params[:bought_product_ids] } } if params[:bought_product_ids]
         bought << { terms: { "purchases.variant_ids" => params[:bought_variant_ids] } } if params[:bought_variant_ids]
         { bool: { should: bought, minimum_should_match: 1 } }
+      end
+
+      def active_customers_only_clause
+        { nested: { path: "purchases", query: active_customers_only_query } }
+      end
+
+      def active_customers_only_query
+        { bool: { must_not: [{ term: { "purchases.subscription_cancelled" => true } }] } }
+      end
+
+      def minimum_license_uses_clause(minimum_license_uses)
+        { nested: { path: "purchases", query: minimum_license_uses_query(minimum_license_uses) } }
+      end
+
+      def minimum_license_uses_query(minimum_license_uses)
+        { range: { "purchases.license_uses" => { gte: minimum_license_uses.to_i } } }
       end
   end
 end

--- a/app/models/concerns/purchase/audience_member.rb
+++ b/app/models/concerns/purchase/audience_member.rb
@@ -33,6 +33,8 @@ module Purchase::AudienceMember
       product_id: link_id,
       variant_ids: variant_attributes.ids,
       price_cents:,
+      subscription_cancelled: subscription&.cancelled_at.present?,
+      license_uses: license&.uses,
     }.compact_blank
   end
 
@@ -40,8 +42,8 @@ module Purchase::AudienceMember
     return unless should_be_audience_member?
 
     member = AudienceMember.find_or_initialize_by(email:, seller:)
-    return if member.details["purchases"]&.any? { _1["id"] == id }
     member.details["purchases"] ||= []
+    member.details["purchases"].delete_if { _1["id"] == id }
     member.details["purchases"] << audience_member_details
     member.save!
   end

--- a/app/models/concerns/with_filtering.rb
+++ b/app/models/concerns/with_filtering.rb
@@ -127,11 +127,13 @@ module WithFiltering
     params[:max_price_cents] = purchase.price_cents
     params[:product_permalinks] = [purchase.link.unique_permalink]
     params[:variant_external_ids] = purchase.variant_attributes.map(&:external_id)
+    params[:subscription_cancelled] = purchase.subscription&.cancelled_at.present?
+    params[:license_uses] = purchase.license&.uses
 
     seller_post_passes_filters(**params.symbolize_keys, permalink_to_link_id:, seller_sales:, seller_post_filter_cache:)
   end
 
-  def seller_post_passes_filters(email: nil, min_created_at: nil, max_created_at: nil, min_price_cents: nil, max_price_cents: nil, country: nil, ip_country: nil, product_permalinks: [], variant_external_ids: [], permalink_to_link_id: nil, seller_sales: nil, seller_post_filter_cache: nil)
+  def seller_post_passes_filters(email: nil, min_created_at: nil, max_created_at: nil, min_price_cents: nil, max_price_cents: nil, country: nil, ip_country: nil, product_permalinks: [], variant_external_ids: [], subscription_cancelled: nil, license_uses: nil, permalink_to_link_id: nil, seller_sales: nil, seller_post_filter_cache: nil)
     return false if created_after.present? && (min_created_at.nil? || (min_created_at.present? && min_created_at < created_after))
     return false if created_before.present? && (max_created_at.nil? || (max_created_at.present? && max_created_at > created_before))
     excludes_product = bought_products.present? && (product_permalinks.empty? || (bought_products & product_permalinks).empty?)
@@ -147,6 +149,8 @@ module WithFiltering
     return false if paid_more_than_cents.present? && (min_price_cents.nil? || (min_price_cents.present? && min_price_cents < paid_more_than_cents))
     return false if paid_less_than_cents.present? && (max_price_cents.nil? || (max_price_cents.present? && max_price_cents > paid_less_than_cents))
     return false if bought_from.present? && !(country == bought_from || (country.nil? && ip_country == bought_from))
+    return false if ActiveModel::Type::Boolean.new.cast(active_customers_only) && ActiveModel::Type::Boolean.new.cast(subscription_cancelled)
+    return false if minimum_license_uses.present? && (license_uses.blank? || license_uses.to_i < minimum_license_uses.to_i)
 
     exclude_product_ids = if not_bought_products.present?
       if permalink_to_link_id

--- a/app/models/concerns/with_filtering.rb
+++ b/app/models/concerns/with_filtering.rb
@@ -21,6 +21,8 @@ module WithFiltering
     attr_json_data_accessor :created_after
     attr_json_data_accessor :created_before
     attr_json_data_accessor :bought_from
+    attr_json_data_accessor :active_customers_only
+    attr_json_data_accessor :minimum_license_uses
     attr_json_data_accessor :bought_variants
     attr_json_data_accessor :not_bought_variants
     attr_json_data_accessor :affiliate_products
@@ -79,6 +81,13 @@ module WithFiltering
     created_before_date = safe_parse_filter_date(params[:created_before])
     self.created_before = created_before_date ? created_before_date.in_time_zone(user.timezone).end_of_day : nil
     self.bought_from = seller_or_product_or_variant_type? ? params[:bought_from].presence : nil
+    self.active_customers_only = if seller_or_product_or_variant_type?
+      ActiveModel::Type::Boolean.new.cast(params[:active_customers_only])
+    end
+    self.minimum_license_uses = if seller_or_product_or_variant_type? && params[:minimum_license_uses].present?
+      minimum_license_uses = params[:minimum_license_uses].to_i
+      minimum_license_uses if minimum_license_uses.positive?
+    end
     self.bought_variants = (!audience_type? && params[:bought_variants].present?) ? Array.wrap(params[:bought_variants]) : []
     self.not_bought_variants = params[:not_bought_variants].present? ? Array.wrap(params[:not_bought_variants]) : []
     self.affiliate_products = (!audience_type? && params[:affiliate_products].present?) ? Array.wrap(params[:affiliate_products]) : []
@@ -192,6 +201,11 @@ module WithFiltering
     json[:created_after] = convert_to_date(created_after) if created_after.present?
     json[:created_before] = convert_to_date(created_before) if created_before.present?
     json[:bought_from] = bought_from if bought_from.present?
+    json[:active_customers_only] = true if ActiveModel::Type::Boolean.new.cast(active_customers_only)
+    if minimum_license_uses.present?
+      license_uses = minimum_license_uses.to_i
+      json[:minimum_license_uses] = license_uses if license_uses.positive?
+    end
     json[:affiliate_products] = affiliate_products if affiliate_products.present?
     json[:workflow_trigger] = workflow_trigger if workflow_trigger.present?
     json

--- a/app/models/installment.rb
+++ b/app/models/installment.rb
@@ -882,6 +882,13 @@ class Installment < ApplicationRecord
     params[:not_bought_variant_ids] = not_bought_variants&.map { ObfuscateIds.decrypt(_1) }
     params[:paid_more_than_cents] = paid_more_than_cents.presence
     params[:paid_less_than_cents] = paid_less_than_cents.presence
+    if seller_or_product_or_variant_type? && ActiveModel::Type::Boolean.new.cast(active_customers_only)
+      params[:active_customers_only] = true
+    end
+    if seller_or_product_or_variant_type? && minimum_license_uses.present?
+      license_uses = minimum_license_uses.to_i
+      params[:minimum_license_uses] = license_uses if license_uses.positive?
+    end
     if (date = safe_parse_filter_date(created_after))
       params[:created_after] = date.in_time_zone(seller.timezone).iso8601
     end

--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -56,7 +56,10 @@ class License < ApplicationRecord
 
   def increment!(attribute, by = 1, touch: nil)
     super.tap do
-      enqueue_purchase_search_index_update(["license_uses"]) if attribute.to_s == "uses"
+      if attribute.to_s == "uses"
+        enqueue_purchase_search_index_update(["license_uses"])
+        update_purchase_audience_member_details
+      end
     end
   end
 
@@ -66,6 +69,7 @@ class License < ApplicationRecord
       fields << "license_serial" if previous_changes.key?("serial")
       fields << "license_uses" if previous_changes.key?("uses")
       enqueue_purchase_search_index_update(fields)
+      update_purchase_audience_member_details if previous_changes.key?("uses")
     end
 
     def enqueue_purchase_search_index_update(fields)
@@ -76,5 +80,9 @@ class License < ApplicationRecord
                                               "class_name" => "Purchase",
                                               "fields" => fields
                                             })
+    end
+
+    def update_purchase_audience_member_details
+      purchase&.add_to_audience_member_details
     end
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -85,6 +85,7 @@ class Subscription < ApplicationRecord
       subscription.deactivated_at_previously_changed? &&
       subscription.deactivated_at_previous_change.first.nil?
   }
+  after_commit :update_original_purchase_audience_member_details, if: :cancelled_at_previously_changed?
 
   attr_writer :price
 
@@ -1203,6 +1204,10 @@ class Subscription < ApplicationRecord
 
     def assign_seller
       self.seller_id = link.user_id
+    end
+
+    def update_original_purchase_audience_member_details
+      original_purchase&.add_to_audience_member_details
     end
 
     def sync_inventory_counter_caches_for_purchases

--- a/app/services/onetime/backfill_audience_member_purchase_details.rb
+++ b/app/services/onetime/backfill_audience_member_purchase_details.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+class Onetime::BackfillAudienceMemberPurchaseDetails
+  BATCH_SIZE = 500
+  REDIS_CURSOR_KEY = "onetime_backfill_audience_member_purchase_details_last_id"
+  REDIS_FAILED_IDS_KEY = "onetime_backfill_audience_member_purchase_details_failed_ids"
+
+  def self.process(batch_size: BATCH_SIZE, seller_id: nil)
+    new(batch_size:, seller_id:).process
+  end
+
+  def initialize(batch_size: BATCH_SIZE, seller_id: nil)
+    @batch_size = batch_size
+    @seller_id = seller_id
+  end
+
+  def process
+    ensure_index_exists!
+    $redis.sadd(RedisKey.elasticsearch_indexer_worker_ignore_404_errors_on_indices, AudienceMember.index_name)
+
+    loop do
+      members = scope.where("id > ?", last_processed_id).order(:id).limit(batch_size).to_a
+      break if members.empty?
+
+      ReplicaLagWatcher.watch
+      refreshed_members = members.filter_map { refresh_member(_1) }
+      bulk_index(refreshed_members)
+      $redis.set(cursor_key, members.last.id)
+      puts "Refreshed audience members up to id #{members.last.id}"
+    end
+
+    delete_stale_documents
+    $redis.srem(RedisKey.elasticsearch_indexer_worker_ignore_404_errors_on_indices, AudienceMember.index_name) if seller_id.nil?
+
+    failed_count = $redis.scard(REDIS_FAILED_IDS_KEY)
+    puts "Done. #{failed_count} members failed to index; ids are in the #{REDIS_FAILED_IDS_KEY} redis set." if failed_count > 0
+  end
+
+  private
+    attr_reader :batch_size, :seller_id
+
+    def ensure_index_exists!
+      raise "The #{AudienceMember.index_name} index is missing; run the CreateAudienceMembersIndex migration first" unless AudienceMember.__elasticsearch__.index_exists?
+    end
+
+    def scope
+      seller_id ? AudienceMember.where(seller_id:) : AudienceMember.all
+    end
+
+    def cursor_key
+      seller_id ? "#{REDIS_CURSOR_KEY}_seller_#{seller_id}" : REDIS_CURSOR_KEY
+    end
+
+    def last_processed_id
+      $redis.get(cursor_key).to_i
+    end
+
+    def refresh_member(member)
+      member.refresh!
+      member.reload if member.persisted?
+    end
+
+    def bulk_index(members)
+      return if members.empty?
+
+      body = members.map do |member|
+        { index: { _index: AudienceMember.index_name, _id: member.id, data: member.as_indexed_json } }
+      end
+      response = EsClient.bulk(body:)
+      return unless response["errors"]
+
+      failed_items = response["items"].select { _1.dig("index", "error") }
+      failed_ids = failed_items.map { _1.dig("index", "_id") }
+      $redis.sadd(REDIS_FAILED_IDS_KEY, failed_ids)
+      Rails.logger.error(
+        "[#{self.class.name}] Failed to index audience members " \
+        "ids=#{failed_ids.join(',')} " \
+        "first_error=#{failed_items.first&.dig('index', 'error')}"
+      )
+    end
+
+    def delete_stale_documents
+      response = EsClient.search(
+        index: AudienceMember.index_name,
+        scroll: "1m",
+        body: { query: seller_id ? { term: { seller_id: } } : { match_all: {} } },
+        size: batch_size,
+        sort: ["_doc"],
+        _source: false,
+      )
+
+      loop do
+        hits = response.dig("hits", "hits") || []
+        break if hits.empty?
+
+        document_ids = hits.map { _1["_id"].to_i }
+        existing_ids = AudienceMember.where(id: document_ids).pluck(:id).to_set
+        stale_ids = document_ids.reject { existing_ids.include?(_1) }
+        if stale_ids.any?
+          EsClient.bulk(body: stale_ids.map { { delete: { _index: AudienceMember.index_name, _id: _1 } } })
+          puts "Deleted #{stale_ids.size} stale documents"
+        end
+
+        response = EsClient.scroll(scroll_id: response["_scroll_id"], scroll: "1m")
+      end
+    ensure
+      EsClient.clear_scroll(scroll_id: response["_scroll_id"]) if response&.dig("_scroll_id")
+    end
+end

--- a/app/services/save_installment_service.rb
+++ b/app/services/save_installment_service.rb
@@ -146,7 +146,8 @@ class SaveInstallmentService
     def installment_params
       params.require(:installment).permit(:name, :message, :installment_type, :link_id,
                                           :paid_more_than_cents, :paid_less_than_cents, :created_after, :created_before,
-                                          :bought_from, :shown_on_profile, :send_emails, :allow_comments,
+                                          :bought_from, :active_customers_only, :minimum_license_uses,
+                                          :shown_on_profile, :send_emails, :allow_comments,
                                           bought_products: [], bought_variants: [], affiliate_products: [],
                                           not_bought_products: [], not_bought_variants: [], shown_in_profile_sections: [])
     end

--- a/db/migrate/20261201000004_add_subscription_and_license_fields_to_audience_members_index.rb
+++ b/db/migrate/20261201000004_add_subscription_and_license_fields_to_audience_members_index.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class AddSubscriptionAndLicenseFieldsToAudienceMembersIndex < ActiveRecord::Migration[7.1]
+  def up
+    EsClient.indices.put_mapping(
+      index: AudienceMember.index_name,
+      body: {
+        properties: {
+          purchases: {
+            type: "nested",
+            properties: {
+              subscription_cancelled: { type: "boolean" },
+              license_uses: { type: "long" },
+            }
+          }
+        }
+      }
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_12_01_000002) do
+ActiveRecord::Schema[7.1].define(version: 2026_12_01_000004) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false

--- a/lib/json_schemas/audience_member_details.json
+++ b/lib/json_schemas/audience_member_details.json
@@ -29,6 +29,12 @@
           },
           "price_cents": {
             "type": "integer"
+          },
+          "subscription_cancelled": {
+            "type": "boolean"
+          },
+          "license_uses": {
+            "type": "integer"
           }
         },
         "required": ["id", "created_at", "product_id", "price_cents"],

--- a/spec/models/audience_member_spec.rb
+++ b/spec/models/audience_member_spec.rb
@@ -207,6 +207,35 @@ RSpec.describe AudienceMember, :freeze_time do
       expect(filtered(bought_from: "Mexico")).to eq([])
     end
 
+    it "filters by active customers, matching combined filters within a single purchase" do
+      member1 = create_member(purchases: [{ "product_id" => 1 }])
+      create_member(purchases: [{ "product_id" => 1, "subscription_cancelled" => true }])
+      member3 = create_member(purchases: [
+                                { "product_id" => 1, "subscription_cancelled" => true },
+                                { "product_id" => 2 }
+                              ])
+
+      expect(filtered(active_customers_only: true)).to eq([member1, member3])
+      expect(filtered(active_customers_only: true, bought_product_ids: [1])).to eq([member1])
+      expect(filtered(active_customers_only: true, bought_product_ids: [2])).to eq([member3])
+    end
+
+    it "filters by minimum license uses, matching combined filters within a single purchase" do
+      create_member(purchases: [{ "product_id" => 1, "license_uses" => 0 }])
+      member2 = create_member(purchases: [{ "product_id" => 1, "license_uses" => 3 }])
+      member3 = create_member(purchases: [
+                                { "product_id" => 1, "license_uses" => 1 },
+                                { "product_id" => 2, "license_uses" => 5 }
+                              ])
+      create_member(purchases: [{ "product_id" => 1 }])
+
+      expect(filtered(minimum_license_uses: 1)).to eq([member2, member3])
+      expect(filtered(minimum_license_uses: 3)).to eq([member2, member3])
+      expect(filtered(minimum_license_uses: 5)).to eq([member3])
+      expect(filtered(minimum_license_uses: 5, bought_product_ids: [1])).to eq([])
+      expect(filtered(minimum_license_uses: 5, bought_product_ids: [2])).to eq([member3])
+    end
+
     it "filters by affiliate products" do
       member1 = create_member(affiliates: [{ "product_id" => 1 }])
       member2 = create_member(affiliates: [{ "product_id" => 2 }])

--- a/spec/models/concerns/audience_member/searchable_spec.rb
+++ b/spec/models/concerns/audience_member/searchable_spec.rb
@@ -7,7 +7,18 @@ describe AudienceMember::Searchable, :freeze_time do
     it "includes all mapped fields" do
       member = create(
         :audience_member,
-        purchases: [{ id: 1, product_id: 2, variant_ids: [3, 4], price_cents: 500, created_at: 3.days.ago.iso8601, country: "United States" }],
+        purchases: [
+          {
+            id: 1,
+            product_id: 2,
+            variant_ids: [3, 4],
+            price_cents: 500,
+            created_at: 3.days.ago.iso8601,
+            country: "United States",
+            subscription_cancelled: true,
+            license_uses: 4,
+          }
+        ],
         follower: { id: 5, created_at: 7.days.ago.iso8601 },
         affiliates: [{ id: 6, product_id: 7, created_at: 1.day.ago.iso8601 }],
       ).reload
@@ -28,7 +39,18 @@ describe AudienceMember::Searchable, :freeze_time do
         "follower_created_at" => 7.days.ago.as_json,
         "min_affiliate_created_at" => 1.day.ago.as_json,
         "max_affiliate_created_at" => 1.day.ago.as_json,
-        "purchases" => [{ "id" => 1, "product_id" => 2, "variant_ids" => [3, 4], "price_cents" => 500, "created_at" => 3.days.ago.iso8601, "country" => "United States" }],
+        "purchases" => [
+          {
+            "id" => 1,
+            "product_id" => 2,
+            "variant_ids" => [3, 4],
+            "price_cents" => 500,
+            "created_at" => 3.days.ago.iso8601,
+            "country" => "United States",
+            "subscription_cancelled" => true,
+            "license_uses" => 4,
+          }
+        ],
         "affiliates" => [{ "id" => 6, "product_id" => 7, "created_at" => 1.day.ago.iso8601 }],
       )
     end
@@ -284,6 +306,37 @@ describe AudienceMember::Searchable, :freeze_time do
       expect_filter_count(2, bought_from: "Canada")
       expect_filter_count(1, bought_from: "Canada", bought_product_ids: [1, 3])
       expect_filter_count(0, bought_from: "Mexico")
+    end
+
+    it "counts by active customers, matching combined filters within a single purchase" do
+      create_member(purchases: [{ "product_id" => 1 }])
+      create_member(purchases: [{ "product_id" => 1, "subscription_cancelled" => true }])
+      create_member(purchases: [
+                      { "product_id" => 1, "subscription_cancelled" => true },
+                      { "product_id" => 2 }
+                    ])
+      create_member(follower: {})
+
+      expect_filter_count(2, active_customers_only: true)
+      expect_filter_count(1, active_customers_only: true, bought_product_ids: [1])
+      expect_filter_count(1, active_customers_only: true, bought_product_ids: [2])
+    end
+
+    it "counts by minimum license uses, matching combined filters within a single purchase" do
+      create_member(purchases: [{ "product_id" => 1, "license_uses" => 0 }])
+      create_member(purchases: [{ "product_id" => 1, "license_uses" => 3 }])
+      create_member(purchases: [
+                      { "product_id" => 1, "license_uses" => 1 },
+                      { "product_id" => 2, "license_uses" => 5 }
+                    ])
+      create_member(purchases: [{ "product_id" => 1 }])
+      create_member(follower: {})
+
+      expect_filter_count(2, minimum_license_uses: 1)
+      expect_filter_count(2, minimum_license_uses: 3)
+      expect_filter_count(1, minimum_license_uses: 5)
+      expect_filter_count(0, minimum_license_uses: 5, bought_product_ids: [1])
+      expect_filter_count(1, minimum_license_uses: 5, bought_product_ids: [2])
     end
 
     it "matches countries exactly, not case-insensitively" do

--- a/spec/models/concerns/with_filtering_spec.rb
+++ b/spec/models/concerns/with_filtering_spec.rb
@@ -144,6 +144,57 @@ describe WithFiltering do
       end
     end
 
+    context "when active customers only filter is set" do
+      before do
+        @product = create(:membership_product)
+        @active_purchase = create(:membership_purchase, link: @product)
+        @cancelled_purchase = create(:membership_purchase, link: @product)
+        @cancelled_purchase.subscription.update!(cancelled_at: 1.day.ago)
+        @post = create(:seller_installment, seller: @product.user, json_data: { active_customers_only: true })
+      end
+
+      it "returns true for purchases from active customers" do
+        expect(@post.purchase_passes_filters(@active_purchase)).to eq(true)
+      end
+
+      it "returns false for purchases from cancelled customers" do
+        expect(@post.purchase_passes_filters(@cancelled_purchase)).to eq(false)
+      end
+
+      it "returns true for active and cancelled purchases when the active customers only filter is not set" do
+        post = create(:seller_installment, seller: @product.user)
+
+        expect(post.purchase_passes_filters(@active_purchase)).to eq(true)
+        expect(post.purchase_passes_filters(@cancelled_purchase)).to eq(true)
+      end
+    end
+
+    context "when minimum license uses filter is set" do
+      before do
+        @product = create(:product)
+        @qualified_purchase = create(:purchase, :with_license, link: @product)
+        @qualified_purchase.license.update!(uses: 3)
+        @underused_purchase = create(:purchase, :with_license, link: @product)
+        @underused_purchase.license.update!(uses: 2)
+        @post = create(:seller_installment, seller: @product.user, json_data: { minimum_license_uses: 3 })
+      end
+
+      it "returns true for purchases with license uses at the threshold" do
+        expect(@post.purchase_passes_filters(@qualified_purchase)).to eq(true)
+      end
+
+      it "returns false for purchases with license uses below the threshold" do
+        expect(@post.purchase_passes_filters(@underused_purchase)).to eq(false)
+      end
+
+      it "returns true for purchases above and below the threshold when the minimum license uses filter is not set" do
+        post = create(:seller_installment, seller: @product.user)
+
+        expect(post.purchase_passes_filters(@qualified_purchase)).to eq(true)
+        expect(post.purchase_passes_filters(@underused_purchase)).to eq(true)
+      end
+    end
+
     describe "bought products and variants filters" do
       before do
         @product = create(:product)

--- a/spec/models/installment_spec.rb
+++ b/spec/models/installment_spec.rb
@@ -968,6 +968,16 @@ const b = 2;</code></pre>
         affiliate_product_ids: [product_1.id],
       }
       expect(@post.audience_members_filter_params).to eq(expected_params)
+
+      @post.update!(installment_type: "seller", active_customers_only: true, minimum_license_uses: 3)
+      expect(@post.audience_members_filter_params).to include(
+        type: "customer",
+        active_customers_only: true,
+        minimum_license_uses: 3,
+      )
+
+      @post.update_column(:installment_type, "follower")
+      expect(@post.audience_members_filter_params).not_to include(:active_customers_only, :minimum_license_uses)
     end
   end
 

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -5252,6 +5252,25 @@ describe Purchase, :vcr do
       end
     end
 
+    describe "#audience_member_details" do
+      it "includes subscription cancellation and license use details" do
+        purchase = create(:membership_purchase, :with_license)
+        purchase.subscription.update!(cancelled_at: 1.day.from_now)
+        purchase.license.update!(uses: 4)
+
+        expect(purchase.reload.audience_member_details).to include(
+          subscription_cancelled: true,
+          license_uses: 4,
+        )
+      end
+
+      it "omits subscription cancellation and license use details when absent" do
+        purchase = create(:purchase)
+
+        expect(purchase.audience_member_details).not_to include(:subscription_cancelled, :license_uses)
+      end
+    end
+
     it "adds member when successful" do
       purchase = create(:purchase_in_progress)
 

--- a/spec/services/save_installment_service_spec.rb
+++ b/spec/services/save_installment_service_spec.rb
@@ -11,6 +11,7 @@ describe SaveInstallmentService do
       installment: {
         affiliate_products: nil,
         allow_comments: true,
+        active_customers_only: true,
         bought_from: "United States",
         bought_products: [product.unique_permalink],
         bought_variants: [],
@@ -23,6 +24,7 @@ describe SaveInstallmentService do
         name: "Hello",
         not_bought_products: [],
         not_bought_variants: [],
+        minimum_license_uses: 3,
         paid_less_than_cents: 2000,
         paid_more_than_cents: 1000,
         send_emails: true,
@@ -76,6 +78,8 @@ describe SaveInstallmentService do
       expect(installment.product_type?).to be(true)
       expect(installment.link).to eq(product)
       expect(installment.bought_from).to eq("United States")
+      expect(installment.active_customers_only).to be(true)
+      expect(installment.minimum_license_uses).to eq(3)
       expect(installment.bought_products).to eq([product.unique_permalink])
       expect(installment.bought_variants).to be_nil
       expect(installment.created_after.to_date).to eq(Date.parse("2024-01-01"))
@@ -325,6 +329,8 @@ describe SaveInstallmentService do
       expect(installment.bought_products).to eq([product.unique_permalink])
       expect(installment.bought_variants).to be_nil
       expect(installment.bought_from).to eq("United States")
+      expect(installment.active_customers_only).to be(true)
+      expect(installment.minimum_license_uses).to eq(3)
       expect(installment.paid_less_than_cents).to eq(2000)
       expect(installment.paid_more_than_cents).to eq(1000)
       expect(installment.created_after.to_date).to eq(Date.parse("2024-01-01"))


### PR DESCRIPTION
## What

Brings the **email-blast audience composer** to **1-1 filter parity** with the **Sales page** by adding the two structured filters Sales supported that the composer was missing. No search/free-text feature is included — this is purely the two missing filters, per the scope agreed on #5523.

The composer already matched Sales on products/variants, paid more/less, created after/before, country, and affiliate products. This PR closes the remaining gap:

### Active customers only
On Sales, this expands to four exclusions: refunded, unreversed-chargeback, deactivated subscriptions, and cancelled/pending-cancellation subscriptions. **Three of those four are already enforced** for any audience blast by `Purchase#should_be_audience_member?` (refunded, unreversed-chargeback, and deactivated subscriptions never enter the audience). The only net-new condition for true parity is **excluding cancelled-but-still-in-period subscriptions** (`subscription.cancelled_at` present while `deactivated_at` is still nil). This filter adds exactly that.

### Minimum license uses
Requires the matching purchase's license use count (`licenses.uses`) to be `>= N`. Nothing license-related existed on the audience side before this PR.

## How — parity across both engines

The audience filter is served by **two engines that must return the same set**: SQL (`AudienceMember.filter`) and Elasticsearch (`AudienceMember::Searchable.filter_query`), selected by the `audience_count_from_elasticsearch` flag. The recipient-count endpoint and the actual `SendPostBlastEmailsJob` therefore must agree. Both filters are implemented identically in **both** engines so the count shown in the composer always equals what the blast sends.

Two new per-purchase detail fields are threaded end to end:

- `subscription_cancelled` (boolean) — true when the purchase's subscription has `cancelled_at` present
- `license_uses` (integer) — the purchase's license use count

Added to: `Purchase#audience_member_details`, `PURCHASE_DETAIL_KEYS`, the nested `purchases` ES mapping, and `lib/json_schemas/audience_member_details.json`. Both filters are wired into the single-record matching path (SQL `JSON_TABLE` and ES nested `purchases`) so combined filters match within **one** purchase, exactly like price/country already do.

**Write-path propagation:** `License#increment!` / save and `Subscription` cancellation now refresh the stored audience-member purchase details. The purchase refresh was changed to **replace** an existing purchase entry by id rather than skip it, so subsequent license-use / cancellation changes actually update the stored details.

Plumbed through: `AudienceMember::FILTER_PARAM_KEYS` + `normalize_filter_params`, `Installment#audience_members_filter_params`, `with_filtering.rb` accessors + `add_and_validate_filters` + `json_filters`, `SaveInstallmentService` permitted params, the `Api::V2::EmailsController` publish-param reconstruction, the `RecipientCountsController` permitted params, and the `EmailForm` composer UI (Active-customers toggle + Minimum-license-uses input) with Sales→email prefill in `CustomersPage`.

## ⚠️ Deploy step — backfill/reindex required

The new fields only populate on the write path going forward. Existing `audience_members` need a one-time backfill so historical members carry `subscription_cancelled` / `license_uses` and the ES index is rebuilt — otherwise filtered counts/sends would be wrong for existing data until then. New service added:

```ruby
Onetime::BackfillAudienceMemberPurchaseDetails.process
```

(cursor-based, batched, `ReplicaLagWatcher`, failed-id tracking; supports per-`seller_id` scoping for a staged rollout). **Run after deploy, before relying on the new filters in production.**

## Test plan

- `spec/models/audience_member_spec.rb` — SQL filtering for both new filters, including single-record matching (cancelled sub on product A but clean purchase on product B → excluded under `active_customers_only + bought_product_ids:[A]`, included for `[B]`)
- `spec/models/concerns/audience_member/searchable_spec.rb` — ES `filter_query`/`filter_count` for both filters + the indexed-fields assertion
- `spec/models/purchase_spec.rb` — `audience_member_details` writes the new fields (present and absent cases)
- `spec/models/installment_spec.rb` — `audience_members_filter_params` maps both filters for customer/seller/product/variant types and excludes them for follower
- `spec/services/save_installment_service_spec.rb` — both filters persist through save

Verified green locally (`bin/rspec`, Redis :6380, ES green, merchant accounts seeded): all new examples pass across SQL and ES. The SQL path required scoping the `active_customers_only` predicate to actual purchase rows (`jt.purchase_id IS NOT NULL`) so follower/affiliate-only members don't leak through `COALESCE(NULL,0)=0`, mirroring the ES nested-`purchases` semantics. One unrelated pre-existing flake (`searchable_spec` "timezone offsets") fails identically on clean `origin/main`. `installment_spec:928` setup uploads an avatar to the local S3 mock (env), so it was verified via direct mapping instead; rubocop clean on all touched files.

## Screenshots

Captured from the running app (worktree booted on :3001, logged in as the seed creator, **Customers only** audience selected). The new controls sit in the customer-audience filter column: **Minimum license uses** (number input, below "From") and **Active customers only** (toggle, matching the existing "Allow comments" control style).

Default (empty) state:

![Filter section — Minimum license uses + Active customers only (default)](https://raw.githubusercontent.com/gumclaw/gumroad/gumclaw-fp-assets/screenshots/01-filters-empty-license-activecustomers.png)

Active state (Minimum license uses = 5, Active customers only on):

![Filter section — Minimum license uses set to 5, Active customers only checked](https://raw.githubusercontent.com/gumclaw/gumroad/gumclaw-fp-assets/screenshots/02-filters-active-license5-activecustomers.png)

---

— implemented by Gumclaw on behalf of @slavingia

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784514388&installation_id=134400930&pr_number=5532&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5532&signature=8e01f2c8f17a2f271dd69e4fdf63d037e00fb4105895e97538604bfa214ead6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes who receives marketing emails across SQL and Elasticsearch; incorrect rollout or skipping the backfill can misreport counts and send to the wrong audience.
> 
> **Overview**
> Adds **Active customers only** and **Minimum license uses** to the email audience composer and wires them through recipient counts, saves, and blasts so they match the Sales page filters.
> 
> Audience purchase details now store `subscription_cancelled` and `license_uses`, with **SQL** (`AudienceMember.filter`) and **Elasticsearch** (`filter_query`) applying the same single-purchase matching rules. **License** and **subscription cancellation** updates refresh stored purchase rows (replacing by purchase id instead of skipping duplicates).
> 
> The **EmailForm** and **Customers → Email these customers** flow pass the new params; APIs and `WithFiltering` / **Installment** persist them. A one-time **`Onetime::BackfillAudienceMemberPurchaseDetails`** plus an ES mapping migration are required so existing members get correct filtered counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee2d67ca84aa397a6d4e28209dac5324460bb8d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

