### PR TITLE
Fix checkout recommended-products reload storm crashing mobile Safari

### DIFF
--- a/app/javascript/pages/Checkout/Show.tsx
+++ b/app/javascript/pages/Checkout/Show.tsx
@@ -240,18 +240,19 @@ const CheckoutIndexPage = () => {
   const [redirecting, setRedirecting] = React.useState(false);
   const addThirdPartyAnalytics = useAddThirdPartyAnalytics();
   const isMobile = !useIsAboveBreakpoint("sm");
-  const cartProductIds = cartForm.data.cart.items.map(({ product }) => product.id).join(",");
+  const cartProductIdsKey = cartForm.data.cart.items.map(({ product }) => product.id).join(",");
+  const cartProductIds = React.useMemo(() => cartProductIdsKey.split(",").filter(Boolean), [cartProductIdsKey]);
   React.useEffect(() => {
-    if (state.status.type !== "input" || !cartProductIds.length) return;
+    if (state.status.type !== "input" || cartProductIds.length === 0) return;
     router.reload({
       data: {
-        cart_product_ids: cartForm.data.cart.items.map(({ product }) => product.id),
+        cart_product_ids: cartProductIds,
         limit: isMobile ? 2 : 6,
       },
       preserveUrl: true,
       only: ["recommended_products"],
     });
-  }, [state.status.type, isMobile, cartForm.data.cart.items]);
+  }, [state.status.type, isMobile, cartProductIds]);
 
   const completedOfferIds = React.useRef(new Set()).current;
   const [offers, setOffers] = React.useState<

--- a/app/javascript/pages/Checkout/Show.tsx
+++ b/app/javascript/pages/Checkout/Show.tsx
@@ -241,18 +241,17 @@ const CheckoutIndexPage = () => {
   const addThirdPartyAnalytics = useAddThirdPartyAnalytics();
   const isMobile = !useIsAboveBreakpoint("sm");
   const cartProductIdsKey = cartForm.data.cart.items.map(({ product }) => product.id).join(",");
-  const cartProductIds = React.useMemo(() => cartProductIdsKey.split(",").filter(Boolean), [cartProductIdsKey]);
   React.useEffect(() => {
-    if (state.status.type !== "input" || cartProductIds.length === 0) return;
+    if (state.status.type !== "input" || cartProductIdsKey === "") return;
     router.reload({
       data: {
-        cart_product_ids: cartProductIds,
+        cart_product_ids: cartProductIdsKey.split(","),
         limit: isMobile ? 2 : 6,
       },
       preserveUrl: true,
       only: ["recommended_products"],
     });
-  }, [state.status.type, isMobile, cartProductIds]);
+  }, [state.status.type, isMobile, cartProductIdsKey]);
 
   const completedOfferIds = React.useRef(new Set()).current;
   const [offers, setOffers] = React.useState<


### PR DESCRIPTION
## What

The checkout page (`Checkout/Show.tsx`) refetches recommended products through an Inertia partial reload (`router.reload({ only: ["recommended_products"] })`). The effect that triggers it was keyed on `cartForm.data.cart.items` — the cart items **array reference** — instead of the stable `cartProductIds` string that was already computed one line above for exactly this purpose.

Inertia's `useForm.setData` deep-clones the entire form data on every call (`lodash.set(cloneDeep(data), …)`). The checkout writes `cart.email` through `setData` on **every keystroke** in the email field, so each keystroke mints a brand-new `cart.items` array reference even though no item changed — re-firing the effect.

This change keys the effect on a memoized id string, so the reload fires only when the set of products in the cart actually changes (add/remove), not on every keystroke.

## Why

The recommendations endpoint is expensive — a recommendation-service call with a 10-second server timeout that returns product-card payloads. Firing it once per keystroke produces a storm of in-flight partial reloads, re-renders of the product-card grid, and `history.replaceState` serializations of the full page props.

On desktop this is wasteful but survivable. On memory-constrained mobile WebKit (iOS Safari, and especially in-app browsers such as the Instagram/Meta-ads webview), the accumulated pressure exhausts the renderer and the tab is killed — surfacing as Safari's "A problem repeatedly occurred."

This matches the reported symptoms: mobile / in-app only, crash a few seconds after interacting with the form, reproduces with and without the gift flow and on a 100%-off purchase (so it's the render path, not payment/3DS), and persists with third-party analytics disabled (it's our own reload effect, not a tracker). The "14× begin_checkout per session" observed in GA4 is a symptom, not the cause: `begin_checkout` fires once per mount, and a GA4 session survives the repeated crash-reloads.

Why this approach: the minimal, lowest-risk fix is to restore the originally-intended dependency. `cartProductIds` is now a `useMemo` whose identity changes only when the joined product-id string changes, which keeps the effect `react-hooks/exhaustive-deps`-clean without disabling the rule. Reworking the broader per-keystroke `setData` deep-clone was deliberately left out to keep this a targeted hotfix.

Closes antiwork/gumroad-private#625

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784735536&installation_id=134400930&pr_number=5544&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5544&signature=a23a9dda6a347d564de6365493add750bbecd30fdabf925a979450b8a78ff501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single localized dependency fix in checkout UI with no auth, payment, or data-model changes.
> 
> **Overview**
> Stops checkout from hammering the expensive `recommended_products` partial Inertia reload on every form update (notably each email keystroke).
> 
> The effect that calls `router.reload({ only: ["recommended_products"] })` now depends on a **joined product-id string** (`cartProductIdsKey`) instead of `cartForm.data.cart.items`. Inertia `setData` deep-clones cart data, so unrelated edits like `cart.email` were producing a new `items` array reference and retriggering the effect even when line items were unchanged. The reload payload uses `cartProductIdsKey.split(",")`, and the early exit treats an empty key as “no products” instead of checking string length on the old variable name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5205f9fd9fac3303902f92ae01850ee29600df3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->