### PR TITLE
Hide deprecated Stripe Connect payout option unless already connected

### DIFF
--- a/app/javascript/pages/Settings/Payments/Show.tsx
+++ b/app/javascript/pages/Settings/Payments/Show.tsx
@@ -1122,9 +1122,7 @@ export default function PaymentsPage() {
                   </Button>
                 </Tab>
               ) : null}
-              {props.user.country_code === "BR" ||
-              props.user.can_connect_stripe ||
-              props.stripe_connect.has_connected_stripe ? (
+              {props.user.country_code === "BR" || props.stripe_connect.has_connected_stripe ? (
                 <Tab key="stripe" isSelected={selectedPayoutMethod === "stripe"} asChild>
                   <Button
                     role="radio"

--- a/app/javascript/types/payments.ts
+++ b/app/javascript/types/payments.ts
@@ -13,7 +13,6 @@ export type User = {
   business_tax_id_entered: boolean;
   business_tax_id_last_four: string | null;
   requires_credit_card: boolean;
-  can_connect_stripe: boolean;
   is_charged_paypal_payout_fee: boolean;
   joined_at: string;
 };

--- a/app/presenters/settings_presenter.rb
+++ b/app/presenters/settings_presenter.rb
@@ -392,7 +392,6 @@ class SettingsPresenter
         business_tax_id_entered: user_compliance_info.business_tax_id.present?,
         business_tax_id_last_four: user_compliance_info.business_tax_id.present? ? user_compliance_info.business_tax_id.decrypt(GlobalConfig.get("STRONGBOX_GENERAL_PASSWORD")).to_s[-4..] : nil,
         requires_credit_card: seller.requires_credit_card?,
-        can_connect_stripe: seller.can_connect_stripe?,
         is_charged_paypal_payout_fee: seller.charge_paypal_payout_fee?,
         joined_at: seller.created_at.iso8601
       }

--- a/spec/presenters/settings_presenter_spec.rb
+++ b/spec/presenters/settings_presenter_spec.rb
@@ -545,7 +545,6 @@ describe SettingsPresenter do
           business_tax_id_entered: false,
           business_tax_id_last_four: nil,
           requires_credit_card: false,
-          can_connect_stripe: false,
           is_charged_paypal_payout_fee: true,
           joined_at: seller.created_at.iso8601,
         },
@@ -1033,16 +1032,6 @@ describe SettingsPresenter do
 
       it "returns the quarterly payout frequency" do
         expect(presenter.payments_props[:payout_frequency]).to eq(User::PayoutSchedule::QUARTERLY)
-      end
-    end
-
-    context "when seller can connect Stripe" do
-      before do
-        seller.update!(can_connect_stripe: true)
-      end
-
-      it "returns true for can_connect_stripe" do
-        expect(presenter.payments_props[:user][:can_connect_stripe]).to eq(true)
       end
     end
 

--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -275,21 +275,13 @@ describe("Payments Settings Scenario", type: :system, js: true) do
       expect(page).to have_button("Disconnect")
     end
 
-    it "allows the creator to connect their Stripe account if they have can_connect_stripe flag enabled" do
+    it "does not show the deprecated Stripe Connect option even if the can_connect_stripe flag is enabled" do
       visit settings_payments_path
       expect(page).not_to have_field("Stripe")
 
       @user.update!(can_connect_stripe: true)
       refresh
-      choose "Stripe"
-      expect(page).to have_content("This feature is available in all countries where Stripe operates, except India, Indonesia, Malaysia, Mexico, Philippines, and Thailand.")
-      expect(page).to have_link("all countries where Stripe operates", href: "https://stripe.com/en-in/global")
-      OmniAuth.config.test_mode = true
-      OmniAuth.config.mock_auth[:stripe_connect] = OmniAuth::AuthHash.new JSON.parse(File.open("#{Rails.root}/spec/support/fixtures/stripe_connect_omniauth.json").read)
-      click_on "Connect with Stripe"
-
-      expect(page).to have_alert(text: "You have successfully connected your Stripe account!")
-      expect(page).to have_button("Disconnect")
+      expect(page).not_to have_field("Stripe")
     end
 
     it "allows the creator to disconnect their Stripe account" do


### PR DESCRIPTION
## What

Hides the deprecated **"Connect to Stripe"** payout-method tab on **Settings → Payments** for sellers who don't already have a Stripe Connect account.

Previously the tab was shown when **any** of these held:

```
user.country_code === "BR"  ||  user.can_connect_stripe  ||  stripe_connect.has_connected_stripe
```

`can_connect_stripe` is a deprecated per-user flag (flag bit 47, off by default). Surfacing the Stripe Connect option to those sellers is confusing — Stripe Connect as a payout rail is deprecated.

## Change

Gate the tab on:

```
user.country_code === "BR"  ||  stripe_connect.has_connected_stripe
```

- **Already-connected sellers** keep the tab so they retain full management + the Disconnect flow.
- **Brazil** keeps it intentionally: Brazil is not in `SUPPORTED_COUNTRIES`, so `native_payouts_supported?` is false — BR sellers have no native bank payouts and rely on Stripe Connect (PayPal remains as fallback).
- The deprecated **`can_connect_stripe`** branch is removed, along with the now-unused `can_connect_stripe` presenter prop (`settings_presenter.rb`) and its TS type field (`types/payments.ts`). The `User#can_connect_stripe?` flag method itself is untouched.

## Why

The extra tab is confusing and points sellers at a deprecated payout method they shouldn't be onboarding onto. Everyone who already uses Stripe Connect is unaffected; Brazil is unaffected.

## Test plan

- Updated `spec/presenters/settings_presenter_spec.rb` (dropped `can_connect_stripe` from the props hash + removed the dedicated context).
- Updated `spec/requests/settings/payments_spec.rb`: the former "flag enables the Stripe tab" test now asserts the flag does **not** reveal the tab. The "Brazil can connect" and "already-connected can disconnect" tests are unchanged and still pass.

## Screenshots

UX screenshots from the running app to follow in a comment below.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785265868&installation_id=134400930&pr_number=5602&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5602&signature=29c8c43c4ee315515eb624a57dc14d8d0fbc3c2607b896db9462c270b347cc68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI gating and prop cleanup on the payments settings page; no changes to payout processing or the disconnect flow for connected accounts.
> 
> **Overview**
> Stops surfacing the deprecated **Connect to Stripe** payout tab on **Settings → Payments** for sellers who only had the legacy `can_connect_stripe` user flag. The tab now appears only when the seller is in **Brazil** or **already has Stripe Connect connected**, so existing users keep manage/disconnect while new onboarding onto that rail is discouraged.
> 
> Removes the unused **`can_connect_stripe`** field from payments page props (`settings_presenter.rb`), the `User` TypeScript type, and related presenter/request specs. The underlying `User#can_connect_stripe?` flag on the model is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23304e8d457e6fc0fe2c12f6c1fa7c05f6b1f5a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->