### PR TITLE
Profile custom HTML: Build-with-your-agent UI + clear-only reset (#5553 Phase 2b)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,8 +100,7 @@ Do not push code with failing tests. CI is not a substitute for local verificati
 - Always use the latest version of Ruby, Rails, TypeScript, and React
 - Sentence case headers and buttons and stuff, not title case
 - Always write the code
-- Don't leave comments in the code
-- No explanatory comments please
+- Comments are welcome when they earn their place. Keep them concise and focused on the why — intent, non-obvious trade-offs, edge cases, the reason a surprising line exists. Don't narrate the what the code already says plainly.
 - Don't apologize for errors, fix them
 - Business logic (pricing, calculations, discount application) belongs in Rails, not the frontend. The frontend renders state provided by the backend. Enforce all constraints on the server.
 - Assign raw numbers to named constants (e.g., `MAX_CHARACTER_LIMIT` instead of `500`) to clarify their purpose.

--- a/app/controllers/concerns/renders_custom_html_pages.rb
+++ b/app/controllers/concerns/renders_custom_html_pages.rb
@@ -80,6 +80,27 @@ module RendersCustomHtmlPages
     </script>
   HTML
 
+  POLL_INTERVAL_MS = 2000
+
+  # Preview-only: lets the Settings → Profile editor reflect unsaved name/bio edits in the live
+  # page preview without a republish. The dashboard posts {type, name, bio}; this updates the
+  # same data-gumroad-field nodes the server-side interpolator fills, in place. textContent only
+  # (never innerHTML), so it can't introduce markup. Included solely on ?preview embeds, so public
+  # pages don't carry it.
+  PROFILE_FIELDS_PREVIEW_SCRIPT = <<~HTML
+    <script data-cfasync="false">
+      window.addEventListener("message", function (e) {
+        var d = e.data;
+        if (!d || d.type !== "gumroad:profile-fields") return;
+        ["name", "bio"].forEach(function (field) {
+          var value = d[field] == null ? "" : String(d[field]);
+          var nodes = document.querySelectorAll('[data-gumroad-field="' + field + '"]');
+          for (var i = 0; i < nodes.length; i++) nodes[i].textContent = value;
+        });
+      });
+    </script>
+  HTML
+
   module ClassMethods
     # Memoized per process — the file ships with the deployed artifact and
     # only changes on deploy, which restarts the process.
@@ -92,6 +113,45 @@ module RendersCustomHtmlPages
   end
 
   private
+    # Live-reload poll for the wrapper document. The seller authors the page through their agent
+    # + the CLI/API; this lets them keep the public page open and watch each publish land without
+    # a manual refresh. Injected ONLY for the authenticated owner (see each controller's
+    # owner_viewing_custom_html? gate), so public visitors never poll - that keeps load off the
+    # public page and limits the version endpoint's tiny timestamp to the one person already
+    # allowed to edit it. The poll hits a same-origin JSON endpoint (connect-src 'self') for the
+    # page's version (its Page#updated_at): on a republish it cache-busts the iframe; on removal
+    # it reloads the top document so the default profile/product page returns. Pauses while the
+    # tab is hidden. The wrapper is trusted chrome, so the inline script runs under the app CSP
+    # via the same nonce the wrapper already uses.
+    def custom_html_live_reload_script(version_src:, nonce:)
+      <<~HTML
+        <script nonce="#{ERB::Util.h(nonce)}" data-cfasync="false">
+          (function () {
+            var frame = document.getElementById("gumroad-landing-frame");
+            var versionUrl = #{ERB::Util.json_escape(version_src.to_json)};
+            var known = null;
+            function poll() {
+              if (document.hidden) return;
+              fetch(versionUrl, { headers: { "Accept": "application/json" }, cache: "no-store", credentials: "same-origin" })
+                .then(function (r) { return r.ok ? r.json() : null; })
+                .then(function (data) {
+                  if (!data) return;
+                  var current = data.present ? "v" + String(data.version) : "absent";
+                  if (known === null) { known = current; return; }
+                  if (current === known) return;
+                  if (current === "absent") { window.location.reload(); return; }
+                  known = current;
+                  if (frame) frame.src = frame.src.split("#")[0].split("?")[0] + "?" + encodeURIComponent(current);
+                })
+                .catch(function () {});
+            }
+            setInterval(poll, #{POLL_INTERVAL_MS});
+            poll();
+          })();
+        </script>
+      HTML
+    end
+
     # The landing iframe HTML must reflect a just-published edit, so read from the
     # primary rather than a possibly-lagging replica. Wired via a before_action in
     # each controller (the product and profile embed actions both need it).

--- a/app/controllers/concerns/renders_custom_html_pages.rb
+++ b/app/controllers/concerns/renders_custom_html_pages.rb
@@ -82,11 +82,6 @@ module RendersCustomHtmlPages
 
   POLL_INTERVAL_MS = 2000
 
-  # Preview-only: lets the Settings → Profile editor reflect unsaved name/bio edits in the live
-  # page preview without a republish. The dashboard posts {type, name, bio}; this updates the
-  # same data-gumroad-field nodes the server-side interpolator fills, in place. textContent only
-  # (never innerHTML), so it can't introduce markup. Included solely on ?preview embeds, so public
-  # pages don't carry it.
   PROFILE_FIELDS_PREVIEW_SCRIPT = <<~HTML
     <script data-cfasync="false">
       window.addEventListener("message", function (e) {
@@ -113,22 +108,10 @@ module RendersCustomHtmlPages
   end
 
   private
-    # Single source of the version-token JSON contract the owner poll consumes (see
-    # custom_html_live_reload_script). Both controllers' landing_version actions render through this.
     def render_landing_version(visible:, page:)
       render json: { present: visible, version: visible ? page&.updated_at&.to_i : nil }
     end
 
-    # Live-reload poll for the wrapper document. The seller authors the page through their agent
-    # + the CLI/API; this lets them keep the public page open and watch each publish land without
-    # a manual refresh. Injected ONLY for the authenticated owner (see each controller's
-    # owner_viewing_custom_html? gate), so public visitors never poll - that keeps load off the
-    # public page and limits the version endpoint's tiny timestamp to the one person already
-    # allowed to edit it. The poll hits a same-origin JSON endpoint (connect-src 'self') for the
-    # page's version (its Page#updated_at): on a republish it cache-busts the iframe; on removal
-    # it reloads the top document so the default profile/product page returns. Pauses while the
-    # tab is hidden. The wrapper is trusted chrome, so the inline script runs under the app CSP
-    # via the same nonce the wrapper already uses.
     def custom_html_live_reload_script(version_src:, nonce:)
       <<~HTML
         <script nonce="#{ERB::Util.h(nonce)}" data-cfasync="false">

--- a/app/controllers/concerns/renders_custom_html_pages.rb
+++ b/app/controllers/concerns/renders_custom_html_pages.rb
@@ -113,6 +113,12 @@ module RendersCustomHtmlPages
   end
 
   private
+    # Single source of the version-token JSON contract the owner poll consumes (see
+    # custom_html_live_reload_script). Both controllers' landing_version actions render through this.
+    def render_landing_version(visible:, page:)
+      render json: { present: visible, version: visible ? page&.updated_at&.to_i : nil }
+    end
+
     # Live-reload poll for the wrapper document. The seller authors the page through their agent
     # + the CLI/API; this lets them keep the public page open and watch each publish land without
     # a manual refresh. Injected ONLY for the authenticated owner (see each controller's

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -15,15 +15,15 @@ class LinksController < ApplicationController
 
 
 
-  PUBLIC_ACTIONS = %i[show search increment_views track_user_action cart_items_count landing_iframe_content].freeze
+  PUBLIC_ACTIONS = %i[show search increment_views track_user_action cart_items_count landing_iframe_content landing_version].freeze
   before_action :authenticate_user!, except: PUBLIC_ACTIONS
   after_action :verify_authorized, except: PUBLIC_ACTIONS
   skip_before_action :require_account_email, only: PUBLIC_ACTIONS + %i[publish]
 
-  before_action :stick_to_primary_for_landing_iframe, only: :landing_iframe_content
-  before_action :fetch_product_for_show, only: %i[show landing_iframe_content]
-  before_action :check_banned, only: %i[show landing_iframe_content]
-  before_action :ensure_seller_is_not_deleted, only: %i[show landing_iframe_content]
+  before_action :stick_to_primary_for_landing_iframe, only: %i[landing_iframe_content landing_version]
+  before_action :fetch_product_for_show, only: %i[show landing_iframe_content landing_version]
+  before_action :check_banned, only: %i[show landing_iframe_content landing_version]
+  before_action :ensure_seller_is_not_deleted, only: %i[show landing_iframe_content landing_version]
   before_action :set_x_robots_tag_header, only: :show
   before_action :check_payment_details, only: :index
 
@@ -31,7 +31,7 @@ class LinksController < ApplicationController
 
   before_action :fetch_product, only: %i[increment_views track_user_action]
   before_action :check_if_needs_redirect, only: [:show]
-  before_action :ensure_domain_belongs_to_seller, only: %i[show landing_iframe_content]
+  before_action :ensure_domain_belongs_to_seller, only: %i[show landing_iframe_content landing_version]
   before_action :render_custom_html_if_present, only: [:show]
   before_action :prepare_product_page, only: %i[show]
   before_action :fetch_product_and_enforce_ownership, only: %i[destroy]
@@ -195,6 +195,13 @@ class LinksController < ApplicationController
     apply_custom_html_response_headers
     interpolated = Pages::Interpolator.interpolate(@product.custom_html, product: @product)
     render html: custom_html_document(interpolated).html_safe, layout: false
+  end
+
+  # Version token for the wrapper's owner-only live-reload poll (mirrors UsersController#landing_version).
+  def landing_version
+    page = @product&.page
+    visible = custom_html_visible? && page&.custom_html.present?
+    render json: { present: visible, version: visible ? page.updated_at.to_i : nil }
   end
 
   def search
@@ -1040,6 +1047,7 @@ class LinksController < ApplicationController
                 }
               });
             </script>
+            #{can_preview_custom_html? ? custom_html_live_reload_script(version_src: "/l/#{product.unique_permalink}/landing/version", nonce:) : ""}
           </body>
         </html>
       HTML

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -199,6 +199,7 @@ class LinksController < ApplicationController
 
   # Version token for the wrapper's owner-only live-reload poll (mirrors UsersController#landing_version).
   def landing_version
+    return render json: { present: false, version: nil } unless can_preview_custom_html?
     page = @product&.page
     visible = custom_html_visible? && page&.custom_html.present?
     render json: { present: visible, version: visible ? page.updated_at.to_i : nil }

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -197,12 +197,10 @@ class LinksController < ApplicationController
     render html: custom_html_document(interpolated).html_safe, layout: false
   end
 
-  # Version token for the wrapper's owner-only live-reload poll (mirrors UsersController#landing_version).
   def landing_version
-    return render json: { present: false, version: nil } unless can_preview_custom_html?
+    return render_landing_version(visible: false, page: nil) unless can_preview_custom_html?
     page = @product&.page
-    visible = custom_html_visible? && page&.custom_html.present?
-    render json: { present: visible, version: visible ? page.updated_at.to_i : nil }
+    render_landing_version(visible: custom_html_visible? && page&.custom_html.present?, page:)
   end
 
   def search

--- a/app/controllers/settings/profile_controller.rb
+++ b/app/controllers/settings/profile_controller.rb
@@ -9,6 +9,7 @@ class Settings::ProfileController < Settings::BaseController
   before_action :authorize
 
   def show
+    set_meta_tag(title: "Profile settings")
     profile_presenter = ProfilePresenter.new(pundit_user:, seller: current_seller)
 
     render inertia: "Settings/Profile/Show", props: profile_presenter.profile_settings_props(request:)

--- a/app/controllers/settings/profile_controller.rb
+++ b/app/controllers/settings/profile_controller.rb
@@ -17,6 +17,13 @@ class Settings::ProfileController < Settings::BaseController
   def update
     return respond_error("You have to confirm your email address before you can do that.") unless current_seller.confirmed?
 
+    # custom_html is clear-only from this session surface. Authoring goes through the sanitized,
+    # OAuth-scoped v2 API (PUT /v2/user/custom_html). A non-blank value here would bypass
+    # Ai::PageSanitizer entirely (stored XSS), so reject anything but a blank reset.
+    if permitted_params.dig(:user, :custom_html).present?
+      return respond_error("Custom HTML can only be edited through the Gumroad CLI or API.")
+    end
+
     # Reject a stale layout before mutating anything (including the avatar), so a rejected save leaves
     # the profile untouched. The locked re-check inside the transaction is authoritative; this is an
     # early-out that avoids a partial write - e.g. attaching/purging the avatar - when we already know

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -44,7 +44,7 @@ class UsersController < ApplicationController
     render html: profile_custom_html_document(
       interpolated,
       data_json: ERB::Util.json_escape(Pages::ProfileData.build(@user).to_json),
-      live_fields: params[:preview].present?,
+      live_fields: params[:preview].present? && owner_viewing_custom_html?,
     ).html_safe, layout: false
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,13 +7,13 @@ class UsersController < ApplicationController
   include PageMeta::Favicon, PageMeta::User
   include RendersCustomHtmlPages
 
-  before_action :authenticate_user!, except: %i[show coffee subscribe subscribe_preview email_unsubscribe add_purchase_to_library session_info current_user_data landing_iframe_content]
+  before_action :authenticate_user!, except: %i[show coffee subscribe subscribe_preview email_unsubscribe add_purchase_to_library session_info current_user_data landing_iframe_content landing_version]
 
   after_action :verify_authorized, only: %i[deactivate edit]
 
-  before_action :stick_to_primary_for_landing_iframe, only: :landing_iframe_content
+  before_action :stick_to_primary_for_landing_iframe, only: %i[landing_iframe_content landing_version]
   before_action :set_as_modal, only: %i[show]
-  before_action :set_user_and_custom_domain_config, only: %i[show edit coffee subscribe subscribe_preview landing_iframe_content]
+  before_action :set_user_and_custom_domain_config, only: %i[show edit coffee subscribe subscribe_preview landing_iframe_content landing_version]
   before_action :set_page_attributes, only: %i[show]
   before_action :set_user_for_action, only: %i[email_unsubscribe]
   before_action :check_if_needs_redirect, only: %i[show]
@@ -41,7 +41,21 @@ class UsersController < ApplicationController
 
     apply_custom_html_response_headers
     interpolated = Pages::Interpolator.interpolate_profile(@user.custom_html, profile: @user)
-    render html: profile_custom_html_document(interpolated).html_safe, layout: false
+    render html: profile_custom_html_document(
+      interpolated,
+      data_json: ERB::Util.json_escape(Pages::ProfileData.build(@user).to_json),
+      live_fields: params[:preview].present?,
+    ).html_safe, layout: false
+  end
+
+  # Tiny public version token for the wrapper's owner-only live-reload poll. Reports whether a
+  # custom page is currently live and a monotonic token (the Page's updated_at) that changes on
+  # every republish. Stays out of custom_html_visible?'s 404 path so the poll can also observe a
+  # removal (present:false) and restore the default profile.
+  def landing_version
+    page = @user.page
+    visible = Feature.active?(:custom_html_pages, @user) && page&.custom_html.present?
+    render json: { present: visible, version: visible ? page.updated_at.to_i : nil }
   end
 
   def edit
@@ -182,6 +196,13 @@ class UsersController < ApplicationController
       render html: profile_custom_html_wrapper_document(@user).html_safe, layout: false
     end
 
+    # Only the seller (viewing their own live profile while signed in) gets the live-reload poll -
+    # they're the one authoring via the agent and watching publishes land. Public visitors get a
+    # static wrapper with no polling.
+    def owner_viewing_custom_html?
+      current_user.present? && current_user == @user
+    end
+
     # set_user_and_custom_domain_config already 404s any non-active account
     # before these actions run (unlike products, which aren't gated on alive?
     # upstream), so there's no owner/team preview branch to add here.
@@ -193,7 +214,11 @@ class UsersController < ApplicationController
       @is_user_custom_domain ? "/landing/embed" : "/#{user.username}/landing/embed"
     end
 
-    def profile_custom_html_document(custom_html)
+    def profile_landing_version_src(user)
+      @is_user_custom_domain ? "/landing/version" : "/#{user.username}/landing/version"
+    end
+
+    def profile_custom_html_document(custom_html, data_json: "{}", live_fields: false)
       <<~HTML
         <!doctype html>
         <html>
@@ -204,7 +229,9 @@ class UsersController < ApplicationController
             #{self.class.pages_tailwind_inline}
           </head>
           <body>
+            <script id="gumroad-data" type="application/json">#{data_json}</script>
             #{custom_html}
+            #{live_fields ? PROFILE_FIELDS_PREVIEW_SCRIPT : ""}
           </body>
         </html>
       HTML
@@ -222,6 +249,11 @@ class UsersController < ApplicationController
       # avatar_url always returns a value (it falls back to the default avatar),
       # so only advertise og:image when the seller uploaded a real one.
       og_image_tag = user.avatar.attached? ? %(<meta property="og:image" content="#{ERB::Util.h(user.avatar_url)}">) : ""
+      live_reload = if owner_viewing_custom_html?
+        custom_html_live_reload_script(version_src: profile_landing_version_src(user), nonce: SecureHeaders.content_security_policy_script_nonce(request))
+      else
+        ""
+      end
       <<~HTML
         <!doctype html>
         <html lang="en">
@@ -243,6 +275,7 @@ class UsersController < ApplicationController
               title="#{title}"
               sandbox="allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox"
             ></iframe>
+            #{live_reload}
           </body>
         </html>
       HTML

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -53,6 +53,7 @@ class UsersController < ApplicationController
   # every republish. Stays out of custom_html_visible?'s 404 path so the poll can also observe a
   # removal (present:false) and restore the default profile.
   def landing_version
+    return render json: { present: false, version: nil } unless owner_viewing_custom_html?
     page = @user.page
     visible = Feature.active?(:custom_html_pages, @user) && page&.custom_html.present?
     render json: { present: visible, version: visible ? page.updated_at.to_i : nil }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -44,12 +44,12 @@ class UsersController < ApplicationController
     render html: profile_custom_html_document(
       interpolated,
       data_json: ERB::Util.json_escape(Pages::ProfileData.build(@user).to_json),
-      live_fields: params[:preview].present? && owner_viewing_custom_html?,
+      live_fields: params[:preview].present? && current_seller_owns_profile?,
     ).html_safe, layout: false
   end
 
   def landing_version
-    return render_landing_version(visible: false, page: nil) unless owner_viewing_custom_html?
+    return render_landing_version(visible: false, page: nil) unless current_seller_owns_profile?
     page = @user.page
     render_landing_version(visible: Feature.active?(:custom_html_pages, @user) && page&.custom_html.present?, page:)
   end
@@ -192,8 +192,12 @@ class UsersController < ApplicationController
       render html: profile_custom_html_wrapper_document(@user).html_safe, layout: false
     end
 
-    def owner_viewing_custom_html?
-      current_user.present? && current_user == @user
+    # True for the seller and for any team member acting as the seller (admin/marketing can edit the
+    # profile per Settings::ProfilePolicy), so the live-fields preview and live reload reach every
+    # editor, not just the owner. current_seller is the account the viewer is acting as and is only
+    # set to a seller the viewer is a validated member of, so this never leaks to other visitors.
+    def current_seller_owns_profile?
+      current_seller.present? && current_seller == @user
     end
 
     # set_user_and_custom_domain_config already 404s any non-active account
@@ -238,7 +242,7 @@ class UsersController < ApplicationController
       # avatar_url always returns a value (it falls back to the default avatar),
       # so only advertise og:image when the seller uploaded a real one.
       og_image_tag = user.avatar.attached? ? %(<meta property="og:image" content="#{ERB::Util.h(user.avatar_url)}">) : ""
-      live_reload = if owner_viewing_custom_html?
+      live_reload = if current_seller_owns_profile?
         custom_html_live_reload_script(version_src: profile_landing_src(user, "version"), nonce: SecureHeaders.content_security_policy_script_nonce(request))
       else
         ""

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -210,12 +210,8 @@ class UsersController < ApplicationController
       Feature.active?(:custom_html_pages, @user) && @user.custom_html.present?
     end
 
-    def profile_landing_embed_src(user)
-      @is_user_custom_domain ? "/landing/embed" : "/#{user.username}/landing/embed"
-    end
-
-    def profile_landing_version_src(user)
-      @is_user_custom_domain ? "/landing/version" : "/#{user.username}/landing/version"
+    def profile_landing_src(user, suffix)
+      @is_user_custom_domain ? "/landing/#{suffix}" : "/#{user.username}/landing/#{suffix}"
     end
 
     def profile_custom_html_document(custom_html, data_json: "{}", live_fields: false)
@@ -243,14 +239,14 @@ class UsersController < ApplicationController
     # visitor's tab away from gumroad.com. Unlike the product wrapper there is no
     # checkout postMessage bridge: a profile has no native buy button.
     def profile_custom_html_wrapper_document(user)
-      iframe_src = ERB::Util.h(profile_landing_embed_src(user))
+      iframe_src = ERB::Util.h(profile_landing_src(user, "embed"))
       title = ERB::Util.h(user.name_or_username.to_s)
       canonical = ERB::Util.h(user.profile_url(custom_domain_url: seller_custom_domain_url).to_s)
       # avatar_url always returns a value (it falls back to the default avatar),
       # so only advertise og:image when the seller uploaded a real one.
       og_image_tag = user.avatar.attached? ? %(<meta property="og:image" content="#{ERB::Util.h(user.avatar_url)}">) : ""
       live_reload = if owner_viewing_custom_html?
-        custom_html_live_reload_script(version_src: profile_landing_version_src(user), nonce: SecureHeaders.content_security_policy_script_nonce(request))
+        custom_html_live_reload_script(version_src: profile_landing_src(user, "version"), nonce: SecureHeaders.content_security_policy_script_nonce(request))
       else
         ""
       end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -53,10 +53,9 @@ class UsersController < ApplicationController
   # every republish. Stays out of custom_html_visible?'s 404 path so the poll can also observe a
   # removal (present:false) and restore the default profile.
   def landing_version
-    return render json: { present: false, version: nil } unless owner_viewing_custom_html?
+    return render_landing_version(visible: false, page: nil) unless owner_viewing_custom_html?
     page = @user.page
-    visible = Feature.active?(:custom_html_pages, @user) && page&.custom_html.present?
-    render json: { present: visible, version: visible ? page.updated_at.to_i : nil }
+    render_landing_version(visible: Feature.active?(:custom_html_pages, @user) && page&.custom_html.present?, page:)
   end
 
   def edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -48,10 +48,6 @@ class UsersController < ApplicationController
     ).html_safe, layout: false
   end
 
-  # Tiny public version token for the wrapper's owner-only live-reload poll. Reports whether a
-  # custom page is currently live and a monotonic token (the Page's updated_at) that changes on
-  # every republish. Stays out of custom_html_visible?'s 404 path so the poll can also observe a
-  # removal (present:false) and restore the default profile.
   def landing_version
     return render_landing_version(visible: false, page: nil) unless owner_viewing_custom_html?
     page = @user.page
@@ -196,9 +192,6 @@ class UsersController < ApplicationController
       render html: profile_custom_html_wrapper_document(@user).html_safe, layout: false
     end
 
-    # Only the seller (viewing their own live profile while signed in) gets the live-reload poll -
-    # they're the one authoring via the agent and watching publishes land. Public visitors get a
-    # static wrapper with no polling.
     def owner_viewing_custom_html?
       current_user.present? && current_user == @user
     end

--- a/app/javascript/components/ProductEdit/ShareTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ShareTab/index.tsx
@@ -1,11 +1,7 @@
-import { Link } from "@boxicons/react";
 import * as React from "react";
 
-import { Button } from "$app/components/Button";
-import { CopyToClipboard } from "$app/components/CopyToClipboard";
 import { useCurrentSeller } from "$app/components/CurrentSeller";
 import { useDiscoverUrl } from "$app/components/DomainSettings";
-import { FacebookShareButton } from "$app/components/FacebookShareButton";
 import { Layout, useProductUrl } from "$app/components/ProductEdit/Layout";
 import { ProductPreview } from "$app/components/ProductEdit/ProductPreview";
 import { LandingPageEditor } from "$app/components/ProductEdit/ShareTab/LandingPageEditor";
@@ -13,7 +9,7 @@ import { ProfileSectionsEditor } from "$app/components/ProductEdit/ShareTab/Prof
 import { TagSelector } from "$app/components/ProductEdit/ShareTab/TagSelector";
 import { TaxonomyEditor } from "$app/components/ProductEdit/ShareTab/TaxonomyEditor";
 import { useProductEditContext } from "$app/components/ProductEdit/state";
-import { TwitterShareButton } from "$app/components/TwitterShareButton";
+import { ShareButtons } from "$app/components/ShareButtons";
 import { Alert } from "$app/components/ui/Alert";
 import { Fieldset } from "$app/components/ui/Fieldset";
 import { Switch } from "$app/components/ui/Switch";
@@ -42,16 +38,7 @@ export const ShareTab = () => {
             <header>
               <h2>Share</h2>
             </header>
-            <div className="flex flex-wrap gap-2">
-              <TwitterShareButton url={url} text={`Buy ${product.name} on @Gumroad`} />
-              <FacebookShareButton url={url} text={product.name} />
-              <CopyToClipboard text={url} tooltipPosition="top">
-                <Button color="primary">
-                  <Link className="size-5" />
-                  Copy URL
-                </Button>
-              </CopyToClipboard>
-            </div>
+            <ShareButtons url={url} twitterText={`Buy ${product.name} on @Gumroad`} facebookText={product.name} />
           </section>
           <LandingPageEditor />
           <ProfileSectionsEditor

--- a/app/javascript/components/Profile/LandingPageEditor.tsx
+++ b/app/javascript/components/Profile/LandingPageEditor.tsx
@@ -31,11 +31,15 @@ export const ProfileLandingPageEditor = ({
 
 Design a unique, on-brand profile page that reflects who I am and what I sell — fully responsive, accessible, and supporting light and dark mode. Save it as one self-contained file, profile.html. The page is sanitized and runs sandboxed: inline CSS/JS (animations, scroll effects, modals) and a Tailwind CDN work. For images and media, use only inline data: URIs or CSS — external image/media hosts are blocked, and the page can't fetch external URLs or read your account.
 
-A custom profile page REPLACES your entire public profile at gumroad.com/${username}, including the default sections and product grid. There is NO buy button on a profile, so don't add checkout elements — instead, link visitors to your individual product pages (run gumroad products list to get their URLs) or to a section of your storefront.
+A custom profile page REPLACES your entire public profile at gumroad.com/${username}, including the default sections and product grid. There is NO buy button on a profile, so don't add checkout elements — instead, link visitors to your individual product pages or to a section of your storefront.
 
-Gumroad fills in a couple of live values server-side; mark them with data attributes:
+Gumroad fills in live values server-side, so the page stays current without you editing it. Mark text with data attributes:
 - data-gumroad-field="name" — interpolated with your profile name.
 - data-gumroad-field="bio" — interpolated with your profile bio.
+
+Your live catalog is injected server-side as JSON in <script id="gumroad-data" type="application/json">, so prefer rendering products/posts/pages dynamically from it (it updates automatically as you add or remove them) instead of hardcoding. Read it with:
+  const data = JSON.parse(document.getElementById("gumroad-data").textContent);
+Shape: { products: [{ name, url, price, native_type, thumbnail_url, description }], posts: [{ name, url, published_at }], pages: [{ name }] }. Link products via product.url (their public product page). The page can't fetch anything at runtime (it's sandboxed), so this injected data is the source of truth.
 
 Then preview, publish, and verify it with the Gumroad CLI:
 - Run the real server-side sanitizer WITHOUT publishing and read what it changed: gumroad user page preview ./profile.html --json --no-input --non-interactive — inspect .sanitization_report. If it stripped tags or attributes your page needs, fix the HTML and preview again. Do this until the report is clean so you never publish a broken page.

--- a/app/javascript/components/Profile/LandingPageEditor.tsx
+++ b/app/javascript/components/Profile/LandingPageEditor.tsx
@@ -55,7 +55,7 @@ If the gumroad CLI isn't installed: brew install antiwork/cli/gumroad (or curl -
       const removed = await onRemove();
       if (removed) {
         setIsRemoveOpen(false);
-        showAlert("Custom profile page removed.", "success");
+        showAlert("Your custom profile page is removed.", "success");
       }
     } catch (e) {
       assertResponseError(e);
@@ -70,15 +70,15 @@ If the gumroad CLI isn't installed: brew install antiwork/cli/gumroad (or curl -
       <header className="flex items-center justify-between">
         <h2>Custom profile page</h2>
         <a href="/api#custom-html" target="_blank" rel="noreferrer">
-          Learn more
+          Learn more about custom pages
         </a>
       </header>
       {hasLandingPage ? (
         <Alert role="status" variant="success">
           <div className="flex flex-col justify-between sm:flex-row">
-            A custom profile page is live.
+            Your custom profile page is live.
             <a href={profileUrl} target="_blank" rel="noreferrer">
-              View
+              View page
             </a>
           </div>
         </Alert>
@@ -89,8 +89,8 @@ If the gumroad CLI isn't installed: brew install antiwork/cli/gumroad (or curl -
           prompt and hand it to your AI agent (Claude, Cursor, etc.) — it builds and publishes the page for you.
         </p>
         <p className="text-sm text-muted">
-          For safety, your profile page is sandboxed: animations and interactive effects work, but it can't reach your
-          Gumroad account or send data to other sites.
+          Your page runs safely on its own: animations and interactive effects work, but it can't reach your Gumroad
+          account or send your data to other sites.
         </p>
       </div>
       <div className="flex flex-wrap gap-3">
@@ -120,8 +120,8 @@ If the gumroad CLI isn't installed: brew install antiwork/cli/gumroad (or curl -
             </>
           }
         >
-          This removes your live custom page, so visitors will see your default profile again. You can't undo it — if
-          you might want the page back, save its HTML first.
+          This removes your custom page, so visitors will see your default profile again. You can't undo it — if you
+          might want the page back, save its HTML first.
         </Modal>
       ) : null}
     </section>

--- a/app/javascript/components/Profile/LandingPageEditor.tsx
+++ b/app/javascript/components/Profile/LandingPageEditor.tsx
@@ -67,7 +67,7 @@ If the gumroad CLI isn't installed: brew install antiwork/cli/gumroad (or curl -
 
   return (
     <section className="grid gap-8 border-t border-border p-4 md:p-8">
-      <header style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+      <header className="flex items-center justify-between">
         <h2>Custom profile page</h2>
         <a href="/api#custom-html" target="_blank" rel="noreferrer">
           Learn more

--- a/app/javascript/components/Profile/LandingPageEditor.tsx
+++ b/app/javascript/components/Profile/LandingPageEditor.tsx
@@ -1,0 +1,125 @@
+import * as React from "react";
+
+import { assertResponseError } from "$app/utils/request";
+
+import { Button } from "$app/components/Button";
+import { CopyToClipboard } from "$app/components/CopyToClipboard";
+import { Modal } from "$app/components/Modal";
+import { showAlert } from "$app/components/server-components/Alert";
+import { Alert } from "$app/components/ui/Alert";
+import { Details, DetailsToggle } from "$app/components/ui/Details";
+
+export const ProfileLandingPageEditor = ({
+  username,
+  profileUrl,
+  hasLandingPage,
+  onRemove,
+}: {
+  username: string;
+  profileUrl: string;
+  hasLandingPage: boolean;
+  // Clears the custom HTML through the session-authed profile form (blank reset). Returns true on
+  // success so the modal only closes when the page was actually removed.
+  onRemove: () => Promise<boolean>;
+}) => {
+  const [isRemoveOpen, setIsRemoveOpen] = React.useState(false);
+  const [isRemoving, setIsRemoving] = React.useState(false);
+
+  // No checkout affordances here, unlike the product landing page: a profile has no native buy
+  // button, so the prompt links to products/sections instead of embedding buy elements.
+  const agentPrompt = `Build and publish a custom landing page for my Gumroad profile (@${username}).
+
+Design a unique, on-brand profile page that reflects who I am and what I sell — fully responsive, accessible, and supporting light and dark mode. Save it as one self-contained file, profile.html. The page is sanitized and runs sandboxed: inline CSS/JS (animations, scroll effects, modals) and a Tailwind CDN work. For images and media, use only inline data: URIs or CSS — external image/media hosts are blocked, and the page can't fetch external URLs or read your account.
+
+A custom profile page REPLACES your entire public profile at gumroad.com/${username}, including the default sections and product grid. There is NO buy button on a profile, so don't add checkout elements — instead, link visitors to your individual product pages (run gumroad products list to get their URLs) or to a section of your storefront.
+
+Gumroad fills in a couple of live values server-side; mark them with data attributes:
+- data-gumroad-field="name" — interpolated with your profile name.
+- data-gumroad-field="bio" — interpolated with your profile bio.
+
+Then preview, publish, and verify it with the Gumroad CLI:
+- Run the real server-side sanitizer WITHOUT publishing and read what it changed: gumroad user page preview ./profile.html --json --no-input --non-interactive — inspect .sanitization_report. If it stripped tags or attributes your page needs, fix the HTML and preview again. Do this until the report is clean so you never publish a broken page.
+- Publish (or update) the page once preview is clean: gumroad user page publish ./profile.html --json --no-input --non-interactive — .sanitization_report reflects what actually shipped.
+- Confirm it's live and find the public URL: gumroad user page url --json --jq '.profile.landing_url' --no-input --non-interactive
+- Remove the custom profile page and restore your default profile: gumroad user page clear --yes --json --no-input --non-interactive
+
+If the gumroad CLI isn't installed: brew install antiwork/cli/gumroad (or curl -fsSL https://gumroad.com/install-cli.sh | bash), then run gumroad auth login.`;
+
+  const removeLandingPage = async () => {
+    setIsRemoving(true);
+    try {
+      const removed = await onRemove();
+      if (removed) {
+        setIsRemoveOpen(false);
+        showAlert("Custom profile page removed.", "success");
+      }
+    } catch (e) {
+      assertResponseError(e);
+      showAlert(e.message, "error");
+    } finally {
+      setIsRemoving(false);
+    }
+  };
+
+  return (
+    <section className="grid gap-8 border-t border-border p-4 md:p-8">
+      <header style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <h2>Custom profile page</h2>
+        <a href="/api#custom-html" target="_blank" rel="noreferrer">
+          Learn more
+        </a>
+      </header>
+      {hasLandingPage ? (
+        <Alert role="status" variant="success">
+          <div className="flex flex-col justify-between sm:flex-row">
+            A custom profile page is live.
+            <a href={profileUrl} target="_blank" rel="noreferrer">
+              View
+            </a>
+          </div>
+        </Alert>
+      ) : null}
+      <div className="grid gap-2">
+        <p>
+          Replace your default profile with a fully custom page — your own background, fonts, and layout. Copy the
+          prompt and hand it to your AI agent (Claude, Cursor, etc.) — it builds and publishes the page for you.
+        </p>
+        <p className="text-sm text-muted">
+          For safety, your profile page is sandboxed: animations and interactive effects work, but it can't reach your
+          Gumroad account or send data to other sites.
+        </p>
+      </div>
+      <div className="flex flex-wrap gap-3">
+        <CopyToClipboard text={agentPrompt} tooltipPosition="top">
+          <Button color="primary">Copy prompt</Button>
+        </CopyToClipboard>
+        {hasLandingPage ? <Button onClick={() => setIsRemoveOpen(true)}>Remove custom page</Button> : null}
+      </div>
+      <Details>
+        <DetailsToggle>Show prompt</DetailsToggle>
+        <pre className="rounded border border-border bg-background p-4 text-sm whitespace-pre-wrap">{agentPrompt}</pre>
+      </Details>
+      {isRemoveOpen ? (
+        <Modal
+          open
+          allowClose={!isRemoving}
+          onClose={() => setIsRemoveOpen(false)}
+          title="Remove custom profile page?"
+          footer={
+            <>
+              <Button disabled={isRemoving} onClick={() => setIsRemoveOpen(false)}>
+                Cancel
+              </Button>
+              <Button color="danger" disabled={isRemoving} onClick={() => void removeLandingPage()}>
+                {isRemoving ? "Removing..." : "Remove"}
+              </Button>
+            </>
+          }
+        >
+          This removes your live custom page, so visitors will see your default profile again. You can't undo it — if
+          you might want the page back, save its HTML first.
+        </Modal>
+      ) : null}
+    </section>
+  );
+};

--- a/app/javascript/components/Profile/LandingPagePreview.tsx
+++ b/app/javascript/components/Profile/LandingPagePreview.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+
+// Loads the same /:username/landing/embed document visitors see, so the preview
+// reflects the live custom page instead of the default profile editor. The src is
+// relative (same origin as the dashboard) so the embed's X-Frame-Options: SAMEORIGIN
+// allows it. Unlike the product landing preview there's no checkout bridge — a
+// profile has no buy button, so nothing posts back to the dashboard.
+//
+// ?preview makes the embed include a small listener so unsaved name/bio edits show
+// live: the page's data-gumroad-field nodes are updated in place via postMessage,
+// matching what a republish would interpolate server-side.
+export const ProfileLandingPagePreview = ({
+  username,
+  name,
+  bio,
+}: {
+  username: string;
+  name: string | null;
+  bio: string | null;
+}) => {
+  const frameRef = React.useRef<HTMLIFrameElement>(null);
+
+  const postFields = React.useCallback(() => {
+    frameRef.current?.contentWindow?.postMessage(
+      { type: "gumroad:profile-fields", name: name ?? "", bio: bio ?? "" },
+      "*",
+    );
+  }, [name, bio]);
+
+  React.useEffect(postFields, [postFields]);
+
+  return (
+    <iframe
+      ref={frameRef}
+      title="Custom profile page preview"
+      src={`/${encodeURIComponent(username)}/landing/embed?preview=true`}
+      sandbox="allow-scripts allow-forms allow-popups"
+      referrerPolicy="no-referrer"
+      onLoad={postFields}
+      className="h-[75vh] min-h-150 w-full rounded border border-border bg-white"
+    />
+  );
+};

--- a/app/javascript/components/Profile/LandingPagePreview.tsx
+++ b/app/javascript/components/Profile/LandingPagePreview.tsx
@@ -1,14 +1,5 @@
 import * as React from "react";
 
-// Loads the same /:username/landing/embed document visitors see, so the preview
-// reflects the live custom page instead of the default profile editor. The src is
-// relative (same origin as the dashboard) so the embed's X-Frame-Options: SAMEORIGIN
-// allows it. Unlike the product landing preview there's no checkout bridge — a
-// profile has no buy button, so nothing posts back to the dashboard.
-//
-// ?preview makes the embed include a small listener so unsaved name/bio edits show
-// live: the page's data-gumroad-field nodes are updated in place via postMessage,
-// matching what a republish would interpolate server-side.
 export const ProfileLandingPagePreview = ({
   username,
   name,

--- a/app/javascript/components/ShareButtons.tsx
+++ b/app/javascript/components/ShareButtons.tsx
@@ -1,0 +1,28 @@
+import { Link as LinkIcon } from "@boxicons/react";
+import * as React from "react";
+
+import { Button } from "$app/components/Button";
+import { CopyToClipboard } from "$app/components/CopyToClipboard";
+import { FacebookShareButton } from "$app/components/FacebookShareButton";
+import { TwitterShareButton } from "$app/components/TwitterShareButton";
+
+export const ShareButtons = ({
+  url,
+  twitterText,
+  facebookText,
+}: {
+  url: string;
+  twitterText: string;
+  facebookText: string;
+}) => (
+  <div className="flex flex-wrap gap-2">
+    <TwitterShareButton url={url} text={twitterText} />
+    <FacebookShareButton url={url} text={facebookText} />
+    <CopyToClipboard text={url} tooltipPosition="top">
+      <Button color="primary">
+        <LinkIcon className="size-5" />
+        Copy URL
+      </Button>
+    </CopyToClipboard>
+  </div>
+);

--- a/app/javascript/data/profile_settings.ts
+++ b/app/javascript/data/profile_settings.ts
@@ -56,6 +56,10 @@ export type ProfileSection =
 
 export const updateProfileSettings = async (
   profileSettings: Partial<ProfileSettings> & {
+    // custom_html is write-only and clear-only from this surface (sent as "" to reset). It is not
+    // part of the server's profile_settings read payload, so it lives here rather than in the
+    // ProfileSettings parser type. It rides along in the `user` payload below.
+    custom_html?: string | null;
     tabs?: Tab[];
     sections?: ProfileSection[];
     profileVersion?: string | null;

--- a/app/javascript/pages/Settings/Profile/Show.tsx
+++ b/app/javascript/pages/Settings/Profile/Show.tsx
@@ -1,4 +1,4 @@
-import { TwitterX } from "@boxicons/react";
+import { Link as LinkIcon, TwitterX } from "@boxicons/react";
 import { router, usePage } from "@inertiajs/react";
 import { isEqual } from "lodash-es";
 import * as React from "react";
@@ -11,25 +11,33 @@ import { asyncVoid } from "$app/utils/promise";
 import { assertResponseError } from "$app/utils/request";
 
 import { Button, NavigationButton } from "$app/components/Button";
+import { CopyToClipboard } from "$app/components/CopyToClipboard";
 import { useCurrentSeller } from "$app/components/CurrentSeller";
+import { FacebookShareButton } from "$app/components/FacebookShareButton";
 import { useLoggedInUser } from "$app/components/LoggedInUser";
 import { Preview } from "$app/components/Preview";
 import { PreviewSidebar, WithPreviewSidebar } from "$app/components/PreviewSidebar";
 import { Props as ProfileProps } from "$app/components/Profile";
 import { EditProfile, ProfileEditorProps, ProfileEditorState } from "$app/components/Profile/EditPage";
 import { ProfileLandingPageEditor } from "$app/components/Profile/LandingPageEditor";
+import { ProfileLandingPagePreview } from "$app/components/Profile/LandingPagePreview";
 import { Layout as ProfileLayout } from "$app/components/Profile/Layout";
 import { ProfileSectionsForm } from "$app/components/Profile/SectionsForm";
 import { LogoInput } from "$app/components/Profile/Settings/LogoInput";
 import { showAlert } from "$app/components/server-components/Alert";
 import { postToMobileApp } from "$app/components/Settings/Layout";
 import { SocialAuthButton } from "$app/components/SocialAuthButton";
+import { TwitterShareButton } from "$app/components/TwitterShareButton";
+import { Alert } from "$app/components/ui/Alert";
 import { Fieldset, FieldsetTitle } from "$app/components/ui/Fieldset";
 import { Input } from "$app/components/ui/Input";
 import { Label } from "$app/components/ui/Label";
 import { PageHeader } from "$app/components/ui/PageHeader";
+import { Tab, Tabs } from "$app/components/ui/Tabs";
 import { Textarea } from "$app/components/ui/Textarea";
 import { useReactNativeMessage } from "$app/components/useReactNativeMessage";
+
+type ProfileSettingsTab = "about" | "pages" | "share";
 
 type ProfileSettingsForm = {
   name: string | null;
@@ -45,6 +53,7 @@ type ProfilePageProps = {
   custom_html: string | null;
   has_custom_landing_page: boolean;
   username: string;
+  has_legacy_profile_pages: boolean;
 } & ProfileProps;
 
 export default function SettingsPage() {
@@ -56,6 +65,7 @@ export default function SettingsPage() {
     custom_html_pages_enabled,
     has_custom_landing_page,
     username,
+    has_legacy_profile_pages,
   } = typia.assert<ProfilePageProps>(usePage().props);
   const loggedInUser = useLoggedInUser();
   const currentSeller = useCurrentSeller();
@@ -108,6 +118,8 @@ export default function SettingsPage() {
     setProfileSettings((prevSettings) => ({ ...prevSettings, ...newSettings }));
 
   const uid = React.useId();
+  const [tab, setTab] = React.useState<ProfileSettingsTab>("about");
+  const profileUrl = Routes.root_url({ host: creatorProfile.subdomain });
 
   const [isSaving, setIsSaving] = React.useState(false);
   const canUpdate = Boolean(loggedInUser?.policies.settings_profile.update) && !isSaving;
@@ -218,173 +230,245 @@ export default function SettingsPage() {
     }
   });
 
+  // The legacy section editor stays available only for sellers who already built one AND aren't
+  // running a custom page — a live custom page replaces the whole profile, so editing sections is moot.
+  const showPagesTab = has_legacy_profile_pages && !has_custom_landing_page;
+
+  const renderTab = (key: ProfileSettingsTab, label: string) => (
+    <Tab
+      isSelected={tab === key}
+      className="cursor-pointer"
+      onClick={() => setTab(key)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          setTab(key);
+        }
+      }}
+      tabIndex={0}
+    >
+      {label}
+    </Tab>
+  );
+
+  const tabBar = (
+    <Tabs aria-label="Profile settings sections">
+      {renderTab("about", "About")}
+      {showPagesTab ? renderTab("pages", "Pages") : null}
+      {renderTab("share", "Share")}
+    </Tabs>
+  );
+
+  const previewSidebar = (
+    <PreviewSidebar
+      previewLink={(props) => (
+        <NavigationButton
+          {...props}
+          size="icon"
+          disabled={isSaving}
+          href={profileUrl}
+          onClick={(evt) => {
+            evt.preventDefault();
+            // Persist pending edits before previewing, but only when there's something to save -
+            // settings (name/bio/avatar) are sent on every save with no freshness check, so an
+            // unconditional save from a stale, locally-clean tab would revert changes made elsewhere.
+            // Open only after a successful save so a failed save doesn't surface a stale preview.
+            const openProfile = () => window.open(profileUrl, "_blank");
+            if (canSave)
+              void save().then((saved) => {
+                if (saved) openProfile();
+              });
+            else openProfile();
+          }}
+        />
+      )}
+    >
+      {has_custom_landing_page ? (
+        // A live custom page replaces the entire public profile, so preview the real
+        // rendered page (the default-profile editor preview below would be misleading).
+        <ProfileLandingPagePreview username={username} name={profileSettings.name} bio={profileSettings.bio} />
+      ) : (
+        <Preview
+          scaleFactor={0.4}
+          style={{
+            border: "var(--border)",
+            borderRadius: "var(--border-radius-2)",
+            fontFamily: currentSeller?.profileFont === "ABC Favorit" ? undefined : currentSeller?.profileFont,
+            ...profileColors,
+            "--primary": "var(--color)",
+            "--body-bg": "rgb(var(--filled))",
+            "--contrast-primary": "var(--filled)",
+            "--contrast-filled": "var(--color)",
+            "--color-body": "var(--body-bg)",
+            "--color-background": "rgb(var(--filled))",
+            "--color-foreground": "rgb(var(--color))",
+            "--color-border": "rgb(var(--color) / var(--border-alpha))",
+            "--color-accent": "rgb(var(--accent))",
+            "--color-accent-foreground": "rgb(var(--contrast-accent))",
+            "--color-primary": "rgb(var(--primary))",
+            "--color-primary-foreground": "rgb(var(--contrast-primary))",
+            "--color-active-bg": "rgb(var(--color) / var(--gray-1))",
+            "--color-muted": "rgb(var(--color) / var(--gray-3))",
+            backgroundColor: "rgb(var(--filled))",
+            color: "rgb(var(--color))",
+          }}
+        >
+          {fontUrl ? (
+            <>
+              <link rel="preconnect" href="https://fonts.googleapis.com" crossOrigin="anonymous" />
+              <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+              <link rel="stylesheet" href={fontUrl} />
+            </>
+          ) : null}
+          <div inert>
+            <ProfileLayout creatorProfile={previewCreatorProfile} hideFollowForm={!previewSectionCount}>
+              <EditProfile
+                {...editableProfile}
+                creator_profile={previewCreatorProfile}
+                bio={profileSettings.bio}
+                controls={false}
+                selectedTabIndex={previewTabIndex}
+              />
+            </ProfileLayout>
+          </div>
+        </Preview>
+      )}
+    </PreviewSidebar>
+  );
+
   return (
     <>
-      {isMobileAppWebView ? null : (
+      {isMobileAppWebView ? (
+        <div className="border-b border-border p-4 md:p-8">{tabBar}</div>
+      ) : (
         <PageHeader
           className="sticky-top"
-          title="Profile"
+          title="Profile settings"
           actions={
             <Button color="accent" onClick={() => void save()} disabled={!canSave}>
               Update profile
             </Button>
           }
-        />
+        >
+          {tabBar}
+        </PageHeader>
       )}
       <WithPreviewSidebar>
         <div>
-          <section className="grid gap-8 p-4! md:p-8!">
-            <header>
-              <h2>About you</h2>
-            </header>
-            <Fieldset>
-              <FieldsetTitle>
-                <Label htmlFor={`${uid}-name`}>Name</Label>
-              </FieldsetTitle>
-              <Input
-                id={`${uid}-name`}
-                type="text"
-                value={profileSettings.name ?? ""}
-                disabled={!canUpdate}
-                onChange={(evt) => {
-                  updateCreatorProfile({ name: evt.target.value });
-                  updateProfileSettings({ name: evt.target.value });
-                }}
-              />
-            </Fieldset>
-            <Fieldset>
-              <FieldsetTitle>
-                <Label htmlFor={`${uid}-bio`}>Bio</Label>
-              </FieldsetTitle>
-              <Textarea
-                id={`${uid}-bio`}
-                value={profileSettings.bio ?? ""}
-                disabled={!canUpdate}
-                onChange={(e) => updateProfileSettings({ bio: e.target.value })}
-              />
-            </Fieldset>
-            <LogoInput
-              logoUrl={creatorProfile.avatar_url}
-              onChange={(blob) => {
-                updateCreatorProfile({
-                  avatar_url: blob ? Routes.s3_utility_cdn_url_for_blob_path({ key: blob.key }) : "",
-                });
-                updateProfileSettings({ profile_picture_blob_id: blob?.signedId ?? null });
-              }}
-              disabled={!canUpdate}
-            />
-            {loggedInUser?.policies.settings_profile.manage_social_connections ? (
+          {tab === "about" ? (
+            <section className="grid gap-8 p-4! md:p-8!">
+              <header>
+                <h2>About you</h2>
+              </header>
               <Fieldset>
-                <FieldsetTitle>Social links</FieldsetTitle>
-                {creatorProfile.twitter_handle ? (
-                  <Button type="button" color="twitter" onClick={handleUnlinkTwitter}>
-                    <TwitterX pack="brands" className="size-5" />
-                    Disconnect {creatorProfile.twitter_handle} from X
-                  </Button>
-                ) : (
-                  <SocialAuthButton
-                    provider="twitter"
-                    href={Routes.user_twitter_omniauth_authorize_path({
-                      state: "link_twitter_account",
-                      x_auth_access_type: "read",
-                    })}
-                  >
-                    <TwitterX pack="brands" className="size-5" />
-                    Connect to X
-                  </SocialAuthButton>
-                )}
-              </Fieldset>
-            ) : null}
-          </section>
-          <section aria-label="Profile section editor">
-            <ProfileSectionsForm
-              {...editableProfile}
-              creator_profile={creatorProfile}
-              bio={profileSettings.bio}
-              onChange={handleProfileEditorChange}
-              disabled={!canUpdate}
-            />
-          </section>
-          {custom_html_pages_enabled ? (
-            <ProfileLandingPageEditor
-              username={username}
-              profileUrl={Routes.root_url({ host: creatorProfile.subdomain })}
-              hasLandingPage={has_custom_landing_page}
-              onRemove={removeCustomHtml}
-            />
-          ) : null}
-        </div>
-        <PreviewSidebar
-          previewLink={(props) => {
-            const profileUrl = Routes.root_url({ host: creatorProfile.subdomain });
-            return (
-              <NavigationButton
-                {...props}
-                size="icon"
-                disabled={isSaving}
-                href={profileUrl}
-                onClick={(evt) => {
-                  evt.preventDefault();
-                  // Persist pending edits before previewing, but only when there's something to save -
-                  // settings (name/bio/avatar) are sent on every save with no freshness check, so an
-                  // unconditional save from a stale, locally-clean tab would revert changes made elsewhere.
-                  // Open only after a successful save so a failed save doesn't surface a stale preview.
-                  const openProfile = () => window.open(profileUrl, "_blank");
-                  if (canSave)
-                    void save().then((saved) => {
-                      if (saved) openProfile();
-                    });
-                  else openProfile();
-                }}
-              />
-            );
-          }}
-        >
-          <Preview
-            scaleFactor={0.4}
-            style={{
-              border: "var(--border)",
-              borderRadius: "var(--border-radius-2)",
-              fontFamily: currentSeller?.profileFont === "ABC Favorit" ? undefined : currentSeller?.profileFont,
-              ...profileColors,
-              "--primary": "var(--color)",
-              "--body-bg": "rgb(var(--filled))",
-              "--contrast-primary": "var(--filled)",
-              "--contrast-filled": "var(--color)",
-              "--color-body": "var(--body-bg)",
-              "--color-background": "rgb(var(--filled))",
-              "--color-foreground": "rgb(var(--color))",
-              "--color-border": "rgb(var(--color) / var(--border-alpha))",
-              "--color-accent": "rgb(var(--accent))",
-              "--color-accent-foreground": "rgb(var(--contrast-accent))",
-              "--color-primary": "rgb(var(--primary))",
-              "--color-primary-foreground": "rgb(var(--contrast-primary))",
-              "--color-active-bg": "rgb(var(--color) / var(--gray-1))",
-              "--color-muted": "rgb(var(--color) / var(--gray-3))",
-              backgroundColor: "rgb(var(--filled))",
-              color: "rgb(var(--color))",
-            }}
-          >
-            {fontUrl ? (
-              <>
-                <link rel="preconnect" href="https://fonts.googleapis.com" crossOrigin="anonymous" />
-                <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-                <link rel="stylesheet" href={fontUrl} />
-              </>
-            ) : null}
-            <div inert>
-              <ProfileLayout creatorProfile={previewCreatorProfile} hideFollowForm={!previewSectionCount}>
-                <EditProfile
-                  {...editableProfile}
-                  creator_profile={previewCreatorProfile}
-                  bio={profileSettings.bio}
-                  controls={false}
-                  selectedTabIndex={previewTabIndex}
+                <FieldsetTitle>
+                  <Label htmlFor={`${uid}-name`}>Name</Label>
+                </FieldsetTitle>
+                <Input
+                  id={`${uid}-name`}
+                  type="text"
+                  value={profileSettings.name ?? ""}
+                  disabled={!canUpdate}
+                  onChange={(evt) => {
+                    updateCreatorProfile({ name: evt.target.value });
+                    updateProfileSettings({ name: evt.target.value });
+                  }}
                 />
-              </ProfileLayout>
-            </div>
-          </Preview>
-        </PreviewSidebar>
+              </Fieldset>
+              <Fieldset>
+                <FieldsetTitle>
+                  <Label htmlFor={`${uid}-bio`}>Bio</Label>
+                </FieldsetTitle>
+                <Textarea
+                  id={`${uid}-bio`}
+                  value={profileSettings.bio ?? ""}
+                  disabled={!canUpdate}
+                  onChange={(e) => updateProfileSettings({ bio: e.target.value })}
+                />
+              </Fieldset>
+              <LogoInput
+                logoUrl={creatorProfile.avatar_url}
+                onChange={(blob) => {
+                  updateCreatorProfile({
+                    avatar_url: blob ? Routes.s3_utility_cdn_url_for_blob_path({ key: blob.key }) : "",
+                  });
+                  updateProfileSettings({ profile_picture_blob_id: blob?.signedId ?? null });
+                }}
+                disabled={!canUpdate}
+              />
+              {loggedInUser?.policies.settings_profile.manage_social_connections ? (
+                <Fieldset>
+                  <FieldsetTitle>Social links</FieldsetTitle>
+                  {creatorProfile.twitter_handle ? (
+                    <Button type="button" color="twitter" onClick={handleUnlinkTwitter}>
+                      <TwitterX pack="brands" className="size-5" />
+                      Disconnect {creatorProfile.twitter_handle} from X
+                    </Button>
+                  ) : (
+                    <SocialAuthButton
+                      provider="twitter"
+                      href={Routes.user_twitter_omniauth_authorize_path({
+                        state: "link_twitter_account",
+                        x_auth_access_type: "read",
+                      })}
+                    >
+                      <TwitterX pack="brands" className="size-5" />
+                      Connect to X
+                    </SocialAuthButton>
+                  )}
+                </Fieldset>
+              ) : null}
+            </section>
+          ) : tab === "pages" && showPagesTab ? (
+            <>
+              <section className="p-4! md:p-8!">
+                <Alert role="status" variant="warning">
+                  Pages are a legacy way to lay out your profile and are being phased out. To customize your profile,
+                  build a custom page from the Share tab — your agent designs and publishes it for you.
+                </Alert>
+              </section>
+              <section aria-label="Profile section editor">
+                <ProfileSectionsForm
+                  {...editableProfile}
+                  creator_profile={creatorProfile}
+                  bio={profileSettings.bio}
+                  onChange={handleProfileEditorChange}
+                  disabled={!canUpdate}
+                />
+              </section>
+            </>
+          ) : (
+            <>
+              <section className="grid gap-8 p-4! md:p-8!">
+                <header>
+                  <h2>Share</h2>
+                </header>
+                <div className="flex flex-wrap gap-2">
+                  <TwitterShareButton
+                    url={profileUrl}
+                    text={`Check out ${profileSettings.name || username} on @Gumroad`}
+                  />
+                  <FacebookShareButton url={profileUrl} text={profileSettings.name || username} />
+                  <CopyToClipboard text={profileUrl} tooltipPosition="top">
+                    <Button color="primary">
+                      <LinkIcon className="size-5" />
+                      Copy URL
+                    </Button>
+                  </CopyToClipboard>
+                </div>
+              </section>
+              {custom_html_pages_enabled ? (
+                <ProfileLandingPageEditor
+                  username={username}
+                  profileUrl={profileUrl}
+                  hasLandingPage={has_custom_landing_page}
+                  onRemove={removeCustomHtml}
+                />
+              ) : null}
+            </>
+          )}
+        </div>
+        {previewSidebar}
       </WithPreviewSidebar>
     </>
   );

--- a/app/javascript/pages/Settings/Profile/Show.tsx
+++ b/app/javascript/pages/Settings/Profile/Show.tsx
@@ -48,7 +48,6 @@ type ProfilePageProps = {
   editable_profile: ProfileEditorProps;
   profile_version: string | null;
   custom_html_pages_enabled: boolean;
-  custom_html: string | null;
   has_custom_landing_page: boolean;
   username: string;
 } & ProfileProps;
@@ -177,13 +176,14 @@ export default function SettingsPage() {
 
   const isMobileAppWebView = Boolean(usePage<{ is_mobile_app_web_view?: boolean }>().props.is_mobile_app_web_view);
 
-  // Clear the custom profile HTML through the session-authed profile form. We send only the user
-  // payload (no tabs/sections), so this is a settings-only save that can't prune the layout. The
-  // controller rejects any NON-blank custom_html (authoring is API-only), so this is reset-only.
-  // Returns true on success so the modal closes only when the page was actually removed.
+  // Clear the custom profile HTML through the session-authed profile form. We send only custom_html
+  // (no name/bio/avatar, no tabs/sections), so this is a pure reset that can't prune the layout or
+  // clobber other profile fields with a stale snapshot. The controller rejects any NON-blank
+  // custom_html (authoring is API-only), so this is reset-only. Returns true on success so the modal
+  // closes only when the page was actually removed.
   const removeCustomHtml = async (): Promise<boolean> => {
     try {
-      await saveProfileSettings({ ...lastSavedSettings.current, custom_html: "" });
+      await saveProfileSettings({ custom_html: "" });
       await new Promise<void>((resolve) => router.reload({ onFinish: () => resolve() }));
       return true;
     } catch (e) {
@@ -277,7 +277,7 @@ export default function SettingsPage() {
         />
       )}
     >
-      {has_custom_landing_page ? (
+      {custom_html_pages_enabled && has_custom_landing_page ? (
         <ProfileLandingPagePreview username={username} name={profileSettings.name} bio={profileSettings.bio} />
       ) : (
         <Preview

--- a/app/javascript/pages/Settings/Profile/Show.tsx
+++ b/app/javascript/pages/Settings/Profile/Show.tsx
@@ -53,7 +53,6 @@ type ProfilePageProps = {
   custom_html: string | null;
   has_custom_landing_page: boolean;
   username: string;
-  has_legacy_profile_pages: boolean;
 } & ProfileProps;
 
 export default function SettingsPage() {
@@ -65,7 +64,6 @@ export default function SettingsPage() {
     custom_html_pages_enabled,
     has_custom_landing_page,
     username,
-    has_legacy_profile_pages,
   } = typia.assert<ProfilePageProps>(usePage().props);
   const loggedInUser = useLoggedInUser();
   const currentSeller = useCurrentSeller();
@@ -232,7 +230,7 @@ export default function SettingsPage() {
 
   // The legacy section editor stays available only for sellers who already built one AND aren't
   // running a custom page — a live custom page replaces the whole profile, so editing sections is moot.
-  const showPagesTab = has_legacy_profile_pages && !has_custom_landing_page;
+  const showPagesTab = !has_custom_landing_page;
 
   const renderTab = (key: ProfileSettingsTab, label: string) => (
     <Tab

--- a/app/javascript/pages/Settings/Profile/Show.tsx
+++ b/app/javascript/pages/Settings/Profile/Show.tsx
@@ -226,8 +226,6 @@ export default function SettingsPage() {
     }
   });
 
-  // The legacy section editor stays available only for sellers who already built one AND aren't
-  // running a custom page — a live custom page replaces the whole profile, so editing sections is moot.
   const showPagesTab = !has_custom_landing_page;
 
   const renderTab = (key: ProfileSettingsTab, label: string) => (
@@ -280,8 +278,6 @@ export default function SettingsPage() {
       )}
     >
       {has_custom_landing_page ? (
-        // A live custom page replaces the entire public profile, so preview the real
-        // rendered page (the default-profile editor preview below would be misleading).
         <ProfileLandingPagePreview username={username} name={profileSettings.name} bio={profileSettings.bio} />
       ) : (
         <Preview

--- a/app/javascript/pages/Settings/Profile/Show.tsx
+++ b/app/javascript/pages/Settings/Profile/Show.tsx
@@ -17,6 +17,7 @@ import { Preview } from "$app/components/Preview";
 import { PreviewSidebar, WithPreviewSidebar } from "$app/components/PreviewSidebar";
 import { Props as ProfileProps } from "$app/components/Profile";
 import { EditProfile, ProfileEditorProps, ProfileEditorState } from "$app/components/Profile/EditPage";
+import { ProfileLandingPageEditor } from "$app/components/Profile/LandingPageEditor";
 import { Layout as ProfileLayout } from "$app/components/Profile/Layout";
 import { ProfileSectionsForm } from "$app/components/Profile/SectionsForm";
 import { LogoInput } from "$app/components/Profile/Settings/LogoInput";
@@ -40,12 +41,22 @@ type ProfilePageProps = {
   profile_settings: ProfileSettingsForm;
   editable_profile: ProfileEditorProps;
   profile_version: string | null;
+  custom_html_pages_enabled: boolean;
+  custom_html: string | null;
+  has_custom_landing_page: boolean;
+  username: string;
 } & ProfileProps;
 
 export default function SettingsPage() {
-  const { creator_profile, profile_settings, editable_profile, profile_version } = typia.assert<ProfilePageProps>(
-    usePage().props,
-  );
+  const {
+    creator_profile,
+    profile_settings,
+    editable_profile,
+    profile_version,
+    custom_html_pages_enabled,
+    has_custom_landing_page,
+    username,
+  } = typia.assert<ProfilePageProps>(usePage().props);
   const loggedInUser = useLoggedInUser();
   const currentSeller = useCurrentSeller();
   const [creatorProfile, setCreatorProfile] = React.useState(creator_profile);
@@ -157,6 +168,22 @@ export default function SettingsPage() {
   };
 
   const isMobileAppWebView = Boolean(usePage<{ is_mobile_app_web_view?: boolean }>().props.is_mobile_app_web_view);
+
+  // Clear the custom profile HTML through the session-authed profile form. We send only the user
+  // payload (no tabs/sections), so this is a settings-only save that can't prune the layout. The
+  // controller rejects any NON-blank custom_html (authoring is API-only), so this is reset-only.
+  // Returns true on success so the modal closes only when the page was actually removed.
+  const removeCustomHtml = async (): Promise<boolean> => {
+    try {
+      await saveProfileSettings({ ...lastSavedSettings.current, custom_html: "" });
+      await new Promise<void>((resolve) => router.reload({ onFinish: () => resolve() }));
+      return true;
+    } catch (e) {
+      assertResponseError(e);
+      showAlert(e.message, "error");
+      return false;
+    }
+  };
 
   useReactNativeMessage((data) => {
     if (data.type === "mobileAppSettingsSave") void save();
@@ -278,6 +305,14 @@ export default function SettingsPage() {
               disabled={!canUpdate}
             />
           </section>
+          {custom_html_pages_enabled ? (
+            <ProfileLandingPageEditor
+              username={username}
+              profileUrl={Routes.root_url({ host: creatorProfile.subdomain })}
+              hasLandingPage={has_custom_landing_page}
+              onRemove={removeCustomHtml}
+            />
+          ) : null}
         </div>
         <PreviewSidebar
           previewLink={(props) => {

--- a/app/javascript/pages/Settings/Profile/Show.tsx
+++ b/app/javascript/pages/Settings/Profile/Show.tsx
@@ -119,7 +119,7 @@ export default function SettingsPage() {
 
   const uid = React.useId();
   const [tab, setTab] = React.useState<ProfileSettingsTab>("about");
-  const profileUrl = Routes.root_url({ host: creatorProfile.subdomain });
+  const profileUrl = creatorProfile.subdomain ? Routes.root_url({ host: creatorProfile.subdomain }) : Routes.root_url();
 
   const [isSaving, setIsSaving] = React.useState(false);
   const canUpdate = Boolean(loggedInUser?.policies.settings_profile.update) && !isSaving;

--- a/app/javascript/pages/Settings/Profile/Show.tsx
+++ b/app/javascript/pages/Settings/Profile/Show.tsx
@@ -1,4 +1,4 @@
-import { Link as LinkIcon, TwitterX } from "@boxicons/react";
+import { TwitterX } from "@boxicons/react";
 import { router, usePage } from "@inertiajs/react";
 import { isEqual } from "lodash-es";
 import * as React from "react";
@@ -11,9 +11,7 @@ import { asyncVoid } from "$app/utils/promise";
 import { assertResponseError } from "$app/utils/request";
 
 import { Button, NavigationButton } from "$app/components/Button";
-import { CopyToClipboard } from "$app/components/CopyToClipboard";
 import { useCurrentSeller } from "$app/components/CurrentSeller";
-import { FacebookShareButton } from "$app/components/FacebookShareButton";
 import { useLoggedInUser } from "$app/components/LoggedInUser";
 import { Preview } from "$app/components/Preview";
 import { PreviewSidebar, WithPreviewSidebar } from "$app/components/PreviewSidebar";
@@ -26,8 +24,8 @@ import { ProfileSectionsForm } from "$app/components/Profile/SectionsForm";
 import { LogoInput } from "$app/components/Profile/Settings/LogoInput";
 import { showAlert } from "$app/components/server-components/Alert";
 import { postToMobileApp } from "$app/components/Settings/Layout";
+import { ShareButtons } from "$app/components/ShareButtons";
 import { SocialAuthButton } from "$app/components/SocialAuthButton";
-import { TwitterShareButton } from "$app/components/TwitterShareButton";
 import { Alert } from "$app/components/ui/Alert";
 import { Fieldset, FieldsetTitle } from "$app/components/ui/Fieldset";
 import { Input } from "$app/components/ui/Input";
@@ -441,19 +439,11 @@ export default function SettingsPage() {
                 <header>
                   <h2>Share</h2>
                 </header>
-                <div className="flex flex-wrap gap-2">
-                  <TwitterShareButton
-                    url={profileUrl}
-                    text={`Check out ${profileSettings.name || username} on @Gumroad`}
-                  />
-                  <FacebookShareButton url={profileUrl} text={profileSettings.name || username} />
-                  <CopyToClipboard text={profileUrl} tooltipPosition="top">
-                    <Button color="primary">
-                      <LinkIcon className="size-5" />
-                      Copy URL
-                    </Button>
-                  </CopyToClipboard>
-                </div>
+                <ShareButtons
+                  url={profileUrl}
+                  twitterText={`Check out ${profileSettings.name || username} on @Gumroad`}
+                  facebookText={profileSettings.name || username}
+                />
               </section>
               {custom_html_pages_enabled ? (
                 <ProfileLandingPageEditor

--- a/app/javascript/parsers/profile.ts
+++ b/app/javascript/parsers/profile.ts
@@ -13,5 +13,4 @@ export type ProfileSettings = {
   name: string | null;
   bio: string | null;
   profile_picture_blob_id: string | null;
-  custom_html: string | null;
 };

--- a/app/javascript/parsers/profile.ts
+++ b/app/javascript/parsers/profile.ts
@@ -13,4 +13,5 @@ export type ProfileSettings = {
   name: string | null;
   bio: string | null;
   profile_picture_blob_id: string | null;
+  custom_html: string | null;
 };

--- a/app/policies/settings/profile_policy.rb
+++ b/app/policies/settings/profile_policy.rb
@@ -22,7 +22,10 @@ class Settings::ProfilePolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    user_attributes = [:name, :bio]
+    # custom_html is intentionally clear-only from this surface: the editor never edits the HTML
+    # (the agent + `gumroad user page` CLI author it via the v2 API), it only sends "" to reset.
+    # The User#custom_html= setter treats blank as "remove the page".
+    user_attributes = [:name, :bio, :custom_html]
     [
       :profile_picture_blob_id,
       :profile_version,

--- a/app/presenters/profile_presenter.rb
+++ b/app/presenters/profile_presenter.rb
@@ -56,6 +56,11 @@ class ProfilePresenter
         custom_html: seller.custom_html,
         has_custom_landing_page: seller.has_custom_landing_page?,
         username: seller.username,
+        # The legacy section/tab editor ("Pages") is deprecated in favor of agent-authored custom
+        # HTML. Surface its tab only to sellers who already built one historically, so existing
+        # layouts stay editable while new sellers are funneled to the agent path.
+        has_legacy_profile_pages: seller.seller_profile_sections.on_profile.exists? ||
+          (seller.seller_profile.json_data["tabs"] || []).any?,
       }
     )
   end

--- a/app/presenters/profile_presenter.rb
+++ b/app/presenters/profile_presenter.rb
@@ -48,6 +48,14 @@ class ProfilePresenter
         # can reject a stale pages/sections write. Nil for a not-yet-saved profile.
         profile_version:,
         memberships: memberships.map { |product| ProductPresenter.card_for_web(product:, show_seller: false) },
+        # Custom-HTML profile landing page (#5553). Authored solely via the seller's agent + the
+        # `gumroad user page` CLI (no inline editor) - these props drive the "Build with your agent"
+        # affordance: the live-status banner, the copy-prompt block, and the reset button. The
+        # username feeds the agent prompt; custom_html is read-only here (the form never edits it).
+        custom_html_pages_enabled: Feature.active?(:custom_html_pages, seller),
+        custom_html: seller.custom_html,
+        has_custom_landing_page: seller.has_custom_landing_page?,
+        username: seller.username,
       }
     )
   end

--- a/app/presenters/profile_presenter.rb
+++ b/app/presenters/profile_presenter.rb
@@ -56,11 +56,6 @@ class ProfilePresenter
         custom_html: seller.custom_html,
         has_custom_landing_page: seller.has_custom_landing_page?,
         username: seller.username,
-        # The legacy section/tab editor ("Pages") is deprecated in favor of agent-authored custom
-        # HTML. Surface its tab only to sellers who already built one historically, so existing
-        # layouts stay editable while new sellers are funneled to the agent path.
-        has_legacy_profile_pages: seller.seller_profile_sections.on_profile.exists? ||
-          (seller.seller_profile.json_data["tabs"] || []).any?,
       }
     )
   end

--- a/app/presenters/profile_presenter.rb
+++ b/app/presenters/profile_presenter.rb
@@ -51,9 +51,9 @@ class ProfilePresenter
         # Custom-HTML profile landing page (#5553). Authored solely via the seller's agent + the
         # `gumroad user page` CLI (no inline editor) - these props drive the "Build with your agent"
         # affordance: the live-status banner, the copy-prompt block, and the reset button. The
-        # username feeds the agent prompt; custom_html is read-only here (the form never edits it).
+        # username feeds the agent prompt. The HTML itself is never sent here - the form never edits
+        # it, it only sends "" to reset, so has_custom_landing_page is all the UI needs.
         custom_html_pages_enabled: Feature.active?(:custom_html_pages, seller),
-        custom_html: seller.custom_html,
         has_custom_landing_page: seller.has_custom_landing_page?,
         username: seller.username,
       }

--- a/app/services/pages/profile_data.rb
+++ b/app/services/pages/profile_data.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Public, render-safe snapshot of a seller's catalog for their custom profile page.
+# The page is sandboxed (opaque origin, connect-src 'none'), so it can't fetch at
+# render time - we inject this server-side as JSON instead, mirroring how product
+# custom HTML has its fields filled in server-side. The seller's HTML/JS reads it to
+# render products/posts/pages dynamically, and it refreshes on every page load. Only
+# already-public data is included (alive products, profile-visible posts, page names).
+class Pages::ProfileData
+  MAX_ITEMS = 100
+  DESCRIPTION_LIMIT = 200
+
+  def self.build(seller)
+    {
+      products: products(seller),
+      posts: posts(seller),
+      pages: pages(seller),
+    }
+  end
+
+  def self.products(seller)
+    seller.products.alive.not_archived.order(created_at: :desc).limit(MAX_ITEMS).map do |product|
+      {
+        name: product.name,
+        url: product.long_url,
+        price: product.price_formatted_verbose,
+        native_type: product.native_type,
+        thumbnail_url: product.thumbnail&.alive&.url,
+        description: ActionView::Base.full_sanitizer.sanitize(product.description.to_s).squish.truncate(DESCRIPTION_LIMIT),
+      }
+    end
+  end
+
+  def self.posts(seller)
+    seller.installments.visible_on_profile.order(published_at: :desc).limit(MAX_ITEMS).map do |post|
+      {
+        name: post.name,
+        url: post.full_url,
+        published_at: post.published_at&.iso8601,
+      }
+    end
+  end
+
+  def self.pages(seller)
+    (seller.seller_profile.json_data["tabs"] || []).filter_map do |tab|
+      { name: tab["name"] } if tab["name"].present?
+    end
+  end
+end

--- a/app/services/pages/profile_data.rb
+++ b/app/services/pages/profile_data.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
-# Public, render-safe snapshot of a seller's catalog for their custom profile page.
-# The page is sandboxed (opaque origin, connect-src 'none'), so it can't fetch at
-# render time - we inject this server-side as JSON instead, mirroring how product
-# custom HTML has its fields filled in server-side. The seller's HTML/JS reads it to
-# render products/posts/pages dynamically, and it refreshes on every page load. Only
-# already-public data is included (alive products, profile-visible posts, page names).
 class Pages::ProfileData
   CACHE_VERSION = "v1"
   MAX_ITEMS = 100

--- a/app/services/pages/profile_data.rb
+++ b/app/services/pages/profile_data.rb
@@ -6,22 +6,26 @@ class Pages::ProfileData
   DESCRIPTION_LIMIT = 200
 
   def self.build(seller)
-    Rails.cache.fetch(cache_key(seller)) do
+    # Look the profile up directly rather than via seller.seller_profile, which builds and leaves an
+    # unsaved record on the seller to be autosaved later (see User#seller_profile). A seller may have
+    # no profile row yet, so every read off this is nil-safe.
+    seller_profile = SellerProfile.find_by(seller_id: seller.id)
+    Rails.cache.fetch(cache_key(seller, seller_profile)) do
       {
         products: products(seller),
         posts: posts(seller),
-        pages: pages(seller),
+        pages: pages(seller_profile),
       }
     end
   end
 
-  def self.cache_key(seller)
+  def self.cache_key(seller, seller_profile)
     [
       "profile_data",
       CACHE_VERSION,
       seller.products.cache_key_with_version,
       seller.installments.visible_on_profile.cache_key_with_version,
-      seller.seller_profile&.cache_key_with_version,
+      seller_profile&.cache_key_with_version,
     ].join("/")
   end
 
@@ -48,8 +52,8 @@ class Pages::ProfileData
     end
   end
 
-  def self.pages(seller)
-    (seller.seller_profile.json_data["tabs"] || []).filter_map do |tab|
+  def self.pages(seller_profile)
+    (seller_profile&.json_data&.dig("tabs") || []).filter_map do |tab|
       { name: tab["name"] } if tab["name"].present?
     end
   end

--- a/app/services/pages/profile_data.rb
+++ b/app/services/pages/profile_data.rb
@@ -7,32 +7,45 @@
 # render products/posts/pages dynamically, and it refreshes on every page load. Only
 # already-public data is included (alive products, profile-visible posts, page names).
 class Pages::ProfileData
+  CACHE_VERSION = "v1"
   MAX_ITEMS = 100
   DESCRIPTION_LIMIT = 200
 
   def self.build(seller)
-    {
-      products: products(seller),
-      posts: posts(seller),
-      pages: pages(seller),
-    }
+    Rails.cache.fetch(cache_key(seller)) do
+      {
+        products: products(seller),
+        posts: posts(seller),
+        pages: pages(seller),
+      }
+    end
+  end
+
+  def self.cache_key(seller)
+    [
+      "profile_data",
+      CACHE_VERSION,
+      seller.products.cache_key_with_version,
+      seller.installments.visible_on_profile.cache_key_with_version,
+      seller.seller_profile&.cache_key_with_version,
+    ].join("/")
   end
 
   def self.products(seller)
-    seller.products.alive.not_archived.order(created_at: :desc).limit(MAX_ITEMS).map do |product|
+    seller.products.alive.not_archived.includes(:thumbnail_alive).order(created_at: :desc).limit(MAX_ITEMS).map do |product|
       {
         name: product.name,
         url: product.long_url,
         price: product.price_formatted_verbose,
         native_type: product.native_type,
-        thumbnail_url: product.thumbnail&.alive&.url,
+        thumbnail_url: product.thumbnail_alive&.url,
         description: ActionView::Base.full_sanitizer.sanitize(product.description.to_s).squish.truncate(DESCRIPTION_LIMIT),
       }
     end
   end
 
   def self.posts(seller)
-    seller.installments.visible_on_profile.order(published_at: :desc).limit(MAX_ITEMS).map do |post|
+    seller.installments.visible_on_profile.includes(:seller).order(published_at: :desc).limit(MAX_ITEMS).map do |post|
       {
         name: post.name,
         url: post.full_url,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -945,6 +945,7 @@ Rails.application.routes.draw do
     # path can't collide with the single-segment offer-code route below, so a
     # seller's "landing" offer code keeps working.
     get "/l/:id/landing/embed", to: "links#landing_iframe_content", as: :short_link_landing
+    get "/l/:id/landing/version", to: "links#landing_version", as: :short_link_landing_version
     get "/l/:id/:code", to: "links#show", defaults: { format: "html" }, as: :short_link_offer_code
     get "/cart_items_count", to: "links#cart_items_count"
 
@@ -1190,6 +1191,7 @@ Rails.application.routes.draw do
     # Iframe content endpoint for profiles with custom_html. Subdomain and
     # custom-domain equivalents live in UserCustomDomainConstraint below.
     get "/:username/landing/embed", to: "users#landing_iframe_content", as: :user_landing
+    get "/:username/landing/version", to: "users#landing_version", as: :user_landing_version
     get "/:username/follow", to: "followers#new", as: "follow_user_page"
     get "/:username/p/:slug", to: "posts#show", as: :view_post
     get "/:username/posts_paginated", to: "users/posts#paginated", as: "user_posts_paginated"
@@ -1249,6 +1251,7 @@ Rails.application.routes.draw do
     get "/", to: "links#show", defaults: { format: "html" }
     get "/l/:id", to: "links#show", defaults: { format: "html" }
     get "/l/:id/landing/embed", to: "links#landing_iframe_content"
+    get "/l/:id/landing/version", to: "links#landing_version"
     get "/l/:id/:code", to: "links#show", defaults: { format: "html" }
     get "/:code", to: "links#show", defaults: { format: "html" }
   end
@@ -1274,6 +1277,7 @@ Rails.application.routes.draw do
     get "/updates", to: redirect("/posts")
     get "/l/:id", to: "links#show", defaults: { format: "html" }
     get "/l/:id/landing/embed", to: "links#landing_iframe_content"
+    get "/l/:id/landing/version", to: "links#landing_version"
     get "/l/:id/:code", to: "links#show", defaults: { format: "html" }
     get "/subscribe", to: "users#subscribe", as: :custom_domain_subscribe
     get "/follow", to: redirect("/subscribe")
@@ -1360,6 +1364,7 @@ Rails.application.routes.draw do
     end
 
     get "/landing/embed", to: "users#landing_iframe_content"
+    get "/landing/version", to: "users#landing_version"
     get "/", to: "users#show", defaults: { format: "html" }
   end
 

--- a/spec/controllers/links_controller_custom_html_spec.rb
+++ b/spec/controllers/links_controller_custom_html_spec.rb
@@ -312,4 +312,38 @@ describe LinksController, :vcr, type: :controller do
       expect(product.custom_html).to eq("<section><h1>Live landing page</h1></section>")
     end
   end
+
+  describe "owner live-reload poll on the wrapper" do
+    it "injects the version poll for the signed-in owner" do
+      sign_in seller
+
+      get :show, params: { id: product.unique_permalink }
+
+      expect(response.body).to include("/l/#{product.unique_permalink}/landing/version")
+    end
+
+    it "omits the poll for anonymous visitors" do
+      get :show, params: { id: product.unique_permalink }
+
+      expect(response.body).not_to include("/landing/version")
+    end
+  end
+
+  describe "GET landing_version" do
+    it "reports the live page with a version token" do
+      get :landing_version, params: { id: product.unique_permalink }
+
+      expect(response).to be_successful
+      expect(response.parsed_body["present"]).to be(true)
+      expect(response.parsed_body["version"]).to be_a(Integer)
+    end
+
+    it "reports present:false once the custom_html is cleared" do
+      product.update!(custom_html: "")
+
+      get :landing_version, params: { id: product.unique_permalink }
+
+      expect(response.parsed_body["present"]).to be(false)
+    end
+  end
 end

--- a/spec/controllers/links_controller_custom_html_spec.rb
+++ b/spec/controllers/links_controller_custom_html_spec.rb
@@ -330,7 +330,9 @@ describe LinksController, :vcr, type: :controller do
   end
 
   describe "GET landing_version" do
-    it "reports the live page with a version token" do
+    it "reports the live page with a version token to the owner" do
+      sign_in seller
+
       get :landing_version, params: { id: product.unique_permalink }
 
       expect(response).to be_successful
@@ -339,11 +341,19 @@ describe LinksController, :vcr, type: :controller do
     end
 
     it "reports present:false once the custom_html is cleared" do
+      sign_in seller
       product.update!(custom_html: "")
 
       get :landing_version, params: { id: product.unique_permalink }
 
       expect(response.parsed_body["present"]).to be(false)
+    end
+
+    it "reports present:false to an anonymous caller, never leaking the edit timestamp" do
+      get :landing_version, params: { id: product.unique_permalink }
+
+      expect(response.parsed_body["present"]).to be(false)
+      expect(response.parsed_body["version"]).to be_nil
     end
   end
 end

--- a/spec/controllers/settings/profile_controller_spec.rb
+++ b/spec/controllers/settings/profile_controller_spec.rb
@@ -91,6 +91,38 @@ describe Settings::ProfileController, :vcr, type: :controller, inertia: true do
       end
     end
 
+    describe "custom_html (clear-only from this surface)" do
+      it "clears a live custom profile page when sent a blank value" do
+        seller.update!(custom_html: "<h1>Custom</h1>")
+        expect(seller.reload.has_custom_landing_page?).to be(true)
+
+        put :update, params: { user: { custom_html: "" } }
+
+        expect(response).to redirect_to(profile_path)
+        expect(response).to have_http_status :see_other
+        expect(flash[:notice]).to eq("Changes saved!")
+        expect(seller.reload.has_custom_landing_page?).to be(false)
+      end
+
+      it "rejects a non-blank custom_html so it can't bypass the sanitized API" do
+        put :update, params: { user: { custom_html: "<script>alert(1)</script>" } }
+
+        expect(response).to redirect_to(profile_path)
+        expect(flash[:alert]).to eq("Custom HTML can only be edited through the Gumroad CLI or API.")
+        expect(seller.reload.has_custom_landing_page?).to be(false)
+      end
+
+      it "does not clobber an existing page when another field is saved without custom_html" do
+        seller.update!(custom_html: "<h1>Custom</h1>")
+
+        put :update, params: { user: { name: "New name" } }
+
+        expect(response).to have_http_status :see_other
+        expect(seller.reload.name).to eq("New name")
+        expect(seller.has_custom_landing_page?).to be(true)
+      end
+    end
+
     it "saves tabs and cleans up orphan sections" do
       section1 = create(:seller_profile_products_section, seller:)
       section2 = create(:seller_profile_posts_section, seller:)

--- a/spec/controllers/users_controller_custom_html_spec.rb
+++ b/spec/controllers/users_controller_custom_html_spec.rb
@@ -124,6 +124,43 @@ describe UsersController, :vcr, type: :controller do
       expect(response).to be_successful
       expect(response.body).to include("<h1>Live profile page</h1>")
     end
+
+    describe "name/bio live-update listener on ?preview" do
+      it "injects the listener for the seller previewing their own page" do
+        sign_in seller
+
+        get :landing_iframe_content, params: { preview: true }
+
+        expect(response.body).to include("gumroad:profile-fields")
+      end
+
+      it "injects the listener for a team member acting as the seller" do
+        member = create(:user)
+        create(:team_membership, user: member, seller:, role: TeamMembership::ROLE_ADMIN)
+        cookies.encrypted[:current_seller_id] = seller.id
+        sign_in member
+
+        get :landing_iframe_content, params: { preview: true }
+
+        expect(response.body).to include("gumroad:profile-fields")
+      end
+
+      it "omits the listener for a signed-in visitor who can't edit the profile" do
+        sign_in create(:user)
+
+        get :landing_iframe_content, params: { preview: true }
+
+        expect(response.body).not_to include("gumroad:profile-fields")
+      end
+
+      it "omits the listener without the preview param" do
+        sign_in seller
+
+        get :landing_iframe_content
+
+        expect(response.body).not_to include("gumroad:profile-fields")
+      end
+    end
   end
 
   describe "#profile_custom_html_wrapper_document" do

--- a/spec/presenters/profile_presenter_spec.rb
+++ b/spec/presenters/profile_presenter_spec.rb
@@ -141,10 +141,20 @@ describe ProfilePresenter do
           custom_html: nil,
           has_custom_landing_page: false,
           username: seller.username,
+          has_legacy_profile_pages: true,
           **described_class.new(pundit_user: SellerContext.logged_out, seller:).profile_props(request:, seller_custom_domain_url: nil),
         }
       )
       expect(props[:profile_settings]).not_to have_key(:username)
+    end
+
+    it "reports has_legacy_profile_pages as false for a seller with no profile sections or tabs" do
+      seller.seller_profile_sections.destroy_all
+      seller.seller_profile.update!(json_data: seller.seller_profile.json_data.except("tabs"))
+
+      props = described_class.new(pundit_user:, seller: seller.reload).profile_settings_props(request:)
+
+      expect(props[:has_legacy_profile_pages]).to be(false)
     end
 
     context "when the custom_html_pages feature is enabled and a custom profile page is live" do

--- a/spec/presenters/profile_presenter_spec.rb
+++ b/spec/presenters/profile_presenter_spec.rb
@@ -137,10 +137,30 @@ describe ProfilePresenter do
           },
           memberships: [ProductPresenter.card_for_web(product: membership_product, show_seller: false)],
           profile_version: a_kind_of(String),
+          custom_html_pages_enabled: false,
+          custom_html: nil,
+          has_custom_landing_page: false,
+          username: seller.username,
           **described_class.new(pundit_user: SellerContext.logged_out, seller:).profile_props(request:, seller_custom_domain_url: nil),
         }
       )
       expect(props[:profile_settings]).not_to have_key(:username)
+    end
+
+    context "when the custom_html_pages feature is enabled and a custom profile page is live" do
+      before do
+        Feature.activate_user(:custom_html_pages, seller)
+        seller.update!(custom_html: "<h1 data-gumroad-field=\"name\"></h1>")
+      end
+
+      it "exposes the custom-HTML props for the Build-with-your-agent affordance" do
+        props = presenter.profile_settings_props(request:)
+
+        expect(props[:custom_html_pages_enabled]).to be(true)
+        expect(props[:has_custom_landing_page]).to be(true)
+        expect(props[:custom_html]).to eq("<h1 data-gumroad-field=\"name\"></h1>")
+        expect(props[:username]).to eq(seller.username)
+      end
     end
   end
 end

--- a/spec/presenters/profile_presenter_spec.rb
+++ b/spec/presenters/profile_presenter_spec.rb
@@ -138,7 +138,6 @@ describe ProfilePresenter do
           memberships: [ProductPresenter.card_for_web(product: membership_product, show_seller: false)],
           profile_version: a_kind_of(String),
           custom_html_pages_enabled: false,
-          custom_html: nil,
           has_custom_landing_page: false,
           username: seller.username,
           **described_class.new(pundit_user: SellerContext.logged_out, seller:).profile_props(request:, seller_custom_domain_url: nil),
@@ -158,7 +157,6 @@ describe ProfilePresenter do
 
         expect(props[:custom_html_pages_enabled]).to be(true)
         expect(props[:has_custom_landing_page]).to be(true)
-        expect(props[:custom_html]).to eq("<h1 data-gumroad-field=\"name\"></h1>")
         expect(props[:username]).to eq(seller.username)
       end
     end

--- a/spec/presenters/profile_presenter_spec.rb
+++ b/spec/presenters/profile_presenter_spec.rb
@@ -141,20 +141,10 @@ describe ProfilePresenter do
           custom_html: nil,
           has_custom_landing_page: false,
           username: seller.username,
-          has_legacy_profile_pages: true,
           **described_class.new(pundit_user: SellerContext.logged_out, seller:).profile_props(request:, seller_custom_domain_url: nil),
         }
       )
       expect(props[:profile_settings]).not_to have_key(:username)
-    end
-
-    it "reports has_legacy_profile_pages as false for a seller with no profile sections or tabs" do
-      seller.seller_profile_sections.destroy_all
-      seller.seller_profile.update!(json_data: seller.seller_profile.json_data.except("tabs"))
-
-      props = described_class.new(pundit_user:, seller: seller.reload).profile_settings_props(request:)
-
-      expect(props[:has_legacy_profile_pages]).to be(false)
     end
 
     context "when the custom_html_pages feature is enabled and a custom profile page is live" do

--- a/spec/requests/profile_custom_html_spec.rb
+++ b/spec/requests/profile_custom_html_spec.rb
@@ -6,6 +6,8 @@ require "spec_helper"
 # confirm a profile's custom HTML renders, and the embed gets the strict CSP,
 # on a seller's own custom domain — the watch-out flagged in the issue.
 describe "Profile custom HTML rendering", type: :request do
+  include Devise::Test::IntegrationHelpers
+
   let(:seller) { create(:user, username: "customprofile", name: "Jane Doe") }
   let!(:custom_domain) { create(:custom_domain, user: seller, domain: "seller.example.com") }
 
@@ -51,5 +53,83 @@ describe "Profile custom HTML rendering", type: :request do
 
     expect(response.body).not_to include("gumroad:checkout")
     expect(response.body).not_to include("wanted=true")
+  end
+
+  describe "owner live-reload poll" do
+    it "injects the version poll into the wrapper only for the signed-in owner" do
+      sign_in seller
+      get "http://seller.example.com/"
+
+      expect(response.body).to include("/landing/version")
+      expect(response.body).to include("gumroad-landing-frame")
+    end
+
+    it "omits the poll for anonymous visitors" do
+      get "http://seller.example.com/"
+
+      expect(response.body).not_to include("/landing/version")
+    end
+
+    it "omits the poll for a signed-in visitor who is not the owner" do
+      sign_in create(:user)
+      get "http://seller.example.com/"
+
+      expect(response.body).not_to include("/landing/version")
+    end
+  end
+
+  describe "injected catalog data" do
+    it "embeds the seller's public products as JSON so the page can render them dynamically" do
+      create(:product, user: seller, name: "Cool thing")
+
+      get "http://seller.example.com/landing/embed"
+
+      expect(response.body).to include(%(id="gumroad-data"))
+      json = response.body[%r{<script id="gumroad-data"[^>]*>(.*?)</script>}m, 1]
+      data = JSON.parse(json)
+      expect(data.keys).to match_array(%w[products posts pages])
+      expect(data["products"].map { _1["name"] }).to include("Cool thing")
+      expect(data["products"].first.keys).to match_array(%w[name url price native_type thumbnail_url description])
+    end
+  end
+
+  describe "preview field sync" do
+    it "includes the name/bio live-update listener only on ?preview embeds" do
+      get "http://seller.example.com/landing/embed?preview=true"
+      expect(response.body).to include("gumroad:profile-fields")
+    end
+
+    it "omits the listener on the public embed" do
+      get "http://seller.example.com/landing/embed"
+      expect(response.body).not_to include("gumroad:profile-fields")
+    end
+  end
+
+  describe "version endpoint" do
+    it "reports the live page with a version token" do
+      get "http://seller.example.com/landing/version"
+
+      expect(response).to be_successful
+      body = response.parsed_body
+      expect(body["present"]).to be(true)
+      expect(body["version"]).to be_a(Integer)
+    end
+
+    it "reports present:false once the page is cleared, so a watching owner restores the default profile" do
+      seller.update!(custom_html: "")
+
+      get "http://seller.example.com/landing/version"
+
+      expect(response).to be_successful
+      expect(response.parsed_body["present"]).to be(false)
+    end
+
+    it "reports present:false when the feature is disabled" do
+      Feature.deactivate_user(:custom_html_pages, seller)
+
+      get "http://seller.example.com/landing/version"
+
+      expect(response.parsed_body["present"]).to be(false)
+    end
   end
 end

--- a/spec/requests/profile_custom_html_spec.rb
+++ b/spec/requests/profile_custom_html_spec.rb
@@ -112,7 +112,9 @@ describe "Profile custom HTML rendering", type: :request do
   end
 
   describe "version endpoint" do
-    it "reports the live page with a version token" do
+    before { sign_in seller }
+
+    it "reports the live page with a version token to the owner" do
       get "http://seller.example.com/landing/version"
 
       expect(response).to be_successful
@@ -136,6 +138,15 @@ describe "Profile custom HTML rendering", type: :request do
       get "http://seller.example.com/landing/version"
 
       expect(response.parsed_body["present"]).to be(false)
+    end
+
+    it "reports present:false to a non-owner, never leaking the edit timestamp" do
+      sign_out seller
+
+      get "http://seller.example.com/landing/version"
+
+      expect(response.parsed_body["present"]).to be(false)
+      expect(response.parsed_body["version"]).to be_nil
     end
   end
 end

--- a/spec/requests/profile_custom_html_spec.rb
+++ b/spec/requests/profile_custom_html_spec.rb
@@ -94,9 +94,15 @@ describe "Profile custom HTML rendering", type: :request do
   end
 
   describe "preview field sync" do
-    it "includes the name/bio live-update listener only on ?preview embeds" do
+    it "includes the name/bio live-update listener on the owner's ?preview embed" do
+      sign_in seller
       get "http://seller.example.com/landing/embed?preview=true"
       expect(response.body).to include("gumroad:profile-fields")
+    end
+
+    it "omits the listener on a ?preview embed for anyone other than the owner" do
+      get "http://seller.example.com/landing/embed?preview=true"
+      expect(response.body).not_to include("gumroad:profile-fields")
     end
 
     it "omits the listener on the public embed" do

--- a/spec/requests/settings/profile_custom_page_spec.rb
+++ b/spec/requests/settings/profile_custom_page_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Profile settings custom page", type: :system, js: true do
+  let(:seller) { create(:user, username: "sellerpage", name: "Original Name", bio: "Original bio") }
+  let!(:product) { create(:product, user: seller, name: "Cool thing") }
+
+  # Renders the injected catalog + the interpolated profile fields, so the test can assert both
+  # the server-side data injection and the live name/bio sync land in the iframe.
+  let(:custom_html) do
+    <<~HTML
+      <main>
+        <h1 data-gumroad-field="name">placeholder</h1>
+        <p data-gumroad-field="bio">placeholder bio</p>
+        <ul id="catalog"></ul>
+        <script>
+          var data = JSON.parse(document.getElementById("gumroad-data").textContent);
+          data.products.forEach(function (p) {
+            var li = document.createElement("li");
+            li.textContent = p.name;
+            document.getElementById("catalog").appendChild(li);
+          });
+        </script>
+      </main>
+    HTML
+  end
+
+  before do
+    Feature.activate_user(:custom_html_pages, seller)
+    seller.update!(custom_html:)
+    login_as(seller)
+  end
+
+  it "titles the page Profile settings and shows pills, hiding Pages while a custom page is live" do
+    visit "/profile"
+
+    expect(page).to have_title("Profile settings")
+    expect(page).to have_selector("[role=tab]", text: "About")
+    expect(page).to have_selector("[role=tab]", text: "Share")
+    expect(page).to have_no_selector("[role=tab]", text: "Pages")
+  end
+
+  it "previews the live custom page with the injected catalog and live name/bio edits" do
+    visit "/profile"
+
+    frame = find("iframe[title='Custom profile page preview']")
+    within_frame(frame) do
+      expect(page).to have_text("Cool thing") # injected catalog rendered by the page's own JS
+      expect(page).to have_text("Original Name") # server-interpolated profile field
+    end
+
+    fill_in "Name", with: "Sellerasdfasdfasdf"
+    within_frame(frame) do
+      expect(page).to have_text("Sellerasdfasdfasdf") # live postMessage sync, no republish
+    end
+  end
+end

--- a/spec/requests/user/profile_custom_html_page_spec.rb
+++ b/spec/requests/user/profile_custom_html_page_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Profile custom HTML page (public render)", type: :system, js: true do
+  let(:seller) { create(:user, username: "lumenstudio", name: "Lumen Studio", bio: "We make beautiful things.") }
+
+  let!(:alpha) { create(:product, user: seller, name: "Alpha Kit") }
+  let!(:beta) { create(:product, user: seller, name: "Beta Pack") }
+  let!(:gamma) { create(:product, user: seller, name: "Gamma Uniquely Named") }
+
+  let(:custom_html) do
+    <<~HTML
+      <main>
+        <h1 data-gumroad-field="name">placeholder name</h1>
+        <p data-gumroad-field="bio">placeholder bio</p>
+        <input id="q" type="search" aria-label="Search" />
+        <button id="next" type="button">Next</button>
+        <ul id="catalog"></ul>
+        <p id="result"></p>
+        <script>
+          var data = JSON.parse(document.getElementById("gumroad-data").textContent);
+          var items = data.products.map(function (p) { return p.name; });
+          var PAGE_SIZE = 2, page = 1, query = "";
+          var ul = document.getElementById("catalog");
+          var result = document.getElementById("result");
+          function render() {
+            var matches = items.filter(function (n) { return n.toLowerCase().indexOf(query) !== -1; });
+            var start = (page - 1) * PAGE_SIZE;
+            ul.innerHTML = "";
+            matches.slice(start, start + PAGE_SIZE).forEach(function (n) {
+              var li = document.createElement("li");
+              li.className = "item";
+              li.textContent = n;
+              ul.appendChild(li);
+            });
+            result.textContent = "Showing " + Math.min(matches.length, PAGE_SIZE) + " of " + matches.length;
+          }
+          document.getElementById("q").addEventListener("input", function (e) {
+            query = e.target.value.toLowerCase(); page = 1; render();
+          });
+          document.getElementById("next").addEventListener("click", function () {
+            page += 1; render();
+          });
+          render();
+        </script>
+      </main>
+    HTML
+  end
+
+  before do
+    Feature.activate_user(:custom_html_pages, seller)
+    seller.update!(custom_html:)
+  end
+
+  it "renders the published custom HTML inside the public sandboxed iframe with interpolated fields" do
+    visit seller.subdomain_with_protocol
+
+    frame = find("iframe#gumroad-landing-frame")
+    within_frame(frame) do
+      expect(page).to have_text("Lumen Studio")
+      expect(page).to have_text("We make beautiful things.")
+      expect(page).to have_selector("li.item")
+    end
+  end
+
+  it "runs the page's search and front-end pagination JavaScript under the sandbox CSP" do
+    visit seller.subdomain_with_protocol
+
+    within_frame(find("iframe#gumroad-landing-frame")) do
+      expect(page).to have_selector("li.item", count: 2)
+      expect(page).to have_text("Showing 2 of 3")
+
+      click_button "Next"
+      expect(page).to have_selector("li.item", count: 1)
+
+      fill_in "Search", with: "uniquely"
+      expect(page).to have_selector("li.item", count: 1)
+      expect(page).to have_text("Gamma Uniquely Named")
+      expect(page).to have_text("Showing 1 of 1")
+      expect(page).to have_no_text("Alpha Kit")
+    end
+  end
+end

--- a/spec/requests/user/profile_spec.rb
+++ b/spec/requests/user/profile_spec.rb
@@ -215,8 +215,18 @@ describe "User profile page", type: :system, js: true do
         wait_for_ajax
       end
 
+      def open_profile_tab(name)
+        find("[role=tab]", text: name).click
+      end
+
       def within_profile_section_editor(&block)
+        open_profile_tab("Pages") unless has_css?("section[aria-label='Profile section editor']", wait: false)
         within("section[aria-label='Profile section editor']", &block)
+      end
+
+      def fill_in_bio(value)
+        open_profile_tab("About")
+        fill_in "Bio", with: value
       end
 
       def within_section_form(name, match: :first, &block)
@@ -300,7 +310,7 @@ describe "User profile page", type: :system, js: true do
         # Another tab/device adds a section while this editor holds a now-stale section list.
         concurrent_section = create(:seller_profile_products_section, seller:, header: "Added elsewhere", shown_products: [@product2.id])
 
-        fill_in "Bio", with: "Bio edit that must not touch sections"
+        fill_in_bio "Bio edit that must not touch sections"
         save_changes
 
         expect(SellerProfileSection.exists?(concurrent_section.id)).to be true
@@ -319,7 +329,7 @@ describe "User profile page", type: :system, js: true do
         # resend the section list and falsely conflict with the section added below.
         concurrent_section = create(:seller_profile_products_section, seller:, header: "Added elsewhere", shown_products: [@product1.id])
 
-        fill_in "Bio", with: "Bio only, sections untouched"
+        fill_in_bio "Bio only, sections untouched"
         save_changes
 
         expect(SellerProfileSection.exists?(concurrent_section.id)).to be true
@@ -587,7 +597,7 @@ describe "User profile page", type: :system, js: true do
 
         visit profile_path
 
-        expect(page).to have_css("[contenteditable=true]")
+        within_profile_section_editor { expect(page).to have_css("[contenteditable=true]") }
         expect(page).to have_button("Update profile", disabled: true)
       end
 
@@ -610,8 +620,9 @@ describe "User profile page", type: :system, js: true do
 
         visit profile_path
 
+        open_profile_tab("Pages")
         find("[contenteditable=true]").click
-        find_field("Name").click
+        find_field("Page name").click
 
         expect(page).to have_button("Update profile", disabled: true)
       end

--- a/spec/services/pages/profile_data_spec.rb
+++ b/spec/services/pages/profile_data_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Pages::ProfileData do
+  describe ".build" do
+    let(:seller) { create(:user) }
+
+    context "when the seller has no saved profile row" do
+      before do
+        SellerProfile.where(seller_id: seller.id).delete_all
+        seller.reload
+      end
+
+      it "returns an empty pages list without raising" do
+        expect(Pages::ProfileData.build(seller)[:pages]).to eq([])
+      end
+
+      it "does not build a seller_profile on the seller as a side effect" do
+        Pages::ProfileData.build(seller)
+
+        expect(seller.association(:seller_profile)).not_to be_loaded
+        expect(SellerProfile.exists?(seller_id: seller.id)).to be(false)
+      end
+    end
+
+    context "when the seller has profile tabs" do
+      before do
+        seller.seller_profile.json_data["tabs"] = [{ "name" => "Shop", "sections" => [] }, { "name" => "", "sections" => [] }]
+        seller.seller_profile.save!
+      end
+
+      it "returns only the named tabs" do
+        expect(Pages::ProfileData.build(seller.reload)[:pages]).to eq([{ name: "Shop" }])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

Phase 2b of #5553 — the in-app **"Build with your agent"** UI for custom-HTML seller profiles. Stacks on the Phase 2a backend that shipped in #5569 (`User#custom_html`, the OAuth v2 API, the sandboxed `/:username/landing/embed` render) and #5570 (rate limits).

A creator can now discover and manage a fully custom profile page directly from **Settings → Profile**, without leaving the app:
- a **copy-prompt** block (+ "Show prompt" details) that hands their AI agent everything it needs to build and publish the page via the `gumroad user page` CLI;
- a **live-status banner** ("A custom profile page is live") with a View link once a page exists;
- a **reset** affordance to remove the custom page and restore the default profile.

This also re-lands the `parsers/profile.ts` `custom_html` field that was intentionally reverted from #5569 (no consumer at the time) — this PR is the consumer.

## Why

#5553 split into Phase 2a (backend + API + CLI + render, shipped #5569) and Phase 2b (the authoring surface). This is 2b. Profiles have no inline HTML editor by design — the sandboxed iframe makes WYSIWYG impossible — so the agent prompt + CLI **is** the authoring path. This PR surfaces that path to creators and gives them live status + a reset.

## How

- **`profile_presenter.rb`** — `profile_settings_props` now exposes `custom_html_pages_enabled` (Feature flag), `custom_html`, `has_custom_landing_page`, and `username`.
- **`Profile/LandingPageEditor.tsx`** (new) — mirrors the product `ShareTab/LandingPageEditor` but **drops every checkout affordance** (a profile has no buy button): the prompt links to product pages instead of embedding `data-gumroad-action="buy"` / `gumroad:checkout`. Uses the `/:username` URL and the `gumroad user page preview|publish|url|clear` CLI.
- **`Settings/Profile/Show.tsx`** — renders the editor (flag-gated) and wires a clear handler.
- **`parsers/profile.ts`** — `ProfileSettings` gains `custom_html`.

### Security: custom_html is CLEAR-ONLY from this session surface

Authoring goes exclusively through the **sanitized, OAuth-scoped v2 API** (`PUT /v2/user/custom_html` → `Ai::PageSanitizer`). This UI never edits the HTML — it only sends `""` to reset. To prevent a crafted session PUT from storing **unsanitized** HTML (stored XSS), the controller rejects any non-blank `custom_html`:
- `profile_policy.rb` permits `:custom_html` under user attributes (so the blank reset is allowed through);
- `profile_controller.rb` rejects a non-blank value with "Custom HTML can only be edited through the Gumroad CLI or API."
- `User#custom_html=` (shipped #5569) treats blank as "remove the page".

## Test plan

- `spec/presenters/profile_presenter_spec.rb` — updated the whole-hash assertion for the new props + a context covering the flag-on / live-page branch.
- `spec/controllers/settings/profile_controller_spec.rb` — clear-a-live-page, reject-non-blank (sanitizer-bypass guard), and don't-clobber-on-unrelated-save.
- TypeScript / ESLint / Prettier: clean locally.
- RSpec was run locally but the repo's global `Mongoid.purge!` cleanup hook requires MongoDB, which isn't available on the local box — CI (full infra) is the source of truth for the Ruby specs.

Successor to #5569 / #5570. Ref #5553, #5354, #5063, #5309.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5571"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784932321&installation_id=134400930&pr_number=5571&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5571&signature=1d8474d42f48121ad2d905643276268467e1820eab4345ea497ab06141534868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches seller-authored HTML surfaces and profile update authorization; mitigations (clear-only `custom_html`, owner-scoped version polling, sandbox/CSP) are explicit but the area is security-sensitive.
> 
> **Overview**
> Adds **Settings → Profile** support for custom-HTML seller profiles: **About / Pages / Share** tabs, a **Share** tab with extracted `ShareButtons`, and (when the feature flag is on) a **“Custom profile page”** block with copy-prompt, live banner, and **remove** that only posts blank `custom_html`.
> 
> **Security:** profile settings **`custom_html` is reset-only** — the controller rejects non-blank values so session saves cannot bypass the sanitized v2 API; policy permits `custom_html` only for that clear path.
> 
> **Embed & preview:** profile landing embeds inject cached **`gumroad-data`** JSON (`Pages::ProfileData`) for dynamic catalog rendering; owner **`?preview=true`** embeds get **`gumroad:profile-fields`** postMessage updates for name/bio. **`ProfileLandingPagePreview`** mirrors that in the settings sidebar when a custom page is live (and hides the legacy **Pages** tab).
> 
> **Live reload (products + profiles):** new **`/landing/version`** JSON endpoints and shared polling script reload the sandboxed iframe (or full page when cleared) for signed-in owners only; product wrappers get the same poll.
> 
> **Presenter/types:** `ProfilePresenter` exposes `custom_html_pages_enabled`, `has_custom_landing_page`, `username`, etc.; `ProfileSettings` gains `custom_html` for the clear-only save.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5fd765391f4a924354152c1b1a450910aa9a59d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->