### PR TITLE
Make preview apps opt-in via a `preview` label and report the URL to GitHub

### DIFF
--- a/.buildkite/preview.yml
+++ b/.buildkite/preview.yml
@@ -1,6 +1,6 @@
 steps:
   - label: ":docker: Build Base Image"
-    key: build-base-image
+    key: preview-build-base-image
     command: ".buildkite/scripts/build_base.sh"
     timeout_in_minutes: 60
     plugins:
@@ -9,9 +9,9 @@ steps:
           password-env: DOCKERHUB_PASSWORD
 
   - label: ":docker: Build Web Image"
-    key: build-web-image
+    key: preview-build-web-image
     command: ".buildkite/scripts/build_web.sh"
-    depends_on: build-base-image
+    depends_on: preview-build-base-image
     timeout_in_minutes: 25
     plugins:
       - docker-login#v3.0.0:
@@ -19,8 +19,8 @@ steps:
           password-env: DOCKERHUB_PASSWORD
 
   - label: ":gear: Compile Assets"
-    key: compile-assets
-    depends_on: build-web-image
+    key: preview-compile-assets
+    depends_on: preview-build-web-image
     command: ".buildkite/scripts/compile_assets.sh"
     artifact_paths: "log/**/*"
     parallelism: 2
@@ -36,7 +36,7 @@ steps:
 
   - label: ":rocket: Deploy Preview App"
     key: build-and-deploy-preview
-    depends_on: compile-assets
+    depends_on: preview-compile-assets
     command: ".buildkite/scripts/deploy_branch.sh"
     timeout_in_minutes: 45
     plugins:

--- a/.buildkite/preview.yml
+++ b/.buildkite/preview.yml
@@ -1,12 +1,6 @@
 steps:
-  - label: ":mag: Preview gate"
-    key: preview-gate
-    branches: "!main !comp-assets-*"
-    command: ".buildkite/scripts/preview_gate.sh"
-
   - label: ":docker: Build Base Image"
     key: build-base-image
-    branches: "main comp-assets-*"
     command: ".buildkite/scripts/build_base.sh"
     timeout_in_minutes: 60
     plugins:
@@ -16,7 +10,6 @@ steps:
 
   - label: ":docker: Build Web Image"
     key: build-web-image
-    branches: "main comp-assets-*"
     command: ".buildkite/scripts/build_web.sh"
     depends_on: build-base-image
     timeout_in_minutes: 25
@@ -27,7 +20,6 @@ steps:
 
   - label: ":gear: Compile Assets"
     key: compile-assets
-    branches: "main comp-assets-*"
     depends_on: build-web-image
     command: ".buildkite/scripts/compile_assets.sh"
     artifact_paths: "log/**/*"
@@ -42,20 +34,11 @@ steps:
           username: gumroad
           password-env: QUAY_PASSWORD
 
-  - block: "Approval required for production deployment"
-    key: require-approval
-    branches: "main"
-    prompt: "Are you sure you want to proceed with the deployment?"
-    blocked_state: running
-
-  - label: ":rocket: Deploy to Production"
-    key: production-deployment
-    depends_on:
-      - compile-assets
-      - require-approval
-    branches: "main"
-    command: ".buildkite/scripts/deploy_production.sh"
-    timeout_in_minutes: 120
+  - label: ":rocket: Deploy Preview App"
+    key: build-and-deploy-preview
+    depends_on: compile-assets
+    command: ".buildkite/scripts/deploy_branch.sh"
+    timeout_in_minutes: 45
     plugins:
       - docker-login#v3.0.0:
           username: "gumroadteam"

--- a/.buildkite/scripts/deploy_branch.sh
+++ b/.buildkite/scripts/deploy_branch.sh
@@ -11,6 +11,16 @@ logger() {
 AWS_BRANCH_APP_NGINX_REPO=${ECR_REGISTRY}/gumroad/branch_app_nginx
 REVISION=${BUILDKITE_COMMIT}
 
+# Surface the preview app on the PR via GitHub's Deployments API ("View deployment")
+source nomad/staging/deploy_branch/deploy_branch_common.sh
+source .buildkite/scripts/github_deployment.sh
+
+APP_NAME=$(get_app_name "$BUILDKITE_BRANCH")
+PREVIEW_URL="https://${APP_NAME}.apps.staging.gumroad.org"
+DEPLOYMENT_ID=$(create_github_deployment "$BUILDKITE_COMMIT" "preview/${APP_NAME}" || true)
+set_github_deployment_status "$DEPLOYMENT_ID" "in_progress" || true
+trap 'set_github_deployment_status "$DEPLOYMENT_ID" "failure" || true' ERR
+
 function generate_nginx_tag(){
   local paths=()
   local app_dir
@@ -81,3 +91,6 @@ cd nomad/staging/deploy_branch
 BRANCH=$BRANCH \
   DEPLOY_TAG=$DEPLOY_TAG \
   ./deploy.sh
+
+set_github_deployment_status "$DEPLOYMENT_ID" "success" "$PREVIEW_URL" || true
+logger "Preview app available at ${PREVIEW_URL}"

--- a/.buildkite/scripts/deploy_branch.sh
+++ b/.buildkite/scripts/deploy_branch.sh
@@ -11,16 +11,6 @@ logger() {
 AWS_BRANCH_APP_NGINX_REPO=${ECR_REGISTRY}/gumroad/branch_app_nginx
 REVISION=${BUILDKITE_COMMIT}
 
-# Surface the preview app on the PR via GitHub's Deployments API ("View deployment")
-source nomad/staging/deploy_branch/deploy_branch_common.sh
-source .buildkite/scripts/github_deployment.sh
-
-APP_NAME=$(get_app_name "$BUILDKITE_BRANCH")
-PREVIEW_URL="https://${APP_NAME}.apps.staging.gumroad.org"
-DEPLOYMENT_ID=$(create_github_deployment "$BUILDKITE_COMMIT" "preview/${APP_NAME}" || true)
-set_github_deployment_status "$DEPLOYMENT_ID" "in_progress" || true
-trap 'set_github_deployment_status "$DEPLOYMENT_ID" "failure" || true' ERR
-
 function generate_nginx_tag(){
   local paths=()
   local app_dir
@@ -74,6 +64,17 @@ install_nomad
 # Copy secrets from credentials repo
 source .buildkite/scripts/copy_secrets.sh
 copy_secrets
+
+# Surface the preview app on the PR via GitHub's Deployments API ("View deployment").
+# Sourced here because deploy_branch_common.sh is provided by copy_secrets above.
+source nomad/staging/deploy_branch/deploy_branch_common.sh
+source .buildkite/scripts/github_deployment.sh
+
+APP_NAME=$(get_app_name "$BUILDKITE_BRANCH")
+PREVIEW_URL="https://${APP_NAME}.apps.staging.gumroad.org"
+DEPLOYMENT_ID=$(create_github_deployment "$BUILDKITE_COMMIT" "preview/${APP_NAME}" || true)
+set_github_deployment_status "$DEPLOYMENT_ID" "in_progress" || true
+trap 'set_github_deployment_status "$DEPLOYMENT_ID" "failure" || true' ERR
 
 BRANCH=${BUILDKITE_BRANCH}
 DEPLOY_TAG="staging-${WEB_TAG}"

--- a/.buildkite/scripts/ensure_gh.sh
+++ b/.buildkite/scripts/ensure_gh.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Sourced as a library; does not change the caller's shell options.
+
+GH_CLI_VERSION="2.65.0"
+
+ensure_gh() {
+  if command -v gh >/dev/null 2>&1; then
+    return 0
+  fi
+
+  curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_amd64.tar.gz" -o /tmp/gh.tar.gz
+  tar -xzf /tmp/gh.tar.gz -C /tmp
+  sudo mv "/tmp/gh_${GH_CLI_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh
+  rm -rf /tmp/gh.tar.gz "/tmp/gh_${GH_CLI_VERSION}_linux_amd64"
+}

--- a/.buildkite/scripts/github_deployment.sh
+++ b/.buildkite/scripts/github_deployment.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Sourced as a library; does not change the caller's shell options.
+
+PREVIEW_GITHUB_REPO="${PREVIEW_GITHUB_REPO:-antiwork/gumroad}"
+
+source .buildkite/scripts/ensure_gh.sh
+
+create_github_deployment() {
+  local ref="$1"
+  local environment="$2"
+
+  export GH_TOKEN="${GITHUB_TOKEN:-}"
+  [ -z "$GH_TOKEN" ] && return 0
+  ensure_gh
+
+  gh api --method POST "repos/${PREVIEW_GITHUB_REPO}/deployments" --input - <<JSON | jq -r '.id // empty'
+{
+  "ref": "${ref}",
+  "environment": "${environment}",
+  "description": "Preview app",
+  "auto_merge": false,
+  "transient_environment": true,
+  "production_environment": false,
+  "required_contexts": []
+}
+JSON
+}
+
+set_github_deployment_status() {
+  local deployment_id="$1"
+  local state="$2"
+  local environment_url="${3:-}"
+
+  [ -z "$deployment_id" ] && return 0
+  export GH_TOKEN="${GITHUB_TOKEN:-}"
+  [ -z "$GH_TOKEN" ] && return 0
+  ensure_gh
+
+  local args=(--method POST "repos/${PREVIEW_GITHUB_REPO}/deployments/${deployment_id}/statuses"
+    -f "state=${state}"
+    -f "log_url=${BUILDKITE_BUILD_URL:-}")
+  if [ -n "$environment_url" ]; then
+    args+=(-f "environment_url=${environment_url}")
+  fi
+
+  gh api "${args[@]}" >/dev/null
+}

--- a/.buildkite/scripts/preview_gate.sh
+++ b/.buildkite/scripts/preview_gate.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -euo pipefail
+
+GREEN="\033[0;32m"
+NC="\033[0m"
+logger() {
+  echo -e "${GREEN}$(date "+%Y/%m/%d %H:%M:%S") preview_gate.sh: $1${NC}"
+}
+
+PREVIEW_LABEL="preview"
+PREVIEW_GITHUB_REPO="${PREVIEW_GITHUB_REPO:-antiwork/gumroad}"
+
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+  logger "Error: GITHUB_TOKEN is not set"
+  exit 1
+fi
+export GH_TOKEN="$GITHUB_TOKEN"
+
+source .buildkite/scripts/ensure_gh.sh
+ensure_gh
+
+pr_number="${BUILDKITE_PULL_REQUEST:-false}"
+if [ "$pr_number" = "false" ] || [ -z "$pr_number" ]; then
+  pr_number=$(gh pr list --repo "$PREVIEW_GITHUB_REPO" --head "$BUILDKITE_BRANCH" --state open --json number --jq '.[0].number // empty')
+fi
+
+if [ -z "$pr_number" ]; then
+  logger "No open PR for ${BUILDKITE_BRANCH}; skipping preview app"
+  buildkite-agent annotate "No open PR for \`${BUILDKITE_BRANCH}\`. Open a PR and add the \`${PREVIEW_LABEL}\` label to deploy a preview app." --style "info" --context "preview" || true
+  exit 0
+fi
+
+has_label=$(gh pr view "$pr_number" --repo "$PREVIEW_GITHUB_REPO" --json labels --jq "any(.labels[]; .name == \"${PREVIEW_LABEL}\")")
+if [ "$has_label" != "true" ]; then
+  logger "PR #${pr_number} is not labeled '${PREVIEW_LABEL}'; skipping preview app"
+  buildkite-agent annotate "Add the \`${PREVIEW_LABEL}\` label to PR #${pr_number} to deploy a preview app." --style "info" --context "preview" || true
+  exit 0
+fi
+
+logger "PR #${pr_number} is labeled '${PREVIEW_LABEL}'; provisioning preview app"
+buildkite-agent pipeline upload .buildkite/preview.yml

--- a/.github/workflows/preview-app.yml
+++ b/.github/workflows/preview-app.yml
@@ -1,0 +1,37 @@
+name: Preview app
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  deploy:
+    if: github.event.label.name == 'preview'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger preview app build on Buildkite
+        env:
+          BUILDKITE_API_TOKEN: ${{ secrets.BUILDKITE_API_TOKEN }}
+          BUILDKITE_ORG: ${{ vars.BUILDKITE_ORG }}
+          BUILDKITE_PIPELINE: ${{ vars.BUILDKITE_PIPELINE }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [ -z "$BUILDKITE_API_TOKEN" ] || [ -z "$BUILDKITE_ORG" ] || [ -z "$BUILDKITE_PIPELINE" ]; then
+            echo "Buildkite credentials are not configured; skipping. A push to the branch will still deploy the preview app."
+            exit 0
+          fi
+
+          curl -fsSL -X POST \
+            "https://api.buildkite.com/v2/organizations/${BUILDKITE_ORG}/pipelines/${BUILDKITE_PIPELINE}/builds" \
+            -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d @- <<JSON
+          {
+            "commit": "${HEAD_SHA}",
+            "branch": "${HEAD_REF}",
+            "message": "Preview app for #${PR_NUMBER}",
+            "ignore_pipeline_branch_filters": true
+          }
+          JSON


### PR DESCRIPTION
## What

Two changes to the preview-app (branch-app) deploy flow:

1. **Opt-in via a `preview` label instead of a manual Buildkite approval.** Today every push to a non-`main` branch starts the pipeline with a manual `block` step ("Provision and deploy a preview app for this branch?") that someone has to unblock — on every push. This replaces that block with a `preview-gate` step that reads the PR's labels and only deploys when the PR has the `preview` label. Once labeled, every push auto-deploys; unlabeled branches run only the cheap gate and stop (no expensive build).

2. **Report the preview URL to GitHub's native "View deployment".** The deploy now creates a GitHub Deployment for the PR commit and posts `in_progress` → `success` (with `environment_url`) / `failure` statuses, so the PR shows the **View deployment** button and a Deployments entry. Previously the URL was only posted to Slack.

### Changes

- `.buildkite/pipeline.yml` — replaced the `require-preview-approval` block with a `preview-gate` command step (`branches: "!main !comp-assets-*"`). Scoped the shared build chain (Build Base / Web / Compile Assets) to `branches: "main comp-assets-*"` so production deploys and `comp-assets-*` asset warming are unchanged.
- `.buildkite/preview.yml` (new) — the build + deploy chain, uploaded by the gate only when the `preview` label is present.
- `.buildkite/scripts/preview_gate.sh` (new) — resolves the PR (from `BUILDKITE_PULL_REQUEST`, falling back to `gh pr list --head`), checks for the `preview` label, and `buildkite-agent pipeline upload`s `preview.yml` when present.
- `.buildkite/scripts/github_deployment.sh` (new) — helpers to create a deployment and post statuses via `gh api`. Transient environment, `required_contexts: []`, best-effort (never fails the deploy).
- `.buildkite/scripts/ensure_gh.sh` (new) — installs the GitHub CLI on the agent if missing (extracted from the pattern in `create_github_release.sh`).
- `.buildkite/scripts/deploy_branch.sh` — creates the deployment + posts `in_progress` before deploying, `success` with the URL after, and `failure` via an `ERR` trap.
- `.github/workflows/preview-app.yml` (new) — triggers a Buildkite build when the `preview` label is added, so enabling a preview takes effect immediately rather than on the next push.

## Why

The manual block was the only thing standing between a push and a preview deploy, so it had to be clicked on every push and gave no way to mark a PR as "always deploy previews." A label is a GitHub-native, toggleable opt-in that CI can read directly. Gating the *build* (via dynamic pipeline upload) rather than just the deploy means unlabeled branches don't pay for a ~45-min build they don't want — preserving the cost savings the manual block used to provide.

The build chain is shared by three branch classes (`main` → production, `comp-assets-*` → production asset warming, feature branches → previews). Keeping `main`/`comp-assets-*` on a static chain and giving previews their own uploaded chain keeps the production path byte-for-byte equivalent while letting the preview path be label-gated.

GitHub Deployments are the standard way to attach an environment URL to a PR; using them gives reviewers the "View deployment" button for free and lets GitHub deactivate transient environments when the branch is deleted.

## Configuration required before this works

- The `preview-gate` and `deploy_branch.sh` steps need `GITHUB_TOKEN` available (the same PAT already used by `create_github_release.sh`), with `deployments: write` on the repo. `PREVIEW_GITHUB_REPO` defaults to `antiwork/gumroad` and can be overridden if Buildkite builds a different mirror.
- The label-trigger workflow needs `secrets.BUILDKITE_API_TOKEN` and `vars.BUILDKITE_ORG` / `vars.BUILDKITE_PIPELINE`. If unset, the workflow no-ops cleanly — a push to the branch still deploys.

## Out of scope / follow-up

- **Teardown.** Nomad teardown (`delete_app.sh`) is still manual, same as today; wiring it to the `unlabeled`/`closed` events is a natural follow-up. Transient deployments are already deactivated by GitHub on branch deletion.

## Before/After

Non-user-facing CI change — no UI. I was not able to record a Buildkite walkthrough video from this environment; happy to add one. Behavior to verify on a labeled PR: the manual approval no longer appears, the build runs straight through, and the PR shows a "View deployment" link to `{name}.apps.staging.gumroad.org`.

## Test Results

No Ruby/JS/specs are affected (CI config + shell only). Validated locally:
- `bash -n` on all new/changed shell scripts — pass.
- YAML parse of `pipeline.yml`, `preview.yml`, and the workflow — pass.
- Heredoc deployment payload parses as valid JSON.
- Confirmed the `main` and `comp-assets-*` step graph is unchanged after the restructure.

---

AI disclosure: drafted with Claude Opus 4.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5545"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784742874&installation_id=134400930&pr_number=5545&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5545&signature=a47cdf7ac4b4fc2f9b2d5d75761990a2ed0bcec46f25b9fcc4c32dee7b24a6cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Restructures CI branch routing and preview deploy triggers; production path is intentionally isolated but misconfiguration of tokens or branch filters could affect when previews or main builds run.
> 
> **Overview**
> Replaces the per-push Buildkite **manual approval** for preview deploys with a **`preview` label** gate. Non-`main` / non-`comp-assets-*` branches run only `preview_gate.sh`, which uploads `.buildkite/preview.yml` (build + deploy) when the open PR has the label; otherwise the pipeline stops after a cheap gate with an annotate hint.
> 
> The **main / `comp-assets-*` build chain** stays in `pipeline.yml` only (preview deploy was removed from that file), so production and asset-warming behavior is unchanged.
> 
> **`deploy_branch.sh`** now creates a transient GitHub Deployment and posts `in_progress` → `success` (with staging URL) or `failure`, enabling PR **View deployment**. New helpers: `github_deployment.sh`, `ensure_gh.sh`.
> 
> A **GitHub Actions** workflow on `pull_request` `labeled` (`preview`) can trigger a Buildkite build immediately via API when Buildkite secrets/vars are set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4487f74a89c67556e69466cfd88bbd9523ffce5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->