### PR TITLE
Pause repeatedly-failing PayPal payouts and record a diagnostic for reason-less IPN failures

### DIFF
--- a/app/business/payments/payouts/processor/paypal/paypal_payout_processor.rb
+++ b/app/business/payments/payouts/processor/paypal/paypal_payout_processor.rb
@@ -165,10 +165,21 @@ class PaypalPayoutProcessor
     correlation_id = parsed_paypal_response["CORRELATIONID"]
 
     payments.each { |payment| payment.update(correlation_id:) }
-    payments.each(&:mark_failed!) unless transaction_succeeded
+    return if transaction_succeeded
 
-    errors = errors_for_parsed_paypal_response(parsed_paypal_response) if ack_status != "Success"
+    errors = errors_for_parsed_paypal_response(parsed_paypal_response)
     Rails.logger.info("Paypal Payouts: Payout errors for user IDs #{user_ids}: #{errors.inspect}") if errors.present?
+
+    if payments.size > 1
+      payments.each_slice((payments.size / 2.0).ceil) { |chunk| perform_payments(chunk) }
+    else
+      payments.first.mark_failed!(failure_reason_for_paypal_response(parsed_paypal_response))
+    end
+  end
+
+  def self.failure_reason_for_paypal_response(parsed_paypal_response)
+    error_code = parsed_paypal_response["L_ERRORCODE0"]
+    error_code.present? ? "PAYPAL #{error_code}" : "PAYPAL payout rejected"
   end
 
   # Public: Sends the money in `split_payment_by_cents(payment.user)` increments.

--- a/app/business/payments/payouts/processor/paypal/paypal_payout_processor.rb
+++ b/app/business/payments/payouts/processor/paypal/paypal_payout_processor.rb
@@ -170,16 +170,17 @@ class PaypalPayoutProcessor
     errors = errors_for_parsed_paypal_response(parsed_paypal_response)
     Rails.logger.info("Paypal Payouts: Payout errors for user IDs #{user_ids}: #{errors.inspect}") if errors.present?
 
+    error_code = parsed_paypal_response["L_ERRORCODE0"]
+    unless Payment.paypal_recipient_level_failure?(error_code)
+      payments.each(&:mark_failed!)
+      return
+    end
+
     if payments.size > 1
       payments.each_slice((payments.size / 2.0).ceil) { |chunk| perform_payments(chunk) }
     else
-      payments.first.mark_failed!(failure_reason_for_paypal_response(parsed_paypal_response))
+      payments.first.mark_failed!("PAYPAL #{error_code}")
     end
-  end
-
-  def self.failure_reason_for_paypal_response(parsed_paypal_response)
-    error_code = parsed_paypal_response["L_ERRORCODE0"]
-    error_code.present? ? "PAYPAL #{error_code}" : "PAYPAL payout rejected"
   end
 
   # Public: Sends the money in `split_payment_by_cents(payment.user)` increments.

--- a/app/business/payments/payouts/processor/paypal/paypal_payout_processor.rb
+++ b/app/business/payments/payouts/processor/paypal/paypal_payout_processor.rb
@@ -165,22 +165,10 @@ class PaypalPayoutProcessor
     correlation_id = parsed_paypal_response["CORRELATIONID"]
 
     payments.each { |payment| payment.update(correlation_id:) }
-    return if transaction_succeeded
+    payments.each(&:mark_failed!) unless transaction_succeeded
 
-    errors = errors_for_parsed_paypal_response(parsed_paypal_response)
+    errors = errors_for_parsed_paypal_response(parsed_paypal_response) if ack_status != "Success"
     Rails.logger.info("Paypal Payouts: Payout errors for user IDs #{user_ids}: #{errors.inspect}") if errors.present?
-
-    error_code = parsed_paypal_response["L_ERRORCODE0"]
-    unless Payment.paypal_recipient_level_failure?(error_code)
-      payments.each(&:mark_failed!)
-      return
-    end
-
-    if payments.size > 1
-      payments.each_slice((payments.size / 2.0).ceil) { |chunk| perform_payments(chunk) }
-    else
-      payments.first.mark_failed!("PAYPAL #{error_code}")
-    end
   end
 
   # Public: Sends the money in `split_payment_by_cents(payment.user)` increments.
@@ -309,7 +297,7 @@ class PaypalPayoutProcessor
         UpdatePayoutStatusWorker.perform_in(5.minutes, payment.id)
       elsif payment.state != new_payment_state
         if new_payment_state == "failed"
-          failure_reason = "PAYPAL #{paypal_event["reason_code"]}" if paypal_event["reason_code"].present?
+          failure_reason = paypal_event["reason_code"].present? ? "PAYPAL #{paypal_event["reason_code"]}" : Payment::FailureReason::PAYPAL_PAYOUT_FAILED
           payment.mark_failed!(failure_reason)
         else
           payment.mark!(new_payment_state)

--- a/app/models/concerns/payment/failure_reason.rb
+++ b/app/models/concerns/payment/failure_reason.rb
@@ -8,8 +8,10 @@ module Payment::FailureReason
   INSUFFICIENT_FUNDS = "insufficient_funds"
   BANK_ACCOUNT_NOT_FOUND_AT_STRIPE = "bank_account_not_found_at_stripe"
   CURRENCY_MISMATCH = "currency_mismatch"
+  PAYPAL_PAYOUT_FAILED = "PAYPAL payout failed"
 
   PAYPAL_MASS_PAY = {
+    PAYPAL_PAYOUT_FAILED => "PayPal rejected the payout without returning a reason code",
     "PAYPAL 1000" => "Unknown error",
     "PAYPAL 1001" => "Receiver's account is invalid",
     "PAYPAL 1002" => "Sender has insufficient funds",
@@ -150,16 +152,6 @@ module Payment::FailureReason
     },
   }
   private_constant :STRIPE_FAILURE_SOLUTIONS
-
-  PAYPAL_RECIPIENT_LEVEL_FAILURE_CODES = %w[
-    1001 3004 3015 3047 3148 3501 3535 3558 8330 9302 11711 14159 14550 14765 14766 14767
-  ].freeze
-
-  class_methods do
-    def paypal_recipient_level_failure?(paypal_error_code)
-      PAYPAL_RECIPIENT_LEVEL_FAILURE_CODES.include?(paypal_error_code.to_s)
-    end
-  end
 
   private
     def add_payment_failure_reason_comment

--- a/app/models/concerns/payment/failure_reason.rb
+++ b/app/models/concerns/payment/failure_reason.rb
@@ -151,6 +151,16 @@ module Payment::FailureReason
   }
   private_constant :STRIPE_FAILURE_SOLUTIONS
 
+  PAYPAL_RECIPIENT_LEVEL_FAILURE_CODES = %w[
+    1001 3004 3015 3047 3148 3501 3535 3558 8330 9302 11711 14159 14550 14765 14766 14767
+  ].freeze
+
+  class_methods do
+    def paypal_recipient_level_failure?(paypal_error_code)
+      PAYPAL_RECIPIENT_LEVEL_FAILURE_CODES.include?(paypal_error_code.to_s)
+    end
+  end
+
   private
     def add_payment_failure_reason_comment
       return unless failure_reason.present?

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -271,19 +271,27 @@ class Payment < ApplicationRecord
     end
 
     def pause_payouts_after_repeated_failures
-      return if bank_account_id.blank?
       return if user.nil? || user.payouts_paused?
 
-      payouts_for_bank_account = user.payments.where(bank_account_id:)
-      last_completed_at = payouts_for_bank_account.completed.maximum(:created_at)
-      failed_payouts = payouts_for_bank_account.where(state: [FAILED, RETURNED])
+      if bank_account_id.present?
+        destination = "bank account"
+        payouts_to_destination = user.payments.where(bank_account_id:)
+      elsif processor == PayoutProcessorType::PAYPAL && payment_address.present?
+        destination = "PayPal account"
+        payouts_to_destination = user.payments.where(processor: PayoutProcessorType::PAYPAL, payment_address:)
+      else
+        return
+      end
+
+      last_completed_at = payouts_to_destination.completed.maximum(:created_at)
+      failed_payouts = payouts_to_destination.where(state: [FAILED, RETURNED])
       failed_payouts = failed_payouts.where("created_at > ?", last_completed_at) if last_completed_at
       failed_count = failed_payouts.count
       return if failed_count < MAX_CONSECUTIVE_FAILED_PAYOUTS
 
       user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_SYSTEM)
       user.comments.create!(
-        content: "Payouts paused automatically after #{failed_count} consecutive failed payouts to the same bank account. Verify the seller's payout details before resuming.",
+        content: "Payouts paused automatically after #{failed_count} consecutive failed payouts to the same #{destination}. Verify the seller's payout details before resuming.",
         comment_type: Comment::COMMENT_TYPE_ON_PROBATION,
         author_name: User::SYSTEM_PAYOUT_PAUSE_COMMENT_AUTHORS[:repeated_failed_payouts]
       )

--- a/spec/business/payments/payouts/processor/paypal/paypal_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/paypal/paypal_payout_processor_spec.rb
@@ -504,7 +504,7 @@ describe PaypalPayoutProcessor do
 
       expect(@u1.unpaid_balance_cents).to eq 99
       expect(p2.state).to eq "failed"
-      expect(p2.failure_reason).to be_nil
+      expect(p2.failure_reason).to eq(Payment::FailureReason::PAYPAL_PAYOUT_FAILED)
     end
 
     it "behaves idempotently" do
@@ -1066,54 +1066,28 @@ describe PaypalPayoutProcessor do
     end
   end
 
-  describe ".perform_payments" do
-    let(:good_payment_1) { create(:payment, payment_address: "good1@example.com", amount_cents: 5_000) }
-    let(:unpayable_payment) { create(:payment, payment_address: "rejected@example.com", amount_cents: 6_000) }
-    let(:good_payment_2) { create(:payment, payment_address: "good2@example.com", amount_cents: 7_000) }
+  describe "IPN item-level failure without a reason code" do
+    let(:user) { create(:singaporean_user_with_compliance_info, payment_address: "seller@example.com") }
+    let(:payment) { create(:payment, user:, payment_address: user.payment_address, amount_cents: 5_000) }
 
-    before do
-      WebMock.stub_request(:post, PAYPAL_ENDPOINT).to_return do |request|
-        if request.body.include?("rejected")
-          { body: "TIMESTAMP=2012%2d10%2d26T20%3a29%3a14Z&CORRELATIONID=c51c5e0cecbce&ACK=Failure&L_ERRORCODE0=3148&L_SHORTMESSAGE0=non%2dreceivable&L_LONGMESSAGE0=Receiver%20is%20in%20a%20non%2dreceivable%20country" }
-        else
-          { body: "TIMESTAMP=2012%2d10%2d26T20%3a29%3a14Z&CORRELATIONID=c51c5e0cecbce&ACK=Success&VERSION=90%2e0&BUILD=4072860" }
-        end
-      end
+    it "records a generic diagnostic reason so the failure is not silently retried" do
+      described_class.handle_paypal_event_for_non_split_payment(payment.id.to_s,
+                                                                "masspay_txn_id" => "",
+                                                                "status" => "Failed",
+                                                                "unique_id" => payment.id)
+
+      expect(payment.reload.state).to eq("failed")
+      expect(payment.failure_reason).to eq(Payment::FailureReason::PAYPAL_PAYOUT_FAILED)
     end
 
-    it "fails only the unpayable recipient and leaves the rest of the batch processing" do
-      described_class.perform_payments([good_payment_1, unpayable_payment, good_payment_2])
+    it "still records the PayPal reason code when one is provided" do
+      described_class.handle_paypal_event_for_non_split_payment(payment.id.to_s,
+                                                                "masspay_txn_id" => "",
+                                                                "status" => "Failed",
+                                                                "reason_code" => "3148",
+                                                                "unique_id" => payment.id)
 
-      expect(good_payment_1.reload.state).to eq("processing")
-      expect(good_payment_2.reload.state).to eq("processing")
-      expect(unpayable_payment.reload.state).to eq("failed")
-      expect(unpayable_payment.failure_reason).to eq("PAYPAL 3148")
-    end
-
-    it "records the PayPal error code as the failure reason so the payout is not retried into the same rejection" do
-      described_class.perform_payments([unpayable_payment])
-
-      expect(unpayable_payment.reload.state).to eq("failed")
-      expect(unpayable_payment.failure_reason).to eq("PAYPAL 3148")
-    end
-
-    it "leaves every payment processing when the whole batch is accepted" do
-      described_class.perform_payments([good_payment_1, good_payment_2])
-
-      expect(good_payment_1.reload.state).to eq("processing")
-      expect(good_payment_2.reload.state).to eq("processing")
-    end
-
-    it "marks the batch failed without a reason on a systemic failure so the weekly retry still picks it up" do
-      WebMock.stub_request(:post, PAYPAL_ENDPOINT)
-             .to_return(body: "TIMESTAMP=2012%2d10%2d26T20%3a29%3a14Z&CORRELATIONID=c51c5e0cecbce&ACK=Failure&L_ERRORCODE0=10001&L_SHORTMESSAGE0=Internal+Error&L_LONGMESSAGE0=Internal+Error")
-
-      described_class.perform_payments([good_payment_1, good_payment_2])
-
-      expect(good_payment_1.reload.state).to eq("failed")
-      expect(good_payment_2.reload.state).to eq("failed")
-      expect(good_payment_1.failure_reason).to be_nil
-      expect(good_payment_2.failure_reason).to be_nil
+      expect(payment.reload.failure_reason).to eq("PAYPAL 3148")
     end
   end
 end

--- a/spec/business/payments/payouts/processor/paypal/paypal_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/paypal/paypal_payout_processor_spec.rb
@@ -1065,4 +1065,42 @@ describe PaypalPayoutProcessor do
       end.to raise_error(RuntimeError, error_message)
     end
   end
+
+  describe ".perform_payments" do
+    let(:good_payment_1) { create(:payment, payment_address: "good1@example.com", amount_cents: 5_000) }
+    let(:unpayable_payment) { create(:payment, payment_address: "rejected@example.com", amount_cents: 6_000) }
+    let(:good_payment_2) { create(:payment, payment_address: "good2@example.com", amount_cents: 7_000) }
+
+    before do
+      WebMock.stub_request(:post, PAYPAL_ENDPOINT).to_return do |request|
+        if request.body.include?("rejected")
+          { body: "TIMESTAMP=2012%2d10%2d26T20%3a29%3a14Z&CORRELATIONID=c51c5e0cecbce&ACK=Failure&L_ERRORCODE0=3148&L_SHORTMESSAGE0=non%2dreceivable&L_LONGMESSAGE0=Receiver%20is%20in%20a%20non%2dreceivable%20country" }
+        else
+          { body: "TIMESTAMP=2012%2d10%2d26T20%3a29%3a14Z&CORRELATIONID=c51c5e0cecbce&ACK=Success&VERSION=90%2e0&BUILD=4072860" }
+        end
+      end
+    end
+
+    it "fails only the unpayable recipient and leaves the rest of the batch processing" do
+      described_class.perform_payments([good_payment_1, unpayable_payment, good_payment_2])
+
+      expect(good_payment_1.reload.state).to eq("processing")
+      expect(good_payment_2.reload.state).to eq("processing")
+      expect(unpayable_payment.reload.state).to eq("failed")
+    end
+
+    it "records the PayPal error code as the failure reason so the payout is not retried into the same rejection" do
+      described_class.perform_payments([unpayable_payment])
+
+      expect(unpayable_payment.reload.state).to eq("failed")
+      expect(unpayable_payment.failure_reason).to eq("PAYPAL 3148")
+    end
+
+    it "leaves every payment processing when the whole batch is accepted" do
+      described_class.perform_payments([good_payment_1, good_payment_2])
+
+      expect(good_payment_1.reload.state).to eq("processing")
+      expect(good_payment_2.reload.state).to eq("processing")
+    end
+  end
 end

--- a/spec/business/payments/payouts/processor/paypal/paypal_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/paypal/paypal_payout_processor_spec.rb
@@ -1087,6 +1087,7 @@ describe PaypalPayoutProcessor do
       expect(good_payment_1.reload.state).to eq("processing")
       expect(good_payment_2.reload.state).to eq("processing")
       expect(unpayable_payment.reload.state).to eq("failed")
+      expect(unpayable_payment.failure_reason).to eq("PAYPAL 3148")
     end
 
     it "records the PayPal error code as the failure reason so the payout is not retried into the same rejection" do
@@ -1101,6 +1102,18 @@ describe PaypalPayoutProcessor do
 
       expect(good_payment_1.reload.state).to eq("processing")
       expect(good_payment_2.reload.state).to eq("processing")
+    end
+
+    it "marks the batch failed without a reason on a systemic failure so the weekly retry still picks it up" do
+      WebMock.stub_request(:post, PAYPAL_ENDPOINT)
+             .to_return(body: "TIMESTAMP=2012%2d10%2d26T20%3a29%3a14Z&CORRELATIONID=c51c5e0cecbce&ACK=Failure&L_ERRORCODE0=10001&L_SHORTMESSAGE0=Internal+Error&L_LONGMESSAGE0=Internal+Error")
+
+      described_class.perform_payments([good_payment_1, good_payment_2])
+
+      expect(good_payment_1.reload.state).to eq("failed")
+      expect(good_payment_2.reload.state).to eq("failed")
+      expect(good_payment_1.failure_reason).to be_nil
+      expect(good_payment_2.failure_reason).to be_nil
     end
   end
 end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -878,6 +878,12 @@ describe Payment do
       payment
     end
 
+    def failed_paypal_payout(payment_address: "seller@example.com")
+      payment = create(:payment, user:, processor: PayoutProcessorType::PAYPAL, payment_address:, state: "processing")
+      payment.mark_failed!
+      payment
+    end
+
     it "pauses payouts and flags the account once the consecutive failure limit is reached" do
       (Payment::MAX_CONSECUTIVE_FAILED_PAYOUTS - 1).times { failed_payout }
       expect(user.reload.payouts_paused?).to be(false)
@@ -927,9 +933,29 @@ describe Payment do
       expect(user.reload.payouts_paused?).to be(false)
     end
 
-    it "ignores payouts without a bank account, such as PayPal" do
+    it "pauses PayPal payouts after repeated failures to the same PayPal account" do
+      (Payment::MAX_CONSECUTIVE_FAILED_PAYOUTS - 1).times { failed_paypal_payout }
+      expect(user.reload.payouts_paused?).to be(false)
+
+      failed_paypal_payout
+
+      expect(user.reload.payouts_paused_internally).to be(true)
+      expect(user.payouts_paused_by_source).to eq(User::PAYOUT_PAUSE_SOURCE_SYSTEM)
+      comment = user.comments.with_type_on_probation.last
+      expect(comment.content).to include("#{Payment::MAX_CONSECUTIVE_FAILED_PAYOUTS} consecutive failed payouts to the same PayPal account")
+    end
+
+    it "scopes the count to a single PayPal address so a new address starts fresh" do
+      (Payment::MAX_CONSECUTIVE_FAILED_PAYOUTS - 1).times { failed_paypal_payout(payment_address: "old@example.com") }
+
+      failed_paypal_payout(payment_address: "new@example.com")
+
+      expect(user.reload.payouts_paused?).to be(false)
+    end
+
+    it "ignores PayPal payouts that have no payment address on record" do
       (Payment::MAX_CONSECUTIVE_FAILED_PAYOUTS + 1).times do
-        payment = create(:payment, user:, processor: PayoutProcessorType::PAYPAL, state: "processing")
+        payment = create(:payment, user:, processor: PayoutProcessorType::PAYPAL, payment_address: nil, state: "processing")
         payment.mark_failed!
       end
 


### PR DESCRIPTION
Part of https://github.com/antiwork/gumroad-private/issues/564

## What

Stops PayPal payouts that can't be delivered from silently failing and looping forever, on the path where the data shows the failures actually happen.

- **IPN failures without a reason code now record a diagnostic.** When PayPal's IPN reports an item-level `Failed` with a blank `reason_code`, `handle_paypal_event_for_non_split_payment` recorded `failure_reason: nil`. That left the failure undiagnosable and kept it inside `RetryFailedPaypalPayoutsWorker`'s `failure_reason IS NULL` retry scope. It now records a generic `PAYPAL_PAYOUT_FAILED` diagnostic.
- **Repeated PayPal failures now pause payouts.** `pause_payouts_after_repeated_failures` returned early unless `bank_account_id` was present, so PayPal recipients were never paused — a non-receivable PayPal account was re-attempted every payout cycle indefinitely. It now also keys on `payment_address` for PayPal payouts and pauses after `MAX_CONSECUTIVE_FAILED_PAYOUTS` consecutive failures to the same account, mirroring the existing bank-account behaviour.

## Why

A production review of the failed/`null`-`txn_id` PayPal payments (last 45 days) showed the original premise of this PR was wrong:

- **MassPay is not atomic.** `completed` and `failed` payments coexist under the same `correlation_id` (e.g. `completed:118, failed:105`), which is only possible when `ACK=Success` and individual recipients fail later via IPN.
- **The volume is on the IPN path.** ~79% of stranded rows (827/1052) are `ACK=Success` + per-recipient IPN failures; only ~21% are whole-batch `ACK=Failure`, and most of that is a single batch. The reported seller's case is on the IPN path.
- Most IPN failures already carry a real reason code (e.g. `3148` non-receivable country, `3015` invalid email) and are correctly not retried; the gap was the reason-less ones and the missing pause.

The earlier recursive re-send approach is **dropped**: because MassPay is not atomic, re-sending the "healthy" subset after `ACK=Failure` rests on an unproven assumption (risking double payment on a money-movement path). That isolation idea is parked until PayPal's `ACK=Failure` semantics and `L_UNIQUEID` cross-call idempotency are confirmed. `perform_payments` is reverted to its original whole-batch behaviour, which keeps genuine `ACK=Failure` batches `failure_reason: nil` and therefore still retryable.


---

🤖 AI disclosure: drafted with Claude Opus 4.8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payout failure recording and automatic payout pausing for PayPal sellers; incorrect scoping could pause accounts wrongly or miss bad addresses, but changes are narrow and well-covered by specs.
> 
> **Overview**
> Improves **PayPal payout failure handling** so failures are diagnosable and sellers with bad PayPal details get the same safety rails as bank payouts.
> 
> When a PayPal IPN reports **Failed** without a `reason_code`, the payment is now marked failed with **`Payment::FailureReason::PAYPAL_PAYOUT_FAILED`** instead of leaving `failure_reason` nil. Known codes still use **`PAYPAL <code>`**. A matching entry was added to **`PAYPAL_MASS_PAY`** for humanized messaging.
> 
> **`pause_payouts_after_repeated_failures`** no longer skips all PayPal payouts: it counts consecutive failed/returned payouts per **`payment_address`** (same processor), pauses the user at the existing limit, and updates the probation comment to mention the PayPal account. PayPal rows with no address still do not trigger a pause.
> 
> Specs cover IPN failures with and without reason codes, the generic failure reason on batch IPN paths, and PayPal-specific pause/scoping behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6c43fe04e704bb46f0ed99e6797a453b8a2a601. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->