### PR TITLE
Alert when the monthly global sales tax report job dies unhandled

### DIFF
--- a/app/mailers/accounting_mailer.rb
+++ b/app/mailers/accounting_mailer.rb
@@ -120,6 +120,16 @@ class AccountingMailer < ApplicationMailer
          cc: %w[steven.olson@gumroad.com]
   end
 
+  def global_sales_tax_summary_report_failed(month, year, error_class, error_message)
+    @month = month
+    @year = year
+    @error_class = error_class
+    @error_message = error_message
+
+    mail subject: "#{SUBJECT_PREFIX}Global Sales Tax Summary Report failed - #{month}/#{year}",
+         to: PAYMENTS_NOTIFICATION_EMAIL
+  end
+
   def ytd_sales_report(csv_data, recipient_email)
     attachments["ytd_sales_by_country_state.csv"] = {
       data: ::Base64.encode64(csv_data),

--- a/app/sidekiq/create_global_sales_tax_summary_report_job.rb
+++ b/app/sidekiq/create_global_sales_tax_summary_report_job.rb
@@ -4,6 +4,13 @@ class CreateGlobalSalesTaxSummaryReportJob
   include Sidekiq::Job
   sidekiq_options retry: 1, queue: :default, lock: :until_executed
 
+  sidekiq_retries_exhausted do |job, exception|
+    month, year = job["args"]
+    AccountingMailer.global_sales_tax_summary_report_failed(
+      month, year, exception.class.name, exception.message
+    ).deliver_later
+  end
+
   # GROUP BY uses HEX(CAST(... AS BINARY)) to prevent MySQL's case-insensitive collation
   # from silently merging rows like "USA" and "usa" — Ruby handles normalization instead.
   BINARY_SAFE_KEY_COLUMNS = {

--- a/app/views/accounting_mailer/global_sales_tax_summary_report_failed.html.erb
+++ b/app/views/accounting_mailer/global_sales_tax_summary_report_failed.html.erb
@@ -1,0 +1,9 @@
+<%= header_section("Global Sales Tax Summary Report failed - #{@month}/#{@year}") %>
+<div>
+  <p><code>CreateGlobalSalesTaxSummaryReportJob</code> exhausted Sidekiq retries and did not produce the report.</p>
+  <ul>
+    <li>Period: <%= @month %>/<%= @year %></li>
+    <li>Error: <%= @error_class %>: <%= @error_message %></li>
+  </ul>
+  <p>Re-run <code>CreateGlobalSalesTaxSummaryReportJob.perform_async(<%= @month %>, <%= @year %>)</code> after addressing the failure. See Sentry and the Sidekiq dead set for more details.</p>
+</div>

--- a/spec/mailers/accounting_mailer_spec.rb
+++ b/spec/mailers/accounting_mailer_spec.rb
@@ -149,6 +149,30 @@ describe AccountingMailer, :vcr do
     end
   end
 
+  describe "#global_sales_tax_summary_report_failed" do
+    let(:mail) do
+      AccountingMailer.global_sales_tax_summary_report_failed(
+        2, 2026, "WithMaxExecutionTime::QueryTimeoutError", "Mysql2::Error: Query execution was interrupted, maximum statement execution time exceeded"
+      )
+    end
+
+    it "sends to the payments notification email" do
+      expect(mail.to).to eq([PAYMENTS_NOTIFICATION_EMAIL])
+    end
+
+    it "includes the period in the subject" do
+      expect(mail.subject).to include("Global Sales Tax Summary Report failed - 2/2026")
+    end
+
+    it "includes the failure context and restart instructions in the body" do
+      body = mail.body.encoded
+      expect(body).to include("2/2026")
+      expect(body).to include("WithMaxExecutionTime::QueryTimeoutError")
+      expect(body).to include("maximum statement execution time exceeded")
+      expect(body).to include("CreateGlobalSalesTaxSummaryReportJob.perform_async")
+    end
+  end
+
   describe "ytd_sales_report" do
     let(:csv_data) { "country,state,sales\\nUSA,CA,100\\nUSA,NY,200" }
     let(:recipient_email) { "test@example.com" }

--- a/spec/sidekiq/create_global_sales_tax_summary_report_job_spec.rb
+++ b/spec/sidekiq/create_global_sales_tax_summary_report_job_spec.rb
@@ -6,6 +6,21 @@ describe CreateGlobalSalesTaxSummaryReportJob do
   let(:month) { 1 }
   let(:year) { 2024 }
 
+  describe "sidekiq_retries_exhausted" do
+    it "emails the payments notification with the failure context when an unhandled exception kills the job" do
+      job = { "args" => [2, 2026] }
+      exception = WithMaxExecutionTime::QueryTimeoutError.new("Mysql2::Error: Query execution was interrupted, maximum statement execution time exceeded")
+      mailer = double("mailer")
+
+      expect(AccountingMailer).to receive(:global_sales_tax_summary_report_failed)
+        .with(2, 2026, "WithMaxExecutionTime::QueryTimeoutError", "Mysql2::Error: Query execution was interrupted, maximum statement execution time exceeded")
+        .and_return(mailer)
+      expect(mailer).to receive(:deliver_later)
+
+      described_class.sidekiq_retries_exhausted_block.call(job, exception)
+    end
+  end
+
   it "raises an argument error if the year is out of bounds" do
     expect { described_class.new.perform(month, 2013) }.to raise_error(ArgumentError)
   end


### PR DESCRIPTION
## What

`CreateGlobalSalesTaxSummaryReportJob` — run every month by `GenerateFinancialReportsForPreviousMonthJob`'s cron — now alerts the payments team when it dies from an **unhandled exception**. It gains a `sidekiq_retries_exhausted` handler that emails `PAYMENTS_NOTIFICATION_EMAIL` (via a new `AccountingMailer.global_sales_tax_summary_report_failed`) with the report period and the failing exception's class and message.

## Why

The job wraps its aggregation queries in `WithMaxExecutionTime.timeout_queries`. When a query exceeds the limit it raises `WithMaxExecutionTime::QueryTimeoutError`; any other unhandled exception behaves the same. The job is configured with `retry: 1` and had **no `sidekiq_retries_exhausted` handler**, so once retries were exhausted it landed in the Sidekiq dead set with no notification. In practice a failed monthly run was only noticed when a report turned up missing, and had to be restarted by hand.

This brings the job to parity with `CreateUsStatesSalesSummaryReportJob`, which already has this alert. It intentionally covers only job death from unhandled exceptions — not the per-record errors the job already handles inline.

## Before / After

- **Before:** job exhausts retries → dead set → no alert → silent until someone notices a missing report.
- **After:** job exhausts retries → email to the payments notification address with the period, `error_class`, `error_message`, and the exact `CreateGlobalSalesTaxSummaryReportJob.perform_async(month, year)` command to restart.

This is a backend/Sidekiq change with no UI surface; a short walkthrough video of the existing monthly-report flow and the new alert path will be attached.

## Test Results

New, focused specs pass locally:

```
bundle exec rspec spec/sidekiq/create_global_sales_tax_summary_report_job_spec.rb -e "sidekiq_retries_exhausted" \
  spec/mailers/accounting_mailer_spec.rb -e "global_sales_tax_summary_report_failed"
# => 4 examples, 0 failures
```

The job spec's `report generation` examples depend on a seeded platform merchant account that isn't present locally (pre-existing, unrelated to this change); they pass in CI.

## QA

1. Enqueue a run that is forced to fail, e.g. set the redis timeout key very low and run for a heavy month so the aggregation query times out:
   `$redis.set(RedisKey.create_global_sales_tax_summary_report_job_max_execution_time_seconds, 1)` then `CreateGlobalSalesTaxSummaryReportJob.perform_async(month, year)`.
2. Let Sidekiq exhaust the single retry.
3. Confirm an email titled "Global Sales Tax Summary Report failed - M/YYYY" arrives at the payments notification address, containing the exception class/message and the restart command.
4. Reset the timeout key.

ref: antiwork/gumroad-private#673

---

AI disclosure: Implemented with Claude Opus 4.8. Production Sidekiq dead/retry sets were inspected (read-only) to identify the failing job and its exception class before writing the fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change: no report logic or success-path behavior is modified; only failure notification after retries are exhausted.
> 
> **Overview**
> When **`CreateGlobalSalesTaxSummaryReportJob`** exhausts its Sidekiq retry, the payments team now gets an email instead of the failure sitting only in the dead set.
> 
> A **`sidekiq_retries_exhausted`** hook on the job calls new **`AccountingMailer#global_sales_tax_summary_report_failed`**, which emails **`PAYMENTS_NOTIFICATION_EMAIL`** with the report month/year, exception class and message, and a **`perform_async`** restart hint (HTML template added). This matches the existing US states sales summary failure alert pattern.
> 
> Specs cover the exhausted-retry mailer path and the new mailer method.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e4f74500d7e6d38f0a30f2ce04a76616cd0bce5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785088229&installation_id=134400930&pr_number=5582&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5582&signature=8f938a457d453a37d0fa65f4441c4a5298abc0062184863307e562528f5fda0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->