### PR TITLE
Allow deploys 24/7 (remove Mon-Fri 9am-5pm ET deploy window)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -638,14 +638,6 @@ jobs:
               exit 0
             fi
 
-            # Only deploy Mon-Fri 9am-5pm Eastern
-            CURRENT_HOUR=$(TZ=America/New_York date +%H)
-            CURRENT_DOW=$(TZ=America/New_York date +%u)  # 1=Mon, 7=Sun
-            if [ "$CURRENT_DOW" -gt 5 ] || [ "$CURRENT_HOUR" -lt 9 ] || [ "$CURRENT_HOUR" -ge 17 ]; then
-              echo "Outside deploy window (Mon-Fri 9am-5pm ET). Current: DOW=$CURRENT_DOW Hour=$CURRENT_HOUR. Skipping unblock."
-              exit 0
-            fi
-
             echo "Looking for Buildkite build for commit $COMMIT_SHA on pipeline $ORG_SLUG/$PIPELINE_SLUG..."
             # Fetch builds for the specific commit, including jobs
             BUILD_DATA=$(curl -s -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \


### PR DESCRIPTION
## What

Removes the Mon–Fri 9am–5pm ET deploy window from the `unblock_deployment_from_buildkite` job in `.github/workflows/tests.yml`, so production deploys run **24/7**.

## Why

The job that auto-unblocks the Buildkite deploy step on a green `main` build had a time-window guard:

```bash
# Only deploy Mon-Fri 9am-5pm Eastern
if [ "$CURRENT_DOW" -gt 5 ] || [ "$CURRENT_HOUR" -lt 9 ] || [ "$CURRENT_HOUR" -ge 17 ]; then
  echo "Outside deploy window (Mon-Fri 9am-5pm ET). ... Skipping unblock."
  exit 0
fi
```

This meant any merge to `main` outside business hours (evenings, weekends, holidays) passed CI but never auto-deployed — it sat blocked until someone manually unblocked it or the next weekday window opened. Deploys should be 24/7.

## Change

- Deletes the 6-line `CURRENT_HOUR` / `CURRENT_DOW` time-window check.
- Everything else is unchanged. In particular the `UNBLOCK_DEPLOYMENT_FROM_BUILDKITE != "true"` master switch above it stays — that remains the on/off control for auto-unblock; this PR only removes the *time* restriction, not the feature flag.

## Test plan

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/tests.yml'))"` → YAML valid.
- Verified the surrounding shell block still flows: master-switch guard → find Buildkite build → unblock. No other deploy-window/weekend logic exists in `.github/` or `.buildkite/` (grepped).
- After merge, a green `main` build at any hour/day should auto-unblock the corresponding Buildkite `require-approval` step.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785176766&installation_id=134400930&pr_number=5596&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5596&signature=2a31d26c6735a2b4e18e9f567f187fdf7884cfd8b201b5723c587f2664a7c06f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production deploy timing (more off-hours auto-deploys) while leaving the master unblock flag and Buildkite API behavior intact.
> 
> **Overview**
> **Enables 24/7 auto-unblock** of the Buildkite `require-approval` deploy step after green `main` CI, by removing the Eastern-time weekday/hour guard from `unblock_deployment_from_buildkite` in `.github/workflows/tests.yml`.
> 
> The job still only runs on successful `main` pushes and still honors the **`UNBLOCK_DEPLOYMENT_FROM_BUILDKITE`** secret (`UNBLOCK_DEPLOYMENT != "true"` → skip). Only the deleted shell block that skipped unblocks outside Mon–Fri 9am–5pm ET is gone; Buildkite lookup and unblock API calls are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 168f5db809dae4deecada4a6ffe4fae3b9802f48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->