### PR TITLE
Saved-card coexistence: enter a new card via Payment Element

### DIFF
--- a/app/javascript/components/Checkout/PaymentForm.tsx
+++ b/app/javascript/components/Checkout/PaymentForm.tsx
@@ -742,17 +742,29 @@ const CreditCardContent = () => {
 
   return (
     <div className="flex flex-col gap-4">
-      {stripePaymentElementConfig ? (
-        <PaymentElementInput
-          amount={stripePaymentElementAmount}
-          elementsOptions={stripePaymentElementConfig}
-          disabled={isProcessing(state)}
-          onReady={(controller) => (paymentElementRef.current = controller)}
-          invalid={cardError}
-          onChange={(evt) => {
-            if (evt.complete) setCardError(false);
-          }}
-        />
+      {stripePaymentElementConfig && !useSavedCard ? (
+        <div className="flex flex-col gap-2">
+          {state.savedCreditCard ? (
+            <button
+              type="button"
+              className="cursor-pointer self-start font-normal underline all-unset"
+              disabled={isProcessing(state)}
+              onClick={() => setUseSavedCard(true)}
+            >
+              Use saved card
+            </button>
+          ) : null}
+          <PaymentElementInput
+            amount={stripePaymentElementAmount}
+            elementsOptions={stripePaymentElementConfig}
+            disabled={isProcessing(state)}
+            onReady={(controller) => (paymentElementRef.current = controller)}
+            invalid={cardError}
+            onChange={(evt) => {
+              if (evt.complete) setCardError(false);
+            }}
+          />
+        </div>
       ) : (
         <CreditCardInput
           savedCreditCard={state.savedCreditCard}

--- a/app/javascript/components/Checkout/payment.test.ts
+++ b/app/javascript/components/Checkout/payment.test.ts
@@ -97,14 +97,14 @@ describe("canUseStripePaymentElement", () => {
     expect(canUseStripePaymentElement(state({ checkoutPayment: cardElementConfig }))).toBe(false);
   });
 
-  it("falls back when a saved card is available", () => {
+  it("allows a checkout when a saved card is available (the saved-card toggle handles it)", () => {
     expect(
       canUseStripePaymentElement(
         state({
           savedCreditCard: { type: "visa", number: "**** 4242", expiration_date: "12/30", requires_mandate: false },
         }),
       ),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("falls back for reusable payment method flows", () => {

--- a/app/javascript/components/Checkout/payment.ts
+++ b/app/javascript/components/Checkout/payment.ts
@@ -168,7 +168,6 @@ export function canUseStripePaymentElement(state: State) {
 
   return (
     state.checkoutPayment.integration === "payment_element" &&
-    !state.savedCreditCard &&
     !requiresReusablePaymentMethod(state) &&
     !state.products.some(
       (product) => product.payInInstallments || product.hasFreeTrial || product.nativeType === "commission",

--- a/app/presenters/checkout/stripe_payment_presenter.rb
+++ b/app/presenters/checkout/stripe_payment_presenter.rb
@@ -52,7 +52,6 @@ class Checkout::StripePaymentPresenter
 
     def fallback_reason_for(items)
       return "empty_cart" if items.empty?
-      return "saved_credit_card" if saved_credit_card.present?
 
       sellers = items.map { _1[:seller] }.uniq
       return "unknown_seller" if sellers.any?(&:blank?)

--- a/spec/presenters/checkout/stripe_payment_presenter_spec.rb
+++ b/spec/presenters/checkout/stripe_payment_presenter_spec.rb
@@ -36,6 +36,24 @@ describe Checkout::StripePaymentPresenter do
     )
   end
 
+  it "selects Stripe Payment Element even when the buyer has a saved card" do
+    seller = create(:user)
+    product = create(:product, user: seller, price_cents: 1234)
+    Feature.activate_user(described_class::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, seller)
+    saved_credit_card = { type: "visa", number: "**** **** **** 4242", expiration_date: "12/30", requires_mandate: false }
+
+    expect(stripe_payment_props(add_products: [checkout_product_for(product)], saved_credit_card:)).to eq(
+      integration: described_class::STRIPE_PAYMENT_ELEMENT_INTEGRATION,
+      fallback_reason: nil,
+      elements_options: {
+        mode: "payment",
+        currency: "usd",
+        payment_method_types: ["card"],
+        payment_method_creation: "manual",
+      },
+    )
+  end
+
   it "falls back to CardElement when the Stripe Payment Element seller flag is disabled" do
     product = create(:product, price_cents: 1234)
 

--- a/spec/presenters/checkout_presenter_spec.rb
+++ b/spec/presenters/checkout_presenter_spec.rb
@@ -214,7 +214,7 @@ describe CheckoutPresenter do
         default_tip_option: 15,
         checkout_payment: {
           integration: Checkout::StripePaymentPresenter::STRIPE_CARD_ELEMENT_INTEGRATION,
-          fallback_reason: "saved_credit_card",
+          fallback_reason: "stripe_payment_element_flag_disabled",
           elements_options: nil,
         },
       )


### PR DESCRIPTION
Stacked on the Stripe Payment Element foundation (#5583). Follow-up from the updated plan: **saved-card coexistence**.

## What
Lets a buyer who has a saved card choose to enter a **new** card through the Payment Element, while the existing saved-card checkout stays exactly as-is.

- `StripePaymentPresenter` no longer falls back to CardElement just because a saved card is on file.
- `canUseStripePaymentElement` drops the saved-card exclusion.
- In `PaymentForm`, the saved card is shown by default with the existing toggle; **Use a different card** mounts the Payment Element, **Use saved card** returns to it.

## Per the plan — explicitly NOT doing
- Saved-card display/storage unchanged (Gumroad's own UI + stored card).
- No Stripe Payment Element saved-method UI, no CustomerSession.
- Saved-card charge path unchanged (order omits card params; Rails uses the stored card).

## Verification
- ✅ Server decision matrix (all cases): only the saved-card cart flips to `payment_element`; multi-seller, recurring, commission, installments, free-trial, preorder, $0, unflagged all stay `card_element`.
- ✅ Browser: saved card shown by default; 'Use a different card' mounts the Payment Element; 'Use saved card' returns.
- ✅ `stripe_payment_presenter_spec` (incl. new saved-card test) + touched `checkout_presenter_spec`; rubocop/eslint/tsc clean.
- ⚠️ Payment-completion browser flow not re-confirmed (local login automation flaky); saved-card pay path is unchanged existing code.

Open question: server returns `payment_element` for saved-card carts with the client defaulting to the saved card; alternative is to keep the server lane `card_element` and treat PE as a separate new-card path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785098029&installation_id=134400930&pr_number=5585&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5585&signature=b049b8d41fdf65308065e0753bb5576071c50c8f256587fb70d12e3867318ee3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->