### PR TITLE
Require approval before preview app deployment

### DIFF
--- a/.buildkite/preview.yml
+++ b/.buildkite/preview.yml
@@ -1,6 +1,12 @@
 steps:
+  - block: "Approval required for preview app deployment"
+    key: require-preview-approval
+    prompt: "Provision and deploy a preview app for this branch? Only unblock trusted PR code because the preview pipeline has access to deployment credentials."
+    blocked_state: running
+
   - label: ":docker: Build Base Image"
     key: preview-build-base-image
+    depends_on: require-preview-approval
     command: ".buildkite/scripts/build_base.sh"
     timeout_in_minutes: 60
     plugins:

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -186,9 +186,9 @@ $ nomad run sidekiq_worker.nomad
 
 ## Deploying to a preview app
 
-Add the `preview` label to a pull request to deploy its branch to a preview app. This works for any branch except `main` and `comp-assets-*`.
+Add the `preview` label to a pull request to request a preview app for its branch. This works for any branch except `main` and `comp-assets-*`.
 
-Adding the label triggers a Buildkite build that deploys the branch. Each subsequent push to a labeled branch redeploys automatically.
+Adding the label triggers a Buildkite build with an approval block. Unblock it only after confirming the PR code is trusted to run with the preview deployment credentials. Each subsequent push to a labeled branch creates a new preview build that must be approved before deployment.
 
 The preview app URL is posted on the pull request as a GitHub deployment: look for the "View deployment" button (and the Deployments section), which shows the deploy in progress and links to the running app once it is ready.
 


### PR DESCRIPTION
## Summary

This security fix restores a Buildkite approval gate inside the preview-app pipeline before any build/deploy steps run with deployment credentials.

The `preview` label still requests a preview app, but the uploaded preview pipeline now requires an authorized human to unblock it after confirming the PR code is trusted. The deployment docs are updated to document the approval step.

## Security impact

PR #5545 made the `preview` label sufficient to start a preview build that runs PR-controlled code with Docker/deployment credentials. Label permission can be broader than deployment approval, so this could allow a labeler to escalate into preview deployment credentials. Requiring a Buildkite unblock restores an explicit authorization boundary.

## Testing

- `ruby -e 'require "yaml"; YAML.load_file(".buildkite/preview.yml"); puts "preview.yml ok"'`
- `git diff --check`

Fixes security review finding from #5545.

/assign @nyomanjyotisa

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and documentation only; tightens authorization around preview deploys without changing application runtime code.
> 
> **Overview**
> Restores an explicit human approval step before preview builds run with **Docker and deployment credentials**. The preview pipeline now starts with a **Buildkite block** (`require-preview-approval`); **Build Base Image** and the rest of the chain only run after someone unblocks it.
> 
> The **`preview` label** still kicks off the preview workflow, but labeling alone no longer authorizes deploy—the docs now say reviewers must confirm PR code is trusted before unblocking, and that **each push** on a labeled branch needs approval again.
> 
> **Risk context:** This closes a path where anyone who could add the label could trigger PR-controlled code in a job with deployment secrets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7baa332653dd68ef206d851b802b70b887a61859. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->