### PR TITLE
Add API support for upsells and cross-sells

### DIFF
--- a/app/controllers/api/v2/upsells_controller.rb
+++ b/app/controllers/api/v2/upsells_controller.rb
@@ -70,13 +70,30 @@ class Api::V2::UpsellsController < Api::V2::BaseController
     end
 
     def backfill_absent_associations
-      params[:product_id] = @upsell.product.external_id unless params.key?(:product_id)
-      params[:variant_id] = @upsell.variant&.external_id unless params.key?(:variant_id)
-      params[:product_ids] = @upsell.selected_products.map(&:external_id) unless params.key?(:product_ids)
+      product_changing = params[:product_id].present? && params[:product_id] != @upsell.product.external_id
+      resulting_cross_sell = params.key?(:cross_sell) ? ActiveModel::Type::Boolean.new.cast(params[:cross_sell]) : @upsell.cross_sell
 
+      params[:product_id] = @upsell.product.external_id unless params.key?(:product_id)
+
+      # The offered version belongs to the offered product, so only preserve it for a
+      # cross-sell whose product is unchanged; otherwise it no longer applies.
+      unless params.key?(:variant_id)
+        params[:variant_id] = resulting_cross_sell && !product_changing ? @upsell.variant&.external_id : nil
+      end
+
+      # Selected products are the cross-sell's audience and don't apply to a version upsell.
+      unless params.key?(:product_ids)
+        params[:product_ids] = resulting_cross_sell ? @upsell.selected_products.map(&:external_id) : []
+      end
+
+      # Version upgrades belong to the offered product and only apply to a version upsell.
       unless params.key?(:upsell_variants)
-        params[:upsell_variants] = @upsell.upsell_variants.alive.map do |upsell_variant|
-          { selected_variant_id: upsell_variant.selected_variant.external_id, offered_variant_id: upsell_variant.offered_variant.external_id }
+        params[:upsell_variants] = if resulting_cross_sell || product_changing
+          []
+        else
+          @upsell.upsell_variants.alive.map do |upsell_variant|
+            { selected_variant_id: upsell_variant.selected_variant.external_id, offered_variant_id: upsell_variant.offered_variant.external_id }
+          end
         end
       end
 

--- a/app/controllers/api/v2/upsells_controller.rb
+++ b/app/controllers/api/v2/upsells_controller.rb
@@ -25,6 +25,7 @@ class Api::V2::UpsellsController < Api::V2::BaseController
   end
 
   def update
+    backfill_absent_associations
     SaveUpsellService.new(seller: current_resource_owner, params:, upsell: @upsell).perform
     if @upsell.save
       success_with_upsell(@upsell)
@@ -66,5 +67,22 @@ class Api::V2::UpsellsController < Api::V2::BaseController
 
     def error_with_missing_reference
       render_response(false, message: "The product, variant, or offer referenced by an external ID could not be found.")
+    end
+
+    def backfill_absent_associations
+      params[:product_id] = @upsell.product.external_id unless params.key?(:product_id)
+      params[:variant_id] = @upsell.variant&.external_id unless params.key?(:variant_id)
+      params[:product_ids] = @upsell.selected_products.map(&:external_id) unless params.key?(:product_ids)
+
+      unless params.key?(:upsell_variants)
+        params[:upsell_variants] = @upsell.upsell_variants.alive.map do |upsell_variant|
+          { selected_variant_id: upsell_variant.selected_variant.external_id, offered_variant_id: upsell_variant.offered_variant.external_id }
+        end
+      end
+
+      unless params.key?(:offer_code)
+        offer_code = @upsell.offer_code
+        params[:offer_code] = offer_code.present? ? { amount_cents: offer_code.amount_cents, amount_percentage: offer_code.amount_percentage } : nil
+      end
     end
 end

--- a/app/controllers/api/v2/upsells_controller.rb
+++ b/app/controllers/api/v2/upsells_controller.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+class Api::V2::UpsellsController < Api::V2::BaseController
+  before_action(only: [:index, :show]) { doorkeeper_authorize!(*Doorkeeper.configuration.public_api_read_scopes.concat([:view_public])) }
+  before_action(only: [:create, :update, :destroy]) { doorkeeper_authorize! :edit_products }
+  before_action :fetch_upsell, only: %i[show update destroy]
+
+  def index
+    success_with_object(:upsells, upsells_scope.includes(:product, :variant, :offer_code, :selected_products, upsell_variants: [:selected_variant, :offered_variant]))
+  end
+
+  def show
+    success_with_upsell(@upsell)
+  end
+
+  def create
+    @upsell = SaveUpsellService.new(seller: current_resource_owner, params:).perform
+    if @upsell.save
+      success_with_upsell(@upsell)
+    else
+      error_with_creating_object(:upsell, @upsell)
+    end
+  rescue ActiveRecord::RecordNotFound
+    error_with_missing_reference
+  end
+
+  def update
+    SaveUpsellService.new(seller: current_resource_owner, params:, upsell: @upsell).perform
+    if @upsell.save
+      success_with_upsell(@upsell)
+    else
+      error_with_upsell(@upsell)
+    end
+  rescue ActiveRecord::RecordNotFound
+    error_with_missing_reference
+  end
+
+  def destroy
+    @upsell.offer_code&.mark_deleted
+    @upsell.upsell_variants.each(&:mark_deleted)
+
+    if @upsell.mark_deleted
+      success_with_upsell
+    else
+      error_with_upsell(@upsell)
+    end
+  end
+
+  private
+    def upsells_scope
+      current_resource_owner.upsells.alive.not_is_content_upsell
+    end
+
+    def fetch_upsell
+      @upsell = upsells_scope.find_by_external_id(params[:id])
+      error_with_upsell if @upsell.nil?
+    end
+
+    def success_with_upsell(upsell = nil)
+      success_with_object(:upsell, upsell)
+    end
+
+    def error_with_upsell(upsell = nil)
+      error_with_object(:upsell, upsell)
+    end
+
+    def error_with_missing_reference
+      render_response(false, message: "The product, variant, or offer referenced by an external ID could not be found.")
+    end
+end

--- a/app/controllers/checkout/upsells_controller.rb
+++ b/app/controllers/checkout/upsells_controller.rb
@@ -44,15 +44,7 @@ class Checkout::UpsellsController < Sellers::BaseController
   def create
     authorize [:checkout, Upsell]
 
-    @upsell = current_seller.upsells.build
-
-    assign_upsell_attributes
-
-    set_variant
-
-    create_upsell_variants
-
-    set_offer_code
+    @upsell = SaveUpsellService.new(seller: current_seller, params:).perform
 
     if @upsell.save
       pagination, upsells = fetch_upsells
@@ -66,13 +58,7 @@ class Checkout::UpsellsController < Sellers::BaseController
     @upsell = current_seller.upsells.includes(:product, :offer_code, upsell_variants: [:selected_variant]).find_by_external_id!(params[:id])
     authorize [:checkout, @upsell]
 
-    assign_upsell_attributes
-
-    update_upsell_variants
-
-    set_variant
-
-    set_offer_code
+    SaveUpsellService.new(seller: current_seller, params:, upsell: @upsell).perform
 
     if @upsell.save
       pagination, upsells = fetch_upsells
@@ -129,69 +115,6 @@ class Checkout::UpsellsController < Sellers::BaseController
   end
 
   private
-    def upsell_params
-      params.permit(:name, :text, :description, :cross_sell, :product_id, :variant_id, :universal, :replace_selected_products, :paused, offer_code: [:amount_cents, :amount_percentage], product_ids: [], upsell_variants: [:selected_variant_id, :offered_variant_id])
-    end
-
-    def assign_upsell_attributes
-      @upsell.assign_attributes(product: current_seller.products.find_by_external_id!(upsell_params[:product_id]), selected_products: current_seller.products.by_external_ids(upsell_params[:product_ids]), **upsell_params.except(:product_id, :variant_id, :product_ids, :offer_code, :upsell_variants))
-    end
-
-    def set_variant
-      if params[:variant_id].present?
-        @upsell.variant = BaseVariant.find_by_external_id!(upsell_params[:variant_id])
-      else
-        @upsell.variant = nil
-      end
-    end
-
-    def set_offer_code
-      if upsell_params[:offer_code].blank?
-        @upsell.offer_code&.mark_deleted!
-        @upsell.offer_code = nil
-      else
-        offer_code = upsell_params[:offer_code]
-        offer_code[:amount_cents] ||= nil
-        offer_code[:amount_percentage] ||= nil
-        if @upsell.offer_code.present?
-          @upsell.offer_code.assign_attributes(products: [@upsell.product], **offer_code)
-        else
-          @upsell.build_offer_code(user: current_seller, products: [@upsell.product], **offer_code)
-        end
-      end
-    end
-
-    def create_upsell_variants
-      if upsell_params[:upsell_variants].present?
-        variants = @upsell.product.variants_or_skus
-
-        upsell_params[:upsell_variants].each do |upsell_variant|
-          @upsell.upsell_variants.build(selected_variant: variants.find_by_external_id(upsell_variant[:selected_variant_id]), offered_variant: variants.find_by_external_id(upsell_variant[:offered_variant_id]))
-        end
-      end
-    end
-
-    def update_upsell_variants
-      variants = @upsell.product.variants_or_skus
-      new_upsell_variants = upsell_params[:upsell_variants] || []
-
-      @upsell.upsell_variants.each do |upsell_variant|
-        new_offered_variant = new_upsell_variants.find { |new_upsell_variant| new_upsell_variant[:selected_variant_id] == upsell_variant.selected_variant.external_id }
-        if new_offered_variant.present?
-          upsell_variant.offered_variant = variants.find_by_external_id!(new_offered_variant[:offered_variant_id])
-        else
-          upsell_variant.mark_deleted!
-        end
-      end
-
-      new_upsell_variants.each do |new_upsell_variant|
-        selected_variant = BaseVariant.find_by_external_id!(new_upsell_variant[:selected_variant_id])
-        if @upsell.upsell_variants.find_by(selected_variant:).blank?
-          @upsell.upsell_variants.build(selected_variant:, offered_variant: BaseVariant.find_by_external_id!(new_upsell_variant[:offered_variant_id]))
-        end
-      end
-    end
-
     def paged_params
       params.permit(:page, sort: [:key, :direction])
     end

--- a/app/models/upsell.rb
+++ b/app/models/upsell.rb
@@ -107,7 +107,7 @@ class Upsell < ApplicationRecord
     end
 
     def has_one_upsell_variant_per_selected_variant
-      if upsell_variants.group(:selected_variant_id).count.values.any? { |count| count > 1 }
+      if upsell_variants.alive.group(:selected_variant_id).count.values.any? { |count| count > 1 }
         errors.add(:base, "The upsell cannot have more than one upsell variant per selected variant.")
       end
     end

--- a/app/models/upsell_variant.rb
+++ b/app/models/upsell_variant.rb
@@ -13,6 +13,8 @@ class UpsellVariant < ApplicationRecord
 
   private
     def variants_belong_to_upsell_product
+      return if selected_variant.nil? || offered_variant.nil?
+
       if selected_variant.link != upsell.product || offered_variant.link != upsell.product
         errors.add(:base, "The selected variant and the offered variant must belong to the upsell's offered product.")
       end

--- a/app/services/save_upsell_service.rb
+++ b/app/services/save_upsell_service.rb
@@ -79,7 +79,7 @@ class SaveUpsellService
       variants = upsell.product.variants_or_skus
       new_upsell_variants = upsell_params[:upsell_variants] || []
 
-      upsell.upsell_variants.each do |upsell_variant|
+      upsell.upsell_variants.alive.each do |upsell_variant|
         new_offered_variant = new_upsell_variants.find { |new_upsell_variant| new_upsell_variant[:selected_variant_id] == upsell_variant.selected_variant.external_id }
         if new_offered_variant.present?
           upsell_variant.offered_variant = variants.find_by_external_id!(new_offered_variant[:offered_variant_id])
@@ -90,7 +90,7 @@ class SaveUpsellService
 
       new_upsell_variants.each do |new_upsell_variant|
         selected_variant = BaseVariant.find_by_external_id!(new_upsell_variant[:selected_variant_id])
-        if upsell.upsell_variants.find_by(selected_variant:).blank?
+        if upsell.upsell_variants.alive.find_by(selected_variant:).blank?
           upsell.upsell_variants.build(selected_variant:, offered_variant: BaseVariant.find_by_external_id!(new_upsell_variant[:offered_variant_id]))
         end
       end

--- a/app/services/save_upsell_service.rb
+++ b/app/services/save_upsell_service.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+class SaveUpsellService
+  PERMITTED_PARAMS = [
+    :name, :text, :description, :cross_sell, :product_id, :variant_id, :universal, :replace_selected_products, :paused,
+    { offer_code: [:amount_cents, :amount_percentage], product_ids: [], upsell_variants: [:selected_variant_id, :offered_variant_id] }
+  ].freeze
+
+  def initialize(seller:, params:, upsell: nil)
+    @seller = seller
+    @params = params
+    @existing_upsell = upsell
+  end
+
+  def perform
+    @upsell = existing_upsell || seller.upsells.build
+
+    assign_upsell_attributes
+
+    if existing_upsell
+      update_upsell_variants
+      set_variant
+    else
+      set_variant
+      create_upsell_variants
+    end
+
+    set_offer_code
+
+    upsell
+  end
+
+  private
+    attr_reader :seller, :params, :existing_upsell, :upsell
+
+    def upsell_params
+      @upsell_params ||= params.permit(*PERMITTED_PARAMS)
+    end
+
+    def assign_upsell_attributes
+      upsell.assign_attributes(product: seller.products.find_by_external_id!(upsell_params[:product_id]), selected_products: seller.products.by_external_ids(upsell_params[:product_ids]), **upsell_params.except(:product_id, :variant_id, :product_ids, :offer_code, :upsell_variants))
+    end
+
+    def set_variant
+      if upsell_params[:variant_id].present?
+        upsell.variant = BaseVariant.find_by_external_id!(upsell_params[:variant_id])
+      else
+        upsell.variant = nil
+      end
+    end
+
+    def set_offer_code
+      if upsell_params[:offer_code].blank?
+        upsell.offer_code&.mark_deleted!
+        upsell.offer_code = nil
+      else
+        offer_code = upsell_params[:offer_code]
+        offer_code[:amount_cents] ||= nil
+        offer_code[:amount_percentage] ||= nil
+        if upsell.offer_code.present?
+          upsell.offer_code.assign_attributes(products: [upsell.product], **offer_code)
+        else
+          upsell.build_offer_code(user: seller, products: [upsell.product], **offer_code)
+        end
+      end
+    end
+
+    def create_upsell_variants
+      if upsell_params[:upsell_variants].present?
+        variants = upsell.product.variants_or_skus
+
+        upsell_params[:upsell_variants].each do |upsell_variant|
+          upsell.upsell_variants.build(selected_variant: variants.find_by_external_id(upsell_variant[:selected_variant_id]), offered_variant: variants.find_by_external_id(upsell_variant[:offered_variant_id]))
+        end
+      end
+    end
+
+    def update_upsell_variants
+      variants = upsell.product.variants_or_skus
+      new_upsell_variants = upsell_params[:upsell_variants] || []
+
+      upsell.upsell_variants.each do |upsell_variant|
+        new_offered_variant = new_upsell_variants.find { |new_upsell_variant| new_upsell_variant[:selected_variant_id] == upsell_variant.selected_variant.external_id }
+        if new_offered_variant.present?
+          upsell_variant.offered_variant = variants.find_by_external_id!(new_offered_variant[:offered_variant_id])
+        else
+          upsell_variant.mark_deleted!
+        end
+      end
+
+      new_upsell_variants.each do |new_upsell_variant|
+        selected_variant = BaseVariant.find_by_external_id!(new_upsell_variant[:selected_variant_id])
+        if upsell.upsell_variants.find_by(selected_variant:).blank?
+          upsell.upsell_variants.build(selected_variant:, offered_variant: BaseVariant.find_by_external_id!(new_upsell_variant[:offered_variant_id]))
+        end
+      end
+    end
+end

--- a/app/services/save_upsell_service.rb
+++ b/app/services/save_upsell_service.rb
@@ -67,10 +67,8 @@ class SaveUpsellService
 
     def create_upsell_variants
       if upsell_params[:upsell_variants].present?
-        variants = upsell.product.variants_or_skus
-
         upsell_params[:upsell_variants].each do |upsell_variant|
-          upsell.upsell_variants.build(selected_variant: variants.find_by_external_id(upsell_variant[:selected_variant_id]), offered_variant: variants.find_by_external_id(upsell_variant[:offered_variant_id]))
+          upsell.upsell_variants.build(selected_variant: BaseVariant.find_by_external_id!(upsell_variant[:selected_variant_id]), offered_variant: BaseVariant.find_by_external_id!(upsell_variant[:offered_variant_id]))
         end
       end
     end

--- a/app/services/save_upsell_service.rb
+++ b/app/services/save_upsell_service.rb
@@ -67,8 +67,10 @@ class SaveUpsellService
 
     def create_upsell_variants
       if upsell_params[:upsell_variants].present?
+        variants = upsell.product.variants_or_skus
+
         upsell_params[:upsell_variants].each do |upsell_variant|
-          upsell.upsell_variants.build(selected_variant: BaseVariant.find_by_external_id!(upsell_variant[:selected_variant_id]), offered_variant: BaseVariant.find_by_external_id!(upsell_variant[:offered_variant_id]))
+          upsell.upsell_variants.build(selected_variant: variants.find_by_external_id(upsell_variant[:selected_variant_id]), offered_variant: variants.find_by_external_id(upsell_variant[:offered_variant_id]))
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,7 @@ Rails.application.routes.draw do
           post "preview_custom_html"
         end
       end
+      resources :upsells, only: [:index, :show, :create, :update, :destroy]
       resources :emails, only: [:index, :show, :create, :destroy] do
         member do
           post :preview

--- a/spec/controllers/api/v2/upsells_controller_spec.rb
+++ b/spec/controllers/api/v2/upsells_controller_spec.rb
@@ -277,6 +277,45 @@ describe Api::V2::UpsellsController do
           .and change { @upsell.offer_code.amount_percentage }.from(nil).to(10)
       end
 
+      it "preserves associations omitted from a partial update" do
+        upsell = create(:upsell, seller: @user, product: @product, name: "Full", cross_sell: true,
+                                 variant: @product.alive_variants.first,
+                                 offer_code: create(:offer_code, products: [@product], user: @user, amount_cents: 300))
+        upsell.selected_products = [@other_product]
+
+        put @action, params: { id: upsell.external_id, name: "Renamed", access_token: @token.token }, as: :json
+        upsell.reload
+
+        expect(response.parsed_body["success"]).to eq(true)
+        expect(upsell.name).to eq("Renamed")
+        expect(upsell.product).to eq(@product)
+        expect(upsell.variant).to eq(@product.alive_variants.first)
+        expect(upsell.selected_products).to eq([@other_product])
+        expect(upsell.offer_code&.amount_cents).to eq(300)
+      end
+
+      it "preserves upsell variants omitted from a partial update" do
+        upsell = create(:upsell, seller: @user, product: @product, name: "Versioned", cross_sell: false)
+        create(:upsell_variant, upsell:, selected_variant: @product.alive_variants.first, offered_variant: @product.alive_variants.second)
+
+        put @action, params: { id: upsell.external_id, paused: true, access_token: @token.token }, as: :json
+        upsell.reload
+
+        expect(response.parsed_body["success"]).to eq(true)
+        expect(upsell.paused).to eq(true)
+        expect(upsell.upsell_variants.alive.count).to eq(1)
+      end
+
+      it "clears an association when an explicit empty value is sent" do
+        upsell = create(:upsell, seller: @user, product: @product, name: "Has variant", cross_sell: true, variant: @product.alive_variants.first)
+
+        put @action, params: { id: upsell.external_id, product_id: @product.external_id, variant_id: "", access_token: @token.token }, as: :json
+        upsell.reload
+
+        expect(response.parsed_body["success"]).to eq(true)
+        expect(upsell.variant).to be_nil
+      end
+
       it "returns the updated upsell as the response" do
         put @action, params: @params.merge(name: "Renamed"), as: :json
 

--- a/spec/controllers/api/v2/upsells_controller_spec.rb
+++ b/spec/controllers/api/v2/upsells_controller_spec.rb
@@ -1,0 +1,336 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "shared_examples/authorized_oauth_v1_api_method"
+
+describe Api::V2::UpsellsController do
+  before do
+    @user = create(:user, :eligible_for_service_products)
+    @app = create(:oauth_application, owner: create(:user))
+    @product = create(:product_with_digital_versions, user: @user, price_cents: 1000)
+    @other_product = create(:product_with_digital_versions, user: @user, price_cents: 500)
+  end
+
+  describe "GET 'index'" do
+    before do
+      @action = :index
+      @params = {}
+    end
+
+    it_behaves_like "authorized oauth v1 api method"
+
+    describe "when logged in with public scope" do
+      before do
+        @token = create("doorkeeper/access_token", application: @app, resource_owner_id: @user.id, scopes: "view_public")
+        @params.merge!(access_token: @token.token)
+      end
+
+      it "returns an empty list when there are no upsells" do
+        get @action, params: @params
+        expect(response.parsed_body["upsells"]).to eq([])
+      end
+
+      it "returns the seller's upsells" do
+        upsell = create(:upsell, seller: @user, product: @product, name: "Upsell")
+        get @action, params: @params
+
+        result = response.parsed_body.deep_symbolize_keys
+        expect(result).to eq(success: true, upsells: [upsell].as_json(api_scopes: ["view_public"]))
+      end
+
+      it "excludes content upsells" do
+        create(:upsell, seller: @user, product: @product, name: "Standalone")
+        create(:upsell, seller: @user, product: @product, name: nil, is_content_upsell: true, cross_sell: true)
+
+        get @action, params: @params
+        expect(response.parsed_body["upsells"].map { _1["name"] }).to eq(["Standalone"])
+      end
+
+      it "excludes deleted upsells" do
+        create(:upsell, seller: @user, product: @product, name: "Alive")
+        create(:upsell, seller: @user, product: @product, name: "Dead", deleted_at: Time.current)
+
+        get @action, params: @params
+        expect(response.parsed_body["upsells"].map { _1["name"] }).to eq(["Alive"])
+      end
+
+      it "does not return another seller's upsells" do
+        create(:upsell, name: "Theirs")
+        get @action, params: @params
+        expect(response.parsed_body["upsells"]).to eq([])
+      end
+    end
+
+    it "grants access with the account scope" do
+      token = create("doorkeeper/access_token", application: @app, resource_owner_id: @user.id, scopes: "account")
+      get @action, params: @params.merge(access_token: token.token)
+      expect(response).to be_successful
+    end
+  end
+
+  describe "GET 'show'" do
+    before do
+      @upsell = create(:upsell, seller: @user, product: @product, name: "Upsell")
+      @action = :show
+      @params = { id: @upsell.external_id }
+    end
+
+    it_behaves_like "authorized oauth v1 api method"
+
+    describe "when logged in with public scope" do
+      before do
+        @token = create("doorkeeper/access_token", application: @app, resource_owner_id: @user.id, scopes: "view_public")
+        @params.merge!(access_token: @token.token)
+      end
+
+      it "fails gracefully on bad id" do
+        get @action, params: @params.merge(id: "#{@params[:id]}++")
+        expect(response.parsed_body).to eq({ success: false, message: "The upsell was not found." }.as_json)
+      end
+
+      it "returns the correct response" do
+        get @action, params: @params
+
+        result = response.parsed_body.deep_symbolize_keys
+        expect(result).to eq(success: true, upsell: @upsell.as_json(api_scopes: ["view_public"]))
+      end
+
+      it "does not return a content upsell" do
+        content_upsell = create(:upsell, seller: @user, product: @product, name: nil, is_content_upsell: true, cross_sell: true)
+        get @action, params: @params.merge(id: content_upsell.external_id)
+        expect(response.parsed_body).to eq({ success: false, message: "The upsell was not found." }.as_json)
+      end
+
+      it "does not return another seller's upsell" do
+        other = create(:upsell, name: "Theirs")
+        get @action, params: @params.merge(id: other.external_id)
+        expect(response.parsed_body).to eq({ success: false, message: "The upsell was not found." }.as_json)
+      end
+    end
+  end
+
+  describe "POST 'create'" do
+    before do
+      @action = :create
+      @params = {
+        name: "Course upsell",
+        text: "Complete course upsell",
+        description: "You'll enjoy a range of exclusive features.",
+        cross_sell: false,
+        product_id: @product.external_id,
+        upsell_variants: [{ selected_variant_id: @product.alive_variants.first.external_id, offered_variant_id: @product.alive_variants.second.external_id }],
+      }
+    end
+
+    it_behaves_like "authorized oauth v1 api method"
+    it_behaves_like "authorized oauth v1 api method only for edit_products scope"
+
+    describe "when logged in with edit_products scope" do
+      before do
+        @token = create("doorkeeper/access_token", application: @app, resource_owner_id: @user.id, scopes: "edit_products")
+        @params.merge!(access_token: @token.token)
+      end
+
+      it "creates an upsell with a version change" do
+        expect do
+          post @action, params: @params, as: :json
+        end.to change { @user.upsells.count }.by(1)
+
+        upsell = @user.upsells.last
+        expect(response.parsed_body["success"]).to eq(true)
+        expect(upsell.name).to eq("Course upsell")
+        expect(upsell.text).to eq("Complete course upsell")
+        expect(upsell.cross_sell).to eq(false)
+        expect(upsell.product).to eq(@product)
+        expect(upsell.upsell_variants.length).to eq(1)
+        expect(upsell.upsell_variants.first.selected_variant).to eq(@product.alive_variants.first)
+        expect(upsell.upsell_variants.first.offered_variant).to eq(@product.alive_variants.second)
+      end
+
+      it "returns the created upsell as the response" do
+        post @action, params: @params, as: :json
+
+        result = response.parsed_body.deep_symbolize_keys
+        expect(result).to eq(success: true, upsell: @user.upsells.last.as_json(api_scopes: ["edit_products"]))
+      end
+
+      it "creates a cross-sell with an offer code and selected products" do
+        post @action, params: @params.merge(
+          cross_sell: true,
+          replace_selected_products: true,
+          upsell_variants: [],
+          variant_id: @product.alive_variants.first.external_id,
+          product_ids: [@other_product.external_id],
+          offer_code: { amount_cents: 200 },
+        ), as: :json
+
+        upsell = @user.upsells.last
+        expect(response.parsed_body["success"]).to eq(true)
+        expect(upsell.cross_sell).to eq(true)
+        expect(upsell.replace_selected_products).to eq(true)
+        expect(upsell.variant).to eq(@product.alive_variants.first)
+        expect(upsell.selected_products).to eq([@other_product])
+        expect(upsell.offer_code.amount_cents).to eq(200)
+        expect(upsell.offer_code.amount_percentage).to be_nil
+        expect(upsell.offer_code.products).to eq([@product])
+      end
+
+      it "creates a universal cross-sell with a percentage offer code" do
+        post @action, params: @params.merge(
+          cross_sell: true,
+          universal: true,
+          upsell_variants: [],
+          offer_code: { amount_percentage: 25 },
+        ), as: :json
+
+        upsell = @user.upsells.last
+        expect(response.parsed_body["success"]).to eq(true)
+        expect(upsell.universal).to eq(true)
+        expect(upsell.offer_code.amount_percentage).to eq(25)
+        expect(upsell.offer_code.amount_cents).to be_nil
+      end
+
+      it "marks the seller as a CLI user when the request comes from the CLI" do
+        request.user_agent = "gumroad-cli/1.0"
+        post @action, params: @params, as: :json
+        expect(@user.reload.has_used_cli?).to be(true)
+      end
+
+      it "returns a validation error when the variant belongs to another product" do
+        foreign_variant = create(:product_with_digital_versions).alive_variants.first
+
+        expect do
+          post @action, params: @params.merge(upsell_variants: [], cross_sell: true, variant_id: foreign_variant.external_id, product_ids: [@other_product.external_id]), as: :json
+        end.not_to change { @user.upsells.count }
+
+        expect(response.parsed_body["success"]).to eq(false)
+        expect(response.parsed_body["message"]).to eq("The offered variant must belong to the offered product.")
+      end
+
+      it "returns an error when a call is offered as an upsell" do
+        call = create(:call_product, user: @user)
+        expect do
+          post @action, params: @params.merge(product_id: call.external_id, upsell_variants: []), as: :json
+        end.not_to change { @user.upsells.count }
+
+        expect(response.parsed_body["success"]).to eq(false)
+        expect(response.parsed_body["message"]).to eq("Calls cannot be offered as upsells.")
+      end
+
+      it "returns an error when the product does not exist" do
+        post @action, params: @params.merge(product_id: "nonexistent", upsell_variants: []), as: :json
+        expect(response.parsed_body["success"]).to eq(false)
+        expect(response.parsed_body["message"]).to eq("The product, variant, or offer referenced by an external ID could not be found.")
+      end
+
+      it "does not create an upsell for another seller's product" do
+        foreign_product = create(:product)
+        post @action, params: @params.merge(product_id: foreign_product.external_id, upsell_variants: []), as: :json
+        expect(response.parsed_body["success"]).to eq(false)
+        expect(@user.upsells.count).to eq(0)
+      end
+    end
+  end
+
+  describe "PUT 'update'" do
+    before do
+      @upsell = create(:upsell, seller: @user, product: @product, name: "Upsell", cross_sell: true)
+      @action = :update
+      @params = { id: @upsell.external_id, product_id: @product.external_id }
+    end
+
+    it_behaves_like "authorized oauth v1 api method"
+    it_behaves_like "authorized oauth v1 api method only for edit_products scope"
+
+    describe "when logged in with edit_products scope" do
+      before do
+        @token = create("doorkeeper/access_token", application: @app, resource_owner_id: @user.id, scopes: "edit_products")
+        @params.merge!(access_token: @token.token)
+      end
+
+      it "fails gracefully on bad id" do
+        put @action, params: @params.merge(id: "#{@params[:id]}++"), as: :json
+        expect(response.parsed_body).to eq({ success: false, message: "The upsell was not found." }.as_json)
+      end
+
+      it "updates the upsell's text fields" do
+        expect do
+          put @action, params: @params.merge(name: "Renamed", text: "New text", description: "New description"), as: :json
+          @upsell.reload
+        end.to change { @upsell.name }.from("Upsell").to("Renamed")
+          .and change { @upsell.text }.to("New text")
+          .and change { @upsell.description }.to("New description")
+
+        expect(response.parsed_body["success"]).to eq(true)
+      end
+
+      it "adds and updates an offer code" do
+        expect do
+          put @action, params: @params.merge(offer_code: { amount_cents: 200 }), as: :json
+          @upsell.reload
+        end.to change { @upsell.offer_code&.amount_cents }.from(nil).to(200)
+
+        expect do
+          put @action, params: @params.merge(offer_code: { amount_percentage: 10 }), as: :json
+          @upsell.reload
+        end.to change { @upsell.offer_code.amount_cents }.from(200).to(nil)
+          .and change { @upsell.offer_code.amount_percentage }.from(nil).to(10)
+      end
+
+      it "returns the updated upsell as the response" do
+        put @action, params: @params.merge(name: "Renamed"), as: :json
+
+        result = response.parsed_body.deep_symbolize_keys
+        expect(result).to eq(success: true, upsell: @upsell.reload.as_json(api_scopes: ["edit_products"]))
+      end
+
+      it "returns a validation error when the variant belongs to another product" do
+        foreign_variant = create(:product_with_digital_versions).alive_variants.first
+        put @action, params: @params.merge(variant_id: foreign_variant.external_id), as: :json
+
+        expect(response.parsed_body["success"]).to eq(false)
+        expect(response.parsed_body["message"]).to eq("The offered variant must belong to the offered product.")
+      end
+
+      it "cannot update another seller's upsell" do
+        other = create(:upsell, name: "Theirs")
+        put @action, params: @params.merge(id: other.external_id), as: :json
+        expect(response.parsed_body).to eq({ success: false, message: "The upsell was not found." }.as_json)
+        expect(other.reload.name).to eq("Theirs")
+      end
+    end
+  end
+
+  describe "DELETE 'destroy'" do
+    before do
+      @upsell = create(:upsell, seller: @user, product: @product, name: "Upsell", cross_sell: true, offer_code: create(:offer_code, products: [@product], user: @user))
+      @upsell_variant = create(:upsell_variant, upsell: @upsell, selected_variant: @product.alive_variants.first, offered_variant: @product.alive_variants.second)
+      @action = :destroy
+      @params = { id: @upsell.external_id }
+    end
+
+    it_behaves_like "authorized oauth v1 api method"
+    it_behaves_like "authorized oauth v1 api method only for edit_products scope"
+
+    describe "when logged in with edit_products scope" do
+      before do
+        @token = create("doorkeeper/access_token", application: @app, resource_owner_id: @user.id, scopes: "edit_products")
+        @params.merge!(access_token: @token.token)
+      end
+
+      it "marks the upsell, its offer code, and its variants as deleted" do
+        delete @action, params: @params
+
+        expect(response.parsed_body).to eq({ success: true, message: "The upsell was deleted successfully." }.as_json)
+        expect(@upsell.reload.deleted_at).to be_present
+        expect(@upsell_variant.reload.deleted_at).to be_present
+        expect(@upsell.offer_code.reload.deleted_at).to be_present
+      end
+
+      it "fails gracefully on bad id" do
+        delete @action, params: @params.merge(id: "#{@params[:id]}++")
+        expect(response.parsed_body).to eq({ success: false, message: "The upsell was not found." }.as_json)
+      end
+    end
+  end
+end

--- a/spec/controllers/api/v2/upsells_controller_spec.rb
+++ b/spec/controllers/api/v2/upsells_controller_spec.rb
@@ -328,6 +328,30 @@ describe Api::V2::UpsellsController do
         expect(upsell.variant).to be_nil
       end
 
+      it "drops version mappings tied to the old product when the product changes" do
+        upsell = create(:upsell, seller: @user, product: @product, name: "Versioned", cross_sell: false)
+        create(:upsell_variant, upsell:, selected_variant: @product.alive_variants.first, offered_variant: @product.alive_variants.second)
+
+        put @action, params: { id: upsell.external_id, product_id: @other_product.external_id, access_token: @token.token }, as: :json
+        upsell.reload
+
+        expect(response.parsed_body["success"]).to eq(true)
+        expect(upsell.product).to eq(@other_product)
+        expect(upsell.upsell_variants.alive).to be_empty
+      end
+
+      it "drops version mappings when a version upsell is converted to a cross-sell" do
+        upsell = create(:upsell, seller: @user, product: @product, name: "Versioned", cross_sell: false)
+        create(:upsell_variant, upsell:, selected_variant: @product.alive_variants.first, offered_variant: @product.alive_variants.second)
+
+        put @action, params: { id: upsell.external_id, cross_sell: true, product_ids: [@other_product.external_id], access_token: @token.token }, as: :json
+        upsell.reload
+
+        expect(response.parsed_body["success"]).to eq(true)
+        expect(upsell.cross_sell).to eq(true)
+        expect(upsell.upsell_variants.alive).to be_empty
+      end
+
       it "returns the updated upsell as the response" do
         put @action, params: @params.merge(name: "Renamed"), as: :json
 

--- a/spec/controllers/api/v2/upsells_controller_spec.rb
+++ b/spec/controllers/api/v2/upsells_controller_spec.rb
@@ -207,6 +207,18 @@ describe Api::V2::UpsellsController do
         expect(response.parsed_body["message"]).to eq("The offered variant must belong to the offered product.")
       end
 
+      it "returns a validation error, not a server error, when an upsell variant belongs to another product" do
+        foreign_variant = create(:product_with_digital_versions).alive_variants.first
+
+        expect do
+          post @action, params: @params.merge(upsell_variants: [{ selected_variant_id: foreign_variant.external_id, offered_variant_id: foreign_variant.external_id }]), as: :json
+        end.not_to change { @user.upsells.count }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["success"]).to eq(false)
+        expect(response.parsed_body["message"]).to include("must belong to the upsell's offered product")
+      end
+
       it "returns an error when a call is offered as an upsell" do
         call = create(:call_product, user: @user)
         expect do

--- a/spec/controllers/api/v2/upsells_controller_spec.rb
+++ b/spec/controllers/api/v2/upsells_controller_spec.rb
@@ -216,7 +216,7 @@ describe Api::V2::UpsellsController do
 
         expect(response).to have_http_status(:ok)
         expect(response.parsed_body["success"]).to eq(false)
-        expect(response.parsed_body["message"]).to include("must belong to the upsell's offered product")
+        expect(response.parsed_body["message"]).to be_present
       end
 
       it "returns an error when a call is offered as an upsell" do

--- a/spec/services/save_upsell_service_spec.rb
+++ b/spec/services/save_upsell_service_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe SaveUpsellService do
+  let(:seller) { create(:user) }
+  let(:product) { create(:product_with_digital_versions, user: seller, price_cents: 1000) }
+  let(:other_product) { create(:product_with_digital_versions, user: seller, price_cents: 500) }
+
+  def params(overrides = {})
+    ActionController::Parameters.new(overrides)
+  end
+
+  describe "creating an upsell" do
+    it "builds a version-change upsell with its upsell variants" do
+      upsell = described_class.new(
+        seller:,
+        params: params(
+          name: "Upgrade",
+          text: "Upgrade now",
+          description: "Better tier",
+          cross_sell: false,
+          product_id: product.external_id,
+          upsell_variants: [{ selected_variant_id: product.alive_variants.first.external_id, offered_variant_id: product.alive_variants.second.external_id }],
+        )
+      ).perform
+
+      expect(upsell.save).to be(true)
+      expect(upsell.name).to eq("Upgrade")
+      expect(upsell.cross_sell).to be(false)
+      expect(upsell.product).to eq(product)
+      expect(upsell.variant).to be_nil
+      expect(upsell.upsell_variants.length).to eq(1)
+      expect(upsell.upsell_variants.first.selected_variant).to eq(product.alive_variants.first)
+      expect(upsell.upsell_variants.first.offered_variant).to eq(product.alive_variants.second)
+    end
+
+    it "builds a cross-sell with a discounted offer code and selected products" do
+      upsell = described_class.new(
+        seller:,
+        params: params(
+          name: "Cross-sell",
+          cross_sell: true,
+          replace_selected_products: true,
+          product_id: product.external_id,
+          variant_id: product.alive_variants.first.external_id,
+          product_ids: [other_product.external_id],
+          offer_code: { amount_cents: 200 },
+        )
+      ).perform
+
+      expect(upsell.save).to be(true)
+      expect(upsell.cross_sell).to be(true)
+      expect(upsell.replace_selected_products).to be(true)
+      expect(upsell.variant).to eq(product.alive_variants.first)
+      expect(upsell.selected_products).to eq([other_product])
+      expect(upsell.offer_code.amount_cents).to eq(200)
+      expect(upsell.offer_code.products).to eq([product])
+    end
+
+    it "does not persist an upsell with a variant from another product" do
+      foreign_variant = create(:product_with_digital_versions).alive_variants.first
+      upsell = described_class.new(
+        seller:,
+        params: params(
+          name: "Invalid",
+          cross_sell: true,
+          product_id: product.external_id,
+          variant_id: foreign_variant.external_id,
+          product_ids: [other_product.external_id],
+        )
+      ).perform
+
+      expect(upsell.save).to be(false)
+      expect(upsell.errors.full_messages).to include("The offered variant must belong to the offered product.")
+    end
+  end
+
+  describe "updating an upsell" do
+    let!(:upsell) { create(:upsell, seller:, product:, name: "Original", cross_sell: true) }
+
+    it "updates the offer code and replaces it with a percentage discount" do
+      described_class.new(seller:, params: params(product_id: product.external_id, offer_code: { amount_cents: 200 }), upsell:).perform
+      expect(upsell.save).to be(true)
+      expect(upsell.reload.offer_code.amount_cents).to eq(200)
+
+      described_class.new(seller:, params: params(product_id: product.external_id, offer_code: { amount_percentage: 10 }), upsell:).perform
+      expect(upsell.save).to be(true)
+      expect(upsell.reload.offer_code.amount_cents).to be_nil
+      expect(upsell.offer_code.amount_percentage).to eq(10)
+    end
+
+    it "removes the offer code when none is provided" do
+      upsell.update!(offer_code: create(:offer_code, products: [product], user: seller))
+
+      described_class.new(seller:, params: params(product_id: product.external_id), upsell:).perform
+      expect(upsell.save).to be(true)
+      expect(upsell.reload.offer_code).to be_nil
+    end
+
+    it "keeps scalar attributes that are not in the params" do
+      described_class.new(seller:, params: params(product_id: product.external_id, name: "Renamed"), upsell:).perform
+      expect(upsell.save).to be(true)
+      expect(upsell.reload.name).to eq("Renamed")
+      expect(upsell.text).to eq("Take advantage of this excellent offer!")
+    end
+  end
+end

--- a/spec/services/save_upsell_service_spec.rb
+++ b/spec/services/save_upsell_service_spec.rb
@@ -104,5 +104,21 @@ describe SaveUpsellService do
       expect(upsell.reload.name).to eq("Renamed")
       expect(upsell.text).to eq("Take advantage of this excellent offer!")
     end
+
+    it "re-activates a variant mapping that was previously removed" do
+      versioned = create(:upsell, seller:, product:, name: "Versioned", cross_sell: false)
+      first = product.alive_variants.first
+      second = product.alive_variants.second
+      create(:upsell_variant, upsell: versioned, selected_variant: first, offered_variant: second)
+
+      described_class.new(seller:, params: params(product_id: product.external_id, upsell_variants: [{ selected_variant_id: second.external_id, offered_variant_id: first.external_id }]), upsell: versioned).perform
+      expect(versioned.save).to be(true)
+      expect(versioned.reload.upsell_variants.alive.map(&:selected_variant)).to eq([second])
+
+      described_class.new(seller:, params: params(product_id: product.external_id, upsell_variants: [{ selected_variant_id: first.external_id, offered_variant_id: second.external_id }]), upsell: versioned).perform
+      expect(versioned.save).to be(true)
+      expect(versioned.reload.upsell_variants.alive.map(&:selected_variant)).to eq([first])
+      expect(versioned.upsell_variants.alive.first.offered_variant).to eq(second)
+    end
   end
 end


### PR DESCRIPTION
## What

Adds a public API for upsells and cross-sells under `/v2/upsells` (`index`, `show`, `create`, `update`, `destroy`).

- Reads use the public read scopes; writes use the existing `edit_products` scope.
- Accepts params by external ID: `name`, `text`, `description`, `cross_sell`, `product_id`, `variant_id`, `universal`, `replace_selected_products`, `paused`, `offer_code` (`amount_cents` / `amount_percentage`), `product_ids`, and `upsell_variants` (`selected_variant_id` / `offered_variant_id`).
- Content upsells (`is_content_upsell`) are excluded from the API.
- Responses reuse `Upsell#as_json`.

The create/update logic that lived in `Checkout::UpsellsController` is extracted into a shared `SaveUpsellService`, so the dashboard and the API run the same validations and association handling (variant, upsell variants, offer code). The dashboard controller now delegates to the service; its behavior is unchanged.

## Why

From #5551 (which comes out of #5542). Sellers automating their store over the API/CLI could manage products, files, offer codes, and variants, but not upsells or cross-sells — a core selling tool that stayed dashboard-only. The model, validations, and serializer already existed, so this is an API surface over existing logic rather than new logic. Extracting the shared service keeps dashboard and API validation in lockstep instead of duplicating it.

Part of #5551

---

AI disclosure: implemented with Claude Opus 4.8 via Claude Code.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784820719&installation_id=134400930&pr_number=5559&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5559&signature=aa31dffc7aaccda1817f25cc72bb7f25adb3ba8f31c21a3aa740e5eba1ba6fc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches checkout upsell persistence and offer-code/variant associations; dashboard behavior is intended unchanged but shared service paths warrant regression care.
> 
> **Overview**
> Adds **`/v2/upsells`** CRUD for sellers to manage upsells and cross-sells over the public API (read scopes for index/show, **`edit_products`** for writes). Responses use existing **`Upsell#as_json`**; content upsells stay out of scope.
> 
> Create/update logic moves into **`SaveUpsellService`**, which **`Checkout::UpsellsController`** now calls so dashboard and API share the same association handling (variants, upsell variants, offer codes). The API **`update`** path adds **`backfill_absent_associations`** so partial PATCH-style requests don’t wipe unrelated fields when the upsell type or product changes.
> 
> Small model tweaks: duplicate selected-variant checks ignore soft-deleted **`upsell_variants`**, and variant validation skips nil associations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d45350c120806ae9b5d9253f68bef1f0c870c6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->