### PR TITLE
Strip invisible separator characters from pasted bank account numbers

### DIFF
--- a/app/services/update_payout_method.rb
+++ b/app/services/update_payout_method.rb
@@ -193,9 +193,11 @@ class UpdatePayoutMethod
 
     MAX_ENCRYPTED_FIELD_LENGTH = 200
 
+    ACCOUNT_NUMBER_SEPARATOR_CHARACTERS = /[[:space:]\p{Cf}-]/
+
     def process_full_bank_account_replacement
-      account_number = params[:bank_account][:account_number].delete("-").strip
-      account_number_confirmation = params[:bank_account][:account_number_confirmation].to_s.delete("-").strip
+      account_number = normalize_account_number(params[:bank_account][:account_number])
+      account_number_confirmation = normalize_account_number(params[:bank_account][:account_number_confirmation])
       return { error: :account_number_does_not_match } if account_number != account_number_confirmation
       return { error: :bank_account_error, data: "Account number is too long" } if account_number.length > MAX_ENCRYPTED_FIELD_LENGTH
 
@@ -282,6 +284,10 @@ class UpdatePayoutMethod
       bank_account_type = params[:bank_account][:type]
       permitted_params = BANK_ACCOUNT_TYPES[bank_account_type][:permitted_params]
       params[:bank_account].permit(*permitted_params)
+    end
+
+    def normalize_account_number(value)
+      value.to_s.gsub(ACCOUNT_NUMBER_SEPARATOR_CHARACTERS, "")
     end
 
     def paypal_payouts_supported?

--- a/spec/services/update_payout_method_spec.rb
+++ b/spec/services/update_payout_method_spec.rb
@@ -192,6 +192,37 @@ describe UpdatePayoutMethod do
       end
     end
 
+    describe "when the IBAN is pasted with invisible separator characters" do
+      let(:user) { create(:named_user) }
+
+      before { allow(Rails.env).to receive(:production?).and_return(true) }
+
+      it "strips non-breaking and zero-width characters so a valid IBAN is accepted and stored clean" do
+        clean_iban = "BH29BMAG1299123456BH00"
+        non_breaking_space = [0x00A0].pack("U")
+        zero_width_space = [0x200B].pack("U")
+        pasted_iban = "BH29#{non_breaking_space}BMAG#{zero_width_space}1299123456BH00"
+
+        params = ActionController::Parameters.new(
+          bank_account: {
+            type: BahrainBankAccount.name,
+            account_holder_full_name: "Named User",
+            bank_code: "AAAABHBMXYZ",
+            account_number: pasted_iban,
+            account_number_confirmation: pasted_iban,
+          }
+        )
+
+        result = described_class.new(user_params: params, seller: user).process
+
+        expect(result).to eq(success: true)
+        bank_account = user.reload.active_bank_account
+        expect(bank_account).to be_a(BahrainBankAccount)
+        expect(bank_account.send(:account_number_decrypted)).to eq(clean_iban)
+        expect(bank_account.account_number_last_four).to eq("BH00")
+      end
+    end
+
     describe "switching to card payouts" do
       let(:user) { create(:named_user) }
       let!(:existing_bank_account) { create(:ach_account, user:) }


### PR DESCRIPTION
Closes https://github.com/antiwork/gumroad-private/issues/536

## What

Fixes a payout setup failure where a seller with a **structurally valid IBAN** (correct country code, check digits, length, and characters) could not save their bank account: every attempt was rejected with "The account number is invalid." and no `bank_accounts` row was ever persisted.

`UpdatePayoutMethod` now normalizes the submitted account number (and its confirmation) by removing all Unicode whitespace and zero-width/format characters, in addition to the dash removal it already did — before validation and before the value is stored.

Fixes an internal issue (details tracked privately).

## Why

The model validation, the form, and Stripe all accept the clean IBAN (verified against Ibandit 1.26.1 and the existing Bahrain `StripeMerchantAccountManager` cassette). So the rejection only reproduced when the **submitted bytes differed from the visible value**.

`process_full_bank_account_replacement` cleaned the input with `account_number.delete("-").strip`. The problem:

- Ruby's `String#strip` removes **only ASCII** whitespace, and only at the ends.
- Ibandit's own normalization only strips ASCII `\s`.

So non-breaking space (U+00A0), narrow no-break space (U+202F), zero-width space (U+200B), BOM (U+FEFF) and similar characters **survive both layers**. These are exactly what gets injected when a seller copies a space-grouped IBAN (`BH29 BMAG 1299 1234 56BH 00`) from a bank's PDF IBAN certificate, a messaging app, or an email. The IBAN looks pixel-perfect, but `Ibandit::IBAN#valid?` returns `false`, so validation fails before the row is created — hence the "valid IBAN rejected, zero rows" signature.

Reproduced against Ibandit 1.26.1 (synthetic IBAN):

```ruby
Ibandit::IBAN.new("BH29 BMAG1299123456BH00").valid?  # => false  (non-breaking space)
Ibandit::IBAN.new("BH29BMAG1299123456BH00").valid?        # => true   (clean)
"BH29 BMAG1299123456BH00".strip == "BH29 BMAG1299123456BH00"  # => true (strip is a no-op here)
```

### Approach

```ruby
ACCOUNT_NUMBER_SEPARATOR_CHARACTERS = /[[:space:]\p{Cf}-]/

def normalize_account_number(value)
  value.to_s.gsub(ACCOUNT_NUMBER_SEPARATOR_CHARACTERS, "")
end
```

`[[:space:]]` covers Unicode whitespace (NBSP, narrow-NBSP, ideographic space); `\p{Cf}` covers zero-width / format characters (ZWSP, ZWJ, BOM). Normalizing before storage (not just before validation) keeps the value Stripe later receives clean too, so it also prevents a silent post-save sync failure. Genuinely invalid numbers (bad checksum, wrong length, missing country prefix) are still rejected. Bank account numbers never legitimately contain whitespace or format characters, so this is safe for every country — not only IBAN ones — and it's the single server-side entry point for bank account creation.

This is the same *class* of report as the Côte d'Ivoire (#5417) and Oman (#5455) "valid IBAN rejected" fixes, but a different layer: input normalization rather than validator coverage.

---

AI disclosure: investigated and written with Claude Code (Claude Opus 4.8).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ec3692fb1fd0cac1f188cdffb257913be8e0ab08. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->