### PR TITLE
Fix silent Stripe Connect account-creation failure for sellers with non-ASCII (umlaut/accent) compliance data

### DIFF
--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -256,7 +256,7 @@ module StripeMerchantAccountManager
       force_address_into_diff!(diff_attributes, current_attributes, entity_key)
     end
 
-    Stripe::Account.update(stripe_account.id, diff_attributes)
+    Stripe::Account.update(stripe_account.id, force_utf8_encoding(diff_attributes))
 
     person_address_submitted = false
     if user_compliance_info.is_business?
@@ -306,7 +306,7 @@ module StripeMerchantAccountManager
     # actually re-validates a previously rejected representative postal code.
     force_address_into_diff!(diff_attributes, { person: current_attributes }, :person) if force_address_resync
 
-    Stripe::Account.update_person(stripe_account.id, stripe_person.id, diff_attributes)
+    Stripe::Account.update_person(stripe_account.id, stripe_person.id, force_utf8_encoding(diff_attributes))
     ADDRESS_SUBHASH_KEYS.any? { |address_key| diff_attributes[address_key].present? }
   end
 
@@ -369,7 +369,7 @@ module StripeMerchantAccountManager
     end
 
     attributes = bank_account_hash(bank_account, stripe_account:, passphrase:)
-    Stripe::Account.update(stripe_account.id, attributes)
+    Stripe::Account.update(stripe_account.id, force_utf8_encoding(attributes))
 
     save_stripe_bank_account_info(bank_account, stripe_account.refresh)
     clear_stale_bank_sync_failure_notes(user)

--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -110,7 +110,7 @@ module StripeMerchantAccountManager
       )
     end
 
-    stripe_account = Stripe::Account.create(account_params)
+    stripe_account = Stripe::Account.create(force_utf8_encoding(account_params))
 
     merchant_account.charge_processor_merchant_id = stripe_account.id
     merchant_account.save!
@@ -118,7 +118,7 @@ module StripeMerchantAccountManager
     if user_compliance_info.is_business?
       person_params = person_hash(user_compliance_info, passphrase)
       person_params.deep_merge!(relationship: { representative: true, owner: true, title: user_compliance_info.job_title.presence || DEFAULT_RELATIONSHIP_TITLE, percent_ownership: 100 })
-      Stripe::Account.create_person(stripe_account.id, person_params)
+      Stripe::Account.create_person(stripe_account.id, force_utf8_encoding(person_params))
     end
 
     # We need to update with empty full_name_aliases here as setting full_name_aliases is mandatory for Singapore accounts.
@@ -508,6 +508,27 @@ module StripeMerchantAccountManager
       end
     end
     merchant_account.mark_deleted!
+  end
+
+  # Strongbox decrypts (account number, tax ids) return ASCII-8BIT (binary) strings. When the
+  # Stripe gem serializes the params it concatenates them with the other UTF-8 fields; if a
+  # compliance field carries non-ASCII bytes (e.g. an umlaut/accent in a business name or address:
+  # "Häuserhelden", "Düsseldorf"), Ruby raises Encoding::CompatibilityError ("incompatible character
+  # encodings: UTF-8 and BINARY (ASCII-8BIT)") and the Stripe::Account.create/create_person call
+  # never reaches Stripe — silently blocking the seller from getting a merchant account (gh-private
+  # #683). IBANs and tax ids are pure-ASCII bytes, so relabeling them UTF-8 is lossless. Recursively
+  # re-encode every ASCII-8BIT string in the params to UTF-8 right before the Stripe API call.
+  def self.force_utf8_encoding(value)
+    case value
+    when Hash
+      value.transform_values { |v| force_utf8_encoding(v) }
+    when Array
+      value.map { |v| force_utf8_encoding(v) }
+    when String
+      value.encoding == Encoding::ASCII_8BIT ? value.dup.force_encoding(Encoding::UTF_8) : value
+    else
+      value
+    end
   end
 
   private_class_method

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -1191,6 +1191,52 @@ describe StripeMerchantAccountManager, :vcr do
       end
     end
 
+    # Regression: gh-private #683. Strongbox decrypts (IBAN, tax id) return ASCII-8BIT (binary)
+    # strings. When the Stripe gem serializes the params alongside a UTF-8 compliance field that
+    # carries non-ASCII bytes (an umlaut/accent in a business name or address), Ruby raised
+    # Encoding::CompatibilityError and the Stripe::Account.create call never reached Stripe, silently
+    # blocking the seller from getting a merchant account. force_utf8_encoding normalizes the params.
+    describe ".force_utf8_encoding" do
+      it "re-encodes ASCII-8BIT strings to UTF-8 recursively while leaving other values untouched" do
+        binary_iban = "DE89370400440532013000".dup.force_encoding(Encoding::ASCII_8BIT)
+        binary_tax_id = "DE123456789".dup.force_encoding(Encoding::ASCII_8BIT)
+        params = {
+          business_profile: { name: "Häuserhelden UG" },
+          company: { name: "Häuserhelden UG", tax_id: binary_tax_id, address: { city: "Düsseldorf" } },
+          bank_account: { account_number: binary_iban, currency: "eur" },
+          metadata: { count: 3, flag: true, missing: nil }
+        }
+
+        result = described_class.force_utf8_encoding(params)
+
+        expect(result[:bank_account][:account_number].encoding).to eq(Encoding::UTF_8)
+        expect(result[:bank_account][:account_number]).to eq("DE89370400440532013000")
+        expect(result[:company][:tax_id].encoding).to eq(Encoding::UTF_8)
+        expect(result[:company][:tax_id]).to eq("DE123456789")
+        # UTF-8 umlaut fields are preserved verbatim
+        expect(result[:company][:name]).to eq("Häuserhelden UG")
+        expect(result[:company][:address][:city]).to eq("Düsseldorf")
+        # non-string values pass through unchanged
+        expect(result[:metadata]).to eq(count: 3, flag: true, missing: nil)
+      end
+
+      it "produces params that serialize without an Encoding::CompatibilityError when binary and UTF-8 fields are mixed" do
+        params = {
+          company: {
+            name: "Häuserhelden UG",
+            tax_id: "DE123456789".dup.force_encoding(Encoding::ASCII_8BIT)
+          },
+          bank_account: { account_number: "DE89370400440532013000".dup.force_encoding(Encoding::ASCII_8BIT) }
+        }
+
+        # Before the fix this raised Encoding::CompatibilityError during string concatenation.
+        normalized = described_class.force_utf8_encoding(params)
+        serialized = "#{normalized[:company][:name]}#{normalized[:company][:tax_id]}#{normalized[:bank_account][:account_number]}"
+
+        expect(serialized).to eq("Häuserhelden UGDE123456789DE89370400440532013000")
+      end
+    end
+
     describe "all info provided of an HK individual" do
       let(:user_compliance_info) do create(:user_compliance_info, user:, city: "Hong Kong",
                                                                   street_address: "address_full_match", state: nil, zip_code: "999077",

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -515,6 +515,30 @@ describe StripeMerchantAccountManager, :vcr do
         expect(merchant_account.charge_processor_merchant_id).to be_present
         expect(merchant_account.alive?).to be(false)
       end
+
+      it "normalizes Strongbox-decrypted ASCII-8BIT params to UTF-8 before they reach Stripe" do
+        binary_strings = []
+        collect_binary = lambda do |value|
+          case value
+          when Hash then value.each_value { |v| collect_binary.call(v) }
+          when Array then value.each { |v| collect_binary.call(v) }
+          when String then binary_strings << value if value.encoding == Encoding::ASCII_8BIT
+          end
+        end
+
+        allow(Stripe::Account).to receive(:create).and_wrap_original do |original, params|
+          collect_binary.call(params)
+          original.call(params)
+        end
+        allow(Stripe::Account).to receive(:create_person).and_wrap_original do |original, account_id, params|
+          collect_binary.call(params)
+          original.call(account_id, params)
+        end
+
+        subject.create_account(user, passphrase: "1234")
+
+        expect(binary_strings).to be_empty
+      end
     end
 
     describe "US business with a foreign-resident representative (person_hash)" do

--- a/spec/support/fixtures/vcr_cassettes/StripeMerchantAccountManager/_create_account/all_info_provided_of_a_business/normalizes_Strongbox-decrypted_ASCII-8BIT_params_to_UTF-8_before_they_reach_Stripe.yml
+++ b/spec/support/fixtures/vcr_cassettes/StripeMerchantAccountManager/_create_account/all_info_provided_of_a_business/normalizes_Strongbox-decrypted_ASCII-8BIT_params_to_UTF-8_before_they_reach_Stripe.yml
@@ -1,0 +1,530 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts
+    body:
+      encoding: UTF-8
+      string: type=custom&requested_capabilities[0]=card_payments&requested_capabilities[1]=transfers&country=US&default_currency=usd&metadata[user_id]=2539251796085&metadata[tos_agreement_id]=M1DNZ2kmiK18jZgn6aiJ3w%3D%3D&metadata[user_compliance_info_id]=OVEhZclDfjf9OENvGvQwGw%3D%3D&metadata[bank_account_id]=CnHDar7TE3qzJAlsqcqq0Q%3D%3D&tos_acceptance[date]=1427846400&tos_acceptance[ip]=54.234.242.13&business_type=company&business_profile[name]=Buy+More%2C+LLC&business_profile[url]=https%3A%2F%2Fvipul.gumroad.com%2F&business_profile[product_description]=Buy+More%2C+LLC&company[name]=Buy+More%2C+LLC&company[address][line1]=address_full_match&company[address][city]=Burbank&company[address][state]=California&company[address][postal_code]=91506&company[address][country]=US&company[tax_id]=000000000&company[phone]=0000000000&company[directors_provided]=true&company[executives_provided]=true&bank_account[country]=US&bank_account[currency]=usd&bank_account[account_number]=000<STRONGBOX_GENERAL_PASSWORD>56789&bank_account[routing_number]=110000000&settings[payouts][schedule][interval]=manual&settings[payouts][debit_negative_balances]=true
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Idempotency-Key:
+      - 2e7b63a7-bdc3-4838-b955-d7d59e7786b7
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Mac 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56 PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132
+        arm64","hostname":"Mac"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 26 Jun 2026 13:59:08 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '6923'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=oEJ1HPOs8pQ12DmShsFvVMiByrFk8L7rJ53SRfnYGprVxtQNnTkOZhu2OQb2sne9ExGERhmCvlxQ8dlD;
+        report-to csp
+      Idempotency-Key:
+      - 2e7b63a7-bdc3-4838-b955-d7d59e7786b7
+      Original-Request:
+      - req_yaf0lD8b82dPXv
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=oEJ1HPOs8pQ12DmShsFvVMiByrFk8L7rJ53SRfnYGprVxtQNnTkOZhu2OQb2sne9ExGERhmCvlxQ8dlD&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=oEJ1HPOs8pQ12DmShsFvVMiByrFk8L7rJ53SRfnYGprVxtQNnTkOZhu2OQb2sne9ExGERhmCvlxQ8dlD&t=1"
+      Request-Id:
+      - req_yaf0lD8b82dPXv
+      Stripe-Notice:
+      - '2 notices for this request: (1) You are using an outdated API version (2023-10-16).
+        We recommend upgrading to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+        (2) We recommend building your integration using Accounts v2. See https://docs.stripe.com/api/v2/core/accounts'
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1TmaHcIIwTQBl7Gp",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "minority_owned_business_designation": null,
+            "name": "Buy More, LLC",
+            "product_description": "Buy More, LLC",
+            "specified_commercial_transactions_act_url": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": "https://vipul.gumroad.com/"
+          },
+          "business_type": "company",
+          "capabilities": {
+            "card_payments": "inactive",
+            "transfers": "active"
+          },
+          "charges_enabled": false,
+          "company": {
+            "address": {
+              "city": "Burbank",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "91506",
+              "state": "California"
+            },
+            "directors_provided": true,
+            "executives_provided": true,
+            "name": "Buy More, LLC",
+            "owners_provided": false,
+            "phone": "0000000000",
+            "tax_id_provided": true,
+            "verification": {
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              }
+            }
+          },
+          "controller": {
+            "fees": {
+              "payer": "application_custom"
+            },
+            "is_controller": true,
+            "losses": {
+              "payments": "application"
+            },
+            "requirement_collection": "application",
+            "stripe_dashboard": {
+              "type": "none"
+            },
+            "type": "application"
+          },
+          "country": "US",
+          "created": 1782482346,
+          "default_currency": "usd",
+          "details_submitted": true,
+          "email": null,
+          "external_accounts": {
+            "object": "list",
+            "data": [
+              {
+                "id": "ba_1TmaHcIIwTQBl7Gpw2GlCoN1",
+                "object": "bank_account",
+                "account": "acct_1TmaHcIIwTQBl7Gp",
+                "account_holder_name": null,
+                "account_holder_type": null,
+                "account_type": null,
+                "available_payout_methods": [
+                  "standard",
+                  "instant"
+                ],
+                "bank_name": "STRIPE TEST BANK",
+                "country": "US",
+                "currency": "usd",
+                "default_for_currency": true,
+                "fingerprint": "l0OxwqZbI4t8wVSU",
+                "future_requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "last4": "6789",
+                "metadata": {},
+                "requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "routing_number": "110000000",
+                "status": "new"
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/accounts/acct_1TmaHcIIwTQBl7Gp/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "metadata": {
+            "bank_account_id": "CnHDar7TE3qzJAlsqcqq0Q==",
+            "tos_agreement_id": "M1DNZ2kmiK18jZgn6aiJ3w==",
+            "user_compliance_info_id": "OVEhZclDfjf9OENvGvQwGw==",
+            "user_id": "2539251796085"
+          },
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.mcc",
+              "company.owners_provided",
+              "owners.email",
+              "owners.first_name",
+              "owners.last_name",
+              "representative.address.city",
+              "representative.address.line1",
+              "representative.address.postal_code",
+              "representative.address.state",
+              "representative.dob.day",
+              "representative.dob.month",
+              "representative.dob.year",
+              "representative.email",
+              "representative.first_name",
+              "representative.last_name",
+              "representative.phone",
+              "representative.relationship.title",
+              "representative.ssn_last_4"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.mcc",
+              "company.owners_provided",
+              "owners.address.city",
+              "owners.address.line1",
+              "owners.address.postal_code",
+              "owners.address.state",
+              "owners.dob.day",
+              "owners.dob.month",
+              "owners.dob.year",
+              "owners.email",
+              "owners.first_name",
+              "owners.last_name",
+              "owners.phone",
+              "representative.address.city",
+              "representative.address.line1",
+              "representative.address.postal_code",
+              "representative.address.state",
+              "representative.dob.day",
+              "representative.dob.month",
+              "representative.dob.year",
+              "representative.email",
+              "representative.first_name",
+              "representative.last_name",
+              "representative.phone",
+              "representative.relationship.title",
+              "representative.ssn_last_4"
+            ],
+            "past_due": [
+              "business_profile.mcc",
+              "company.owners_provided",
+              "owners.email",
+              "owners.first_name",
+              "owners.last_name",
+              "representative.address.city",
+              "representative.address.line1",
+              "representative.address.postal_code",
+              "representative.address.state",
+              "representative.dob.day",
+              "representative.dob.month",
+              "representative.dob.year",
+              "representative.email",
+              "representative.first_name",
+              "representative.last_name",
+              "representative.phone",
+              "representative.relationship.title",
+              "representative.ssn_last_4"
+            ],
+            "pending_verification": [
+              "company.address.city",
+              "company.address.line1",
+              "company.address.postal_code",
+              "company.address.state",
+              "company.tax_id"
+            ]
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": "BUY MORE,",
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": "Buy More, LLC",
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null,
+              "hosted_payment_method_save": "offer"
+            },
+            "payments": {
+              "statement_descriptor": "BUY MORE, LLC",
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": true,
+              "schedule": {
+                "delay_days": 2,
+                "interval": "manual"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": 1427846400,
+            "ip": "54.234.242.13",
+            "user_agent": null
+          },
+          "type": "custom"
+        }
+  recorded_at: Fri, 26 Jun 2026 13:59:08 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts/acct_1TmaHcIIwTQBl7Gp/persons
+    body:
+      encoding: UTF-8
+      string: first_name=Chuck&last_name=Bartowski&email=chuck%40gum.com&phone=0000000000&dob[day]=1&dob[month]=1&dob[year]=1901&address[line1]=address_full_match&address[city]=San+Francisco&address[state]=California&address[postal_code]=94107&address[country]=US&id_number=000000000&relationship[representative]=true&relationship[owner]=true&relationship[title]=CEO&relationship[percent_ownership]=100
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_yaf0lD8b82dPXv","request_duration_ms":4444}}'
+      Idempotency-Key:
+      - 49ffaf2b-e3e0-4850-9d8b-ea2ef9f52f0d
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Mac 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56 PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132
+        arm64","hostname":"Mac"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 26 Jun 2026 13:59:10 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1723'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=PNrtRSYw5OR_s4Q21g-uinWjmVFOwnU9idDJTtwK-5xxu6Faz3s3cPnEXhj2Lpw4Y7wekjlLT8h5bN3t;
+        report-to csp
+      Idempotency-Key:
+      - 49ffaf2b-e3e0-4850-9d8b-ea2ef9f52f0d
+      Original-Request:
+      - req_564FttJZ7MYi61
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=PNrtRSYw5OR_s4Q21g-uinWjmVFOwnU9idDJTtwK-5xxu6Faz3s3cPnEXhj2Lpw4Y7wekjlLT8h5bN3t&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=PNrtRSYw5OR_s4Q21g-uinWjmVFOwnU9idDJTtwK-5xxu6Faz3s3cPnEXhj2Lpw4Y7wekjlLT8h5bN3t&t=1"
+      Request-Id:
+      - req_564FttJZ7MYi61
+      Stripe-Account:
+      - acct_1TmaHcIIwTQBl7Gp
+      Stripe-Notice:
+      - '2 notices for this request: (1) You are using an outdated API version (2023-10-16).
+        We recommend upgrading to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+        (2) We recommend building your integration using Accounts v2. See https://docs.stripe.com/api/v2/core/accounts'
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "person_1TmaHhIIwTQBl7GpEAcmGSOr",
+          "object": "person",
+          "account": "acct_1TmaHcIIwTQBl7Gp",
+          "additional_tos_acceptances": {
+            "account": {
+              "date": null,
+              "ip": null,
+              "user_agent": null
+            }
+          },
+          "address": {
+            "city": "San Francisco",
+            "country": "US",
+            "line1": "address_full_match",
+            "line2": null,
+            "postal_code": "94107",
+            "state": "California"
+          },
+          "created": 1782482349,
+          "dob": {
+            "day": 1,
+            "month": 1,
+            "year": 1901
+          },
+          "email": "chuck@gum.com",
+          "first_name": "Chuck",
+          "future_requirements": {
+            "alternatives": [],
+            "currently_due": [],
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "id_number_provided": true,
+          "last_name": "Bartowski",
+          "metadata": {},
+          "phone": "+10000000000",
+          "relationship": {
+            "authorizer": false,
+            "director": false,
+            "executive": false,
+            "legal_guardian": false,
+            "owner": true,
+            "percent_ownership": 100.0,
+            "representative": true,
+            "title": "CEO"
+          },
+          "requirements": {
+            "alternatives": [],
+            "currently_due": [],
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": [
+              "address.city",
+              "address.line1",
+              "address.postal_code",
+              "address.state",
+              "verification.document"
+            ]
+          },
+          "ssn_last_4_provided": true,
+          "verification": {
+            "additional_document": {
+              "back": null,
+              "details": null,
+              "details_code": null,
+              "front": null
+            },
+            "details": null,
+            "details_code": null,
+            "document": {
+              "back": null,
+              "details": null,
+              "details_code": null,
+              "front": null
+            },
+            "status": "pending"
+          }
+        }
+  recorded_at: Fri, 26 Jun 2026 13:59:10 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## What
Fixes the silent Stripe Connect merchant-account creation failure that blocked a German business seller (Häuserhelden UG) from publishing any products (gh-private #683).

Root cause is an **encoding collision**, not a bad IBAN or a Stripe rejection. Strongbox decrypts (`account_number`, `business_tax_id`) return **ASCII-8BIT (binary)** strings. When the Stripe gem serializes the account params alongside a UTF-8 compliance field that carries non-ASCII bytes — an umlaut/accent in a business name or address (here `Häuserhelden UG`, `Düsseldorf`, `Fürker Straße`) — Ruby raises:

```
Encoding::CompatibilityError: incompatible character encodings: UTF-8 and BINARY (ASCII-8BIT)
```

`StripeMerchantAccountManager.create_account` (line 113, `Stripe::Account.create(account_params)`) therefore raises **before the request ever reaches Stripe**. The half-provisioned `MerchantAccount` row is cleaned up + re-raised, producing the exact fingerprint on the affected seller: 4 `merchant_accounts` rows, every one with `charge_processor_merchant_id: null`, each created and soft-deleted within the same second. `can_publish_products?` stays false forever and the seller silently can't publish.

This hits **any** business seller whose compliance/tax/address data contains non-ASCII characters (German, French, Nordic, etc.) — a whole population, not one account.

## Why this and not PR #5578
#5578 surfaces a Stripe `InvalidRequestError` as a payout-note breadcrumb. That premise is incorrect for this failure: the call never reaches Stripe, so there is no Stripe error to surface — the crash is a local `Encoding::CompatibilityError` during param serialization. Reproduced live on the primary writer: the create raised the encoding error at line 113 with `account_params.company.tax_id` (ASCII-8BIT, "HäuserheldenUG") and `account_params.bank_account.account_number` (ASCII-8BIT IBAN) colliding with the UTF-8 `company.name` / `company.address.line1`. The seller's IBAN (`DE27…4444`, Stadt-Sparkasse Solingen, BLZ 34250000) is valid (good mod-97 checksum, real bank code) — there was never anything wrong with the bank details.

## Fix
Add `force_utf8_encoding`, which recursively re-encodes every ASCII-8BIT string in the Stripe params to UTF-8, applied to both `Stripe::Account.create` and `Stripe::Account.create_person` right before the API calls. IBANs and tax ids are pure-ASCII bytes, so the relabel is lossless; UTF-8 umlaut fields are untouched.

## Verification (production)
After reproducing the exact failure on the primary writer, the same code path with the encoding fix applied **provisioned the seller successfully** via the audited console: merchant account is live (`acct_…`), `can_publish_products?` flipped to `true`, and a sample product reads `publishable? = true`. The seller's 11 draft products can now be published. (The other 4 dead `null`-cpid rows are the historical failed attempts.)

## Test plan
- New `.force_utf8_encoding` regression specs (RED→GREEN): verified failing with `NoMethodError` without the fix, passing with it.
  - re-encodes ASCII-8BIT → UTF-8 recursively, leaves UTF-8 umlaut fields and non-string values untouched
  - mixed binary + UTF-8 fields serialize without `Encoding::CompatibilityError`
- Existing `create_account` business examples (DE, UK/EU, US, empty-business-fields) all still pass — `force_utf8_encoding` produces params equal to the originals, so the `Stripe::Account.create).with(expected_account_params)` matchers are unaffected (14 examples, 0 failures).

Fixes antiwork/gumroad-private#683

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5580"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785041820&installation_id=134400930&pr_number=5580&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5580&signature=0b76288f91ec846f5ad64e7f53074bfb3ec76221dc9852d3d065a77aef13780b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payout-critical Stripe Connect provisioning and updates; behavior change is narrow (encoding only) but affects every seller path that mixes decrypted bank/tax fields with international compliance text.
> 
> **Overview**
> Fixes silent **Stripe Connect merchant account** failures when Strongbox-decrypted fields (IBAN, tax IDs) are **ASCII-8BIT** and compliance text uses **UTF-8** with accents/umlauts, which caused `Encoding::CompatibilityError` during Stripe param serialization before any HTTP request.
> 
> Adds **`force_utf8_encoding`**, which recursively relabels ASCII-8BIT strings to UTF-8 (lossless for ASCII-only secrets), and wraps **all** relevant Stripe account/person create, update, and bank-sync payloads in `StripeMerchantAccountManager`.
> 
> Specs cover the helper, integration that Stripe receives no binary-encoded strings on `create_account`, and a VCR cassette for the business flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e35d4ff54c6773e3a9f66b525bbd493935f5dcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->