### PR TITLE
Fix AU mobile phone validation [option 1: bump libphonenumber-js] (gumroad-private#733)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "immer": "^10.0.0",
         "js-yaml": "^4.1.0",
         "json-schema-to-ts": "^3.0.0",
-        "libphonenumber-js": "^1.12.23",
+        "libphonenumber-js": "^1.13.7",
         "lodash-es": "^4.17.22",
         "lowlight": "^3.0.0",
         "pdfjs-dist": "4.5.136",
@@ -9903,9 +9903,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.12.23",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.23.tgz",
-      "integrity": "sha512-RN3q3gImZ91BvRDYjWp7ICz3gRn81mW5L4SW+2afzNCC0I/nkXstBgZThQGTE3S/9q5J90FH4dP+TXx8NhdZKg==",
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.7.tgz",
+      "integrity": "sha512-rvr3HIMdOgzhz1RFGjftji+wjoAFlzhqCNqJOU/MKTZQ8d9NZxAR/tI+0weDicyoucqVR0U1GCniqHJ0f8aM2A==",
       "license": "MIT"
     },
     "node_modules/lightningcss": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "immer": "^10.0.0",
     "js-yaml": "^4.1.0",
     "json-schema-to-ts": "^3.0.0",
-    "libphonenumber-js": "^1.12.23",
+    "libphonenumber-js": "^1.13.7",
     "lodash-es": "^4.17.22",
     "lowlight": "^3.0.0",
     "pdfjs-dist": "4.5.136",


### PR DESCRIPTION
## Option 1 of 2 — Dependency bump (immediate unblock)

Draft fix for the AU mobile phone rejection in payout settings. **Investigation:** antiwork/gumroad-private#733 (rung: Confirmed).
**Sibling option:** see the companion draft PR that relaxes the validator instead — engineer to decide which (if any) to merge.

### Confirmed root cause
`app/javascript/pages/Settings/Payments/Show.tsx:250-253` validates the payout phone with strict `isValid()`:
```ts
return input && parsePhoneNumberFromString(input, countryCode)?.isValid();
```
The pinned `libphonenumber-js@1.12.23` has stale metadata that does **not** include the AU `0494 6x` mobile block. `isValid()` requires the national number to match a known allocated range, so a genuinely-allocated number (`+61494684171`) is rejected and the form blocks save. Not account- or browser-specific — matches the customer's "multiple browsers/numbers, no JS errors, HTTP 200s" report.

### What this PR does
Bumps `libphonenumber-js` `^1.12.23` → `^1.13.7` (current latest). Minimal change — `package.json` + `package-lock.json` only, no app-code change.

### Verification (real dependency, not mocked)
| version | `isValid("+61494684171","AU")` | control `+61412345678` |
|---|---|---|
| 1.12.23 (current pin) | **false** ❌ | true |
| 1.13.7 (this PR) | **true** ✅ | true |

This inverts the confirmed prediction: the same input that returns `false` at `Show.tsx:630` now returns truthy, letting the form save.

### Trade-off vs. the sibling PR
- ✅ Smallest possible diff; fixes this seller and the rest of the `0494 6x` block.
- ⚠️ Metadata lag **recurs** — a future newly-allocated range will hit the same wall until the next bump. The companion PR (relax `isValid()` → `isPossiblePhoneNumber()`) is the durable guard but changes validation semantics. Doing **both** is reasonable; this one is the immediate unblock.

### Notes
- Pure version bump → autoreview trivial-change exemption.
- Precedent: PR #1662 ("Upgrade libphonenumber to improve validation", merged 2025-10-14) set the current pin; the team already treats validation gaps as "bump the lib."

Opened as **draft** for your merge decision — not converting to ready or merging without your go-ahead.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785163425&installation_id=134400930&pr_number=5593&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5593&signature=e51e40f6f82c7db160fc0ad7f96f7b006f1a91b9bdd5caad647967fdcde2d9e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only version bump with no logic changes; risk is limited to broader phone validation behavior shifts from updated libphonenumber metadata.
> 
> **Overview**
> Bumps **`libphonenumber-js`** from `^1.12.23` to `^1.13.7` in `package.json` and `package-lock.json` only—no application code changes.
> 
> Payout settings still validate phones with `parsePhoneNumberFromString(...).isValid()` in `Show.tsx`, but the newer library metadata recognizes recently allocated AU mobile ranges (e.g. `0494 6x`), so valid numbers that were incorrectly rejected can pass and save.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dfe31870885dbb62ef0e6825a20ae622a789376. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->