### PR TITLE
Make download email-confirmation copy gift-aware

### DIFF
--- a/app/controllers/url_redirects_controller.rb
+++ b/app/controllers/url_redirects_controller.rb
@@ -184,6 +184,7 @@ class UrlRedirectsController < ApplicationController
         destination: params[:destination].presence || (@url_redirect.rich_content_json.present? ? "download_page" : nil),
         display: params[:display],
         email: params[:email],
+        is_gift: @url_redirect.purchase&.is_gift_receiver_purchase || false,
       },
     )
     props = UrlRedirectPresenter.new(url_redirect: @url_redirect, logged_in_user:).download_page_without_content_props(extra_props)

--- a/app/controllers/url_redirects_controller.rb
+++ b/app/controllers/url_redirects_controller.rb
@@ -184,7 +184,7 @@ class UrlRedirectsController < ApplicationController
         destination: params[:destination].presence || (@url_redirect.rich_content_json.present? ? "download_page" : nil),
         display: params[:display],
         email: params[:email],
-        is_gift: @url_redirect.purchase&.is_gift_receiver_purchase || false,
+        is_gift: @url_redirect.purchase&.is_gift_receiver_purchase? || false,
       },
     )
     props = UrlRedirectPresenter.new(url_redirect: @url_redirect, logged_in_user:).download_page_without_content_props(extra_props)

--- a/app/javascript/pages/UrlRedirects/ConfirmPage.tsx
+++ b/app/javascript/pages/UrlRedirects/ConfirmPage.tsx
@@ -12,6 +12,7 @@ type ConfirmationInfo = {
   destination: string | null;
   display: string | null;
   email: string | null;
+  is_gift: boolean;
 };
 
 type PageProps = LayoutProps & {
@@ -75,8 +76,16 @@ const EmailConfirmation = ({
 
   return (
     <Placeholder>
-      <h2>You've viewed this product a few times already</h2>
-      <p>Once you enter the email address used to purchase this product, you'll be able to access it again.</p>
+      <h2>
+        {confirmation_info.is_gift
+          ? "Confirm your email to access this gift"
+          : "You've viewed this product a few times already"}
+      </h2>
+      <p>
+        {confirmation_info.is_gift
+          ? "Enter the email address this gift was sent to, and you'll be able to access it."
+          : "Once you enter the email address used to purchase this product, you'll be able to access it again."}
+      </p>
       <form
         action={Routes.confirm_redirect_path()}
         method="post"

--- a/app/views/purchases/confirm_receipt_email.html.erb
+++ b/app/views/purchases/confirm_receipt_email.html.erb
@@ -1,7 +1,11 @@
 <main class="grid divide-y divide-border bg-background border border-border rounded mx-auto my-4 h-min max-w-md w-[calc(100%-2rem)]">
   <header class="flex flex-col gap-4 p-4 text-center">
     <h2>Confirm your email address</h2>
-    <p>Please enter the email address used to purchase this product to view your receipt.</p>
+    <% if @purchase.is_gift_receiver_purchase? %>
+      <p>Please enter the email address this gift was sent to in order to view your receipt.</p>
+    <% else %>
+      <p>Please enter the email address used to purchase this product to view your receipt.</p>
+    <% end %>
   </header>
   <%= form_tag(receipt_purchase_path(@purchase.external_id), method: "get", class: "flex flex-col gap-4 p-4") do %>
     <%= label_tag :email, "Email address:", class: "form-label" %>

--- a/spec/controllers/purchases_controller_spec.rb
+++ b/spec/controllers/purchases_controller_spec.rb
@@ -1579,6 +1579,17 @@ describe PurchasesController, :vcr do
         expect(assigns(:purchase)).to eq(purchase)
         expect(controller.send(:page_title)).to eq("Confirm Email")
         expect(assigns(:hide_layouts)).to be(true)
+        expect(response.body).to include("the email address used to purchase this product")
+      end
+
+      context "when the purchase is a gift receiver purchase" do
+        let(:purchase) { create(:purchase, is_gift_receiver_purchase: true) }
+
+        it "asks for the email the gift was sent to" do
+          get :confirm_receipt_email, params: { id: purchase.external_id }
+          expect(response.body).to include("the email address this gift was sent to")
+          expect(response.body).not_to include("the email address used to purchase this product")
+        end
       end
     end
 

--- a/spec/controllers/url_redirects_controller_spec.rb
+++ b/spec/controllers/url_redirects_controller_spec.rb
@@ -1543,12 +1543,24 @@ describe UrlRedirectsController, inertia: true do
                                                         destination: nil,
                                                         display: nil,
                                                         email: nil,
+                                                        is_gift: false,
                                                       })
     end
 
     it "assigns the url_redirect correctly" do
       get :confirm_page, params: { id: @url_redirect.token }
       expect(assigns(:url_redirect)).to eq @url_redirect
+    end
+
+    context "when the url redirect belongs to a gift receiver purchase" do
+      before do
+        @url_redirect.purchase.update!(is_gift_receiver_purchase: true)
+      end
+
+      it "marks the confirmation info as a gift" do
+        get :confirm_page, params: { id: @url_redirect.token }
+        expect(inertia.props[:confirmation_info][:is_gift]).to eq(true)
+      end
     end
 
     context "when params[:destination] is set" do


### PR DESCRIPTION
## What

Gift recipients who hit the email-confirmation gate — both on the content download page (`UrlRedirects/ConfirmPage`) and the receipt page (`confirm_receipt_email`) — were shown copy asking for **"the email address used to purchase this product."**

For a gift, the recipient must enter the email the gift was **sent to** (their own address), not the purchaser's. The "used to purchase" wording points them at the giver's email, which never matches, so they get "Wrong email" and stay locked out of content they legitimately own.

This PR makes the copy gift-aware. For gift-receiver purchases:

- **Content confirm page** — heading and body now ask for the email the gift was sent to.
- **Receipt confirm page** — same gift-aware wording.

Non-gift copy is unchanged. The gift flag is threaded from the backend: `confirmation_info.is_gift` (from `purchase.is_gift_receiver_purchase`) for the React page, and `@purchase.is_gift_receiver_purchase?` directly in the ERB.

## Why

The email-confirmation gate assumes the viewer is the purchaser. For gifts that assumption breaks down:

- The recipient's IP never matches `purchase.ip_address` (the bypass in `check_permissions` that normally avoids the gate), and
- The recipient usually has no account, so the logged-in bypass never fires either.

So **every** gift recipient who revisits their link lands on this gate, and the wording sends them to the wrong email. Entering their own email already works — the gift-receiver purchase's `email` is the recipient's address — so only the copy was wrong.

This is a copy-only change. The matching logic and security of the gate are untouched.


Closes antiwork/gumroad-private#632

---

🤖 AI disclosure: Implemented with Claude Opus 4.8 (1M context).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784745997&installation_id=134400930&pr_number=5547&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5547&signature=7b75dc7ee2aa7f996416cd11916e466d32973bb07a65767d06e4be9871e2be25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and prop wiring only; no changes to email verification or access-control logic.
> 
> **Overview**
> Gift recipients hitting the **email confirmation gate** were told to enter **the email used to purchase the product**, which points at the giver’s address and causes repeated “Wrong email” failures even when they enter their own (correct) address.
> 
> This PR threads **`is_gift`** from `purchase.is_gift_receiver_purchase?` into the download **Confirm** Inertia page (`confirmation_info.is_gift`) and switches heading/body copy to ask for **the email the gift was sent to**. The **receipt** confirm ERB page gets the same conditional wording via `@purchase.is_gift_receiver_purchase?`.
> 
> Non-gift purchases keep the existing copy. **Email matching and gate logic are unchanged**; controller specs cover both paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5f5f2176605c38bccd121e4eea779b3c9531684. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->