### PR TITLE
Stop showing fully refunded disputed purchases as charged back

### DIFF
--- a/app/presenters/customer_presenter.rb
+++ b/app/presenters/customer_presenter.rb
@@ -132,7 +132,7 @@ class CustomerPresenter
       paypal_refund_expired: purchase.paypal_refund_expired?,
       refunded: purchase.stripe_refunded?,
       partially_refunded: purchase.stripe_partially_refunded?,
-      chargedback: purchase.chargedback? && !purchase.chargeback_reversed?,
+      chargedback: purchase.chargedback? && !purchase.chargeback_reversed? && !purchase.stripe_refunded?,
       has_options: variant.present? || purchase.link.alive_variants.any?,
       option: variant.present? ?
         (variant.is_a?(Sku) ? variant.to_option_for_product : variant.to_option) :
@@ -168,7 +168,7 @@ class CustomerPresenter
       currency_type: purchase.displayed_price_currency_type.to_s,
       transaction_url_for_seller: purchase.transaction_url_for_seller,
       is_upgrade_purchase: purchase.is_upgrade_purchase?,
-      chargedback: purchase.chargedback? && !purchase.chargeback_reversed?,
+      chargedback: purchase.chargedback? && !purchase.chargeback_reversed? && !purchase.stripe_refunded?,
       paypal_refund_expired: purchase.paypal_refund_expired?,
     }
   end

--- a/spec/presenters/customer_presenter_spec.rb
+++ b/spec/presenters/customer_presenter_spec.rb
@@ -212,6 +212,18 @@ describe CustomerPresenter do
       )
     end
 
+    context "when the purchase is both charged back and fully refunded" do
+      let(:refunded_chargeback_purchase) do
+        create(:purchase, link: create(:product, user: seller), seller:, chargeback_date: Time.current, stripe_refunded: true)
+      end
+
+      it "reports it as refunded, not charged back" do
+        props = described_class.new(purchase: refunded_chargeback_purchase).customer(pundit_user:)
+        expect(props[:refunded]).to be(true)
+        expect(props[:chargedback]).to be(false)
+      end
+    end
+
     context "purchase has a call" do
       let(:call) { create(:call) }
 


### PR DESCRIPTION
Closes antiwork/gumroad-private#183

## What

When a seller refunds a disputed PayPal purchase through PayPal's Resolution Center, the dispute resolves in the buyer's favour and the sale ends up both charged back (the `chargeback_date` set at formalization) and fully refunded. The seller's customers dashboard then shows an open chargeback next to a completed refund for the same purchase.

The dashboard derives its chargeback badge from `chargedback? && !chargeback_reversed?`, which stays true after a full refund. This adds `&& !stripe_refunded?` so a fully refunded sale reads as refunded — the buyer was already made whole, so showing an open chargeback alongside the refund is misleading.

## Why

This is a display-only change. `chargeback_date` is left untouched because it's a durable financial and fraud signal beyond the dashboard:

- buyer auto-blocking counts purchases with `chargeback_date` set,
- the seller chargeback-rate payout-pause keys off it,
- payout exports enumerate charged-back sales by it.

Clearing `chargeback_date` to fix the display (the original idea) would weaken all three, so the fix stays in the presenter that renders the dashboard. The underlying data stays accurate — the purchase genuinely was disputed and refunded; only the seller-facing rendering changes.

---

This PR was implemented with AI assistance using Claude Opus 4.8.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only presenter logic for seller dashboard props; no payment, webhook, or data-migration changes in this diff.
> 
> **Overview**
> Seller-facing customer and charge API props no longer show **`chargedback: true`** when a purchase is **fully refunded** (`stripe_refunded?`), even if chargeback flags are still set on the record.
> 
> The `chargedback` field in `#customer` and `#charge` now requires an active chargeback that is not reversed **and** not fully refunded, so PayPal dispute + refund mismatches display as refunded instead of an open chargeback. A presenter spec covers purchases that are both charged back and fully refunded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdeafd0d7db3cb681159eea0c27e26c332c11ccc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->