### PR TITLE
Make payout settings field grids responsive so controls are usable on mobile

### DIFF
--- a/app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx
@@ -539,7 +539,7 @@ const AccountDetailsSection = ({
             </Fieldset>
           </div>
           {complianceInfo.business_country === "JP" ? (
-            <div style={{ display: "grid", gap: "var(--spacer-5)", gridAutoFlow: "column", gridAutoColumns: "1fr" }}>
+            <div className="grid gap-5 md:auto-cols-fr md:grid-flow-col">
               <Fieldset state={errorFieldNames.has("business_name_kanji") ? "danger" : undefined}>
                 <FieldsetTitle>
                   <Label htmlFor={`${uid}-business-name-kanji`}>Business Name (Kanji)</Label>
@@ -573,15 +573,7 @@ const AccountDetailsSection = ({
           ) : null}
           {complianceInfo.business_country === "JP" ? (
             <>
-              <div
-                style={{
-                  display: "grid",
-                  gap: "var(--spacer-5)",
-                  gridAutoFlow: "column",
-                  gridAutoColumns: "1fr",
-                  alignItems: "end",
-                }}
-              >
+              <div className="grid gap-5 md:auto-cols-fr md:grid-flow-col md:items-end">
                 <Fieldset state={errorFieldNames.has("business_building_number") ? "danger" : undefined}>
                   <FieldsetTitle>
                     <Label htmlFor={`${uid}-business-building-number`}>Block / Building number</Label>
@@ -613,7 +605,7 @@ const AccountDetailsSection = ({
                   />
                 </Fieldset>
               </div>
-              <div style={{ display: "grid", gap: "var(--spacer-5)", gridAutoFlow: "column", gridAutoColumns: "1fr" }}>
+              <div className="grid gap-5 md:auto-cols-fr md:grid-flow-col">
                 <Fieldset state={errorFieldNames.has("business_street_address_kanji") ? "danger" : undefined}>
                   <FieldsetTitle>
                     <Label htmlFor={`${uid}-business-street-address-kanji`}>Business town/Cho-me (Kanji)</Label>
@@ -827,7 +819,7 @@ const AccountDetailsSection = ({
         </section>
       ) : null}
       <section className="grid gap-8">
-        <div style={{ display: "grid", gap: "var(--spacer-5)", gridAutoFlow: "column", gridAutoColumns: "1fr" }}>
+        <div className="grid gap-5 md:auto-cols-fr md:grid-flow-col">
           <Fieldset state={errorFieldNames.has("first_name") ? "danger" : undefined}>
             <FieldsetTitle>
               <Label htmlFor={`${uid}-creator-first-name`}>First name</Label>
@@ -860,7 +852,7 @@ const AccountDetailsSection = ({
         </div>
         {complianceInfo.country === "JP" ? (
           <>
-            <div style={{ display: "grid", gap: "var(--spacer-5)", gridAutoFlow: "column", gridAutoColumns: "1fr" }}>
+            <div className="grid gap-5 md:auto-cols-fr md:grid-flow-col">
               <Fieldset state={errorFieldNames.has("first_name_kanji") ? "danger" : undefined}>
                 <FieldsetTitle>
                   <Label htmlFor={`${uid}-creator-first-name-kanji`}>First name (Kanji)</Label>
@@ -890,7 +882,7 @@ const AccountDetailsSection = ({
                 />
               </Fieldset>
             </div>
-            <div style={{ display: "grid", gap: "var(--spacer-5)", gridAutoFlow: "column", gridAutoColumns: "1fr" }}>
+            <div className="grid gap-5 md:auto-cols-fr md:grid-flow-col">
               <Fieldset state={errorFieldNames.has("first_name_kana") ? "danger" : undefined}>
                 <FieldsetTitle>
                   <Label htmlFor={`${uid}-creator-first-name-kana`}>First name (Kana)</Label>
@@ -926,15 +918,7 @@ const AccountDetailsSection = ({
         ) : null}
         {complianceInfo.country === "JP" ? (
           <>
-            <div
-              style={{
-                display: "grid",
-                gap: "var(--spacer-5)",
-                gridAutoFlow: "column",
-                gridAutoColumns: "1fr",
-                alignItems: "end",
-              }}
-            >
+            <div className="grid gap-5 md:auto-cols-fr md:grid-flow-col md:items-end">
               <Fieldset state={errorFieldNames.has("building_number") ? "danger" : undefined}>
                 <FieldsetTitle>
                   <Label htmlFor={`${uid}-creator-building-number`}>Block / Building number</Label>
@@ -966,7 +950,7 @@ const AccountDetailsSection = ({
                 />
               </Fieldset>
             </div>
-            <div style={{ display: "grid", gap: "var(--spacer-5)", gridAutoFlow: "column", gridAutoColumns: "1fr" }}>
+            <div className="grid gap-5 md:auto-cols-fr md:grid-flow-col">
               <Fieldset state={errorFieldNames.has("street_address_kanji") ? "danger" : undefined}>
                 <FieldsetTitle>
                   <Label htmlFor={`${uid}-creator-street-address-kanji`}>Town/Cho-me (Kanji)</Label>
@@ -1154,7 +1138,7 @@ const AccountDetailsSection = ({
             Why does Gumroad need this information?
           </a>
         </FieldsetTitle>
-        <div style={{ display: "grid", gap: "var(--spacer-5)", gridAutoFlow: "column", gridAutoColumns: "1fr" }}>
+        <div className="grid gap-5 md:auto-cols-fr md:grid-flow-col">
           <Fieldset state={errorFieldNames.has("dob_month") ? "danger" : undefined}>
             <Select
               id={`${uid}-creator-dob-month`}

--- a/app/javascript/components/Settings/PaymentsPage/BankAccountSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/BankAccountSection.tsx
@@ -2493,9 +2493,7 @@ const BankAccountSection = ({
             </div>
           ) : (
             <>
-              <section
-                style={{ display: "grid", gap: "var(--spacer-5)", gridAutoFlow: "column", gridAutoColumns: "1fr" }}
-              >
+              <section className="grid gap-5 md:auto-cols-fr md:grid-flow-col">
                 {bankAccountDetails.routing_number !== null && (
                   <Fieldset>
                     <FieldsetTitle>

--- a/app/javascript/components/Settings/PaymentsPage/BeneficialOwnersSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/BeneficialOwnersSection.tsx
@@ -665,14 +665,7 @@ const BeneficialOwnersSection = ({
 
             {editState.mode === "edit" && editState.owner.relationship.representative ? null : (
               <>
-                <div
-                  style={{
-                    display: "grid",
-                    gap: "var(--spacer-5)",
-                    gridAutoFlow: "column",
-                    gridAutoColumns: "1fr",
-                  }}
-                >
+                <div className="grid gap-5 md:auto-cols-fr md:grid-flow-col">
                   <Fieldset>
                     <FieldsetTitle>
                       <Label htmlFor={`${uid}-first-name`}>First name</Label>
@@ -703,14 +696,7 @@ const BeneficialOwnersSection = ({
 
                 {defaultCountry === "JP" ? (
                   <>
-                    <div
-                      style={{
-                        display: "grid",
-                        gap: "var(--spacer-5)",
-                        gridAutoFlow: "column",
-                        gridAutoColumns: "1fr",
-                      }}
-                    >
+                    <div className="grid gap-5 md:auto-cols-fr md:grid-flow-col">
                       <Fieldset>
                         <FieldsetTitle>
                           <Label htmlFor={`${uid}-first-name-kanji`}>First name (Kanji)</Label>
@@ -738,14 +724,7 @@ const BeneficialOwnersSection = ({
                         />
                       </Fieldset>
                     </div>
-                    <div
-                      style={{
-                        display: "grid",
-                        gap: "var(--spacer-5)",
-                        gridAutoFlow: "column",
-                        gridAutoColumns: "1fr",
-                      }}
-                    >
+                    <div className="grid gap-5 md:auto-cols-fr md:grid-flow-col">
                       <Fieldset>
                         <FieldsetTitle>
                           <Label htmlFor={`${uid}-first-name-kana`}>First name (Kana)</Label>
@@ -778,14 +757,7 @@ const BeneficialOwnersSection = ({
                   </>
                 ) : null}
 
-                <div
-                  style={{
-                    display: "grid",
-                    gap: "var(--spacer-5)",
-                    gridAutoFlow: "column",
-                    gridAutoColumns: "1fr",
-                  }}
-                >
+                <div className="grid gap-5 md:auto-cols-fr md:grid-flow-col">
                   <Fieldset>
                     <FieldsetTitle>
                       <Label htmlFor={`${uid}-email`}>Email</Label>
@@ -819,14 +791,7 @@ const BeneficialOwnersSection = ({
                   <FieldsetTitle>
                     <Label>Date of birth</Label>
                   </FieldsetTitle>
-                  <div
-                    style={{
-                      display: "grid",
-                      gap: "var(--spacer-5)",
-                      gridAutoFlow: "column",
-                      gridAutoColumns: "1fr",
-                    }}
-                  >
+                  <div className="grid gap-5 md:auto-cols-fr md:grid-flow-col">
                     <Fieldset>
                       <Select
                         id={`${uid}-dob-month`}
@@ -889,15 +854,7 @@ const BeneficialOwnersSection = ({
 
                 {formState.address_country === "JP" ? (
                   <>
-                    <div
-                      style={{
-                        display: "grid",
-                        gap: "var(--spacer-5)",
-                        gridAutoFlow: "column",
-                        gridAutoColumns: "1fr",
-                        alignItems: "end",
-                      }}
-                    >
+                    <div className="grid gap-5 md:auto-cols-fr md:grid-flow-col md:items-end">
                       <Fieldset>
                         <FieldsetTitle>
                           <Label htmlFor={`${uid}-building-number`}>Block / Building number</Label>
@@ -927,14 +884,7 @@ const BeneficialOwnersSection = ({
                         />
                       </Fieldset>
                     </div>
-                    <div
-                      style={{
-                        display: "grid",
-                        gap: "var(--spacer-5)",
-                        gridAutoFlow: "column",
-                        gridAutoColumns: "1fr",
-                      }}
-                    >
+                    <div className="grid gap-5 md:auto-cols-fr md:grid-flow-col">
                       <Fieldset>
                         <FieldsetTitle>
                           <Label htmlFor={`${uid}-street-address-kanji`}>Town/Cho-me (Kanji)</Label>
@@ -1221,14 +1171,7 @@ const BeneficialOwnersSection = ({
               </>
             )}
 
-            <div
-              style={{
-                display: "grid",
-                gap: "var(--spacer-5)",
-                gridAutoFlow: "column",
-                gridAutoColumns: "1fr",
-              }}
-            >
+            <div className="grid gap-5 md:auto-cols-fr md:grid-flow-col">
               <Fieldset>
                 <FieldsetTitle>
                   <Label htmlFor={`${uid}-title`}>Job title</Label>
@@ -1267,14 +1210,7 @@ const BeneficialOwnersSection = ({
               <FieldsetTitle>
                 <Label>Relationship</Label>
               </FieldsetTitle>
-              <div
-                style={{
-                  display: "grid",
-                  gap: "var(--spacer-5)",
-                  gridAutoFlow: "column",
-                  gridAutoColumns: "1fr",
-                }}
-              >
+              <div className="grid gap-5 md:auto-cols-fr md:grid-flow-col">
                 <Label className="flex items-center gap-2">
                   <Checkbox
                     checked={formState.director}


### PR DESCRIPTION
## What & why

Fixes antiwork/gumroad-private#750.

A Pakistan-based, **mobile-only** seller (no desktop access) reported that the **"Remove bank account" / change-payout-method** option on **Settings → Payments** was not usable on a mobile browser — even with desktop-site mode on — so they could not switch their PKR bank account to a US bank transfer (Payoneer USD).

## Root cause

The Payments settings page laid out its multi-field rows with a **non-responsive inline style**:

```jsx
style={{ display: "grid", gap: "var(--spacer-5)", gridAutoFlow: "column", gridAutoColumns: "1fr" }}
```

`gridAutoFlow: "column"` forces every row into **side-by-side columns at all viewport widths**. On a narrow phone screen the saved-bank-account display, the country / DOB / address selectors, and the beneficial-owner fields cramp and overflow horizontally, pushing controls — including the **"Change account"** button the seller needs to switch payout methods — off-screen or into an unusable layout. Because it's a fixed `gridAutoFlow` (not a width breakpoint), desktop-site mode doesn't reliably rescue it either.

The same file already uses the correct **responsive** convention for the new-bank-account form:

```jsx
className="grid gap-5 md:auto-cols-fr md:grid-flow-col"   // stacks on mobile, columns at md+
```

## The fix

Replace **all 19** forced-column inline grids across three components with that existing responsive Tailwind convention, so every payout row **stacks vertically on mobile** and goes side-by-side at `md` and up:

- `BankAccountSection.tsx` — the saved bank account display (routing + account number) above the **"Change account"** button.
- `AccountDetailsSection.tsx` — country selector, DOB month/day/year, name and address rows (incl. the JP kanji/kana rows; the two that used `alignItems: "end"` become `md:items-end`).
- `BeneficialOwnersSection.tsx` — owner name / DOB / address rows.

Pure presentational change — no behavioral, data, or API change. Net −82 lines (verbose inline styles → one className each).

## Verification

- **autoreview (Codex): clean** (0.91) — "only replaces fixed inline column grid styles with responsive Tailwind grid utilities, matching existing patterns in this codebase."
- Prettier: clean. ESLint: **no new errors** (the 11 pre-existing `Routes.settings_beneficial_owners_path` errors are present identically on `origin/main` and untouched by this diff).
- The responsive classes (`md:auto-cols-fr md:grid-flow-col`) are already proven on this same page (new-bank-account form), so the behavior below `md` is single-column stacking and at/above is the prior side-by-side layout.
- **Mobile before/after screenshots from the running app to follow** (via the `preview` deploy).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785263251&installation_id=134400930&pr_number=5601&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5601&signature=10977122b6b515253a66b2463c31044919fbd3b099e7876d446e5a25e4dc1bd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentational layout-only changes in payout settings UI; desktop layout at md+ should match prior behavior.
> 
> **Overview**
> Replaces **always-horizontal** inline grid styles (`gridAutoFlow: "column"`) on Settings → Payments with the existing responsive Tailwind pattern `grid gap-5 md:auto-cols-fr md:grid-flow-col` (plus `md:items-end` where rows used `alignItems: "end"`).
> 
> Multi-field rows in **Account details**, **saved bank account** display, and **beneficial owners** now **stack on small viewports** and stay side-by-side from `md` up—matching the new-bank-account form already on the page. No logic, API, or data changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2e4b42bfd27b8ee8d4f89bac5e9b8637b1f57a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->