### PR TITLE
Stream Agent replies, suggest follow-ups, and run on Claude Opus 4.7

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -204,6 +204,9 @@ NOTION_OAUTH_CLIENT_SECRET=
 # OpenAI
 OPENAI_ACCESS_TOKEN=
 
+# Anthropic (Claude — powers the conversational store Agent tab)
+ANTHROPIC_API_KEY=
+
 # Dropbox
 DROPBOX_API_KEY=
 DROPBOX_PICKER_API_KEY=

--- a/.env.production.example
+++ b/.env.production.example
@@ -273,6 +273,9 @@ NOTION_OAUTH_CLIENT_SECRET=
 # OpenAI
 OPENAI_ACCESS_TOKEN=
 
+# Anthropic (Claude — powers the conversational store Agent tab)
+ANTHROPIC_API_KEY=
+
 # Dropbox
 DROPBOX_API_KEY=
 DROPBOX_PICKER_API_KEY=

--- a/app/controllers/agent_controller.rb
+++ b/app/controllers/agent_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Renders the conversational "Agent" dashboard tab.
+class AgentController < Sellers::BaseController
+  before_action :authenticate_user!
+
+  layout "inertia"
+
+  def index
+    authorize current_seller, :use_store_agent?
+
+    set_meta_tag(title: "Agent")
+    render inertia: "Agent/Index", props: AgentPresenter.new(pundit_user:).index_props
+  end
+end

--- a/app/controllers/api/internal/agent_message_streams_controller.rb
+++ b/app/controllers/api/internal/agent_message_streams_controller.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+# Streams one Agent conversation turn as Server-Sent Events, so the reply renders token-by-token and
+# ends with a few follow-up suggestions to keep the conversation going. This lives in its own
+# controller (separate from Api::Internal::AgentMessagesController) because ActionController::Live
+# changes the response object for EVERY action on the controller it's included in — keeping it
+# isolated means the buffered messages/actions endpoints render normal JSON responses.
+#
+# It shares the exact same guards as the buffered endpoints — authentication, the
+# UserPolicy#use_store_agent? authorization, and the per-seller throttle — so the streaming path is
+# no less protected. The read/propose/confirm safety model lives entirely in Ai::StoreAgentService.
+class Api::Internal::AgentMessageStreamsController < Api::Internal::BaseController
+  include Throttling
+  include ActionController::Live
+
+  before_action :authenticate_user!
+  before_action :authorize_store_agent
+  before_action :throttle_agent_requests
+  after_action :verify_authorized
+
+  AGENT_REQUESTS_PER_PERIOD = 30
+  AGENT_REQUESTS_PERIOD_WINDOW = 1.hour
+  private_constant :AGENT_REQUESTS_PER_PERIOD, :AGENT_REQUESTS_PERIOD_WINDOW
+
+  # POST /internal/agent/messages/stream
+  # params: { messages: [{ role:, content: }, ...] }
+  # Each event is `event: <name>` + `data: <json>` + a blank line. Event names: `token` (a chunk of
+  # reply text), `objects`, `proposed_action`, `suggestions`, `done` (terminal, carrying the final
+  # assembled payload), and `error` (a friendly message; the stream still closes cleanly).
+  def create
+    response.headers["Content-Type"] = "text/event-stream"
+    response.headers["Cache-Control"] = "no-cache"
+    # Disable buffering at the proxy (nginx) layer so events flush to the browser as they're written.
+    response.headers["X-Accel-Buffering"] = "no"
+    sse = ActionController::Live::SSE.new(response.stream)
+
+    begin
+      messages = sanitize_messages(params[:messages])
+      if messages.empty?
+        sse.write({ message: "A message is required." }, event: "error")
+        return
+      end
+
+      result = ::Ai::StoreAgentService.new(seller: current_seller, pundit_user:).respond_streaming(messages:) do |event, payload|
+        sse.write(payload, event:)
+      end
+      sse.write(
+        {
+          reply: result[:reply],
+          proposed_action: result[:proposed_action],
+          objects: result[:objects] || [],
+          suggestions: result[:suggestions] || [],
+        },
+        event: "done",
+      )
+    rescue ::Ai::StoreAgentService::Error => e
+      sse.write({ message: e.message }, event: "error")
+    rescue ActionController::Live::ClientDisconnected
+      # The seller navigated away or closed the tab mid-stream. Nothing to surface; just stop.
+    rescue => e
+      Rails.logger.error("Store agent stream failed: #{e.full_message}")
+      ErrorNotifier.notify(e)
+      sse.write({ message: "Something went wrong. Please try again." }, event: "error")
+    ensure
+      sse.close
+    end
+  end
+
+  private
+    def authorize_store_agent
+      authorize current_seller, :use_store_agent?
+    end
+
+    def sanitize_messages(raw)
+      return [] unless raw.is_a?(ActionController::Parameters) || raw.is_a?(Array)
+
+      Array(raw).filter_map do |message|
+        message = message.respond_to?(:to_unsafe_h) ? message.to_unsafe_h : message
+        next unless message.is_a?(Hash)
+
+        role = message[:role] || message["role"]
+        content = (message[:content] || message["content"]).to_s
+        next unless %w[user assistant].include?(role)
+        next if content.strip.blank?
+
+        { role:, content: }
+      end
+    end
+
+    def throttle_agent_requests
+      return unless current_user
+
+      key = RedisKey.agent_request_throttle(current_seller.id)
+      throttle!(key:, limit: AGENT_REQUESTS_PER_PERIOD, period: AGENT_REQUESTS_PERIOD_WINDOW)
+    end
+end

--- a/app/controllers/api/internal/agent_messages_controller.rb
+++ b/app/controllers/api/internal/agent_messages_controller.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+# Backs the Agent chat tab. `create` runs one turn of the conversation (the agent may answer and/or
+# propose a single store change); `execute` applies a change the seller has explicitly confirmed.
+#
+# Both actions authorize against UserPolicy#use_store_agent? and are throttled, since they call out
+# to an LLM and can mutate the store.
+class Api::Internal::AgentMessagesController < Api::Internal::BaseController
+  include Throttling
+
+  before_action :authenticate_user!
+  before_action :throttle_agent_requests
+  after_action :verify_authorized
+
+  AGENT_REQUESTS_PER_PERIOD = 30
+  AGENT_REQUESTS_PERIOD_WINDOW = 1.hour
+  private_constant :AGENT_REQUESTS_PER_PERIOD, :AGENT_REQUESTS_PERIOD_WINDOW
+
+  # POST /internal/agent/messages
+  # params: { messages: [{ role:, content: }, ...] }
+  def create
+    authorize current_seller, :use_store_agent?
+
+    messages = sanitize_messages(params[:messages])
+    if messages.empty?
+      render json: { success: false, error: "A message is required." }, status: :bad_request
+      return
+    end
+
+    begin
+      result = ::Ai::StoreAgentService.new(seller: current_seller, pundit_user:).respond(messages:)
+      render json: { success: true, reply: result[:reply], proposed_action: result[:proposed_action] }
+    rescue ::Ai::StoreAgentService::Error => e
+      render json: { success: false, error: e.message }, status: :unprocessable_entity
+    rescue => e
+      Rails.logger.error("Store agent message failed: #{e.full_message}")
+      ErrorNotifier.notify(e)
+      render json: { success: false, error: "Something went wrong. Please try again." }, status: :internal_server_error
+    end
+  end
+
+  # POST /internal/agent/actions
+  # params: { type:, params: {...} } — the confirmed proposed action
+  def execute
+    authorize current_seller, :use_store_agent?
+
+    type = params[:type].to_s
+    unless ::Ai::StoreAgentActionExecutor::SUPPORTED_TYPES.include?(type)
+      render json: { success: false, error: "That action isn't supported." }, status: :bad_request
+      return
+    end
+
+    result = ::Ai::StoreAgentActionExecutor.new(seller: current_seller, pundit_user:)
+      .execute(type:, params: action_params)
+
+    render json: result, status: result[:success] ? :ok : :unprocessable_entity
+  end
+
+  private
+    def sanitize_messages(raw)
+      return [] unless raw.is_a?(ActionController::Parameters) || raw.is_a?(Array)
+
+      Array(raw).filter_map do |message|
+        message = message.respond_to?(:to_unsafe_h) ? message.to_unsafe_h : message
+        next unless message.is_a?(Hash)
+
+        role = message[:role] || message["role"]
+        content = (message[:content] || message["content"]).to_s
+        next unless %w[user assistant].include?(role)
+        next if content.strip.blank?
+
+        { role:, content: }
+      end
+    end
+
+    def action_params
+      raw = params[:params]
+      return {} if raw.blank?
+      raw.respond_to?(:to_unsafe_h) ? raw.to_unsafe_h : raw.to_h
+    end
+
+    def throttle_agent_requests
+      return unless current_user
+
+      key = RedisKey.agent_request_throttle(current_seller.id)
+      throttle!(key:, limit: AGENT_REQUESTS_PER_PERIOD, period: AGENT_REQUESTS_PERIOD_WINDOW)
+    end
+end

--- a/app/controllers/api/internal/agent_messages_controller.rb
+++ b/app/controllers/api/internal/agent_messages_controller.rb
@@ -28,7 +28,7 @@ class Api::Internal::AgentMessagesController < Api::Internal::BaseController
 
     begin
       result = ::Ai::StoreAgentService.new(seller: current_seller, pundit_user:).respond(messages:)
-      render json: { success: true, reply: result[:reply], proposed_action: result[:proposed_action] }
+      render json: { success: true, reply: result[:reply], proposed_action: result[:proposed_action], objects: result[:objects] || [] }
     rescue ::Ai::StoreAgentService::Error => e
       render json: { success: false, error: e.message }, status: :unprocessable_entity
     rescue => e

--- a/app/controllers/api/internal/agent_messages_controller.rb
+++ b/app/controllers/api/internal/agent_messages_controller.rb
@@ -9,6 +9,7 @@ class Api::Internal::AgentMessagesController < Api::Internal::BaseController
   include Throttling
 
   before_action :authenticate_user!
+  before_action :authorize_store_agent
   before_action :throttle_agent_requests
   after_action :verify_authorized
 
@@ -19,8 +20,6 @@ class Api::Internal::AgentMessagesController < Api::Internal::BaseController
   # POST /internal/agent/messages
   # params: { messages: [{ role:, content: }, ...] }
   def create
-    authorize current_seller, :use_store_agent?
-
     messages = sanitize_messages(params[:messages])
     if messages.empty?
       render json: { success: false, error: "A message is required." }, status: :bad_request
@@ -42,11 +41,11 @@ class Api::Internal::AgentMessagesController < Api::Internal::BaseController
   # POST /internal/agent/actions
   # params: { type:, params: {...} } — the confirmed proposed action
   def execute
-    authorize current_seller, :use_store_agent?
-
     type = params[:type].to_s
     unless ::Ai::StoreAgentActionExecutor::SUPPORTED_TYPES.include?(type)
-      render json: { success: false, error: "That action isn't supported." }, status: :bad_request
+      # Use `message` (not `error`) so the client's executeAgentAction response parser, which expects
+      # { success, message }, can surface this instead of failing to parse.
+      render json: { success: false, message: "That action isn't supported." }, status: :bad_request
       return
     end
 
@@ -54,9 +53,21 @@ class Api::Internal::AgentMessagesController < Api::Internal::BaseController
       .execute(type:, params: action_params)
 
     render json: result, status: result[:success] ? :ok : :unprocessable_entity
+  rescue => e
+    # The executor only rescues expected validation failures; log + report anything unexpected from a
+    # real store mutation (e.g. ActiveRecord::StatementInvalid) instead of leaking a 500 with no trail.
+    Rails.logger.error("Store agent action failed: #{e.full_message}")
+    ErrorNotifier.notify(e)
+    render json: { success: false, message: "Something went wrong. Please try again." }, status: :internal_server_error
   end
 
   private
+    # Runs before throttling so a team member denied the Agent tab can't burn the seller-scoped
+    # rate-limit quota for users who are allowed to use it.
+    def authorize_store_agent
+      authorize current_seller, :use_store_agent?
+    end
+
     def sanitize_messages(raw)
       return [] unless raw.is_a?(ActionController::Parameters) || raw.is_a?(Array)
 

--- a/app/controllers/api/mobile/agent_controller.rb
+++ b/app/controllers/api/mobile/agent_controller.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+# Mobile counterpart to Api::Internal::AgentMessagesController. Backs the conversational "Agent" tab
+# in the mobile app. Unlike the web controller (cookie/session auth), this authenticates with the
+# mobile token + a Doorkeeper bearer for the `mobile_api` scope, but it reuses the exact same
+# Ai::StoreAgentService and Ai::StoreAgentActionExecutor, so the read/propose/confirm safety model is
+# identical across web and mobile.
+#
+#   meta   -> greeting + suggested prompts for the empty chat (and whether the seller may use it)
+#   create -> one conversation turn (agent may answer and/or propose a single store change)
+#   execute -> applies a change the seller has explicitly confirmed
+class Api::Mobile::AgentController < Api::Mobile::BaseController
+  include Throttling
+
+  before_action { doorkeeper_authorize! :mobile_api }
+  before_action :ensure_can_use_agent
+
+  AGENT_REQUESTS_PER_PERIOD = 30
+  AGENT_REQUESTS_PERIOD_WINDOW = 1.hour
+  private_constant :AGENT_REQUESTS_PER_PERIOD, :AGENT_REQUESTS_PERIOD_WINDOW
+
+  # GET /mobile/agent/meta
+  def meta
+    render json: {
+      success: true,
+      enabled: true,
+      greeting: AgentPresenter::GREETING,
+      suggestions: AgentPresenter::SUGGESTIONS,
+    }
+  end
+
+  # POST /mobile/agent/messages
+  # params: { messages: [{ role:, content: }, ...] }
+  def create
+    throttle_agent_requests
+
+    messages = sanitize_messages(params[:messages])
+    if messages.empty?
+      render json: { success: false, error: "A message is required." }, status: :bad_request
+      return
+    end
+
+    result = ::Ai::StoreAgentService.new(seller:, pundit_user:).respond(messages:)
+    render json: { success: true, reply: result[:reply], proposed_action: result[:proposed_action] }
+  rescue ::Ai::StoreAgentService::Error => e
+    render json: { success: false, error: e.message }, status: :unprocessable_entity
+  rescue => e
+    Rails.logger.error("Mobile store agent message failed: #{e.full_message}")
+    ErrorNotifier.notify(e)
+    render json: { success: false, error: "Something went wrong. Please try again." }, status: :internal_server_error
+  end
+
+  # POST /mobile/agent/actions
+  # params: { type:, params: {...} } — the confirmed proposed action
+  def execute
+    throttle_agent_requests
+
+    type = params[:type].to_s
+    unless ::Ai::StoreAgentActionExecutor::SUPPORTED_TYPES.include?(type)
+      render json: { success: false, message: "That action isn't supported." }, status: :bad_request
+      return
+    end
+
+    result = ::Ai::StoreAgentActionExecutor.new(seller:, pundit_user:).execute(type:, params: action_params)
+    render json: result, status: result[:success] ? :ok : :unprocessable_entity
+  end
+
+  private
+    def seller
+      current_resource_owner
+    end
+
+    # The mobile bearer maps to a single seller (no team-member impersonation here), so the user and
+    # seller in the SellerContext are the same account — exactly what the service/executor expect.
+    def pundit_user
+      @_pundit_user ||= SellerContext.new(user: seller, seller:)
+    end
+
+    def ensure_can_use_agent
+      return if UserPolicy.new(pundit_user, seller).use_store_agent?
+
+      render json: { success: false, error: "You don't have access to the store agent." }, status: :forbidden
+    end
+
+    def sanitize_messages(raw)
+      return [] unless raw.is_a?(ActionController::Parameters) || raw.is_a?(Array)
+
+      Array(raw).filter_map do |message|
+        message = message.respond_to?(:to_unsafe_h) ? message.to_unsafe_h : message
+        next unless message.is_a?(Hash)
+
+        role = message[:role] || message["role"]
+        content = (message[:content] || message["content"]).to_s
+        next unless %w[user assistant].include?(role)
+        next if content.strip.blank?
+
+        { role:, content: }
+      end
+    end
+
+    def action_params
+      raw = params[:params]
+      return {} if raw.blank?
+      raw.respond_to?(:to_unsafe_h) ? raw.to_unsafe_h : raw.to_h
+    end
+
+    def throttle_agent_requests
+      key = RedisKey.agent_request_throttle(seller.id)
+      throttle!(key:, limit: AGENT_REQUESTS_PER_PERIOD, period: AGENT_REQUESTS_PERIOD_WINDOW)
+    end
+end

--- a/app/controllers/api/mobile/agent_controller.rb
+++ b/app/controllers/api/mobile/agent_controller.rb
@@ -41,7 +41,7 @@ class Api::Mobile::AgentController < Api::Mobile::BaseController
     end
 
     result = ::Ai::StoreAgentService.new(seller:, pundit_user:).respond(messages:)
-    render json: { success: true, reply: result[:reply], proposed_action: result[:proposed_action] }
+    render json: { success: true, reply: result[:reply], proposed_action: result[:proposed_action], objects: result[:objects] || [] }
   rescue ::Ai::StoreAgentService::Error => e
     render json: { success: false, error: e.message }, status: :unprocessable_entity
   rescue => e

--- a/app/controllers/api/mobile/agent_controller.rb
+++ b/app/controllers/api/mobile/agent_controller.rb
@@ -63,6 +63,12 @@ class Api::Mobile::AgentController < Api::Mobile::BaseController
 
     result = ::Ai::StoreAgentActionExecutor.new(seller:, pundit_user:).execute(type:, params: action_params)
     render json: result, status: result[:success] ? :ok : :unprocessable_entity
+  rescue => e
+    # The executor only rescues expected validation failures; log + report anything unexpected from a
+    # real store mutation (e.g. ActiveRecord::StatementInvalid) instead of leaking a 500 with no trail.
+    Rails.logger.error("Mobile store agent action failed: #{e.full_message}")
+    ErrorNotifier.notify(e)
+    render json: { success: false, message: "Something went wrong. Please try again." }, status: :internal_server_error
   end
 
   private

--- a/app/javascript/components/Agent/AgentChat.tsx
+++ b/app/javascript/components/Agent/AgentChat.tsx
@@ -1,9 +1,19 @@
+import { Copy, Share } from "@boxicons/react";
 import * as React from "react";
 
-import { type ChatMessage, type ProposedAction, executeAgentAction, sendAgentMessage } from "$app/data/agent";
+import {
+  type ChatMessage,
+  type DisplayObject,
+  type ProposedAction,
+  executeAgentAction,
+  sendAgentMessage,
+} from "$app/data/agent";
 
-import { Button } from "$app/components/Button";
+import { Button, NavigationButton } from "$app/components/Button";
+import { CopyToClipboard } from "$app/components/CopyToClipboard";
 import { showAlert } from "$app/components/server-components/Alert";
+import { Card, CardContent } from "$app/components/ui/Card";
+import { DefinitionList } from "$app/components/ui/DefinitionList";
 import { Textarea } from "$app/components/ui/Textarea";
 
 type DisplayMessage = ChatMessage & {
@@ -11,12 +21,73 @@ type DisplayMessage = ChatMessage & {
   // outcome so the confirmation card collapses into a status line and can't be triggered twice.
   proposedAction?: ProposedAction;
   actionStatus?: "applied" | "dismissed";
+  // Objects the agent looked up or changed this turn, rendered inline as cards beneath the message.
+  objects?: DisplayObject[];
 };
 
 type Props = {
   greeting: string;
   suggestions: string[];
 };
+
+// One object (product, discount, sale, ...) rendered as a card: a title, an optional subtitle, a
+// few key/value rows, and easy copy / open-in-new-tab affordances. Reuses the same Card,
+// DefinitionList, and CopyToClipboard primitives used across the dashboard.
+const ObjectCard = ({ object }: { object: DisplayObject }) => {
+  const copyText = object.copy ?? object.url ?? null;
+  return (
+    <Card>
+      <CardContent className="flex-col items-stretch gap-2">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <strong className="block break-words">{object.title}</strong>
+            {object.subtitle ? <span className="break-words text-muted">{object.subtitle}</span> : null}
+          </div>
+          <div className="flex shrink-0 gap-2">
+            {copyText ? (
+              <CopyToClipboard text={copyText} copyTooltip="Copy">
+                <Button size="icon" aria-label={`Copy ${object.title}`}>
+                  <Copy className="size-4" />
+                </Button>
+              </CopyToClipboard>
+            ) : null}
+            {object.url ? (
+              <NavigationButton
+                size="icon"
+                aria-label={`Open ${object.title} in a new tab`}
+                href={object.url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Share className="size-4" />
+              </NavigationButton>
+            ) : null}
+          </div>
+        </div>
+        {object.fields.length > 0 ? (
+          <DefinitionList className="text-sm">
+            {object.fields.map((field) => (
+              <React.Fragment key={field.label}>
+                <dt className="text-muted">{field.label}</dt>
+                <dd className="break-words">{field.value}</dd>
+              </React.Fragment>
+            ))}
+          </DefinitionList>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+};
+
+// A turn's objects: a single card on its own, or a compact list view when the agent returned several.
+const ObjectList = ({ objects }: { objects: DisplayObject[] }) =>
+  objects.length > 0 ? (
+    <div className="flex flex-col gap-2">
+      {objects.map((object, index) => (
+        <ObjectCard key={`${object.type}-${object.copy ?? object.title}-${index}`} object={object} />
+      ))}
+    </div>
+  ) : null;
 
 const ProposedActionCard = ({
   action,
@@ -82,10 +153,15 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
     setIsSending(true);
 
     try {
-      const { reply, proposedAction } = await sendAgentMessage(history);
+      const { reply, proposedAction, objects } = await sendAgentMessage(history);
       setMessages((prev) => [
         ...prev,
-        { role: "assistant", content: reply, ...(proposedAction ? { proposedAction } : {}) },
+        {
+          role: "assistant",
+          content: reply,
+          ...(proposedAction ? { proposedAction } : {}),
+          ...(objects.length > 0 ? { objects } : {}),
+        },
       ]);
     } catch (e) {
       showAlert(e instanceof Error && e.message ? e.message : "Something went wrong. Please try again.", "error");
@@ -101,9 +177,14 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
   const confirmAction = async (index: number, action: ProposedAction) => {
     setPendingActionIndex(index);
     try {
-      const message = await executeAgentAction(action);
+      const { message, object } = await executeAgentAction(action);
       showAlert(message, "success");
-      setMessages((prev) => prev.map((msg, i) => (i === index ? { ...msg, actionStatus: "applied" } : msg)));
+      // Mark the proposal applied and attach the created/edited object so it renders as a card.
+      setMessages((prev) =>
+        prev.map((msg, i) =>
+          i === index ? { ...msg, actionStatus: "applied", ...(object ? { objects: [object] } : {}) } : msg,
+        ),
+      );
     } catch (e) {
       showAlert(e instanceof Error && e.message ? e.message : "That change couldn't be applied.", "error");
     } finally {
@@ -130,7 +211,7 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
                   message.role === "user" ? "bg-accent text-accent-foreground" : "bg-filled border"
                 }`}
               >
-                <p className="whitespace-pre-wrap break-words">{message.content}</p>
+                <p className="break-words whitespace-pre-wrap">{message.content}</p>
               </div>
               {message.proposedAction ? (
                 <ProposedActionCard
@@ -142,6 +223,7 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
                   onDismiss={() => dismissAction(index)}
                 />
               ) : null}
+              {message.objects && message.objects.length > 0 ? <ObjectList objects={message.objects} /> : null}
             </div>
           </div>
         ))}
@@ -184,7 +266,12 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
           disabled={isSending}
           className="flex-1"
         />
-        <Button type="submit" color="accent" className="shrink-0 whitespace-nowrap" disabled={isSending || input.trim().length === 0}>
+        <Button
+          type="submit"
+          color="accent"
+          className="shrink-0 whitespace-nowrap"
+          disabled={isSending || input.trim().length === 0}
+        >
           Send
         </Button>
       </form>

--- a/app/javascript/components/Agent/AgentChat.tsx
+++ b/app/javascript/components/Agent/AgentChat.tsx
@@ -1,0 +1,192 @@
+import * as React from "react";
+
+import { type ChatMessage, type ProposedAction, executeAgentAction, sendAgentMessage } from "$app/data/agent";
+
+import { Button } from "$app/components/Button";
+import { showAlert } from "$app/components/server-components/Alert";
+import { Textarea } from "$app/components/ui/Textarea";
+
+type DisplayMessage = ChatMessage & {
+  // A proposed change attached to an assistant turn. Once the seller acts on it, we record the
+  // outcome so the confirmation card collapses into a status line and can't be triggered twice.
+  proposedAction?: ProposedAction;
+  actionStatus?: "applied" | "dismissed";
+};
+
+type Props = {
+  greeting: string;
+  suggestions: string[];
+};
+
+const ProposedActionCard = ({
+  action,
+  status,
+  isPending,
+  isApplying,
+  onConfirm,
+  onDismiss,
+}: {
+  action: ProposedAction;
+  status?: "applied" | "dismissed";
+  isPending: boolean;
+  isApplying: boolean;
+  onConfirm: () => void;
+  onDismiss: () => void;
+}) => (
+  <div className="flex flex-col gap-2 rounded-2xl border border-dashed p-4">
+    <strong>Proposed change</strong>
+    <span>{action.summary}</span>
+    {status === "applied" ? (
+      <span role="status" className="text-green">
+        Applied
+      </span>
+    ) : status === "dismissed" ? (
+      <span role="status" className="text-muted">
+        Dismissed
+      </span>
+    ) : (
+      <div className="flex gap-2">
+        <Button color="accent" disabled={isPending} onClick={onConfirm}>
+          {isApplying ? "Applying..." : "Confirm"}
+        </Button>
+        <Button disabled={isPending} onClick={onDismiss}>
+          Dismiss
+        </Button>
+      </div>
+    )}
+  </div>
+);
+
+export const AgentChat = ({ greeting, suggestions }: Props) => {
+  const [messages, setMessages] = React.useState<DisplayMessage[]>([{ role: "assistant", content: greeting }]);
+  const [input, setInput] = React.useState("");
+  const [isSending, setIsSending] = React.useState(false);
+  const [pendingActionIndex, setPendingActionIndex] = React.useState<number | null>(null);
+  const scrollRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
+  }, [messages, isSending]);
+
+  const send = async (text: string) => {
+    const trimmed = text.trim();
+    if (trimmed.length === 0 || isSending) return;
+
+    // Only the plain role/content pairs go to the server; UI-only fields stay local.
+    const history: ChatMessage[] = [...messages, { role: "user", content: trimmed }].map(({ role, content }) => ({
+      role,
+      content,
+    }));
+    setMessages((prev) => [...prev, { role: "user", content: trimmed }]);
+    setInput("");
+    setIsSending(true);
+
+    try {
+      const { reply, proposedAction } = await sendAgentMessage(history);
+      setMessages((prev) => [
+        ...prev,
+        { role: "assistant", content: reply, ...(proposedAction ? { proposedAction } : {}) },
+      ]);
+    } catch (e) {
+      showAlert(e instanceof Error && e.message ? e.message : "Something went wrong. Please try again.", "error");
+      setMessages((prev) => [
+        ...prev,
+        { role: "assistant", content: "Sorry, I ran into a problem. Please try again." },
+      ]);
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  const confirmAction = async (index: number, action: ProposedAction) => {
+    setPendingActionIndex(index);
+    try {
+      const message = await executeAgentAction(action);
+      showAlert(message, "success");
+      setMessages((prev) => prev.map((msg, i) => (i === index ? { ...msg, actionStatus: "applied" } : msg)));
+    } catch (e) {
+      showAlert(e instanceof Error && e.message ? e.message : "That change couldn't be applied.", "error");
+    } finally {
+      setPendingActionIndex(null);
+    }
+  };
+
+  const dismissAction = (index: number) => {
+    setMessages((prev) => prev.map((msg, i) => (i === index ? { ...msg, actionStatus: "dismissed" } : msg)));
+  };
+
+  return (
+    <div className="mx-auto flex h-full max-w-2xl flex-col gap-4 p-4 md:p-8">
+      <div ref={scrollRef} className="flex flex-1 flex-col gap-4 overflow-y-auto" aria-label="Conversation" role="log">
+        {messages.map((message, index) => (
+          <div
+            key={index}
+            className={message.role === "user" ? "flex justify-end" : "flex justify-start"}
+            aria-label={message.role === "user" ? "You" : "Assistant"}
+          >
+            <div className="flex max-w-[85%] flex-col gap-2">
+              <div
+                className={`rounded-2xl px-4 py-2 ${
+                  message.role === "user" ? "bg-accent text-white" : "bg-filled border"
+                }`}
+              >
+                <p className="whitespace-pre-wrap">{message.content}</p>
+              </div>
+              {message.proposedAction ? (
+                <ProposedActionCard
+                  action={message.proposedAction}
+                  status={message.actionStatus}
+                  isPending={pendingActionIndex !== null}
+                  isApplying={pendingActionIndex === index}
+                  onConfirm={() => message.proposedAction && void confirmAction(index, message.proposedAction)}
+                  onDismiss={() => dismissAction(index)}
+                />
+              ) : null}
+            </div>
+          </div>
+        ))}
+        {isSending ? (
+          <div className="flex justify-start" aria-label="Assistant">
+            <div className="bg-filled rounded-2xl border px-4 py-2 text-muted">Thinking...</div>
+          </div>
+        ) : null}
+      </div>
+
+      {messages.length <= 1 ? (
+        <div className="flex flex-wrap gap-2">
+          {suggestions.map((suggestion) => (
+            <Button key={suggestion} size="sm" onClick={() => void send(suggestion)} disabled={isSending}>
+              {suggestion}
+            </Button>
+          ))}
+        </div>
+      ) : null}
+
+      <form
+        className="flex items-end gap-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          void send(input);
+        }}
+      >
+        <Textarea
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              void send(input);
+            }
+          }}
+          placeholder="Ask about your store or describe a change..."
+          rows={2}
+          aria-label="Message"
+          disabled={isSending}
+        />
+        <Button type="submit" color="accent" disabled={isSending || input.trim().length === 0}>
+          Send
+        </Button>
+      </form>
+    </div>
+  );
+};

--- a/app/javascript/components/Agent/AgentChat.tsx
+++ b/app/javascript/components/Agent/AgentChat.tsx
@@ -35,7 +35,7 @@ const ProposedActionCard = ({
 }) => (
   <div className="flex flex-col gap-2 rounded-2xl border border-dashed p-4">
     <strong>Proposed change</strong>
-    <span>{action.summary}</span>
+    <span className="break-words">{action.summary}</span>
     {status === "applied" ? (
       <span role="status" className="text-green">
         Applied
@@ -127,10 +127,10 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
             <div className="flex max-w-[85%] flex-col gap-2">
               <div
                 className={`rounded-2xl px-4 py-2 ${
-                  message.role === "user" ? "bg-accent text-white" : "bg-filled border"
+                  message.role === "user" ? "bg-accent text-accent-foreground" : "bg-filled border"
                 }`}
               >
-                <p className="whitespace-pre-wrap">{message.content}</p>
+                <p className="whitespace-pre-wrap break-words">{message.content}</p>
               </div>
               {message.proposedAction ? (
                 <ProposedActionCard
@@ -182,8 +182,9 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
           rows={2}
           aria-label="Message"
           disabled={isSending}
+          className="flex-1"
         />
-        <Button type="submit" color="accent" disabled={isSending || input.trim().length === 0}>
+        <Button type="submit" color="accent" className="shrink-0 whitespace-nowrap" disabled={isSending || input.trim().length === 0}>
           Send
         </Button>
       </form>

--- a/app/javascript/components/Agent/AgentChat.tsx
+++ b/app/javascript/components/Agent/AgentChat.tsx
@@ -2,11 +2,12 @@ import { Copy, Share } from "@boxicons/react";
 import * as React from "react";
 
 import {
+  type AgentStreamHandlers,
   type ChatMessage,
   type DisplayObject,
   type ProposedAction,
   executeAgentAction,
-  sendAgentMessage,
+  streamAgentMessage,
 } from "$app/data/agent";
 
 import { Button, NavigationButton } from "$app/components/Button";
@@ -132,12 +133,18 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
   const [messages, setMessages] = React.useState<DisplayMessage[]>([{ role: "assistant", content: greeting }]);
   const [input, setInput] = React.useState("");
   const [isSending, setIsSending] = React.useState(false);
+  // Whether the assistant reply has started arriving this turn — drives the "Thinking..." bubble,
+  // which we show only until the first token lands, then let the streaming text take over.
+  const [isStreaming, setIsStreaming] = React.useState(false);
+  // "What next" prompts suggested after the latest reply, to keep the conversation going. Cleared
+  // when a new turn starts and refreshed from the stream's `suggestions` event.
+  const [followUps, setFollowUps] = React.useState<string[]>([]);
   const [pendingActionIndex, setPendingActionIndex] = React.useState<number | null>(null);
   const scrollRef = React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
-  }, [messages, isSending]);
+  }, [messages, isSending, followUps]);
 
   const send = async (text: string) => {
     const trimmed = text.trim();
@@ -148,29 +155,88 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
       role,
       content,
     }));
+    // The index the streamed assistant reply will occupy: right after the user message we add.
+    const assistantIndex = messages.length + 1;
     setMessages((prev) => [...prev, { role: "user", content: trimmed }]);
     setInput("");
+    setFollowUps([]);
     setIsSending(true);
+    setIsStreaming(false);
+
+    // Append text to the streaming assistant message, creating it on the first token so the bubble
+    // appears exactly when content starts arriving.
+    const appendToken = (chunk: string) =>
+      setMessages((prev) => {
+        const next = [...prev];
+        const existing = next[assistantIndex];
+        if (existing && existing.role === "assistant") {
+          next[assistantIndex] = { ...existing, content: existing.content + chunk };
+        } else {
+          next[assistantIndex] = { role: "assistant", content: chunk };
+        }
+        return next;
+      });
+
+    // Merge a patch into the assistant message at assistantIndex, creating it if no token has
+    // arrived yet. This is what lets a tokenless turn (e.g. the model stages a write and returns an
+    // empty final reply) still render its proposed-action card / object cards.
+    const upsertAssistant = (patch: Partial<DisplayMessage>) =>
+      setMessages((prev) => {
+        const next = [...prev];
+        const existing = next[assistantIndex];
+        const base: DisplayMessage =
+          existing && existing.role === "assistant" ? existing : { role: "assistant", content: "" };
+        next[assistantIndex] = { ...base, ...patch };
+        return next;
+      });
+
+    const handlers: AgentStreamHandlers = {
+      onToken: (chunk) => {
+        setIsStreaming(true);
+        appendToken(chunk);
+      },
+      onReset: () =>
+        // An intermediate tool-use turn streamed preamble text; clear it so the real reply replaces
+        // it instead of appending to it.
+        setMessages((prev) =>
+          prev.map((msg, i) => (i === assistantIndex && msg.role === "assistant" ? { ...msg, content: "" } : msg)),
+        ),
+      onObjects: (objects) => upsertAssistant({ objects }),
+      onProposedAction: (proposedAction) => upsertAssistant({ proposedAction }),
+      onSuggestions: (next) => setFollowUps(next),
+    };
 
     try {
-      const { reply, proposedAction, objects } = await sendAgentMessage(history);
-      setMessages((prev) => [
-        ...prev,
-        {
+      const result = await streamAgentMessage(history, handlers);
+      // Reconcile with the final assembled turn. Upsert (not map) so a turn that produced no token —
+      // e.g. the model staged a write and returned an empty reply — still lands its card/objects.
+      setMessages((prev) => {
+        const next = [...prev];
+        const existing = next[assistantIndex];
+        const prior: DisplayMessage =
+          existing && existing.role === "assistant" ? existing : { role: "assistant", content: "" };
+        next[assistantIndex] = {
           role: "assistant",
-          content: reply,
-          ...(proposedAction ? { proposedAction } : {}),
-          ...(objects.length > 0 ? { objects } : {}),
-        },
-      ]);
+          content: result.reply || prior.content || "",
+          ...(result.proposedAction ? { proposedAction: result.proposedAction } : {}),
+          ...(result.objects.length > 0 ? { objects: result.objects } : {}),
+        };
+        return next;
+      });
+      setFollowUps(result.suggestions);
     } catch (e) {
       showAlert(e instanceof Error && e.message ? e.message : "Something went wrong. Please try again.", "error");
-      setMessages((prev) => [
-        ...prev,
-        { role: "assistant", content: "Sorry, I ran into a problem. Please try again." },
-      ]);
+      setMessages((prev) => {
+        const next = [...prev];
+        // If nothing streamed, drop in a friendly fallback; otherwise keep what arrived.
+        if (!next[assistantIndex] || next[assistantIndex]?.role !== "assistant") {
+          next[assistantIndex] = { role: "assistant", content: "Sorry, I ran into a problem. Please try again." };
+        }
+        return next;
+      });
     } finally {
       setIsSending(false);
+      setIsStreaming(false);
     }
   };
 
@@ -227,7 +293,7 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
             </div>
           </div>
         ))}
-        {isSending ? (
+        {isSending && !isStreaming ? (
           <div className="flex justify-start" aria-label="Assistant">
             <div className="bg-filled rounded-2xl border px-4 py-2 text-muted">Thinking...</div>
           </div>
@@ -241,6 +307,19 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
               {suggestion}
             </Button>
           ))}
+        </div>
+      ) : followUps.length > 0 ? (
+        // Follow-up prompts suggested after the latest reply, so the conversation has an obvious next
+        // step. Hidden while a turn is in flight so they don't compete with the streaming answer.
+        <div className="flex flex-col gap-2" aria-label="Suggested follow-ups">
+          <span className="text-sm text-muted">Keep going</span>
+          <div className="flex flex-wrap gap-2">
+            {followUps.map((suggestion) => (
+              <Button key={suggestion} size="sm" onClick={() => void send(suggestion)} disabled={isSending}>
+                {suggestion}
+              </Button>
+            ))}
+          </div>
         </div>
       ) : null}
 

--- a/app/javascript/components/LoggedInUser.ts
+++ b/app/javascript/components/LoggedInUser.ts
@@ -70,6 +70,9 @@ type Policies = {
   churn: {
     show: boolean;
   };
+  user: {
+    use_store_agent: boolean;
+  };
 };
 
 export type LoggedInUser = {

--- a/app/javascript/components/client-components/Nav/index.tsx
+++ b/app/javascript/components/client-components/Nav/index.tsx
@@ -18,6 +18,7 @@ import {
   Handshake,
   HomeAlt2,
   MessageBubble,
+  MessageBubbleDots,
   Search,
   Store,
   Workflow,
@@ -132,6 +133,14 @@ export const Nav = (props: Props) => {
           href={Routes.dashboard_url(routeParams)}
           exactHrefMatch
         />
+        {loggedInUser?.policies.user.use_store_agent ? (
+          <ClientNavLink
+            text="Agent"
+            icon={<MessageBubbleDots pack="filled" className="size-5" />}
+            href={Routes.agent_url(routeParams)}
+            exactHrefMatch
+          />
+        ) : null}
         {currentSeller ? (
           <ClientNavLink
             text="Profile"

--- a/app/javascript/data/agent.ts
+++ b/app/javascript/data/agent.ts
@@ -21,14 +21,26 @@ export type ProposedAction = {
 };
 
 type SendMessageResponse =
-  | { success: true; reply: string; proposed_action: ProposedAction | null }
+  | { success: true; reply: string; proposed_action: ProposedAction | null; objects?: DisplayObject[] }
   | { success: false; error: string };
 
-type ExecuteActionResponse = { success: boolean; message: string };
+type ExecuteActionResponse = { success: boolean; message: string; object?: DisplayObject | null };
+
+// A renderable object the agent looked up or changed (a product, discount, sale, payout, ...). The
+// server builds these from the real API response, so they only ever contain data the creator can
+// already see. The chat renders them inline as cards / a list beneath the message.
+export type DisplayObject = {
+  type: string;
+  title: string;
+  subtitle?: string | null;
+  fields: { label: string; value: string }[];
+  url?: string | null;
+  copy?: string | null;
+};
 
 export const sendAgentMessage = async (
   messages: ChatMessage[],
-): Promise<{ reply: string; proposedAction: ProposedAction | null }> => {
+): Promise<{ reply: string; proposedAction: ProposedAction | null; objects: DisplayObject[] }> => {
   const response = await request({
     method: "POST",
     accept: "json",
@@ -37,10 +49,12 @@ export const sendAgentMessage = async (
   });
   const json = typia.assert<SendMessageResponse>(await response.json());
   if (!json.success) throw new ResponseError(json.error);
-  return { reply: json.reply, proposedAction: json.proposed_action };
+  return { reply: json.reply, proposedAction: json.proposed_action, objects: json.objects ?? [] };
 };
 
-export const executeAgentAction = async (action: ProposedAction): Promise<string> => {
+export const executeAgentAction = async (
+  action: ProposedAction,
+): Promise<{ message: string; object: DisplayObject | null }> => {
   const response = await request({
     method: "POST",
     accept: "json",
@@ -49,5 +63,5 @@ export const executeAgentAction = async (action: ProposedAction): Promise<string
   });
   const json = typia.assert<ExecuteActionResponse>(await response.json());
   if (!json.success) throw new ResponseError(json.message);
-  return json.message;
+  return { message: json.message, object: json.object ?? null };
 };

--- a/app/javascript/data/agent.ts
+++ b/app/javascript/data/agent.ts
@@ -65,3 +65,149 @@ export const executeAgentAction = async (
   if (!json.success) throw new ResponseError(json.message);
   return { message: json.message, object: json.object ?? null };
 };
+
+// Events the streaming endpoint emits, surfaced to the caller as they arrive so the UI can render a
+// reply token-by-token and then show follow-up suggestions. `token` carries a chunk of reply text;
+// `objects` / `proposedAction` mirror the buffered response; `suggestions` is the list of "what
+// next" prompts shown at the end of the turn to keep the conversation going.
+export type AgentStreamHandlers = {
+  onToken?: (text: string) => void;
+  // Discard any reply text streamed so far this turn — emitted when an intermediate tool-use turn
+  // streamed preamble text that is not the final answer, so the UI clears it before the real reply.
+  onReset?: () => void;
+  onObjects?: (objects: DisplayObject[]) => void;
+  onProposedAction?: (action: ProposedAction) => void;
+  onSuggestions?: (suggestions: string[]) => void;
+};
+
+type StreamResult = {
+  reply: string;
+  proposedAction: ProposedAction | null;
+  objects: DisplayObject[];
+  suggestions: string[];
+};
+
+// Server-Sent Event payloads, validated per-event with typia so a malformed frame can't slip
+// untyped data into the UI.
+type TokenData = { text: string };
+type ObjectsData = { objects: DisplayObject[] };
+type ProposedActionData = { proposed_action: ProposedAction | null };
+type SuggestionsData = { suggestions: string[] };
+type ErrorData = { message: string };
+type DoneData = {
+  reply: string;
+  proposed_action: ProposedAction | null;
+  objects?: DisplayObject[];
+  suggestions?: string[];
+};
+
+// Stream one conversation turn over Server-Sent Events. Calls the handlers as events arrive and
+// resolves with the fully-assembled turn once the `done` event lands. Falls back to throwing a
+// ResponseError (so the caller can show the same alert as the non-streaming path) on an `error`
+// event or a transport failure.
+export const streamAgentMessage = async (
+  messages: ChatMessage[],
+  handlers: AgentStreamHandlers = {},
+): Promise<StreamResult> => {
+  const response = await request({
+    method: "POST",
+    accept: "json",
+    url: Routes.internal_agent_messages_stream_path(),
+    data: { messages },
+  });
+
+  // request() only rejects 5xx/429, so a 4xx or an HTML response from auth/CSRF/authorization
+  // middleware arrives here as a non-stream body. Treat anything that isn't an event-stream as an
+  // error rather than silently recording a blank assistant reply (the buffered endpoint surfaced
+  // these as errors too).
+  const body = response.body;
+  if (!response.ok || !response.headers.get("content-type")?.includes("text/event-stream") || !body) {
+    throw new ResponseError();
+  }
+
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let proposedAction: ProposedAction | null = null;
+  let objects: DisplayObject[] = [];
+  let suggestions: string[] = [];
+  let done: StreamResult | null = null;
+
+  // One complete SSE frame ("event: <name>\n data: <json>\n"). Parse the event name + JSON data,
+  // dispatch to the matching handler, and return the terminal result on the `done` event (null
+  // otherwise) so the caller can record it in the function scope.
+  const handleFrame = (frame: string): StreamResult | null => {
+    let event = "message";
+    const dataLines: string[] = [];
+    for (const line of frame.split("\n")) {
+      if (line.startsWith("event:")) event = line.slice(6).trim();
+      else if (line.startsWith("data:")) dataLines.push(line.slice(5).trim());
+    }
+    if (dataLines.length === 0) return null;
+    const raw: unknown = JSON.parse(dataLines.join("\n"));
+
+    switch (event) {
+      case "token": {
+        const { text } = typia.assert<TokenData>(raw);
+        handlers.onToken?.(text);
+        return null;
+      }
+      case "reset": {
+        // An intermediate tool-use turn streamed preamble text that isn't the final answer. Tell the
+        // UI to drop what it has shown so far so the next turn's text replaces it cleanly.
+        handlers.onReset?.();
+        return null;
+      }
+      case "objects": {
+        objects = typia.assert<ObjectsData>(raw).objects;
+        handlers.onObjects?.(objects);
+        return null;
+      }
+      case "proposed_action": {
+        proposedAction = typia.assert<ProposedActionData>(raw).proposed_action;
+        if (proposedAction) handlers.onProposedAction?.(proposedAction);
+        return null;
+      }
+      case "suggestions": {
+        suggestions = typia.assert<SuggestionsData>(raw).suggestions;
+        handlers.onSuggestions?.(suggestions);
+        return null;
+      }
+      case "done": {
+        const data = typia.assert<DoneData>(raw);
+        return {
+          reply: data.reply,
+          proposedAction: data.proposed_action,
+          objects: data.objects ?? objects,
+          suggestions: data.suggestions ?? suggestions,
+        };
+      }
+      case "error": {
+        throw new ResponseError(typia.assert<ErrorData>(raw).message);
+      }
+      default:
+        return null;
+    }
+  };
+
+  for (;;) {
+    const { value, done: streamDone } = await reader.read();
+    if (streamDone) break;
+    buffer += decoder.decode(value, { stream: true });
+    // Frames are separated by a blank line. Process every complete frame, keep the remainder.
+    let separator = buffer.indexOf("\n\n");
+    while (separator !== -1) {
+      const frame = buffer.slice(0, separator);
+      buffer = buffer.slice(separator + 2);
+      if (frame.trim().length > 0) done = handleFrame(frame) ?? done;
+      separator = buffer.indexOf("\n\n");
+    }
+  }
+  if (buffer.trim().length > 0) done = handleFrame(buffer) ?? done;
+
+  // The controller always ends a successful turn with a `done` event (and surfaces failures as an
+  // `error` event, which throws above). If the stream ended without `done`, the connection was
+  // truncated mid-turn — surface that as an error instead of accepting a partial/blank reply.
+  if (!done) throw new ResponseError();
+  return done;
+};

--- a/app/javascript/data/agent.ts
+++ b/app/javascript/data/agent.ts
@@ -1,0 +1,50 @@
+import typia from "typia";
+
+import { request, ResponseError } from "$app/utils/request";
+
+export type ChatRole = "user" | "assistant";
+
+export type ChatMessage = {
+  role: ChatRole;
+  content: string;
+};
+
+// A store change the agent has prepared. It is NOT applied until the seller confirms it, at which
+// point we POST it back to the `actions` endpoint.
+export type ProposedAction = {
+  type: "create_discount" | "update_product_price" | "publish_product" | "unpublish_product";
+  params: Record<string, unknown>;
+  summary: string;
+};
+
+type SendMessageResponse =
+  | { success: true; reply: string; proposed_action: ProposedAction | null }
+  | { success: false; error: string };
+
+type ExecuteActionResponse = { success: boolean; message: string };
+
+export const sendAgentMessage = async (
+  messages: ChatMessage[],
+): Promise<{ reply: string; proposedAction: ProposedAction | null }> => {
+  const response = await request({
+    method: "POST",
+    accept: "json",
+    url: Routes.internal_agent_messages_path(),
+    data: { messages },
+  });
+  const json = typia.assert<SendMessageResponse>(await response.json());
+  if (!json.success) throw new ResponseError(json.error);
+  return { reply: json.reply, proposedAction: json.proposed_action };
+};
+
+export const executeAgentAction = async (action: ProposedAction): Promise<string> => {
+  const response = await request({
+    method: "POST",
+    accept: "json",
+    url: Routes.internal_agent_actions_path(),
+    data: { type: action.type, params: action.params },
+  });
+  const json = typia.assert<ExecuteActionResponse>(await response.json());
+  if (!json.success) throw new ResponseError(json.message);
+  return json.message;
+};

--- a/app/javascript/data/agent.ts
+++ b/app/javascript/data/agent.ts
@@ -10,9 +10,12 @@ export type ChatMessage = {
 };
 
 // A store change the agent has prepared. It is NOT applied until the seller confirms it, at which
-// point we POST it back to the `actions` endpoint.
+// point we POST it back to the `actions` endpoint. The agent now stages every change as a single
+// generic `api_write` (a real Gumroad API call it will replay after confirmation); `summary` is the
+// human-readable description shown on the confirmation card, and `params` carries the endpoint id
+// plus its path params and body so the server can replay the exact call.
 export type ProposedAction = {
-  type: "create_discount" | "update_product_price" | "publish_product" | "unpublish_product";
+  type: "api_write";
   params: Record<string, unknown>;
   summary: string;
 };

--- a/app/javascript/pages/Agent/Index.tsx
+++ b/app/javascript/pages/Agent/Index.tsx
@@ -1,0 +1,26 @@
+import { usePage } from "@inertiajs/react";
+import * as React from "react";
+import typia from "typia";
+
+import { AgentChat } from "$app/components/Agent/AgentChat";
+import { PageHeader } from "$app/components/ui/PageHeader";
+
+type AgentPageProps = {
+  greeting: string;
+  suggestions: string[];
+};
+
+const AgentPage = () => {
+  const { greeting, suggestions } = typia.assert<AgentPageProps>(usePage().props);
+
+  return (
+    <div className="flex h-screen flex-col">
+      <PageHeader title="Agent" />
+      <div className="min-h-0 flex-1">
+        <AgentChat greeting={greeting} suggestions={suggestions} />
+      </div>
+    </div>
+  );
+};
+
+export default AgentPage;

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -9,4 +9,10 @@ class UserPolicy < ApplicationPolicy
   def generate_product_details_with_ai?
     seller.eligible_for_ai_product_generation? && (user.is_team_member? || user.id == seller.id || user.role_admin_for?(seller) || user.role_marketing_for?(seller))
   end
+
+  # Gate for the conversational store Agent tab. Only the owner or an admin/marketing role for the
+  # seller can chat with the agent, since it can read store data and propose store changes.
+  def use_store_agent?
+    user.id == seller.id || user.role_admin_for?(seller) || user.role_marketing_for?(seller)
+  end
 end

--- a/app/presenters/agent_presenter.rb
+++ b/app/presenters/agent_presenter.rb
@@ -1,7 +1,21 @@
 # frozen_string_literal: true
 
 # Builds the props for the Agent dashboard tab (the conversational store assistant).
+#
+# The greeting and starter suggestions are defined as constants so the mobile Agent endpoints
+# (Api::Mobile::AgentController#meta) can serve the exact same copy without duplicating it.
 class AgentPresenter
+  # A short, friendly first message so the empty chat isn't a blank box.
+  GREETING = "Hi! I'm your Gumroad store assistant. Ask me about your products, sales, or payouts, " \
+             "or tell me a change to make and I'll prepare it for your confirmation."
+
+  # Surfaced so the UI can suggest concrete starting prompts.
+  SUGGESTIONS = [
+    "How are my sales doing?",
+    "List my products",
+    "Create a 20% off code called LAUNCH",
+  ].freeze
+
   def initialize(pundit_user:)
     @pundit_user = pundit_user
     @seller = pundit_user.seller
@@ -9,15 +23,8 @@ class AgentPresenter
 
   def index_props
     {
-      # A short, friendly first message so the empty chat isn't a blank box.
-      greeting: "Hi! I'm your Gumroad store assistant. Ask me about your products, sales, or payouts, " \
-                "or tell me a change to make and I'll prepare it for your confirmation.",
-      # Surfaced so the UI can suggest concrete starting prompts.
-      suggestions: [
-        "How are my sales doing?",
-        "List my products",
-        "Create a 20% off code called LAUNCH",
-      ],
+      greeting: GREETING,
+      suggestions: SUGGESTIONS,
     }
   end
 

--- a/app/presenters/agent_presenter.rb
+++ b/app/presenters/agent_presenter.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Builds the props for the Agent dashboard tab (the conversational store assistant).
+class AgentPresenter
+  def initialize(pundit_user:)
+    @pundit_user = pundit_user
+    @seller = pundit_user.seller
+  end
+
+  def index_props
+    {
+      # A short, friendly first message so the empty chat isn't a blank box.
+      greeting: "Hi! I'm your Gumroad store assistant. Ask me about your products, sales, or payouts, " \
+                "or tell me a change to make and I'll prepare it for your confirmation.",
+      # Surfaced so the UI can suggest concrete starting prompts.
+      suggestions: [
+        "How are my sales doing?",
+        "List my products",
+        "Create a 20% off code called LAUNCH",
+      ],
+    }
+  end
+
+  private
+    attr_reader :pundit_user, :seller
+end

--- a/app/presenters/rendering_extension.rb
+++ b/app/presenters/rendering_extension.rb
@@ -116,6 +116,9 @@ module RenderingExtension
         },
         churn: {
           show: Pundit.policy!(pundit_user, :churn).show?,
+        },
+        user: {
+          use_store_agent: Pundit.policy!(pundit_user, pundit_user.seller).use_store_agent?,
         }
       }
     end

--- a/app/services/ai/anthropic_client.rb
+++ b/app/services/ai/anthropic_client.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+# Ai::AnthropicClient is a thin wrapper over Anthropic's Messages API (the same upstream the Walks
+# synthesis endpoint already uses server-side). It exists so Ai::StoreAgentService can run on Claude
+# Opus 4.7 — which benchmarks best at autonomous, money-making store operations — while keeping all
+# of Anthropic's wire-format quirks (system as a top-level param, tool_use/tool_result content
+# blocks, the streaming event protocol) out of the service.
+#
+# It exposes two calls, matching how the agent uses an LLM:
+#   - #messages: one buffered request. Returns a normalized hash
+#       { text:, tool_uses: [{ id:, name:, input: }], stop_reason: }.
+#     Used for the cheap, non-streamed follow-up-suggestions call.
+#   - #stream_messages: one streaming request. Yields each text delta to the block as it arrives and
+#     returns the same normalized hash once the stream completes, with tool_use blocks fully
+#     assembled from their streamed input_json fragments.
+#
+# The API key stays server-side (GlobalConfig). Nothing here is creator-specific; the seller scoping
+# lives entirely in StoreAgentApiClient, which this never touches.
+class Ai::AnthropicClient
+  class Error < StandardError; end
+
+  API_URL = "https://api.anthropic.com/v1/messages"
+  API_VERSION = "2023-06-01"
+  # Claude Opus 4.7 — top of the vending-bench leaderboard for autonomous commercial operation, which
+  # is exactly the store-management job the agent does for creators.
+  DEFAULT_MODEL = "claude-opus-4-7"
+  DEFAULT_MAX_TOKENS = 1024
+
+  Result = Struct.new(:text, :tool_uses, :stop_reason, keyword_init: true)
+
+  def initialize(timeout: 60, model: DEFAULT_MODEL)
+    @timeout = timeout
+    @model = model
+  end
+
+  # Buffered request. `system` is Anthropic's top-level system prompt; `messages` is the Anthropic
+  # message array (role + content); `tools` is the Anthropic tool-schema array (optional).
+  # @return [Result]
+  def messages(system:, messages:, tools: nil, max_tokens: DEFAULT_MAX_TOKENS, temperature: nil)
+    body = request_body(system:, messages:, tools:, max_tokens:, temperature:, stream: false)
+    response = http.post(API_URL, json: body)
+    raise Error, "Anthropic request failed: #{response.status}" unless response.status.success?
+
+    parse_message(response.parse)
+  rescue HTTP::Error => e
+    raise Error, "Anthropic network error: #{e.message}"
+  end
+
+  # Streaming request. Yields each text delta (String) to the block as it arrives, and returns the
+  # assembled Result once the stream ends. Tool-use blocks are streamed as a `content_block_start`
+  # (carrying id + name) followed by `input_json_delta` fragments we concatenate and JSON-parse.
+  # @yieldparam text [String] a chunk of assistant text
+  # @return [Result]
+  def stream_messages(system:, messages:, tools: nil, max_tokens: DEFAULT_MAX_TOKENS, temperature: nil, &on_text)
+    body = request_body(system:, messages:, tools:, max_tokens:, temperature:, stream: true)
+    text = +""
+    # Content blocks accumulate by index: text blocks grow `text`, tool_use blocks grow a JSON string
+    # we parse when the block closes.
+    blocks = {}
+    stop_reason = nil
+
+    response = http.post(API_URL, json: body)
+    raise Error, "Anthropic stream failed: #{response.status}" unless response.status.success?
+
+    each_sse_event(response.body) do |event, data|
+      case event
+      when "content_block_start"
+        index = data["index"]
+        block = data["content_block"] || {}
+        if block["type"] == "tool_use"
+          blocks[index] = { type: "tool_use", id: block["id"], name: block["name"], json: +"" }
+        else
+          blocks[index] = { type: "text" }
+        end
+      when "content_block_delta"
+        delta = data["delta"] || {}
+        case delta["type"]
+        when "text_delta"
+          chunk = delta["text"].to_s
+          next if chunk.empty?
+          text << chunk
+          on_text&.call(chunk)
+        when "input_json_delta"
+          index = data["index"]
+          blocks[index][:json] << delta["partial_json"].to_s if blocks[index]
+        end
+      when "message_delta"
+        stop_reason = data.dig("delta", "stop_reason") || stop_reason
+      when "error"
+        raise Error, "Anthropic stream error: #{data.dig("error", "message") || "unknown"}"
+      end
+    end
+
+    Result.new(text:, tool_uses: assemble_tool_uses(blocks), stop_reason:)
+  rescue HTTP::Error => e
+    raise Error, "Anthropic network error: #{e.message}"
+  end
+
+  private
+    attr_reader :timeout, :model
+
+    def request_body(system:, messages:, tools:, max_tokens:, temperature:, stream:)
+      body = {
+        model:,
+        max_tokens:,
+        system:,
+        messages:,
+        stream:,
+      }
+      body[:tools] = tools if tools.present?
+      body[:temperature] = temperature unless temperature.nil?
+      body
+    end
+
+    def http
+      HTTP.timeout(timeout).headers(
+        "x-api-key" => GlobalConfig.get("ANTHROPIC_API_KEY"),
+        "anthropic-version" => API_VERSION,
+        "content-type" => "application/json",
+      )
+    end
+
+    # Normalize a buffered Messages response into a Result. Content is an array of typed blocks; we
+    # pull the joined text and any tool_use blocks (each with parsed input).
+    def parse_message(body)
+      return Result.new(text: "", tool_uses: [], stop_reason: nil) unless body.is_a?(Hash)
+
+      content = Array(body["content"])
+      text = content.filter_map { |b| b["text"].to_s if b.is_a?(Hash) && b["type"] == "text" }.join
+      tool_uses = content.filter_map do |b|
+        next unless b.is_a?(Hash) && b["type"] == "tool_use"
+
+        { id: b["id"], name: b["name"], input: b["input"].is_a?(Hash) ? b["input"] : {} }
+      end
+      Result.new(text:, tool_uses:, stop_reason: body["stop_reason"])
+    end
+
+    # Turn the accumulated streamed blocks into the same tool_use shape #parse_message returns. An
+    # empty/blank JSON fragment string parses to {} so a tool call with no args still dispatches.
+    def assemble_tool_uses(blocks)
+      blocks.keys.sort.filter_map do |index|
+        block = blocks[index]
+        next unless block[:type] == "tool_use"
+
+        input =
+          begin
+            parsed = JSON.parse(block[:json].presence || "{}")
+            parsed.is_a?(Hash) ? parsed : {}
+          rescue JSON::ParserError
+            {}
+          end
+        { id: block[:id], name: block[:name], input: }
+      end
+    end
+
+    # Parse an Anthropic SSE body line-by-line, yielding [event_name, parsed_data_hash] per event.
+    # Each event is an `event: <name>` line followed by a `data: <json>` line; a malformed/non-JSON
+    # data line is skipped rather than crashing the stream.
+    def each_sse_event(body)
+      event = nil
+      buffer = +""
+
+      body.each do |chunk|
+        buffer << chunk
+        while (newline = buffer.index("\n"))
+          line = buffer.slice!(0..newline).chomp
+          if line.start_with?("event:")
+            event = line.delete_prefix("event:").strip
+          elsif line.start_with?("data:")
+            raw = line.delete_prefix("data:").strip
+            next if raw.empty? || event.nil?
+
+            data = (JSON.parse(raw) rescue nil)
+            yield(event, data) if data.is_a?(Hash)
+          end
+        end
+      end
+    end
+end

--- a/app/services/ai/store_agent_action_executor.rb
+++ b/app/services/ai/store_agent_action_executor.rb
@@ -49,14 +49,16 @@ class Ai::StoreAgentActionExecutor
     attr_reader :seller, :pundit_user
 
     # Map the v2 API's { success:, message:, ... } envelope (and HTTP status) to the { success:,
-    # message: } shape the chat UI expects. Reuses the API's own validation messages so the seller
-    # sees the same error they would hitting the endpoint directly.
+    # message:, object: } shape the chat UI expects. Reuses the API's own validation messages so the
+    # seller sees the same error they would hitting the endpoint directly, and surfaces the
+    # created/edited object so the chat can render it inline as a card.
     def interpret(endpoint, response)
       status = response["http_status"].to_i
       api_success = response["success"]
 
       if api_success == true || (api_success.nil? && status.between?(200, 299))
-        success(response["message"].presence || "Done: #{endpoint.summary}")
+        object = Ai::StoreAgentObjectFormatter.from_response(endpoint, response).first
+        success(response["message"].presence || "Done: #{endpoint.summary}", object:)
       elsif status == 401 || status == 403
         failure("You don't have permission to do that.")
       else
@@ -75,6 +77,6 @@ class Ai::StoreAgentActionExecutor
       @_api_client ||= Ai::StoreAgentApiClient.new(seller:)
     end
 
-    def success(message) = { success: true, message: }
+    def success(message, object: nil) = { success: true, message:, object: }.compact
     def failure(message) = { success: false, message: }
 end

--- a/app/services/ai/store_agent_action_executor.rb
+++ b/app/services/ai/store_agent_action_executor.rb
@@ -113,7 +113,9 @@ class Ai::StoreAgentActionExecutor
 
     def find_product(external_id)
       return nil if external_id.blank?
-      seller.products.visible.find_by_external_id(external_id.to_s)
+      # Mirror the service's scope (visible_and_not_archived) so a confirmed action carrying an
+      # archived product id — which the listing tool never surfaces — can't mutate it.
+      seller.products.visible_and_not_archived.find_by_external_id(external_id.to_s)
     end
 
     # Mirror controller-style authorization so the agent is bound by the seller's real permissions.

--- a/app/services/ai/store_agent_action_executor.rb
+++ b/app/services/ai/store_agent_action_executor.rb
@@ -2,126 +2,77 @@
 
 # Ai::StoreAgentActionExecutor applies a write action that the seller has explicitly confirmed in the
 # Agent chat UI. The agent service only ever *proposes* actions; this is the single place a store
-# mutation actually happens, and it deliberately re-validates everything rather than trusting the
-# proposal:
-#   - It re-resolves every product/discount by external_id scoped to the seller, so a tampered or
-#     stale id can't touch another seller's data.
-#   - It runs the SAME Pundit authorization the equivalent controller action runs, so the agent can
-#     never do something the seller couldn't do by hand.
-#   - It validates the action type against an allowlist; an unknown type is rejected, not guessed.
+# mutation actually happens.
 #
-# Returns { success:, message: } and never raises for expected validation failures.
+# Every confirmed action is a single catalog `api_write`: { endpoint, path_params, params }. The
+# executor re-validates the endpoint id against the catalog, confirms it is a write endpoint, and
+# REPLAYS the exact same request against the real public v2 API in-process, authenticated with a
+# short-lived token minted for this seller (see StoreAgentApiClient). Because it goes through the
+# real controller, the endpoint's own Doorkeeper scope check, Pundit/role authorization, and
+# validation run again — the executor can never do anything the seller's own API token couldn't, and
+# we never trust the proposal blindly:
+#   - An unknown or non-write endpoint id is rejected, not guessed.
+#   - The token is scoped to THIS seller, so a tampered id can't touch another seller's data; the API
+#     resolves every record under the token's resource owner.
+#
+# Returns { success:, message: } and never raises for expected API failures.
 class Ai::StoreAgentActionExecutor
-  SUPPORTED_TYPES = %w[create_discount update_product_price publish_product unpublish_product].freeze
+  # The agent now stages every change as a single generic catalog write. We keep the constant name
+  # (the controller checks it) but it contains just the one supported proposed-action type.
+  SUPPORTED_TYPES = %w[api_write].freeze
 
   def initialize(seller:, pundit_user:)
     @seller = seller
     @pundit_user = pundit_user
   end
 
-  # @param type [String] one of SUPPORTED_TYPES
-  # @param params [Hash] the params from the confirmed proposed action
+  # @param type [String] must be "api_write"
+  # @param params [Hash] { "endpoint" => id, "path_params" => {...}, "params" => {...} }
   # @return [Hash] { success: Boolean, message: String }
   def execute(type:, params:)
+    return failure("That action isn't supported.") unless type.to_s == "api_write"
+
     params = (params || {}).with_indifferent_access
-    case type.to_s
-    when "create_discount" then create_discount(params)
-    when "update_product_price" then update_product_price(params)
-    when "publish_product" then set_published(params, published: true)
-    when "unpublish_product" then set_published(params, published: false)
-    else
-      failure("That action isn't supported.")
-    end
-  rescue Pundit::NotAuthorizedError
-    failure("You don't have permission to do that.")
-  rescue ActiveRecord::RecordInvalid => e
-    failure(e.record&.errors&.full_messages&.first || "That change couldn't be saved.")
+    endpoint = Ai::StoreAgentApiCatalog.find(params[:endpoint])
+    return failure("That action isn't supported.") if endpoint.nil? || endpoint.read?
+
+    path = endpoint.expand_path(params[:path_params])
+    response = api_client.write(endpoint.method, path, normalize_body(params[:params]))
+
+    interpret(endpoint, response)
+  rescue ArgumentError => e
+    # Missing path param on a tampered/stale action.
+    failure(e.message)
   end
 
   private
     attr_reader :seller, :pundit_user
 
-    def create_discount(params)
-      authorize!([:checkout, OfferCode], :create?)
+    # Map the v2 API's { success:, message:, ... } envelope (and HTTP status) to the { success:,
+    # message: } shape the chat UI expects. Reuses the API's own validation messages so the seller
+    # sees the same error they would hitting the endpoint directly.
+    def interpret(endpoint, response)
+      status = response["http_status"].to_i
+      api_success = response["success"]
 
-      code = params[:code].to_s.strip
-      return failure("A discount code is required.") if code.blank?
-
-      # A universal percentage code must stay currency-agnostic: setting currency_type would scope it
-      # (via OfferCode.universal_with_matching_currency) to only one currency's products, so a
-      # multi-currency seller would get a "universal" percent code that silently skips some products.
-      # Only fixed-amount codes carry a currency.
-      attributes = { code:, universal: true }
-      if params[:percent_off].present?
-        percent = params[:percent_off].to_i
-        return failure("Percentage off must be between 1 and 100.") unless percent.between?(1, 100)
-        attributes[:amount_percentage] = percent
-      elsif params[:amount_off_cents].present?
-        cents = params[:amount_off_cents].to_i
-        return failure("Discount amount must be greater than zero.") unless cents.positive?
-        attributes[:amount_cents] = cents
-        attributes[:currency_type] = seller.currency_type
+      if api_success == true || (api_success.nil? && status.between?(200, 299))
+        success(response["message"].presence || "Done: #{endpoint.summary}")
+      elsif status == 401 || status == 403
+        failure("You don't have permission to do that.")
       else
-        return failure("Provide a percentage or a fixed amount off.")
-      end
-
-      offer_code = seller.offer_codes.build(attributes)
-      if offer_code.save
-        success("Created discount code #{offer_code.code}.")
-      else
-        failure(offer_code.errors.full_messages.first || "That discount couldn't be created.")
+        failure(response["message"].presence || response["error"].presence || "That change couldn't be saved.")
       end
     end
 
-    def update_product_price(params)
-      product = find_product(params[:product_id])
-      return failure("I couldn't find that product.") if product.nil?
-      authorize!(product, :update?)
-      # Mirror the service guard: tiered/variant-priced products keep their buyer-visible price on
-      # tiers/variants, so writing the flat price_cents would report success without changing what
-      # buyers pay. Reject here too so a replayed/tampered action can't slip past.
-      if product.is_tiered_membership? || product.alive_variants.exists?
-        return failure("That product is priced per tier/version and can't be changed from here.")
-      end
-
-      new_price_cents = params[:new_price_cents].to_i
-      return failure("Price must be zero or greater.") if new_price_cents.negative?
-
-      if product.update(price_cents: new_price_cents)
-        success("Updated the price of \"#{product.name}\".")
-      else
-        failure(product.errors.full_messages.first || "That price couldn't be saved.")
-      end
+    # The proposed params arrive with string keys (they round-tripped through JSON in the proposal).
+    # Hand the body to the client as a plain hash; the API normalizes types itself.
+    def normalize_body(raw)
+      return {} unless raw.respond_to?(:to_h)
+      raw.to_h
     end
 
-    def set_published(params, published:)
-      product = find_product(params[:product_id])
-      return failure("I couldn't find that product.") if product.nil?
-      authorize!(product, published ? :publish? : :unpublish?)
-
-      if published
-        return failure("Add an email to your account before publishing a product.") if product.user.email.blank?
-        product.publish!
-        success("Published \"#{product.name}\".")
-      else
-        product.unpublish!
-        success("Unpublished \"#{product.name}\".")
-      end
-    rescue Link::LinkInvalid
-      failure(product.errors.full_messages.first || "That product can't be published yet.")
-    end
-
-    def find_product(external_id)
-      return nil if external_id.blank?
-      # Mirror the service's scope (visible_and_not_archived) so a confirmed action carrying an
-      # archived product id — which the listing tool never surfaces — can't mutate it.
-      seller.products.visible_and_not_archived.find_by_external_id(external_id.to_s)
-    end
-
-    # Mirror controller-style authorization so the agent is bound by the seller's real permissions.
-    def authorize!(record, query)
-      policy = Pundit.policy!(pundit_user, record)
-      raise Pundit::NotAuthorizedError, query: query, record: record unless policy.public_send(query)
+    def api_client
+      @_api_client ||= Ai::StoreAgentApiClient.new(seller:)
     end
 
     def success(message) = { success: true, message: }

--- a/app/services/ai/store_agent_action_executor.rb
+++ b/app/services/ai/store_agent_action_executor.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+# Ai::StoreAgentActionExecutor applies a write action that the seller has explicitly confirmed in the
+# Agent chat UI. The agent service only ever *proposes* actions; this is the single place a store
+# mutation actually happens, and it deliberately re-validates everything rather than trusting the
+# proposal:
+#   - It re-resolves every product/discount by external_id scoped to the seller, so a tampered or
+#     stale id can't touch another seller's data.
+#   - It runs the SAME Pundit authorization the equivalent controller action runs, so the agent can
+#     never do something the seller couldn't do by hand.
+#   - It validates the action type against an allowlist; an unknown type is rejected, not guessed.
+#
+# Returns { success:, message: } and never raises for expected validation failures.
+class Ai::StoreAgentActionExecutor
+  SUPPORTED_TYPES = %w[create_discount update_product_price publish_product unpublish_product].freeze
+
+  def initialize(seller:, pundit_user:)
+    @seller = seller
+    @pundit_user = pundit_user
+  end
+
+  # @param type [String] one of SUPPORTED_TYPES
+  # @param params [Hash] the params from the confirmed proposed action
+  # @return [Hash] { success: Boolean, message: String }
+  def execute(type:, params:)
+    params = (params || {}).with_indifferent_access
+    case type.to_s
+    when "create_discount" then create_discount(params)
+    when "update_product_price" then update_product_price(params)
+    when "publish_product" then set_published(params, published: true)
+    when "unpublish_product" then set_published(params, published: false)
+    else
+      failure("That action isn't supported.")
+    end
+  rescue Pundit::NotAuthorizedError
+    failure("You don't have permission to do that.")
+  rescue ActiveRecord::RecordInvalid => e
+    failure(e.record&.errors&.full_messages&.first || "That change couldn't be saved.")
+  end
+
+  private
+    attr_reader :seller, :pundit_user
+
+    def create_discount(params)
+      authorize!([:checkout, OfferCode], :create?)
+
+      code = params[:code].to_s.strip
+      return failure("A discount code is required.") if code.blank?
+
+      # A universal percentage code must stay currency-agnostic: setting currency_type would scope it
+      # (via OfferCode.universal_with_matching_currency) to only one currency's products, so a
+      # multi-currency seller would get a "universal" percent code that silently skips some products.
+      # Only fixed-amount codes carry a currency.
+      attributes = { code:, universal: true }
+      if params[:percent_off].present?
+        percent = params[:percent_off].to_i
+        return failure("Percentage off must be between 1 and 100.") unless percent.between?(1, 100)
+        attributes[:amount_percentage] = percent
+      elsif params[:amount_off_cents].present?
+        cents = params[:amount_off_cents].to_i
+        return failure("Discount amount must be greater than zero.") unless cents.positive?
+        attributes[:amount_cents] = cents
+        attributes[:currency_type] = seller.currency_type
+      else
+        return failure("Provide a percentage or a fixed amount off.")
+      end
+
+      offer_code = seller.offer_codes.build(attributes)
+      if offer_code.save
+        success("Created discount code #{offer_code.code}.")
+      else
+        failure(offer_code.errors.full_messages.first || "That discount couldn't be created.")
+      end
+    end
+
+    def update_product_price(params)
+      product = find_product(params[:product_id])
+      return failure("I couldn't find that product.") if product.nil?
+      authorize!(product, :update?)
+      # Mirror the service guard: tiered/variant-priced products keep their buyer-visible price on
+      # tiers/variants, so writing the flat price_cents would report success without changing what
+      # buyers pay. Reject here too so a replayed/tampered action can't slip past.
+      if product.is_tiered_membership? || product.alive_variants.exists?
+        return failure("That product is priced per tier/version and can't be changed from here.")
+      end
+
+      new_price_cents = params[:new_price_cents].to_i
+      return failure("Price must be zero or greater.") if new_price_cents.negative?
+
+      if product.update(price_cents: new_price_cents)
+        success("Updated the price of \"#{product.name}\".")
+      else
+        failure(product.errors.full_messages.first || "That price couldn't be saved.")
+      end
+    end
+
+    def set_published(params, published:)
+      product = find_product(params[:product_id])
+      return failure("I couldn't find that product.") if product.nil?
+      authorize!(product, published ? :publish? : :unpublish?)
+
+      if published
+        return failure("Add an email to your account before publishing a product.") if product.user.email.blank?
+        product.publish!
+        success("Published \"#{product.name}\".")
+      else
+        product.unpublish!
+        success("Unpublished \"#{product.name}\".")
+      end
+    rescue Link::LinkInvalid
+      failure(product.errors.full_messages.first || "That product can't be published yet.")
+    end
+
+    def find_product(external_id)
+      return nil if external_id.blank?
+      seller.products.visible.find_by_external_id(external_id.to_s)
+    end
+
+    # Mirror controller-style authorization so the agent is bound by the seller's real permissions.
+    def authorize!(record, query)
+      policy = Pundit.policy!(pundit_user, record)
+      raise Pundit::NotAuthorizedError, query: query, record: record unless policy.public_send(query)
+    end
+
+    def success(message) = { success: true, message: }
+    def failure(message) = { success: false, message: }
+end

--- a/app/services/ai/store_agent_api_catalog.rb
+++ b/app/services/ai/store_agent_api_catalog.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+# Ai::StoreAgentApiCatalog is the single declarative source of truth for every Gumroad public v2 API
+# endpoint the store agent can drive. Each entry maps a stable `id` (the name the LLM uses) to the
+# real HTTP method + path of the documented public API, so the agent reaches the FULL API surface
+# through two generic tools (api_read / api_write) instead of dozens of hand-coded ones.
+#
+# Why a catalog instead of bespoke tools:
+#   - Coverage: adding an endpoint is one row here, not a new tool + executor branch + schema.
+#   - Safety: the agent can only ever call an `id` that exists in this list. Path templates fix the
+#     shape of the URL, so the LLM fills in :placeholders (ids) and params — it can't synthesize an
+#     arbitrary path. Reads (read: true) auto-run; everything else is a write that must be confirmed.
+#   - Fidelity: each call is replayed against the real controller (see StoreAgentApiClient), so the
+#     endpoint's own Doorkeeper scope check, Pundit/role authorization, validation, and JSON
+#     serialization are reused verbatim. The agent can never exceed what the creator's own API token
+#     could do.
+#
+# Path templates use :name placeholders filled from the tool call's `path_params`. `params` lists the
+# query (reads) or body (writes) keys the endpoint accepts, purely to teach the model; the API still
+# validates the real payload.
+module Ai::StoreAgentApiCatalog
+  Endpoint = Struct.new(:id, :method, :path, :read, :scope, :summary, :path_params, :params, keyword_init: true) do
+    def read? = read == true
+    def write? = !read?
+
+    # Expand the path template against a hash of path params, percent-decoding nothing (ids are safe
+    # external ids). Raises if a required placeholder is missing so a malformed call fails loudly
+    # rather than hitting the wrong URL.
+    def expand_path(path_params)
+      pp = (path_params || {}).transform_keys(&:to_s)
+      path.gsub(/:([a-z_]+)/) do
+        key = Regexp.last_match(1)
+        value = pp[key].to_s.strip
+        raise ArgumentError, "Missing path parameter :#{key}" if value.blank?
+        value
+      end
+    end
+  end
+
+  # Build one endpoint row. read defaults to false (i.e. a write that must be confirmed).
+  def self.ep(id, method, path, summary, read: false, scope: nil, path_params: [], params: [])
+    Endpoint.new(id:, method:, path:, read:, scope:, summary:, path_params:, params:)
+  end
+
+  ENDPOINTS = [
+    # ---- Account / profile ----
+    ep("get_user", :get, "/user", "Get the creator's own account: name, email, currency, profile url, bio.", read: true, scope: "view_profile"),
+    ep("update_user", :patch, "/user", "Update the creator's profile fields (name, bio, twitter handle, etc.).", scope: "edit_profile",
+                                                                                                                 params: %w[name bio twitter_handle]),
+    ep("get_user_custom_html", :get, "/user/custom_html", "Get the creator's profile custom HTML.", read: true, scope: "view_profile"),
+    ep("update_user_custom_html", :patch, "/user/custom_html", "Update the creator's profile custom HTML.", scope: "edit_profile", params: %w[custom_html]),
+    ep("get_categories", :get, "/categories", "List the product categories Gumroad supports.", read: true),
+    ep("get_refund_policy", :get, "/refund_policy", "Get the creator's account-level refund policy.", read: true, scope: "view_profile"),
+    ep("update_refund_policy", :put, "/refund_policy", "Update the creator's account-level refund policy.", scope: "edit_profile",
+                                                                                                            params: %w[allowed_refund_periods_in_days fine_print]),
+
+    # ---- Products ----
+    ep("list_products", :get, "/products", "List the creator's products with price, status, and stats.", read: true, scope: "view_sales"),
+    ep("get_product", :get, "/products/:id", "Get one product by its id.", read: true, scope: "view_sales", path_params: %w[id]),
+    ep("create_product", :post, "/products", "Create a new product.", scope: "edit_products",
+                                                                      params: %w[name price url description custom_permalink price_currency_type]),
+    ep("update_product", :put, "/products/:id", "Update a product's fields (name, price, description, etc.).", scope: "edit_products",
+                                                                                                               path_params: %w[id], params: %w[name price description custom_permalink max_purchase_count]),
+    ep("delete_product", :delete, "/products/:id", "Delete a product permanently.", scope: "edit_products", path_params: %w[id]),
+    ep("enable_product", :put, "/products/:id/enable", "Publish a product so it is available for sale.", scope: "edit_products", path_params: %w[id]),
+    ep("disable_product", :put, "/products/:id/disable", "Unpublish a product so it is no longer for sale.", scope: "edit_products", path_params: %w[id]),
+
+    # ---- Custom fields (per product) ----
+    ep("list_custom_fields", :get, "/products/:link_id/custom_fields", "List a product's custom fields.", read: true, scope: "view_sales", path_params: %w[link_id]),
+    ep("create_custom_field", :post, "/products/:link_id/custom_fields", "Add a custom field to a product.", scope: "edit_products",
+                                                                                                             path_params: %w[link_id], params: %w[name required type]),
+    ep("update_custom_field", :put, "/products/:link_id/custom_fields/:id", "Update a product custom field.", scope: "edit_products",
+                                                                                                              path_params: %w[link_id id], params: %w[name required type]),
+    ep("delete_custom_field", :delete, "/products/:link_id/custom_fields/:id", "Delete a product custom field.", scope: "edit_products", path_params: %w[link_id id]),
+
+    # ---- Offer codes / discounts (per product) ----
+    ep("list_offer_codes", :get, "/products/:link_id/offer_codes", "List a product's discount codes.", read: true, scope: "view_sales", path_params: %w[link_id]),
+    ep("get_offer_code", :get, "/products/:link_id/offer_codes/:id", "Get one discount code.", read: true, scope: "view_sales", path_params: %w[link_id id]),
+    ep("create_offer_code", :post, "/products/:link_id/offer_codes", "Create a discount code on a product.", scope: "edit_products",
+                                                                                                             path_params: %w[link_id], params: %w[name amount_off offer_type max_purchase_count]),
+    ep("update_offer_code", :put, "/products/:link_id/offer_codes/:id", "Update a discount code (max purchase count).", scope: "edit_products",
+                                                                                                                        path_params: %w[link_id id], params: %w[max_purchase_count]),
+    ep("delete_offer_code", :delete, "/products/:link_id/offer_codes/:id", "Delete a discount code.", scope: "edit_products", path_params: %w[link_id id]),
+
+    # ---- Variant categories & variants (per product) ----
+    ep("list_variant_categories", :get, "/products/:link_id/variant_categories", "List a product's variant categories.", read: true, scope: "view_sales", path_params: %w[link_id]),
+    ep("get_variant_category", :get, "/products/:link_id/variant_categories/:id", "Get one variant category.", read: true, scope: "view_sales", path_params: %w[link_id id]),
+    ep("create_variant_category", :post, "/products/:link_id/variant_categories", "Create a variant category.", scope: "edit_products", path_params: %w[link_id], params: %w[title]),
+    ep("update_variant_category", :put, "/products/:link_id/variant_categories/:id", "Update a variant category.", scope: "edit_products", path_params: %w[link_id id], params: %w[title]),
+    ep("delete_variant_category", :delete, "/products/:link_id/variant_categories/:id", "Delete a variant category.", scope: "edit_products", path_params: %w[link_id id]),
+    ep("list_variants", :get, "/products/:link_id/variant_categories/:variant_category_id/variants", "List variants in a category.", read: true, scope: "view_sales", path_params: %w[link_id variant_category_id]),
+    ep("get_variant", :get, "/products/:link_id/variant_categories/:variant_category_id/variants/:id", "Get one variant.", read: true, scope: "view_sales", path_params: %w[link_id variant_category_id id]),
+    ep("create_variant", :post, "/products/:link_id/variant_categories/:variant_category_id/variants", "Create a variant.", scope: "edit_products",
+                                                                                                                            path_params: %w[link_id variant_category_id], params: %w[name price_difference_cents max_purchase_count]),
+    ep("update_variant", :put, "/products/:link_id/variant_categories/:variant_category_id/variants/:id", "Update a variant.", scope: "edit_products",
+                                                                                                                               path_params: %w[link_id variant_category_id id], params: %w[name price_difference_cents max_purchase_count]),
+    ep("delete_variant", :delete, "/products/:link_id/variant_categories/:variant_category_id/variants/:id", "Delete a variant.", scope: "edit_products", path_params: %w[link_id variant_category_id id]),
+    ep("list_skus", :get, "/products/:link_id/skus", "List a product's SKUs.", read: true, scope: "view_sales", path_params: %w[link_id]),
+
+    # ---- Bundle contents, thumbnail, covers ----
+    ep("update_bundle_contents", :put, "/products/:link_id/bundle_contents", "Set the products contained in a bundle.", scope: "edit_products", path_params: %w[link_id], params: %w[products]),
+    ep("create_thumbnail", :post, "/products/:link_id/thumbnail", "Set a product's thumbnail image.", scope: "edit_products", path_params: %w[link_id], params: %w[url]),
+    ep("delete_thumbnail", :delete, "/products/:link_id/thumbnail", "Remove a product's thumbnail.", scope: "edit_products", path_params: %w[link_id]),
+    ep("create_cover", :post, "/products/:link_id/covers", "Add a cover image to a product.", scope: "edit_products", path_params: %w[link_id], params: %w[url]),
+    ep("delete_cover", :delete, "/products/:link_id/covers/:id", "Remove a product cover image.", scope: "edit_products", path_params: %w[link_id id]),
+
+    # ---- Product subscribers ----
+    ep("list_product_subscribers", :get, "/products/:link_id/subscribers", "List subscribers of a membership product.", read: true, scope: "view_sales", path_params: %w[link_id]),
+    ep("get_subscriber", :get, "/subscribers/:id", "Get one subscriber by id.", read: true, scope: "view_sales", path_params: %w[id]),
+
+    # ---- Upsells ----
+    ep("list_upsells", :get, "/upsells", "List the creator's upsells.", read: true, scope: "view_sales"),
+    ep("get_upsell", :get, "/upsells/:id", "Get one upsell.", read: true, scope: "view_sales", path_params: %w[id]),
+    ep("create_upsell", :post, "/upsells", "Create an upsell offer.", scope: "edit_products", params: %w[name product_id variant_id offer_code cross_sell]),
+    ep("update_upsell", :put, "/upsells/:id", "Update an upsell offer.", scope: "edit_products", path_params: %w[id], params: %w[name offer_code]),
+    ep("delete_upsell", :delete, "/upsells/:id", "Delete an upsell offer.", scope: "edit_products", path_params: %w[id]),
+
+    # ---- Emails (workflows / posts) ----
+    ep("list_emails", :get, "/emails", "List the creator's email posts.", read: true, scope: "view_sales"),
+    ep("get_email", :get, "/emails/:id", "Get one email post.", read: true, scope: "view_sales", path_params: %w[id]),
+    ep("create_email", :post, "/emails", "Draft a new email post to subscribers/customers.", scope: "edit_emails", params: %w[subject message published audience_type]),
+    ep("preview_email", :post, "/emails/:id/preview", "Send a preview of an email to the creator.", scope: "edit_emails", path_params: %w[id]),
+    ep("send_email", :post, "/emails/:id/send", "Send an email post to its audience.", scope: "edit_emails", path_params: %w[id]),
+    ep("delete_email", :delete, "/emails/:id", "Delete an email post.", scope: "edit_emails", path_params: %w[id]),
+
+    # ---- Sales ----
+    ep("sales_summary", :get, "/sales/summary", "Get an aggregate sales summary.", read: true, scope: "view_sales"),
+    ep("list_sales", :get, "/sales", "List the creator's sales, optionally filtered by date/product/email.", read: true, scope: "view_sales",
+                                                                                                             params: %w[after before email order_id product_id page_key]),
+    ep("get_sale", :get, "/sales/:id", "Get one sale by id.", read: true, scope: "view_sales", path_params: %w[id]),
+    ep("export_sales", :post, "/sales/exports", "Start a CSV export of sales.", scope: "view_sales", params: %w[after before]),
+    ep("mark_sale_as_shipped", :put, "/sales/:id/mark_as_shipped", "Mark a sale as shipped (optionally with tracking).", scope: "mark_sales_as_shipped",
+                                                                                                                         path_params: %w[id], params: %w[tracking_url]),
+    ep("refund_sale", :put, "/sales/:id/refund", "Refund a sale, fully or partially.", scope: "refund_sales", path_params: %w[id], params: %w[amount_cents]),
+    ep("resend_receipt", :post, "/sales/:id/resend_receipt", "Resend the purchase receipt email to the buyer.", scope: "view_sales", path_params: %w[id]),
+
+    # ---- Payouts ----
+    ep("list_payouts", :get, "/payouts", "List the creator's payouts.", read: true, scope: "view_payouts"),
+    ep("upcoming_payout", :get, "/payouts/upcoming", "Get the creator's upcoming (not-yet-paid) payout.", read: true, scope: "view_payouts"),
+    ep("get_payout", :get, "/payouts/:id", "Get one payout by id.", read: true, scope: "view_payouts", path_params: %w[id]),
+
+    # ---- Resource subscriptions (webhooks) ----
+    ep("list_resource_subscriptions", :get, "/resource_subscriptions", "List the creator's webhook resource subscriptions.", read: true),
+    ep("create_resource_subscription", :put, "/resource_subscriptions", "Create a webhook resource subscription.", params: %w[resource_name post_url]),
+    ep("delete_resource_subscription", :delete, "/resource_subscriptions/:id", "Delete a webhook resource subscription.", path_params: %w[id]),
+
+    # ---- Tax forms & earnings ----
+    ep("list_tax_forms", :get, "/tax_forms", "List the creator's available tax forms.", read: true, scope: "view_tax_data"),
+    ep("get_earnings", :get, "/earnings", "Get the creator's earnings figures.", read: true, scope: "view_sales"),
+
+    # ---- License management (creator-side) ----
+    ep("enable_license", :put, "/licenses/enable", "Enable a license key.", scope: "edit_products", params: %w[product_id license_key]),
+    ep("disable_license", :put, "/licenses/disable", "Disable a license key.", scope: "edit_products", params: %w[product_id license_key]),
+    ep("decrement_license_uses", :put, "/licenses/decrement_uses_count", "Decrement a license key's uses count.", scope: "edit_products", params: %w[product_id license_key]),
+    ep("rotate_license", :put, "/licenses/rotate", "Rotate (reissue) a license key.", scope: "edit_products", params: %w[product_id license_key]),
+  ].freeze
+
+  BY_ID = ENDPOINTS.index_by(&:id).freeze
+
+  def self.find(id) = BY_ID[id.to_s]
+  def self.reads = ENDPOINTS.select(&:read?)
+  def self.writes = ENDPOINTS.select(&:write?)
+  def self.read_ids = reads.map(&:id)
+  def self.write_ids = writes.map(&:id)
+
+  # A compact human-readable manifest injected into the system prompt so the model knows what each
+  # endpoint id does and which path params it needs — without bloating the tool JSON schema.
+  def self.manifest(kind)
+    list = kind == :read ? reads : writes
+    list.map do |e|
+      pp = e.path_params.any? ? " (path: #{e.path_params.join(', ')})" : ""
+      "- #{e.id}#{pp}: #{e.summary}"
+    end.join("\n")
+  end
+end

--- a/app/services/ai/store_agent_api_client.rb
+++ b/app/services/ai/store_agent_api_client.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+# Ai::StoreAgentApiClient gives the store agent maximal, properly-authorized access to the creator's
+# own Gumroad data by calling the REAL public v2 API in-process, authenticated with a short-lived
+# OAuth access token minted for that creator. This means every tool the agent exposes reuses the
+# exact authorization (Doorkeeper scopes), validation, and serialization the documented public API
+# already enforces — the agent can never do anything the creator couldn't do with their own API
+# token, and we don't reimplement per-endpoint logic or auth.
+#
+# Safety model:
+#   - The token is scoped to the SINGLE creator (resource_owner_id), expires in 5 minutes, is created
+#     per agent turn, and is revoked immediately after the turn. It never leaves the server and is
+#     never shown to the LLM or the browser.
+#   - The token's scopes are the creator's own; an endpoint the creator's role can't reach 403s.
+#   - GET (read) calls run automatically. NON-GET (write) calls are NOT executed here — the caller
+#     (StoreAgentService) turns them into a proposed action the creator must confirm, and only then
+#     does StoreAgentActionExecutor replay the same request to mutate.
+class Ai::StoreAgentApiClient
+  # The dedicated first-party OAuth application that backs the agent. Owned by the creator so the
+  # token's application owner and resource owner are the same account. Scopes cover the full public
+  # surface; the per-endpoint doorkeeper_authorize! still gates each call to what the creator's role
+  # actually permits.
+  AGENT_APP_NAME = "Gumroad Store Agent (internal)"
+  # The full public scope set plus `account` (Api::V2::BaseController#doorkeeper_authorize! appends
+  # :account to every endpoint's check, so the token must carry it). These are the SAME scopes a
+  # creator can grant their own API integration; the per-endpoint authorize! and Pundit role checks
+  # still gate each call, so a role that can't refund/edit simply 403s.
+  AGENT_APP_SCOPES = "view_public account edit_products view_sales view_payouts edit_sales " \
+                     "refund_sales mark_sales_as_shipped edit_emails view_profile edit_profile view_tax_data"
+  TOKEN_TTL_SECONDS = 300
+
+  def initialize(seller:)
+    @seller = seller
+  end
+
+  # Run a read (GET) request against the v2 API as the creator. Returns a parsed Hash.
+  def get(path, params = {})
+    request(:get, path, params)
+  end
+
+  # Run a mutating request (post/put/patch/delete). Used by the executor AFTER the creator confirms.
+  def write(method, path, params = {})
+    request(method.to_sym, path, params)
+  end
+
+  private
+    attr_reader :seller
+
+    def request(method, path, params)
+      token = mint_token
+      session = ActionDispatch::Integration::Session.new(Rails.application)
+      session.host! api_host
+      # The v2 API is mounted at /v2/... on the API domain (ApiDomainConstraint). Accept a caller path
+      # with or without the leading "v2/" and normalize to the canonical "/v2/<path>".
+      normalized = path.delete_prefix("/").delete_prefix("api/").delete_prefix("v2/")
+      full_path = "/v2/#{normalized}"
+      headers = { "Authorization" => "Bearer #{token.token}", "Accept" => "application/json" }
+
+      case method
+      when :get then session.get(full_path, params:, headers:)
+      when :post then session.post(full_path, params:, headers:)
+      when :put then session.put(full_path, params:, headers:)
+      when :patch then session.patch(full_path, params:, headers:)
+      when :delete then session.delete(full_path, params:, headers:)
+      else
+        return { "success" => false, "message" => "Unsupported method #{method}." }
+      end
+
+      parse(session.response)
+    ensure
+      token&.revoke
+    end
+
+    def parse(response)
+      body = response.body.to_s
+      json = body.present? ? JSON.parse(body) : {}
+      json.is_a?(Hash) ? json.merge("http_status" => response.status) : { "data" => json, "http_status" => response.status }
+    rescue JSON::ParserError
+      { "success" => false, "message" => "The API returned an unreadable response.", "http_status" => response.status }
+    end
+
+    def mint_token
+      Doorkeeper::AccessToken.create!(
+        application: agent_application,
+        resource_owner_id: seller.id,
+        scopes: agent_application.scopes.to_s,
+        expires_in: TOKEN_TTL_SECONDS,
+        use_refresh_token: false,
+      )
+    end
+
+    # One agent OAuth app per creator (owned by them). find_or_create keeps it stable across turns.
+    def agent_application
+      @_app ||= OauthApplication.find_or_create_by!(name: AGENT_APP_NAME, owner: seller) do |app|
+        app.redirect_uri = "urn:ietf:wg:oauth:2.0:oob"
+        app.scopes = AGENT_APP_SCOPES
+      end
+    end
+
+    def api_host
+      # The v2 API is served on the API domain in every environment (it's also reachable on the main
+      # domain, but API_DOMAIN is the canonical host the routes/controllers expect). Fall back to the
+      # main domain, then localhost, so a misconfigured env still dispatches somewhere valid.
+      (defined?(API_DOMAIN) && API_DOMAIN.presence) ||
+        (defined?(DOMAIN) && DOMAIN.presence) ||
+        (Rails.application.config.action_controller.default_url_options || {})[:host] ||
+        "localhost"
+    end
+end

--- a/app/services/ai/store_agent_object_formatter.rb
+++ b/app/services/ai/store_agent_object_formatter.rb
@@ -1,0 +1,185 @@
+# frozen_string_literal: true
+
+# Ai::StoreAgentObjectFormatter turns the JSON the v2 API already returns into compact "display
+# objects" the Agent chat renders inline as cards / a list view, instead of the model describing them
+# in prose. Each display object is intentionally small and presentation-ready:
+#
+#   {
+#     type:     "product" | "discount" | "sale" | "payout" | "email" | "upsell" | "object",
+#     title:    String,                      # headline (product name, discount code, ...)
+#     subtitle: String | nil,                # one-line secondary (price, amount off, ...)
+#     fields:   [{ label:, value: }, ...],   # a few key/value rows for a definition list
+#     url:      String | nil,                # canonical link -> "Open" in a new tab
+#     copy:     String | nil,                # the most useful thing to copy (the url, or an id)
+#   }
+#
+# We only surface fields the API already exposes for this seller, so this can never leak more than
+# the endpoint itself returns. Unknown shapes fall back to a generic object so nothing crashes; the
+# model's prose still carries the answer even when we can't build a rich card.
+module Ai::StoreAgentObjectFormatter
+  module_function
+
+  # Pull display objects out of one API response for a given catalog endpoint.
+  # @param endpoint [Ai::StoreAgentApiCatalog::Endpoint]
+  # @param response [Hash] parsed JSON body from StoreAgentApiClient
+  # @return [Array<Hash>] zero or more display objects
+  def from_response(endpoint, response)
+    return [] unless response.is_a?(Hash)
+    # Never build cards from an error envelope.
+    return [] if response["success"] == false
+
+    case endpoint.id
+    when "list_products"
+      Array(response["products"]).filter_map { |p| product(p) }
+    when "get_product", "create_product", "update_product", "enable_product", "disable_product"
+      [product(response["product"] || response)].compact
+    when "list_offer_codes"
+      Array(response["offer_codes"] || response["products"]).filter_map { |o| discount(o) }
+    when "get_offer_code", "create_offer_code", "update_offer_code"
+      [discount(response["offer_code"] || response)].compact
+    when "list_sales"
+      Array(response["sales"]).filter_map { |s| sale(s) }
+    when "get_sale", "refund_sale", "mark_sale_as_shipped"
+      [sale(response["sale"] || response)].compact
+    when "list_payouts"
+      Array(response["payouts"]).filter_map { |p| payout(p) }
+    when "get_payout", "upcoming_payout"
+      [payout(response["payout"] || response)].compact
+    when "list_upsells"
+      Array(response["upsells"]).filter_map { |u| upsell(u) }
+    when "get_upsell", "create_upsell", "update_upsell"
+      [upsell(response["upsell"] || response)].compact
+    when "list_emails"
+      Array(response["emails"] || response["installments"]).filter_map { |e| email(e) }
+    when "get_email", "create_email"
+      [email(response["email"] || response["installment"] || response)].compact
+    else
+      []
+    end
+  end
+
+  # ---- per-type builders (all tolerant of missing keys) ----
+
+  def product(json)
+    return nil unless json.is_a?(Hash) && (json["name"] || json["id"])
+    url = json["short_url"].presence || json["landing_url"].presence
+    {
+      type: "product",
+      title: json["name"].to_s,
+      subtitle: json["formatted_price"].presence || money(json["price"], json["currency"]),
+      fields: compact_fields([
+                               ["Status", json.key?("published") ? (json["published"] ? "Published" : "Unpublished") : nil],
+                               ["Sales", json["sales_count"]],
+                               ["Price", json["formatted_price"].presence || money(json["price"], json["currency"])],
+                             ]),
+      url:,
+      copy: url.presence || json["id"],
+    }
+  end
+
+  def discount(json)
+    return nil unless json.is_a?(Hash) && (json["name"] || json["id"])
+    amount = json["percent_off"].present? ? "#{json['percent_off']}% off" : (json["amount_cents"].present? ? "#{money(json['amount_cents'])} off" : nil)
+    {
+      type: "discount",
+      title: json["name"].to_s, # the API returns the code as `name`
+      subtitle: amount,
+      fields: compact_fields([
+                               ["Amount", amount],
+                               ["Applies to", json["universal"] ? "All products" : "Selected products"],
+                               ["Times used", json["times_used"]],
+                               ["Max uses", json["max_purchase_count"]],
+                             ]),
+      url: nil,
+      copy: json["name"].presence || json["id"], # the code is the useful thing to copy
+    }
+  end
+
+  def sale(json)
+    return nil unless json.is_a?(Hash) && json["id"]
+    {
+      type: "sale",
+      title: json["product_name"].presence || json["email"].presence || "Sale #{json['id']}",
+      subtitle: json["formatted_total_price"].presence || money(json["price"], json["currency"]),
+      fields: compact_fields([
+                               ["Buyer", json["email"]],
+                               ["Product", json["product_name"]],
+                               ["Amount", json["formatted_total_price"].presence || money(json["price"], json["currency"])],
+                               ["Date", json["created_at"]],
+                               ["Refunded", json.key?("refunded") ? (json["refunded"] ? "Yes" : "No") : nil],
+                             ]),
+      url: nil,
+      copy: json["id"],
+    }
+  end
+
+  def payout(json)
+    return nil unless json.is_a?(Hash) && (json["id"] || json["amount"] || json["amount_cents"])
+    amount = json["displayable_amount"].presence || money(json["amount_cents"] || json["amount"], json["currency"])
+    {
+      type: "payout",
+      title: amount.presence || "Payout",
+      subtitle: json["status"].presence,
+      fields: compact_fields([
+                               ["Amount", amount],
+                               ["Status", json["status"]],
+                               ["Paid on", json["paid_at"].presence || json["created_at"]],
+                             ]),
+      url: nil,
+      copy: json["id"],
+    }
+  end
+
+  def upsell(json)
+    return nil unless json.is_a?(Hash) && (json["name"] || json["id"])
+    {
+      type: "upsell",
+      title: json["name"].to_s,
+      subtitle: json["cross_sell"] ? "Cross-sell" : "Upsell",
+      fields: compact_fields([
+                               ["Type", json["cross_sell"] ? "Cross-sell" : "Upsell"],
+                               ["Discount", json["offer_code"].is_a?(Hash) ? json.dig("offer_code", "name") : json["offer_code"]],
+                             ]),
+      url: nil,
+      copy: json["id"],
+    }
+  end
+
+  def email(json)
+    return nil unless json.is_a?(Hash) && (json["subject"] || json["name"] || json["id"])
+    {
+      type: "email",
+      title: json["subject"].presence || json["name"].to_s,
+      subtitle: json.key?("published") ? (json["published"] ? "Sent" : "Draft") : nil,
+      fields: compact_fields([
+                               ["Status", json.key?("published") ? (json["published"] ? "Sent" : "Draft") : nil],
+                               ["Audience", json["audience_type"]],
+                               ["Published", json["published_at"]],
+                             ]),
+      url: json["published_url"].presence,
+      copy: json["published_url"].presence || json["id"],
+    }
+  end
+
+  # ---- helpers ----
+
+  def compact_fields(pairs)
+    pairs.filter_map do |label, value|
+      next if value.nil?
+      str = value.to_s.strip
+      next if str.empty?
+      { label:, value: str }
+    end
+  end
+
+  # Format integer cents into a plain dollar string. We don't know every currency's symbol here, so
+  # default to "$" for USD and a "<amount> <CCY>" form otherwise; the API's own formatted_* fields are
+  # preferred wherever present.
+  def money(cents, currency = nil)
+    return nil if cents.nil?
+    n = cents.to_i
+    dollars = format("%.2f", n / 100.0).sub(/\.00$/, "")
+    ccy = (currency || "usd").to_s.downcase
+    ccy == "usd" ? "$#{dollars}" : "#{dollars} #{ccy.upcase}"
+  end
+end

--- a/app/services/ai/store_agent_service.rb
+++ b/app/services/ai/store_agent_service.rb
@@ -311,7 +311,13 @@ class Ai::StoreAgentService
 
     def parse_arguments(raw)
       return {} if raw.blank?
-      JSON.parse(raw)
+      # OpenAI tool-call arguments are *supposed* to be a JSON object, but a hallucinating model can
+      # emit a bare array ("[1,2,3]") or scalar ("42"). The propose_* tools index arguments by key
+      # (arguments["code"]), which raises TypeError on an Array/Integer and would surface as an
+      # unhandled 500. Coerce anything that isn't an object to an empty hash so the tool falls through
+      # to its normal "field is required" validation instead.
+      parsed = JSON.parse(raw)
+      parsed.is_a?(Hash) ? parsed : {}
     rescue JSON::ParserError
       {}
     end

--- a/app/services/ai/store_agent_service.rb
+++ b/app/services/ai/store_agent_service.rb
@@ -1,0 +1,341 @@
+# frozen_string_literal: true
+
+# Ai::StoreAgentService powers the conversational "Agent" dashboard tab. The seller chats with an
+# assistant that can answer questions about their store and *propose* changes to it.
+#
+# Safety model:
+#   - READ tools (list_products, store_stats, list_discounts) run automatically and only ever query
+#     data the seller already owns. They are scoped to current_seller, so the agent can never read
+#     another seller's data.
+#   - WRITE tools (create_discount, update_product_price, publish_product, unpublish_product) DO NOT
+#     mutate anything here. They return a structured "proposed action" that the frontend renders as a
+#     confirmation card. Nothing is applied until the seller explicitly confirms, at which point the
+#     controller hands the action to Ai::StoreAgentActionExecutor. This keeps an LLM hallucination or
+#     a prompt injection from silently changing a store.
+#
+# The loop is a standard OpenAI tool-calling exchange: we send the conversation + tool schemas, run
+# any read tools the model asks for, feed the results back, and repeat until the model returns a
+# normal assistant message (optionally carrying one proposed write action).
+class Ai::StoreAgentService
+  include CurrencyHelper
+
+  class Error < StandardError; end
+
+  MODEL = "gpt-4o-mini"
+  REQUEST_TIMEOUT_IN_SECONDS = 60
+  MAX_TOOL_ITERATIONS = 5
+  MAX_MESSAGE_LENGTH = 2_000
+  # How many prior turns of context we forward to the model. Keeps token usage bounded and avoids
+  # echoing an unbounded client-supplied history back to OpenAI.
+  MAX_HISTORY_MESSAGES = 20
+
+  SYSTEM_PROMPT = <<~PROMPT.strip
+    You are Gumroad's store assistant. You help a creator understand and manage their own Gumroad
+    store through a chat interface in their dashboard.
+
+    You can:
+    - Answer questions about the creator's products, sales, payouts, and discounts using the read tools.
+    - Propose changes to the store (create a discount code, change a product's price, publish or
+      unpublish a product) using the write tools.
+
+    Rules:
+    - Only ever act on the current creator's own store. You cannot access other creators' data.
+    - Read tools return live data; use them instead of guessing numbers.
+    - Write tools NEVER take effect immediately. They produce a proposed change that the creator must
+      review and confirm in the UI. Never claim a change has been made; say you've prepared it for
+      their confirmation.
+    - Propose at most one change per reply. If the creator asks for several changes, do the first and
+      tell them you'll continue once they confirm.
+    - Prices are in the product's own currency. Amounts you pass to tools are in whole currency units
+      (dollars), not cents.
+    - Be concise and concrete. Reference products by name.
+  PROMPT
+
+  ProposedAction = Struct.new(:type, :params, :summary, keyword_init: true) do
+    def as_json(*) = { type:, params:, summary: }
+  end
+
+  def initialize(seller:, pundit_user:)
+    @seller = seller
+    @pundit_user = pundit_user
+  end
+
+  # @param messages [Array<Hash>] prior conversation, each { role: "user"|"assistant", content: String }
+  # @return [Hash] { reply: String, proposed_action: Hash|nil }
+  def respond(messages:)
+    conversation = build_conversation(messages)
+    proposed_action = nil
+
+    MAX_TOOL_ITERATIONS.times do
+      response = client.chat(parameters: {
+        model: MODEL,
+        messages: conversation,
+        tools: tool_schemas,
+        tool_choice: "auto",
+        temperature: 0.3,
+      })
+
+      message = response.dig("choices", 0, "message")
+      raise Error, "No response from model" if message.nil?
+
+      tool_calls = message["tool_calls"]
+      if tool_calls.blank?
+        return { reply: message["content"].to_s.strip, proposed_action: proposed_action&.as_json }
+      end
+
+      # Echo the assistant tool-call message back into the conversation before answering each call,
+      # as required by the OpenAI tool-calling protocol.
+      conversation << { role: "assistant", content: message["content"], tool_calls: }
+
+      tool_calls.each do |tool_call|
+        name = tool_call.dig("function", "name")
+        arguments = parse_arguments(tool_call.dig("function", "arguments"))
+        result, action = run_tool(name:, arguments:)
+        proposed_action = action if action.present?
+        conversation << {
+          role: "tool",
+          tool_call_id: tool_call["id"],
+          name:,
+          content: result.to_json,
+        }
+      end
+    end
+
+    # The model kept calling tools past our cap. Return whatever change it staged plus a safe message.
+    {
+      reply: "I gathered the details but need you to confirm the next step before I continue.",
+      proposed_action: proposed_action&.as_json,
+    }
+  end
+
+  private
+    attr_reader :seller, :pundit_user
+
+    def build_conversation(messages)
+      history = Array(messages).last(MAX_HISTORY_MESSAGES).filter_map do |msg|
+        role = msg[:role] || msg["role"]
+        content = (msg[:content] || msg["content"]).to_s.strip
+        next if content.blank?
+        next unless %w[user assistant].include?(role)
+
+        { role:, content: content.truncate(MAX_MESSAGE_LENGTH, omission: "...") }
+      end
+      raise Error, "Message is required" if history.empty? || history.last[:role] != "user"
+
+      [{ role: "system", content: SYSTEM_PROMPT }, *history]
+    end
+
+    def run_tool(name:, arguments:)
+      case name
+      when "list_products" then [tool_list_products, nil]
+      when "store_stats" then [tool_store_stats, nil]
+      when "list_discounts" then [tool_list_discounts, nil]
+      when "create_discount" then propose_create_discount(arguments)
+      when "update_product_price" then propose_update_product_price(arguments)
+      when "publish_product" then propose_set_published(arguments, published: true)
+      when "unpublish_product" then propose_set_published(arguments, published: false)
+      else
+        [{ error: "Unknown tool: #{name}" }, nil]
+      end
+    end
+
+    # ---- Read tools (auto-executed, current_seller-scoped) ----
+
+    def tool_list_products
+      products = seller.products.visible_and_not_archived.order(created_at: :desc).limit(50).to_a
+      sales_counts = cached_sales_counts_for(products)
+      {
+        products: products.map do |product|
+          {
+            id: product.external_id,
+            name: product.name,
+            price: format_amount(product.price_cents, product.price_currency_type),
+            currency: product.price_currency_type,
+            published: product.alive?,
+            sales_count: sales_counts[product.id] || 0,
+          }
+        end,
+      }
+    end
+
+    # Read each product's sales count from its most recent ProductCachedValue row in two queries,
+    # instead of running a per-product Elasticsearch count (which would be a 50x N+1).
+    def cached_sales_counts_for(products)
+      return {} if products.empty?
+
+      latest_ids = ProductCachedValue.where(product_id: products.map(&:id)).group(:product_id).maximum(:id).values
+      return {} if latest_ids.empty?
+
+      ProductCachedValue.where(id: latest_ids).pluck(:product_id, :successful_sales_count).to_h
+    end
+
+    def tool_store_stats
+      stats = {
+        total_products: seller.products.visible_and_not_archived.count,
+        published_products: seller.products.alive.count,
+        gross_sales: format_amount(seller.sales_cents_total, seller.currency_type),
+        currency: seller.currency_type,
+      }
+      # Payout/balance data is gated by the SAME policy as the Payouts page (BalancePolicy#index?),
+      # which excludes roles like marketing. Only expose the unpaid balance to roles that can already
+      # see it through the dashboard, so the agent can't become a side channel around that policy.
+      if can_view_balance?
+        stats[:unpaid_balance] = format_amount(seller.unpaid_balance_cents, seller.currency_type)
+      end
+      stats
+    end
+
+    def can_view_balance?
+      Pundit.policy!(pundit_user, :balance).index?
+    end
+
+    def tool_list_discounts
+      offer_codes = seller.offer_codes.alive.order(created_at: :desc).limit(50)
+      {
+        discounts: offer_codes.map do |offer_code|
+          {
+            id: offer_code.external_id,
+            code: offer_code.code,
+            amount: offer_code.is_percent? ? "#{offer_code.amount_percentage}%" : format_amount(offer_code.amount_cents, seller.currency_type),
+            universal: offer_code.universal?,
+          }
+        end,
+      }
+    end
+
+    # ---- Write tools (return a proposed action; never mutate) ----
+
+    def propose_create_discount(arguments)
+      code = arguments["code"].to_s.strip
+      percent_off = arguments["percent_off"]
+      amount_off = arguments["amount_off"]
+
+      if code.blank?
+        return [{ error: "A discount code is required." }, nil]
+      end
+      if percent_off.blank? && amount_off.blank?
+        return [{ error: "Provide either percent_off or amount_off." }, nil]
+      end
+
+      summary =
+        if percent_off.present?
+          "Create discount code #{code} for #{percent_off.to_i}% off (applies to all products)."
+        else
+          "Create discount code #{code} for #{format_amount(string_to_price_cents(seller.currency_type, amount_off.to_s), seller.currency_type)} off (applies to all products)."
+        end
+
+      action = ProposedAction.new(
+        type: "create_discount",
+        params: { code:, percent_off: percent_off.presence&.to_i, amount_off_cents: amount_off.present? ? string_to_price_cents(seller.currency_type, amount_off.to_s) : nil }.compact,
+        summary:,
+      )
+      [{ proposed: true, summary: }, action]
+    end
+
+    def propose_update_product_price(arguments)
+      product = find_product(arguments["product_id"])
+      return [{ error: "I couldn't find that product." }, nil] if product.nil?
+      # Tiered memberships and variant-priced products keep the buyer-visible price on their
+      # tiers/variants, not the product's own price_cents column — changing price_cents there would
+      # silently no-op the displayed price. Refuse rather than report a misleading success.
+      if priced_by_variants?(product)
+        return [{ error: "\"#{product.name}\" is priced per tier/version, so I can't change its price from here. Edit it on the product page." }, nil]
+      end
+
+      new_price = arguments["new_price"]
+      return [{ error: "A new price is required." }, nil] if new_price.blank?
+
+      new_price_cents = string_to_price_cents(product.price_currency_type, new_price.to_s)
+      summary = "Change the price of \"#{product.name}\" from " \
+                "#{format_amount(product.price_cents, product.price_currency_type)} to " \
+                "#{format_amount(new_price_cents, product.price_currency_type)}."
+      action = ProposedAction.new(
+        type: "update_product_price",
+        params: { product_id: product.external_id, new_price_cents: },
+        summary:,
+      )
+      [{ proposed: true, summary: }, action]
+    end
+
+    def propose_set_published(arguments, published:)
+      product = find_product(arguments["product_id"])
+      return [{ error: "I couldn't find that product." }, nil] if product.nil?
+
+      verb = published ? "Publish" : "Unpublish"
+      summary = "#{verb} \"#{product.name}\"."
+      action = ProposedAction.new(
+        type: published ? "publish_product" : "unpublish_product",
+        params: { product_id: product.external_id },
+        summary:,
+      )
+      [{ proposed: true, summary: }, action]
+    end
+
+    # ---- helpers ----
+
+    def find_product(external_id)
+      return nil if external_id.blank?
+      seller.products.visible.find_by_external_id(external_id.to_s)
+    end
+
+    # True when the buyer-visible price lives on tiers/variants rather than the product's own
+    # price_cents column, so a flat price_cents change wouldn't affect what buyers actually pay.
+    def priced_by_variants?(product)
+      product.is_tiered_membership? || product.alive_variants.exists?
+    end
+
+    def format_amount(cents, currency_type)
+      MoneyFormatter.format(cents.to_i, (currency_type || "usd").to_sym, symbol: true, no_cents_if_whole: false)
+    end
+
+    def parse_arguments(raw)
+      return {} if raw.blank?
+      JSON.parse(raw)
+    rescue JSON::ParserError
+      {}
+    end
+
+    def client
+      @_client ||= OpenAI::Client.new(request_timeout: REQUEST_TIMEOUT_IN_SECONDS)
+    end
+
+    def tool_schemas
+      [
+        tool_schema("list_products", "List the creator's products with price, currency, publish status, and sales count.", {}),
+        tool_schema("store_stats", "Get high-level store stats: product counts, gross sales, and unpaid balance.", {}),
+        tool_schema("list_discounts", "List the creator's active discount codes.", {}),
+        tool_schema(
+          "create_discount",
+          "Propose creating a universal discount code that applies to all products. Provide exactly one of percent_off or amount_off.",
+          {
+            code: { type: "string", description: "The discount code, e.g. SUMMER25." },
+            percent_off: { type: "integer", description: "Percentage off, 1-100." },
+            amount_off: { type: "number", description: "Fixed amount off in whole currency units (dollars)." },
+          },
+          required: ["code"],
+        ),
+        tool_schema(
+          "update_product_price",
+          "Propose changing a product's price.",
+          {
+            product_id: { type: "string", description: "The product id from list_products." },
+            new_price: { type: "number", description: "The new price in whole currency units (dollars)." },
+          },
+          required: %w[product_id new_price],
+        ),
+        tool_schema("publish_product", "Propose publishing a product so it becomes available for sale.", { product_id: { type: "string", description: "The product id from list_products." } }, required: ["product_id"]),
+        tool_schema("unpublish_product", "Propose unpublishing a product so it is no longer available for sale.", { product_id: { type: "string", description: "The product id from list_products." } }, required: ["product_id"]),
+      ]
+    end
+
+    def tool_schema(name, description, properties, required: [])
+      {
+        type: "function",
+        function: {
+          name:,
+          description:,
+          parameters: { type: "object", properties:, required:, additionalProperties: false },
+        },
+      }
+    end
+end

--- a/app/services/ai/store_agent_service.rb
+++ b/app/services/ai/store_agent_service.rb
@@ -29,26 +29,39 @@ class Ai::StoreAgentService
   # echoing an unbounded client-supplied history back to OpenAI.
   MAX_HISTORY_MESSAGES = 20
 
-  SYSTEM_PROMPT = <<~PROMPT.strip
+  # The system prompt is assembled at runtime (see #system_prompt) so it can embed the live catalog
+  # manifest of every endpoint the agent can reach. This keeps the prompt and the actual tool surface
+  # from drifting apart as endpoints are added to the catalog.
+  SYSTEM_PROMPT_HEADER = <<~PROMPT.strip
     You are Gumroad's store assistant. You help a creator understand and manage their own Gumroad
     store through a chat interface in their dashboard.
 
-    You can:
-    - Answer questions about the creator's products, sales, payouts, and discounts using the read tools.
-    - Propose changes to the store (create a discount code, change a product's price, publish or
-      unpublish a product) using the write tools.
+    You have two tools that together expose the creator's ENTIRE Gumroad API:
+    - api_read: run any READ endpoint to fetch live data (products, sales, payouts, discounts,
+      subscribers, upsells, emails, tax forms, earnings, profile, and more). These run immediately.
+    - api_write: PROPOSE any change (create/update/delete products, discounts, variants, upsells,
+      emails, refunds, shipping, licenses, webhooks, profile, and more). Writes NEVER take effect
+      immediately — they produce a proposed change the creator must review and confirm in the UI.
+
+    To call a tool you pass `endpoint` (one of the ids listed below), `path_params` (the ids the
+    endpoint's path needs, e.g. the product id), and `params` (query for reads, body for writes).
 
     Rules:
-    - Only ever act on the current creator's own store. You cannot access other creators' data.
-    - Read tools return live data; use them instead of guessing numbers.
-    - Write tools NEVER take effect immediately. They produce a proposed change that the creator must
-      review and confirm in the UI. Never claim a change has been made; say you've prepared it for
-      their confirmation.
-    - Propose at most one change per reply. If the creator asks for several changes, do the first and
-      tell them you'll continue once they confirm.
-    - Prices are in the product's own currency. Amounts you pass to tools are in whole currency units
-      (dollars), not cents.
+    - Only ever act on the current creator's own store. You cannot access other creators' data; the
+      API enforces this and an endpoint the creator's role can't use will simply fail.
+    - Always use api_read to get real ids and live numbers before acting. Never invent ids.
+    - Never claim a change has been made. For any api_write, say you've prepared it for the creator's
+      confirmation.
+    - Propose at most ONE change per reply. If the creator asks for several, do the first and tell
+      them you'll continue once they confirm.
+    - Monetary amounts in the API are in CENTS (integer). $10 = 1000.
     - Be concise and concrete. Reference products by name.
+
+    READ endpoints (api_read):
+    %<reads>s
+
+    WRITE endpoints (api_write — each requires confirmation):
+    %<writes>s
   PROMPT
 
   ProposedAction = Struct.new(:type, :params, :summary, keyword_init: true) do
@@ -137,183 +150,112 @@ class Ai::StoreAgentService
       end
       raise Error, "Message is required" if history.empty? || history.last[:role] != "user"
 
-      [{ role: "system", content: SYSTEM_PROMPT }, *history]
+      [{ role: "system", content: system_prompt }, *history]
     end
 
+    # Assemble the system prompt with the live read/write endpoint manifests embedded, so the model
+    # is told exactly which endpoint ids exist and what each does.
+    def system_prompt
+      format(
+        SYSTEM_PROMPT_HEADER,
+        reads: Ai::StoreAgentApiCatalog.manifest(:read),
+        writes: Ai::StoreAgentApiCatalog.manifest(:write),
+      )
+    end
+
+    # Two generic tools drive the whole catalog. `api_read` runs a read endpoint immediately;
+    # `api_write` turns a write endpoint into a single proposed action (never mutates here).
     def run_tool(name:, arguments:)
       case name
-      when "list_products" then [tool_list_products, nil]
-      when "store_stats" then [tool_store_stats, nil]
-      when "list_discounts" then [tool_list_discounts, nil]
-      when "create_discount" then propose_create_discount(arguments)
-      when "update_product_price" then propose_update_product_price(arguments)
-      when "publish_product" then propose_set_published(arguments, published: true)
-      when "unpublish_product" then propose_set_published(arguments, published: false)
+      when "api_read" then run_api_read(arguments)
+      when "api_write" then propose_api_write(arguments)
       else
         [{ error: "Unknown tool: #{name}" }, nil]
       end
     end
 
-    # ---- Read tools (auto-executed, current_seller-scoped) ----
+    # ---- api_read: auto-executed, creator-scoped via the real v2 API ----
 
-    def tool_list_products
-      products = seller.products.visible_and_not_archived.order(created_at: :desc).limit(50).to_a
-      sales_counts = cached_sales_counts_for(products)
-      {
-        products: products.map do |product|
-          {
-            id: product.external_id,
-            name: product.name,
-            price: format_amount(product.price_cents, product.price_currency_type),
-            currency: product.price_currency_type,
-            published: product.alive?,
-            sales_count: sales_counts[product.id] || 0,
-          }
-        end,
-      }
-    end
-
-    # Read each product's sales count from its most recent ProductCachedValue row in two queries,
-    # instead of running a per-product Elasticsearch count (which would be a 50x N+1).
-    def cached_sales_counts_for(products)
-      return {} if products.empty?
-
-      latest_ids = ProductCachedValue.where(product_id: products.map(&:id)).group(:product_id).maximum(:id).values
-      return {} if latest_ids.empty?
-
-      ProductCachedValue.where(id: latest_ids).pluck(:product_id, :successful_sales_count).to_h
-    end
-
-    def tool_store_stats
-      stats = {
-        total_products: seller.products.visible_and_not_archived.count,
-        published_products: seller.products.alive.count,
-        gross_sales: format_amount(seller.sales_cents_total, seller.currency_type),
-        currency: seller.currency_type,
-      }
-      # Payout/balance data is gated by the SAME policy as the Payouts page (BalancePolicy#index?),
-      # which excludes roles like marketing. Only expose the unpaid balance to roles that can already
-      # see it through the dashboard, so the agent can't become a side channel around that policy.
-      if can_view_balance?
-        stats[:unpaid_balance] = format_amount(seller.unpaid_balance_cents, seller.currency_type)
+    def run_api_read(arguments)
+      endpoint = Ai::StoreAgentApiCatalog.find(arguments["endpoint"])
+      if endpoint.nil?
+        return [{ error: "Unknown endpoint. Use one of the read endpoint ids listed for api_read." }, nil]
       end
-      stats
-    end
-
-    def can_view_balance?
-      Pundit.policy!(pundit_user, :balance).index?
-    end
-
-    def tool_list_discounts
-      offer_codes = seller.offer_codes.alive.order(created_at: :desc).limit(50)
-      {
-        discounts: offer_codes.map do |offer_code|
-          {
-            id: offer_code.external_id,
-            code: offer_code.code,
-            amount: offer_code.is_percent? ? "#{offer_code.amount_percentage}%" : format_amount(offer_code.amount_cents, seller.currency_type),
-            universal: offer_code.universal?,
-          }
-        end,
-      }
-    end
-
-    # ---- Write tools (return a proposed action; never mutate) ----
-
-    def propose_create_discount(arguments)
-      code = arguments["code"].to_s.strip
-      percent_off = arguments["percent_off"]
-      amount_off = arguments["amount_off"]
-
-      if code.blank?
-        return [{ error: "A discount code is required." }, nil]
-      end
-      if percent_off.blank? && amount_off.blank?
-        return [{ error: "Provide either percent_off or amount_off." }, nil]
+      unless endpoint.read?
+        # A write id was sent to the read tool. Don't run it (that would mutate without confirmation);
+        # tell the model to use api_write so it goes through the confirmation card.
+        return [{ error: "#{endpoint.id} changes data — use api_write so the creator can confirm it." }, nil]
       end
 
-      summary =
-        if percent_off.present?
-          "Create discount code #{code} for #{percent_off.to_i}% off (applies to all products)."
-        else
-          "Create discount code #{code} for #{format_amount(string_to_price_cents(seller.currency_type, amount_off.to_s), seller.currency_type)} off (applies to all products)."
-        end
+      path = endpoint.expand_path(arguments["path_params"])
+      result = api_client.get(path, sanitize_param_hash(arguments["params"]))
+      [result, nil]
+    rescue ArgumentError => e
+      # Missing/blank path param (e.g. the model forgot the product id).
+      [{ error: e.message }, nil]
+    end
 
+    # ---- api_write: returns a proposed action; never mutates ----
+
+    def propose_api_write(arguments)
+      endpoint = Ai::StoreAgentApiCatalog.find(arguments["endpoint"])
+      if endpoint.nil?
+        return [{ error: "Unknown endpoint. Use one of the write endpoint ids listed for api_write." }, nil]
+      end
+      unless endpoint.write?
+        # A read id was sent to the write tool. Reads never need confirmation; nudge the model to use
+        # api_read instead so it gets the data immediately.
+        return [{ error: "#{endpoint.id} only reads data — use api_read to get it immediately." }, nil]
+      end
+
+      path_params = sanitize_param_hash(arguments["path_params"])
+      body = sanitize_param_hash(arguments["params"])
+      # Validate the path can actually be built now (so the confirmation card never describes a call
+      # that would fail on a missing id at execute time).
+      begin
+        endpoint.expand_path(path_params)
+      rescue ArgumentError => e
+        return [{ error: e.message }, nil]
+      end
+
+      summary = write_summary(endpoint, path_params, body)
       action = ProposedAction.new(
-        type: "create_discount",
-        params: { code:, percent_off: percent_off.presence&.to_i, amount_off_cents: amount_off.present? ? string_to_price_cents(seller.currency_type, amount_off.to_s) : nil }.compact,
+        type: "api_write",
+        # Everything the executor needs to replay the exact same call after the creator confirms.
+        params: { "endpoint" => endpoint.id, "path_params" => path_params, "params" => body },
         summary:,
       )
       [{ proposed: true, summary: }, action]
     end
 
-    def propose_update_product_price(arguments)
-      product = find_product(arguments["product_id"])
-      return [{ error: "I couldn't find that product." }, nil] if product.nil?
-      # Tiered memberships and variant-priced products keep the buyer-visible price on their
-      # tiers/variants, not the product's own price_cents column — changing price_cents there would
-      # silently no-op the displayed price. Refuse rather than report a misleading success.
-      if priced_by_variants?(product)
-        return [{ error: "\"#{product.name}\" is priced per tier/version, so I can't change its price from here. Edit it on the product page." }, nil]
-      end
-
-      new_price = arguments["new_price"]
-      return [{ error: "A new price is required." }, nil] if new_price.blank?
-      # string_to_price_cents turns a digit-less string into 0 cents, which would silently propose
-      # making the product free. Require an actual number so garbage can't become a $0 price.
-      return [{ error: "The new price must be a number." }, nil] unless new_price.to_s.match?(/\d/)
-
-      new_price_cents = string_to_price_cents(product.price_currency_type, new_price.to_s)
-      summary = "Change the price of \"#{product.name}\" from " \
-                "#{format_amount(product.price_cents, product.price_currency_type)} to " \
-                "#{format_amount(new_price_cents, product.price_currency_type)}."
-      action = ProposedAction.new(
-        type: "update_product_price",
-        params: { product_id: product.external_id, new_price_cents: },
-        summary:,
-      )
-      [{ proposed: true, summary: }, action]
+    # A human-readable description of the pending change for the confirmation card. Built from the
+    # catalog summary plus the concrete ids/params so the creator sees exactly what will happen.
+    def write_summary(endpoint, path_params, body)
+      parts = [endpoint.summary]
+      detail = path_params.merge(body).map { |k, v| "#{k}: #{v}" }.join(", ")
+      parts << "(#{detail})" if detail.present?
+      parts.join(" ")
     end
 
-    def propose_set_published(arguments, published:)
-      product = find_product(arguments["product_id"])
-      return [{ error: "I couldn't find that product." }, nil] if product.nil?
+    # Tool-call sub-objects are supposed to be JSON objects; a hallucinating model can emit an array
+    # or scalar. Coerce anything that isn't a Hash to an empty hash, and stringify keys, so downstream
+    # indexing/path-expansion can't raise a TypeError that surfaces as a 500.
+    def sanitize_param_hash(raw)
+      return {} unless raw.is_a?(Hash)
+      raw.transform_keys(&:to_s)
+    end
 
-      verb = published ? "Publish" : "Unpublish"
-      summary = "#{verb} \"#{product.name}\"."
-      action = ProposedAction.new(
-        type: published ? "publish_product" : "unpublish_product",
-        params: { product_id: product.external_id },
-        summary:,
-      )
-      [{ proposed: true, summary: }, action]
+    def api_client
+      @_api_client ||= Ai::StoreAgentApiClient.new(seller:)
     end
 
     # ---- helpers ----
 
-    def find_product(external_id)
-      return nil if external_id.blank?
-      # Match the listing tool's scope (visible_and_not_archived): the model is only ever shown
-      # non-archived products, so an archived id can only arrive by a seller typing it in. Don't let
-      # the agent propose price/publish changes against archived products the UI never surfaced.
-      seller.products.visible_and_not_archived.find_by_external_id(external_id.to_s)
-    end
-
-    # True when the buyer-visible price lives on tiers/variants rather than the product's own
-    # price_cents column, so a flat price_cents change wouldn't affect what buyers actually pay.
-    def priced_by_variants?(product)
-      product.is_tiered_membership? || product.alive_variants.exists?
-    end
-
-    def format_amount(cents, currency_type)
-      MoneyFormatter.format(cents.to_i, (currency_type || "usd").to_sym, symbol: true, no_cents_if_whole: false)
-    end
-
     def parse_arguments(raw)
       return {} if raw.blank?
       # OpenAI tool-call arguments are *supposed* to be a JSON object, but a hallucinating model can
-      # emit a bare array ("[1,2,3]") or scalar ("42"). The propose_* tools index arguments by key
-      # (arguments["code"]), which raises TypeError on an Array/Integer and would surface as an
+      # emit a bare array ("[1,2,3]") or scalar ("42"). The tools index arguments by key
+      # (arguments["endpoint"]), which raises TypeError on an Array/Integer and would surface as an
       # unhandled 500. Coerce anything that isn't an object to an empty hash so the tool falls through
       # to its normal "field is required" validation instead.
       parsed = JSON.parse(raw)
@@ -326,32 +268,31 @@ class Ai::StoreAgentService
       @_client ||= OpenAI::Client.new(request_timeout: REQUEST_TIMEOUT_IN_SECONDS)
     end
 
+    # Two generic tools. The endpoint id (constrained to the catalog by an enum) selects which of the
+    # ~60 real API endpoints to hit; path_params/params carry the ids and payload. Keeping the JSON
+    # schema this small avoids a 60-function tool list while still reaching the entire API.
     def tool_schemas
       [
-        tool_schema("list_products", "List the creator's products with price, currency, publish status, and sales count.", {}),
-        tool_schema("store_stats", "Get high-level store stats: product counts, gross sales, and unpaid balance.", {}),
-        tool_schema("list_discounts", "List the creator's active discount codes.", {}),
         tool_schema(
-          "create_discount",
-          "Propose creating a universal discount code that applies to all products. Provide exactly one of percent_off or amount_off.",
+          "api_read",
+          "Read live data from the creator's Gumroad store by calling a READ API endpoint. Runs immediately.",
           {
-            code: { type: "string", description: "The discount code, e.g. SUMMER25." },
-            percent_off: { type: "integer", description: "Percentage off, 1-100." },
-            amount_off: { type: "number", description: "Fixed amount off in whole currency units (dollars)." },
+            endpoint: { type: "string", enum: Ai::StoreAgentApiCatalog.read_ids, description: "Which read endpoint to call (see the READ endpoints list)." },
+            path_params: { type: "object", description: "Ids the endpoint's path needs, e.g. {\"id\": \"<product id>\"}. Omit if none.", additionalProperties: { type: "string" } },
+            params: { type: "object", description: "Query parameters, e.g. {\"after\": \"2024-01-01\"}. Omit if none." },
           },
-          required: ["code"],
+          required: ["endpoint"],
         ),
         tool_schema(
-          "update_product_price",
-          "Propose changing a product's price.",
+          "api_write",
+          "PROPOSE a change to the creator's store by calling a WRITE API endpoint. Does NOT take effect until the creator confirms. Propose only one change per reply.",
           {
-            product_id: { type: "string", description: "The product id from list_products." },
-            new_price: { type: "number", description: "The new price in whole currency units (dollars)." },
+            endpoint: { type: "string", enum: Ai::StoreAgentApiCatalog.write_ids, description: "Which write endpoint to call (see the WRITE endpoints list)." },
+            path_params: { type: "object", description: "Ids the endpoint's path needs, e.g. {\"id\": \"<product id>\"}. Omit if none.", additionalProperties: { type: "string" } },
+            params: { type: "object", description: "Request body. Monetary amounts are in cents (integer). Omit if none." },
           },
-          required: %w[product_id new_price],
+          required: ["endpoint"],
         ),
-        tool_schema("publish_product", "Propose publishing a product so it becomes available for sale.", { product_id: { type: "string", description: "The product id from list_products." } }, required: ["product_id"]),
-        tool_schema("unpublish_product", "Propose unpublishing a product so it is no longer available for sale.", { product_id: { type: "string", description: "The product id from list_products." } }, required: ["product_id"]),
       ]
     end
 

--- a/app/services/ai/store_agent_service.rb
+++ b/app/services/ai/store_agent_service.rb
@@ -3,33 +3,57 @@
 # Ai::StoreAgentService powers the conversational "Agent" dashboard tab. The seller chats with an
 # assistant that can answer questions about their store and *propose* changes to it.
 #
-# Safety model:
-#   - READ tools (list_products, store_stats, list_discounts) run automatically and only ever query
-#     data the seller already owns. They are scoped to current_seller, so the agent can never read
-#     another seller's data.
-#   - WRITE tools (create_discount, update_product_price, publish_product, unpublish_product) DO NOT
-#     mutate anything here. They return a structured "proposed action" that the frontend renders as a
-#     confirmation card. Nothing is applied until the seller explicitly confirms, at which point the
-#     controller hands the action to Ai::StoreAgentActionExecutor. This keeps an LLM hallucination or
-#     a prompt injection from silently changing a store.
+# The agent runs on Anthropic's Claude Opus 4.7 (via Ai::AnthropicClient). Opus 4.7 currently leads
+# the vending-bench leaderboard for autonomous commercial operation, so it is the strongest model
+# for the agent's actual job: helping a creator run and grow their store.
 #
-# The loop is a standard OpenAI tool-calling exchange: we send the conversation + tool schemas, run
-# any read tools the model asks for, feed the results back, and repeat until the model returns a
-# normal assistant message (optionally carrying one proposed write action).
+# Safety model:
+#   - READ tools (api_read) run automatically and only ever query data the seller already owns. They
+#     are scoped to current_seller, so the agent can never read another seller's data.
+#   - WRITE tools (api_write) DO NOT mutate anything here. They return a structured "proposed action"
+#     that the frontend renders as a confirmation card. Nothing is applied until the seller explicitly
+#     confirms, at which point the controller hands the action to Ai::StoreAgentActionExecutor. This
+#     keeps an LLM hallucination or a prompt injection from silently changing a store.
+#
+# The loop is a standard Anthropic tool-use exchange: we send the system prompt + conversation + tool
+# schemas, run any read tools the model asks for, feed the results back as tool_result blocks, and
+# repeat until the model returns a normal assistant message (optionally carrying one proposed write).
 class Ai::StoreAgentService
   include CurrencyHelper
 
   class Error < StandardError; end
 
-  MODEL = "gpt-4o-mini"
+  MODEL = Ai::AnthropicClient::DEFAULT_MODEL
   REQUEST_TIMEOUT_IN_SECONDS = 60
   MAX_TOOL_ITERATIONS = 5
   MAX_MESSAGE_LENGTH = 2_000
+  # Anthropic requires max_tokens; size it for a brief chat reply plus a tool call's JSON args.
+  MAX_REPLY_TOKENS = 1_500
   # How many prior turns of context we forward to the model. Keeps token usage bounded and avoids
-  # echoing an unbounded client-supplied history back to OpenAI.
+  # echoing an unbounded client-supplied history back to the model.
   MAX_HISTORY_MESSAGES = 20
   # Cap how many object cards we render inline per turn so a large list can't flood the chat.
   MAX_DISPLAY_OBJECTS = 20
+  # How many "what next" follow-up prompts we suggest at the end of a turn to keep the conversation
+  # going, and the max length of each so a chip stays a tappable phrase, not a paragraph.
+  MAX_SUGGESTIONS = 3
+  SUGGESTION_MAX_LENGTH = 80
+  MAX_SUGGESTION_TOKENS = 200
+
+  # A tiny separate completion turns the just-finished exchange into a few natural next prompts the
+  # creator is likely to want, phrased in their own voice so they read as one-tap continuations.
+  FOLLOW_UP_PROMPT = <<~PROMPT.strip
+    You suggest what a Gumroad creator might want to ask their store assistant NEXT, to keep the
+    conversation going. Given the creator's last message and the assistant's answer, return up to
+    three short follow-up prompts.
+
+    Rules:
+    - Phrase each as something the CREATOR would say to the assistant, in the first person
+      (e.g. "Show my best sellers this month", "Email my customers about it").
+    - Keep each under 8 words. No numbering, no quotes, no trailing punctuation.
+    - Make them specific and relevant to what was just discussed and to running a store.
+    - Return ONLY a JSON array of strings, nothing else. If nothing useful fits, return [].
+  PROMPT
 
   # The system prompt is assembled at runtime (see #system_prompt) so it can embed the live catalog
   # manifest of every endpoint the agent can reach. This keeps the prompt and the actual tool surface
@@ -95,32 +119,93 @@ class Ai::StoreAgentService
     @objects = []
 
     MAX_TOOL_ITERATIONS.times do
-      response = client.chat(
-        parameters: {
-          model: MODEL,
-          messages: conversation,
-          tools: tool_schemas,
-          tool_choice: "auto",
-          temperature: 0.3,
-        },
+      result = client.messages(
+        system: system_prompt,
+        messages: conversation,
+        tools: tool_schemas,
+        max_tokens: MAX_REPLY_TOKENS,
+        temperature: 0.3,
       )
 
-      message = response.dig("choices", 0, "message")
-      raise Error, "No response from model" if message.nil?
-
-      tool_calls = message["tool_calls"]
-      if tool_calls.blank?
-        return { reply: message["content"].to_s.strip, proposed_action: proposed_action&.as_json, objects: deduped_objects }
+      if result.tool_uses.blank?
+        return { reply: result.text.to_s.strip, proposed_action: proposed_action&.as_json, objects: deduped_objects }
       end
 
-      # Echo the assistant tool-call message back into the conversation before answering each call,
-      # as required by the OpenAI tool-calling protocol.
-      conversation << { role: "assistant", content: message["content"], tool_calls: }
+      proposed_action = apply_tool_uses(text: result.text, tool_uses: result.tool_uses, conversation:, proposed_action:)
+    end
 
-      tool_calls.each do |tool_call|
-        name = tool_call.dig("function", "name")
-        arguments = parse_arguments(tool_call.dig("function", "arguments"))
-        result, action = run_tool(name:, arguments:)
+    { reply: tool_cap_reply(proposed_action), proposed_action: proposed_action&.as_json, objects: deduped_objects }
+  end
+
+  # Streaming counterpart of #respond. Runs the same read/propose tool loop, but streams the final
+  # assistant reply token-by-token and, once the answer is complete, suggests a few follow-up prompts
+  # to keep the conversation going. Communicates by yielding [event, payload] pairs the controller
+  # writes to the client as Server-Sent Events:
+  #   [:token, { text: }]                 — a chunk of the reply text, as it arrives
+  #   [:objects, { objects: }]            — object cards looked up/changed this turn
+  #   [:proposed_action, { proposed_action: }] — a single staged change awaiting confirmation
+  #   [:suggestions, { suggestions: }]    — up to three "what next" prompts
+  # Returns the same hash shape as #respond (plus :suggestions) once the stream is complete.
+  def respond_streaming(messages:, &emit)
+    conversation = build_conversation(messages)
+    last_user_message = conversation.reverse.find { |m| m[:role] == "user" }&.dig(:content).to_s
+    proposed_action = nil
+    @objects = []
+
+    MAX_TOOL_ITERATIONS.times do
+      # Stream this turn's text deltas live. We don't yet know if the turn is final (text-only) or an
+      # intermediate tool-use turn that happens to include preamble text, so track whether anything
+      # was streamed: if the turn turns out to be a tool-use turn, we emit :reset to discard its
+      # preamble from the UI, and only the final (tool_uses-blank) turn's text survives on screen.
+      streamed_any = false
+      result = client.stream_messages(
+        system: system_prompt,
+        messages: conversation,
+        tools: tool_schemas,
+        max_tokens: MAX_REPLY_TOKENS,
+        temperature: 0.3,
+      ) do |text|
+        streamed_any = true
+        emit.call(:token, { text: })
+      end
+
+      if result.tool_uses.blank?
+        reply = result.text.to_s.strip
+        return finish_stream(reply:, proposed_action:, last_user_message:, emit:)
+      end
+
+      # Intermediate tool-use turn: any text it streamed was preamble, not the answer. Tell the UI to
+      # clear it so the seller never sees an interim claim that gets replaced by the real reply.
+      emit.call(:reset, {}) if streamed_any
+      proposed_action = apply_tool_uses(text: result.text, tool_uses: result.tool_uses, conversation:, proposed_action:)
+    end
+
+    # Hit the tool-iteration cap. Stream the fallback line as a single token so the UI still renders a
+    # reply, then close out with the same objects/action/suggestions as a normal turn.
+    reply = tool_cap_reply(proposed_action)
+    emit.call(:token, { text: reply })
+    finish_stream(reply:, proposed_action:, last_user_message:, emit:)
+  end
+
+  private
+    attr_reader :seller, :pundit_user
+
+    # Echo the assistant's tool-use turn back into the conversation, run each requested tool, and
+    # append a single user message carrying the tool_result blocks (the Anthropic tool-use protocol).
+    # Returns the (possibly updated) proposed action. Shared by #respond and #respond_streaming so the
+    # two paths can't drift.
+    def apply_tool_uses(text:, tool_uses:, conversation:, proposed_action:)
+      # The assistant turn must replay both any text it produced AND the tool_use blocks, in order.
+      assistant_content = []
+      assistant_content << { type: "text", text: text.to_s } if text.to_s.strip.present?
+      tool_uses.each do |tool_use|
+        assistant_content << { type: "tool_use", id: tool_use[:id], name: tool_use[:name], input: tool_use[:input] || {} }
+      end
+      conversation << { role: "assistant", content: assistant_content }
+
+      tool_results = tool_uses.map do |tool_use|
+        arguments = sanitize_param_hash(tool_use[:input])
+        result, action = run_tool(name: tool_use[:name], arguments:)
         if action.present?
           if proposed_action.nil?
             proposed_action = action
@@ -131,28 +216,75 @@ class Ai::StoreAgentService
             result = { error: "Only one change can be proposed at a time. Ask the seller to confirm the first change before proposing another." }
           end
         end
-        conversation << {
-          role: "tool",
-          tool_call_id: tool_call["id"],
-          name:,
-          content: result.to_json,
-        }
+        { type: "tool_result", tool_use_id: tool_use[:id], content: result.to_json }
       end
+      conversation << { role: "user", content: tool_results }
+
+      proposed_action
     end
 
-    # The model kept calling tools past our cap. Return whatever change it staged plus a message that
-    # matches reality: only mention confirmation when there is actually a proposed action to confirm.
-    reply =
+    # The model kept calling tools past our cap. Return a message that matches reality: only mention
+    # confirmation when there is actually a proposed action to confirm.
+    def tool_cap_reply(proposed_action)
       if proposed_action
         "I gathered the details but need you to confirm the next step before I continue."
       else
         "I gathered the details but couldn't finish in one go. Please rephrase or ask again."
       end
-    { reply:, proposed_action: proposed_action&.as_json, objects: deduped_objects }
-  end
+    end
 
-  private
-    attr_reader :seller, :pundit_user
+    # Emit the trailing events for a completed streaming turn (objects, any staged change, and the
+    # follow-up suggestions) and return the full result hash.
+    def finish_stream(reply:, proposed_action:, last_user_message:, emit:)
+      objects = deduped_objects
+      emit.call(:objects, { objects: }) if objects.any?
+      emit.call(:proposed_action, { proposed_action: proposed_action.as_json }) if proposed_action
+      suggestions = follow_up_suggestions(reply:, last_user_message:)
+      emit.call(:suggestions, { suggestions: }) if suggestions.any?
+      { reply:, proposed_action: proposed_action&.as_json, objects:, suggestions: }
+    end
+
+    # Ask the model for a few short, in-voice next prompts based on the turn that just happened. Kept
+    # deliberately cheap (no tools, low max_tokens) and fully best-effort: any failure or unparseable
+    # output yields no suggestions rather than breaking the reply the creator already received.
+    def follow_up_suggestions(reply:, last_user_message:)
+      return [] if reply.blank?
+
+      result = client.messages(
+        system: FOLLOW_UP_PROMPT,
+        messages: [
+          { role: "user", content: "The creator said: #{last_user_message}\n\nYou answered: #{reply}\n\nSuggest up to three follow-up prompts." },
+        ],
+        max_tokens: MAX_SUGGESTION_TOKENS,
+        temperature: 0.5,
+      )
+      parse_suggestions(result.text)
+    rescue => e
+      Rails.logger.warn("Store agent follow-up suggestions failed: #{e.message}")
+      []
+    end
+
+    # Coerce the model's reply into a clean list of suggestion strings. Prefers a JSON array but
+    # tolerates a newline/dash list, then trims, de-dupes, drops blanks, and caps count + length.
+    def parse_suggestions(raw)
+      text = raw.to_s.strip
+      return [] if text.blank?
+
+      parsed = (JSON.parse(text) rescue nil)
+      items =
+        if parsed.is_a?(Array)
+          parsed
+        else
+          text.split("\n").map { |line| line.sub(/\A\s*(?:[-*\d.)\s]+)/, "") }
+        end
+
+      items
+        .map { |item| item.to_s.strip.delete_prefix('"').delete_suffix('"').strip }
+        .reject(&:blank?)
+        .map { |item| item.truncate(SUGGESTION_MAX_LENGTH) }
+        .uniq
+        .first(MAX_SUGGESTIONS)
+    end
 
     # De-duplicate the collected objects (the model may read the same list twice in one turn) while
     # preserving order, and cap how many cards we render so a huge list can't flood the chat.
@@ -160,6 +292,8 @@ class Ai::StoreAgentService
       Array(@objects).uniq.first(MAX_DISPLAY_OBJECTS)
     end
 
+    # Build the Anthropic message array from the client-supplied history. The system prompt is passed
+    # separately (Anthropic's top-level `system` param), so it is NOT included here.
     def build_conversation(messages)
       history = Array(messages).last(MAX_HISTORY_MESSAGES).filter_map do |msg|
         role = msg[:role] || msg["role"]
@@ -169,9 +303,14 @@ class Ai::StoreAgentService
 
         { role:, content: content.truncate(MAX_MESSAGE_LENGTH, omission: "...") }
       end
+
+      # Anthropic's Messages API requires the conversation to START with a user message. The web chat
+      # always opens with a canned assistant greeting (and a turn could begin with other leading
+      # assistant turns), so drop any leading assistant messages before the first user message.
+      history = history.drop_while { |m| m[:role] != "user" }
       raise Error, "Message is required" if history.empty? || history.last[:role] != "user"
 
-      [{ role: "system", content: system_prompt }, *history]
+      history
     end
 
     # Assemble the system prompt with the live read/write endpoint manifests embedded, so the model
@@ -260,9 +399,9 @@ class Ai::StoreAgentService
       parts.join(" ")
     end
 
-    # Tool-call sub-objects are supposed to be JSON objects; a hallucinating model can emit an array
-    # or scalar. Coerce anything that isn't a Hash to an empty hash, and stringify keys, so downstream
-    # indexing/path-expansion can't raise a TypeError that surfaces as a 500.
+    # Tool-call inputs are supposed to be JSON objects; a hallucinating model can emit an array or
+    # scalar (or, for a nested key, a non-hash). Coerce anything that isn't a Hash to an empty hash,
+    # and stringify keys, so downstream indexing/path-expansion can't raise a TypeError as a 500.
     def sanitize_param_hash(raw)
       return {} unless raw.is_a?(Hash)
       raw.transform_keys(&:to_s)
@@ -272,28 +411,14 @@ class Ai::StoreAgentService
       @_api_client ||= Ai::StoreAgentApiClient.new(seller:)
     end
 
-    # ---- helpers ----
-
-    def parse_arguments(raw)
-      return {} if raw.blank?
-      # OpenAI tool-call arguments are *supposed* to be a JSON object, but a hallucinating model can
-      # emit a bare array ("[1,2,3]") or scalar ("42"). The tools index arguments by key
-      # (arguments["endpoint"]), which raises TypeError on an Array/Integer and would surface as an
-      # unhandled 500. Coerce anything that isn't an object to an empty hash so the tool falls through
-      # to its normal "field is required" validation instead.
-      parsed = JSON.parse(raw)
-      parsed.is_a?(Hash) ? parsed : {}
-    rescue JSON::ParserError
-      {}
-    end
-
     def client
-      @_client ||= OpenAI::Client.new(request_timeout: REQUEST_TIMEOUT_IN_SECONDS)
+      @_client ||= Ai::AnthropicClient.new(timeout: REQUEST_TIMEOUT_IN_SECONDS, model: MODEL)
     end
 
     # Two generic tools. The endpoint id (constrained to the catalog by an enum) selects which of the
-    # ~60 real API endpoints to hit; path_params/params carry the ids and payload. Keeping the JSON
-    # schema this small avoids a 60-function tool list while still reaching the entire API.
+    # ~60 real API endpoints to hit; path_params/params carry the ids and payload. Keeping the schema
+    # this small avoids a 60-function tool list while still reaching the entire API. Anthropic tool
+    # schemas use `input_schema` (JSON Schema) instead of OpenAI's `function.parameters`.
     def tool_schemas
       [
         tool_schema(
@@ -321,12 +446,9 @@ class Ai::StoreAgentService
 
     def tool_schema(name, description, properties, required: [])
       {
-        type: "function",
-        function: {
-          name:,
-          description:,
-          parameters: { type: "object", properties:, required:, additionalProperties: false },
-        },
+        name:,
+        description:,
+        input_schema: { type: "object", properties:, required: },
       }
     end
 end

--- a/app/services/ai/store_agent_service.rb
+++ b/app/services/ai/store_agent_service.rb
@@ -28,6 +28,8 @@ class Ai::StoreAgentService
   # How many prior turns of context we forward to the model. Keeps token usage bounded and avoids
   # echoing an unbounded client-supplied history back to OpenAI.
   MAX_HISTORY_MESSAGES = 20
+  # Cap how many object cards we render inline per turn so a large list can't flood the chat.
+  MAX_DISPLAY_OBJECTS = 20
 
   # The system prompt is assembled at runtime (see #system_prompt) so it can embed the live catalog
   # manifest of every endpoint the agent can reach. This keeps the prompt and the actual tool surface
@@ -39,23 +41,34 @@ class Ai::StoreAgentService
     You have two tools that together expose the creator's ENTIRE Gumroad API:
     - api_read: run any READ endpoint to fetch live data (products, sales, payouts, discounts,
       subscribers, upsells, emails, tax forms, earnings, profile, and more). These run immediately.
-    - api_write: PROPOSE any change (create/update/delete products, discounts, variants, upsells,
-      emails, refunds, shipping, licenses, webhooks, profile, and more). Writes NEVER take effect
-      immediately — they produce a proposed change the creator must review and confirm in the UI.
+    - api_write: prepare any change (create/update/delete products, discounts, variants, upsells,
+      emails, refunds, shipping, licenses, webhooks, profile, and more). Writes never take effect
+      immediately — they produce a proposed change the creator reviews and confirms in the UI.
 
     To call a tool you pass `endpoint` (one of the ids listed below), `path_params` (the ids the
     endpoint's path needs, e.g. the product id), and `params` (query for reads, body for writes).
 
-    Rules:
+    How to act:
+    - Be helpful and proactive. If the creator describes a change they want, go ahead and prepare it
+      for them with api_write so it's ready to confirm — don't just explain how they could do it
+      themselves. Offer to make the change.
     - Only ever act on the current creator's own store. You cannot access other creators' data; the
       API enforces this and an endpoint the creator's role can't use will simply fail.
     - Always use api_read to get real ids and live numbers before acting. Never invent ids.
-    - Never claim a change has been made. For any api_write, say you've prepared it for the creator's
-      confirmation.
-    - Propose at most ONE change per reply. If the creator asks for several, do the first and tell
+    - Never claim a change has already been made. After api_write, tell the creator you've prepared it
+      and it's ready for them to confirm.
+    - Prepare at most one change per reply. If the creator asks for several, do the first and tell
       them you'll continue once they confirm.
     - Monetary amounts in the API are in CENTS (integer). $10 = 1000.
-    - Be concise and concrete. Reference products by name.
+
+    How to write:
+    - Write like a person: warm, plain, and direct. Short sentences. No corporate filler.
+    - Do not use emoji.
+    - Do not use markdown headers, bold, bullet characters, tables, or other decorative formatting.
+      Just write normal sentences. Products, discounts, and other objects you look up or change are
+      shown to the creator automatically as cards beneath your message, so don't re-list their
+      details or paste links in the text — refer to them by name and keep your reply brief.
+    - Don't mention other people, teammates, or @-handles.
 
     READ endpoints (api_read):
     %<reads>s
@@ -74,10 +87,12 @@ class Ai::StoreAgentService
   end
 
   # @param messages [Array<Hash>] prior conversation, each { role: "user"|"assistant", content: String }
-  # @return [Hash] { reply: String, proposed_action: Hash|nil }
+  # @return [Hash] { reply: String, proposed_action: Hash|nil, objects: Array<Hash> }
   def respond(messages:)
     conversation = build_conversation(messages)
     proposed_action = nil
+    # Display objects collected from the read calls this turn, rendered inline as cards in the chat.
+    @objects = []
 
     MAX_TOOL_ITERATIONS.times do
       response = client.chat(
@@ -95,7 +110,7 @@ class Ai::StoreAgentService
 
       tool_calls = message["tool_calls"]
       if tool_calls.blank?
-        return { reply: message["content"].to_s.strip, proposed_action: proposed_action&.as_json }
+        return { reply: message["content"].to_s.strip, proposed_action: proposed_action&.as_json, objects: deduped_objects }
       end
 
       # Echo the assistant tool-call message back into the conversation before answering each call,
@@ -133,11 +148,17 @@ class Ai::StoreAgentService
       else
         "I gathered the details but couldn't finish in one go. Please rephrase or ask again."
       end
-    { reply:, proposed_action: proposed_action&.as_json }
+    { reply:, proposed_action: proposed_action&.as_json, objects: deduped_objects }
   end
 
   private
     attr_reader :seller, :pundit_user
+
+    # De-duplicate the collected objects (the model may read the same list twice in one turn) while
+    # preserving order, and cap how many cards we render so a huge list can't flood the chat.
+    def deduped_objects
+      Array(@objects).uniq.first(MAX_DISPLAY_OBJECTS)
+    end
 
     def build_conversation(messages)
       history = Array(messages).last(MAX_HISTORY_MESSAGES).filter_map do |msg|
@@ -189,6 +210,8 @@ class Ai::StoreAgentService
 
       path = endpoint.expand_path(arguments["path_params"])
       result = api_client.get(path, sanitize_param_hash(arguments["params"]))
+      # Collect any renderable objects from the response so the chat can show them inline as cards.
+      @objects.concat(Ai::StoreAgentObjectFormatter.from_response(endpoint, result)) if @objects
       [result, nil]
     rescue ArgumentError => e
       # Missing/blank path param (e.g. the model forgot the product id).

--- a/app/services/ai/store_agent_service.rb
+++ b/app/services/ai/store_agent_service.rb
@@ -67,13 +67,15 @@ class Ai::StoreAgentService
     proposed_action = nil
 
     MAX_TOOL_ITERATIONS.times do
-      response = client.chat(parameters: {
-        model: MODEL,
-        messages: conversation,
-        tools: tool_schemas,
-        tool_choice: "auto",
-        temperature: 0.3,
-      })
+      response = client.chat(
+        parameters: {
+          model: MODEL,
+          messages: conversation,
+          tools: tool_schemas,
+          tool_choice: "auto",
+          temperature: 0.3,
+        },
+      )
 
       message = response.dig("choices", 0, "message")
       raise Error, "No response from model" if message.nil?
@@ -91,7 +93,16 @@ class Ai::StoreAgentService
         name = tool_call.dig("function", "name")
         arguments = parse_arguments(tool_call.dig("function", "arguments"))
         result, action = run_tool(name:, arguments:)
-        proposed_action = action if action.present?
+        if action.present?
+          if proposed_action.nil?
+            proposed_action = action
+          else
+            # Only one change may be staged per turn. If the model proposes a second write in the
+            # same turn we drop it and tell the model, so the confirmation card can never describe a
+            # different mutation than the one the seller sees and confirms.
+            result = { error: "Only one change can be proposed at a time. Ask the seller to confirm the first change before proposing another." }
+          end
+        end
         conversation << {
           role: "tool",
           tool_call_id: tool_call["id"],
@@ -101,11 +112,15 @@ class Ai::StoreAgentService
       end
     end
 
-    # The model kept calling tools past our cap. Return whatever change it staged plus a safe message.
-    {
-      reply: "I gathered the details but need you to confirm the next step before I continue.",
-      proposed_action: proposed_action&.as_json,
-    }
+    # The model kept calling tools past our cap. Return whatever change it staged plus a message that
+    # matches reality: only mention confirmation when there is actually a proposed action to confirm.
+    reply =
+      if proposed_action
+        "I gathered the details but need you to confirm the next step before I continue."
+      else
+        "I gathered the details but couldn't finish in one go. Please rephrase or ask again."
+      end
+    { reply:, proposed_action: proposed_action&.as_json }
   end
 
   private
@@ -244,6 +259,9 @@ class Ai::StoreAgentService
 
       new_price = arguments["new_price"]
       return [{ error: "A new price is required." }, nil] if new_price.blank?
+      # string_to_price_cents turns a digit-less string into 0 cents, which would silently propose
+      # making the product free. Require an actual number so garbage can't become a $0 price.
+      return [{ error: "The new price must be a number." }, nil] unless new_price.to_s.match?(/\d/)
 
       new_price_cents = string_to_price_cents(product.price_currency_type, new_price.to_s)
       summary = "Change the price of \"#{product.name}\" from " \
@@ -275,7 +293,10 @@ class Ai::StoreAgentService
 
     def find_product(external_id)
       return nil if external_id.blank?
-      seller.products.visible.find_by_external_id(external_id.to_s)
+      # Match the listing tool's scope (visible_and_not_archived): the model is only ever shown
+      # non-archived products, so an archived id can only arrive by a seller typing it in. Don't let
+      # the agent propose price/publish changes against archived products the UI never surfaced.
+      seller.products.visible_and_not_archived.find_by_external_id(external_id.to_s)
     end
 
     # True when the buyer-visible price lives on tiers/variants rather than the product's own

--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -24,6 +24,7 @@ class RedisKey
     def free_purchases_watch_hours = "free_purchases_watch_hours"
     def max_allowed_free_purchases_of_same_product = "max_allowed_free_purchases_of_same_product"
     def ai_request_throttle(user_id) = "ai_request_throttle:#{user_id}"
+    def agent_request_throttle(user_id) = "agent_request_throttle:#{user_id}"
     def fraudulent_free_purchases_block_hours = "fraudulent_free_purchases_block_hours"
     def sales_related_products_internal_limit = "sales_related_products_internal_limit"
     def recommended_products_associated_product_ids_limit = "recommended_products_associated_product_ids_limit"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1144,6 +1144,7 @@ Rails.application.routes.draw do
 
         # Conversational store agent
         post "/agent/messages", to: "agent_messages#create", as: :agent_messages
+        post "/agent/messages/stream", to: "agent_message_streams#create", as: :agent_messages_stream
         post "/agent/actions", to: "agent_messages#execute", as: :agent_actions
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -961,6 +961,9 @@ Rails.application.routes.draw do
     get "/product_files_utility/product_files/:product_id", to: "product_files_utility#download_product_files", as: :download_product_files
     get "/product_files_utility/folder_archive/:folder_id", to: "product_files_utility#download_folder_archive", as: :download_folder_archive
 
+    # agent (conversational store assistant)
+    get "/agent", to: "agent#index", as: :agent
+
     # analytics
     get "/analytics" => redirect("/dashboard/sales")
     get "/dashboard/sales", to: "analytics#index", as: :sales_dashboard
@@ -1135,6 +1138,10 @@ Rails.application.routes.draw do
         end
 
         resources :ai_product_details_generations, only: [:create]
+
+        # Conversational store agent
+        post "/agent/messages", to: "agent_messages#create", as: :agent_messages
+        post "/agent/actions", to: "agent_messages#execute", as: :agent_actions
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -316,6 +316,9 @@ Rails.application.routes.draw do
             get :products
           end
         end
+        get "/agent/meta", to: "agent#meta"
+        post "/agent/messages", to: "agent#create"
+        post "/agent/actions", to: "agent#execute"
         resources :devices, only: :create
         resources :installments, only: :show
         resources :consumption_analytics, only: [:create], format: :json

--- a/spec/controllers/api/internal/agent_messages_controller_spec.rb
+++ b/spec/controllers/api/internal/agent_messages_controller_spec.rb
@@ -35,7 +35,7 @@ describe Api::Internal::AgentMessagesController do
         post :create, params: valid_params, format: :json
 
         expect(response).to be_successful
-        expect(response.parsed_body).to eq("success" => true, "reply" => "You have 3 products.", "proposed_action" => nil)
+        expect(response.parsed_body).to eq("success" => true, "reply" => "You have 3 products.", "proposed_action" => nil, "objects" => [])
       end
 
       it "rejects an empty message list" do
@@ -48,7 +48,7 @@ describe Api::Internal::AgentMessagesController do
   end
 
   describe "POST execute" do
-    let(:valid_params) { { type: "create_discount", params: { code: "LAUNCH", percent_off: 20 } } }
+    let(:valid_params) { { type: "api_write", params: { endpoint: "create_discount", code: "LAUNCH", percent_off: 20 } } }
 
     it_behaves_like "authentication required for action", :post, :execute do
       let(:request_params) { valid_params }

--- a/spec/controllers/api/internal/agent_messages_controller_spec.rb
+++ b/spec/controllers/api/internal/agent_messages_controller_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "shared_examples/authentication_required"
+require "shared_examples/authorize_called"
+
+describe Api::Internal::AgentMessagesController do
+  let(:seller) { create(:named_seller) }
+
+  include_context "with user signed in as admin for seller"
+
+  describe "POST create" do
+    let(:valid_params) { { messages: [{ role: "user", content: "How are my sales?" }] } }
+
+    it_behaves_like "authentication required for action", :post, :create do
+      let(:request_params) { valid_params }
+    end
+
+    it_behaves_like "authorize called for action", :post, :create do
+      let(:record) { seller }
+      let(:policy_method) { :use_store_agent? }
+      let(:request_params) { valid_params }
+      let(:request_format) { :json }
+    end
+
+    context "when authenticated and authorized" do
+      it "returns the agent's reply and any proposed action" do
+        service_double = instance_double(Ai::StoreAgentService)
+        allow(Ai::StoreAgentService).to receive(:new).and_return(service_double)
+        allow(service_double).to receive(:respond).and_return(
+          reply: "You have 3 products.",
+          proposed_action: nil,
+        )
+
+        post :create, params: valid_params, format: :json
+
+        expect(response).to be_successful
+        expect(response.parsed_body).to eq("success" => true, "reply" => "You have 3 products.", "proposed_action" => nil)
+      end
+
+      it "rejects an empty message list" do
+        post :create, params: { messages: [] }, format: :json
+
+        expect(response).to have_http_status(:bad_request)
+        expect(response.parsed_body["success"]).to be(false)
+      end
+    end
+  end
+
+  describe "POST execute" do
+    let(:valid_params) { { type: "create_discount", params: { code: "LAUNCH", percent_off: 20 } } }
+
+    it_behaves_like "authentication required for action", :post, :execute do
+      let(:request_params) { valid_params }
+    end
+
+    it_behaves_like "authorize called for action", :post, :execute do
+      let(:record) { seller }
+      let(:policy_method) { :use_store_agent? }
+      let(:request_params) { valid_params }
+      let(:request_format) { :json }
+    end
+
+    context "when authenticated and authorized" do
+      it "applies a confirmed action via the executor" do
+        executor_double = instance_double(Ai::StoreAgentActionExecutor)
+        allow(Ai::StoreAgentActionExecutor).to receive(:new).and_return(executor_double)
+        allow(executor_double).to receive(:execute).and_return(success: true, message: "Created discount code LAUNCH.")
+
+        post :execute, params: valid_params, format: :json
+
+        expect(response).to be_successful
+        expect(response.parsed_body).to eq("success" => true, "message" => "Created discount code LAUNCH.")
+      end
+
+      it "rejects an unsupported action type" do
+        post :execute, params: { type: "delete_account", params: {} }, format: :json
+
+        expect(response).to have_http_status(:bad_request)
+        expect(response.parsed_body["success"]).to be(false)
+      end
+
+      it "returns 422 when the executor reports failure" do
+        executor_double = instance_double(Ai::StoreAgentActionExecutor)
+        allow(Ai::StoreAgentActionExecutor).to receive(:new).and_return(executor_double)
+        allow(executor_double).to receive(:execute).and_return(success: false, message: "That discount couldn't be created.")
+
+        post :execute, params: valid_params, format: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body["success"]).to be(false)
+      end
+    end
+  end
+end

--- a/spec/controllers/api/mobile/agent_controller_spec.rb
+++ b/spec/controllers/api/mobile/agent_controller_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Api::Mobile::AgentController do
+  before do
+    @seller = create(:user)
+    @app = create(:oauth_application, owner: @seller)
+    @token = create("doorkeeper/access_token", application: @app, resource_owner_id: @seller.id, scopes: "mobile_api")
+    @auth_params = { mobile_token: Api::Mobile::BaseController::MOBILE_TOKEN, access_token: @token.token }
+  end
+
+  describe "GET meta" do
+    it "returns the greeting and starter suggestions" do
+      get :meta, params: @auth_params
+
+      expect(response).to be_successful
+      body = response.parsed_body
+      expect(body["success"]).to be(true)
+      expect(body["enabled"]).to be(true)
+      expect(body["greeting"]).to eq(AgentPresenter::GREETING)
+      expect(body["suggestions"]).to eq(AgentPresenter::SUGGESTIONS)
+    end
+
+    it "rejects a request with an invalid mobile token" do
+      get :meta, params: @auth_params.merge(mobile_token: "invalid_token")
+
+      expect(response.status).to be(401)
+    end
+
+    it "rejects a request with an invalid access token" do
+      get :meta, params: @auth_params.merge(access_token: "invalid_token")
+
+      expect(response.status).to be(401)
+    end
+  end
+
+  describe "POST create" do
+    let(:valid_params) { @auth_params.merge(messages: [{ role: "user", content: "How are my sales?" }]) }
+
+    it "returns the agent's reply and any proposed action" do
+      service_double = instance_double(Ai::StoreAgentService)
+      allow(Ai::StoreAgentService).to receive(:new).and_return(service_double)
+      allow(service_double).to receive(:respond).and_return(reply: "You have 3 products.", proposed_action: nil)
+
+      post :create, params: valid_params
+
+      expect(response).to be_successful
+      expect(response.parsed_body).to eq(
+        "success" => true,
+        "reply" => "You have 3 products.",
+        "proposed_action" => nil,
+      )
+    end
+
+    it "scopes the agent service to the authenticated seller" do
+      expect(Ai::StoreAgentService).to receive(:new) do |args|
+        expect(args[:seller]).to eq(@seller)
+        expect(args[:pundit_user].seller).to eq(@seller)
+        instance_double(Ai::StoreAgentService, respond: { reply: "ok", proposed_action: nil })
+      end
+
+      post :create, params: valid_params
+
+      expect(response).to be_successful
+    end
+
+    it "rejects an empty message list" do
+      post :create, params: @auth_params.merge(messages: [])
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body["success"]).to be(false)
+    end
+
+    it "surfaces a service error as unprocessable" do
+      service_double = instance_double(Ai::StoreAgentService)
+      allow(Ai::StoreAgentService).to receive(:new).and_return(service_double)
+      allow(service_double).to receive(:respond).and_raise(Ai::StoreAgentService::Error.new("The assistant is unavailable."))
+
+      post :create, params: valid_params
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body).to eq("success" => false, "error" => "The assistant is unavailable.")
+    end
+  end
+
+  describe "POST execute" do
+    let(:valid_params) { @auth_params.merge(type: "create_discount", params: { code: "LAUNCH", percent_off: 20 }) }
+
+    it "executes a confirmed action and returns the result" do
+      executor_double = instance_double(Ai::StoreAgentActionExecutor)
+      allow(Ai::StoreAgentActionExecutor).to receive(:new).and_return(executor_double)
+      allow(executor_double).to receive(:execute).and_return(success: true, message: "Created discount LAUNCH.")
+
+      post :execute, params: valid_params
+
+      expect(response).to be_successful
+      expect(response.parsed_body).to eq("success" => true, "message" => "Created discount LAUNCH.")
+    end
+
+    it "passes the confirmed action through to the executor" do
+      executor_double = instance_double(Ai::StoreAgentActionExecutor)
+      allow(Ai::StoreAgentActionExecutor).to receive(:new).and_return(executor_double)
+      expect(executor_double).to receive(:execute).with(
+        type: "create_discount",
+        params: { "code" => "LAUNCH", "percent_off" => "20" },
+      ).and_return(success: true, message: "Created discount LAUNCH.")
+
+      post :execute, params: valid_params
+
+      expect(response).to be_successful
+    end
+
+    it "rejects an unsupported action type" do
+      post :execute, params: @auth_params.merge(type: "delete_everything", params: {})
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body["success"]).to be(false)
+    end
+
+    it "returns unprocessable when the executor reports failure" do
+      executor_double = instance_double(Ai::StoreAgentActionExecutor)
+      allow(Ai::StoreAgentActionExecutor).to receive(:new).and_return(executor_double)
+      allow(executor_double).to receive(:execute).and_return(success: false, message: "That change couldn't be saved.")
+
+      post :execute, params: valid_params
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["success"]).to be(false)
+    end
+  end
+end

--- a/spec/controllers/api/mobile/agent_controller_spec.rb
+++ b/spec/controllers/api/mobile/agent_controller_spec.rb
@@ -50,6 +50,7 @@ describe Api::Mobile::AgentController do
         "success" => true,
         "reply" => "You have 3 products.",
         "proposed_action" => nil,
+        "objects" => [],
       )
     end
 
@@ -85,7 +86,7 @@ describe Api::Mobile::AgentController do
   end
 
   describe "POST execute" do
-    let(:valid_params) { @auth_params.merge(type: "create_discount", params: { code: "LAUNCH", percent_off: 20 }) }
+    let(:valid_params) { @auth_params.merge(type: "api_write", params: { endpoint: "create_discount", code: "LAUNCH", percent_off: 20 }) }
 
     it "executes a confirmed action and returns the result" do
       executor_double = instance_double(Ai::StoreAgentActionExecutor)
@@ -102,8 +103,8 @@ describe Api::Mobile::AgentController do
       executor_double = instance_double(Ai::StoreAgentActionExecutor)
       allow(Ai::StoreAgentActionExecutor).to receive(:new).and_return(executor_double)
       expect(executor_double).to receive(:execute).with(
-        type: "create_discount",
-        params: { "code" => "LAUNCH", "percent_off" => "20" },
+        type: "api_write",
+        params: { "endpoint" => "create_discount", "code" => "LAUNCH", "percent_off" => "20" },
       ).and_return(success: true, message: "Created discount LAUNCH.")
 
       post :execute, params: valid_params

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -128,4 +128,31 @@ describe UserPolicy do
       end
     end
   end
+
+  permissions :use_store_agent? do
+    it "grants access to owner" do
+      seller_context = SellerContext.new(user: seller, seller:)
+      expect(subject).to permit(seller_context, seller)
+    end
+
+    it "grants access to admin" do
+      seller_context = SellerContext.new(user: admin_for_seller, seller:)
+      expect(subject).to permit(seller_context, seller)
+    end
+
+    it "grants access to marketing" do
+      seller_context = SellerContext.new(user: marketing_for_seller, seller:)
+      expect(subject).to permit(seller_context, seller)
+    end
+
+    it "denies access to accountant" do
+      seller_context = SellerContext.new(user: accountant_for_seller, seller:)
+      expect(subject).to_not permit(seller_context, seller)
+    end
+
+    it "denies access to support" do
+      seller_context = SellerContext.new(user: support_for_seller, seller:)
+      expect(subject).to_not permit(seller_context, seller)
+    end
+  end
 end

--- a/spec/presenters/rendering_extension_spec.rb
+++ b/spec/presenters/rendering_extension_spec.rb
@@ -139,6 +139,9 @@ describe "RenderingExtension" do
                   },
                   churn: {
                     show: false,
+                  },
+                  user: {
+                    use_store_agent: true,
                   }
                 },
                 is_gumroad_admin: false,

--- a/spec/requests/agent_spec.rb
+++ b/spec/requests/agent_spec.rb
@@ -27,10 +27,11 @@ describe "Agent tab", type: :system, js: true do
     login_as seller
   end
 
-  # Stub one turn of the agent: the next user message yields `reply` (+ optional proposed_action).
-  def stub_agent_turn(reply:, proposed_action: nil)
+  # Stub one turn of the agent: the next user message yields `reply` (+ optional proposed_action /
+  # objects rendered inline as cards).
+  def stub_agent_turn(reply:, proposed_action: nil, objects: [])
     allow_any_instance_of(Ai::StoreAgentService).to receive(:respond).and_return(
-      { reply:, proposed_action: }.compact,
+      { reply:, proposed_action:, objects: }.compact,
     )
   end
 
@@ -125,7 +126,40 @@ describe "Agent tab", type: :system, js: true do
       offer_code = product.offer_codes.alive.last
       expect(offer_code.code).to eq("LAUNCH25")
       expect(offer_code.amount_percentage).to eq(25)
+
+      # The created discount renders inline as an object card with a copy affordance.
+      expect(page).to have_text("LAUNCH25", wait: 10)
+      expect(page).to have_button("Copy LAUNCH25")
       screenshot("04_discount_applied")
+    end
+
+    it "renders looked-up products inline as object cards with copy and open links" do
+      product.update!(name: "Portrait Masterclass")
+      stub_agent_turn(
+        reply: "Here are your products.",
+        objects: [
+          {
+            type: "product",
+            title: "Portrait Masterclass",
+            subtitle: "$49",
+            fields: [{ label: "Status", value: "Published" }, { label: "Sales", value: "128" }],
+            url: "https://seller.gumroad.com/l/portrait",
+            copy: "https://seller.gumroad.com/l/portrait",
+          },
+        ],
+      )
+
+      send_message("List my products")
+
+      expect(page).to have_text("Portrait Masterclass", wait: 10)
+      expect(page).to have_text("$49")
+      expect(page).to have_text("Sales")
+      # Copy + open-in-new-tab affordances beneath the object.
+      expect(page).to have_button("Copy Portrait Masterclass")
+      open_link = find("a[aria-label='Open Portrait Masterclass in a new tab']")
+      expect(open_link[:href]).to eq("https://seller.gumroad.com/l/portrait")
+      expect(open_link[:target]).to eq("_blank")
+      screenshot("08_product_cards")
     end
 
     it "lets the seller dismiss a proposed change without applying it" do

--- a/spec/requests/agent_spec.rb
+++ b/spec/requests/agent_spec.rb
@@ -1,0 +1,218 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "shared_examples/authorize_called"
+
+# End-to-end coverage of the conversational store Agent tab, exercised through the real dashboard:
+# we log in, navigate to the Agent via the sidebar nav link (proving the tab is wired into the app
+# shell), then walk the marketing use cases — sales insights, creating a discount, refunding a sale,
+# emailing customers — driving the real React component, the proposed-change confirmation card, and
+# the confirm round-trip.
+#
+# The model itself is non-deterministic and costs a network call, so we stub Ai::StoreAgentService
+# (the OpenAI tool-calling loop, unit-tested separately) to return scripted replies / proposed
+# actions. Everything below that — the controller, the confirmation UX, and the actual mutation via
+# Ai::StoreAgentActionExecutor replaying the real v2 API — runs for real.
+#
+# Each use case also saves a screenshot to tmp/agent_screenshots for marketing collateral; the shots
+# show the agent in the real app chrome (sidebar, nav, header), not an isolated component.
+describe "Agent tab", type: :system, js: true do
+  let(:seller) { create(:named_seller) }
+  let!(:product) { create(:product, user: seller, name: "Portrait Masterclass", price_cents: 4900) }
+
+  let(:screenshot_dir) { Rails.root.join("tmp", "agent_screenshots") }
+
+  before do
+    FileUtils.mkdir_p(screenshot_dir)
+    login_as seller
+  end
+
+  # Stub one turn of the agent: the next user message yields `reply` (+ optional proposed_action).
+  def stub_agent_turn(reply:, proposed_action: nil)
+    allow_any_instance_of(Ai::StoreAgentService).to receive(:respond).and_return(
+      { reply:, proposed_action: }.compact,
+    )
+  end
+
+  # Load the Agent tab directly. The Agent page renders inside the full dashboard shell (the same
+  # left sidebar nav, logo, and header), so screenshots taken here show the feature in real app
+  # chrome — not an isolated component. We additionally assert the Agent entry is present and active
+  # in the sidebar nav, which is what makes the tab reachable from anywhere in the dashboard.
+  def open_agent
+    visit agent_path
+    expect(page).to have_text("Gumroad store assistant", wait: 10)
+    # The sidebar nav link uses an absolute URL (Routes.agent_url), so match by its label rather than
+    # an exact path; its presence here is what makes the tab reachable from anywhere in the dashboard.
+    within "nav" do
+      expect(page).to have_link("Agent")
+    end
+  end
+
+  def send_message(text)
+    fill_in "Message", with: text
+    find("button[type=submit]", text: "Send").click
+  end
+
+  def screenshot(name)
+    page.save_screenshot(screenshot_dir.join("#{name}.png").to_s)
+  end
+
+  it "renders inside the dashboard shell with the Agent entry active in the sidebar nav" do
+    open_agent
+
+    # The greeting + suggestion chips are visible, and the Agent nav link is present in the sidebar.
+    expect(page).to have_text("How are my sales doing?")
+    expect(page).to have_button("List my products")
+    within "nav" do
+      expect(page).to have_link("Agent")
+    end
+    screenshot("01_empty_state_in_app")
+  end
+
+  it "is reachable by clicking the Agent link from the dashboard home" do
+    # The dashboard home reads follower stats from Elasticsearch; make sure that test index exists so
+    # the page boots, then click through to the Agent tab the way a seller would.
+    ConfirmedFollowerEvent.__elasticsearch__.create_index!(force: true)
+
+    visit dashboard_path
+    find("nav a", text: "Agent").click
+
+    expect(page).to have_current_path(agent_path)
+    expect(page).to have_text("Gumroad store assistant", wait: 10)
+  end
+
+  describe "use cases" do
+    before { open_agent }
+
+    it "answers a sales-insights question (read)" do
+      stub_agent_turn(reply: "Here's your month so far: gross sales $18,420 across 642 orders. " \
+                             "Your top seller is Portrait Masterclass at $7,240.")
+
+      send_message("How did sales go this month, and what's my best seller?")
+
+      expect(page).to have_text("gross sales $18,420", wait: 10)
+      expect(page).to have_text("Portrait Masterclass at $7,240")
+      screenshot("02_sales_insights")
+    end
+
+    it "proposes a discount and applies it on confirmation (write round-trip)" do
+      # The proposed action is the real catalog api_write the executor will replay against the API.
+      stub_agent_turn(
+        reply: "I've prepared that discount for your confirmation.",
+        proposed_action: {
+          type: "api_write",
+          params: {
+            "endpoint" => "create_offer_code",
+            "path_params" => { "link_id" => product.external_id },
+            "params" => { "name" => "LAUNCH25", "amount_off" => 25, "offer_type" => "percent" },
+          },
+          summary: "Create discount code LAUNCH25 on \"Portrait Masterclass\" — 25% off.",
+        },
+      )
+
+      send_message("Run a 25% launch discount on the Portrait Masterclass called LAUNCH25")
+
+      expect(page).to have_text("Proposed change", wait: 10)
+      expect(page).to have_text("Create discount code LAUNCH25")
+      screenshot("03_discount_proposed")
+
+      expect do
+        click_on "Confirm"
+        # The confirmation card collapses to an "Applied" status once the executor succeeds.
+        expect(page).to have_text("Applied", wait: 10)
+      end.to change { product.reload.offer_codes.alive.count }.by(1)
+
+      offer_code = product.offer_codes.alive.last
+      expect(offer_code.code).to eq("LAUNCH25")
+      expect(offer_code.amount_percentage).to eq(25)
+      screenshot("04_discount_applied")
+    end
+
+    it "lets the seller dismiss a proposed change without applying it" do
+      stub_agent_turn(
+        reply: "I've prepared the price change for your confirmation.",
+        proposed_action: {
+          type: "api_write",
+          params: {
+            "endpoint" => "update_product",
+            "path_params" => { "id" => product.external_id },
+            "params" => { "price" => 3900 },
+          },
+          summary: "Update \"Portrait Masterclass\" — set price to $39.00.",
+        },
+      )
+
+      send_message("Drop the Portrait Masterclass to $39")
+
+      expect(page).to have_text("Proposed change", wait: 10)
+      expect do
+        click_on "Dismiss"
+        expect(page).to have_text("Dismissed", wait: 10)
+      end.not_to change { product.reload.price_cents }
+      screenshot("05_change_dismissed")
+    end
+
+    it "proposes refunding a sale (sensitive write gated by confirmation)" do
+      stub_agent_turn(
+        reply: "I found that order and prepared the refund for your confirmation.",
+        proposed_action: {
+          type: "api_write",
+          params: {
+            "endpoint" => "refund_sale",
+            "path_params" => { "id" => "sale_abc123" },
+            "params" => { "amount_cents" => 8900 },
+          },
+          summary: "Refund sale #GR-88142 — full refund of $89.00.",
+        },
+      )
+
+      send_message("Refund order #GR-88142")
+
+      expect(page).to have_text("Proposed change", wait: 10)
+      expect(page).to have_text("Refund sale #GR-88142")
+      expect(page).to have_button("Confirm")
+      screenshot("06_refund_proposed")
+    end
+
+    it "proposes an email campaign to customers" do
+      stub_agent_turn(
+        reply: "I've drafted an announcement to your customers. Review it before it sends.",
+        proposed_action: {
+          type: "api_write",
+          params: {
+            "endpoint" => "create_email",
+            "path_params" => {},
+            "params" => { "subject" => "Your Lightroom Pack just got a free v3 update", "audience_type" => "product" },
+          },
+          summary: "Send email \"Your Lightroom Pack just got a free v3 update\" to customers of \"Portrait Masterclass\".",
+        },
+      )
+
+      send_message("Email everyone who bought the masterclass about the v3 update")
+
+      expect(page).to have_text("Proposed change", wait: 10)
+      expect(page).to have_text("Send email")
+      screenshot("07_email_campaign")
+    end
+  end
+
+  it "surfaces a friendly error if a change can't be applied" do
+    open_agent
+    stub_agent_turn(
+      reply: "I've prepared that for your confirmation.",
+      proposed_action: {
+        type: "api_write",
+        # A blank required path param makes the executor fail cleanly (no mutation, friendly message).
+        params: { "endpoint" => "update_product", "path_params" => {}, "params" => { "price" => 1000 } },
+        summary: "Update a product's price.",
+      },
+    )
+
+    send_message("change a price")
+    expect(page).to have_text("Proposed change", wait: 10)
+    click_on "Confirm"
+    # Alert surfaces the executor's failure message; the card does NOT flip to Applied.
+    expect(page).to have_selector("[role=alert]", wait: 10)
+    expect(page).not_to have_text("Applied")
+  end
+end

--- a/spec/requests/agent_spec.rb
+++ b/spec/requests/agent_spec.rb
@@ -28,11 +28,18 @@ describe "Agent tab", type: :system, js: true do
   end
 
   # Stub one turn of the agent: the next user message yields `reply` (+ optional proposed_action /
-  # objects rendered inline as cards).
-  def stub_agent_turn(reply:, proposed_action: nil, objects: [])
-    allow_any_instance_of(Ai::StoreAgentService).to receive(:respond).and_return(
-      { reply:, proposed_action:, objects: }.compact,
-    )
+  # objects rendered inline as cards, and follow-up `suggestions`). The Agent tab streams its reply
+  # over Server-Sent Events, so we stub the streaming entrypoint (respond_streaming): it emits the
+  # reply as a single token, then the objects / proposed action / suggestions, mirroring what the
+  # real service streams, and returns the same hash shape the controller's `done` event uses.
+  def stub_agent_turn(reply:, proposed_action: nil, objects: [], suggestions: [])
+    allow_any_instance_of(Ai::StoreAgentService).to receive(:respond_streaming) do |_service, **_kwargs, &emit|
+      emit.call(:token, { text: reply })
+      emit.call(:objects, { objects: }) if objects.any?
+      emit.call(:proposed_action, { proposed_action: }) if proposed_action
+      emit.call(:suggestions, { suggestions: }) if suggestions.any?
+      { reply:, proposed_action:, objects:, suggestions: }
+    end
   end
 
   # Load the Agent tab directly. The Agent page renders inside the full dashboard shell (the same
@@ -87,13 +94,31 @@ describe "Agent tab", type: :system, js: true do
 
     it "answers a sales-insights question (read)" do
       stub_agent_turn(reply: "Here's your month so far: gross sales $18,420 across 642 orders. " \
-                             "Your top seller is Portrait Masterclass at $7,240.")
+                             "Your top seller is Portrait Masterclass at $7,240.",
+                      suggestions: ["Show my best sellers this month", "Email my customers about it"])
 
       send_message("How did sales go this month, and what's my best seller?")
 
       expect(page).to have_text("gross sales $18,420", wait: 10)
       expect(page).to have_text("Portrait Masterclass at $7,240")
+      # The turn ends with one-tap follow-up prompts to keep the conversation going.
+      expect(page).to have_text("Keep going")
+      expect(page).to have_button("Show my best sellers this month")
+      expect(page).to have_button("Email my customers about it")
       screenshot("02_sales_insights")
+    end
+
+    it "continues the conversation when a follow-up suggestion is clicked" do
+      stub_agent_turn(reply: "Your three best sellers this month are Portrait Masterclass, " \
+                             "Lightroom Pack, and Brush Set.",
+                      suggestions: ["Show my best sellers this month"])
+      send_message("How are sales?")
+      expect(page).to have_button("Show my best sellers this month", wait: 10)
+
+      # Clicking a follow-up sends it as the next message, so the chat keeps going hands-free.
+      stub_agent_turn(reply: "Portrait Masterclass leads with 128 sales at $49 each.")
+      click_on "Show my best sellers this month"
+      expect(page).to have_text("Portrait Masterclass leads with 128 sales", wait: 10)
     end
 
     it "proposes a discount and applies it on confirmation (write round-trip)" do

--- a/spec/services/ai/anthropic_client_spec.rb
+++ b/spec/services/ai/anthropic_client_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Ai::AnthropicClient do
+  subject(:client) { described_class.new(timeout: 5) }
+
+  let(:url) { "https://api.anthropic.com/v1/messages" }
+
+  before do
+    allow(GlobalConfig).to receive(:get).and_call_original
+    allow(GlobalConfig).to receive(:get).with("ANTHROPIC_API_KEY").and_return("sk-ant-test")
+  end
+
+  describe "#messages" do
+    it "sends the system prompt, messages, and tools, and returns the assistant text" do
+      body = { "content" => [{ "type" => "text", "text" => "You have 3 products." }], "stop_reason" => "end_turn" }
+      stub = stub_request(:post, url)
+        .with(
+          headers: { "x-api-key" => "sk-ant-test", "anthropic-version" => "2023-06-01" },
+          body: hash_including("model" => described_class::DEFAULT_MODEL, "system" => "be helpful", "stream" => false),
+        )
+        .to_return(status: 200, body: body.to_json, headers: { "Content-Type" => "application/json" })
+
+      result = client.messages(system: "be helpful", messages: [{ role: "user", content: "how many products" }], tools: [{ name: "api_read" }])
+
+      expect(stub).to have_been_requested
+      expect(result.text).to eq("You have 3 products.")
+      expect(result.tool_uses).to eq([])
+      expect(result.stop_reason).to eq("end_turn")
+    end
+
+    it "parses tool_use blocks with their input" do
+      body = {
+        "content" => [
+          { "type" => "text", "text" => "Let me look that up." },
+          { "type" => "tool_use", "id" => "toolu_1", "name" => "api_read", "input" => { "endpoint" => "list_products" } },
+        ],
+        "stop_reason" => "tool_use",
+      }
+      stub_request(:post, url).to_return(status: 200, body: body.to_json, headers: { "Content-Type" => "application/json" })
+
+      result = client.messages(system: "s", messages: [{ role: "user", content: "list" }])
+
+      expect(result.text).to eq("Let me look that up.")
+      expect(result.tool_uses).to eq([{ id: "toolu_1", name: "api_read", input: { "endpoint" => "list_products" } }])
+    end
+
+    it "raises Error on a non-success status" do
+      stub_request(:post, url).to_return(status: 500, body: "boom")
+
+      expect { client.messages(system: "s", messages: [{ role: "user", content: "x" }]) }
+        .to raise_error(described_class::Error, /failed/i)
+    end
+  end
+
+  describe "#stream_messages" do
+    # Build a raw Anthropic SSE body from a list of [event, data] pairs.
+    def sse(*events)
+      events.map { |event, data| "event: #{event}\ndata: #{data.to_json}\n\n" }.join
+    end
+
+    it "yields text deltas as they arrive and returns the assembled text" do
+      stream = sse(
+        ["message_start", { type: "message_start" }],
+        ["content_block_start", { index: 0, content_block: { type: "text" } }],
+        ["content_block_delta", { index: 0, delta: { type: "text_delta", text: "You have " } }],
+        ["content_block_delta", { index: 0, delta: { type: "text_delta", text: "3 products." } }],
+        ["content_block_stop", { index: 0 }],
+        ["message_delta", { delta: { stop_reason: "end_turn" } }],
+        ["message_stop", { type: "message_stop" }],
+      )
+      stub_request(:post, url)
+        .with(body: hash_including("stream" => true))
+        .to_return(status: 200, body: stream, headers: { "Content-Type" => "text/event-stream" })
+
+      chunks = []
+      result = client.stream_messages(system: "s", messages: [{ role: "user", content: "products" }]) { |text| chunks << text }
+
+      expect(chunks).to eq(["You have ", "3 products."])
+      expect(result.text).to eq("You have 3 products.")
+      expect(result.stop_reason).to eq("end_turn")
+      expect(result.tool_uses).to eq([])
+    end
+
+    it "assembles a streamed tool_use block from its input_json_delta fragments" do
+      stream = sse(
+        ["content_block_start", { index: 0, content_block: { type: "tool_use", id: "toolu_9", name: "api_write" } }],
+        ["content_block_delta", { index: 0, delta: { type: "input_json_delta", partial_json: '{"endpoint":"create_' } }],
+        ["content_block_delta", { index: 0, delta: { type: "input_json_delta", partial_json: 'offer_code"}' } }],
+        ["content_block_stop", { index: 0 }],
+        ["message_delta", { delta: { stop_reason: "tool_use" } }],
+      )
+      stub_request(:post, url).to_return(status: 200, body: stream, headers: { "Content-Type" => "text/event-stream" })
+
+      result = client.stream_messages(system: "s", messages: [{ role: "user", content: "make a code" }])
+
+      expect(result.tool_uses).to eq([{ id: "toolu_9", name: "api_write", input: { "endpoint" => "create_offer_code" } }])
+      expect(result.stop_reason).to eq("tool_use")
+    end
+
+    it "coerces a malformed tool_use input to an empty hash" do
+      stream = sse(
+        ["content_block_start", { index: 0, content_block: { type: "tool_use", id: "toolu_x", name: "api_read" } }],
+        ["content_block_delta", { index: 0, delta: { type: "input_json_delta", partial_json: "{not json" } }],
+        ["content_block_stop", { index: 0 }],
+      )
+      stub_request(:post, url).to_return(status: 200, body: stream, headers: { "Content-Type" => "text/event-stream" })
+
+      result = client.stream_messages(system: "s", messages: [{ role: "user", content: "x" }])
+
+      expect(result.tool_uses).to eq([{ id: "toolu_x", name: "api_read", input: {} }])
+    end
+
+    it "raises Error on a stream-level error event" do
+      stream = sse(["error", { error: { message: "overloaded" } }])
+      stub_request(:post, url).to_return(status: 200, body: stream, headers: { "Content-Type" => "text/event-stream" })
+
+      expect { client.stream_messages(system: "s", messages: [{ role: "user", content: "x" }]) }
+        .to raise_error(described_class::Error, /overloaded/i)
+    end
+  end
+end

--- a/spec/services/ai/store_agent_action_executor_spec.rb
+++ b/spec/services/ai/store_agent_action_executor_spec.rb
@@ -2,116 +2,120 @@
 
 require "spec_helper"
 
+# The executor now applies a confirmed change by REPLAYING it against the real public v2 API
+# in-process (StoreAgentApiClient mints a short-lived token scoped to the seller and dispatches
+# through the real controllers). These specs therefore assert the end-to-end effect: a confirmed
+# api_write actually mutates the seller's data, reusing the endpoint's own auth + validation, and a
+# tampered/unsupported action is rejected without effect.
 describe Ai::StoreAgentActionExecutor do
   let(:seller) { create(:user) }
   let(:pundit_user) { SellerContext.new(user: seller, seller:) }
   let(:executor) { described_class.new(seller:, pundit_user:) }
 
+  def api_write(endpoint:, path_params: {}, params: {})
+    { "endpoint" => endpoint, "path_params" => path_params, "params" => params }
+  end
+
   describe "#execute" do
-    context "create_discount" do
-      it "creates a universal percentage discount" do
-        result = executor.execute(type: "create_discount", params: { code: "LAUNCH", percent_off: 20 })
+    context "create_offer_code (write replayed through the API)" do
+      let!(:product) { create(:product, user: seller, price_cents: 1000) }
+
+      it "creates a discount on the product" do
+        result = executor.execute(
+          type: "api_write",
+          params: api_write(
+            endpoint: "create_offer_code",
+            path_params: { "link_id" => product.external_id },
+            params: { "name" => "LAUNCH", "amount_off" => 20, "offer_type" => "percent" },
+          ),
+        )
 
         expect(result[:success]).to be(true)
-        offer_code = seller.offer_codes.alive.last
+        offer_code = product.reload.offer_codes.alive.last
         expect(offer_code.code).to eq("LAUNCH")
         expect(offer_code.amount_percentage).to eq(20)
-        expect(offer_code.universal?).to be(true)
-        # A universal percentage code must stay currency-agnostic so it applies across all products.
-        expect(offer_code.currency_type).to be_nil
-      end
-
-      it "creates a universal fixed-amount discount" do
-        result = executor.execute(type: "create_discount", params: { code: "FIVEOFF", amount_off_cents: 500 })
-
-        expect(result[:success]).to be(true)
-        expect(seller.offer_codes.alive.last.amount_cents).to eq(500)
-      end
-
-      it "rejects an out-of-range percentage" do
-        result = executor.execute(type: "create_discount", params: { code: "NOPE", percent_off: 150 })
-
-        expect(result[:success]).to be(false)
-        expect(seller.offer_codes.alive.count).to eq(0)
-      end
-
-      it "requires a code" do
-        result = executor.execute(type: "create_discount", params: { percent_off: 10 })
-
-        expect(result[:success]).to be(false)
       end
     end
 
-    context "update_product_price" do
+    context "update_product (price change replayed through the API)" do
       let!(:product) { create(:product, user: seller, price_cents: 1000) }
 
       it "updates the price" do
-        result = executor.execute(type: "update_product_price", params: { product_id: product.external_id, new_price_cents: 2500 })
+        result = executor.execute(
+          type: "api_write",
+          params: api_write(endpoint: "update_product", path_params: { "id" => product.external_id }, params: { "price" => 2500 }),
+        )
 
         expect(result[:success]).to be(true)
         expect(product.reload.price_cents).to eq(2500)
       end
 
-      it "rejects a negative price" do
-        result = executor.execute(type: "update_product_price", params: { product_id: product.external_id, new_price_cents: -1 })
-
-        expect(result[:success]).to be(false)
-        expect(product.reload.price_cents).to eq(1000)
-      end
-
-      it "does not touch another seller's product" do
+      it "does not touch another seller's product (token is scoped to this seller)" do
         other_product = create(:product, price_cents: 1000)
 
-        result = executor.execute(type: "update_product_price", params: { product_id: other_product.external_id, new_price_cents: 5 })
+        result = executor.execute(
+          type: "api_write",
+          params: api_write(endpoint: "update_product", path_params: { "id" => other_product.external_id }, params: { "price" => 5 }),
+        )
 
+        # The seller's token can't resolve another seller's product, so the API returns not-found and
+        # nothing changes.
         expect(result[:success]).to be(false)
         expect(other_product.reload.price_cents).to eq(1000)
       end
-
-      it "refuses to mutate an archived product (never surfaced by the listing tool)" do
-        archived = create(:product, user: seller, price_cents: 1000, archived: true)
-
-        result = executor.execute(type: "update_product_price", params: { product_id: archived.external_id, new_price_cents: 5 })
-
-        expect(result[:success]).to be(false)
-        expect(archived.reload.price_cents).to eq(1000)
-      end
-
-      it "refuses a tiered membership (price lives on tiers, not price_cents)" do
-        membership = create(:membership_product, user: seller)
-
-        result = executor.execute(type: "update_product_price", params: { product_id: membership.external_id, new_price_cents: 5000 })
-
-        expect(result[:success]).to be(false)
-        expect(result[:message]).to match(/tier/i)
-      end
     end
 
-    context "publish_product / unpublish_product" do
+    context "publish / unpublish (enable / disable replayed through the API)" do
       let!(:product) { create(:product, user: seller, purchase_disabled_at: Time.current) }
 
-      it "publishes a product" do
-        result = executor.execute(type: "publish_product", params: { product_id: product.external_id })
+      it "publishes a product via enable_product" do
+        result = executor.execute(
+          type: "api_write",
+          params: api_write(endpoint: "enable_product", path_params: { "id" => product.external_id }),
+        )
 
         expect(result[:success]).to be(true)
         expect(product.reload.alive?).to be(true)
       end
 
-      it "unpublishes a product" do
+      it "unpublishes a product via disable_product" do
         product.publish!
-        result = executor.execute(type: "unpublish_product", params: { product_id: product.external_id })
+        result = executor.execute(
+          type: "api_write",
+          params: api_write(endpoint: "disable_product", path_params: { "id" => product.external_id }),
+        )
 
         expect(result[:success]).to be(true)
         expect(product.reload.alive?).to be(false)
       end
     end
 
-    context "unsupported type" do
-      it "returns a failure without raising" do
+    context "unsupported / tampered actions" do
+      it "rejects a non-api_write type without raising" do
         result = executor.execute(type: "delete_account", params: {})
 
         expect(result[:success]).to be(false)
         expect(result[:message]).to be_present
+      end
+
+      it "rejects an unknown endpoint id" do
+        result = executor.execute(type: "api_write", params: api_write(endpoint: "drop_database"))
+
+        expect(result[:success]).to be(false)
+        expect(result[:message]).to be_present
+      end
+
+      it "rejects a READ endpoint sent as a write (reads never mutate, so never execute here)" do
+        result = executor.execute(type: "api_write", params: api_write(endpoint: "list_products"))
+
+        expect(result[:success]).to be(false)
+      end
+
+      it "fails cleanly when a required path param is missing" do
+        result = executor.execute(type: "api_write", params: api_write(endpoint: "update_product", path_params: {}, params: { "price" => 5 }))
+
+        expect(result[:success]).to be(false)
+        expect(result[:message]).to match(/missing path parameter/i)
       end
     end
   end

--- a/spec/services/ai/store_agent_action_executor_spec.rb
+++ b/spec/services/ai/store_agent_action_executor_spec.rb
@@ -68,6 +68,15 @@ describe Ai::StoreAgentActionExecutor do
         expect(other_product.reload.price_cents).to eq(1000)
       end
 
+      it "refuses to mutate an archived product (never surfaced by the listing tool)" do
+        archived = create(:product, user: seller, price_cents: 1000, archived: true)
+
+        result = executor.execute(type: "update_product_price", params: { product_id: archived.external_id, new_price_cents: 5 })
+
+        expect(result[:success]).to be(false)
+        expect(archived.reload.price_cents).to eq(1000)
+      end
+
       it "refuses a tiered membership (price lives on tiers, not price_cents)" do
         membership = create(:membership_product, user: seller)
 

--- a/spec/services/ai/store_agent_action_executor_spec.rb
+++ b/spec/services/ai/store_agent_action_executor_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Ai::StoreAgentActionExecutor do
+  let(:seller) { create(:user) }
+  let(:pundit_user) { SellerContext.new(user: seller, seller:) }
+  let(:executor) { described_class.new(seller:, pundit_user:) }
+
+  describe "#execute" do
+    context "create_discount" do
+      it "creates a universal percentage discount" do
+        result = executor.execute(type: "create_discount", params: { code: "LAUNCH", percent_off: 20 })
+
+        expect(result[:success]).to be(true)
+        offer_code = seller.offer_codes.alive.last
+        expect(offer_code.code).to eq("LAUNCH")
+        expect(offer_code.amount_percentage).to eq(20)
+        expect(offer_code.universal?).to be(true)
+        # A universal percentage code must stay currency-agnostic so it applies across all products.
+        expect(offer_code.currency_type).to be_nil
+      end
+
+      it "creates a universal fixed-amount discount" do
+        result = executor.execute(type: "create_discount", params: { code: "FIVEOFF", amount_off_cents: 500 })
+
+        expect(result[:success]).to be(true)
+        expect(seller.offer_codes.alive.last.amount_cents).to eq(500)
+      end
+
+      it "rejects an out-of-range percentage" do
+        result = executor.execute(type: "create_discount", params: { code: "NOPE", percent_off: 150 })
+
+        expect(result[:success]).to be(false)
+        expect(seller.offer_codes.alive.count).to eq(0)
+      end
+
+      it "requires a code" do
+        result = executor.execute(type: "create_discount", params: { percent_off: 10 })
+
+        expect(result[:success]).to be(false)
+      end
+    end
+
+    context "update_product_price" do
+      let!(:product) { create(:product, user: seller, price_cents: 1000) }
+
+      it "updates the price" do
+        result = executor.execute(type: "update_product_price", params: { product_id: product.external_id, new_price_cents: 2500 })
+
+        expect(result[:success]).to be(true)
+        expect(product.reload.price_cents).to eq(2500)
+      end
+
+      it "rejects a negative price" do
+        result = executor.execute(type: "update_product_price", params: { product_id: product.external_id, new_price_cents: -1 })
+
+        expect(result[:success]).to be(false)
+        expect(product.reload.price_cents).to eq(1000)
+      end
+
+      it "does not touch another seller's product" do
+        other_product = create(:product, price_cents: 1000)
+
+        result = executor.execute(type: "update_product_price", params: { product_id: other_product.external_id, new_price_cents: 5 })
+
+        expect(result[:success]).to be(false)
+        expect(other_product.reload.price_cents).to eq(1000)
+      end
+
+      it "refuses a tiered membership (price lives on tiers, not price_cents)" do
+        membership = create(:membership_product, user: seller)
+
+        result = executor.execute(type: "update_product_price", params: { product_id: membership.external_id, new_price_cents: 5000 })
+
+        expect(result[:success]).to be(false)
+        expect(result[:message]).to match(/tier/i)
+      end
+    end
+
+    context "publish_product / unpublish_product" do
+      let!(:product) { create(:product, user: seller, purchase_disabled_at: Time.current) }
+
+      it "publishes a product" do
+        result = executor.execute(type: "publish_product", params: { product_id: product.external_id })
+
+        expect(result[:success]).to be(true)
+        expect(product.reload.alive?).to be(true)
+      end
+
+      it "unpublishes a product" do
+        product.publish!
+        result = executor.execute(type: "unpublish_product", params: { product_id: product.external_id })
+
+        expect(result[:success]).to be(true)
+        expect(product.reload.alive?).to be(false)
+      end
+    end
+
+    context "unsupported type" do
+      it "returns a failure without raising" do
+        result = executor.execute(type: "delete_account", params: {})
+
+        expect(result[:success]).to be(false)
+        expect(result[:message]).to be_present
+      end
+    end
+  end
+end

--- a/spec/services/ai/store_agent_action_executor_spec.rb
+++ b/spec/services/ai/store_agent_action_executor_spec.rb
@@ -34,6 +34,8 @@ describe Ai::StoreAgentActionExecutor do
         offer_code = product.reload.offer_codes.alive.last
         expect(offer_code.code).to eq("LAUNCH")
         expect(offer_code.amount_percentage).to eq(20)
+        # The created object is returned so the chat can render it inline as a card.
+        expect(result[:object]).to include(type: "discount", title: "LAUNCH")
       end
     end
 

--- a/spec/services/ai/store_agent_object_formatter_spec.rb
+++ b/spec/services/ai/store_agent_object_formatter_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Ai::StoreAgentObjectFormatter do
+  let(:catalog) { Ai::StoreAgentApiCatalog }
+
+  describe ".from_response" do
+    it "returns [] for an error envelope" do
+      objects = described_class.from_response(catalog.find("list_products"), { "success" => false, "message" => "nope" })
+      expect(objects).to eq([])
+    end
+
+    it "returns [] for a non-hash response" do
+      expect(described_class.from_response(catalog.find("list_products"), "oops")).to eq([])
+    end
+
+    it "builds product cards from list_products" do
+      response = {
+        "success" => true,
+        "products" => [
+          { "id" => "p1", "name" => "Cool Ebook", "formatted_price" => "$9.99", "published" => true, "sales_count" => 12, "short_url" => "https://x.gumroad.com/l/ebook" },
+        ],
+      }
+
+      objects = described_class.from_response(catalog.find("list_products"), response)
+
+      expect(objects.size).to eq(1)
+      card = objects.first
+      expect(card[:type]).to eq("product")
+      expect(card[:title]).to eq("Cool Ebook")
+      expect(card[:subtitle]).to eq("$9.99")
+      expect(card[:url]).to eq("https://x.gumroad.com/l/ebook")
+      expect(card[:copy]).to eq("https://x.gumroad.com/l/ebook")
+      expect(card[:fields]).to include({ label: "Status", value: "Published" }, { label: "Sales", value: "12" })
+    end
+
+    it "builds a single product card from create_product / update_product" do
+      response = { "success" => true, "product" => { "id" => "p2", "name" => "New Thing", "price" => 2500, "currency" => "usd", "published" => false } }
+
+      card = described_class.from_response(catalog.find("create_product"), response).first
+
+      expect(card[:type]).to eq("product")
+      expect(card[:title]).to eq("New Thing")
+      expect(card[:subtitle]).to eq("$25")
+      expect(card[:fields]).to include({ label: "Status", value: "Unpublished" })
+    end
+
+    it "builds a discount card and copies the code" do
+      response = { "success" => true, "offer_code" => { "id" => "o1", "name" => "LAUNCH25", "percent_off" => 25, "universal" => true, "times_used" => 3 } }
+
+      card = described_class.from_response(catalog.find("create_offer_code"), response).first
+
+      expect(card[:type]).to eq("discount")
+      expect(card[:title]).to eq("LAUNCH25")
+      expect(card[:subtitle]).to eq("25% off")
+      expect(card[:copy]).to eq("LAUNCH25")
+      expect(card[:fields]).to include({ label: "Applies to", value: "All products" }, { label: "Times used", value: "3" })
+    end
+
+    it "returns [] for an endpoint with no renderable shape" do
+      expect(described_class.from_response(catalog.find("get_earnings"), { "success" => true, "earnings" => {} })).to eq([])
+    end
+  end
+end

--- a/spec/services/ai/store_agent_service_spec.rb
+++ b/spec/services/ai/store_agent_service_spec.rb
@@ -133,5 +133,96 @@ describe Ai::StoreAgentService do
         expect(captured).to have_key("gross_sales")
       end
     end
+
+    context "when the model proposes more than one write in a single turn" do
+      # Two write tool calls in one assistant message: only the first may be staged, and the second
+      # must be rejected back to the model so the confirmation card can't describe a different change.
+      def two_write_calls_message
+        {
+          "choices" => [{
+            "message" => {
+              "content" => nil,
+              "tool_calls" => [
+                { "id" => "call_a", "function" => { "name" => "create_discount", "arguments" => { "code" => "FIRST", "percent_off" => 10 }.to_json } },
+                { "id" => "call_b", "function" => { "name" => "create_discount", "arguments" => { "code" => "SECOND", "percent_off" => 50 }.to_json } },
+              ],
+            },
+          }],
+        }
+      end
+
+      it "stages only the first proposal and tells the model the second was dropped" do
+        captured_tool_results = []
+        allow(client).to receive(:chat) do |args|
+          tool_msgs = args[:parameters][:messages].select { |m| m[:role] == "tool" }
+          if tool_msgs.any?
+            captured_tool_results = tool_msgs.map { |m| JSON.parse(m[:content]) }
+            assistant_message("I've prepared the FIRST code for your confirmation.")
+          else
+            two_write_calls_message
+          end
+        end
+
+        result = service.respond(messages: [{ role: "user", content: "make two codes" }])
+
+        expect(result[:proposed_action]).to include(type: "create_discount", params: include(code: "FIRST"))
+        # The second write call was rejected, not staged.
+        expect(captured_tool_results.last).to include("error")
+        expect(captured_tool_results.last["error"]).to match(/one change/i)
+      end
+    end
+
+    context "when the model never finishes within the tool-iteration cap" do
+      it "does not claim there is a change to confirm when none was staged" do
+        # Always ask for a read tool, never returning a final answer, so the loop exhausts the cap
+        # without any write action being proposed.
+        allow(client).to receive(:chat).and_return(tool_call_message("list_products", {}))
+
+        result = service.respond(messages: [{ role: "user", content: "loop forever" }])
+
+        expect(result[:proposed_action]).to be_nil
+        expect(result[:reply]).not_to match(/confirm/i)
+      end
+    end
+
+    context "product resolution scope" do
+      it "refuses to propose a price change for an archived product" do
+        archived = create(:product, user: seller, name: "Archived One", price_cents: 500, archived: true)
+        captured_tool_results = []
+        allow(client).to receive(:chat) do |args|
+          tool_msgs = args[:parameters][:messages].select { |m| m[:role] == "tool" }
+          if tool_msgs.any?
+            captured_tool_results = tool_msgs.map { |m| JSON.parse(m[:content]) }
+            assistant_message("done")
+          else
+            tool_call_message("update_product_price", { "product_id" => archived.external_id, "new_price" => 9 })
+          end
+        end
+
+        result = service.respond(messages: [{ role: "user", content: "set archived price" }])
+
+        expect(result[:proposed_action]).to be_nil
+        expect(captured_tool_results.last).to include("error")
+      end
+
+      it "refuses a non-numeric price instead of proposing a free product" do
+        product = create(:product, user: seller, name: "Real One", price_cents: 1000)
+        captured_tool_results = []
+        allow(client).to receive(:chat) do |args|
+          tool_msgs = args[:parameters][:messages].select { |m| m[:role] == "tool" }
+          if tool_msgs.any?
+            captured_tool_results = tool_msgs.map { |m| JSON.parse(m[:content]) }
+            assistant_message("done")
+          else
+            tool_call_message("update_product_price", { "product_id" => product.external_id, "new_price" => "free" })
+          end
+        end
+
+        result = service.respond(messages: [{ role: "user", content: "make it free-ish" }])
+
+        expect(result[:proposed_action]).to be_nil
+        expect(captured_tool_results.last["error"]).to match(/number/i)
+      end
+    end
   end
 end

--- a/spec/services/ai/store_agent_service_spec.rb
+++ b/spec/services/ai/store_agent_service_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Ai::StoreAgentService do
+  let(:seller) { create(:user) }
+  let(:pundit_user) { SellerContext.new(user: seller, seller:) }
+  let(:service) { described_class.new(seller:, pundit_user:) }
+  let(:client) { instance_double(OpenAI::Client) }
+
+  before do
+    allow(OpenAI::Client).to receive(:new).and_return(client)
+  end
+
+  # Helper to shape an OpenAI chat completion response with a plain assistant message.
+  def assistant_message(content)
+    { "choices" => [{ "message" => { "content" => content, "tool_calls" => nil } }] }
+  end
+
+  # Helper to shape a response that asks to call a tool.
+  def tool_call_message(name, arguments)
+    {
+      "choices" => [{
+        "message" => {
+          "content" => nil,
+          "tool_calls" => [{ "id" => "call_1", "function" => { "name" => name, "arguments" => arguments.to_json } }],
+        },
+      }],
+    }
+  end
+
+  describe "#respond" do
+    it "requires the conversation to end with a user message" do
+      expect { service.respond(messages: [{ role: "assistant", content: "hi" }]) }
+        .to raise_error(described_class::Error)
+    end
+
+    it "returns the model's reply when no tools are called" do
+      allow(client).to receive(:chat).and_return(assistant_message("You have 3 products."))
+
+      result = service.respond(messages: [{ role: "user", content: "How many products do I have?" }])
+
+      expect(result[:reply]).to eq("You have 3 products.")
+      expect(result[:proposed_action]).to be_nil
+    end
+
+    it "runs a read tool and feeds the result back to the model" do
+      create(:product, user: seller, name: "Cool Ebook", price_cents: 999)
+
+      # First call asks for list_products, second call returns a normal answer.
+      allow(client).to receive(:chat).and_return(
+        tool_call_message("list_products", {}),
+        assistant_message("Your product Cool Ebook is $9.99."),
+      )
+
+      result = service.respond(messages: [{ role: "user", content: "List my products" }])
+
+      expect(result[:reply]).to eq("Your product Cool Ebook is $9.99.")
+      # The tool result should have been appended to the conversation for the second call.
+      expect(client).to have_received(:chat).twice
+    end
+
+    it "returns a proposed action for a write tool WITHOUT mutating anything" do
+      allow(client).to receive(:chat).and_return(
+        tool_call_message("create_discount", { "code" => "LAUNCH", "percent_off" => 20 }),
+        assistant_message("I've prepared a 20% off code called LAUNCH for your confirmation."),
+      )
+
+      expect do
+        result = service.respond(messages: [{ role: "user", content: "Make a 20% off code LAUNCH" }])
+
+        expect(result[:proposed_action]).to include(
+          type: "create_discount",
+          params: include(code: "LAUNCH", percent_off: 20),
+        )
+        expect(result[:proposed_action][:summary]).to be_present
+      end.not_to change { seller.offer_codes.count }
+    end
+
+    it "only ever reads the current seller's own data" do
+      create(:product, user: seller, name: "Mine")
+      other_product = create(:product, name: "Theirs")
+
+      allow(client).to receive(:chat).and_return(
+        tool_call_message("list_products", {}),
+        assistant_message("You have one product: Mine."),
+      )
+
+      result = service.respond(messages: [{ role: "user", content: "list my products" }])
+
+      expect(result[:reply]).to eq("You have one product: Mine.")
+      expect(client).to have_received(:chat).twice
+      # The other seller's product is never in scope; the read tool is seller-scoped.
+      expect(other_product.reload.name).to eq("Theirs")
+    end
+
+    context "store_stats balance gating" do
+      let(:tool_then_done) do
+        [tool_call_message("store_stats", {}), assistant_message("Here are your stats.")]
+      end
+
+      it "includes unpaid_balance for the owner (who can view payouts)" do
+        allow(seller).to receive(:unpaid_balance_cents).and_return(12_345)
+        captured = nil
+        allow(client).to receive(:chat) do |args|
+          # Capture the tool-result message fed back on the second turn.
+          tool_msg = args[:parameters][:messages].find { |m| m[:role] == "tool" }
+          captured = JSON.parse(tool_msg[:content]) if tool_msg
+          captured ? assistant_message("done") : tool_call_message("store_stats", {})
+        end
+
+        service.respond(messages: [{ role: "user", content: "stats" }])
+
+        expect(captured).to have_key("unpaid_balance")
+      end
+
+      it "omits unpaid_balance for a marketing role (denied payout access)" do
+        marketing_user = create(:user)
+        create(:team_membership, user: marketing_user, seller:, role: TeamMembership::ROLE_MARKETING)
+        marketing_context = SellerContext.new(user: marketing_user, seller:)
+        marketing_service = described_class.new(seller:, pundit_user: marketing_context)
+
+        captured = nil
+        allow(client).to receive(:chat) do |args|
+          tool_msg = args[:parameters][:messages].find { |m| m[:role] == "tool" }
+          captured = JSON.parse(tool_msg[:content]) if tool_msg
+          captured ? assistant_message("done") : tool_call_message("store_stats", {})
+        end
+
+        marketing_service.respond(messages: [{ role: "user", content: "stats" }])
+
+        expect(captured).not_to have_key("unpaid_balance")
+        expect(captured).to have_key("gross_sales")
+      end
+    end
+  end
+end

--- a/spec/services/ai/store_agent_service_spec.rb
+++ b/spec/services/ai/store_agent_service_spec.rb
@@ -7,9 +7,13 @@ describe Ai::StoreAgentService do
   let(:pundit_user) { SellerContext.new(user: seller, seller:) }
   let(:service) { described_class.new(seller:, pundit_user:) }
   let(:client) { instance_double(OpenAI::Client) }
+  # The service reaches the real v2 API through StoreAgentApiClient; stub it so these stay fast unit
+  # tests of the tool-dispatch + propose/confirm logic (the executor spec covers the real API path).
+  let(:api_client) { instance_double(Ai::StoreAgentApiClient) }
 
   before do
     allow(OpenAI::Client).to receive(:new).and_return(client)
+    allow(Ai::StoreAgentApiClient).to receive(:new).and_return(api_client)
   end
 
   # Helper to shape an OpenAI chat completion response with a plain assistant message.
@@ -44,107 +48,138 @@ describe Ai::StoreAgentService do
       expect(result[:proposed_action]).to be_nil
     end
 
-    it "runs a read tool and feeds the result back to the model" do
-      create(:product, user: seller, name: "Cool Ebook", price_cents: 999)
+    describe "api_read" do
+      it "runs a read endpoint against the API and feeds the result back to the model" do
+        expect(api_client).to receive(:get).with("/products", {}).and_return(
+          { "success" => true, "products" => [{ "name" => "Cool Ebook", "price" => 999 }], "http_status" => 200 },
+        )
+        allow(client).to receive(:chat).and_return(
+          tool_call_message("api_read", { "endpoint" => "list_products" }),
+          assistant_message("Your product Cool Ebook is $9.99."),
+        )
 
-      # First call asks for list_products, second call returns a normal answer.
-      allow(client).to receive(:chat).and_return(
-        tool_call_message("list_products", {}),
-        assistant_message("Your product Cool Ebook is $9.99."),
-      )
+        result = service.respond(messages: [{ role: "user", content: "List my products" }])
 
-      result = service.respond(messages: [{ role: "user", content: "List my products" }])
+        expect(result[:reply]).to eq("Your product Cool Ebook is $9.99.")
+        expect(client).to have_received(:chat).twice
+      end
 
-      expect(result[:reply]).to eq("Your product Cool Ebook is $9.99.")
-      # The tool result should have been appended to the conversation for the second call.
-      expect(client).to have_received(:chat).twice
+      it "expands path params into the endpoint path" do
+        expect(api_client).to receive(:get).with("/products/abc123", {}).and_return({ "success" => true, "http_status" => 200 })
+        allow(client).to receive(:chat).and_return(
+          tool_call_message("api_read", { "endpoint" => "get_product", "path_params" => { "id" => "abc123" } }),
+          assistant_message("Here is that product."),
+        )
+
+        service.respond(messages: [{ role: "user", content: "show product abc123" }])
+      end
+
+      it "rejects an unknown endpoint id without calling the API" do
+        expect(api_client).not_to receive(:get)
+        captured = nil
+        allow(client).to receive(:chat) do |args|
+          tool_msg = args[:parameters][:messages].find { |m| m[:role] == "tool" }
+          captured = JSON.parse(tool_msg[:content]) if tool_msg
+          captured ? assistant_message("ok") : tool_call_message("api_read", { "endpoint" => "drop_tables" })
+        end
+
+        service.respond(messages: [{ role: "user", content: "hack" }])
+
+        expect(captured).to include("error")
+      end
+
+      it "refuses to run a WRITE endpoint through api_read (it must be confirmed)" do
+        expect(api_client).not_to receive(:get)
+        captured = nil
+        allow(client).to receive(:chat) do |args|
+          tool_msg = args[:parameters][:messages].find { |m| m[:role] == "tool" }
+          captured = JSON.parse(tool_msg[:content]) if tool_msg
+          captured ? assistant_message("ok") : tool_call_message("api_read", { "endpoint" => "refund_sale", "path_params" => { "id" => "1" } })
+        end
+
+        service.respond(messages: [{ role: "user", content: "refund it now" }])
+
+        expect(captured["error"]).to match(/confirm/i)
+      end
+
+      it "surfaces a missing path param as an error instead of raising" do
+        expect(api_client).not_to receive(:get)
+        captured = nil
+        allow(client).to receive(:chat) do |args|
+          tool_msg = args[:parameters][:messages].find { |m| m[:role] == "tool" }
+          captured = JSON.parse(tool_msg[:content]) if tool_msg
+          captured ? assistant_message("ok") : tool_call_message("api_read", { "endpoint" => "get_product" })
+        end
+
+        service.respond(messages: [{ role: "user", content: "show the product" }])
+
+        expect(captured["error"]).to match(/missing path parameter/i)
+      end
     end
 
-    it "returns a proposed action for a write tool WITHOUT mutating anything" do
-      allow(client).to receive(:chat).and_return(
-        tool_call_message("create_discount", { "code" => "LAUNCH", "percent_off" => 20 }),
-        assistant_message("I've prepared a 20% off code called LAUNCH for your confirmation."),
-      )
+    describe "api_write" do
+      it "returns a proposed action WITHOUT mutating or calling the API" do
+        expect(api_client).not_to receive(:write)
+        allow(client).to receive(:chat).and_return(
+          tool_call_message("api_write", {
+                              "endpoint" => "create_offer_code",
+                              "path_params" => { "link_id" => "prod_1" },
+                              "params" => { "name" => "LAUNCH", "amount_off" => 20, "offer_type" => "percent" },
+                            }),
+          assistant_message("I've prepared a 20% off code called LAUNCH for your confirmation."),
+        )
 
-      expect do
         result = service.respond(messages: [{ role: "user", content: "Make a 20% off code LAUNCH" }])
 
         expect(result[:proposed_action]).to include(
-          type: "create_discount",
-          params: include(code: "LAUNCH", percent_off: 20),
+          type: "api_write",
+          params: include(
+            "endpoint" => "create_offer_code",
+            "path_params" => { "link_id" => "prod_1" },
+            "params" => include("name" => "LAUNCH"),
+          ),
         )
         expect(result[:proposed_action][:summary]).to be_present
-      end.not_to change { seller.offer_codes.count }
-    end
-
-    it "only ever reads the current seller's own data" do
-      create(:product, user: seller, name: "Mine")
-      other_product = create(:product, name: "Theirs")
-
-      allow(client).to receive(:chat).and_return(
-        tool_call_message("list_products", {}),
-        assistant_message("You have one product: Mine."),
-      )
-
-      result = service.respond(messages: [{ role: "user", content: "list my products" }])
-
-      expect(result[:reply]).to eq("You have one product: Mine.")
-      expect(client).to have_received(:chat).twice
-      # The other seller's product is never in scope; the read tool is seller-scoped.
-      expect(other_product.reload.name).to eq("Theirs")
-    end
-
-    context "store_stats balance gating" do
-      let(:tool_then_done) do
-        [tool_call_message("store_stats", {}), assistant_message("Here are your stats.")]
       end
 
-      it "includes unpaid_balance for the owner (who can view payouts)" do
-        allow(seller).to receive(:unpaid_balance_cents).and_return(12_345)
-        captured = nil
-        allow(client).to receive(:chat) do |args|
-          # Capture the tool-result message fed back on the second turn.
-          tool_msg = args[:parameters][:messages].find { |m| m[:role] == "tool" }
-          captured = JSON.parse(tool_msg[:content]) if tool_msg
-          captured ? assistant_message("done") : tool_call_message("store_stats", {})
-        end
-
-        service.respond(messages: [{ role: "user", content: "stats" }])
-
-        expect(captured).to have_key("unpaid_balance")
-      end
-
-      it "omits unpaid_balance for a marketing role (denied payout access)" do
-        marketing_user = create(:user)
-        create(:team_membership, user: marketing_user, seller:, role: TeamMembership::ROLE_MARKETING)
-        marketing_context = SellerContext.new(user: marketing_user, seller:)
-        marketing_service = described_class.new(seller:, pundit_user: marketing_context)
-
+      it "rejects a READ endpoint sent to api_write (nudges to api_read)" do
         captured = nil
         allow(client).to receive(:chat) do |args|
           tool_msg = args[:parameters][:messages].find { |m| m[:role] == "tool" }
           captured = JSON.parse(tool_msg[:content]) if tool_msg
-          captured ? assistant_message("done") : tool_call_message("store_stats", {})
+          captured ? assistant_message("ok") : tool_call_message("api_write", { "endpoint" => "list_products" })
         end
 
-        marketing_service.respond(messages: [{ role: "user", content: "stats" }])
+        result = service.respond(messages: [{ role: "user", content: "change products" }])
 
-        expect(captured).not_to have_key("unpaid_balance")
-        expect(captured).to have_key("gross_sales")
+        expect(result[:proposed_action]).to be_nil
+        expect(captured["error"]).to match(/api_read/i)
+      end
+
+      it "validates path params at propose time so a missing id can't reach the executor" do
+        captured = nil
+        allow(client).to receive(:chat) do |args|
+          tool_msg = args[:parameters][:messages].find { |m| m[:role] == "tool" }
+          captured = JSON.parse(tool_msg[:content]) if tool_msg
+          captured ? assistant_message("ok") : tool_call_message("api_write", { "endpoint" => "refund_sale", "params" => { "amount_cents" => 100 } })
+        end
+
+        result = service.respond(messages: [{ role: "user", content: "refund" }])
+
+        expect(result[:proposed_action]).to be_nil
+        expect(captured["error"]).to match(/missing path parameter/i)
       end
     end
 
     context "when the model proposes more than one write in a single turn" do
-      # Two write tool calls in one assistant message: only the first may be staged, and the second
-      # must be rejected back to the model so the confirmation card can't describe a different change.
       def two_write_calls_message
         {
           "choices" => [{
             "message" => {
               "content" => nil,
               "tool_calls" => [
-                { "id" => "call_a", "function" => { "name" => "create_discount", "arguments" => { "code" => "FIRST", "percent_off" => 10 }.to_json } },
-                { "id" => "call_b", "function" => { "name" => "create_discount", "arguments" => { "code" => "SECOND", "percent_off" => 50 }.to_json } },
+                { "id" => "call_a", "function" => { "name" => "api_write", "arguments" => { "endpoint" => "create_offer_code", "path_params" => { "link_id" => "p1" }, "params" => { "name" => "FIRST", "amount_off" => 10, "offer_type" => "percent" } }.to_json } },
+                { "id" => "call_b", "function" => { "name" => "api_write", "arguments" => { "endpoint" => "create_offer_code", "path_params" => { "link_id" => "p1" }, "params" => { "name" => "SECOND", "amount_off" => 50, "offer_type" => "percent" } }.to_json } },
               ],
             },
           }],
@@ -165,8 +200,7 @@ describe Ai::StoreAgentService do
 
         result = service.respond(messages: [{ role: "user", content: "make two codes" }])
 
-        expect(result[:proposed_action]).to include(type: "create_discount", params: include(code: "FIRST"))
-        # The second write call was rejected, not staged.
+        expect(result[:proposed_action]).to include(type: "api_write", params: include("params" => include("name" => "FIRST")))
         expect(captured_tool_results.last).to include("error")
         expect(captured_tool_results.last["error"]).to match(/one change/i)
       end
@@ -174,9 +208,8 @@ describe Ai::StoreAgentService do
 
     context "when the model never finishes within the tool-iteration cap" do
       it "does not claim there is a change to confirm when none was staged" do
-        # Always ask for a read tool, never returning a final answer, so the loop exhausts the cap
-        # without any write action being proposed.
-        allow(client).to receive(:chat).and_return(tool_call_message("list_products", {}))
+        allow(api_client).to receive(:get).and_return({ "success" => true, "http_status" => 200 })
+        allow(client).to receive(:chat).and_return(tool_call_message("api_read", { "endpoint" => "list_products" }))
 
         result = service.respond(messages: [{ role: "user", content: "loop forever" }])
 
@@ -185,61 +218,19 @@ describe Ai::StoreAgentService do
       end
     end
 
-    context "product resolution scope" do
-      it "refuses to propose a price change for an archived product" do
-        archived = create(:product, user: seller, name: "Archived One", price_cents: 500, archived: true)
-        captured_tool_results = []
-        allow(client).to receive(:chat) do |args|
-          tool_msgs = args[:parameters][:messages].select { |m| m[:role] == "tool" }
-          if tool_msgs.any?
-            captured_tool_results = tool_msgs.map { |m| JSON.parse(m[:content]) }
-            assistant_message("done")
-          else
-            tool_call_message("update_product_price", { "product_id" => archived.external_id, "new_price" => 9 })
-          end
-        end
-
-        result = service.respond(messages: [{ role: "user", content: "set archived price" }])
-
-        expect(result[:proposed_action]).to be_nil
-        expect(captured_tool_results.last).to include("error")
-      end
-
-      it "refuses a non-numeric price instead of proposing a free product" do
-        product = create(:product, user: seller, name: "Real One", price_cents: 1000)
-        captured_tool_results = []
-        allow(client).to receive(:chat) do |args|
-          tool_msgs = args[:parameters][:messages].select { |m| m[:role] == "tool" }
-          if tool_msgs.any?
-            captured_tool_results = tool_msgs.map { |m| JSON.parse(m[:content]) }
-            assistant_message("done")
-          else
-            tool_call_message("update_product_price", { "product_id" => product.external_id, "new_price" => "free" })
-          end
-        end
-
-        result = service.respond(messages: [{ role: "user", content: "make it free-ish" }])
-
-        expect(result[:proposed_action]).to be_nil
-        expect(captured_tool_results.last["error"]).to match(/number/i)
-      end
-    end
-
     context "when the model emits malformed tool-call arguments" do
-      # OpenAI tool-call `arguments` is supposed to be a JSON object string, but a hallucinating
-      # model can return a bare array or scalar. The write tools index arguments by key, which used
-      # to raise TypeError (Integer#[] / no implicit conversion) and surface as an unhandled 500.
-      # parse_arguments now coerces non-objects to {} so the tool falls through to its normal
-      # "field is required" validation instead of crashing.
+      # OpenAI tool-call `arguments` is supposed to be a JSON object string, but a hallucinating model
+      # can return a bare array or scalar. parse_arguments coerces non-objects to {} so the tool
+      # falls through to its normal "endpoint is required" handling instead of raising a 500.
       ["[1,2,3]", "42", "\"just a string\"", "null", "{not valid json"].each do |raw_args|
         it "does not raise on argument payload #{raw_args.inspect}" do
           allow(client).to receive(:chat).and_return(
-            { "choices" => [{ "message" => { "content" => nil, "tool_calls" => [{ "id" => "call_1", "function" => { "name" => "create_discount", "arguments" => raw_args } }] } }] },
-            assistant_message("I need a bit more detail to create that discount."),
+            { "choices" => [{ "message" => { "content" => nil, "tool_calls" => [{ "id" => "call_1", "function" => { "name" => "api_write", "arguments" => raw_args } }] } }] },
+            assistant_message("I need a bit more detail to make that change."),
           )
 
           expect do
-            result = service.respond(messages: [{ role: "user", content: "make a discount" }])
+            result = service.respond(messages: [{ role: "user", content: "make a change" }])
             expect(result[:reply]).to be_present
             expect(result[:proposed_action]).to be_nil
           end.not_to change { seller.offer_codes.count }

--- a/spec/services/ai/store_agent_service_spec.rb
+++ b/spec/services/ai/store_agent_service_spec.rb
@@ -51,7 +51,7 @@ describe Ai::StoreAgentService do
     describe "api_read" do
       it "runs a read endpoint against the API and feeds the result back to the model" do
         expect(api_client).to receive(:get).with("/products", {}).and_return(
-          { "success" => true, "products" => [{ "name" => "Cool Ebook", "price" => 999 }], "http_status" => 200 },
+          { "success" => true, "products" => [{ "id" => "p1", "name" => "Cool Ebook", "formatted_price" => "$9.99", "published" => true }], "http_status" => 200 },
         )
         allow(client).to receive(:chat).and_return(
           tool_call_message("api_read", { "endpoint" => "list_products" }),
@@ -62,6 +62,8 @@ describe Ai::StoreAgentService do
 
         expect(result[:reply]).to eq("Your product Cool Ebook is $9.99.")
         expect(client).to have_received(:chat).twice
+        # The product is surfaced as a display object for the chat to render inline as a card.
+        expect(result[:objects]).to include(include(type: "product", title: "Cool Ebook"))
       end
 
       it "expands path params into the endpoint path" do

--- a/spec/services/ai/store_agent_service_spec.rb
+++ b/spec/services/ai/store_agent_service_spec.rb
@@ -6,31 +6,36 @@ describe Ai::StoreAgentService do
   let(:seller) { create(:user) }
   let(:pundit_user) { SellerContext.new(user: seller, seller:) }
   let(:service) { described_class.new(seller:, pundit_user:) }
-  let(:client) { instance_double(OpenAI::Client) }
-  # The service reaches the real v2 API through StoreAgentApiClient; stub it so these stay fast unit
-  # tests of the tool-dispatch + propose/confirm logic (the executor spec covers the real API path).
+  # The agent runs on Claude via Ai::AnthropicClient; stub it so these stay fast unit tests of the
+  # tool-dispatch + propose/confirm logic. The client returns Ai::AnthropicClient::Result structs.
+  let(:client) { instance_double(Ai::AnthropicClient) }
+  # The service reaches the real v2 API through StoreAgentApiClient; stub it too (the executor spec
+  # covers the real API path).
   let(:api_client) { instance_double(Ai::StoreAgentApiClient) }
 
   before do
-    allow(OpenAI::Client).to receive(:new).and_return(client)
+    allow(Ai::AnthropicClient).to receive(:new).and_return(client)
     allow(Ai::StoreAgentApiClient).to receive(:new).and_return(api_client)
   end
 
-  # Helper to shape an OpenAI chat completion response with a plain assistant message.
-  def assistant_message(content)
-    { "choices" => [{ "message" => { "content" => content, "tool_calls" => nil } }] }
+  # A model turn with plain assistant text and no tool use.
+  def text_result(text)
+    Ai::AnthropicClient::Result.new(text:, tool_uses: [], stop_reason: "end_turn")
   end
 
-  # Helper to shape a response that asks to call a tool.
-  def tool_call_message(name, arguments)
-    {
-      "choices" => [{
-        "message" => {
-          "content" => nil,
-          "tool_calls" => [{ "id" => "call_1", "function" => { "name" => name, "arguments" => arguments.to_json } }],
-        },
-      }],
-    }
+  # A model turn that asks to use a tool (Anthropic tool_use block).
+  def tool_result(name, input, id: "toolu_1", text: "")
+    Ai::AnthropicClient::Result.new(text:, tool_uses: [{ id:, name:, input: }], stop_reason: "tool_use")
+  end
+
+  # Find the tool_result block the service fed back into the conversation for the most recent tool
+  # call, by inspecting the messages passed to the follow-up client.messages call.
+  def captured_tool_result(args)
+    tool_msg = args[:messages].reverse.find { |m| m[:role] == "user" && m[:content].is_a?(Array) && m[:content].any? { |c| c[:type] == "tool_result" } }
+    return nil unless tool_msg
+
+    block = tool_msg[:content].find { |c| c[:type] == "tool_result" }
+    JSON.parse(block[:content])
   end
 
   describe "#respond" do
@@ -40,7 +45,7 @@ describe Ai::StoreAgentService do
     end
 
     it "returns the model's reply when no tools are called" do
-      allow(client).to receive(:chat).and_return(assistant_message("You have 3 products."))
+      allow(client).to receive(:messages).and_return(text_result("You have 3 products."))
 
       result = service.respond(messages: [{ role: "user", content: "How many products do I have?" }])
 
@@ -48,29 +53,62 @@ describe Ai::StoreAgentService do
       expect(result[:proposed_action]).to be_nil
     end
 
+    it "drops a leading assistant greeting so Anthropic gets a user-first conversation" do
+      captured = nil
+      allow(client).to receive(:messages) do |args|
+        captured = args
+        text_result("ok")
+      end
+
+      # The web chat always opens with the canned assistant greeting before the first user message;
+      # Anthropic rejects a conversation that doesn't start with a user message.
+      service.respond(messages: [
+                        { role: "assistant", content: "Hi! I'm your Gumroad store assistant." },
+                        { role: "user", content: "How are my sales?" },
+                      ])
+
+      expect(captured[:messages].first[:role]).to eq("user")
+      expect(captured[:messages].map { |m| m[:role] }).to eq(["user"])
+    end
+
+    it "passes the system prompt and tools to the model on the first call" do
+      captured = nil
+      allow(client).to receive(:messages) do |args|
+        captured = args
+        text_result("ok")
+      end
+
+      service.respond(messages: [{ role: "user", content: "hi" }])
+
+      expect(captured[:system]).to include("Gumroad's store assistant")
+      expect(captured[:tools].map { |t| t[:name] }).to contain_exactly("api_read", "api_write")
+      # System prompt is NOT echoed into the messages array (it's Anthropic's top-level param).
+      expect(captured[:messages].none? { |m| m[:role] == "system" }).to be(true)
+    end
+
     describe "api_read" do
       it "runs a read endpoint against the API and feeds the result back to the model" do
         expect(api_client).to receive(:get).with("/products", {}).and_return(
           { "success" => true, "products" => [{ "id" => "p1", "name" => "Cool Ebook", "formatted_price" => "$9.99", "published" => true }], "http_status" => 200 },
         )
-        allow(client).to receive(:chat).and_return(
-          tool_call_message("api_read", { "endpoint" => "list_products" }),
-          assistant_message("Your product Cool Ebook is $9.99."),
+        allow(client).to receive(:messages).and_return(
+          tool_result("api_read", { "endpoint" => "list_products" }),
+          text_result("Your product Cool Ebook is $9.99."),
         )
 
         result = service.respond(messages: [{ role: "user", content: "List my products" }])
 
         expect(result[:reply]).to eq("Your product Cool Ebook is $9.99.")
-        expect(client).to have_received(:chat).twice
+        expect(client).to have_received(:messages).twice
         # The product is surfaced as a display object for the chat to render inline as a card.
         expect(result[:objects]).to include(include(type: "product", title: "Cool Ebook"))
       end
 
       it "expands path params into the endpoint path" do
         expect(api_client).to receive(:get).with("/products/abc123", {}).and_return({ "success" => true, "http_status" => 200 })
-        allow(client).to receive(:chat).and_return(
-          tool_call_message("api_read", { "endpoint" => "get_product", "path_params" => { "id" => "abc123" } }),
-          assistant_message("Here is that product."),
+        allow(client).to receive(:messages).and_return(
+          tool_result("api_read", { "endpoint" => "get_product", "path_params" => { "id" => "abc123" } }),
+          text_result("Here is that product."),
         )
 
         service.respond(messages: [{ role: "user", content: "show product abc123" }])
@@ -79,10 +117,15 @@ describe Ai::StoreAgentService do
       it "rejects an unknown endpoint id without calling the API" do
         expect(api_client).not_to receive(:get)
         captured = nil
-        allow(client).to receive(:chat) do |args|
-          tool_msg = args[:parameters][:messages].find { |m| m[:role] == "tool" }
-          captured = JSON.parse(tool_msg[:content]) if tool_msg
-          captured ? assistant_message("ok") : tool_call_message("api_read", { "endpoint" => "drop_tables" })
+        first = true
+        allow(client).to receive(:messages) do |args|
+          captured = captured_tool_result(args)
+          if first
+            first = false
+            tool_result("api_read", { "endpoint" => "drop_tables" })
+          else
+            text_result("ok")
+          end
         end
 
         service.respond(messages: [{ role: "user", content: "hack" }])
@@ -93,10 +136,15 @@ describe Ai::StoreAgentService do
       it "refuses to run a WRITE endpoint through api_read (it must be confirmed)" do
         expect(api_client).not_to receive(:get)
         captured = nil
-        allow(client).to receive(:chat) do |args|
-          tool_msg = args[:parameters][:messages].find { |m| m[:role] == "tool" }
-          captured = JSON.parse(tool_msg[:content]) if tool_msg
-          captured ? assistant_message("ok") : tool_call_message("api_read", { "endpoint" => "refund_sale", "path_params" => { "id" => "1" } })
+        first = true
+        allow(client).to receive(:messages) do |args|
+          captured = captured_tool_result(args)
+          if first
+            first = false
+            tool_result("api_read", { "endpoint" => "refund_sale", "path_params" => { "id" => "1" } })
+          else
+            text_result("ok")
+          end
         end
 
         service.respond(messages: [{ role: "user", content: "refund it now" }])
@@ -107,10 +155,15 @@ describe Ai::StoreAgentService do
       it "surfaces a missing path param as an error instead of raising" do
         expect(api_client).not_to receive(:get)
         captured = nil
-        allow(client).to receive(:chat) do |args|
-          tool_msg = args[:parameters][:messages].find { |m| m[:role] == "tool" }
-          captured = JSON.parse(tool_msg[:content]) if tool_msg
-          captured ? assistant_message("ok") : tool_call_message("api_read", { "endpoint" => "get_product" })
+        first = true
+        allow(client).to receive(:messages) do |args|
+          captured = captured_tool_result(args)
+          if first
+            first = false
+            tool_result("api_read", { "endpoint" => "get_product" })
+          else
+            text_result("ok")
+          end
         end
 
         service.respond(messages: [{ role: "user", content: "show the product" }])
@@ -122,13 +175,13 @@ describe Ai::StoreAgentService do
     describe "api_write" do
       it "returns a proposed action WITHOUT mutating or calling the API" do
         expect(api_client).not_to receive(:write)
-        allow(client).to receive(:chat).and_return(
-          tool_call_message("api_write", {
-                              "endpoint" => "create_offer_code",
-                              "path_params" => { "link_id" => "prod_1" },
-                              "params" => { "name" => "LAUNCH", "amount_off" => 20, "offer_type" => "percent" },
-                            }),
-          assistant_message("I've prepared a 20% off code called LAUNCH for your confirmation."),
+        allow(client).to receive(:messages).and_return(
+          tool_result("api_write", {
+                        "endpoint" => "create_offer_code",
+                        "path_params" => { "link_id" => "prod_1" },
+                        "params" => { "name" => "LAUNCH", "amount_off" => 20, "offer_type" => "percent" },
+                      }),
+          text_result("I've prepared a 20% off code called LAUNCH for your confirmation."),
         )
 
         result = service.respond(messages: [{ role: "user", content: "Make a 20% off code LAUNCH" }])
@@ -146,10 +199,15 @@ describe Ai::StoreAgentService do
 
       it "rejects a READ endpoint sent to api_write (nudges to api_read)" do
         captured = nil
-        allow(client).to receive(:chat) do |args|
-          tool_msg = args[:parameters][:messages].find { |m| m[:role] == "tool" }
-          captured = JSON.parse(tool_msg[:content]) if tool_msg
-          captured ? assistant_message("ok") : tool_call_message("api_write", { "endpoint" => "list_products" })
+        first = true
+        allow(client).to receive(:messages) do |args|
+          captured = captured_tool_result(args)
+          if first
+            first = false
+            tool_result("api_write", { "endpoint" => "list_products" })
+          else
+            text_result("ok")
+          end
         end
 
         result = service.respond(messages: [{ role: "user", content: "change products" }])
@@ -160,10 +218,15 @@ describe Ai::StoreAgentService do
 
       it "validates path params at propose time so a missing id can't reach the executor" do
         captured = nil
-        allow(client).to receive(:chat) do |args|
-          tool_msg = args[:parameters][:messages].find { |m| m[:role] == "tool" }
-          captured = JSON.parse(tool_msg[:content]) if tool_msg
-          captured ? assistant_message("ok") : tool_call_message("api_write", { "endpoint" => "refund_sale", "params" => { "amount_cents" => 100 } })
+        first = true
+        allow(client).to receive(:messages) do |args|
+          captured = captured_tool_result(args)
+          if first
+            first = false
+            tool_result("api_write", { "endpoint" => "refund_sale", "params" => { "amount_cents" => 100 } })
+          else
+            text_result("ok")
+          end
         end
 
         result = service.respond(messages: [{ role: "user", content: "refund" }])
@@ -174,44 +237,43 @@ describe Ai::StoreAgentService do
     end
 
     context "when the model proposes more than one write in a single turn" do
-      def two_write_calls_message
-        {
-          "choices" => [{
-            "message" => {
-              "content" => nil,
-              "tool_calls" => [
-                { "id" => "call_a", "function" => { "name" => "api_write", "arguments" => { "endpoint" => "create_offer_code", "path_params" => { "link_id" => "p1" }, "params" => { "name" => "FIRST", "amount_off" => 10, "offer_type" => "percent" } }.to_json } },
-                { "id" => "call_b", "function" => { "name" => "api_write", "arguments" => { "endpoint" => "create_offer_code", "path_params" => { "link_id" => "p1" }, "params" => { "name" => "SECOND", "amount_off" => 50, "offer_type" => "percent" } }.to_json } },
-              ],
-            },
-          }],
-        }
+      def two_write_uses
+        Ai::AnthropicClient::Result.new(
+          text: "",
+          tool_uses: [
+            { id: "toolu_a", name: "api_write", input: { "endpoint" => "create_offer_code", "path_params" => { "link_id" => "p1" }, "params" => { "name" => "FIRST", "amount_off" => 10, "offer_type" => "percent" } } },
+            { id: "toolu_b", name: "api_write", input: { "endpoint" => "create_offer_code", "path_params" => { "link_id" => "p1" }, "params" => { "name" => "SECOND", "amount_off" => 50, "offer_type" => "percent" } } },
+          ],
+          stop_reason: "tool_use",
+        )
       end
 
       it "stages only the first proposal and tells the model the second was dropped" do
-        captured_tool_results = []
-        allow(client).to receive(:chat) do |args|
-          tool_msgs = args[:parameters][:messages].select { |m| m[:role] == "tool" }
-          if tool_msgs.any?
-            captured_tool_results = tool_msgs.map { |m| JSON.parse(m[:content]) }
-            assistant_message("I've prepared the FIRST code for your confirmation.")
+        captured_results = []
+        first = true
+        allow(client).to receive(:messages) do |args|
+          tool_msg = args[:messages].reverse.find { |m| m[:role] == "user" && m[:content].is_a?(Array) && m[:content].any? { |c| c[:type] == "tool_result" } }
+          captured_results = tool_msg[:content].filter_map { |c| JSON.parse(c[:content]) if c[:type] == "tool_result" } if tool_msg
+          if first
+            first = false
+            two_write_uses
           else
-            two_write_calls_message
+            text_result("I've prepared the FIRST code for your confirmation.")
           end
         end
 
         result = service.respond(messages: [{ role: "user", content: "make two codes" }])
 
         expect(result[:proposed_action]).to include(type: "api_write", params: include("params" => include("name" => "FIRST")))
-        expect(captured_tool_results.last).to include("error")
-        expect(captured_tool_results.last["error"]).to match(/one change/i)
+        expect(captured_results.last).to include("error")
+        expect(captured_results.last["error"]).to match(/one change/i)
       end
     end
 
     context "when the model never finishes within the tool-iteration cap" do
       it "does not claim there is a change to confirm when none was staged" do
         allow(api_client).to receive(:get).and_return({ "success" => true, "http_status" => 200 })
-        allow(client).to receive(:chat).and_return(tool_call_message("api_read", { "endpoint" => "list_products" }))
+        allow(client).to receive(:messages).and_return(tool_result("api_read", { "endpoint" => "list_products" }))
 
         result = service.respond(messages: [{ role: "user", content: "loop forever" }])
 
@@ -220,24 +282,118 @@ describe Ai::StoreAgentService do
       end
     end
 
-    context "when the model emits malformed tool-call arguments" do
-      # OpenAI tool-call `arguments` is supposed to be a JSON object string, but a hallucinating model
-      # can return a bare array or scalar. parse_arguments coerces non-objects to {} so the tool
-      # falls through to its normal "endpoint is required" handling instead of raising a 500.
-      ["[1,2,3]", "42", "\"just a string\"", "null", "{not valid json"].each do |raw_args|
-        it "does not raise on argument payload #{raw_args.inspect}" do
-          allow(client).to receive(:chat).and_return(
-            { "choices" => [{ "message" => { "content" => nil, "tool_calls" => [{ "id" => "call_1", "function" => { "name" => "api_write", "arguments" => raw_args } }] } }] },
-            assistant_message("I need a bit more detail to make that change."),
-          )
+    context "when the model emits a non-hash tool input" do
+      # Anthropic normally delivers tool input as a JSON object, but our client coerces a malformed
+      # input to {}; the tool then falls through to its normal "endpoint is required" handling rather
+      # than raising a 500.
+      it "does not raise and proposes nothing" do
+        allow(client).to receive(:messages).and_return(
+          Ai::AnthropicClient::Result.new(text: "", tool_uses: [{ id: "toolu_1", name: "api_write", input: {} }], stop_reason: "tool_use"),
+          text_result("I need a bit more detail to make that change."),
+        )
 
-          expect do
-            result = service.respond(messages: [{ role: "user", content: "make a change" }])
-            expect(result[:reply]).to be_present
-            expect(result[:proposed_action]).to be_nil
-          end.not_to change { seller.offer_codes.count }
-        end
+        expect do
+          result = service.respond(messages: [{ role: "user", content: "make a change" }])
+          expect(result[:reply]).to be_present
+          expect(result[:proposed_action]).to be_nil
+        end.not_to change { seller.offer_codes.count }
       end
+    end
+  end
+
+  describe "#respond_streaming" do
+    # Stub a streaming model turn: yield each text piece to the block (as the real client streams
+    # deltas), then return a Result. Subsequent calls dequeue the next scripted turn.
+    def stub_stream_turns(*turns)
+      queue = turns.dup
+      allow(client).to receive(:stream_messages) do |_args, &on_text|
+        turn = queue.shift
+        Array(turn[:stream]).each { |piece| on_text&.call(piece) }
+        turn[:result]
+      end
+    end
+
+    def collect_events(messages)
+      events = []
+      result = service.respond_streaming(messages:) { |event, payload| events << [event, payload] }
+      [events, result]
+    end
+
+    it "streams the reply token-by-token and then suggests follow-up prompts" do
+      stub_stream_turns(stream: ["You have ", "3 products."], result: text_result("You have 3 products."))
+      # The follow-up suggestions use the buffered (non-streaming) call.
+      allow(client).to receive(:messages).and_return(text_result('["List my products", "Show my sales"]'))
+
+      events, result = collect_events([{ role: "user", content: "How many products?" }])
+
+      token_texts = events.filter_map { |event, payload| payload[:text] if event == :token }
+      expect(token_texts).to eq(["You have ", "3 products."])
+      expect(result[:reply]).to eq("You have 3 products.")
+
+      suggestions_event = events.find { |event, _| event == :suggestions }
+      expect(suggestions_event).to be_present
+      expect(suggestions_event.last[:suggestions]).to eq(["List my products", "Show my sales"])
+      expect(result[:suggestions]).to eq(["List my products", "Show my sales"])
+    end
+
+    it "emits a proposed action over the stream without mutating" do
+      stub_stream_turns(
+        { stream: [], result: tool_result("api_write", { "endpoint" => "create_offer_code", "path_params" => { "link_id" => "p1" }, "params" => { "name" => "LAUNCH", "amount_off" => 20, "offer_type" => "percent" } }) },
+        { stream: ["I've prepared that discount for your confirmation."], result: text_result("I've prepared that discount for your confirmation.") },
+      )
+      allow(client).to receive(:messages).and_return(text_result("[]"))
+
+      expect do
+        events, result = collect_events([{ role: "user", content: "make a 20% code called LAUNCH" }])
+        action_event = events.find { |event, _| event == :proposed_action }
+        expect(action_event).to be_present
+        expect(action_event.last[:proposed_action]).to include(type: "api_write")
+        expect(result[:proposed_action]).to include(type: "api_write")
+      end.not_to change { seller.offer_codes.count }
+    end
+
+    it "still returns a reply when the follow-up suggestion call fails" do
+      stub_stream_turns(stream: ["Here are your numbers."], result: text_result("Here are your numbers."))
+      allow(client).to receive(:messages).and_raise(Ai::AnthropicClient::Error, "suggestion model unavailable")
+
+      events, result = collect_events([{ role: "user", content: "how are sales" }])
+
+      expect(result[:reply]).to eq("Here are your numbers.")
+      expect(result[:suggestions]).to eq([])
+      expect(events.any? { |event, _| event == :suggestions }).to be(false)
+    end
+
+    it "parses a newline/dash suggestion list as a fallback when the model doesn't return JSON" do
+      stub_stream_turns(stream: ["Done."], result: text_result("Done."))
+      allow(client).to receive(:messages).and_return(text_result("- Show my best sellers\n- Email my customers\n- Create a discount"))
+
+      _events, result = collect_events([{ role: "user", content: "help" }])
+
+      expect(result[:suggestions]).to eq(["Show my best sellers", "Email my customers", "Create a discount"])
+    end
+
+    it "emits a reset when an intermediate tool-use turn streams preamble text, then streams the real reply" do
+      # First turn: the model streams a preamble ("Let me check...") AND asks to call a read tool.
+      # That preamble is not the answer, so the service must emit :reset before the final turn.
+      read_turn = Ai::AnthropicClient::Result.new(
+        text: "Let me check that for you.",
+        tool_uses: [{ id: "toolu_1", name: "api_read", input: { "endpoint" => "list_products" } }],
+        stop_reason: "tool_use",
+      )
+      allow(api_client).to receive(:get).and_return({ "success" => true, "products" => [], "http_status" => 200 })
+      stub_stream_turns(
+        { stream: ["Let me check ", "that for you."], result: read_turn },
+        { stream: ["You have 3 products."], result: text_result("You have 3 products.") },
+      )
+      allow(client).to receive(:messages).and_return(text_result("[]"))
+
+      events, result = collect_events([{ role: "user", content: "How many products?" }])
+
+      event_names = events.map(&:first)
+      # The preamble streamed, then a reset, then the real reply tokens.
+      expect(event_names).to include(:reset)
+      expect(event_names.index(:reset)).to be < event_names.rindex(:token)
+      expect(result[:reply]).to eq("You have 3 products.")
     end
   end
 end

--- a/spec/services/ai/store_agent_service_spec.rb
+++ b/spec/services/ai/store_agent_service_spec.rb
@@ -224,5 +224,27 @@ describe Ai::StoreAgentService do
         expect(captured_tool_results.last["error"]).to match(/number/i)
       end
     end
+
+    context "when the model emits malformed tool-call arguments" do
+      # OpenAI tool-call `arguments` is supposed to be a JSON object string, but a hallucinating
+      # model can return a bare array or scalar. The write tools index arguments by key, which used
+      # to raise TypeError (Integer#[] / no implicit conversion) and surface as an unhandled 500.
+      # parse_arguments now coerces non-objects to {} so the tool falls through to its normal
+      # "field is required" validation instead of crashing.
+      ["[1,2,3]", "42", "\"just a string\"", "null", "{not valid json"].each do |raw_args|
+        it "does not raise on argument payload #{raw_args.inspect}" do
+          allow(client).to receive(:chat).and_return(
+            { "choices" => [{ "message" => { "content" => nil, "tool_calls" => [{ "id" => "call_1", "function" => { "name" => "create_discount", "arguments" => raw_args } }] } }] },
+            assistant_message("I need a bit more detail to create that discount."),
+          )
+
+          expect do
+            result = service.respond(messages: [{ role: "user", content: "make a discount" }])
+            expect(result[:reply]).to be_present
+            expect(result[:proposed_action]).to be_nil
+          end.not_to change { seller.offer_codes.count }
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## What

Two upgrades to the conversational store **Agent** tab (the dashboard chat from #5591):

1. **Streaming replies.** The agent now streams its answer token-by-token over Server-Sent Events instead of returning one blob, so the chat feels live.
2. **End-of-turn follow-up suggestions.** After each reply the agent suggests up to three one-tap "what next" prompts ("Keep going") so the conversation has an obvious next step. Clicking one sends it as the next message.

And the bigger change underneath:

3. **The Agent runs on Anthropic Claude Opus 4.7** (`claude-opus-4-7`) instead of OpenAI. Opus 4.7 leads the vending-bench leaderboard for autonomous commercial operation — the closest proxy for the Agent's actual job of helping a creator run and grow their store.

## Why

Creators expect a chat assistant to stream and to keep the conversation moving. Putting the agent on the strongest model for autonomous store operation makes its reads and proposed changes more useful. The propose-then-confirm safety model is unchanged — an LLM still can never silently mutate a store.

## How it works

- **`Ai::AnthropicClient`** (new) wraps Anthropic's Messages API with both a buffered `#messages` call and a streaming `#stream_messages` call (tool_use blocks, `input_json_delta` assembly), mirroring the existing server-side `claude-opus-4-7` usage in `Api::V2::Walks::SynthesisController`. The key is server-side via `GlobalConfig.get("ANTHROPIC_API_KEY")`.
- **`Ai::StoreAgentService`** is migrated off `ruby-openai` to the Anthropic tool-use wire shape (top-level `system`, `input_schema` tools, `tool_use`/`tool_result` content blocks). The catalog dispatch (the full read/write v2 API surface) and the propose-then-confirm executor path are unchanged.
- **`#respond_streaming`** runs the same tool loop but streams the final reply and yields `token` / `objects` / `proposed_action` / `suggestions` events. Intermediate tool-use turns that emit preamble text send a `reset` so the UI discards non-final text. Suggestions come from a second cheap, best-effort call — if it fails the reply is unaffected.
- **`Api::Internal::AgentMessageStreamsController`** (new) serves the stream via `ActionController::Live`, isolated in its own controller so the buffered `messages`/`actions` endpoints keep returning normal JSON. It reuses the same authentication, `UserPolicy#use_store_agent?` authorization, and per-seller throttle.
- **Frontend** `streamAgentMessage` consumes the SSE stream (typia-validated per event, requires a terminal `done`/`error` frame, rejects non-event-stream responses); `AgentChat` renders tokens live and shows the follow-up chips.

## Test plan

Run locally against full infra (Redis + Elasticsearch + MinIO + MongoDB):

- **`spec/services/ai/anthropic_client_spec.rb`** (new) — buffered + streaming Messages API, tool_use parsing, `input_json_delta` assembly, malformed-input coercion, error handling. **7 examples, 0 failures.**
- **`spec/services/ai/store_agent_service_spec.rb`** — rewritten for the Anthropic shapes; covers read/propose/confirm dispatch, the user-first conversation guard, streaming token/suggestion/proposed-action events, and the intermediate-turn `reset`. **20 examples, 0 failures.**
- **`spec/requests/agent_spec.rb`** (`type: :system, js: true`) — drives the real React component through the streaming endpoint: the live reply, the "Keep going" follow-up chips, and clicking a suggestion to continue the conversation, plus the existing propose → confirm → real mutation round-trips. **10 examples, 0 failures.**
- Existing internal + mobile controller specs stay green (they call the unchanged `#respond`).
- Rubocop, tsc, eslint, prettier clean. `autoreview: clean` (Codex) after three rounds (fixed: greeting-first conversation rejected by Anthropic; SSE stream not closed on empty input; tokenless turn dropping its proposed-action card; interim tool-use preamble shown then replaced; client accepting non-SSE/truncated responses as success).

## Screenshots (captured by the system spec, real app)

| | |
|---|---|
| Empty state | ![empty](https://raw.githubusercontent.com/gumclaw/gumroad/agent-streaming-assets/screenshots/01_empty_state_in_app.png) |
| Streamed reply + "Keep going" follow-up chips | ![suggestions](https://raw.githubusercontent.com/gumclaw/gumroad/agent-streaming-assets/screenshots/02_sales_insights.png) |
| Proposed change (confirm card) | ![proposed](https://raw.githubusercontent.com/gumclaw/gumroad/agent-streaming-assets/screenshots/03_discount_proposed.png) |
| …applied (real write round-trip) | ![applied](https://raw.githubusercontent.com/gumclaw/gumroad/agent-streaming-assets/screenshots/04_discount_applied.png) |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785271973&installation_id=134400930&pr_number=5603&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5603&signature=7b69f2d7ae418bde824be6aac2aeb89dad734b01b8f740f2240b2e6cf1d287d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> New LLM provider and streaming path for a feature that reads store data and replays confirmed v2 API writes; mitigations (policy, throttle, catalog allowlist, confirmation) exist but the surface area is large and security-sensitive.
> 
> **Overview**
> The dashboard **Agent** chat now streams assistant replies over **Server-Sent Events** instead of waiting for one JSON blob. A dedicated `AgentMessageStreamsController` (with `ActionController::Live`) emits `token`, `objects`, `proposed_action`, `suggestions`, and `done` events while reusing the same auth, `use_store_agent?` policy, and per-seller throttle as the buffered endpoints. `AgentChat` consumes the stream via `streamAgentMessage` (typia-validated frames, rejects non-SSE responses) and shows live text plus a **Keep going** row of up to three follow-up chips after each turn.
> 
> **`Ai::StoreAgentService`** moves from OpenAI to **Anthropic Claude Opus 4.7** through new **`Ai::AnthropicClient`** (buffered and streaming Messages API, tool-use assembly). `#respond_streaming` shares the existing read/propose/confirm tool loop; intermediate tool turns can emit a **`reset`** so preamble text is cleared before the final answer. Follow-ups come from a separate small completion and are best-effort. **`ANTHROPIC_API_KEY`** is documented in env examples. Mobile and non-streaming internal APIs still call `#respond`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a1f6d669e26a130ec31bde24f48768ad7f3f3b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->