### PR TITLE
Fix unclosed repeat() in customers email filter grid

### DIFF
--- a/app/javascript/components/EmailsPage/EmailForm.tsx
+++ b/app/javascript/components/EmailsPage/EmailForm.tsx
@@ -1065,7 +1065,7 @@ export const EmailForm = ({ context, installment }: EmailFormProps) => {
                   style={{
                     display: "grid",
                     gap: "var(--spacer-4)",
-                    gridTemplateColumns: "repeat(auto-fit, minmax(var(--dynamic-grid), 1fr)",
+                    gridTemplateColumns: "repeat(auto-fit, minmax(var(--dynamic-grid), 1fr))",
                   }}
                   className="grow"
                 >


### PR DESCRIPTION
## What

The "Paid more than / Paid less than" filter in the email composer rendered its two price inputs stacked vertically instead of side-by-side. The `gridTemplateColumns` value was missing the closing paren on `repeat(`:

```diff
- gridTemplateColumns: "repeat(auto-fit, minmax(var(--dynamic-grid), 1fr)",
+ gridTemplateColumns: "repeat(auto-fit, minmax(var(--dynamic-grid), 1fr))",
```

This closes the paren so the value is valid CSS and the grid lays out in two columns.

## Why

An invalid CSS value is dropped entirely by the browser, so the grid template never applied and the inputs fell back to single-column flow. The fix matches the form used by the sibling grids in the same component (the date "After/Before" grid and the "From country / Minimum license uses" grid), which were already correct.

---

This PR was implemented with AI assistance using Claude Opus 4.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784836622&installation_id=134400930&pr_number=5566&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5566&signature=d8dd177e799baa0c574276a91b294930d7ffedf419ea9e13e4e7d5dde856af3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-character CSS string fix in the email form UI with no backend or data-handling impact.
> 
> **Overview**
> Fixes invalid **`gridTemplateColumns`** on the customers-only **Paid more than / Paid less than** row in the email composer so the two price fields sit side-by-side again.
> 
> The value was missing the closing `)` on `repeat(...)`, so the browser dropped the rule and the inputs stacked in a single column. The string now matches the other filter grids in the same form (date range and country / license uses).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d342559c849eefafbfb78d33e719baa129b447a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->