### PR TITLE
Strip deleted product ids from profile sections on delete

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -415,6 +415,7 @@ class Link < ApplicationRecord
   def delete!
     mark_deleted!
     clear_featured_product_sections!
+    remove_from_profile_sections!
     custom_domain&.mark_deleted!
     alive_public_files.update_all(scheduled_for_deletion_at: 10.minutes.from_now)
     CancelSubscriptionsForProductWorker.perform_in(10.minutes, id) if subscriptions.active.present?
@@ -1366,6 +1367,20 @@ class Link < ApplicationRecord
         .where(seller_id: user_id)
         .where('CAST(JSON_EXTRACT(json_data, "$.featured_product_id") AS UNSIGNED) = ?', id)
         .find_each { |section| section.update!(json_data: section.json_data.except("featured_product_id")) }
+    end
+
+    # When a product is soft-deleted, strip its id from any
+    # SellerProfileProductsSection.shown_products (a JSON array of product ids).
+    # Without this, the section keeps pointing at the dead product id and
+    # renders as an empty container the seller can't remove, since
+    # ProfileSectionsPresenter filters shown products by is_alive_on_profile.
+    def remove_from_profile_sections!
+      user.with_profile_sections_lock do
+        user.seller_profile_products_sections.reload.each do |section|
+          next unless section.shown_products.include?(id)
+          section.update!(shown_products: section.shown_products - [id])
+        end
+      end
     end
 
     def compute_ppp_prices(price_cents, factors, currency)

--- a/db/migrate/20261201000005_backfill_orphaned_shown_products_in_profile_sections.rb
+++ b/db/migrate/20261201000005_backfill_orphaned_shown_products_in_profile_sections.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# One-time cleanup for the leak fixed in Link#remove_from_profile_sections!.
+# Before that fix, soft-deleting a product never stripped its id from
+# SellerProfileProductsSection.shown_products, so sections kept pointing at
+# dead product ids and rendered as empty containers the seller couldn't remove
+# (issue gumroad-private#685). This strips every deleted product id out of the
+# shown_products arrays. Forward-only; there is nothing meaningful to restore.
+class BackfillOrphanedShownProductsInProfileSections < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    # json_data is a native MySQL `json` column, so AR auto-casts it to a Hash.
+    sections = Class.new(ActiveRecord::Base) do
+      self.table_name = "seller_profile_sections"
+    end
+
+    sections
+      .where(type: "SellerProfileProductsSection")
+      .find_each(batch_size: 500) do |section|
+        data = section.json_data
+        next unless data.is_a?(Hash)
+
+        shown = data["shown_products"]
+        next unless shown.is_a?(Array) && shown.present?
+
+        alive_ids = Link.where(id: shown, deleted_at: nil).pluck(:id).to_set
+        cleaned = shown.select { |pid| alive_ids.include?(pid) }
+        next if cleaned.length == shown.length
+
+        section.update_columns(
+          json_data: data.merge("shown_products" => cleaned),
+          updated_at: Time.current
+        )
+      end
+  end
+
+  def down
+    # No-op: removed ids referenced soft-deleted products and carried no value.
+  end
+end

--- a/db/migrate/20261201000005_backfill_orphaned_shown_products_in_profile_sections.rb
+++ b/db/migrate/20261201000005_backfill_orphaned_shown_products_in_profile_sections.rb
@@ -15,6 +15,16 @@ class BackfillOrphanedShownProductsInProfileSections < ActiveRecord::Migration[7
       self.table_name = "seller_profile_sections"
     end
 
+    # Use an anonymous AR stub for links too, rather than the live `Link` model.
+    # A backfill migration must be reproducible years from now from a fresh
+    # `db:migrate`; coupling it to the application model means a future rename,
+    # default scope, or change to how `deleted_at` is interpreted would silently
+    # alter what this one-time cleanup considers "alive". The stub pins the
+    # behavior to the raw table + column as they exist at write time.
+    links = Class.new(ActiveRecord::Base) do
+      self.table_name = "links"
+    end
+
     sections
       .where(type: "SellerProfileProductsSection")
       .find_each(batch_size: 500) do |section|
@@ -24,7 +34,7 @@ class BackfillOrphanedShownProductsInProfileSections < ActiveRecord::Migration[7
         shown = data["shown_products"]
         next unless shown.is_a?(Array) && shown.present?
 
-        alive_ids = Link.where(id: shown, deleted_at: nil).pluck(:id).to_set
+        alive_ids = links.where(id: shown, deleted_at: nil).pluck(:id).to_set
         cleaned = shown.select { |pid| alive_ids.include?(pid) }
         next if cleaned.length == shown.length
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_12_01_000004) do
+ActiveRecord::Schema[7.1].define(version: 2026_12_01_000005) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -3045,6 +3045,19 @@ describe Link, :vcr do
       expect { product.delete! }.not_to raise_error
       expect(product.reload.deleted?).to be(true)
     end
+
+    it "removes the deleted product's id from every profile products section's shown_products" do
+      seller = create(:user)
+      product = create(:product, user: seller)
+      other_product = create(:product, user: seller)
+      section_with_product = create(:seller_profile_products_section, seller:, shown_products: [product.id, other_product.id])
+      section_without_product = create(:seller_profile_products_section, seller:, shown_products: [other_product.id])
+
+      product.delete!
+
+      expect(section_with_product.reload.shown_products).to eq([other_product.id])
+      expect(section_without_product.reload.shown_products).to eq([other_product.id])
+    end
   end
 
   describe "#ordered_by_ids" do


### PR DESCRIPTION
## What

Soft-deleting a product never removed its id from `SellerProfileProductsSection.shown_products`, so the section kept pointing at the dead product id and rendered as an empty container the seller couldn't remove from the profile editor.

Fixes the issue tracked in gumroad-private#685 (seller `marquee00` had two products sections whose `shown_products` referenced only deleted products, showing as empty frames).

## Why

`Link#delete!` called `clear_featured_product_sections!`, which cleaned the **featured-product** JSON reference only. There was **no equivalent cleanup for `SellerProfileProductsSection.shown_products`** (a JSON array of product ids) — ids are only ever *added* (via `add_to_profile_sections` on create and `show_in_sections!`), never stripped on delete.

At render time `ProfileSectionsPresenter#section_search_results` searches with `is_alive_on_profile: true` (`alive? && !archived?`), so a deleted product is filtered out and the section returns zero products → the profile renders an empty section frame with no product inside. With a blank header it shows as a bare container the seller can't target.

## Changes

- **Stop the leak.** Add private `Link#remove_from_profile_sections!`, called from `delete!` right after `clear_featured_product_sections!`. It mirrors the existing `with_profile_sections_lock` + `reload` pattern used by `add_to_profile_sections` / `show_in_sections!`, and strips the deleted id from every section's `shown_products`.
- **Backfill existing orphans.** One-time migration (`disable_ddl_transaction!`, batched `find_each`) that intersects each `SellerProfileProductsSection.shown_products` against the live `links` and strips any id whose product is soft-deleted. Only writes rows that actually contain dead ids. This remediates the already-broken empty containers (e.g. `marquee00`).
- **Spec.** Asserts that after `product.delete!` the product's id is gone from every products section's `shown_products`, while other products' ids are untouched.

## Test plan

- `bundle exec rspec spec/models/link_spec.rb -e "removes the deleted product's id from every profile products section"` → **1 example, 0 failures**.
- Verified RED → GREEN: with the `delete!` call removed the spec fails (1 failure); with it in place it passes.
- `RAILS_ENV=test bundle exec rails db:migrate` runs the backfill cleanly.
- `rubocop` clean on all three changed files.

Backend-only change; no user-facing UI surface, so no screenshots.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784979053&installation_id=134400930&pr_number=5576&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5576&signature=f14c5b4a5929548c23bca9e73fcc0ab00448d5d9abf5b6ca061cc93485b53fff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to profile JSON cleanup on product soft-delete plus a forward-only data backfill; no payment, auth, or checkout paths.
> 
> **Overview**
> Fixes seller profile **products sections** that showed as empty frames after a product was soft-deleted, because `shown_products` still held the dead id while rendering only includes alive products.
> 
> **`Link#delete!`** now calls **`remove_from_profile_sections!`** right after **`clear_featured_product_sections!`**, using the same **`with_profile_sections_lock`** pattern as **`add_to_profile_sections`** / **`show_in_sections!`** to remove the product id from every **`SellerProfileProductsSection.shown_products`**.
> 
> A **one-time backfill migration** batched over **`seller_profile_sections`**, intersects each section’s **`shown_products`** with non-deleted **`links`** rows (via anonymous AR stubs, not **`Link`**), and updates **`json_data`** only when orphaned ids are present.
> 
> Adds a **`link_spec`** example asserting **`delete!`** clears the id from affected sections without touching other products’ ids.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ff9260269174fa5664503d37dcd1354b788cf08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->