### PR TITLE
Open payout help-article links in a new tab

### DIFF
--- a/app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx
@@ -431,7 +431,9 @@ const AccountDetailsSection = ({
           <Fieldset>
             <FieldsetTitle>
               <Label>Account type</Label>
-              <a href="/help/article/260-your-payout-settings-page">What type of account should I choose?</a>
+              <a href="/help/article/260-your-payout-settings-page" target="_blank" rel="noreferrer">
+                What type of account should I choose?
+              </a>
             </FieldsetTitle>
           </Fieldset>
           <Tabs variant="buttons" className="grid-cols-1 gap-4 sm:grid-cols-2" role="radiogroup">
@@ -747,7 +749,9 @@ const AccountDetailsSection = ({
                 <Label htmlFor={`${uid}-${businessTaxIdConfig.idSuffix}`}>{businessTaxIdConfig.label}</Label>
                 {complianceInfo.business_country === "US" ? (
                   <div className="small">
-                    <a href="/help/article/260-your-payout-settings-page">I'm not sure what my Tax ID is.</a>
+                    <a href="/help/article/260-your-payout-settings-page" target="_blank" rel="noreferrer">
+                      I'm not sure what my Tax ID is.
+                    </a>
                   </div>
                 ) : null}
               </FieldsetTitle>
@@ -1146,7 +1150,9 @@ const AccountDetailsSection = ({
       <Fieldset>
         <FieldsetTitle>
           <Label>Date of Birth</Label>
-          <a href="/help/article/260-your-payout-settings-page">Why does Gumroad need this information?</a>
+          <a href="/help/article/260-your-payout-settings-page" target="_blank" rel="noreferrer">
+            Why does Gumroad need this information?
+          </a>
         </FieldsetTitle>
         <div style={{ display: "grid", gap: "var(--spacer-5)", gridAutoFlow: "column", gridAutoColumns: "1fr" }}>
           <Fieldset state={errorFieldNames.has("dob_month") ? "danger" : undefined}>


### PR DESCRIPTION
### What

Three help-article links on the **payout settings** page navigated away in-place because they lacked `target="_blank"`:
- "What type of account should I choose?" (account type)
- "I'm not sure what my Tax ID is." (Tax ID)
- "Why does Gumroad need this information?" (date of birth)

This adds `target="_blank" rel="noreferrer"` to all three, matching the page's other help links (the payout-settings link and the PayPal Connect "Learn more" link, which already open in a new tab).

### Why

- **Web:** clicking a help link no longer drops the seller out of a half-filled payout form.
- **Mobile app:** the payout settings WebView opens `target="_blank"` links in the system browser (via `onOpenWindow`); without `target="_blank"` these links loaded inside the chrome-less WebView and stranded the user.

### Scope

Presentational only — three `<a>` tags in `AccountDetailsSection.tsx`. Prettier + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784700641&installation_id=134400930&pr_number=5540&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5540&signature=7d2559d96200c8950f842ea7e68da716ae58f83bf3e9a202f27a39bfb346b27c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentational anchor attribute changes only; no payout logic, validation, or data handling.
> 
> **Overview**
> Three payout-settings help links in **Account details** (account type, US Tax ID, date of birth) now use `target="_blank"` and `rel="noreferrer"`, aligned with other help links on the same page (e.g. PayPal “Learn more”).
> 
> Sellers keep the in-progress payout form when opening help on web; in the mobile WebView, those URLs open in the system browser instead of trapping navigation inside the chrome-less view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4e4e3425f18b12bf35befaf10e4d63f30f96427. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->