### PR TITLE
Fix discount inspector closing when copying a product's discounted link

### DIFF
--- a/app/javascript/components/ui/Sheet.tsx
+++ b/app/javascript/components/ui/Sheet.tsx
@@ -22,6 +22,9 @@ export const Sheet = ({
         onPointerDownOutside={(e) => {
           if (!modal) e.preventDefault();
         }}
+        onFocusOutside={(e) => {
+          if (!modal) e.preventDefault();
+        }}
       >
         {children}
       </Dialog.Content>

--- a/spec/requests/checkout/discounts_spec.rb
+++ b/spec/requests/checkout/discounts_spec.rb
@@ -127,6 +127,23 @@ describe("Checkout discounts page", type: :system, js: true) do
       end
     end
 
+    it "keeps the discount inspector open after copying a product's discounted link" do
+      visit checkout_discounts_path
+      find(:table_row, { "Discount" => "Discount 1" }).click
+
+      within_modal "Discount 1" do
+        within_section "Products" do
+          find(:button, "Copy link with discount", match: :first).click
+        end
+      end
+
+      expect(page).to have_selector(:modal)
+      within_modal "Discount 1" do
+        expect(page).to have_section("Details")
+        expect(page).to have_button("Copy link with discount", count: 5)
+      end
+    end
+
     context "when the creator has no discounts" do
       it "displays a placeholder message" do
         login_as create(:user)


### PR DESCRIPTION
## What

Clicking **Copy link with discount** inside the Checkout → Discounts inspector now copies the link and leaves the inspector open, instead of dismissing it back to the full discount list.

Closes #5562.

## Why

The discount inspector is a **non-modal** `Sheet` (`app/javascript/components/ui/Sheet.tsx`). It already guards `onPointerDownOutside` so clicking elsewhere on the page doesn't dismiss it — but it left `onFocusOutside` unguarded.

The copy button uses `CopyToClipboard`, which is backed by ClipboardJS. When the copy target is a function-provided string (not an input), ClipboardJS performs the copy by creating an off-screen `<textarea>`, appending it to `document.body`, and focusing + selecting it. That focus shift lands **outside** the Sheet's content, so Radix's `DismissableLayer` interprets it as an outside interaction and dismisses the non-modal dialog. The result: the inspector closes the moment you click copy.

The fix guards `onFocusOutside` for non-modal sheets, mirroring the existing `onPointerDownOutside` guard:

```tsx
onPointerDownOutside={(e) => {
  if (!modal) e.preventDefault();
}}
onFocusOutside={(e) => {
  if (!modal) e.preventDefault();
}}
```

This is the same workaround already used for the copy button inside `Product/ShareSection.tsx` (`onFocusOutside={(e) => e.preventDefault()}`), so the behavior is now consistent across the app. Fixing it at the `Sheet` level (rather than per call-site) covers any non-modal sheet whose content programmatically moves focus — modal sheets are unaffected because Radix already prevents focus-outside dismissal for them.

---

🤖 This PR was written by Claude Opus 4.8 (via Claude Code).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5564"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784833506&installation_id=134400930&pr_number=5564&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5564&signature=646627cb434325ff0945ddac8978a55bc282fe97aa6a8608e84e1192da9eef6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI interaction fix in shared Sheet component plus a regression test; no auth, data, or payment changes.
> 
> **Overview**
> Non-modal **`Sheet`** dialogs no longer dismiss when focus moves outside the content—matching the existing **`onPointerDownOutside`** guard—so actions like **Copy link with discount** (ClipboardJS focusing a hidden textarea) no longer close the Checkout discount inspector.
> 
> A **system spec** in **`discounts_spec.rb`** opens the discount inspector, triggers copy, and asserts the modal stays open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72c5f73df602767c2fd5570174bc9a821ecbadb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->