### PR TITLE
Allow JW Player entitlements endpoint in CSP connect-src

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -80,6 +80,9 @@ SecureHeaders::Configuration.default do |config|
       FILE_DOWNLOAD_DISTRIBUTION_URL,
       HLS_DISTRIBUTION_URL,
 
+      # jw player
+      "entitlements.jwplayer.com",
+
       # paypal
       "*.braintreegateway.com",
       "www.paypalobjects.com",


### PR DESCRIPTION
## What

Adds `entitlements.jwplayer.com` to the `connect-src` directive of the Content Security Policy in `config/initializers/secure_headers.rb`.

## Why

JW Player's player JS is loaded from `cdn.jwplayer.com` / `*.jwpcdn.com`, which are already allowed in `script-src`. At runtime, however, the player issues a `fetch` to `https://entitlements.jwplayer.com/<id>.json` to validate playback entitlements. That host was never present in `connect-src`, so the browser blocked the request:

```
Connecting to 'https://entitlements.jwplayer.com/CQZZ5GJsEeeaeQpVuA4vVw.json' violates the following Content Security Policy directive: "connect-src 'self' blob: ... assets.gumroad.com". The action has been blocked.
```

The entitlement check failing breaks playback for affected videos. The fix is a single, scoped addition to the allowlist — no wildcard, just the specific host that was being blocked. JW Player's CDN/script hosts already had this script-vs-connect split, so this aligns `connect-src` with the player's actual runtime behavior.

## Before / After

- **Before:** Browser console logs a CSP `connect-src` violation when the JW Player attempts the entitlement request; the request is blocked.
- **After:** The entitlement request is permitted and the violation no longer appears.

This is a CSP config change with no rendered UI surface, so there is no visual before/after. Verification is via the browser console no longer reporting the blocked request once the header is updated.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AI disclosure: drafted with assistance from Claude Opus 4.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5563"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784833040&installation_id=134400930&pr_number=5563&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5563&signature=00f7369665a851f00c56d4c071fa061faeca8da8e833aadf1a90e4e8fe756bf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CSP allowlist change for one known JW Player host; no application logic or auth changes.
> 
> **Overview**
> **Fixes JW Player playback blocked by CSP** by adding `entitlements.jwplayer.com` to the `connect-src` allowlist in `secure_headers.rb`.
> 
> JW Player scripts were already permitted via `script-src` (`cdn.jwplayer.com`, `*.jwpcdn.com`), but the player’s runtime entitlement `fetch` to that host was not, so the browser blocked it and playback could fail. This is a single-host allowlist addition aligned with existing JW Player CSP entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7313db37e72e49bb2569fb9b50b5b4b7acf423c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->