### PR TITLE
Fix STI crash in profile-sections backfill migration

### DIFF
--- a/db/migrate/20261201000005_backfill_orphaned_shown_products_in_profile_sections.rb
+++ b/db/migrate/20261201000005_backfill_orphaned_shown_products_in_profile_sections.rb
@@ -11,8 +11,13 @@ class BackfillOrphanedShownProductsInProfileSections < ActiveRecord::Migration[7
 
   def up
     # json_data is a native MySQL `json` column, so AR auto-casts it to a Hash.
+    # `seller_profile_sections` has an STI `type` column; disable inheritance on
+    # the stub so AR loads every row as a plain record instead of trying to
+    # resolve `type` (e.g. "SellerProfileProductsSection") to a subclass of this
+    # anonymous class — which it isn't, raising ActiveRecord::SubclassNotFound.
     sections = Class.new(ActiveRecord::Base) do
       self.table_name = "seller_profile_sections"
+      self.inheritance_column = :_type_disabled
     end
 
     # Use an anonymous AR stub for links too, rather than the live `Link` model.

--- a/spec/migrations/backfill_orphaned_shown_products_in_profile_sections_spec.rb
+++ b/spec/migrations/backfill_orphaned_shown_products_in_profile_sections_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require Rails.root.join("db/migrate/20261201000005_backfill_orphaned_shown_products_in_profile_sections").to_s
+
+describe BackfillOrphanedShownProductsInProfileSections do
+  subject(:migration) { described_class.new }
+
+  let(:seller) { create(:user) }
+
+  # Reproduce the pre-fix orphaned state directly: a soft-deleted product id
+  # lingering in shown_products. We write it via update_columns so the new
+  # Link#remove_from_profile_sections! callback can't strip it first.
+  def orphan_section(shown:)
+    section = create(:seller_profile_products_section, seller:, add_new_products: false)
+    section.update_columns(json_data: section.json_data.merge("shown_products" => shown))
+    section
+  end
+
+  it "strips soft-deleted product ids out of shown_products" do
+    alive = create(:product, user: seller)
+    deleted = create(:product, user: seller)
+    deleted.update_columns(deleted_at: Time.current)
+    section = orphan_section(shown: [alive.id, deleted.id])
+
+    migration.up
+
+    expect(section.reload.shown_products).to eq([alive.id])
+  end
+
+  it "leaves a section with only alive products untouched" do
+    alive_one = create(:product, user: seller)
+    alive_two = create(:product, user: seller)
+    section = orphan_section(shown: [alive_one.id, alive_two.id])
+    updated_at_before = section.reload.updated_at
+
+    migration.up
+
+    expect(section.reload.shown_products).to eq([alive_one.id, alive_two.id])
+    expect(section.updated_at).to eq(updated_at_before)
+  end
+end


### PR DESCRIPTION
Follow-up to #5576.

## What

Migration `20261201000005_backfill_orphaned_shown_products_in_profile_sections` aborted with `ActiveRecord::SubclassNotFound` and never ran. It builds an anonymous AR stub over `seller_profile_sections`, which has an STI `type` column — so `find_each` made ActiveRecord try to resolve each row's `type` (`"SellerProfileProductsSection"`) to a subclass of the anonymous stub, which it isn't, raising on the first row.

The fix sets `self.inheritance_column = :_type_disabled` on the stub so rows load as plain records. `.where(type: "SellerProfileProductsSection")` still works as an ordinary column filter. Adds a `spec/migrations` regression test that exercises a real products-section row and asserts dead product ids are stripped while clean sections are left untouched.

## Why

The migration shipped in #5576 with no migration spec, so it only ever ran against an empty test DB — where `find_each` yields no rows and never instantiates anything, so CI passed. Its first run against real data was in production, where it failed deterministically, hung the deploy on the `db:migrate` wait, and left the deployment lock held until the build timed out. The DB was unaffected (the failure is a read-time error inside the migration before any write; the version was never recorded in `schema_migrations`).

`:_type_disabled` is the standard Rails idiom for opting a model out of STI and keeps the migration's intent — an anonymous stub pinned to the raw table, decoupled from the live `SellerProfileSection` models — exactly as the original author wrote it.

---

This PR was implemented with AI assistance using Claude Opus 4.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785088203&installation_id=134400930&pr_number=5581&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5581&signature=713a7ebf0eb6ccd141c31197688d5f5c8b8ae35fe4e4f0789c87134f03919b30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted migration fix plus tests; no auth or API changes, and the backfill only trims already-deleted product ids from JSON.
> 
> **Overview**
> Fixes a production **`ActiveRecord::SubclassNotFound`** in `BackfillOrphanedShownProductsInProfileSections` by setting **`self.inheritance_column = :_type_disabled`** on the anonymous `seller_profile_sections` AR stub, so `find_each` no longer treats the `type` column as STI when loading real `SellerProfileProductsSection` rows.
> 
> Adds **`spec/migrations/backfill_orphaned_shown_products_in_profile_sections_spec.rb`** to run `migration.up` against a real products section: soft-deleted product ids are removed from `shown_products`, and sections with only live products are not updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e09dec5e278ae5bca3b4138d6591151a9afc7e75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->