### PR TITLE
Surface silent Stripe Connect account-creation failures as a payout-note breadcrumb

### DIFF
--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -17,6 +17,7 @@ module StripeMerchantAccountManager
 
   BANK_SYNC_FAILURE_NOTE_PREFIX = "Stripe bank sync failed"
   POSTAL_CODE_FAILURE_NOTE_PREFIX = "Stripe postal code rejected"
+  ACCOUNT_CREATION_FAILURE_NOTE_PREFIX = "Stripe account creation failed"
 
   STRIPE_PAYOUTS_SYNC_COMMENT_AUTHOR = "Stripe payouts sync"
   private_constant :STRIPE_PAYOUTS_SYNC_COMMENT_AUTHOR
@@ -149,6 +150,7 @@ module StripeMerchantAccountManager
 
     clear_stale_postal_code_failure_notes(user)
     clear_stale_bank_sync_failure_notes(user)
+    clear_stale_account_creation_failure_notes(user)
 
     merchant_account
   rescue => e
@@ -156,8 +158,21 @@ module StripeMerchantAccountManager
       cleanup_failed_merchant_account(merchant_account)
       ErrorNotifier.notify(e)
     end
-    record_postal_code_failure_note(user, e) if notify && postal_code_invalid_error?(e)
-    record_bank_sync_failure_note(user, e) if notify && bank_account_invalid_error?(e)
+    if notify
+      if postal_code_invalid_error?(e)
+        record_postal_code_failure_note(user, e)
+      elsif bank_account_invalid_error?(e)
+        record_bank_sync_failure_note(user, e)
+      elsif e.is_a?(Stripe::InvalidRequestError)
+        # Catch-all breadcrumb: a Stripe::InvalidRequestError that neither specific
+        # matcher recognized (e.g. "We couldn't find the bank for that BIC / bank code")
+        # would otherwise fail completely silently — the half-provisioned merchant
+        # account is cleaned up above and the seller is left unable to publish with no
+        # signal anywhere (gumroad-private#683). Record a payout-note breadcrumb so the
+        # failure is visible in admin and the seller can be told what to fix.
+        record_account_creation_failure_note(user, e)
+      end
+    end
     raise
   end
 
@@ -416,6 +431,28 @@ module StripeMerchantAccountManager
         .update_all(deleted_at: Time.current)
   rescue => e
     Rails.logger.error "Failed to clear stale bank sync failure notes for user #{user&.id}: #{e.class}: #{e.message}"
+    ErrorNotifier.notify(e)
+  end
+
+  private_class_method
+  def self.record_account_creation_failure_note(user, error)
+    code = error.respond_to?(:code) ? error.code : nil
+    user.add_payout_note(content: "#{ACCOUNT_CREATION_FAILURE_NOTE_PREFIX}: #{code || 'unknown'} — #{error.message.to_s.truncate(200)}")
+  rescue => e
+    Rails.logger.error "Failed to record account-creation payout-note breadcrumb for user #{user&.id}: #{e.class}: #{e.message}"
+    ErrorNotifier.notify(e)
+  end
+
+  private_class_method
+  def self.clear_stale_account_creation_failure_notes(user)
+    user.comments
+        .with_type_payout_note
+        .alive
+        .where(author_id: GUMROAD_ADMIN_ID)
+        .where("content LIKE ?", "#{ACCOUNT_CREATION_FAILURE_NOTE_PREFIX}%")
+        .update_all(deleted_at: Time.current)
+  rescue => e
+    Rails.logger.error "Failed to clear stale account creation failure notes for user #{user&.id}: #{e.class}: #{e.message}"
     ErrorNotifier.notify(e)
   end
 

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -128,6 +128,35 @@ describe StripeMerchantAccountManager, :vcr do
         end.to raise_error(Stripe::InvalidRequestError)
       end
 
+      it "records an account-creation failure payout note when account creation fails with an otherwise-unrecognized Stripe::InvalidRequestError" do
+        error_message = "We couldn't find the bank for that BIC / bank code (BRSTN)"
+        allow(Stripe::Account).to receive(:create).and_raise(Stripe::InvalidRequestError.new(error_message, "bank_code", code: "invalid_bank_code"))
+
+        expect do
+          subject.create_account(user, passphrase: "1234")
+        end.to raise_error(Stripe::InvalidRequestError)
+
+        note = user.reload.comments.with_type_payout_note.alive
+                   .where("content LIKE ?", "#{described_class::ACCOUNT_CREATION_FAILURE_NOTE_PREFIX}%").last
+        expect(note).to be_present
+        expect(note.content).to include("invalid_bank_code")
+        expect(note.content).to include("BIC / bank code")
+      end
+
+      it "does not record a generic account-creation failure note when the error is already covered by the bank-sync matcher" do
+        allow(Stripe::Account).to receive(:create)
+          .and_raise(Stripe::InvalidRequestError.new("We couldn't find the bank for that routing number", "bank_account[routing_number]", code: "routing_number_invalid"))
+
+        expect do
+          subject.create_account(user, passphrase: "1234")
+        end.to raise_error(Stripe::InvalidRequestError)
+
+        expect(user.reload.comments.with_type_payout_note.alive
+                   .where("content LIKE ?", "#{described_class::ACCOUNT_CREATION_FAILURE_NOTE_PREFIX}%")).to be_empty
+        expect(user.comments.with_type_payout_note.alive
+                   .where("content LIKE ?", "#{described_class::BANK_SYNC_FAILURE_NOTE_PREFIX}%")).to be_present
+      end
+
       it "cleans up the merchant account when onboarding is interrupted by a non-Stripe error" do
         allow(Stripe::Account).to receive(:create).and_raise(Timeout::Error.new("execution expired"))
         expect do


### PR DESCRIPTION
## What

When a seller's Stripe Connect account creation fails with a `Stripe::InvalidRequestError` that isn't matched by the two existing narrow matchers (`postal_code_invalid_error?` / `bank_account_invalid_error?`), `StripeMerchantAccountManager.create_account` now records an `ACCOUNT_CREATION_FAILURE_NOTE_PREFIX` payout-note breadcrumb on the user (and clears it on a later successful onboarding), mirroring the existing postal-code and bank-sync note patterns. Backend-only; no UI surface changes.

## Why

`create_account` builds the local `MerchantAccount` row inside `user.with_lock`, then calls `Stripe::Account.create(account_params)` **outside** the lock. If that call raises, the `rescue` cleans up the half-provisioned row (`cleanup_failed_merchant_account`) and re-raises — but only records a payout note for the two recognized error classes. Any other `Stripe::InvalidRequestError` fails **completely silently**: the merchant account is rolled back, nothing is recorded in admin, nothing surfaces to the seller, and `can_publish_products?` stays false because no merchant account exists. The seller is stuck unable to publish and silently retries onboarding.

This was hit in production (gumroad-private#683): a German business seller submitted complete KYC + an IBAN, but `Stripe::Account.create` rejected the bank code (`We couldn't find the bank for that BIC / bank code`). Four onboarding attempts over five days each left a `charge_processor_merchant_id: null` merchant-account row created and soft-deleted within the same second, no payout note, and the seller blocked from publishing 20 products with no signal anywhere. The matching error in the bank-**sync** path (`update_bank_account`) is already caught and noted; the **create** path had no equivalent catch-all.

With this change the failure is visible in admin (payout note carries the Stripe error code + message) so support can tell the seller the actionable cause (here: re-enter a valid IBAN), instead of the failure vanishing.

This is the surfacing half of the issue. The deeper structural item — the non-atomic create that leaves orphaned `null`-id rows (see `app/services/onetime/cleanup_wedged_stripe_merchant_accounts.rb`, #487) — is out of scope for this PR.

## Test plan

- New specs in `stripe_merchant_account_manager_spec.rb` `#create_account`:
  - records an `ACCOUNT_CREATION_FAILURE_NOTE_PREFIX` payout note (with the Stripe error code + message) when `Stripe::Account.create` raises an otherwise-unrecognized `Stripe::InvalidRequestError` (the BIC/bank-code case).
  - does **not** record the generic note when the error is already covered by the bank-sync matcher (`routing_number_invalid`) — that path still records its own bank-sync note, no double-noting.
- Verified RED→GREEN locally: both new examples fail on `main` (no note recorded), pass with the fix; pre-existing `raises the Stripe::InvalidRequestError` example still green (3 examples, 0 failures).
- `rubocop` clean on both changed files.

Ref antiwork/gumroad-private#683.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5578"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784982047&installation_id=134400930&pr_number=5578&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5578&signature=0bc37e7a8922d7d1b2b2766f1a5b01e65df5327dc909c3343a031bbdb47e80b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change in Stripe onboarding error handling; behavior on failure is still re-raise after cleanup, with no change to account creation success paths.
> 
> **Overview**
> **Stripe Connect `create_account`** now leaves an admin-visible breadcrumb when `Stripe::Account.create` fails with a `Stripe::InvalidRequestError` that is not already handled by the postal-code or bank-account matchers.
> 
> On **`notify`**, the rescue path uses an **`elsif`** chain: postal and bank errors keep their existing notes; any other **`Stripe::InvalidRequestError`** gets a payout note prefixed with **`Stripe account creation failed`**, including Stripe’s error code and a truncated message (e.g. invalid BIC/bank code). Successful onboarding clears stale notes via **`clear_stale_account_creation_failure_notes`**, same pattern as postal and bank sync.
> 
> Specs cover the generic note for an unrecognized invalid-request error and assert bank-matched errors still only get the bank-sync note, not a duplicate account-creation note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eda30e83ae8cd15c85e699899e2aa64070d97b24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->