### PR TITLE
Fire the Purchase pixel on the library page for multi-product orders

### DIFF
--- a/app/controllers/library_controller.rb
+++ b/app/controllers/library_controller.rb
@@ -62,12 +62,9 @@ class LibraryController < Sellers::BaseController
         .first(MAX_TRACKED_PURCHASE_ANALYTICS)
       return {} if external_ids.empty?
 
-      external_ids.each_with_object({}) do |external_id, props|
-        purchase = logged_in_user.purchases.find_by_external_id(external_id)
-        next unless purchase
-
+      logged_in_user.purchases.by_external_ids(external_ids).each_with_object({}) do |purchase, props|
         analytics = PurchaseSellerAnalyticsPresenter.new(purchase).props
-        props[external_id] = analytics if analytics
+        props[purchase.external_id] = analytics if analytics
       end
     end
 

--- a/app/controllers/library_controller.rb
+++ b/app/controllers/library_controller.rb
@@ -11,6 +11,9 @@ class LibraryController < Sellers::BaseController
   RESEND_CONFIRMATION_EMAIL_TIME_LIMIT = 24.hours
   private_constant :RESEND_CONFIRMATION_EMAIL_TIME_LIMIT
 
+  MAX_TRACKED_PURCHASE_ANALYTICS = 50
+  private_constant :MAX_TRACKED_PURCHASE_ANALYTICS
+
   def index
     authorize Purchase
 
@@ -21,6 +24,7 @@ class LibraryController < Sellers::BaseController
       results: purchase_results,
       creators: creator_counts,
       bundles:,
+      purchase_analytics: purchase_analytics_props,
       reviews_page_enabled: Feature.active?(:reviews_page, current_seller),
       following_wishlists_enabled: Feature.active?(:follow_wishlists, current_seller),
     }
@@ -51,6 +55,22 @@ class LibraryController < Sellers::BaseController
   end
 
   private
+    def purchase_analytics_props
+      raw_ids = params[:purchase_id]
+      external_ids = (raw_ids.is_a?(Array) ? raw_ids : Array(raw_ids))
+        .select { |id| id.is_a?(String) }
+        .first(MAX_TRACKED_PURCHASE_ANALYTICS)
+      return {} if external_ids.empty?
+
+      external_ids.each_with_object({}) do |external_id, props|
+        purchase = logged_in_user.purchases.find_by_external_id(external_id)
+        next unless purchase
+
+        analytics = PurchaseSellerAnalyticsPresenter.new(purchase).props
+        props[external_id] = analytics if analytics
+      end
+    end
+
     def set_purchase
       @purchase = logged_in_user.purchases.find_by_external_id!(params[:id])
     end

--- a/app/javascript/components/DownloadPage/WithContent.tsx
+++ b/app/javascript/components/DownloadPage/WithContent.tsx
@@ -4,10 +4,8 @@ import * as React from "react";
 import typia from "typia";
 
 import { getFolderArchiveDownloadUrl, getProductFileDownloadInfos, saveLastContentPage } from "$app/data/products";
-import { AnalyticsData, BuyerCurrencyDisplay } from "$app/parsers/product";
 import { RichContent, RichContentPage } from "$app/parsers/richContent";
 import { assertDefined } from "$app/utils/assert";
-import { CurrencyCode, getIsSingleUnitCurrency } from "$app/utils/currency";
 import FileUtils from "$app/utils/file";
 import {
   generatePageIcon,
@@ -15,7 +13,7 @@ import {
   PAGE_ICON_LABELS,
   type PageIconType,
 } from "$app/utils/rich_content_page";
-import { startTrackingForSeller, trackProductEvent } from "$app/utils/user_analytics";
+import { SellerAnalyticsProps, trackSellerPurchaseEvent } from "$app/utils/user_analytics";
 
 import { Button } from "$app/components/Button";
 import { DiscordButton } from "$app/components/DiscordButton";
@@ -103,20 +101,7 @@ export type ContentProps = {
   community_chat_url: string | null;
 };
 
-export type SellerAnalyticsProps = {
-  seller_id: string;
-  analytics: AnalyticsData;
-  purchase_event: {
-    permalink: string;
-    purchase_external_id: string;
-    product_name: string;
-    value: number;
-    currency: string;
-    quantity: number;
-    tax: string;
-    buyer_currency_display?: BuyerCurrencyDisplay;
-  };
-};
+export type { SellerAnalyticsProps };
 
 export const WithContent = ({
   content,
@@ -166,23 +151,7 @@ export const WithContent = ({
           purchaseId: props.purchase.id,
         });
 
-      if (seller_analytics) {
-        const { seller_id, analytics, purchase_event } = seller_analytics;
-        startTrackingForSeller(seller_id, analytics);
-        trackProductEvent(seller_id, {
-          action: "purchased",
-          seller_id,
-          permalink: purchase_event.permalink,
-          purchase_external_id: purchase_event.purchase_external_id,
-          product_name: purchase_event.product_name,
-          value: purchase_event.value,
-          valueIsSingleUnit: getIsSingleUnitCurrency(typia.assert<CurrencyCode>(purchase_event.currency)),
-          currency: purchase_event.currency.toUpperCase(),
-          quantity: purchase_event.quantity,
-          tax: purchase_event.tax,
-          buyer_currency_display: purchase_event.buyer_currency_display,
-        });
-      }
+      if (seller_analytics) trackSellerPurchaseEvent(seller_analytics);
     }
   });
   const isDesktop = useIsAboveBreakpoint("lg");

--- a/app/javascript/pages/Checkout/Show.tsx
+++ b/app/javascript/pages/Checkout/Show.tsx
@@ -513,6 +513,7 @@ const CheckoutIndexPage = () => {
           redirectTo = "content-page";
         else if (
           !!user &&
+          user.confirmed &&
           results.every(({ result }) => result.success && result.content_url != null && !result.test_purchase_notice)
         )
           redirectTo = "library-page";

--- a/app/javascript/pages/Checkout/Show.tsx
+++ b/app/javascript/pages/Checkout/Show.tsx
@@ -520,7 +520,7 @@ const CheckoutIndexPage = () => {
 
       for (const { result, item } of results) {
         if (!result.success) continue;
-        if (redirectTo !== "content-page") {
+        if (!redirectTo) {
           trackProductEvent(item.product.creator.id, {
             action: "purchased",
             seller_id: result.seller_id,
@@ -532,7 +532,9 @@ const CheckoutIndexPage = () => {
             valueIsSingleUnit: getIsSingleUnitCurrency(typia.assert<CurrencyCode>(result.currency_type)),
             quantity: result.quantity,
             tax: result.non_formatted_seller_tax_amount,
-            buyer_currency_display: item.product.buyer_currency_display,
+            ...(item.product.buyer_currency_display
+              ? { buyer_currency_display: item.product.buyer_currency_display }
+              : {}),
           });
         }
         if (result.has_third_party_analytics && !redirectTo)
@@ -561,7 +563,7 @@ const CheckoutIndexPage = () => {
       } else if (redirectTo === "library-page") {
         const purchases = results.flatMap(({ result }) => (result.success ? result.id : []));
         const libraryUrl = new URL(Routes.library_url());
-        for (const purchase of purchases) libraryUrl.searchParams.append("purchase_id", purchase);
+        for (const purchase of purchases) libraryUrl.searchParams.append("purchase_id[]", purchase);
         window.location.href = libraryUrl.toString();
       }
 

--- a/app/javascript/pages/Library/Index.tsx
+++ b/app/javascript/pages/Library/Index.tsx
@@ -11,6 +11,7 @@ import { classNames } from "$app/utils/classNames";
 import { asyncVoid } from "$app/utils/promise";
 import { assertResponseError } from "$app/utils/request";
 import { writeQueryParams } from "$app/utils/url";
+import { SellerAnalyticsProps, trackSellerPurchaseEvent } from "$app/utils/user_analytics";
 
 import { Button } from "$app/components/Button";
 import { useDiscoverUrl } from "$app/components/DomainSettings";
@@ -182,6 +183,7 @@ type Props = {
   results: Result[];
   creators: { id: string; name: string }[];
   bundles: { id: string; label: string }[];
+  purchase_analytics: Record<string, SellerAnalyticsProps>;
   reviews_page_enabled: boolean;
   following_wishlists_enabled: boolean;
 };
@@ -253,9 +255,8 @@ const extractParams = (rawParams: URLSearchParams): Params => ({
 });
 
 export default function LibraryPage() {
-  const { results, creators, bundles, reviews_page_enabled, following_wishlists_enabled } = typia.assert<Props>(
-    usePage().props,
-  );
+  const { results, creators, bundles, purchase_analytics, reviews_page_enabled, following_wishlists_enabled } =
+    typia.assert<Props>(usePage().props);
 
   const originalLocation = useOriginalLocation();
   const discoverUrl = useDiscoverUrl();
@@ -332,10 +333,10 @@ export default function LibraryPage() {
   const url = new URL(useOriginalLocation());
   const addThirdPartyAnalytics = useAddThirdPartyAnalytics();
   useRunOnce(() => {
-    const purchaseIds = url.searchParams.getAll("purchase_id");
+    const purchaseIds = url.searchParams.getAll("purchase_id[]");
     if (purchaseIds.length === 0) return;
 
-    url.searchParams.delete("purchase_id");
+    url.searchParams.delete("purchase_id[]");
     router.replace({ url: url.pathname + url.search, preserveState: true, preserveScroll: true });
 
     const email = results.find(({ purchase }) => purchase.id === purchaseIds[0])?.purchase.email;
@@ -351,6 +352,9 @@ export default function LibraryPage() {
           location: "receipt",
           purchaseId,
         });
+
+      const analytics = purchase_analytics[purchaseId];
+      if (analytics) trackSellerPurchaseEvent(analytics);
     }
   });
 

--- a/app/javascript/pages/Library/Index.tsx
+++ b/app/javascript/pages/Library/Index.tsx
@@ -333,28 +333,27 @@ export default function LibraryPage() {
   const url = new URL(useOriginalLocation());
   const addThirdPartyAnalytics = useAddThirdPartyAnalytics();
   useRunOnce(() => {
-    const purchaseIds = url.searchParams.getAll("purchase_id[]");
+    const purchaseIds = [...url.searchParams.getAll("purchase_id[]"), ...url.searchParams.getAll("purchase_id")];
     if (purchaseIds.length === 0) return;
 
     url.searchParams.delete("purchase_id[]");
+    url.searchParams.delete("purchase_id");
     router.replace({ url: url.pathname + url.search, preserveState: true, preserveScroll: true });
 
     const email = results.find(({ purchase }) => purchase.id === purchaseIds[0])?.purchase.email;
     if (email) showAlert(`Your purchase was successful! We sent a receipt to ${email}.`, "success");
 
     for (const purchaseId of purchaseIds) {
-      const product = results.find(({ purchase }) => purchase.id === purchaseId)?.product;
-      if (!product) continue;
+      const analytics = purchase_analytics[purchaseId];
+      if (analytics) trackSellerPurchaseEvent(analytics);
 
-      if (product.has_third_party_analytics)
+      const product = results.find(({ purchase }) => purchase.id === purchaseId)?.product;
+      if (product?.has_third_party_analytics)
         addThirdPartyAnalytics({
           permalink: product.permalink,
           location: "receipt",
           purchaseId,
         });
-
-      const analytics = purchase_analytics[purchaseId];
-      if (analytics) trackSellerPurchaseEvent(analytics);
     }
   });
 

--- a/app/javascript/pages/Library/Index.tsx
+++ b/app/javascript/pages/Library/Index.tsx
@@ -333,7 +333,9 @@ export default function LibraryPage() {
   const url = new URL(useOriginalLocation());
   const addThirdPartyAnalytics = useAddThirdPartyAnalytics();
   useRunOnce(() => {
-    const purchaseIds = [...url.searchParams.getAll("purchase_id[]"), ...url.searchParams.getAll("purchase_id")];
+    const purchaseIds = [
+      ...new Set([...url.searchParams.getAll("purchase_id[]"), ...url.searchParams.getAll("purchase_id")]),
+    ];
     if (purchaseIds.length === 0) return;
 
     url.searchParams.delete("purchase_id[]");

--- a/app/javascript/utils/user_analytics.ts
+++ b/app/javascript/utils/user_analytics.ts
@@ -1,7 +1,10 @@
+import typia from "typia";
+
 import * as FacebookPixel from "$app/data/facebook_pixel";
 import * as GoogleAnalytics from "$app/data/google_analytics";
 import * as TikTokPixel from "$app/data/tiktok_pixel";
 import { AnalyticsData, BuyerCurrencyDisplay } from "$app/parsers/product";
+import { CurrencyCode, getIsSingleUnitCurrency } from "$app/utils/currency";
 
 export type GumroadEvents = keyof typeof ProductEventsTitles;
 
@@ -81,6 +84,40 @@ export function trackProductEvent(id: string | undefined, data: ProductAnalytics
   GoogleAnalytics.trackProductEvent(config, data);
   if (data.action !== "begin_checkout") FacebookPixel.trackProductEvent(config, data);
   if (data.action !== "begin_checkout") TikTokPixel.trackProductEvent(config, data);
+}
+
+export type SellerPurchaseEvent = {
+  permalink: string;
+  purchase_external_id: string;
+  product_name: string;
+  value: number;
+  currency: string;
+  quantity: number;
+  tax: string;
+  buyer_currency_display?: BuyerCurrencyDisplay;
+};
+
+export type SellerAnalyticsProps = {
+  seller_id: string;
+  analytics: AnalyticsData;
+  purchase_event: SellerPurchaseEvent;
+};
+
+export function trackSellerPurchaseEvent({ seller_id, analytics, purchase_event }: SellerAnalyticsProps) {
+  startTrackingForSeller(seller_id, analytics);
+  trackProductEvent(seller_id, {
+    action: "purchased",
+    seller_id,
+    permalink: purchase_event.permalink,
+    purchase_external_id: purchase_event.purchase_external_id,
+    product_name: purchase_event.product_name,
+    value: purchase_event.value,
+    valueIsSingleUnit: getIsSingleUnitCurrency(typia.assert<CurrencyCode>(purchase_event.currency)),
+    currency: purchase_event.currency.toUpperCase(),
+    quantity: purchase_event.quantity,
+    tax: purchase_event.tax,
+    ...(purchase_event.buyer_currency_display ? { buyer_currency_display: purchase_event.buyer_currency_display } : {}),
+  });
 }
 
 export function trackBuyerCurrencyDisplayView(id: string | undefined, data: BuyerCurrencyDisplay | undefined) {

--- a/app/presenters/purchase_seller_analytics_presenter.rb
+++ b/app/presenters/purchase_seller_analytics_presenter.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class PurchaseSellerAnalyticsPresenter
+  include CurrencyHelper
+
+  def initialize(purchase)
+    @purchase = purchase
+  end
+
+  def props
+    return nil unless purchase
+
+    product = purchase.link
+    return nil unless product
+
+    analytics = product.analytics_data
+    return nil unless analytics[:facebook_pixel_id] || analytics[:google_analytics_id] || analytics[:tiktok_pixel_id]
+
+    currency_type = purchase.displayed_price_currency_type.to_s
+    {
+      seller_id: product.user.external_id,
+      analytics:,
+      purchase_event: {
+        permalink: product.unique_permalink,
+        purchase_external_id: purchase.external_id,
+        product_name: product.name,
+        value: Money.new(purchase.displayed_price_cents, currency_type).cents,
+        currency: currency_type,
+        quantity: purchase.quantity,
+        tax: Money.new(purchase.seller_taxes_in_purchase_currency, currency_type).format(no_cents_if_whole: true, symbol: false),
+        buyer_currency_display: buyer_currency_display_props(product:, price_cents: purchase.displayed_price_cents, ip: purchase.ip_address),
+      }
+    }
+  end
+
+  private
+    attr_reader :purchase
+end

--- a/app/presenters/url_redirect_presenter.rb
+++ b/app/presenters/url_redirect_presenter.rb
@@ -3,7 +3,6 @@
 class UrlRedirectPresenter
   include Rails.application.routes.url_helpers
   include ProductsHelper
-  include CurrencyHelper
   include ActionView::Helpers::TextHelper
 
   CONTENT_UNAVAILABILITY_REASON_CODES = {
@@ -82,27 +81,7 @@ class UrlRedirectPresenter
 
   private
     def seller_analytics_props
-      return nil unless purchase
-
-      product = purchase.link
-      analytics = product.analytics_data
-      return nil unless analytics[:facebook_pixel_id] || analytics[:google_analytics_id] || analytics[:tiktok_pixel_id]
-
-      currency_type = purchase.displayed_price_currency_type.to_s
-      {
-        seller_id: product.user.external_id,
-        analytics:,
-        purchase_event: {
-          permalink: product.unique_permalink,
-          purchase_external_id: purchase.external_id,
-          product_name: product.name,
-          value: Money.new(purchase.displayed_price_cents, currency_type).cents,
-          currency: currency_type,
-          quantity: purchase.quantity,
-          tax: Money.new(purchase.seller_taxes_in_purchase_currency, currency_type).format(no_cents_if_whole: true, symbol: false),
-          buyer_currency_display: buyer_currency_display_props(product:, price_cents: purchase.displayed_price_cents, ip: purchase.ip_address),
-        }
-      }
+      PurchaseSellerAnalyticsPresenter.new(purchase).props
     end
 
     def download_page_layout_props(email_confirmation_required: false)

--- a/spec/controllers/library_controller_spec.rb
+++ b/spec/controllers/library_controller_spec.rb
@@ -74,6 +74,42 @@ describe LibraryController, :vcr, type: :controller, inertia: true do
       end
     end
 
+    describe "purchase_analytics prop" do
+      it "is empty when no purchase_id params are present" do
+        get :index
+        expect(inertia.props[:purchase_analytics]).to eq({})
+      end
+
+      it "includes analytics for the buyer's purchases whose seller has a pixel" do
+        seller = create(:user, facebook_pixel_id: "1234567890")
+        purchase = create(:free_purchase, purchaser: user, link: create(:product, user: seller))
+
+        get :index, params: { purchase_id: [purchase.external_id] }
+
+        analytics = inertia.props[:purchase_analytics]
+        expect(analytics.keys.map(&:to_s)).to include(purchase.external_id)
+        expect(analytics.values.first[:analytics][:facebook_pixel_id]).to eq("1234567890")
+        expect(analytics.values.first[:purchase_event][:purchase_external_id]).to eq(purchase.external_id)
+      end
+
+      it "excludes purchases whose seller has no third-party analytics configured" do
+        purchase = create(:free_purchase, purchaser: user, link: create(:product))
+
+        get :index, params: { purchase_id: [purchase.external_id] }
+
+        expect(inertia.props[:purchase_analytics]).to eq({})
+      end
+
+      it "does not expose analytics for purchases that don't belong to the buyer" do
+        seller = create(:user, facebook_pixel_id: "1234567890")
+        other_purchase = create(:free_purchase, link: create(:product, user: seller))
+
+        get :index, params: { purchase_id: [other_purchase.external_id] }
+
+        expect(inertia.props[:purchase_analytics]).to eq({})
+      end
+    end
+
     context "when an unconfirmed user attempts to access the library" do
       shared_examples "sends confirmation instructions" do
         it "disallows access and sends confirmation instructions" do

--- a/spec/controllers/library_controller_spec.rb
+++ b/spec/controllers/library_controller_spec.rb
@@ -92,6 +92,17 @@ describe LibraryController, :vcr, type: :controller, inertia: true do
         expect(analytics.values.first[:purchase_event][:purchase_external_id]).to eq(purchase.external_id)
       end
 
+      it "includes analytics when a single purchase_id is given (bundle redirect)" do
+        seller = create(:user, facebook_pixel_id: "1234567890")
+        purchase = create(:free_purchase, purchaser: user, link: create(:product, user: seller))
+
+        get :index, params: { purchase_id: purchase.external_id }
+
+        analytics = inertia.props[:purchase_analytics]
+        expect(analytics.keys.map(&:to_s)).to include(purchase.external_id)
+        expect(analytics.values.first[:analytics][:facebook_pixel_id]).to eq("1234567890")
+      end
+
       it "excludes purchases whose seller has no third-party analytics configured" do
         purchase = create(:free_purchase, purchaser: user, link: create(:product))
 

--- a/spec/presenters/purchase_seller_analytics_presenter_spec.rb
+++ b/spec/presenters/purchase_seller_analytics_presenter_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe PurchaseSellerAnalyticsPresenter do
+  describe "#props" do
+    it "returns nil when there is no purchase" do
+      expect(described_class.new(nil).props).to be_nil
+    end
+
+    it "returns nil when the seller has no third-party analytics configured" do
+      purchase = create(:free_purchase, link: create(:product))
+
+      expect(described_class.new(purchase).props).to be_nil
+    end
+
+    context "when the seller has a Facebook pixel configured" do
+      let(:seller) { create(:user, facebook_pixel_id: "1234567890") }
+      let(:product) { create(:product, user: seller, name: "My Product") }
+      let(:purchase) { create(:free_purchase, link: product, displayed_price_cents: 14_99) }
+
+      it "returns the seller id, analytics data, and purchase event payload" do
+        props = described_class.new(purchase).props
+
+        expect(props[:seller_id]).to eq(seller.external_id)
+        expect(props[:analytics][:facebook_pixel_id]).to eq("1234567890")
+        expect(props[:purchase_event]).to include(
+          permalink: product.unique_permalink,
+          purchase_external_id: purchase.external_id,
+          product_name: "My Product",
+          value: 14_99,
+          currency: purchase.displayed_price_currency_type.to_s,
+          quantity: purchase.quantity,
+        )
+        expect(props[:purchase_event][:buyer_currency_display]).to be_present
+      end
+    end
+
+    it "returns the analytics payload when only Google Analytics is configured" do
+      seller = create(:user, google_analytics_id: "G-ABC123")
+      purchase = create(:free_purchase, link: create(:product, user: seller))
+
+      props = described_class.new(purchase).props
+
+      expect(props[:analytics][:google_analytics_id]).to eq("G-ABC123")
+      expect(props[:analytics][:facebook_pixel_id]).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## What

Fires the Meta/GA/TikTok `Purchase` analytics event for **multi-product orders** (a main offer plus upsells), which currently lose it.

- Checkout skips client-side `Purchase` firing for **any** post-purchase redirect (`!redirectTo`), not just the single-product `content-page` redirect.
- The library page — where multi-product, signed-in buyers land after checkout — now fires `Purchase` on load for each freshly purchased product, mirroring the receipt page.
- Per-purchase analytics props are built server-side and handed to the library page; purchase ids travel as `purchase_id[]` so the controller can resolve them (scoped to the buyer's own purchases).
- The purchase → analytics-event mapping is extracted into `PurchaseSellerAnalyticsPresenter` (shared by the receipt and library flows), with a `trackSellerPurchaseEvent` helper shared by both pages.

## Why

#5147 moved `Purchase` off the checkout-redirect race onto the receipt page, but only for single-product orders (the `content-page` redirect). Multi-product orders redirect signed-in buyers to the **library page**, and those kept firing `Purchase` from checkout immediately before `window.location.href` — the exact race #5147 set out to fix. The in-flight pixel request was cancelled, so `Purchase` never reached the seller's pixel, and the library page fired no `Purchase` of its own. Sellers whose orders include upsells therefore saw `ViewContent` and `InitiateCheckout` fire but never `Purchase`.

This generalizes #5147's receipt-page approach to the library/multi-product path rather than special-casing a single redirect type.

Closes antiwork/gumroad-private#614

---

AI disclosure: implemented with Claude Opus 4.8 (1M context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784714634&installation_id=134400930&pr_number=5541&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5541&signature=89f867ef4fa23c9cfbc26e966aa7c4d365e251d42941947d4c27ae5eb926a7e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches post-checkout analytics and redirect gating (confirmed users); incorrect skipping or double-firing would affect seller conversion tracking, but scope is limited to the buyer’s own purchases with new specs.
> 
> **Overview**
> Fixes **missing Meta/GA/TikTok Purchase events** for signed-in buyers who land on the **library** after multi-item checkout (main offer + upsells), where pixels were still fired at checkout right before `window.location.href` and got cancelled.
> 
> **Checkout** no longer fires client-side `purchased` (or receipt third-party analytics) when **any** post-purchase redirect is chosen (`content-page` or `library-page`), not only single-product content redirects. Library redirects now require a **confirmed** user and pass purchase IDs as `purchase_id[]`.
> 
> **Library** loads server-built `purchase_analytics` (via new `PurchaseSellerAnalyticsPresenter`, capped at 50 IDs and limited to the buyer’s purchases) and fires `trackSellerPurchaseEvent` on first paint—same pattern as the receipt/`WithContent` flow after URL cleanup.
> 
> Analytics payload building is **centralized** in `PurchaseSellerAnalyticsPresenter` (receipt presenter now delegates to it).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03d2eb594f3f1671ca4c89599c4f54f96d5dcde8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->