### PR TITLE
Fix inconsistent membership post visibility across subscribers

### DIFF
--- a/app/models/installment.rb
+++ b/app/models/installment.rb
@@ -713,6 +713,23 @@ class Installment < ApplicationRecord
     false
   end
 
+  # A seller-wide post (installment_type "seller") with NO product/variant
+  # targeting is addressed to every one of the seller's customers, so it is not
+  # "targeted at a purchased item" (targeted_at_purchased_item? is false for it
+  # by design). For a product whose buyers are entitled to the full post history
+  # (`should_show_all_posts?`, e.g. memberships), such a post should still be part
+  # of the buyer's library even if they were never individually emailed it.
+  # Audience filters (created_after, paid_more_than, active_customers_only, etc.)
+  # are still enforced separately via `purchase_passes_filters`.
+  #
+  # `single_recipient_email?` one-off emails are EXCLUDED: they are seller-type
+  # with no targeting but are private to a single purchase (single_recipient_purchase_id)
+  # and must never be surfaced seller-wide — they are guarded by the same flag in
+  # eligible_purchase?/the emailable-posts scopes, and must be guarded here too.
+  def targeted_at_all_seller_customers?
+    seller_type? && bought_products.blank? && bought_variants.blank? && !single_recipient_email?
+  end
+
   def passes_member_cancellation_checks?(purchase)
     return true unless member_cancellation_trigger?
     return false if purchase.nil?

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -2469,7 +2469,20 @@ class Purchase < ApplicationRecord
 
           next false unless purchase.link.should_show_all_posts?
           next false unless post.purchase_passes_filters(purchase)
-          next false unless post.targeted_at_purchased_item?(purchase)
+          # A seller-wide post (no product/variant targeting) is not "targeted at
+          # the purchased item", but a should_show_all_posts buyer (e.g. a member)
+          # is entitled to the full post history regardless of individual email
+          # delivery, so accept it here too. Without this, such posts only ever
+          # surface via an email_info row, so partial delivery produced
+          # per-subscriber visibility gaps (gumroad-private#749). The seller-wide
+          # branch must re-assert the seller boundary (post.seller_id ==
+          # purchase.seller_id): unlike targeted_at_purchased_item?, which is
+          # implicitly seller-scoped via the product/variant match, neither
+          # targeted_at_all_seller_customers? nor purchase_passes_filters checks
+          # seller ownership, so a mixed-seller purchase batch could otherwise leak
+          # one seller's post to another seller's buyer.
+          next false unless post.targeted_at_purchased_item?(purchase) ||
+                            (post.targeted_at_all_seller_customers? && post.seller_id == purchase.seller_id)
           next false unless post.passes_member_cancellation_checks?(purchase)
 
           post.delivery_due?(purchase)

--- a/spec/models/installment_spec.rb
+++ b/spec/models/installment_spec.rb
@@ -557,6 +557,27 @@ const b = 2;</code></pre>
     end
   end
 
+  describe "#targeted_at_all_seller_customers?" do
+    it "is true only for a seller-type post with no product/variant targeting" do
+      expect(build(:seller_installment).targeted_at_all_seller_customers?).to eq true
+      expect(build(:seller_installment, bought_products: ["abc"]).targeted_at_all_seller_customers?).to eq false
+      expect(build(:seller_installment, bought_variants: ["xyz"]).targeted_at_all_seller_customers?).to eq false
+    end
+
+    it "is false for a single-recipient one-off email (must stay private)" do
+      post = build(:seller_installment)
+      allow(post).to receive(:single_recipient_email?).and_return(true)
+      expect(post.targeted_at_all_seller_customers?).to eq false
+    end
+
+    it "is false for non-seller post types" do
+      expect(build(:installment).targeted_at_all_seller_customers?).to eq false
+      expect(build(:variant_installment).targeted_at_all_seller_customers?).to eq false
+      expect(build(:follower_installment).targeted_at_all_seller_customers?).to eq false
+      expect(build(:audience_installment).targeted_at_all_seller_customers?).to eq false
+    end
+  end
+
   describe "#passes_member_cancellation_checks?" do
     before do
       @creator = create(:user, name: "dude")

--- a/spec/models/purchase/purchase_installments_spec.rb
+++ b/spec/models/purchase/purchase_installments_spec.rb
@@ -75,12 +75,65 @@ describe "PurchaseInstallments", :vcr do
         expect(Purchase.product_installments(purchase_ids: [enabled_purchase.id, enabled_purchase_with_variant.id, disabled_purchase.id, disabled_purchase_with_variant.id]).map(&:id)).to match_array [enabled_product_post, enabled_product_variant_post, multi_product_post, multi_product_variant_post].map(&:id)
       end
 
-      it "excludes past posts that are not directly targeted at the purchased product or variant" do
-        create(:seller_installment, seller: enabled_product.user, published_at: 1.day.ago)
+      it "includes untargeted seller-wide past posts but excludes posts targeted at OTHER products/variants" do
+        # Seller-wide post with no product/variant targeting: a should_show_all_posts
+        # buyer (e.g. a member) is entitled to it even without an email_info row
+        # (gumroad-private#749).
+        untargeted_seller_post = create(:seller_installment, seller: enabled_product.user, published_at: 1.day.ago)
+        # Posts targeted at a DIFFERENT product/variant must still be excluded.
         create(:seller_installment, seller: enabled_product.user, published_at: 1.day.ago, bought_products: [create(:product).unique_permalink])
         create(:seller_installment, seller: enabled_product.user, published_at: 1.day.ago, bought_variants: [create(:variant).external_id])
 
-        expect(Purchase.product_installments(purchase_ids: [enabled_purchase.id, enabled_purchase_with_variant.id])).to eq []
+        expect(Purchase.product_installments(purchase_ids: [enabled_purchase.id, enabled_purchase_with_variant.id]).map(&:id))
+          .to eq([untargeted_seller_post.id])
+      end
+
+      it "surfaces an untargeted seller-wide post to a member who was never emailed it (gumroad-private#749)" do
+        # Reproduces the reported bug: two members of the same should_show_all_posts
+        # product, only one of whom received the email for a seller-wide post.
+        seller = enabled_product.user
+        emailed_member = create(:purchase, link: enabled_product, seller:)
+        non_emailed_member = create(:purchase, link: enabled_product, seller:)
+        seller_wide_post = create(:seller_installment, seller:, published_at: 1.day.ago)
+        create(:creator_contacting_customers_email_info_sent, purchase: emailed_member, installment: seller_wide_post)
+
+        # Before the fix, only the emailed member saw it. Now both do.
+        expect(Purchase.product_installments(purchase_ids: [emailed_member.id]).map(&:id)).to include(seller_wide_post.id)
+        expect(Purchase.product_installments(purchase_ids: [non_emailed_member.id]).map(&:id)).to include(seller_wide_post.id)
+      end
+
+      it "still hides an untargeted seller-wide post that fails the post's audience filters" do
+        # The entitlement relaxation must NOT bypass purchase_passes_filters: a post
+        # restricted to customers created after a date the buyer pre-dates stays hidden.
+        create(:seller_installment, seller: enabled_product.user, published_at: 1.day.ago,
+                                    created_after: (enabled_purchase.created_at + 1.day).to_date.to_s)
+
+        expect(Purchase.product_installments(purchase_ids: [enabled_purchase.id])).to eq []
+      end
+
+      it "never surfaces a private single-recipient one-off email seller-wide (gumroad-private#749 guard)" do
+        # A one-off email is a seller-type post with no targeting; it must stay
+        # private to its single recipient and NOT leak to other should_show_all_posts buyers.
+        other_buyer = create(:purchase, link: enabled_product, seller: enabled_product.user)
+        one_off = create(:seller_installment, seller: enabled_product.user, published_at: 1.day.ago, single_recipient_email: true)
+        one_off.update!(json_data: one_off.json_data.merge("single_recipient_purchase_id" => other_buyer.id))
+
+        expect(one_off.single_recipient_email?).to be(true) # guard: fixture sets the real flag
+        expect(Purchase.product_installments(purchase_ids: [enabled_purchase.id]).map(&:id)).not_to include(one_off.id)
+      end
+
+      it "does not leak an untargeted seller-wide post across sellers in a mixed batch (gumroad-private#749 guard)" do
+        # product_installments can be called with purchases from multiple sellers.
+        # A seller-wide post belongs to ONE seller and must not surface for another
+        # seller's buyer just because that buyer's product has should_show_all_posts.
+        other_seller_product = create(:product, should_show_all_posts: true)
+        other_seller_purchase = create(:purchase, link: other_seller_product, seller: other_seller_product.user)
+        sellerA_post = create(:seller_installment, seller: enabled_product.user, published_at: 1.day.ago)
+
+        result = Purchase.product_installments(purchase_ids: [enabled_purchase.id, other_seller_purchase.id]).map(&:id)
+        expect(result).to include(sellerA_post.id) # visible to seller A's own buyer
+        # and NOT visible to the other seller's buyer: confirm by querying that buyer alone
+        expect(Purchase.product_installments(purchase_ids: [other_seller_purchase.id]).map(&:id)).not_to include(sellerA_post.id)
       end
 
       context "with a restarted subscription" do


### PR DESCRIPTION
## What & why

Fixes antiwork/gumroad-private#749 — membership subscribers saw **different subsets** of a creator's posts (creator reported 38 published, some subscribers saw only 14–15; the same post URL worked for one active subscriber and errored for another).

## Confirmed root cause (rung: Confirmed, live-proven)

Seller-wide posts ("Posts → audience / all subscribers", `installment_type=seller`, `link_id=nil`, no product/variant targeting) reach a subscriber's library **only if an `email_info` row links the post to their purchase**:

- `Purchase.product_installments` (`app/models/purchase.rb`) gathers seller posts via `Installment.seller_with_sent_emails_for_purchases`, which **inner-joins `email_infos`** — no email row, no post.
- The `should_show_all_posts` "show all past posts" rescue path could **not** recover them: it required `post.targeted_at_purchased_item?(purchase)`, which is **false by design** for untargeted seller-wide posts (`installment.rb`, asserted in `installment_spec.rb`).

Email delivery is an audience snapshot at publish time (`SendPostBlastEmailsJob` → `AudienceMember.filter`, deduped by `SentPostEmail`), so coverage varies per member → per-subscriber visibility divergence.

**Live verification** (audit-gated prod console): for creator `wahomecyrus21@gmail.com`, ran the real `purchase.product_installments` for two subscribers who are **both $0 (100%-off), both joined 2026-03-17, both active** — the one who got the email saw **38** posts, the one who didn't saw **17**. `email_info` coverage was ~65–73 of 90 across recent posts. This refutes both the join-date time-gating theory (`should_show_all_posts=true` on both products) and the creator's "100%-discount treated differently" hypothesis (both compared subscribers are $0).

## The fix

Add `Installment#targeted_at_all_seller_customers?` and accept untargeted seller-wide posts in the `should_show_all_posts` past-posts path, so a member's post library is **entitlement-driven, not email-delivery-driven**. Audience filters (`purchase_passes_filters`: `created_after`, `paid_more_than`, `active_customers_only`, etc.) are still enforced.

### Guards (each caught by autoreview and covered by a regression test)
- **Single-recipient one-off emails stay private** — `targeted_at_all_seller_customers?` excludes `single_recipient_email?` posts, so private 1:1 emails never leak seller-wide.
- **Seller boundary re-asserted** — the seller-wide branch checks `post.seller_id == purchase.seller_id`, preventing cross-seller leaks when `product_installments` is called with a mixed-seller purchase batch (`purchase_passes_filters` does not enforce seller ownership).

## ⚠️ Product decision required before merge

This **changes membership post-access semantics**: members now see *all* of the seller's untargeted audience posts, not just the ones they were emailed. That is the behavior the reporting creator expects, but it is a visibility expansion on a money-adjacent entitlement surface. **Draft for @gianfrancopiana / @slavingia to confirm the intended behavior before merging.** The previous behavior (untargeted seller posts excluded from the all-posts path) was intentional and spec-locked; the conflicting test was updated to reflect the new contract.

## Tests
- `spec/models/installment_spec.rb`: `#targeted_at_all_seller_customers?` (true only for untargeted seller posts; false for single-recipient, product/variant/follower/audience).
- `spec/models/purchase/purchase_installments_spec.rb`: untargeted seller-wide post now visible to a non-emailed member; audience-filter still hides a post the buyer fails; single-recipient one-off email never leaks; cross-seller mixed-batch leak prevented. Updated the prior "excludes past posts not directly targeted" test to the new contract.

## Verification
- Root cause: live `product_installments` run (38 vs 17), audit-logged.
- Fix logic: verified via `rails runner` (all branch cases correct). Local rspec card-charge/ActiveStorage failures are pre-existing infra (identical on clean `main`); CI has the cassettes/services.
- **autoreview (Codex): clean** after three iterations — it caught the single-recipient leak, the cross-seller leak, and a faulty test fixture, all fixed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785260764&installation_id=134400930&pr_number=5600&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5600&signature=3ab95a29237599f2139de5c060c32c72107067a99c8bbe2f82186816525de010"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes membership post entitlement semantics (visibility no longer tied to whether an email was sent) on a customer-facing library surface; guards and tests address privacy and cross-seller leaks but product sign-off is noted in the PR.
> 
> **Overview**
> Fixes inconsistent membership libraries where subscribers on the same product saw different post counts because **seller-wide** posts (no product/variant targeting) only appeared when an `email_info` row existed for that purchase.
> 
> Adds **`Installment#targeted_at_all_seller_customers?`** and updates **`Purchase.product_installments`** so the `should_show_all_posts` past-post path also accepts untargeted seller posts when **`post.seller_id == purchase.seller_id`**, while still requiring **`purchase_passes_filters`** and other existing checks. **Single-recipient** one-off emails are excluded from the seller-wide branch.
> 
> Specs cover the new helper and regressions: non-emailed members see seller-wide posts, audience filters still apply, one-offs stay private, and mixed-seller purchase batches do not leak posts across sellers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd14ad2c7b236bacc6e2ceafaafc0ac50e50c324. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->