### PR TITLE
Fix open redirect in the safe-redirect helper

### DIFF
--- a/app/services/safe_redirect_path_service.rb
+++ b/app/services/safe_redirect_path_service.rb
@@ -21,7 +21,8 @@ class SafeRedirectPathService
     def normalize_path_separators(path)
       return path if path.nil?
       authority_and_path, separator, query_and_fragment = path.partition(/[?#]/)
-      "#{authority_and_path.tr("\\", "/")}#{separator}#{query_and_fragment}"
+      normalized_authority_and_path = authority_and_path.tr("\\", "/").gsub(/%5[Cc]/, "/")
+      "#{normalized_authority_and_path}#{separator}#{query_and_fragment}"
     end
 
     def relative_path

--- a/app/services/safe_redirect_path_service.rb
+++ b/app/services/safe_redirect_path_service.rb
@@ -2,7 +2,7 @@
 
 class SafeRedirectPathService
   def initialize(path, request, allow_subdomain_host: true)
-    @path = path
+    @path = normalize_path_separators(path)
     @allow_subdomain_host = allow_subdomain_host
     @request = request
   end
@@ -17,6 +17,12 @@ class SafeRedirectPathService
 
   private
     attr_reader :path, :request, :allow_subdomain_host
+
+    def normalize_path_separators(path)
+      return path if path.nil?
+      authority_and_path, separator, query_and_fragment = path.partition(/[?#]/)
+      "#{authority_and_path.tr("\\", "/")}#{separator}#{query_and_fragment}"
+    end
 
     def relative_path
       _path = url.path.gsub(/^\/+/, "/")

--- a/spec/services/safe_redirect_path_service_spec.rb
+++ b/spec/services/safe_redirect_path_service_spec.rb
@@ -68,6 +68,24 @@ describe "SafeRedirectPathService" do
       end
     end
 
+    context "when path uses a backslash to disguise an external host" do
+      it "treats the backslash as a path separator like browsers do and returns a relative path on the current host" do
+        stub_const("ROOT_DOMAIN", "test.gumroad.com")
+        @path = "https://evil.com\\@username.test.gumroad.com/l/ggocri"
+
+        expect(service.process).to eq "/@username.test.gumroad.com/l/ggocri"
+      end
+    end
+
+    context "when a same-host path has a backslash in the query string" do
+      it "preserves the backslash because browsers do not treat it as a separator in the query" do
+        @request = OpenStruct.new(host: "test2.gumroad.com")
+        @path = "https://test2.gumroad.com/search?q=C:\\foo"
+
+        expect(service.process).to eq "https://test2.gumroad.com/search?q=C:\\foo"
+      end
+    end
+
     context "when domain contains regex special characters" do
       before do
         stub_const("ROOT_DOMAIN", "gumroad.com")

--- a/spec/services/safe_redirect_path_service_spec.rb
+++ b/spec/services/safe_redirect_path_service_spec.rb
@@ -77,6 +77,15 @@ describe "SafeRedirectPathService" do
       end
     end
 
+    context "when path uses a percent-encoded backslash to disguise an external host" do
+      it "treats the decoded backslash as a path separator like browsers do and returns a relative path on the current host" do
+        stub_const("ROOT_DOMAIN", "test.gumroad.com")
+        @path = "https://evil.com%5C@username.test.gumroad.com/l/ggocri"
+
+        expect(service.process).to eq "/@username.test.gumroad.com/l/ggocri"
+      end
+    end
+
     context "when a same-host path has a backslash in the query string" do
       it "preserves the backslash because browsers do not treat it as a separator in the query" do
         @request = OpenStruct.new(host: "test2.gumroad.com")


### PR DESCRIPTION
## What

When someone logs in, signs up, or completes two-factor, we let them carry a "next" web address so they land back where they started. The helper that decides whether that address is safe could be fooled.

A crafted address like `https://evil.com\@creator.gumroad.com/` looked like a Gumroad address to our safety check, but a browser reads the same address as `evil.com`. So an attacker could send someone a normal-looking login link that quietly bounced them to an outside site right after they signed in.

This change makes the safety check read the address the same way a browser does, so a disguised address is no longer mistaken for a Gumroad one and the redirect stays on Gumroad.

## Why

The check was looking at a cleaned-up copy of the address but then redirecting to the original raw text — and the two disagreed about where the address actually pointed.

The fix only adjusts the part of the address before the "?", so ordinary links that happen to contain a backslash in their query are left exactly as they were.

---

This PR was implemented with AI assistance using Claude Opus 4.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784574169&installation_id=134400930&pr_number=5535&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5535&signature=a9d8d385072fd65d0b46ddc16e11dbbd6363f6d3cf12b211fee1c8e06e394f57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication redirect validation; incorrect normalization could still allow external redirects or break legitimate same-host URLs with special characters in the path.
> 
> **Overview**
> Closes an **open redirect** in post-login/signup/2FA “next” URL handling: crafted URLs such as `https://evil.com\@creator.gumroad.com/...` could pass the host check while browsers still navigate to the external host.
> 
> `SafeRedirectPathService` now **normalizes path separators on input** via `normalize_path_separators`, converting `\` and percent-encoded `%5C` to `/` only in the authority and path segment (everything before `?` or `#`), so host/subdomain validation aligns with browser parsing. Unsafe URLs are reduced to a **relative path on the current host** instead of being returned verbatim. Query strings are unchanged, so same-host URLs with backslashes in the query (e.g. `C:\foo`) still pass through intact.
> 
> Specs cover backslash and `%5C` disguise cases and query preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40fac76957dbcd7f739a514efd26c2e64ccdf842. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->