### PR TITLE
Count pending Stripe funds in the balance check

### DIFF
--- a/app/business/payments/transfers/stripe/stripe_transfer_externally_to_gumroad.rb
+++ b/app/business/payments/transfers/stripe/stripe_transfer_externally_to_gumroad.rb
@@ -23,6 +23,26 @@ module StripeTransferExternallyToGumroad
     available_balances
   end
 
+  # Public: Returns a hash of currencies to the balance in cents that can fund
+  # upcoming payouts: the available balance plus settling (pending) funds.
+  # Pending sales settle within a couple of business days, well inside the
+  # weekly payout window, so they will be available before the payout runs.
+  # Pending is clamped at zero per currency because refunds, disputes, and
+  # reversals can push it negative, and subtracting that would understate the
+  # funds that `available` alone already covers. Mirrors the "reachable" balance
+  # StripePayoutProcessor uses to check a connected account can cover a payout.
+  def self.reachable_balances
+    balance = Stripe::Balance.retrieve
+    reachable_balances = Hash.new(0)
+    balance.available.each do |balance_for_currency|
+      reachable_balances[balance_for_currency["currency"]] += balance_for_currency["amount"]
+    end
+    balance.pending.each do |balance_for_currency|
+      reachable_balances[balance_for_currency["currency"]] += [balance_for_currency["amount"], 0].max
+    end
+    reachable_balances
+  end
+
   # Public: Transfers the amount from the Stripe master account to
   # the default bank account for the given currency.
   def self.transfer(currency, amount_cents)

--- a/app/services/stripe_balance_check_service.rb
+++ b/app/services/stripe_balance_check_service.rb
@@ -9,7 +9,11 @@
 class StripeBalanceCheckService
   def initialize
     @upcoming_payouts_cents = calculate_upcoming_payouts_cents
-    @current_balance_cents = StripeTransferExternallyToGumroad.available_balances["usd"].to_i
+    # Count settling (pending) funds alongside the available balance. Pending
+    # sales settle within a couple of business days -- well inside the weekly
+    # payout window -- so they fund the upcoming payouts. Using available-only
+    # over-reports the needed top-up and fires false alarms.
+    @current_balance_cents = StripeTransferExternallyToGumroad.reachable_balances["usd"].to_i
   end
 
   attr_reader :upcoming_payouts_cents, :current_balance_cents

--- a/spec/business/payments/transfers/stripe/stripe_transfer_externally_to_gumroad_spec.rb
+++ b/spec/business/payments/transfers/stripe/stripe_transfer_externally_to_gumroad_spec.rb
@@ -130,4 +130,27 @@ describe StripeTransferExternallyToGumroad, :vcr do
       end
     end
   end
+
+  describe "reachable_balances" do
+    before do
+      allow(Stripe::Balance).to receive(:retrieve).and_return(
+        Stripe::Balance.construct_from(
+          available: [{ currency: "usd", amount: 200_00 }, { currency: "cad", amount: 100_00 }],
+          pending: [{ currency: "usd", amount: 50_00 }, { currency: "cad", amount: -30_00 }]
+        )
+      )
+    end
+
+    it "sums the available and settling (pending) balance per currency" do
+      expect(described_class.reachable_balances["usd"]).to eq(250_00)
+    end
+
+    it "clamps negative pending at zero so refunds and disputes don't understate the balance" do
+      expect(described_class.reachable_balances["cad"]).to eq(100_00)
+    end
+
+    it "treats a currency with no balance as zero" do
+      expect(described_class.reachable_balances["gbp"]).to eq(0)
+    end
+  end
 end

--- a/spec/services/stripe_balance_check_service_spec.rb
+++ b/spec/services/stripe_balance_check_service_spec.rb
@@ -7,14 +7,14 @@ describe StripeBalanceCheckService do
     allow(PayoutEstimates).to receive(:estimate_gumroad_held_stripe_cents)
       .with(User::PayoutSchedule.next_scheduled_payout_end_date)
       .and_return(300_000_00)
-    allow(StripeTransferExternallyToGumroad).to receive(:available_balances).and_return({ "usd" => 1_000_000_00 })
+    allow(StripeTransferExternallyToGumroad).to receive(:reachable_balances).and_return({ "usd" => 1_000_000_00 })
   end
 
   it "uses the Gumroad-held Stripe estimate as the upcoming payout amount" do
     expect(described_class.new.upcoming_payouts_cents).to eq(300_000_00)
   end
 
-  it "reads the available USD balance from Stripe" do
+  it "reads the available-plus-pending USD balance from Stripe" do
     expect(described_class.new.current_balance_cents).to eq(1_000_000_00)
   end
 
@@ -28,7 +28,7 @@ describe StripeBalanceCheckService do
 
   context "when the balance is below the upcoming payouts" do
     before do
-      allow(StripeTransferExternallyToGumroad).to receive(:available_balances).and_return({ "usd" => 200_000_00 })
+      allow(StripeTransferExternallyToGumroad).to receive(:reachable_balances).and_return({ "usd" => 200_000_00 })
     end
 
     it "needs a top-up of the shortfall" do
@@ -38,9 +38,21 @@ describe StripeBalanceCheckService do
     end
   end
 
+  context "when settling funds bring the balance above the upcoming payouts" do
+    before do
+      allow(StripeTransferExternallyToGumroad).to receive(:reachable_balances).and_return({ "usd" => 350_000_00 })
+    end
+
+    it "does not need a top-up" do
+      service = described_class.new
+      expect(service.topup_needed?).to eq(false)
+      expect(service.topup_amount_cents).to eq(-50_000_00)
+    end
+  end
+
   context "when Stripe has no USD balance entry" do
     before do
-      allow(StripeTransferExternallyToGumroad).to receive(:available_balances).and_return({})
+      allow(StripeTransferExternallyToGumroad).to receive(:reachable_balances).and_return({})
     end
 
     it "treats the current balance as zero" do

--- a/spec/sidekiq/send_stripe_balance_check_notification_job_spec.rb
+++ b/spec/sidekiq/send_stripe_balance_check_notification_job_spec.rb
@@ -11,7 +11,7 @@ describe SendStripeBalanceCheckNotificationJob do
 
     context "when the balance is insufficient" do
       before do
-        allow(StripeTransferExternallyToGumroad).to receive(:available_balances).and_return({ "usd" => 200_000_00 })
+        allow(StripeTransferExternallyToGumroad).to receive(:reachable_balances).and_return({ "usd" => 200_000_00 })
       end
 
       it "sends a notification with the required top-up and sets the redis key to true" do
@@ -28,7 +28,7 @@ describe SendStripeBalanceCheckNotificationJob do
 
     context "when the balance is sufficient" do
       before do
-        allow(StripeTransferExternallyToGumroad).to receive(:available_balances).and_return({ "usd" => 1_000_000_00 })
+        allow(StripeTransferExternallyToGumroad).to receive(:reachable_balances).and_return({ "usd" => 1_000_000_00 })
       end
 
       it "does not notify and sets the redis key to false" do
@@ -49,7 +49,7 @@ describe SendStripeBalanceCheckNotificationJob do
 
     context "when the disable_stripe_balance_check_notification flag is active" do
       before do
-        allow(StripeTransferExternallyToGumroad).to receive(:available_balances).and_return({ "usd" => 200_000_00 })
+        allow(StripeTransferExternallyToGumroad).to receive(:reachable_balances).and_return({ "usd" => 200_000_00 })
         Feature.activate(:disable_stripe_balance_check_notification)
       end
 


### PR DESCRIPTION
## What

The daily Stripe balance check (`SendStripeBalanceCheckNotificationJob` → `StripeBalanceCheckService`) decides whether Gumroad needs to top up its platform Stripe balance to cover upcoming seller payouts. It compared the payout obligation against only `Stripe::Balance.available` — the immediately-transferable balance — and ignored `Stripe::Balance.pending`.

- Add `StripeTransferExternallyToGumroad.reachable_balances`, which sums the available and pending balance per currency, clamping pending at zero.
- The balance check now reads `reachable_balances["usd"]` instead of `available_balances["usd"]`.
- `available_balances` is left unchanged: `transfer_all_available_balances` can only move funds that are actually available, not pending.

## Why

Pending funds are recent sales settling on Stripe's rolling ~2-business-day schedule. Seller payouts run on a weekly cadence with a 7-day holdback, so funds pending today reliably become available before the payout runs. Comparing the obligation against the available balance alone over-reported the required top-up and produced false "top-up needed" alerts whenever a large settling balance was in flight (e.g. after a weekend of sales).

Illustrative: upcoming payouts need $300k, the available balance is $200k, and $150k is settling. The old check reports a $100k top-up, even though the real balance ($350k) comfortably covers the obligation. The new check reflects that no top-up is needed.

Pending is clamped at zero per currency because refunds, disputes, and reversals can push it negative, and subtracting that would understate funds that `available` alone already covers. This mirrors the "reachable" balance (`available + clamped pending`) that `StripePayoutProcessor` already uses when checking whether a connected account can cover a payout.

**Scope / non-goal:** this does not address the separate payout-timing risk. Seller payouts are Transfers that draw only from `available`, and Stripe's daily auto-sweep to the corporate bank drains `available`. If a sweep empties `available` right before a payout run while pending hasn't settled, a payout can still fail — that belongs in the Stripe payout-schedule/sweep timing, not this alert. A rigorous follow-up could count only pending whose `available_on` ≤ the payout date via the Balance Transactions API.

## Before / After

Backend-only change with no UI surface. Walkthrough video to be attached.

## Test Results

```
bundle exec rspec spec/services/stripe_balance_check_service_spec.rb \
  spec/sidekiq/send_stripe_balance_check_notification_job_spec.rb \
  spec/business/payments/transfers/stripe/stripe_transfer_externally_to_gumroad_spec.rb

23 examples, 0 failures
```

- The regression guard in `stripe_transfer_externally_to_gumroad_spec.rb` asserts `reachable_balances` returns available **+** pending and clamps negative pending. It fails if the check reverts to available-only or drops the clamp.
- `bundle exec rubocop`: 5 files inspected, no offenses detected.

---

AI disclosure: implemented with Claude Opus 4.8 (1M context).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784674233&installation_id=134400930&pr_number=5538&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5538&signature=ea1eeb3c20493172d7ce921fbe23198c4feb5c62d9d8b1f975bf706857452d5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how payment ops interprets platform liquidity for alerts; actual transfers still use available-only, and counting all pending assumes settlement before payout (not timing-filtered by available_on).
> 
> **Overview**
> The proactive **Stripe balance top-up alert** now compares upcoming seller payouts against **available plus settling (pending) USD**, not available alone.
> 
> A new **`StripeTransferExternallyToGumroad.reachable_balances`** sums `Stripe::Balance` available and pending per currency, with **pending clamped at zero** so negative pending from refunds/disputes does not shrink the total. **`StripeBalanceCheckService`** (and its notification job specs) switch from `available_balances` to this reachable total. **`available_balances`** and bank sweeps via **`transfer_all_available_balances`** are unchanged—only immediately transferable funds are moved.
> 
> Specs cover aggregation, the negative-pending clamp, and the case where pending makes the platform balance look sufficient when available-only would have triggered a false alarm.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97b8d11d2341c019039801f4ff1f72a746c48823. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->