### PR TITLE
Add API support for editing seller name and bio

### DIFF
--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -2,6 +2,7 @@
 
 class Api::V2::UsersController < Api::V2::BaseController
   before_action -> { doorkeeper_authorize!(*Doorkeeper.configuration.public_api_read_scopes.concat([:view_public])) }, only: [:show, :ifttt_sale_trigger]
+  before_action(only: [:update]) { doorkeeper_authorize! :edit_profile }
 
   def show
     if params[:is_ifttt]
@@ -11,6 +12,16 @@ class Api::V2::UsersController < Api::V2::BaseController
     end
 
     success_with_object(:user, current_resource_owner)
+  end
+
+  def update
+    user = current_resource_owner
+
+    if user.update(permitted_update_params)
+      success_with_object(:user, user)
+    else
+      error_with_object(:user, user)
+    end
   end
 
   def ifttt_status
@@ -38,4 +49,9 @@ class Api::V2::UsersController < Api::V2::BaseController
 
     success_with_object(:data, sales)
   end
+
+  private
+    def permitted_update_params
+      params.permit(:name, :bio)
+    end
 end

--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -17,6 +17,8 @@ class Api::V2::UsersController < Api::V2::BaseController
   def update
     user = current_resource_owner
 
+    return render_response(false, message: "You have to confirm your email address before you can do that.") unless user.confirmed?
+
     if user.update(permitted_update_params)
       success_with_object(:user, user)
     else

--- a/app/javascript/components/ApiDocumentation/Scopes.tsx
+++ b/app/javascript/components/ApiDocumentation/Scopes.tsx
@@ -12,6 +12,10 @@ const SCOPES = [
     description: "read-only access to the user's public information and products.",
   },
   {
+    name: "edit_profile",
+    description: "write access to the user's profile name and bio.",
+  },
+  {
     name: "edit_products",
     description: "read/write access to the user's products and their variants, offer codes, custom fields, and files.",
   },

--- a/app/javascript/pages/Settings/AuthorizedApplications/Index.tsx
+++ b/app/javascript/pages/Settings/AuthorizedApplications/Index.tsx
@@ -35,6 +35,7 @@ type Scope =
   | "edit_sales"
   | "unfurl"
   | "view_profile"
+  | "edit_profile"
   | "view_public"
   | "view_sales"
   | "view_payouts"
@@ -53,6 +54,7 @@ const SCOPE_DESCRIPTIONS: Record<Scope, string> = {
   edit_sales: "Refund your sales and resend purchase receipts to customers.",
   unfurl: "Fetch public information of any product to preview it in Notion.",
   view_profile: "See your profile data.",
+  edit_profile: "Edit your profile name and bio.",
   view_public: "See your public information (name, bio).",
   view_sales: "See your sales data.",
   view_payouts: "See your payouts data.",

--- a/app/models/concerns/user/as_json.rb
+++ b/app/models/concerns/user/as_json.rb
@@ -28,11 +28,11 @@ module User::AsJson
 
   private
     def view_profile_scope?(options)
-      (api_scopes_options(options) & %w[view_profile account]).present?
+      (api_scopes_options(options) & %w[view_profile edit_profile account]).present?
     end
 
     def valid_api_scope?(options)
-      (%w[edit_products view_sales revenue_share ifttt view_profile account] & api_scopes_options(options)).present?
+      (%w[edit_products view_sales revenue_share ifttt view_profile edit_profile account] & api_scopes_options(options)).present?
     end
 
     def api_scopes_options(options)

--- a/app/models/concerns/user/as_json.rb
+++ b/app/models/concerns/user/as_json.rb
@@ -28,11 +28,11 @@ module User::AsJson
 
   private
     def view_profile_scope?(options)
-      (api_scopes_options(options) & %w[view_profile edit_profile account]).present?
+      (api_scopes_options(options) & %w[view_profile account]).present?
     end
 
     def valid_api_scope?(options)
-      (%w[edit_products view_sales revenue_share ifttt view_profile edit_profile account] & api_scopes_options(options)).present?
+      (%w[edit_products view_sales revenue_share ifttt view_profile account] & api_scopes_options(options)).present?
     end
 
     def api_scopes_options(options)

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -7,11 +7,11 @@ module VisibleScopes
   # These are the scopes that the public should be aware of. Update this list when adding scopes to Doorkeeper.
   # Mobile Api scope is not included because we don't want the public to have knowledge of that scope.
   def public_scopes
-    %i[edit_products edit_emails view_sales mark_sales_as_shipped edit_sales revenue_share ifttt view_profile view_payouts view_tax_data account]
+    %i[edit_products edit_emails view_sales mark_sales_as_shipped edit_sales revenue_share ifttt view_profile edit_profile view_payouts view_tax_data account]
   end
 
   def public_api_read_scopes
-    public_scopes - %i[edit_emails]
+    public_scopes - %i[edit_emails edit_profile]
   end
 end
 
@@ -40,7 +40,7 @@ Doorkeeper.configure do
   # access token scopes for providers
   default_scopes :view_public
   optional_scopes :edit_products, :edit_emails, :view_sales, :view_payouts, :mark_sales_as_shipped, :refund_sales, :edit_sales, :revenue_share, :ifttt, :mobile_api,
-                  :creator_api, :view_profile, :unfurl, :helper_api, :view_tax_data, :account
+                  :creator_api, :view_profile, :edit_profile, :unfurl, :helper_api, :view_tax_data, :account
 
   use_refresh_token
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,7 @@ Rails.application.routes.draw do
       end
 
       get "/user", to: "users#show"
+      match "/user", to: "users#update", via: [:put, :patch]
       resources :categories, only: [:index]
       resource :refund_policy, only: [:show, :update], controller: :refund_policies
       resources :links, path: "products", only: [:index, :show, :update, :create, :destroy] do

--- a/spec/controllers/api/v2/users_controller_spec.rb
+++ b/spec/controllers/api/v2/users_controller_spec.rb
@@ -106,6 +106,16 @@ describe Api::V2::UsersController do
         expect(@user.bio).to eq("I make great things.")
       end
 
+      it "rejects the update when the seller's email is unconfirmed" do
+        @user.update_columns(confirmed_at: nil)
+
+        put @action, params: @params
+
+        expect(response.parsed_body["success"]).to eq(false)
+        expect(response.parsed_body["message"]).to include("confirm your email address")
+        expect(@user.reload.name).to_not eq("Jane Seller")
+      end
+
       it "updates only the provided attribute" do
         @user.update!(name: "Original", bio: "Original bio")
 

--- a/spec/controllers/api/v2/users_controller_spec.rb
+++ b/spec/controllers/api/v2/users_controller_spec.rb
@@ -133,13 +133,11 @@ describe Api::V2::UsersController do
                                            "user" => @user.reload.as_json(api_scopes: ["edit_profile"]))
       end
 
-      it "serializes the full user (not the sparse public view) for the edit_profile scope" do
+      it "does not expose email to a write-only edit_profile token" do
         put @action, params: @params
 
-        user = response.parsed_body["user"]
-        expect(user["email"]).to be_present
-        expect(user["display_name"]).to be_present
-        expect(user).to have_key("currency_type")
+        expect(response.parsed_body["success"]).to eq(true)
+        expect(response.parsed_body["user"]).to_not have_key("email")
       end
 
       it "returns a validation error when the name is invalid" do

--- a/spec/controllers/api/v2/users_controller_spec.rb
+++ b/spec/controllers/api/v2/users_controller_spec.rb
@@ -123,6 +123,15 @@ describe Api::V2::UsersController do
                                            "user" => @user.reload.as_json(api_scopes: ["edit_profile"]))
       end
 
+      it "serializes the full user (not the sparse public view) for the edit_profile scope" do
+        put @action, params: @params
+
+        user = response.parsed_body["user"]
+        expect(user["email"]).to be_present
+        expect(user["display_name"]).to be_present
+        expect(user).to have_key("currency_type")
+      end
+
       it "returns a validation error when the name is invalid" do
         put @action, params: @params.merge(name: "Jane: Seller")
 

--- a/spec/controllers/api/v2/users_controller_spec.rb
+++ b/spec/controllers/api/v2/users_controller_spec.rb
@@ -77,6 +77,70 @@ describe Api::V2::UsersController do
     end
   end
 
+  describe "PUT 'update'" do
+    before do
+      @action = :update
+      @params = { name: "Jane Seller", bio: "I make great things." }
+    end
+
+    it_behaves_like "authorized oauth v1 api method"
+
+    it "rejects a token without the edit_profile scope" do
+      token = create("doorkeeper/access_token", application: @app, resource_owner_id: @user.id, scopes: "view_profile")
+      put @action, params: @params.merge(access_token: token.token)
+      expect(response.status).to eq(403)
+      expect(response.body.strip).to be_empty
+    end
+
+    describe "when logged in with edit_profile scope" do
+      before do
+        @token = create("doorkeeper/access_token", application: @app, resource_owner_id: @user.id, scopes: "edit_profile")
+        @params.merge!(access_token: @token.token)
+      end
+
+      it "updates the seller name and bio" do
+        put @action, params: @params
+
+        expect(response.parsed_body["success"]).to eq(true)
+        expect(@user.reload.name).to eq("Jane Seller")
+        expect(@user.bio).to eq("I make great things.")
+      end
+
+      it "updates only the provided attribute" do
+        @user.update!(name: "Original", bio: "Original bio")
+
+        put @action, params: { access_token: @token.token, bio: "Updated bio" }
+
+        expect(response.parsed_body["success"]).to eq(true)
+        expect(@user.reload.name).to eq("Original")
+        expect(@user.bio).to eq("Updated bio")
+      end
+
+      it "returns the updated user in the response" do
+        put @action, params: @params
+
+        expect(response.parsed_body).to eq("success" => true,
+                                           "user" => @user.reload.as_json(api_scopes: ["edit_profile"]))
+      end
+
+      it "returns a validation error when the name is invalid" do
+        put @action, params: @params.merge(name: "Jane: Seller")
+
+        expect(response.parsed_body["success"]).to eq(false)
+        expect(response.parsed_body["message"]).to include("colons")
+        expect(@user.reload.name).to_not eq("Jane: Seller")
+      end
+
+      it "marks the user as a CLI user when requested from the CLI" do
+        request.user_agent = "gumroad-cli/1.0"
+
+        put @action, params: @params
+
+        expect(@user.reload.has_used_cli?).to be(true)
+      end
+    end
+  end
+
   describe "GET 'ifttt_sale_trigger'" do
     before do
       @action = :ifttt_sale_trigger

--- a/spec/requests/oauth_applications_pages_spec.rb
+++ b/spec/requests/oauth_applications_pages_spec.rb
@@ -89,7 +89,7 @@ describe "OauthApplicationsPages", type: :system, js: true do
     expect(page).to have_field("Access Token", with: application.access_tokens.last.token)
     expect(application.access_grants.count).to eq 1
     expect(application.access_tokens.count).to eq 1
-    expect(application.access_tokens.last.scopes.to_a).to eq %w[edit_products edit_emails view_sales mark_sales_as_shipped edit_sales revenue_share ifttt view_profile view_payouts view_tax_data account]
+    expect(application.access_tokens.last.scopes.to_a).to eq %w[edit_products edit_emails view_sales mark_sales_as_shipped edit_sales revenue_share ifttt view_profile edit_profile view_payouts view_tax_data account]
   end
 
   it "doesn't list the application if there are no grants for it" do


### PR DESCRIPTION
## What

Adds `Api::V2::UsersController#update` for `PATCH`/`PUT /v2/user`, letting sellers edit their `name` and `bio` over the API. Validation goes through the existing `User` validations and returns the standard API error envelope.

Introduces a write-only `edit_profile` OAuth scope: it is registered in Doorkeeper `optional_scopes` and `public_scopes` but kept out of `public_api_read_scopes`, so `#show` stays on `view_profile` and only `#update` requires `edit_profile`. (`Api::V2::BaseController` appends `:account`, so existing CLI/account tokens keep working.)

No schema change — `name` and `bio` already exist on `users`, and the `users` table is not altered.

## Why

From #5552 (out of #5542). Sellers automating their store still had to open the dashboard just to edit a name or bio. These fields are already editable through `Settings::ProfileController`, so this exposes existing, validated behavior over the API.

Part of #5552

---

AI disclosure: implemented with Claude Opus 4.8 via Claude Code

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5560"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784820722&installation_id=134400930&pr_number=5560&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5560&signature=0a4376fe1c6505d50433b5ec010e0494f32c00f39531cd9d043c904fc42ddc6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new OAuth write scope and mutates seller profile fields over the API, but changes are limited to `name`/`bio` with existing validations and scope separation from read endpoints.
> 
> **Overview**
> Adds **`PATCH`/`PUT /v2/user`** so OAuth clients can update a seller’s **`name`** and **`bio`** via `Api::V2::UsersController#update`, using existing `User` validations, the standard success/error envelope, and a **confirmed-email** guard before writes.
> 
> Introduces a write-only **`edit_profile`** scope in Doorkeeper (`optional_scopes`, `public_scopes`) and keeps it out of **`public_api_read_scopes`**, so **`GET /user`** still relies on read scopes while **`#update`** requires **`edit_profile`** ( **`account`** tokens still work via `BaseController`).
> 
> Docs and settings UI list the new scope; request specs cover scope enforcement, partial updates, validation failures, and that **`edit_profile`** responses do not expose email.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a97ee2977de206d489d9b4e9cd50c2e58880ba6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->