### PR TITLE
Rate-limit the profile custom_html API endpoints

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -390,6 +390,19 @@ class Rack::Attack
   throttle_by_ip path: /\A\/(api\/)?v2\/products\/[^\/]+\/preview_custom_html(\.\w+)?\z/, method: :post, requests: 60, period: 60.seconds
   throttle_by_params path: /\A\/(api\/)?v2\/products\/[^\/]+\/preview_custom_html(\.\w+)?\z/, method: :post, requests: 60, period: 60.seconds, throttle_params: v2_product_token
 
+  # Profile custom HTML mirrors the product custom_html limits: the agent-driven
+  # PUT (publish) and the CPU-heavy preview sanitizer need the same per-IP +
+  # per-token ceilings. The token extractor above is generic, so it's reused.
+  # Initial: 30rpm, Max: 150 requests/9 hours
+  throttle_by_ip path: /\A\/(api\/)?v2\/user\/custom_html(\.\w+)?\z/, method: :put, requests: 30, period: 60.seconds
+  throttle_by_ip path: /\A\/(api\/)?v2\/user\/custom_html(\.\w+)?\z/, method: :patch, requests: 30, period: 60.seconds
+  throttle_by_params path: /\A\/(api\/)?v2\/user\/custom_html(\.\w+)?\z/, method: :put, requests: 30, period: 60.seconds, throttle_params: v2_product_token
+  throttle_by_params path: /\A\/(api\/)?v2\/user\/custom_html(\.\w+)?\z/, method: :patch, requests: 30, period: 60.seconds, throttle_params: v2_product_token
+
+  # Initial: 60rpm, Max: 300 requests/9 hours
+  throttle_by_ip path: /\A\/(api\/)?v2\/user\/preview_custom_html(\.\w+)?\z/, method: :post, requests: 60, period: 60.seconds
+  throttle_by_params path: /\A\/(api\/)?v2\/user\/preview_custom_html(\.\w+)?\z/, method: :post, requests: 60, period: 60.seconds, throttle_params: v2_product_token
+
   # Do not throttle for health check requests
   safelist("allow from localhost", &:localhost?)
 end

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -373,4 +373,58 @@ describe "Rack::Attack throttle", type: :request do
       end
     end
   end
+
+  describe "PUT /api/v2/user/custom_html per-token throttle" do
+    before { reset_rack_attack! }
+    after { reset_rack_attack! }
+
+    it "throttles past 30 PUTs/min per token even when the source IP rotates" do
+      user = create(:user)
+      app = create(:oauth_application, owner: create(:user))
+      token = create("doorkeeper/access_token", application: app, resource_owner_id: user.id, scopes: "edit_profile").token
+      Feature.activate_user(:custom_html_pages, user)
+
+      travel_to(Time.current) do
+        30.times do |i|
+          put "/api/v2/user/custom_html",
+              params: { access_token: token, custom_html: "<p>#{i}</p>" },
+              headers: { "HTTP_CF_CONNECTING_IP" => "10.2.0.#{i + 1}" }
+          expect(response.status).not_to eq(429), "request #{i + 1} unexpectedly throttled"
+        end
+
+        put "/api/v2/user/custom_html",
+            params: { access_token: token, custom_html: "<p>over</p>" },
+            headers: { "HTTP_CF_CONNECTING_IP" => "10.2.0.99" }
+
+        expect(response.status).to eq(429)
+      end
+    end
+  end
+
+  describe "POST /api/v2/user/preview_custom_html per-token throttle" do
+    before { reset_rack_attack! }
+    after { reset_rack_attack! }
+
+    it "throttles past 60 preview requests/min per token even when the source IP rotates" do
+      user = create(:user)
+      app = create(:oauth_application, owner: create(:user))
+      token = create("doorkeeper/access_token", application: app, resource_owner_id: user.id, scopes: "edit_profile").token
+      Feature.activate_user(:custom_html_pages, user)
+
+      travel_to(Time.current) do
+        60.times do |i|
+          post "/api/v2/user/preview_custom_html",
+               params: { access_token: token, custom_html: "<p>#{i}</p>" },
+               headers: { "HTTP_CF_CONNECTING_IP" => "10.3.0.#{i + 1}" }
+          expect(response.status).not_to eq(429), "request #{i + 1} unexpectedly throttled"
+        end
+
+        post "/api/v2/user/preview_custom_html",
+             params: { access_token: token, custom_html: "<p>over</p>" },
+             headers: { "HTTP_CF_CONNECTING_IP" => "10.3.0.99" }
+
+        expect(response.status).to eq(429)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What

Adds Rack::Attack throttles for the profile custom_html API endpoints shipped in #5569:

- `PUT|PATCH /v2/user/custom_html` → **30/min**
- `POST /v2/user/preview_custom_html` → **60/min**

Each is throttled **per IP and per token** (reusing the generic v2 token extractor), exactly mirroring the existing product custom_html rules.

## Why

#5569 added the endpoints and the API docs already promise *"Rate limits per token: 30 PUTs/min, 60 previews/min"* — but the throttles were never wired up. The existing Rack::Attack rules only match `/\A\/(api\/)?v2\/products\/...`, so `/v2/user/custom_html` and `/v2/user/preview_custom_html` were **completely unthrottled**. That left the documented limits unenforced and, more importantly, left the **CPU-heavy sanitizer** on `preview_custom_html` (Nokogiri-parsing up to 500 KB) open to abuse.

The per-token layer on top of per-IP is the same defense the product endpoints use: it blocks the IP-rotation bypass and gives token-level attribution when an agent runs away.

## Test Results

Two request specs mirror the product throttle specs — they send 30 PUTs / 60 previews with a **rotating source IP** and assert the next request (same token) returns `429`:

```
spec/requests/rack_attack_spec.rb
  PUT /api/v2/user/custom_html per-token throttle              ✓
  POST /api/v2/user/preview_custom_html per-token throttle     ✓
2 examples, 0 failures
```

`rubocop` clean; initializer loads (`ruby -c` OK).

Follow-up to #5569.

---

🤖 AI disclosure: implemented with Claude Opus 4.8 (1M context) via Claude Code.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784927039&installation_id=134400930&pr_number=5570&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5570&signature=191c83ca3cb28b5f8c19fd785450e71177560f4e18fdfad2700f85a2c96acfaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive rate limiting that copies an existing, tested pattern; reduces abuse risk on CPU-heavy preview without changing handler logic.
> 
> **Overview**
> Wires **Rack::Attack** throttles for the profile custom HTML v2 APIs that were documented but not enforced after #5569.
> 
> **`PUT`/`PATCH` `/v2/user/custom_html`** now get **30 requests/min** per IP and per OAuth token; **`POST` `/v2/user/preview_custom_html`** gets **60/min** with the same layering. Limits and the shared `v2_product_token` extractor match the existing product `custom_html` rules (including exponential backoff tiers noted in comments).
> 
> Request specs assert the **per-token** cap returns **429** on the 31st PUT and 61st preview when the client IP rotates, parallel to the product throttle tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 004c2195374ba1865258d17675dae4c823037c5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->