### PR TITLE
Require the verification digit for Peru DNI tax IDs

### DIFF
--- a/app/javascript/pages/Settings/Payments/Show.tsx
+++ b/app/javascript/pages/Settings/Payments/Show.tsx
@@ -49,6 +49,8 @@ const HAS_JAPANESE_CHARS = /[\u3000-\u303F\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FF
 const HAS_KATAKANA = /[\u30A0-\u30FF\u31F0-\u31FF\uFF65-\uFF9F]/u;
 
 const PAYOUT_FREQUENCIES = ["daily", "weekly", "monthly", "quarterly"] as const;
+
+const PERU_DNI_DIGIT_COUNT = 9;
 type PayoutFrequency = (typeof PAYOUT_FREQUENCIES)[number];
 
 type PaymentsPageProps = {
@@ -647,6 +649,17 @@ export default function PaymentsPage() {
       !form.data.user.individual_tax_id
     ) {
       markFieldInvalid("individual_tax_id");
+    }
+    if (
+      form.data.user.country === "PE" &&
+      !form.data.user.is_business &&
+      form.data.user.individual_tax_id &&
+      form.data.user.individual_tax_id.replace(/\D/gu, "").length !== PERU_DNI_DIGIT_COUNT
+    ) {
+      markFieldInvalid("individual_tax_id");
+      setClientErrorMessage({
+        message: "Your DNI must include the verification digit (for example, 12345678-9).",
+      });
     }
     if (form.data.user.is_business) {
       if (!form.data.user.business_type) {

--- a/app/javascript/pages/Settings/Payments/Show.tsx
+++ b/app/javascript/pages/Settings/Payments/Show.tsx
@@ -650,9 +650,11 @@ export default function PaymentsPage() {
     ) {
       markFieldInvalid("individual_tax_id");
     }
+    const peruDniRequired = form.data.user.is_business
+      ? form.data.user.business_country === "PE"
+      : form.data.user.country === "PE";
     if (
-      form.data.user.country === "PE" &&
-      !form.data.user.is_business &&
+      peruDniRequired &&
       form.data.user.individual_tax_id &&
       form.data.user.individual_tax_id.replace(/\D/gu, "").length !== PERU_DNI_DIGIT_COUNT
     ) {

--- a/app/services/update_user_compliance_info.rb
+++ b/app/services/update_user_compliance_info.rb
@@ -81,6 +81,9 @@ class UpdateUserComplianceInfo
         return { success: true }
       end
 
+      peru_dni_error = peru_individual_dni_error(old_compliance_info)
+      return { success: false, error_message: peru_dni_error } if peru_dni_error
+
       saved, new_compliance_info = if encrypted_compliance_info_params_present?
         dup_and_save_compliance_info(old_compliance_info)
       else
@@ -94,14 +97,6 @@ class UpdateUserComplianceInfo
       if new_compliance_info.is_business && new_compliance_info.legal_entity_country_code == "US" &&
           submitted_tax_id_for(:business_tax_id).present? && new_compliance_info.business_tax_id.length != 9
         return { success: false, error_message: "US business tax IDs (EIN) must have 9 digits." }
-      end
-
-      submitted_individual_tax_id = submitted_tax_id_for(:individual_tax_id)
-      if !new_compliance_info.is_business &&
-          new_compliance_info.legal_entity_country_code == Compliance::Countries::PER.alpha2 &&
-          submitted_individual_tax_id.present? &&
-          submitted_individual_tax_id.gsub(/\D/, "").length != PERU_DNI_DIGIT_COUNT
-        return { success: false, error_message: "Your Peru DNI must include the verification digit (for example, 12345678-9)." }
       end
 
       begin
@@ -256,6 +251,16 @@ class UpdateUserComplianceInfo
       return nil if value.blank?
       return value.gsub(/\D/, "") if country_code == "US"
       value.gsub(/[\s-]+/, "")
+    end
+
+    def peru_individual_dni_error(old_compliance_info)
+      submitted = submitted_tax_id_for(:individual_tax_id)
+      return if submitted.blank?
+      submitting_as_business = compliance_params[:is_business].nil? ? old_compliance_info.is_business? : ActiveModel::Type::Boolean.new.cast(compliance_params[:is_business])
+      return if submitting_as_business
+      return unless old_compliance_info.country_code == Compliance::Countries::PER.alpha2
+      return if submitted.gsub(/\D/, "").length == PERU_DNI_DIGIT_COUNT
+      "Your Peru DNI must include the verification digit (for example, 12345678-9)."
     end
 
     def encrypted_compliance_info_params_present?

--- a/app/services/update_user_compliance_info.rb
+++ b/app/services/update_user_compliance_info.rb
@@ -256,11 +256,18 @@ class UpdateUserComplianceInfo
     def peru_individual_dni_error(old_compliance_info)
       submitted = submitted_tax_id_for(:individual_tax_id)
       return if submitted.blank?
-      submitting_as_business = compliance_params[:is_business].nil? ? old_compliance_info.is_business? : ActiveModel::Type::Boolean.new.cast(compliance_params[:is_business])
-      return if submitting_as_business
-      return unless old_compliance_info.country_code == Compliance::Countries::PER.alpha2
+      return unless effective_legal_entity_country_code(old_compliance_info) == Compliance::Countries::PER.alpha2
       return if submitted.gsub(/\D/, "").length == PERU_DNI_DIGIT_COUNT
       "Your Peru DNI must include the verification digit (for example, 12345678-9)."
+    end
+
+    def effective_legal_entity_country_code(old_compliance_info)
+      submitting_as_business = compliance_params[:is_business].nil? ? old_compliance_info.is_business? : ActiveModel::Type::Boolean.new.cast(compliance_params[:is_business])
+      if submitting_as_business
+        compliance_params[:business_country].presence || old_compliance_info.business_country_code
+      else
+        old_compliance_info.country_code
+      end
     end
 
     def encrypted_compliance_info_params_present?

--- a/app/services/update_user_compliance_info.rb
+++ b/app/services/update_user_compliance_info.rb
@@ -19,6 +19,7 @@ class UpdateUserComplianceInfo
 
   MAX_ENCRYPTED_FIELD_LENGTH = 200
   MASKED_TAX_ID_PATTERN = /[\u2022*]/
+  PERU_DNI_DIGIT_COUNT = 9
   ENCRYPTED_FIELD_LABELS = {
     individual_tax_id: "Individual tax id",
     ssn_last_four: "Individual tax id",
@@ -93,6 +94,14 @@ class UpdateUserComplianceInfo
       if new_compliance_info.is_business && new_compliance_info.legal_entity_country_code == "US" &&
           submitted_tax_id_for(:business_tax_id).present? && new_compliance_info.business_tax_id.length != 9
         return { success: false, error_message: "US business tax IDs (EIN) must have 9 digits." }
+      end
+
+      submitted_individual_tax_id = submitted_tax_id_for(:individual_tax_id)
+      if !new_compliance_info.is_business &&
+          new_compliance_info.legal_entity_country_code == Compliance::Countries::PER.alpha2 &&
+          submitted_individual_tax_id.present? &&
+          submitted_individual_tax_id.gsub(/\D/, "").length != PERU_DNI_DIGIT_COUNT
+        return { success: false, error_message: "Your Peru DNI must include the verification digit (for example, 12345678-9)." }
       end
 
       begin

--- a/spec/services/update_user_compliance_info_spec.rb
+++ b/spec/services/update_user_compliance_info_spec.rb
@@ -175,6 +175,86 @@ describe UpdateUserComplianceInfo do
       end
     end
 
+    context "with a Peru individual" do
+      def create_peru_individual_user(individual_tax_id:)
+        create(:user).tap do |u|
+          create(
+            :user_compliance_info,
+            user: u,
+            country: "Peru",
+            state: nil,
+            city: "Lima",
+            zip_code: "15074",
+            individual_tax_id:,
+          )
+        end
+      end
+
+      it "rejects a bare 8-digit DNI submitted without the verification digit" do
+        user = create_peru_individual_user(individual_tax_id: "12345678-9")
+
+        params = ActionController::Parameters.new(
+          is_business: false,
+          individual_tax_id: "12349316",
+        )
+
+        expect(StripeMerchantAccountManager).not_to receive(:handle_new_user_compliance_info)
+
+        result = described_class.new(compliance_params: params, user:).process
+
+        expect(result[:success]).to be false
+        expect(result[:error_message]).to eq("Your Peru DNI must include the verification digit (for example, 12345678-9).")
+      end
+
+      it "rejects a DNI longer than 9 digits" do
+        user = create_peru_individual_user(individual_tax_id: "12345678-9")
+
+        params = ActionController::Parameters.new(
+          is_business: false,
+          individual_tax_id: "1234567890",
+        )
+
+        expect(StripeMerchantAccountManager).not_to receive(:handle_new_user_compliance_info)
+
+        result = described_class.new(compliance_params: params, user:).process
+
+        expect(result[:success]).to be false
+        expect(result[:error_message]).to eq("Your Peru DNI must include the verification digit (for example, 12345678-9).")
+      end
+
+      it "accepts the DNI with its verification digit and a dash" do
+        user = create_peru_individual_user(individual_tax_id: "00000000-0")
+
+        params = ActionController::Parameters.new(
+          is_business: false,
+          individual_tax_id: "12345678-9",
+        )
+
+        expect(StripeMerchantAccountManager).to receive(:handle_new_user_compliance_info)
+
+        result = described_class.new(compliance_params: params, user:).process
+
+        expect(result[:success]).to be true
+        stored = user.reload.alive_user_compliance_info.individual_tax_id.decrypt(GlobalConfig.get("STRONGBOX_GENERAL_PASSWORD"))
+        expect(stored).to eq("12345678-9")
+      end
+
+      it "accepts the DNI with its verification digit and no dash" do
+        user = create_peru_individual_user(individual_tax_id: "00000000-0")
+
+        params = ActionController::Parameters.new(
+          is_business: false,
+          individual_tax_id: "123456789",
+        )
+
+        expect(StripeMerchantAccountManager).to receive(:handle_new_user_compliance_info)
+
+        result = described_class.new(compliance_params: params, user:).process
+
+        expect(result[:success]).to be true
+      end
+    end
+
     context "with a non-US business" do
       def create_ie_business_user(business_tax_id:)
         create(:user).tap do |u|

--- a/spec/services/update_user_compliance_info_spec.rb
+++ b/spec/services/update_user_compliance_info_spec.rb
@@ -258,6 +258,55 @@ describe UpdateUserComplianceInfo do
 
         expect(result[:success]).to be true
       end
+
+      it "rejects a representative's bare 8-digit DNI for a Peru business" do
+        user = create(:user).tap do |u|
+          create(
+            :user_compliance_info_business,
+            user: u,
+            country: "Peru",
+            business_country: "Peru",
+            business_type: UserComplianceInfo::BusinessTypes::CORPORATION,
+            individual_tax_id: "12345678-9",
+          )
+        end
+
+        params = ActionController::Parameters.new(
+          is_business: true,
+          individual_tax_id: "12349316",
+        )
+
+        expect(StripeMerchantAccountManager).not_to receive(:handle_new_user_compliance_info)
+
+        result = described_class.new(compliance_params: params, user:).process
+
+        expect(result[:success]).to be false
+        expect(result[:error_message]).to eq("Your Peru DNI must include the verification digit (for example, 12345678-9).")
+      end
+
+      it "accepts a representative's 9-digit DNI for a Peru business" do
+        user = create(:user).tap do |u|
+          create(
+            :user_compliance_info_business,
+            user: u,
+            country: "Peru",
+            business_country: "Peru",
+            business_type: UserComplianceInfo::BusinessTypes::CORPORATION,
+            individual_tax_id: "00000000-0",
+          )
+        end
+
+        params = ActionController::Parameters.new(
+          is_business: true,
+          individual_tax_id: "12345678-9",
+        )
+
+        expect(StripeMerchantAccountManager).to receive(:handle_new_user_compliance_info)
+
+        result = described_class.new(compliance_params: params, user:).process
+
+        expect(result[:success]).to be true
+      end
     end
 
     context "with a non-US business" do

--- a/spec/services/update_user_compliance_info_spec.rb
+++ b/spec/services/update_user_compliance_info_spec.rb
@@ -192,6 +192,7 @@ describe UpdateUserComplianceInfo do
 
       it "rejects a bare 8-digit DNI submitted without the verification digit" do
         user = create_peru_individual_user(individual_tax_id: "12345678-9")
+        original = user.alive_user_compliance_info
 
         params = ActionController::Parameters.new(
           is_business: false,
@@ -200,10 +201,14 @@ describe UpdateUserComplianceInfo do
 
         expect(StripeMerchantAccountManager).not_to receive(:handle_new_user_compliance_info)
 
-        result = described_class.new(compliance_params: params, user:).process
+        result = nil
+        expect do
+          result = described_class.new(compliance_params: params, user:).process
+        end.not_to change { UserComplianceInfo.count }
 
         expect(result[:success]).to be false
         expect(result[:error_message]).to eq("Your Peru DNI must include the verification digit (for example, 12345678-9).")
+        expect(user.reload.alive_user_compliance_info.id).to eq(original.id)
       end
 
       it "rejects a DNI longer than 9 digits" do


### PR DESCRIPTION
## What

Peru sellers who enter only the bare 8-digit DNI can never complete payout setup. Stripe's Peru `pe_dni` `individual.id_number` expects the 8-digit DNI **plus its 1-digit verification digit** (commonly written `12345678-9`). An 8-digit value is rejected at Connect account creation with *"That identification number does not appear to be valid."*

This PR enforces the verification digit:

- **Server-side (authoritative):** `UpdateUserComplianceInfo` now rejects a Peru individual tax ID that isn't exactly 9 digits (after stripping a separator), mirroring the existing US-EIN length check, with a clear message.
- **Client-side:** the payouts form surfaces an inline error instead of silently submitting an invalid value.

## Why

The payouts form already prompts for the full `12345678-9` format (placeholder + `minLength={10}`), but that minimum was only an HTML hint — the form's own validation (`pages/Settings/Payments/Show.tsx`) checked **presence only**, so a bare 8-digit DNI passed straight through, and there was no server-side guard either. Every such submission then failed synchronously at `Stripe::Account.create`, leaving the seller stuck with no actionable feedback.

Business logic belongs on the server, so the digit-count check is enforced in `UpdateUserComplianceInfo`; the client check is just for fast, friendly feedback. Scoped to Peru so other countries' working formats are untouched. The dash is accepted (Stripe tolerates it) — the value just has to contain the 9 DNI digits.

Why this wasn't caught before: the spec/VCR fixtures use Stripe **test mode**, which accepts the dummy `00000000-0`, masking the live-mode rejection.

Resolves antiwork/gumroad-private#605


---

🤖 AI disclosure: implemented with Claude Opus 4.8

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784733314&installation_id=134400930&pr_number=5543&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5543&signature=7bcf4b058e9f8e49e76a8403173256a2bc65c1c6bac6dc29d678136cf4c72e69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Peru-only tax ID length checks on compliance save; no auth or payout logic changes beyond blocking invalid IDs before Stripe.
> 
> **Overview**
> Peru sellers can no longer save an **8-digit DNI** without the check digit; both the payouts form and **`UpdateUserComplianceInfo`** now require **exactly 9 digits** after stripping separators (e.g. `12345678-9`), with a clear error message.
> 
> **Server:** validation runs before persisting compliance info and calling Stripe, for individuals and Peru businesses (representative DNI), using the effective legal-entity country.
> 
> **Client:** the payments settings form blocks submit with the same rule for `individual_tax_id` when country/business country is `PE`.
> 
> Specs cover reject/accept cases for individuals and Peru businesses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e20d4b83e046a9477a3479880ade2507588e5895. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->