### PR TITLE
Don't moderate a seller's own first-party storefront URL as content (gumroad-private#727)

### DIFF
--- a/app/services/content_moderation/content_extractor.rb
+++ b/app/services/content_moderation/content_extractor.rb
@@ -11,17 +11,75 @@ class ContentModeration::ContentExtractor
   def extract_from_product(product)
     description_text = Nokogiri::HTML(product.description.to_s).text
     text = "Name: #{product.name} Description: #{description_text} " + rich_content_text(product.alive_rich_contents)
+    text = strip_seller_first_party_urls(text, product.user)
     Result.new(text: text, image_urls: product_image_urls(product))
   end
 
   def extract_from_post(installment)
     parsed_message = Nokogiri::HTML(installment.message)
     text = "Name: #{installment.name} Message: #{parsed_message.text}"
+    text = strip_seller_first_party_urls(text, installment.user)
     image_urls = parsed_message.css("img").filter_map { |img| img["src"] }.reject(&:empty?)
     Result.new(text: text, image_urls: image_urls)
   end
 
   private
+    # A seller linking to their OWN storefront/profile (or one of their own
+    # product pages) is inherently first-party and must never be treated as
+    # policy-violating content. Domain labels are arbitrary identifiers
+    # (usernames, brand names) that can coincidentally contain a blocklisted
+    # word as a boundary-delimited token, producing false positives such as a
+    # bulk email being rejected for including the seller's own subdomain URL.
+    # We neutralize only the scheme+host (the arbitrary domain label) of the
+    # seller's own URLs, while PRESERVING any path/query text so user-controlled
+    # content in a permalink or query string is still moderated. Third-party
+    # URLs are left fully intact so genuine off-site abuse is still caught.
+    def strip_seller_first_party_urls(text, seller)
+      hosts = seller_first_party_hosts(seller)
+      return text if hosts.empty?
+
+      text.gsub(URI::DEFAULT_PARSER.make_regexp(%w[http https])) do |url|
+        uri = begin
+          URI.parse(url)
+        rescue URI::InvalidURIError
+          nil
+        end
+        next url unless uri&.host && hosts.include?(uri.host.downcase)
+
+        # Drop scheme+host (the false-positive domain label); keep path/query/
+        # fragment so any blocklisted term the seller put after the host is still
+        # seen by the keyword/AI strategies.
+        remainder = [uri.path.presence, uri.query.present? ? "?#{uri.query}" : nil,
+                     uri.fragment.present? ? "##{uri.fragment}" : nil].compact.join
+        remainder.presence || " "
+      end
+    end
+
+    def seller_first_party_hosts(seller)
+      return [] if seller.blank?
+
+      # Only treat a custom domain as first-party when it is ACTIVE (verified +
+      # valid cert) — matching UrlService#custom_domain_with_protocol. An alive
+      # but unverified custom domain can be an arbitrary off-site URL the seller
+      # set without proving ownership, so stripping it would let genuine off-site
+      # links bypass moderation.
+      custom_domain = seller.custom_domain&.active? ? seller.custom_domain.domain : nil
+
+      [seller.subdomain, custom_domain]
+        .compact_blank
+        .filter_map { |value| normalize_host(value) }
+        .uniq
+    end
+
+    # `subdomain` carries a `:port` in dev/test (e.g. "name.test.gumroad.com:31337")
+    # while `URI.parse(url).host` never does, so normalize both sides to a bare,
+    # port-less, scheme-less hostname before comparing.
+    def normalize_host(value)
+      URI.parse(value.include?("//") ? value : "//#{value}").host&.downcase
+    rescue URI::InvalidURIError
+      nil
+    end
+
     def product_image_urls(product)
       cover_image_urls = product.display_asset_previews.joins(file_attachment: :blob)
                                 .where(active_storage_blobs: { content_type: PERMITTED_IMAGE_TYPES })

--- a/spec/services/content_moderation/content_extractor_spec.rb
+++ b/spec/services/content_moderation/content_extractor_spec.rb
@@ -159,5 +159,62 @@ RSpec.describe ContentModeration::ContentExtractor do
 
       expect(result.image_urls).to eq(["https://cdn.example.com/post.png"])
     end
+
+    context "when the message links to the seller's own first-party storefront" do
+      let(:seller) { create(:user, username: "xinnxsya") }
+      let(:post) do
+        build(
+          :post,
+          seller:,
+          name: "Weekly update",
+          message: %(<p>New drop here: #{seller.subdomain_with_protocol}</p>)
+        )
+      end
+
+      it "strips the seller's own subdomain URL from the moderated text" do
+        # Regression for antiwork/gumroad-private#727: a seller's own first-party
+        # storefront URL must never be judged as policy-violating content.
+        result = extractor.extract_from_post(post)
+
+        expect(result.text).not_to include(seller.subdomain)
+        expect(result.text).to include("New drop here:")
+      end
+
+      it "leaves third-party URLs intact so off-site abuse is still moderated" do
+        post.message = %(<p>Mine: #{seller.subdomain_with_protocol} and theirs: https://evil.example.com/scam</p>)
+
+        result = extractor.extract_from_post(post)
+
+        expect(result.text).not_to include(seller.subdomain)
+        expect(result.text).to include("https://evil.example.com/scam")
+      end
+
+      it "does not strip an unverified custom domain (only active ones are first-party)" do
+        # Guard against a moderation bypass: an alive-but-unverified custom domain
+        # is an arbitrary off-site URL the seller never proved they own, so it must
+        # still be moderated. Mirrors UrlService#custom_domain_with_protocol.
+        allow(seller).to receive(:custom_domain).and_return(
+          double(active?: false, domain: "unverified-offsite.example.com")
+        )
+        post.message = %(<p>Check https://unverified-offsite.example.com/x</p>)
+
+        result = extractor.extract_from_post(post)
+
+        expect(result.text).to include("https://unverified-offsite.example.com/x")
+      end
+
+      it "preserves path/query text on the seller's own URL so it is still moderated" do
+        # Only the gibberish domain label is the false positive; user-controlled
+        # path/query text must still reach moderation so a seller can't hide a
+        # blocked term inside their own URL.
+        post.message = %(<p>See #{seller.subdomain_with_protocol}/forbidden-term?q=alsoflagged</p>)
+
+        result = extractor.extract_from_post(post)
+
+        expect(result.text).not_to include(seller.subdomain)
+        expect(result.text).to include("forbidden-term")
+        expect(result.text).to include("alsoflagged")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Draft fix — don't moderate a seller's own first-party storefront URL as content

**Investigation:** antiwork/gumroad-private#727 (rung: Confirmed). Opened as **draft** for your merge decision — not converting to ready or merging without your go-ahead.

### Confirmed root cause
Bulk emails / posts run through the content-moderation pipeline (`Installment#content_moderation_check` → `ModerateRecordService` → `ContentExtractor`). The extractor passed the seller's **own first-party storefront URL** straight to the blocklist/AI strategies. A random-looking subdomain label (the reporting seller's was `xinnxsya.gumroad.com`) trips the AI spam preset's "machine-generated nonsense / random tokens / gibberish" rule (`prompt_strategy.rb:83-84`), producing the generic *"may violate our content guidelines"* block. Removing the link removes the offending token — exactly the seller's reported **"remove link → sends, include link → blocked"** determinism. The prod blocklist is empty (verified, audit-gated), so the flag is the AI spam preset, and the generic seller message narrows it to `PromptStrategy`.

### What this PR does
In `ContentModeration::ContentExtractor`, before the blocklist/AI strategies run, neutralize the **scheme + host** of URLs that point to the seller's own subdomain or active custom domain. Applied to both `extract_from_post` and `extract_from_product`.

Two safeguards were added during review (both have regression tests):
1. **Only an `active?` (verified) custom domain counts as first-party** — matching `UrlService#custom_domain_with_protocol`. An alive-but-unverified custom domain is an arbitrary off-site URL the seller never proved they own, so it must still be moderated (otherwise: a moderation bypass).
2. **Only scheme+host is dropped; path/query/fragment text is preserved** — so a seller can't hide a blocked term inside their own URL path (`…gumroad.com/blocked-term`) and skip moderation.

Third-party URLs are left fully intact so genuine off-site abuse is still caught.

### Verification — D1 RED → GREEN (RSpec, real models)
```
spec/services/content_moderation/content_extractor_spec.rb
  #extract_from_post  ·  "first-party storefront" context
```
| spec | on origin/main | with fix |
|---|---|---|
| strips the seller's own subdomain URL | **RED** ❌ | GREEN ✅ |
| leaves third-party URLs intact | **RED** ❌ | GREEN ✅ |
| does NOT strip an unverified custom domain | (n/a) | GREEN ✅ |
| preserves path/query so it's still moderated | (n/a) | GREEN ✅ |

All 7 `#extract_from_post` examples pass with the fix; the original exact-text-equality spec is unchanged. (The 3 `#extract_from_product` examples fail identically with and without this change — a pre-existing local S3-bucket flake in test *setup*, not introduced here.)

### Checks
- **autoreview (Codex/gpt-5.5): clean** — "no actionable defects introduced." It caught both safeguards above as findings in earlier iterations; I verified each against `UrlService` / `CustomDomain#active?` and fixed them before finalizing.
- `rubocop -a`: no offenses.

### Secondary finding (not fixed here — separate, low priority)
`ModerateRecordService#leave_admin_comment` writes the admin audit comment from **inside** the failing validation transaction, so when a post is blocked the comment INSERT rolls back too — blocked content leaves no admin trail (confirmed: this seller had `COMMENT_COUNT=0`). Worth a separate PR to write the comment outside the transaction; out of scope for this fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5595"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785166232&installation_id=134400930&pr_number=5595&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5595&signature=a9614f18d1ebab1d6d2d37d4144aa42eeb6b98ba96984877a2716822bec4940d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what text reaches blocklist/AI moderation for all posts and products; safeguards limit bypass risk but incorrect host matching could hide or over-strip URLs.
> 
> **Overview**
> Fixes false-positive blocks when sellers include their own Gumroad storefront or product links in posts and product copy (e.g. AI spam rules flagging random-looking subdomain labels).
> 
> **`ContentModeration::ContentExtractor`** now runs **`strip_seller_first_party_urls`** on text from **`extract_from_post`** and **`extract_from_product`**. For `http`/`https` URLs whose host matches the seller’s subdomain or **verified** (`active?`) custom domain, only **scheme + host** are removed; **path, query, and fragment** stay in the moderated text so blocked terms in permalinks are still checked. Third-party URLs are unchanged.
> 
> Specs add a **`#extract_from_post`** context covering subdomain stripping, third-party URLs left intact, unverified custom domains not treated as first-party, and path/query preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit beb5c28b6c2907b4a3607ee10f1dfea9c7ef3948. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->