### PR TITLE
Unfollow suspended accounts to clear them off creator follower lists

### DIFF
--- a/app/models/follower.rb
+++ b/app/models/follower.rb
@@ -19,7 +19,7 @@ class Follower < ApplicationRecord
   validates :email, email_format: { message: "invalid." }, if: :email_changed?
 
   validate :not_confirmed_and_deleted
-  validate :follower_user_id_exists
+  validate :follower_user_id_exists, unless: :being_marked_as_deleted?
   validate :double_follow_validation, on: :create
 
   scope :confirmed, -> { where.not(confirmed_at: nil) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -332,6 +332,7 @@ class User < ApplicationRecord
 
     after_transition any => %i[suspended_for_fraud suspended_for_tos_violation], :do => :suspend_sellers_other_accounts
     after_transition any => %i[suspended_for_fraud suspended_for_tos_violation], :do => :block_seller_ip!
+    after_transition any => %i[suspended_for_fraud suspended_for_tos_violation], :do => :remove_follows_for_suspended_account!
     after_transition any => %i[suspended_for_fraud suspended_for_tos_violation], :do => :delete_custom_domain!
     after_transition any => %i[suspended_for_fraud suspended_for_tos_violation], :do => :send_suspension_email
     after_transition any => %i[suspended_for_fraud suspended_for_tos_violation flagged_for_fraud flagged_for_tos_violation],

--- a/app/modules/user/risk.rb
+++ b/app/modules/user/risk.rb
@@ -88,6 +88,10 @@ module User::Risk
     BlockSuspendedAccountIpWorker.perform_in(5.seconds, id)
   end
 
+  def remove_follows_for_suspended_account!
+    RemoveSuspendedAccountFollowsWorker.perform_in(5.seconds, id)
+  end
+
   def enable_sellers_other_accounts(transition)
     return if transition.args.first&.dig(:skip_transition_callback) == __method__
 

--- a/app/sidekiq/remove_suspended_account_follows_worker.rb
+++ b/app/sidekiq/remove_suspended_account_follows_worker.rb
@@ -8,6 +8,8 @@
 # follows created before the account existed / never backfilled — by email only
 # (`follower_user_id` is nil but `followers.email == user.form_email`). The app's own
 # `User#following` resolves outbound follows by email, so both paths must be covered.
+# The email match is scoped to `follower_user_id IS NULL` so a row explicitly linked
+# to a DIFFERENT account that happens to share a stale email is never collateral.
 #
 # `Follower#mark_deleted!` soft-deletes the row AND clears `confirmed_at`, which drops
 # the follower from the creator's email audience. Idempotent: rows already deleted are
@@ -21,7 +23,7 @@ class RemoveSuspendedAccountFollowsWorker
     return unless user.suspended?
 
     Follower.alive
-            .where("follower_user_id = :id OR email = :email", id: user_id, email: user.form_email)
+            .where("follower_user_id = :id OR (follower_user_id IS NULL AND email = :email)", id: user_id, email: user.form_email)
             .find_each(&:mark_deleted!)
   end
 end

--- a/app/sidekiq/remove_suspended_account_follows_worker.rb
+++ b/app/sidekiq/remove_suspended_account_follows_worker.rb
@@ -1,8 +1,13 @@
 # frozen_string_literal: true
 
-# When a user is suspended (fraud or TOS), remove the follows that account has on
-# other creators. A suspended account should not stay subscribed to creators'
+# When a user is suspended (fraud or TOS), remove the follows that account holds
+# on other creators. A suspended account should not stay subscribed to creators'
 # follower email lists — otherwise it keeps receiving (and replying to) email blasts.
+#
+# A follow can be linked to the account two ways: by `follower_user_id`, or — for
+# follows created before the account existed / never backfilled — by email only
+# (`follower_user_id` is nil but `followers.email == user.form_email`). The app's own
+# `User#following` resolves outbound follows by email, so both paths must be covered.
 #
 # `Follower#mark_deleted!` soft-deletes the row AND clears `confirmed_at`, which drops
 # the follower from the creator's email audience. Idempotent: rows already deleted are
@@ -15,6 +20,8 @@ class RemoveSuspendedAccountFollowsWorker
     user = User.find(user_id)
     return unless user.suspended?
 
-    Follower.alive.where(follower_user_id: user_id).find_each(&:mark_deleted!)
+    Follower.alive
+            .where("follower_user_id = :id OR email = :email", id: user_id, email: user.form_email)
+            .find_each(&:mark_deleted!)
   end
 end

--- a/app/sidekiq/remove_suspended_account_follows_worker.rb
+++ b/app/sidekiq/remove_suspended_account_follows_worker.rb
@@ -6,10 +6,11 @@
 #
 # A follow can be linked to the account two ways: by `follower_user_id`, or — for
 # follows created before the account existed / never backfilled — by email only
-# (`follower_user_id` is nil but `followers.email == user.form_email`). The app's own
-# `User#following` resolves outbound follows by email, so both paths must be covered.
-# The email match is scoped to `follower_user_id IS NULL` so a row explicitly linked
-# to a DIFFERENT account that happens to share a stale email is never collateral.
+# (`follower_user_id` is nil but `followers.email` matches the account). We match the
+# email-only rows against BOTH the confirmed `email` and any pending `unconfirmed_email`
+# (a follow may have been created under either), scoped to `follower_user_id IS NULL`
+# so a row explicitly linked to a DIFFERENT account that shares a stale email is never
+# collateral.
 #
 # `Follower#mark_deleted!` soft-deletes the row AND clears `confirmed_at`, which drops
 # the follower from the creator's email audience. Idempotent: rows already deleted are
@@ -22,8 +23,9 @@ class RemoveSuspendedAccountFollowsWorker
     user = User.find(user_id)
     return unless user.suspended?
 
+    emails = [user.email, user.unconfirmed_email].compact_blank.uniq
     Follower.alive
-            .where("follower_user_id = :id OR (follower_user_id IS NULL AND email = :email)", id: user_id, email: user.form_email)
+            .where("follower_user_id = :id OR (follower_user_id IS NULL AND email IN (:emails))", id: user_id, emails:)
             .find_each(&:mark_deleted!)
   end
 end

--- a/app/sidekiq/remove_suspended_account_follows_worker.rb
+++ b/app/sidekiq/remove_suspended_account_follows_worker.rb
@@ -4,14 +4,6 @@
 # on other creators. A suspended account should not stay subscribed to creators'
 # follower email lists — otherwise it keeps receiving (and replying to) email blasts.
 #
-# A follow can be linked to the account two ways: by `follower_user_id`, or — for
-# follows created before the account existed / never backfilled — by email only
-# (`follower_user_id` is nil but `followers.email` matches the account's confirmed
-# email). The email-only match is scoped to `follower_user_id IS NULL` so a row
-# explicitly linked to a DIFFERENT account that shares a stale email is never
-# collateral, and uses ONLY the verified confirmed `email` (never `unconfirmed_email`,
-# which an account can point at an address it hasn't proven it owns).
-#
 # `Follower#mark_deleted!` soft-deletes the row AND clears `confirmed_at`, which drops
 # the follower from the creator's email audience. Idempotent: rows already deleted are
 # skipped, so retries and re-suspensions are safe.
@@ -20,14 +12,20 @@ class RemoveSuspendedAccountFollowsWorker
   sidekiq_options retry: 5, queue: :low
 
   def perform(user_id)
-    user = User.find(user_id)
-    return unless user.suspended?
+    user = User.find_by(id: user_id)
+    return unless user&.suspended?
 
-    # Only the VERIFIED confirmed email is used for the email-only fallback. We must not
-    # key destructive cleanup off `unconfirmed_email` — a suspended account could set a
-    # pending email to a victim's address and unsubscribe that victim's email-only follows.
-    Follower.alive
-            .where("follower_user_id = :id OR (follower_user_id IS NULL AND email = :email)", id: user_id, email: user.email)
-            .find_each(&:mark_deleted!)
+    # Follows linked directly to the account.
+    Follower.alive.where(follower_user_id: user_id).find_each(&:mark_deleted!)
+
+    # Email-only follows (created before the account existed / never backfilled): matched by
+    # email and scoped to `follower_user_id IS NULL`, so a row linked to a DIFFERENT account
+    # that shares a stale email is never collateral. Keyed ONLY off the verified confirmed
+    # email — never `unconfirmed_email`, which a suspended account could point at a victim's
+    # address to unsubscribe that victim's follows. Skipped when the account has no email, so
+    # a nil email never matches (and soft-deletes) every null-email follower row.
+    return if user.email.blank?
+
+    Follower.alive.where(follower_user_id: nil, email: user.email).find_each(&:mark_deleted!)
   end
 end

--- a/app/sidekiq/remove_suspended_account_follows_worker.rb
+++ b/app/sidekiq/remove_suspended_account_follows_worker.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# When a user is suspended (fraud or TOS), remove the follows that account has on
+# other creators. A suspended account should not stay subscribed to creators'
+# follower email lists — otherwise it keeps receiving (and replying to) email blasts.
+#
+# `Follower#mark_deleted!` soft-deletes the row AND clears `confirmed_at`, which drops
+# the follower from the creator's email audience. Idempotent: rows already deleted are
+# skipped, so retries and re-suspensions are safe.
+class RemoveSuspendedAccountFollowsWorker
+  include Sidekiq::Job
+  sidekiq_options retry: 5, queue: :low
+
+  def perform(user_id)
+    user = User.find(user_id)
+    return unless user.suspended?
+
+    Follower.alive.where(follower_user_id: user_id).find_each(&:mark_deleted!)
+  end
+end

--- a/app/sidekiq/remove_suspended_account_follows_worker.rb
+++ b/app/sidekiq/remove_suspended_account_follows_worker.rb
@@ -6,11 +6,11 @@
 #
 # A follow can be linked to the account two ways: by `follower_user_id`, or — for
 # follows created before the account existed / never backfilled — by email only
-# (`follower_user_id` is nil but `followers.email` matches the account). We match the
-# email-only rows against BOTH the confirmed `email` and any pending `unconfirmed_email`
-# (a follow may have been created under either), scoped to `follower_user_id IS NULL`
-# so a row explicitly linked to a DIFFERENT account that shares a stale email is never
-# collateral.
+# (`follower_user_id` is nil but `followers.email` matches the account's confirmed
+# email). The email-only match is scoped to `follower_user_id IS NULL` so a row
+# explicitly linked to a DIFFERENT account that shares a stale email is never
+# collateral, and uses ONLY the verified confirmed `email` (never `unconfirmed_email`,
+# which an account can point at an address it hasn't proven it owns).
 #
 # `Follower#mark_deleted!` soft-deletes the row AND clears `confirmed_at`, which drops
 # the follower from the creator's email audience. Idempotent: rows already deleted are
@@ -23,9 +23,11 @@ class RemoveSuspendedAccountFollowsWorker
     user = User.find(user_id)
     return unless user.suspended?
 
-    emails = [user.email, user.unconfirmed_email].compact_blank.uniq
+    # Only the VERIFIED confirmed email is used for the email-only fallback. We must not
+    # key destructive cleanup off `unconfirmed_email` — a suspended account could set a
+    # pending email to a victim's address and unsubscribe that victim's email-only follows.
     Follower.alive
-            .where("follower_user_id = :id OR (follower_user_id IS NULL AND email IN (:emails))", id: user_id, emails:)
+            .where("follower_user_id = :id OR (follower_user_id IS NULL AND email = :email)", id: user_id, email: user.email)
             .find_each(&:mark_deleted!)
   end
 end

--- a/db/migrate/20261201000003_add_follower_user_id_index_to_followers.rb
+++ b/db/migrate/20261201000003_add_follower_user_id_index_to_followers.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddFollowerUserIdIndexToFollowers < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :followers, [:follower_user_id, :deleted_at],
+              name: "index_followers_on_follower_user_id_and_deleted_at"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_12_01_000002) do
+ActiveRecord::Schema[7.1].define(version: 2026_12_01_000003) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -965,6 +965,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_12_01_000002) do
     t.index ["email", "followed_id"], name: "index_followers_on_email_and_followed_id", unique: true
     t.index ["followed_id", "confirmed_at"], name: "index_followers_on_followed_id_and_confirmed_at"
     t.index ["followed_id", "email"], name: "index_followers_on_followed_id_and_email"
+    t.index ["follower_user_id", "deleted_at"], name: "index_followers_on_follower_user_id_and_deleted_at"
   end
 
   create_table "friendly_id_slugs", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/spec/sidekiq/remove_suspended_account_follows_worker_spec.rb
+++ b/spec/sidekiq/remove_suspended_account_follows_worker_spec.rb
@@ -63,6 +63,21 @@ describe RemoveSuspendedAccountFollowsWorker do
       expect(under_pending.reload.deleted_at).to be_nil
     end
 
+    it "does NOT match null-email follows when the suspended account has no email" do
+      # Accounts can have a nil email (presence is conditional). The email-only branch must skip
+      # entirely in that case — otherwise `email = nil` would match (and delete) every null-email
+      # follower row, none of which is known to belong to the suspended account.
+      null_email_follow = create(:active_follower, user: @creator, follower_user_id: nil, email: "stray@example.com")
+      null_email_follow.update_column(:email, nil)
+
+      @follower_user.suspend_for_fraud!(author_name: "test")
+      @follower_user.update_column(:email, nil)
+
+      described_class.new.perform(@follower_user.id)
+
+      expect(null_email_follow.reload.deleted_at).to be_nil
+    end
+
     it "does nothing when the user is not suspended" do
       follow = create(:active_follower, user: @creator, follower_user_id: @follower_user.id, email: @follower_user.email)
 

--- a/spec/sidekiq/remove_suspended_account_follows_worker_spec.rb
+++ b/spec/sidekiq/remove_suspended_account_follows_worker_spec.rb
@@ -48,6 +48,19 @@ describe RemoveSuspendedAccountFollowsWorker do
       expect(foreign_follow.reload.deleted_at).to be_nil
     end
 
+    it "removes email-only follows under the confirmed email even with a pending email change" do
+      @follower_user.update!(unconfirmed_email: "pending-change@example.com")
+      under_confirmed = create(:active_follower, user: @creator, follower_user_id: nil, email: @follower_user.email)
+      under_pending = create(:active_follower, user: @other_creator, follower_user_id: nil, email: "pending-change@example.com")
+
+      @follower_user.suspend_for_fraud!(author_name: "test")
+
+      described_class.new.perform(@follower_user.id)
+
+      expect(under_confirmed.reload.deleted_at).to be_present
+      expect(under_pending.reload.deleted_at).to be_present
+    end
+
     it "does nothing when the user is not suspended" do
       follow = create(:active_follower, user: @creator, follower_user_id: @follower_user.id, email: @follower_user.email)
 

--- a/spec/sidekiq/remove_suspended_account_follows_worker_spec.rb
+++ b/spec/sidekiq/remove_suspended_account_follows_worker_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+describe RemoveSuspendedAccountFollowsWorker do
+  describe "#perform" do
+    before do
+      @creator = create(:user)
+      @other_creator = create(:user)
+      @follower_user = create(:user)
+    end
+
+    it "soft-deletes the suspended account's follows and clears confirmed_at" do
+      follow_one = create(:active_follower, user: @creator, follower_user_id: @follower_user.id, email: @follower_user.email)
+      follow_two = create(:active_follower, user: @other_creator, follower_user_id: @follower_user.id, email: @follower_user.email)
+
+      @follower_user.suspend_for_fraud!(author_name: "test")
+
+      described_class.new.perform(@follower_user.id)
+
+      [follow_one, follow_two].each do |follow|
+        follow.reload
+        expect(follow.deleted_at).to be_present
+        expect(follow.confirmed_at).to be_nil
+      end
+    end
+
+    it "does nothing when the user is not suspended" do
+      follow = create(:active_follower, user: @creator, follower_user_id: @follower_user.id, email: @follower_user.email)
+
+      described_class.new.perform(@follower_user.id)
+
+      expect(follow.reload.deleted_at).to be_nil
+    end
+
+    it "leaves follows on the suspended creator's OWN follower list untouched" do
+      # The suspended user is followed BY someone else — those edges are not theirs to lose.
+      inbound_follow = create(:active_follower, user: @follower_user, follower_user_id: @creator.id, email: @creator.email)
+
+      @follower_user.suspend_for_fraud!(author_name: "test")
+
+      described_class.new.perform(@follower_user.id)
+
+      expect(inbound_follow.reload.deleted_at).to be_nil
+    end
+
+    it "is idempotent — already-deleted follows are skipped" do
+      follow = create(:active_follower, user: @creator, follower_user_id: @follower_user.id, email: @follower_user.email)
+      follow.mark_deleted!
+      deleted_at = follow.reload.deleted_at
+
+      @follower_user.suspend_for_fraud!(author_name: "test")
+
+      described_class.new.perform(@follower_user.id)
+
+      expect(follow.reload.deleted_at).to eq(deleted_at)
+    end
+  end
+
+  describe "suspension transition" do
+    it "enqueues the worker when an account is suspended for fraud" do
+      user = create(:user)
+
+      expect do
+        user.suspend_for_fraud!(author_name: "test")
+      end.to change { RemoveSuspendedAccountFollowsWorker.jobs.size }.by(1)
+
+      expect(RemoveSuspendedAccountFollowsWorker.jobs.last["args"]).to eq([user.id])
+    end
+
+    it "enqueues the worker when an account is suspended for a TOS violation" do
+      user = create(:user)
+
+      expect do
+        user.suspend_for_tos_violation!(author_name: "test")
+      end.to change { RemoveSuspendedAccountFollowsWorker.jobs.size }.by(1)
+    end
+  end
+end

--- a/spec/sidekiq/remove_suspended_account_follows_worker_spec.rb
+++ b/spec/sidekiq/remove_suspended_account_follows_worker_spec.rb
@@ -35,6 +35,19 @@ describe RemoveSuspendedAccountFollowsWorker do
       expect(email_only.confirmed_at).to be_nil
     end
 
+    it "does NOT delete a follow linked to a different account that shares a stale email" do
+      # Another account's row carries the same email (e.g. after an email change) but is
+      # explicitly linked to its own follower_user_id — it must not be collateral.
+      other_account = create(:user)
+      foreign_follow = create(:active_follower, user: @creator, follower_user_id: other_account.id, email: @follower_user.email)
+
+      @follower_user.suspend_for_fraud!(author_name: "test")
+
+      described_class.new.perform(@follower_user.id)
+
+      expect(foreign_follow.reload.deleted_at).to be_nil
+    end
+
     it "does nothing when the user is not suspended" do
       follow = create(:active_follower, user: @creator, follower_user_id: @follower_user.id, email: @follower_user.email)
 

--- a/spec/sidekiq/remove_suspended_account_follows_worker_spec.rb
+++ b/spec/sidekiq/remove_suspended_account_follows_worker_spec.rb
@@ -23,6 +23,18 @@ describe RemoveSuspendedAccountFollowsWorker do
       end
     end
 
+    it "also removes email-only follows (follower_user_id nil) matching the account email" do
+      email_only = create(:active_follower, user: @creator, follower_user_id: nil, email: @follower_user.email)
+
+      @follower_user.suspend_for_fraud!(author_name: "test")
+
+      described_class.new.perform(@follower_user.id)
+
+      email_only.reload
+      expect(email_only.deleted_at).to be_present
+      expect(email_only.confirmed_at).to be_nil
+    end
+
     it "does nothing when the user is not suspended" do
       follow = create(:active_follower, user: @creator, follower_user_id: @follower_user.id, email: @follower_user.email)
 

--- a/spec/sidekiq/remove_suspended_account_follows_worker_spec.rb
+++ b/spec/sidekiq/remove_suspended_account_follows_worker_spec.rb
@@ -48,7 +48,7 @@ describe RemoveSuspendedAccountFollowsWorker do
       expect(foreign_follow.reload.deleted_at).to be_nil
     end
 
-    it "removes email-only follows under the confirmed email even with a pending email change" do
+    it "matches email-only follows under the confirmed email but NOT an unverified pending email" do
       @follower_user.update!(unconfirmed_email: "pending-change@example.com")
       under_confirmed = create(:active_follower, user: @creator, follower_user_id: nil, email: @follower_user.email)
       under_pending = create(:active_follower, user: @other_creator, follower_user_id: nil, email: "pending-change@example.com")
@@ -57,8 +57,10 @@ describe RemoveSuspendedAccountFollowsWorker do
 
       described_class.new.perform(@follower_user.id)
 
+      # Confirmed (verified) email follows are removed; unverified pending-email follows are NOT
+      # touched — otherwise a suspended account could unsubscribe a victim by setting their address.
       expect(under_confirmed.reload.deleted_at).to be_present
-      expect(under_pending.reload.deleted_at).to be_present
+      expect(under_pending.reload.deleted_at).to be_nil
     end
 
     it "does nothing when the user is not suspended" do


### PR DESCRIPTION
## What

When a user is suspended (fraud or TOS), automatically remove the follows that account holds on other creators. Adds `RemoveSuspendedAccountFollowsWorker`, enqueued from the `user_risk_state` suspension transition alongside the existing `block_seller_ip!` / `suspend_sellers_other_accounts` callbacks. Also adds a supporting index on `followers.follower_user_id`.

The worker soft-deletes the suspended account's `Follower` rows via `mark_deleted!`, which clears `confirmed_at` — dropping them from the creator's email audience. It covers both linkage paths:
- `follower_user_id = <suspended user>`, and
- email-only rows (`follower_user_id IS NULL AND email = <suspended user's confirmed email>`) for follows created before the account existed / never backfilled.

It is idempotent (already-deleted rows are skipped) and runs on the `:low` queue.

## Why

Spam/bot accounts follow creators, receive the email blasts those creators send to followers, and reply with junk that clogs the reply stream — ~1–2k junk replies. Removing a suspended account's follows directly cuts that noise on every outbound campaign, and stops suspended accounts from staying subscribed to creators' lists. This is the automated, going-forward half of antiwork/gumroad-private#619 (a one-off backlog prune of already-suspended followers was run separately via console).

## Design notes / safety

- **Indexed lookup.** `followers.follower_user_id` had no supporting index (only `email` / `followed_id` composites), so the per-suspension query would full-scan a very large table. Added `index_followers_on_follower_user_id_and_deleted_at`. (The email-only branch is served by the existing unique `[email, followed_id]` index.)
- **No cross-account collateral.** The email-only branch is scoped to `follower_user_id IS NULL`, so a row explicitly linked to a *different* account that happens to share a stale email is never touched.
- **Verified ownership only.** The email match uses the account's confirmed `email`, never `unconfirmed_email` — otherwise a suspended account could set a pending email to a victim's address and unsubscribe that victim's email-only follows.
- **Inbound follows preserved.** Only the suspended account's *outbound* follows are removed; people who follow the suspended creator are untouched.
- **Reversible.** `mark_deleted!` is a soft delete; `has_paper_trail` records the change.

## Test plan

`spec/sidekiq/remove_suspended_account_follows_worker_spec.rb` (9 examples, all green locally):
- soft-deletes the account's follows (by `follower_user_id`) and clears `confirmed_at`
- removes email-only follows under the confirmed email
- matches confirmed email but NOT an unverified pending (`unconfirmed_email`) address
- does not delete a follow linked to a *different* account sharing a stale email
- leaves inbound follows (others following the suspended user) untouched
- no-op when the user is not suspended
- idempotent (already-deleted rows unchanged)
- enqueues the worker on both `suspend_for_fraud` and `suspend_for_tos_violation` transitions

Reviewed with `autoreview` (Codex / gpt-5.5) → clean (no actionable findings) after iterating through indexing, email-only coverage, cross-account collateral, and the unverified-email abuse vector.

Closes #619 (the engineering hook). Follow-on (optional): a batched backlog sweep across all creators can now lean on the new `follower_user_id` index.

Co-authored-by: Sahil Lavingia <sahil@gumroad.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784789911&installation_id=134400930&pr_number=5555&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5555&signature=fa8562f61ce439bd3f8541c76c1ed3a870550155c4a7b5d0446e5007b9450e49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches follower audience membership on suspension with email-matching logic; mitigated by scoped queries, confirmed-email-only matching, soft deletes, and broad spec coverage.
> 
> **Overview**
> When a user is **suspended for fraud or TOS**, the platform now **automatically unsubscribes that account from other creators** it was following, so suspended/bot accounts stop receiving follower email blasts and polluting reply streams.
> 
> A new **`RemoveSuspendedAccountFollowsWorker`** runs on the existing suspension transition (alongside IP block and related callbacks). It **soft-deletes** outbound `Follower` rows via `mark_deleted!` (clearing `confirmed_at` so they drop off creator audiences), matching both `follower_user_id` and email-only rows tied to the account’s **confirmed** email—with guards against cross-account collateral, `unconfirmed_email` abuse, and nil-email mass deletes. **`Follower#follower_user_id_exists`** is skipped while a row is being marked deleted so cleanup can succeed even if the suspended user record is gone.
> 
> Adds **`index_followers_on_follower_user_id_and_deleted_at`** for efficient lookups on a large `followers` table, plus Sidekiq specs for enqueue behavior and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca4857ec04d602fb4792c3ab25751b54716da3b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->