### PR TITLE
Add reusable Payment Element card flows

### DIFF
--- a/app/javascript/components/Checkout/PaymentForm.tsx
+++ b/app/javascript/components/Checkout/PaymentForm.tsx
@@ -44,6 +44,7 @@ import {
   isProcessing,
   isSubmitDisabled,
   PaymentMethodType,
+  requiresReusablePaymentMethodForCardCollection,
   requiresPayment,
   requiresReusablePaymentMethod,
   usePayLabel,
@@ -738,7 +739,8 @@ const CreditCardContent = ({
               email: state.email,
             };
 
-      const paymentMethod = await (!useStripePaymentElement && requiresReusablePaymentMethod(state)
+      const useReusablePaymentMethod = requiresReusablePaymentMethodForCardCollection(state, useStripePaymentElement);
+      const paymentMethod = await (useReusablePaymentMethod
         ? getReusablePaymentMethodResult(selectedPaymentMethod, { products: state.products })
         : getPaymentMethodResult(selectedPaymentMethod));
 

--- a/app/javascript/components/Checkout/payment.test.ts
+++ b/app/javascript/components/Checkout/payment.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, it } from "vitest";
 import {
   canUseStripePaymentElement,
   getStripePaymentElementAmount,
+  requiresPaymentElementReusablePaymentMethod,
+  requiresReusablePaymentMethodForCardCollection,
+  requiresReusablePaymentMethod,
   type CheckoutPaymentConfig,
   type Product,
   type State,
@@ -113,7 +116,7 @@ describe("canUseStripePaymentElement", () => {
     ).toBe(false);
   });
 
-  it("falls back for reusable payment method flows", () => {
+  it("falls back for multi-seller carts", () => {
     expect(
       canUseStripePaymentElement(
         state({
@@ -124,9 +127,12 @@ describe("canUseStripePaymentElement", () => {
         }),
       ),
     ).toBe(false);
-    expect(canUseStripePaymentElement(state({ products: [product({ subscription_id: "sub_123" })] }))).toBe(false);
-    expect(canUseStripePaymentElement(state({ products: [product({ recurrence: "monthly" })] }))).toBe(false);
-    expect(canUseStripePaymentElement(state({ products: [product({ nativeType: "commission" })] }))).toBe(false);
+  });
+
+  it("allows reusable card flows that keep the stripe payment method contract", () => {
+    expect(canUseStripePaymentElement(state({ products: [product({ subscription_id: "sub_123" })] }))).toBe(true);
+    expect(canUseStripePaymentElement(state({ products: [product({ recurrence: "monthly" })] }))).toBe(true);
+    expect(canUseStripePaymentElement(state({ products: [product({ nativeType: "commission" })] }))).toBe(true);
   });
 
   it("falls back for setup, installment, preorder, and free-trial flows", () => {
@@ -153,6 +159,54 @@ describe("canUseStripePaymentElement", () => {
         }),
       ),
     ).toBe(false);
+  });
+});
+
+describe("requiresReusablePaymentMethod", () => {
+  it("keeps the existing reusable setup contract for non-Payment Element paths", () => {
+    expect(requiresReusablePaymentMethod(state())).toBe(false);
+    expect(requiresReusablePaymentMethod(state({ products: [product({ subscription_id: "sub_123" })] }))).toBe(true);
+    expect(requiresReusablePaymentMethod(state({ products: [product({ recurrence: "monthly" })] }))).toBe(false);
+    expect(requiresReusablePaymentMethod(state({ products: [product({ nativeType: "commission" })] }))).toBe(true);
+  });
+});
+
+describe("requiresPaymentElementReusablePaymentMethod", () => {
+  it("requires reusable setup for Payment Element future-charge card flows", () => {
+    expect(requiresPaymentElementReusablePaymentMethod(state())).toBe(false);
+    expect(
+      requiresPaymentElementReusablePaymentMethod(state({ products: [product({ subscription_id: "sub_123" })] })),
+    ).toBe(true);
+    expect(requiresPaymentElementReusablePaymentMethod(state({ products: [product({ recurrence: "monthly" })] }))).toBe(
+      true,
+    );
+    expect(
+      requiresPaymentElementReusablePaymentMethod(state({ products: [product({ nativeType: "commission" })] })),
+    ).toBe(true);
+    expect(
+      requiresPaymentElementReusablePaymentMethod(
+        state({ products: [product(), product({ permalink: "membership", recurrence: "monthly" })] }),
+      ),
+    ).toBe(true);
+    expect(
+      requiresPaymentElementReusablePaymentMethod(
+        state({ products: [product(), product({ permalink: "subscription", subscription_id: "sub_123" })] }),
+      ),
+    ).toBe(true);
+    expect(
+      requiresPaymentElementReusablePaymentMethod(
+        state({ products: [product(), product({ permalink: "commission", nativeType: "commission" })] }),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("requiresReusablePaymentMethodForCardCollection", () => {
+  it("routes recurring products through reusable setup only for Payment Element card collection", () => {
+    const recurringState = state({ products: [product({ recurrence: "monthly" })] });
+
+    expect(requiresReusablePaymentMethodForCardCollection(recurringState, true)).toBe(true);
+    expect(requiresReusablePaymentMethodForCardCollection(recurringState, false)).toBe(false);
   });
 });
 

--- a/app/javascript/components/Checkout/payment.ts
+++ b/app/javascript/components/Checkout/payment.ts
@@ -159,12 +159,29 @@ export function requiresPayment(state: State) {
   return getTotalPrice(state) !== 0 || state.products.some((item) => item.requirePayment);
 }
 
+function hasMultipleSellers(state: State) {
+  return new Set(state.products.map((product) => product.creator.id)).size > 1;
+}
+
 export function requiresReusablePaymentMethod(state: State) {
   return (
-    new Set(state.products.map((product) => product.creator.id)).size > 1 ||
-    !!state.products[0]?.subscription_id ||
-    state.products[0]?.nativeType === "commission"
+    hasMultipleSellers(state) || !!state.products[0]?.subscription_id || state.products[0]?.nativeType === "commission"
   );
+}
+
+export function requiresPaymentElementReusablePaymentMethod(state: State) {
+  return (
+    requiresReusablePaymentMethod(state) ||
+    state.products.some(
+      (product) => !!product.recurrence || !!product.subscription_id || product.nativeType === "commission",
+    )
+  );
+}
+
+export function requiresReusablePaymentMethodForCardCollection(state: State, useStripePaymentElement: boolean) {
+  return useStripePaymentElement
+    ? requiresPaymentElementReusablePaymentMethod(state)
+    : requiresReusablePaymentMethod(state);
 }
 
 export function canUseStripePaymentElement(state: State) {
@@ -174,16 +191,8 @@ export function canUseStripePaymentElement(state: State) {
   return (
     state.checkoutPayment.integration === "payment_element" &&
     !state.savedCreditCard &&
-    !requiresReusablePaymentMethod(state) &&
-    !state.products.some(
-      (product) =>
-        product.payInInstallments ||
-        product.hasFreeTrial ||
-        product.isPreorder ||
-        !!product.recurrence ||
-        !!product.subscription_id ||
-        product.nativeType === "commission",
-    )
+    !hasMultipleSellers(state) &&
+    !state.products.some((product) => product.payInInstallments || product.hasFreeTrial || product.isPreorder)
   );
 }
 

--- a/app/javascript/data/payment_method_result.test.ts
+++ b/app/javascript/data/payment_method_result.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  confirmCardIfNeeded,
+  prepareFutureCharges,
+  preparePaymentElementPaymentMethodData,
+} from "$app/data/card_payment_method_data";
+import {
+  type CardPaymentMethodParams,
+  type ReusableCardPaymentMethodParams,
+  type StripeErrorParams,
+} from "$app/data/payment_method_params";
+import {
+  getReusablePaymentMethodResult,
+  type NewPaymentElementSelectedPaymentMethod,
+} from "$app/data/payment_method_result";
+
+import { type Product } from "$app/components/Checkout/payment";
+
+vi.mock("$app/data/card_payment_method_data", () => ({
+  confirmCardIfNeeded: vi.fn(async (data) => data.cardParams),
+  prepareCardPaymentMethodData: vi.fn(),
+  prepareFutureCharges: vi.fn(),
+  preparePaymentElementPaymentMethodData: vi.fn(),
+}));
+
+const cardParams: CardPaymentMethodParams = {
+  status: "success",
+  type: "card",
+  reusable: false,
+  stripe_payment_method_id: "pm_123",
+  card_country: "US",
+  card_country_source: "stripe",
+};
+
+const reusableCardParams: ReusableCardPaymentMethodParams = {
+  ...cardParams,
+  reusable: true,
+  stripe_customer_id: "cus_123",
+  stripe_setup_intent_id: "seti_123",
+};
+
+const stripeErrorParams: StripeErrorParams = {
+  status: "error",
+  stripe_error: {
+    type: "validation_error",
+    message: "Card details are incomplete.",
+  },
+};
+
+const product: Product = {
+  permalink: "membership",
+  name: "Membership",
+  creator: { id: "seller-a", name: "Seller A", profile_url: "", avatar_url: "" },
+  quantity: 1,
+  price: 1_000,
+  payInInstallments: false,
+  requireShipping: false,
+  customFields: [],
+  bundleProductCustomFields: [],
+  supportsPaypal: null,
+  testPurchase: false,
+  requirePayment: true,
+  hasFreeTrial: false,
+  hasTippingEnabled: false,
+  isPreorder: false,
+  canGift: false,
+  nativeType: "membership",
+  recurrence: "monthly",
+  shippableCountryCodes: [],
+};
+
+const selectedPaymentMethod = (): NewPaymentElementSelectedPaymentMethod => ({
+  type: "payment-element",
+  stripe: Object.create(null),
+  elements: Object.create(null),
+  email: "buyer@example.com",
+  fullName: "Buyer Name",
+  keepOnFile: true,
+  zipCode: "10001",
+  country: "US",
+  state: "NY",
+  city: "New York",
+  address: "123 Main St",
+});
+
+describe("getReusablePaymentMethodResult", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("routes Payment Element cards through the reusable card setup flow", async () => {
+    vi.mocked(preparePaymentElementPaymentMethodData).mockResolvedValue(cardParams);
+    vi.mocked(prepareFutureCharges).mockResolvedValue({
+      cardParams: reusableCardParams,
+      requiresCardSetup: false,
+    });
+
+    const paymentMethod = selectedPaymentMethod();
+
+    await expect(getReusablePaymentMethodResult(paymentMethod, { products: [product] })).resolves.toEqual({
+      type: "new",
+      cardParamsResult: {
+        type: "cc",
+        cardParams: reusableCardParams,
+        keepOnFile: true,
+        zipCode: "10001",
+      },
+    });
+    expect(preparePaymentElementPaymentMethodData).toHaveBeenCalledWith({
+      stripe: paymentMethod.stripe,
+      elements: paymentMethod.elements,
+      email: "buyer@example.com",
+      fullName: "Buyer Name",
+      zipCode: "10001",
+      country: "US",
+      state: "NY",
+      city: "New York",
+      address: "123 Main St",
+    });
+    expect(prepareFutureCharges).toHaveBeenCalledWith({ products: [product], cardParams });
+    expect(confirmCardIfNeeded).toHaveBeenCalledWith({ cardParams: reusableCardParams, requiresCardSetup: false });
+  });
+
+  it("passes required card setup responses to the card confirmation helper", async () => {
+    vi.mocked(preparePaymentElementPaymentMethodData).mockResolvedValue(cardParams);
+    vi.mocked(prepareFutureCharges).mockResolvedValue({
+      cardParams: reusableCardParams,
+      requiresCardSetup: { client_secret: "seti_secret_123" },
+    });
+
+    await getReusablePaymentMethodResult(selectedPaymentMethod(), { products: [product] });
+
+    expect(confirmCardIfNeeded).toHaveBeenCalledWith({
+      cardParams: reusableCardParams,
+      requiresCardSetup: { client_secret: "seti_secret_123" },
+    });
+  });
+
+  it("does not prepare future charges when Payment Element card creation returns an error", async () => {
+    vi.mocked(preparePaymentElementPaymentMethodData).mockResolvedValue(stripeErrorParams);
+
+    await expect(getReusablePaymentMethodResult(selectedPaymentMethod(), { products: [product] })).resolves.toEqual({
+      type: "new",
+      cardParamsResult: {
+        type: "error",
+        cardParams: stripeErrorParams,
+      },
+    });
+    expect(prepareFutureCharges).not.toHaveBeenCalled();
+    expect(confirmCardIfNeeded).not.toHaveBeenCalled();
+  });
+});

--- a/app/javascript/data/payment_method_result.ts
+++ b/app/javascript/data/payment_method_result.ts
@@ -242,7 +242,7 @@ export async function getReusablePaymentMethodResult(
   options: ReusableOptions,
 ): Promise<PayPalPaymentMethodResult>;
 export async function getReusablePaymentMethodResult(
-  selected: NewCardSelectedPaymentMethod,
+  selected: NewCardSelectedPaymentMethod | NewPaymentElementSelectedPaymentMethod,
   options: ReusableOptions,
 ): Promise<ReusableNewCardPaymentMethodResult>;
 // catch-all

--- a/app/presenters/checkout/stripe_payment_presenter.rb
+++ b/app/presenters/checkout/stripe_payment_presenter.rb
@@ -60,15 +60,10 @@ class Checkout::StripePaymentPresenter
 
       seller = sellers.first
       return "stripe_payment_element_flag_disabled" unless Feature.active?(STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, seller)
-      return "reusable_payment_method_required" if items.any? { requires_reusable_payment_method?(_1) }
       return "setup_or_installment_flow" if items.any? { setup_or_installment_flow?(_1) }
       return "not_charged" unless items.sum { _1[:price_cents].to_i }.positive?
 
       nil
-    end
-
-    def requires_reusable_payment_method?(item)
-      item[:recurrence].present? || item[:native_type] == Link::NATIVE_TYPE_COMMISSION
     end
 
     def setup_or_installment_flow?(item)

--- a/spec/presenters/checkout/stripe_payment_presenter_spec.rb
+++ b/spec/presenters/checkout/stripe_payment_presenter_spec.rb
@@ -98,14 +98,14 @@ describe Checkout::StripePaymentPresenter do
     expect(stripe_payment_props(add_products:)).to eq(card_element_fallback("unknown_seller"))
   end
 
-  it "falls back to CardElement for a recurring membership product" do
+  it "selects Stripe Payment Element for a recurring membership product" do
     expect(stripe_payment_props(add_products: [flagged_seller_product(recurrence: "monthly")]))
-      .to eq(card_element_fallback("reusable_payment_method_required"))
+      .to eq(payment_element_props)
   end
 
-  it "falls back to CardElement for a commission product" do
+  it "selects Stripe Payment Element for a commission product" do
     expect(stripe_payment_props(add_products: [flagged_seller_product(native_type: Link::NATIVE_TYPE_COMMISSION)]))
-      .to eq(card_element_fallback("reusable_payment_method_required"))
+      .to eq(payment_element_props)
   end
 
   it "falls back to CardElement for an installment-plan product" do
@@ -120,6 +120,11 @@ describe Checkout::StripePaymentPresenter do
 
   it "falls back to CardElement for a free-trial product" do
     expect(stripe_payment_props(add_products: [flagged_seller_product(free_trial: true)]))
+      .to eq(card_element_fallback("setup_or_installment_flow"))
+  end
+
+  it "falls back to CardElement for a recurring free-trial product" do
+    expect(stripe_payment_props(add_products: [flagged_seller_product(recurrence: "monthly", free_trial: true)]))
       .to eq(card_element_fallback("setup_or_installment_flow"))
   end
 

--- a/spec/requests/library_spec.rb
+++ b/spec/requests/library_spec.rb
@@ -275,7 +275,7 @@ describe("Library Scenario", type: :system, js: true) do
     purchase_2 = create(:purchase, link: products[1], created_at: 40.minutes.ago, purchaser: @user)
     purchase_3 = create(:purchase, link: products[0], created_at: 30.minutes.ago, purchaser: @user, variant_attributes: [variant_2])
 
-    visit "/library"
+    visit library_path(sort: "purchase_date")
     expect(page).to have_product_card(count: 3)
     expect_to_show_purchases_in_order([purchase_3, purchase_2, purchase_1])
   end

--- a/spec/requests/purchases/product/stripejs_purchase_spec.rb
+++ b/spec/requests/purchases/product/stripejs_purchase_spec.rb
@@ -83,6 +83,50 @@ describe("PurchaseScenario using StripeJs", type: :system, js: true) do
     expect(payment_element_payment_method_ids).not_to be_empty
   end
 
+  it "allows the buyer to pay for a recurring membership using the Payment Element reusable setup path" do
+    seller = create(:user)
+    MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id) ||
+      create(:merchant_account, user: nil, charge_processor_merchant_id: "acct_#{SecureRandom.hex(8)}")
+    product = create(:membership_product_with_preset_tiered_pricing, user: seller)
+    Feature.activate_user(Checkout::StripePaymentPresenter::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, product.user)
+
+    tier = product.variant_categories.alive.first.variants.alive.find_by!(name: "First Tier")
+
+    visit("/checkout?product=#{product.unique_permalink}&option=#{tier.external_id}")
+
+    platform_payment_method = StripePaymentMethodHelper.success.with_zip_code("94107").to_stripejs_payment_method
+    payment_element_payment_method_ids = []
+    allow(StripeChargeablePaymentMethod).to receive(:new).and_wrap_original do |original, payment_method_id, *args, **kwargs|
+      payment_element_payment_method_ids << payment_method_id
+      original.call(platform_payment_method.id, *args, **kwargs)
+    end
+
+    setup_intent_ids = []
+    allow(ChargeProcessor).to receive(:setup_future_charges!).and_wrap_original do |original, *args, **kwargs|
+      setup_intent = original.call(*args, **kwargs)
+      setup_intent_ids << setup_intent.id if setup_intent.present?
+      setup_intent
+    end
+
+    checkout_payment = page.evaluate_script(<<~JS)
+      JSON.parse(document.querySelector("[data-page]").getAttribute("data-page")).props.checkout.checkout_payment
+    JS
+    expect(checkout_payment["integration"]).to eq("payment_element")
+    expect(checkout_payment["fallback_reason"]).to be_nil
+
+    check_out(product, payment_element: true)
+
+    purchase = Purchase.last
+    expect(purchase.successful?).to be(true)
+    expect(purchase.subscription).to be_alive
+    expect(purchase.credit_card).to be_present
+    expect(purchase.credit_card.stripe_customer_id).to be_present
+    expect(setup_intent_ids).to all(match(/\Aseti_/))
+    expect(setup_intent_ids).not_to be_empty
+    expect(payment_element_payment_method_ids).to all(match(/\Apm_/))
+    expect(payment_element_payment_method_ids).not_to be_empty
+  end
+
   describe "save credit card payment" do
     before :each do
       @buyer = create(:user)


### PR DESCRIPTION
Part of https://github.com/antiwork/gumroad/issues/5362

Requires https://github.com/antiwork/gumroad/pull/5583 to be merged.

Ref https://gist.github.com/rmarescu/aa78253f392c2d8ab37397a6c75c9c59

## What

This PR lets eligible recurring memberships and commission products use the Stripe Payment Element card path. Payment Element-created cards now go through Gumroad's existing reusable-card setup flow, so the backend still receives the same `stripe_payment_method_id`-based payload and can create the SetupIntent/customer data it already expects for future charges.

Setup-only flows stay out of this PR: preorders, free trials, installments, saved-card checkout, multi-seller carts, and zero-total checkouts continue to fall back to the existing CardElement path.

## Why

The initial Payment Element rollout was limited to one-off card charges because reusable card flows need future-charge setup. Subscriptions and commissions can safely move next because the Payment Element card still produces a Stripe PaymentMethod compatible with the existing reusable-card backend contract.

Using the current reusable setup path keeps this as a narrow card-flow expansion instead of introducing server-finalized Intents, redirect handling, or setup-mode Payment Element work before those paths are designed.

## Before/After

Before (with Stripe Card Element):


https://github.com/user-attachments/assets/e94ef121-1fbf-4390-be3e-911808c02244


After (with Stripe Payment Element enabled):


https://github.com/user-attachments/assets/f7cc24d4-97d7-402f-a490-4158f6fb74e3


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5607"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785294365&installation_id=134400930&pr_number=5607&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5607&signature=efb71bb6e07ada3c3df4b64dfd21e5c8ecf9a3a05fa1cff2305e2a7a52538208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->