### PR TITLE
Cache compiled assets to skip the vite build on redeploys

### DIFF
--- a/.buildkite/scripts/compile_assets.sh
+++ b/.buildkite/scripts/compile_assets.sh
@@ -54,23 +54,103 @@ push_image() {
   done
 }
 
+# Compiled frontend output produced by the staging precompile (no sprockets):
+# vite build + manifest, widget bundles, and the pages Tailwind stylesheet.
+ASSET_OUTPUT_PATHS="public/vite public/js public/pages-tailwind.css"
+
+get_app_name() {
+  echo "$1" | tr -d '\n' | tr -c '[:alnum:]' '-' | tr '[:upper:]' '[:lower:]' | sed "s/^deploy-//" | cut -c1-32 | sed 's/[^[:alnum:]]$//'
+}
+
+# Most recent commit touching anything that affects the compiled assets. Stable
+# across commits that leave the frontend untouched, so the cache can be reused.
+asset_content_tag() {
+  git rev-list --abbrev-commit --abbrev=12 -1 HEAD -- \
+    app/javascript package.json package-lock.json \
+    vite.config.ts vite.config.widget.ts config/vite.json \
+    scripts/build_pages_tailwind.mjs tsconfig.json 2>/dev/null
+}
+
+# Store the freshly compiled assets as a slim cache image for next time.
+save_staging_asset_cache() {
+  local cache_image=$1 tmp cid path ok=1
+  tmp=$(mktemp -d) || return 1
+  cid=$(docker create "$WEB_REPO:staging-$WEB_TAG") || { rm -rf "$tmp"; return 1; }
+  mkdir -p "$tmp/cache/public"
+  for path in $ASSET_OUTPUT_PATHS; do
+    docker cp "$cid:/app/$path" "$tmp/cache/$path" 2>/dev/null || true
+  done
+  docker rm "$cid" >/dev/null 2>&1 || true
+  printf 'FROM busybox\nCOPY cache /cache\n' > "$tmp/Dockerfile"
+  if docker build -t "$cache_image" "$tmp" >/dev/null 2>&1; then
+    quietly docker push "$cache_image" && ok=0
+  fi
+  rm -rf "$tmp"
+  return $ok
+}
+
+# Overlay cached compiled assets onto the current code image and commit it as the
+# staging image, skipping the (~7 min) vite build. CUSTOM_DOMAIN is baked into the
+# bundle, so the cache is keyed per branch and reuse here is for the same branch.
+overlay_staging_assets() {
+  local cache_image=$1 tmp ccid wcid ok=1
+  docker pull "$cache_image" >/dev/null 2>&1 || return 1
+  tmp=$(mktemp -d) || return 1
+  ccid=$(docker create "$cache_image") || { rm -rf "$tmp"; return 1; }
+  if docker cp "$ccid:/cache/public" "$tmp/public" 2>/dev/null; then
+    wcid=$(docker create "$WEB_REPO:web-$WEB_TAG") || wcid=""
+    if [[ -n "$wcid" ]] && docker cp "$tmp/public/." "$wcid:/app/public/" 2>/dev/null \
+      && docker commit "$wcid" "$WEB_REPO:staging-$WEB_TAG" >/dev/null 2>&1; then
+      ok=0
+    fi
+    [[ -n "$wcid" ]] && docker rm "$wcid" >/dev/null 2>&1 || true
+  fi
+  docker rm "$ccid" >/dev/null 2>&1 || true
+  rm -rf "$tmp"
+  return $ok
+}
+
 logger "Restore web image if not already loaded"
 if [[ ! $(docker images -q --filter "reference=$WEB_REPO:web-$WEB_TAG") ]]; then
   pull_web_image || exit 1
 fi
 
 if [[ $BUILDKITE_PARALLEL_JOB = 0 && $BUILDKITE_BRANCH != "main" ]]; then
-  logger "Building staging assets"
-  docker rm staging-assets || :
-  COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME}_staging \
-    NEW_WEB_TAG=$WEB_TAG \
-    NEW_WEB_REPO=$WEB_REPO \
-    BUILDKITE_BRANCH=${BUILDKITE_BRANCH} \
-    GUM_AWS_ACCESS_KEY_ID=${GUM_AWS_ACCESS_KEY_ID} \
-    GUM_AWS_SECRET_ACCESS_KEY=${GUM_AWS_SECRET_ACCESS_KEY} \
-    RAILS_STAGING_MASTER_KEY="$RAILS_STAGING_MASTER_KEY" \
-    PUSH_ASSETS=true \
-    make build_staging
+  app_name=$(get_app_name "$BUILDKITE_BRANCH")
+  asset_key=$(asset_content_tag || true)
+  asset_cache_image="$WEB_REPO:staging-assets-${asset_key}-${app_name}"
+  compiled_from_cache=false
+
+  if [[ -n "$asset_key" ]] && docker manifest inspect "$asset_cache_image" > /dev/null 2>&1; then
+    logger "Asset cache hit ($asset_cache_image); overlaying onto web-$WEB_TAG and skipping the vite build"
+    if overlay_staging_assets "$asset_cache_image"; then
+      compiled_from_cache=true
+    else
+      logger "Asset overlay failed; falling back to a full compile"
+    fi
+  else
+    logger "Asset cache miss ($asset_cache_image)"
+  fi
+
+  if [[ "$compiled_from_cache" != true ]]; then
+    logger "Building staging assets"
+    docker rm staging-assets || :
+    COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME}_staging \
+      NEW_WEB_TAG=$WEB_TAG \
+      NEW_WEB_REPO=$WEB_REPO \
+      BUILDKITE_BRANCH=${BUILDKITE_BRANCH} \
+      GUM_AWS_ACCESS_KEY_ID=${GUM_AWS_ACCESS_KEY_ID} \
+      GUM_AWS_SECRET_ACCESS_KEY=${GUM_AWS_SECRET_ACCESS_KEY} \
+      RAILS_STAGING_MASTER_KEY="$RAILS_STAGING_MASTER_KEY" \
+      PUSH_ASSETS=true \
+      make build_staging
+
+    if [[ -n "$asset_key" ]]; then
+      save_staging_asset_cache "$asset_cache_image" \
+        && logger "Saved asset cache ($asset_cache_image)" \
+        || logger "Saving asset cache failed; continuing"
+    fi
+  fi
 
   push_image staging || exit 1
 fi

--- a/.buildkite/scripts/compile_assets.sh
+++ b/.buildkite/scripts/compile_assets.sh
@@ -63,13 +63,24 @@ branch_slug() {
   echo "$BUILDKITE_BRANCH" | tr -c '[:alnum:]' '-' | tr '[:upper:]' '[:lower:]' | cut -c1-100 | sed 's/-*$//'
 }
 
-# Most recent commit touching anything that affects the compiled assets. Stable
-# across commits that leave the frontend untouched, so the cache can be reused.
+# Most recent commit touching anything the compiled assets are derived from.
+# This must cover every build input: the JS/TS sources; the Ruby sources that
+# js:export turns into the (gitignored) routes.js and json_schemas; the views
+# Tailwind scans; bundled images/vendor JS/currencies; and all build config.
+# Env-derived values (RAILS_ENV, CUSTOM_DOMAIN, NODE_ENV, ...) are intentionally
+# not hashed here — they are partitioned by the per-target, per-branch cache
+# image tag instead. Keep this list in sync when build inputs change.
 asset_content_tag() {
   git rev-list --abbrev-commit --abbrev=12 -1 HEAD -- \
-    app/javascript package.json package-lock.json \
+    app/javascript app/views public/images \
+    vendor/assets/javascripts config/currencies.json \
+    config/routes.rb config/routes/admin.rb config/domain.rb \
+    config/initializers/js-routes.rb lib/json_schemas \
+    lib/tasks/js_export.rake lib/tasks/vite_widget.rake lib/tasks/pages_tailwind.rake \
+    scripts/build_pages_tailwind.mjs \
     vite.config.ts vite.config.widget.ts config/vite.json \
-    scripts/build_pages_tailwind.mjs tsconfig.json 2>/dev/null
+    postcss.config.js tsconfig.json \
+    package.json package-lock.json Gemfile.lock patches 2>/dev/null
 }
 
 # Store the freshly compiled assets for <target> env as a slim cache image.

--- a/.buildkite/scripts/compile_assets.sh
+++ b/.buildkite/scripts/compile_assets.sh
@@ -54,12 +54,13 @@ push_image() {
   done
 }
 
-# Compiled frontend output produced by the staging precompile (no sprockets):
-# vite build + manifest, widget bundles, and the pages Tailwind stylesheet.
+# Compiled frontend output produced by `assets:precompile` (no sprockets):
+# the vite build + manifest, widget bundles, and the pages Tailwind stylesheet.
 ASSET_OUTPUT_PATHS="public/vite public/js public/pages-tailwind.css"
 
-get_app_name() {
-  echo "$1" | tr -d '\n' | tr -c '[:alnum:]' '-' | tr '[:upper:]' '[:lower:]' | sed "s/^deploy-//" | cut -c1-32 | sed 's/[^[:alnum:]]$//'
+# Sanitized branch name, safe to use as part of an image tag.
+branch_slug() {
+  echo "$BUILDKITE_BRANCH" | tr -c '[:alnum:]' '-' | tr '[:upper:]' '[:lower:]' | cut -c1-100 | sed 's/-*$//'
 }
 
 # Most recent commit touching anything that affects the compiled assets. Stable
@@ -71,11 +72,11 @@ asset_content_tag() {
     scripts/build_pages_tailwind.mjs tsconfig.json 2>/dev/null
 }
 
-# Store the freshly compiled assets as a slim cache image for next time.
-save_staging_asset_cache() {
-  local cache_image=$1 tmp cid path ok=1
+# Store the freshly compiled assets for <target> env as a slim cache image.
+save_asset_cache() {
+  local target=$1 cache_image=$2 tmp cid path ok=1
   tmp=$(mktemp -d) || return 1
-  cid=$(docker create "$WEB_REPO:staging-$WEB_TAG") || { rm -rf "$tmp"; return 1; }
+  cid=$(docker create "$WEB_REPO:$target-$WEB_TAG") || { rm -rf "$tmp"; return 1; }
   mkdir -p "$tmp/cache/public"
   for path in $ASSET_OUTPUT_PATHS; do
     docker cp "$cid:/app/$path" "$tmp/cache/$path" 2>/dev/null || true
@@ -90,17 +91,16 @@ save_staging_asset_cache() {
 }
 
 # Overlay cached compiled assets onto the current code image and commit it as the
-# staging image, skipping the (~7 min) vite build. CUSTOM_DOMAIN is baked into the
-# bundle, so the cache is keyed per branch and reuse here is for the same branch.
-overlay_staging_assets() {
-  local cache_image=$1 tmp ccid wcid ok=1
+# <target> image, skipping the (~7 min) vite build.
+overlay_assets() {
+  local target=$1 cache_image=$2 tmp ccid wcid ok=1
   docker pull "$cache_image" >/dev/null 2>&1 || return 1
   tmp=$(mktemp -d) || return 1
   ccid=$(docker create "$cache_image") || { rm -rf "$tmp"; return 1; }
   if docker cp "$ccid:/cache/public" "$tmp/public" 2>/dev/null; then
     wcid=$(docker create "$WEB_REPO:web-$WEB_TAG") || wcid=""
     if [[ -n "$wcid" ]] && docker cp "$tmp/public/." "$wcid:/app/public/" 2>/dev/null \
-      && docker commit "$wcid" "$WEB_REPO:staging-$WEB_TAG" >/dev/null 2>&1; then
+      && docker commit "$wcid" "$WEB_REPO:$target-$WEB_TAG" >/dev/null 2>&1; then
       ok=0
     fi
     [[ -n "$wcid" ]] && docker rm "$wcid" >/dev/null 2>&1 || true
@@ -110,63 +110,60 @@ overlay_staging_assets() {
   return $ok
 }
 
+# Reuse cached compiled assets when the frontend is unchanged, otherwise compile.
+# Keyed per branch because the bundle can bake in branch-specific values
+# (e.g. CUSTOM_DOMAIN on preview apps); each env keeps its own cache.
+compile_assets_for_env() {
+  local target=$1 master_key=$2
+  local asset_key cache_image compiled_from_cache=false
+  local master_key_var="RAILS_$(printf '%s' "$target" | tr '[:lower:]' '[:upper:]')_MASTER_KEY"
+  asset_key=$(asset_content_tag || true)
+  cache_image="$WEB_REPO:${target}-assets-${asset_key}-$(branch_slug)"
+
+  if [[ -n "$asset_key" ]] && docker manifest inspect "$cache_image" > /dev/null 2>&1; then
+    logger "Asset cache hit ($cache_image); overlaying onto web-$WEB_TAG and skipping the vite build"
+    if overlay_assets "$target" "$cache_image"; then
+      compiled_from_cache=true
+    else
+      logger "Asset overlay failed; falling back to a full compile"
+    fi
+  else
+    logger "Asset cache miss ($cache_image)"
+  fi
+
+  if [[ "$compiled_from_cache" != true ]]; then
+    logger "Building $target assets"
+    docker rm "$target-assets" || :
+    env \
+      COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME}_${target}" \
+      NEW_WEB_TAG="$WEB_TAG" \
+      NEW_WEB_REPO="$WEB_REPO" \
+      BUILDKITE_BRANCH="$BUILDKITE_BRANCH" \
+      GUM_AWS_ACCESS_KEY_ID="$GUM_AWS_ACCESS_KEY_ID" \
+      GUM_AWS_SECRET_ACCESS_KEY="$GUM_AWS_SECRET_ACCESS_KEY" \
+      "$master_key_var=$master_key" \
+      PUSH_ASSETS=true \
+      make "build_$target"
+
+    if [[ -n "$asset_key" ]]; then
+      save_asset_cache "$target" "$cache_image" \
+        && logger "Saved asset cache ($cache_image)" \
+        || logger "Saving asset cache failed; continuing"
+    fi
+  fi
+
+  push_image "$target" || exit 1
+}
+
 logger "Restore web image if not already loaded"
 if [[ ! $(docker images -q --filter "reference=$WEB_REPO:web-$WEB_TAG") ]]; then
   pull_web_image || exit 1
 fi
 
 if [[ $BUILDKITE_PARALLEL_JOB = 0 && $BUILDKITE_BRANCH != "main" ]]; then
-  app_name=$(get_app_name "$BUILDKITE_BRANCH")
-  asset_key=$(asset_content_tag || true)
-  asset_cache_image="$WEB_REPO:staging-assets-${asset_key}-${app_name}"
-  compiled_from_cache=false
-
-  if [[ -n "$asset_key" ]] && docker manifest inspect "$asset_cache_image" > /dev/null 2>&1; then
-    logger "Asset cache hit ($asset_cache_image); overlaying onto web-$WEB_TAG and skipping the vite build"
-    if overlay_staging_assets "$asset_cache_image"; then
-      compiled_from_cache=true
-    else
-      logger "Asset overlay failed; falling back to a full compile"
-    fi
-  else
-    logger "Asset cache miss ($asset_cache_image)"
-  fi
-
-  if [[ "$compiled_from_cache" != true ]]; then
-    logger "Building staging assets"
-    docker rm staging-assets || :
-    COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME}_staging \
-      NEW_WEB_TAG=$WEB_TAG \
-      NEW_WEB_REPO=$WEB_REPO \
-      BUILDKITE_BRANCH=${BUILDKITE_BRANCH} \
-      GUM_AWS_ACCESS_KEY_ID=${GUM_AWS_ACCESS_KEY_ID} \
-      GUM_AWS_SECRET_ACCESS_KEY=${GUM_AWS_SECRET_ACCESS_KEY} \
-      RAILS_STAGING_MASTER_KEY="$RAILS_STAGING_MASTER_KEY" \
-      PUSH_ASSETS=true \
-      make build_staging
-
-    if [[ -n "$asset_key" ]]; then
-      save_staging_asset_cache "$asset_cache_image" \
-        && logger "Saved asset cache ($asset_cache_image)" \
-        || logger "Saving asset cache failed; continuing"
-    fi
-  fi
-
-  push_image staging || exit 1
+  compile_assets_for_env staging "$RAILS_STAGING_MASTER_KEY"
 fi
 
 if [[ $BUILDKITE_PARALLEL_JOB = 1 && ( $BUILDKITE_BRANCH == "main" || $BUILDKITE_BRANCH == comp-assets-* ) ]]; then
-  logger "Building production assets"
-  docker rm production-assets || :
-  COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME}_production \
-    NEW_WEB_TAG=$WEB_TAG \
-    NEW_WEB_REPO=$WEB_REPO \
-    BUILDKITE_BRANCH=${BUILDKITE_BRANCH} \
-    GUM_AWS_ACCESS_KEY_ID=${GUM_AWS_ACCESS_KEY_ID} \
-    GUM_AWS_SECRET_ACCESS_KEY=${GUM_AWS_SECRET_ACCESS_KEY} \
-    RAILS_PRODUCTION_MASTER_KEY="$RAILS_PRODUCTION_MASTER_KEY" \
-    PUSH_ASSETS=true \
-    make build_production
-
-  push_image production || exit 1
+  compile_assets_for_env production "$RAILS_PRODUCTION_MASTER_KEY"
 fi


### PR DESCRIPTION
## What

Speeds up asset compilation by caching the compiled frontend per branch and skipping the Vite build when nothing affecting the assets has changed. Applies to **both** the staging (preview) and production asset builds via one shared helper.

## Why

Profiling a preview build's compile-assets step (build 12834, ~13 min total) showed the time goes almost entirely to the **`vite build` (~6m51s)**, nearly all in `transforming…`. A Vite/Rollup *production* build has no persistent incremental cache, so it redoes that ~7 min on every push — even a Ruby-only change. Warming caches the way `tests.yml` does wouldn't help; only reusing the build *output* removes the ~7 min.

## How

`compile_assets.sh` now has one `compile_assets_for_env <env>` helper used by both the staging and production blocks:

- **Cache key:** `<env>-assets-<content-hash>-<branch-slug>`, where `<content-hash>` is `git rev-list -1` over the frontend inputs (`app/javascript`, `package*.json`, `vite.config.*`, `config/vite.json`, the Tailwind build script, `tsconfig.json`) and `<branch-slug>` is the sanitized branch name. Per-branch because the bundle can bake in branch-specific values (`CUSTOM_DOMAIN` on previews); each env keeps a separate cache.
- **Cache hit:** overlay the cached `public/vite` + `public/js` + `public/pages-tailwind.css` onto the current code image and commit it as `<env>-<sha>`, skipping the Vite build. Code stays current; only the (identical) compiled assets are reused, and the hashed files are already in S3 from the populating build.
- **Cache miss:** compile as before, then save a slim `busybox`-based cache image for next time.

Net effect: the first build of a branch is full cost; subsequent redeploys / non-frontend pushes on that branch skip the ~7-min Vite build.

## Safety

- Env-specific bits (master key, make target, image tag, compose project) are parameterized; production's `build_production` behavior is otherwise unchanged on a cache miss.
- Every cache step is best-effort — overlay failure falls back to a full compile, and save/push failures are logged and ignored, so a cache problem can't break a deploy.

## Verification needed before merge

This must be exercised on the real pipeline before trusting it — especially production, where a stale-asset slip is a site-wide issue rather than a broken preview:

- A cache-miss build (compiles + populates) then a cache-hit build (overlays), confirming the app renders correctly on both, for staging **and** production.
- Audit that the content-hash input list is complete (every input that changes the bundle is covered), since a missed input would let a hit serve stale assets.
- Production cache hits rely on the prior build's hashed assets still being present in the production assets bucket/CDN.

---

AI disclosure: written with Claude Opus 4.8. Build timings were read from the Buildkite API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Stale assets are possible if the content-hash path list is incomplete or overlay logic mis-merges images; production cache hits also assume prior hashed assets remain in the assets bucket/CDN.
> 
> **Overview**
> **`compile_assets.sh`** now routes staging and production through a shared **`compile_assets_for_env`** path that can **reuse prior compiled output** instead of always running the full **`make build_*`** Vite pipeline (~7 min).
> 
> On a **cache hit**, it checks ECR for a slim image tagged **`{env}-assets-{content-hash}-{branch-slug}`**, overlays **`public/vite`**, **`public/js`**, and **`public/pages-tailwind.css`** onto the current **`web-{sha}`** image, commits that as the env image, and skips the build. The **content hash** is the latest commit touching a documented set of frontend/build inputs (JS, views, routes, Vite/Tailwind config, lockfiles, etc.); **branch** is in the tag so preview-specific baked values stay isolated per env.
> 
> On a **miss** or **overlay failure**, behavior matches the old inline **`make build_staging` / `build_production`** flow, then **best-effort** saves the same outputs into a **busybox** cache image for the next run. Cache save/push failures are logged only; deploy still **`push_image`** as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39371995f466b4f2440db1801740a8b211e122a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->