### PR TITLE
Fix AU mobile phone validation [option 2: relax to isPossible()] (gumroad-private#733)

### DIFF
--- a/app/javascript/pages/Settings/Payments/Show.tsx
+++ b/app/javascript/pages/Settings/Payments/Show.tsx
@@ -249,7 +249,12 @@ export default function PaymentsPage() {
 
   const validatePhoneNumber = (input: string | null, country_code: string | null) => {
     const countryCode: CountryCode = typia.assert<CountryCode>(country_code);
-    return input && parsePhoneNumberFromString(input, countryCode)?.isValid();
+    // Use isPossible() (length/structure) rather than isValid() (exact allocated-range
+    // membership). isValid() depends on bundled libphonenumber-js metadata that lags the
+    // real numbering plan, so legitimately-allocated numbers in newly-added ranges (e.g.
+    // AU 0494 6x) get wrongly rejected. Stripe performs the authoritative KYC validation
+    // downstream. See antiwork/gumroad-private#733.
+    return input && parsePhoneNumberFromString(input, countryCode)?.isPossible();
   };
 
   const validateKanaField = (


### PR DESCRIPTION
## Option 2 of 2 — Relax the validator (durable guard)

Draft fix for the AU mobile phone rejection in payout settings. **Investigation:** antiwork/gumroad-private#733 (rung: Confirmed).
**Sibling option:** see the companion draft PR that bumps `libphonenumber-js` instead — engineer to decide which (if any) to merge.

### Confirmed root cause
`app/javascript/pages/Settings/Payments/Show.tsx:250-253` validates the payout phone with strict `isValid()`, which requires the national number to match a known allocated range in the **bundled** `libphonenumber-js` metadata. That metadata lags the real numbering plan, so a genuinely-allocated AU mobile (`+61494684171`, in the `0494 6x` block) is rejected and the form blocks save. Not account- or browser-specific.

### What this PR does
Changes the validator from `isValid()` → `isPossible()` — length/structure validation instead of exact allocated-range membership. One-line logic change (plus an explanatory comment):
```ts
return input && parsePhoneNumberFromString(input, countryCode)?.isPossible();
```
This accepts well-formed numbers in ranges the bundled metadata doesn't yet know about, while still rejecting structurally-invalid input. Stripe performs the authoritative KYC validation downstream, so loosening this client-side check doesn't weaken real verification.

### Verification (real dependency, current pinned 1.12.23 — no bump needed)
| input | `isValid()` (current) | `isPossible()` (this PR) |
|---|---|---|
| `+61494684171` (the bug) | **false** ❌ | **true** ✅ |
| `+61412345678` (control) | true | true |
| `+61123` (junk) | false | **false** ✅ still rejected |

This inverts the confirmed prediction without changing the dependency.

### Trade-off vs. the sibling PR
- ✅ **Durable** — resilient to future metadata lag for *any* country, not just today's AU range. The more robust fix for a global payout form.
- ⚠️ Changes validation semantics: `isPossible()` is laxer than `isValid()` (accepts structurally-valid-but-unallocated numbers). Acceptable here because Stripe is the authoritative validator, but it's a real behavior change reviewers should weigh — vs. the sibling PR's smaller, semantics-preserving dep bump.
- Doing **both** is reasonable: bump for correctness today + relax for resilience tomorrow.

### Checks
- **autoreview (Codex/gpt-5.5): clean** — "no actionable defect introduced by this diff" (0.88). Verified the one surfaced lint finding by removing a committed repro harness that would have tripped the repo `no-console` rule; final diff is the one-line logic change only.
- `pnpm format` applied.

Opened as **draft** for your merge decision — not converting to ready or merging without your go-ahead.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785163710&installation_id=134400930&pr_number=5594&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5594&signature=973cfea8847c5f3f660b26f12ec95afda07b249c26846736e5175418810aaaa6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single client-side validation tweak on payout compliance phones; stricter server/Stripe checks still apply, with slightly looser acceptance of structurally valid but unallocated numbers.
> 
> **Overview**
> Fixes payout settings blocking saves when **libphonenumber-js** rejects real numbers because bundled metadata lags the live numbering plan (e.g. AU `0494 6x` mobiles).
> 
> In `validatePhoneNumber` on the Payments settings page, client-side checks switch from **`isValid()`** to **`isPossible()`**, so validation is length/structure only instead of requiring a known allocated range. Personal and business phone fields both use this helper on submit. Structurally invalid numbers are still rejected; Stripe remains the authoritative KYC check downstream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c520d5d96fd4809383a4837f514cfceeef7e092. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->