### PR TITLE
Add setup-only Payment Element checkout

### DIFF
--- a/app/javascript/components/Checkout/PaymentElementInput.tsx
+++ b/app/javascript/components/Checkout/PaymentElementInput.tsx
@@ -11,7 +11,7 @@ import * as React from "react";
 import { getStripeInstance } from "$app/utils/stripe_loader";
 import { getCssVariable } from "$app/utils/styles";
 
-import { type PaymentElementConfig } from "$app/components/Checkout/payment";
+import { STRIPE_ELEMENTS_MODE_FOR_SETUP_INTENT, type PaymentElementConfig } from "$app/components/Checkout/payment";
 import { useFont } from "$app/components/DesignSettings";
 import { LoadingSpinner } from "$app/components/LoadingSpinner";
 import { Fieldset } from "$app/components/ui/Fieldset";
@@ -49,7 +49,7 @@ export const PaymentElementInput = ({
 
   return (
     <Fieldset state={invalid ? "danger" : undefined} aria-label="Card information">
-      {mountedAmount ? (
+      {elementsOptions.stripe_elements_mode === STRIPE_ELEMENTS_MODE_FOR_SETUP_INTENT || mountedAmount !== null ? (
         <StripePaymentElementProvider amount={mountedAmount} elementsOptions={elementsOptions}>
           <PaymentElementControllerInput
             amount={mountedAmount}
@@ -73,7 +73,7 @@ const PaymentElementControllerInput = ({
   onReady,
   onChange,
 }: {
-  amount: number;
+  amount: number | null;
   disabled?: boolean | undefined;
   onReady: (controller: PaymentElementController | null) => void;
   onChange?: ((event: StripePaymentElementChangeEvent) => void) | undefined;
@@ -88,7 +88,7 @@ const PaymentElementControllerInput = ({
   }, [stripe, elements, ready, onReady]);
 
   React.useEffect(() => {
-    elements?.update({ amount });
+    if (amount !== null) elements?.update({ amount });
   }, [amount, elements]);
 
   return (
@@ -124,7 +124,7 @@ const StripePaymentElementProvider = ({
   elementsOptions,
   children,
 }: {
-  amount: number;
+  amount: number | null;
   elementsOptions: PaymentElementConfig;
   children: React.ReactNode;
 }) => {
@@ -140,9 +140,9 @@ const StripePaymentElementProvider = ({
 
   const options = React.useMemo<StripeElementsOptions>(
     () => ({
-      mode: elementsOptions.mode,
+      mode: elementsOptions.stripe_elements_mode,
       currency: elementsOptions.currency,
-      amount: initialAmount,
+      ...(initialAmount === null ? {} : { amount: initialAmount }),
       paymentMethodTypes: elementsOptions.payment_method_types,
       paymentMethodCreation: elementsOptions.payment_method_creation,
       fonts: [{ family: font.name, src: `url(${font.url})` }],
@@ -204,7 +204,11 @@ const StripePaymentElementProvider = ({
   );
 
   return (
-    <Elements stripe={stripePromise} options={options}>
+    <Elements
+      stripe={stripePromise}
+      options={options}
+      key={`${elementsOptions.stripe_elements_mode}-${elementsOptions.currency}`}
+    >
       {children}
     </Elements>
   );

--- a/app/javascript/components/Checkout/payment.test.ts
+++ b/app/javascript/components/Checkout/payment.test.ts
@@ -7,6 +7,8 @@ import {
   requiresPaymentElementReusablePaymentMethod,
   requiresReusablePaymentMethodForCardCollection,
   requiresReusablePaymentMethod,
+  STRIPE_ELEMENTS_MODE_FOR_PAYMENT_INTENT,
+  STRIPE_ELEMENTS_MODE_FOR_SETUP_INTENT,
   type CheckoutPaymentConfig,
   type Product,
   type State,
@@ -16,7 +18,18 @@ const paymentElementConfig: CheckoutPaymentConfig = {
   integration: "payment_element",
   fallback_reason: null,
   elements_options: {
-    mode: "payment",
+    stripe_elements_mode: STRIPE_ELEMENTS_MODE_FOR_PAYMENT_INTENT,
+    currency: "usd",
+    payment_method_types: ["card"],
+    payment_method_creation: "manual",
+  },
+};
+
+const futureChargePaymentElementConfig: CheckoutPaymentConfig = {
+  integration: "payment_element",
+  fallback_reason: null,
+  elements_options: {
+    stripe_elements_mode: STRIPE_ELEMENTS_MODE_FOR_SETUP_INTENT,
     currency: "usd",
     payment_method_types: ["card"],
     payment_method_creation: "manual",
@@ -146,10 +159,55 @@ describe("canUseStripePaymentElement", () => {
     expect(canUseStripePaymentElement(state({ products: [product({ nativeType: "commission" })] }))).toBe(true);
   });
 
-  it("falls back for setup, installment, preorder, and free-trial flows", () => {
+  it("falls back for future-charge and installment flows in PaymentIntent mode", () => {
     expect(canUseStripePaymentElement(state({ products: [product({ payInInstallments: true })] }))).toBe(false);
     expect(canUseStripePaymentElement(state({ products: [product({ isPreorder: true })] }))).toBe(false);
     expect(canUseStripePaymentElement(state({ products: [product({ hasFreeTrial: true })] }))).toBe(false);
+  });
+
+  it("allows SetupIntent mode when every product is charged in the future", () => {
+    expect(
+      canUseStripePaymentElement(
+        state({ checkoutPayment: futureChargePaymentElementConfig, products: [product({ isPreorder: true })] }),
+      ),
+    ).toBe(true);
+    expect(
+      canUseStripePaymentElement(
+        state({ checkoutPayment: futureChargePaymentElementConfig, products: [product({ hasFreeTrial: true })] }),
+      ),
+    ).toBe(true);
+  });
+
+  it("falls back in SetupIntent mode when future-charge products are mixed with charged products", () => {
+    expect(
+      canUseStripePaymentElement(
+        state({
+          checkoutPayment: futureChargePaymentElementConfig,
+          products: [product({ isPreorder: true }), product({ permalink: "product-b" })],
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("falls back in SetupIntent mode for unsupported reusable, installment, and zero-amount products", () => {
+    expect(
+      canUseStripePaymentElement(
+        state({ checkoutPayment: futureChargePaymentElementConfig, products: [product({ nativeType: "commission" })] }),
+      ),
+    ).toBe(false);
+    expect(
+      canUseStripePaymentElement(
+        state({ checkoutPayment: futureChargePaymentElementConfig, products: [product({ payInInstallments: true })] }),
+      ),
+    ).toBe(false);
+    expect(
+      canUseStripePaymentElement(
+        state({
+          checkoutPayment: futureChargePaymentElementConfig,
+          products: [product({ isPreorder: true, price: 0 })],
+        }),
+      ),
+    ).toBe(false);
   });
 
   it("falls back when loaded checkout total is zero", () => {
@@ -213,7 +271,7 @@ describe("requiresPaymentElementReusablePaymentMethod", () => {
 });
 
 describe("requiresReusablePaymentMethodForCardCollection", () => {
-  it("routes recurring products through reusable setup only for Payment Element card collection", () => {
+  it("routes recurring products through reusable setup for Payment Element card collection", () => {
     const recurringState = state({ products: [product({ recurrence: "monthly" })] });
 
     expect(requiresReusablePaymentMethodForCardCollection(recurringState, true)).toBe(true);
@@ -244,6 +302,14 @@ describe("getStripePaymentElementAmount", () => {
 
   it("returns null until surcharges load", () => {
     expect(getStripePaymentElementAmount(state({ surcharges: { type: "pending" } }))).toBeNull();
+  });
+
+  it("returns null for SetupIntent mode", () => {
+    expect(
+      getStripePaymentElementAmount(
+        state({ checkoutPayment: futureChargePaymentElementConfig, products: [product({ isPreorder: true })] }),
+      ),
+    ).toBeNull();
   });
 });
 

--- a/app/javascript/components/Checkout/payment.test.ts
+++ b/app/javascript/components/Checkout/payment.test.ts
@@ -176,6 +176,17 @@ describe("canUseStripePaymentElement", () => {
         state({ checkoutPayment: futureChargePaymentElementConfig, products: [product({ hasFreeTrial: true })] }),
       ),
     ).toBe(true);
+    expect(
+      canUseStripePaymentElement(
+        state({
+          checkoutPayment: futureChargePaymentElementConfig,
+          products: [
+            product({ isPreorder: true }),
+            product({ permalink: "membership", hasFreeTrial: true, recurrence: "monthly" }),
+          ],
+        }),
+      ),
+    ).toBe(true);
   });
 
   it("falls back in SetupIntent mode when future-charge products are mixed with charged products", () => {
@@ -189,10 +200,13 @@ describe("canUseStripePaymentElement", () => {
     ).toBe(false);
   });
 
-  it("falls back in SetupIntent mode for unsupported reusable, installment, and zero-amount products", () => {
+  it("falls back in SetupIntent mode for non-future-charge, installment, and zero-amount products", () => {
     expect(
       canUseStripePaymentElement(
-        state({ checkoutPayment: futureChargePaymentElementConfig, products: [product({ nativeType: "commission" })] }),
+        state({
+          checkoutPayment: futureChargePaymentElementConfig,
+          products: [product({ nativeType: "commission" })],
+        }),
       ),
     ).toBe(false);
     expect(
@@ -276,6 +290,15 @@ describe("requiresReusablePaymentMethodForCardCollection", () => {
 
     expect(requiresReusablePaymentMethodForCardCollection(recurringState, true)).toBe(true);
     expect(requiresReusablePaymentMethodForCardCollection(recurringState, false)).toBe(false);
+  });
+
+  it("collects a one-off PaymentMethod in Payment Element SetupIntent mode", () => {
+    const setupState = state({
+      checkoutPayment: futureChargePaymentElementConfig,
+      products: [product({ hasFreeTrial: true, recurrence: "monthly" })],
+    });
+
+    expect(requiresReusablePaymentMethodForCardCollection(setupState, true)).toBe(false);
   });
 });
 

--- a/app/javascript/components/Checkout/payment.ts
+++ b/app/javascript/components/Checkout/payment.ts
@@ -22,8 +22,18 @@ enableMapSet();
 
 export type PaymentMethodType = "paypal" | "stripePaymentRequest" | "card";
 export type PaymentMethod = { type: PaymentMethodType; button: React.ReactElement | null };
+
+// Passed through to Stripe Elements as `mode`; these are Stripe's UI configuration values,
+// not a selector for Gumroad's backend PaymentIntent/SetupIntent API path.
+export const STRIPE_ELEMENTS_MODE_FOR_PAYMENT_INTENT = "payment";
+export const STRIPE_ELEMENTS_MODE_FOR_SETUP_INTENT = "setup";
+
+type StripeElementsModeForCheckout =
+  | typeof STRIPE_ELEMENTS_MODE_FOR_PAYMENT_INTENT
+  | typeof STRIPE_ELEMENTS_MODE_FOR_SETUP_INTENT;
+
 export type PaymentElementConfig = {
-  mode: "payment";
+  stripe_elements_mode: StripeElementsModeForCheckout;
   currency: "usd";
   payment_method_types: ["card"];
   payment_method_creation: "manual";
@@ -187,16 +197,35 @@ export function requiresReusablePaymentMethodForCardCollection(state: State, use
 
 export function canUseStripePaymentElement(state: State) {
   if (state.products.length === 0) return false;
+  if (state.checkoutPayment.integration !== "payment_element") return false;
+
+  if (state.checkoutPayment.elements_options.stripe_elements_mode === STRIPE_ELEMENTS_MODE_FOR_SETUP_INTENT) {
+    return canUseStripePaymentElementForFutureChargeSetup(state);
+  }
+
   if (state.surcharges.type === "loaded" && !getTotalPrice(state)) return false;
 
+  return !state.products.some((product) => product.payInInstallments || product.hasFreeTrial || product.isPreorder);
+}
+
+function canUseStripePaymentElementForFutureChargeSetup(state: State) {
   return (
-    state.checkoutPayment.integration === "payment_element" &&
-    !state.products.some((product) => product.payInInstallments || product.hasFreeTrial || product.isPreorder)
+    !hasMultipleSellers(state) &&
+    !state.products.some(
+      (product) => product.payInInstallments || product.subscription_id || product.nativeType === "commission",
+    ) &&
+    state.products.every((product) => product.isPreorder || product.hasFreeTrial) &&
+    state.products.some((product) => product.price > 0)
   );
 }
 
 export function getStripePaymentElementAmount(state: State) {
   if (!canUseStripePaymentElement(state) || state.surcharges.type !== "loaded") return null;
+  if (
+    state.checkoutPayment.integration === "payment_element" &&
+    state.checkoutPayment.elements_options.stripe_elements_mode === STRIPE_ELEMENTS_MODE_FOR_SETUP_INTENT
+  )
+    return null;
   const total = getTotalPrice(state);
   return total && total > 0 ? total : null;
 }

--- a/app/javascript/components/Checkout/payment.ts
+++ b/app/javascript/components/Checkout/payment.ts
@@ -123,6 +123,10 @@ export type State = {
   requireEmailTypoAcknowledgment: boolean;
 };
 
+type StateWithPaymentElementCheckout = State & {
+  checkoutPayment: Extract<CheckoutPaymentConfig, { integration: "payment_element" }>;
+};
+
 export const addressFields = ["address", "city", "state", "zipCode", "fullName", "country"] as const;
 
 type SimpleValue =
@@ -199,7 +203,7 @@ export function requiresReusablePaymentMethodForCardCollection(state: State, use
   return requiresPaymentElementReusablePaymentMethod(state);
 }
 
-export function canUseStripePaymentElement(state: State) {
+export function canUseStripePaymentElement(state: State): state is StateWithPaymentElementCheckout {
   if (state.products.length === 0) return false;
   if (state.checkoutPayment.integration !== "payment_element") return false;
 
@@ -223,10 +227,7 @@ function canUseStripePaymentElementForFutureChargeSetup(state: State) {
 
 export function getStripePaymentElementAmount(state: State) {
   if (!canUseStripePaymentElement(state) || state.surcharges.type !== "loaded") return null;
-  if (
-    state.checkoutPayment.integration === "payment_element" &&
-    state.checkoutPayment.elements_options.stripe_elements_mode === STRIPE_ELEMENTS_MODE_FOR_SETUP_INTENT
-  )
+  if (state.checkoutPayment.elements_options.stripe_elements_mode === STRIPE_ELEMENTS_MODE_FOR_SETUP_INTENT)
     return null;
   const total = getTotalPrice(state);
   return total && total > 0 ? total : null;

--- a/app/javascript/components/Checkout/payment.ts
+++ b/app/javascript/components/Checkout/payment.ts
@@ -190,9 +190,13 @@ export function requiresPaymentElementReusablePaymentMethod(state: State) {
 }
 
 export function requiresReusablePaymentMethodForCardCollection(state: State, useStripePaymentElement: boolean) {
-  return useStripePaymentElement
-    ? requiresPaymentElementReusablePaymentMethod(state)
-    : requiresReusablePaymentMethod(state);
+  if (!useStripePaymentElement) return requiresReusablePaymentMethod(state);
+  if (
+    state.checkoutPayment.integration === "payment_element" &&
+    state.checkoutPayment.elements_options.stripe_elements_mode === STRIPE_ELEMENTS_MODE_FOR_SETUP_INTENT
+  )
+    return false;
+  return requiresPaymentElementReusablePaymentMethod(state);
 }
 
 export function canUseStripePaymentElement(state: State) {
@@ -211,11 +215,9 @@ export function canUseStripePaymentElement(state: State) {
 function canUseStripePaymentElementForFutureChargeSetup(state: State) {
   return (
     !hasMultipleSellers(state) &&
-    !state.products.some(
-      (product) => product.payInInstallments || product.subscription_id || product.nativeType === "commission",
-    ) &&
+    !state.products.some((product) => product.payInInstallments) &&
     state.products.every((product) => product.isPreorder || product.hasFreeTrial) &&
-    state.products.some((product) => product.price > 0)
+    getTotalPriceFromProducts(state) > 0
   );
 }
 

--- a/app/presenters/checkout/stripe_payment_presenter.rb
+++ b/app/presenters/checkout/stripe_payment_presenter.rb
@@ -9,6 +9,10 @@ class Checkout::StripePaymentPresenter
   STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME = :stripe_payment_element_checkout
   STRIPE_CARD_ELEMENT_INTEGRATION = "card_element"
   STRIPE_PAYMENT_ELEMENT_INTEGRATION = "payment_element"
+  # Passed through to Stripe Elements as `mode`; these are Stripe's UI configuration values,
+  # not a selector for Gumroad's backend PaymentIntent/SetupIntent API path.
+  STRIPE_ELEMENTS_MODE_FOR_PAYMENT_INTENT = "payment"
+  STRIPE_ELEMENTS_MODE_FOR_SETUP_INTENT = "setup"
 
   attr_reader :cart, :add_products, :clear_cart, :saved_credit_card
 
@@ -20,19 +24,17 @@ class Checkout::StripePaymentPresenter
   end
 
   def props
-    fallback_reason = fallback_reason_for(items)
+    checkout_items = items
+    fallback_reason = fallback_reason_for(checkout_items)
     return card_element_props(fallback_reason) if fallback_reason.present?
 
-    {
-      integration: STRIPE_PAYMENT_ELEMENT_INTEGRATION,
-      fallback_reason: nil,
-      elements_options: {
-        mode: "payment",
-        currency: "usd",
-        payment_method_types: ["card"],
-        payment_method_creation: "manual",
-      },
-    }
+    stripe_elements_mode =
+      if setup_for_future_charges_without_charging?(checkout_items)
+        STRIPE_ELEMENTS_MODE_FOR_SETUP_INTENT
+      else
+        STRIPE_ELEMENTS_MODE_FOR_PAYMENT_INTENT
+      end
+    payment_element_props(stripe_elements_mode)
   end
 
   private
@@ -50,20 +52,39 @@ class Checkout::StripePaymentPresenter
       }
     end
 
+    def payment_element_props(stripe_elements_mode)
+      {
+        integration: STRIPE_PAYMENT_ELEMENT_INTEGRATION,
+        fallback_reason: nil,
+        elements_options: {
+          stripe_elements_mode:,
+          currency: "usd",
+          payment_method_types: ["card"],
+          payment_method_creation: "manual",
+        },
+      }
+    end
+
     def fallback_reason_for(items)
       return "empty_cart" if items.empty?
 
       sellers = items.map { _1[:seller] }.uniq
       return "unknown_seller" if sellers.any?(&:blank?)
       return "stripe_payment_element_flag_disabled" unless sellers.all? { Feature.active?(STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, _1) }
-      return "setup_or_installment_flow" if items.any? { setup_or_installment_flow?(_1) }
+      return "setup_or_installment_flow" if items.any? { _1[:pay_in_installments] }
+      return nil if sellers.one? && setup_for_future_charges_without_charging?(items)
+      return "setup_or_installment_flow" if items.any? { future_charge_setup_item?(_1) }
       return "not_charged" unless items.sum { _1[:price_cents].to_i }.positive?
 
       nil
     end
 
-    def setup_or_installment_flow?(item)
-      item[:pay_in_installments] || item[:is_preorder] || item[:has_free_trial]
+    def setup_for_future_charges_without_charging?(items)
+      items.all? { future_charge_setup_item?(_1) } && items.sum { _1[:price_cents].to_i }.positive?
+    end
+
+    def future_charge_setup_item?(item)
+      item[:is_preorder] || item[:has_free_trial]
     end
 
     def cart_items

--- a/spec/presenters/checkout/stripe_payment_presenter_spec.rb
+++ b/spec/presenters/checkout/stripe_payment_presenter_spec.rb
@@ -28,12 +28,12 @@ describe Checkout::StripePaymentPresenter do
     { integration: described_class::STRIPE_CARD_ELEMENT_INTEGRATION, fallback_reason: reason, elements_options: nil }
   end
 
-  def payment_element_props
+  def payment_element_props(stripe_elements_mode: described_class::STRIPE_ELEMENTS_MODE_FOR_PAYMENT_INTENT)
     {
       integration: described_class::STRIPE_PAYMENT_ELEMENT_INTEGRATION,
       fallback_reason: nil,
       elements_options: {
-        mode: "payment",
+        stripe_elements_mode:,
         currency: "usd",
         payment_method_types: ["card"],
         payment_method_creation: "manual",
@@ -72,7 +72,7 @@ describe Checkout::StripePaymentPresenter do
       integration: described_class::STRIPE_PAYMENT_ELEMENT_INTEGRATION,
       fallback_reason: nil,
       elements_options: {
-        mode: "payment",
+        stripe_elements_mode: described_class::STRIPE_ELEMENTS_MODE_FOR_PAYMENT_INTENT,
         currency: "usd",
         payment_method_types: ["card"],
         payment_method_creation: "manual",
@@ -138,24 +138,42 @@ describe Checkout::StripePaymentPresenter do
       .to eq(card_element_fallback("setup_or_installment_flow"))
   end
 
-  it "falls back to CardElement for a preorder product" do
+  it "selects Stripe Payment Element SetupIntent mode for a preorder product" do
     expect(stripe_payment_props(add_products: [flagged_seller_product(is_preorder: true)]))
+      .to eq(payment_element_props(stripe_elements_mode: described_class::STRIPE_ELEMENTS_MODE_FOR_SETUP_INTENT))
+  end
+
+  it "selects Stripe Payment Element SetupIntent mode for a free-trial product" do
+    expect(stripe_payment_props(add_products: [flagged_seller_product(free_trial: true, recurrence: "monthly")]))
+      .to eq(payment_element_props(stripe_elements_mode: described_class::STRIPE_ELEMENTS_MODE_FOR_SETUP_INTENT))
+  end
+
+  it "falls back to CardElement when future-charge products are mixed with charged products" do
+    seller = create(:user)
+    Feature.activate_user(described_class::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, seller)
+    future_charge_product = create(:product, user: seller, price_cents: 1234)
+    charged_product = create(:product, user: seller, price_cents: 5678)
+
+    expect(stripe_payment_props(add_products: [
+                                  checkout_product_for(future_charge_product, is_preorder: true),
+                                  checkout_product_for(charged_product),
+                                ]))
       .to eq(card_element_fallback("setup_or_installment_flow"))
   end
 
-  it "falls back to CardElement for a free-trial product" do
-    expect(stripe_payment_props(add_products: [flagged_seller_product(free_trial: true)]))
-      .to eq(card_element_fallback("setup_or_installment_flow"))
-  end
-
-  it "falls back to CardElement for a recurring free-trial product" do
+  it "selects Stripe Payment Element SetupIntent mode for a recurring free-trial product" do
     expect(stripe_payment_props(add_products: [flagged_seller_product(recurrence: "monthly", free_trial: true)]))
-      .to eq(card_element_fallback("setup_or_installment_flow"))
+      .to eq(payment_element_props(stripe_elements_mode: described_class::STRIPE_ELEMENTS_MODE_FOR_SETUP_INTENT))
   end
 
   it "falls back to CardElement when the checkout total is not positive" do
     expect(stripe_payment_props(add_products: [flagged_seller_product(price: 0)]))
       .to eq(card_element_fallback("not_charged"))
+  end
+
+  it "falls back to CardElement for a future-charge product with no future charge amount" do
+    expect(stripe_payment_props(add_products: [flagged_seller_product(is_preorder: true, price: 0)]))
+      .to eq(card_element_fallback("setup_or_installment_flow"))
   end
 
   it "ignores cart products when clear_cart is set" do

--- a/spec/presenters/checkout/stripe_payment_presenter_spec.rb
+++ b/spec/presenters/checkout/stripe_payment_presenter_spec.rb
@@ -166,6 +166,19 @@ describe Checkout::StripePaymentPresenter do
       .to eq(payment_element_props(stripe_elements_mode: described_class::STRIPE_ELEMENTS_MODE_FOR_SETUP_INTENT))
   end
 
+  it "selects Stripe Payment Element SetupIntent mode for mixed future-charge products" do
+    seller = create(:user)
+    Feature.activate_user(described_class::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, seller)
+    preorder_product = create(:product, user: seller, price_cents: 1234)
+    free_trial_product = create(:product, user: seller, price_cents: 5678)
+
+    expect(stripe_payment_props(add_products: [
+                                  checkout_product_for(preorder_product, is_preorder: true),
+                                  checkout_product_for(free_trial_product, free_trial: true, recurrence: "monthly"),
+                                ]))
+      .to eq(payment_element_props(stripe_elements_mode: described_class::STRIPE_ELEMENTS_MODE_FOR_SETUP_INTENT))
+  end
+
   it "falls back to CardElement when the checkout total is not positive" do
     expect(stripe_payment_props(add_products: [flagged_seller_product(price: 0)]))
       .to eq(card_element_fallback("not_charged"))

--- a/spec/requests/purchases/product/stripejs_purchase_spec.rb
+++ b/spec/requests/purchases/product/stripejs_purchase_spec.rb
@@ -289,7 +289,7 @@ describe("PurchaseScenario using StripeJs", type: :system, js: true) do
     expect(new_purchase.preorder_authorization_successful?).to be(true)
     expect(new_purchase.stripe_transaction_id).not_to be_present
     expect(new_purchase.processor_setup_intent_id).to be_present
-    expect(new_purchase.credit_card.stripe_setup_intent_id).to be_present
+    expect(new_purchase.charge.stripe_setup_intent_id).to eq(new_purchase.processor_setup_intent_id)
     expect(payment_element_payment_method_ids).to all(match(/\Apm_/))
     expect(payment_element_payment_method_ids).not_to be_empty
   end

--- a/spec/requests/purchases/product/stripejs_purchase_spec.rb
+++ b/spec/requests/purchases/product/stripejs_purchase_spec.rb
@@ -254,6 +254,106 @@ describe("PurchaseScenario using StripeJs", type: :system, js: true) do
     expect(payment_element_payment_method_ids.uniq.size).to eq(1)
   end
 
+  it "allows the buyer to authorize a preorder using the Payment Element SetupIntent mode" do
+    seller = create(:user)
+    MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id) ||
+      create(:merchant_account, user: nil, charge_processor_merchant_id: "acct_#{SecureRandom.hex(8)}")
+    product = create(:product_with_pdf_file, user: seller, is_in_preorder_state: true)
+    create(:preorder_link, link: product, release_at: 25.hours.from_now)
+    Feature.activate_user(Checkout::StripePaymentPresenter::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, product.user)
+
+    visit("/checkout?product=#{product.unique_permalink}")
+
+    # See the one-off Payment Element spec above: use the frontend-created Payment Method only to prove the
+    # Payment Element path ran, then swap in a known platform Payment Method for the backend Stripe call.
+    platform_payment_method = StripePaymentMethodHelper.success.with_zip_code("94107").to_stripejs_payment_method
+    payment_element_payment_method_ids = []
+    allow(StripeChargeablePaymentMethod).to receive(:new).and_wrap_original do |original, payment_method_id, *args, **kwargs|
+      payment_element_payment_method_ids << payment_method_id
+      original.call(platform_payment_method.id, *args, **kwargs)
+    end
+    expect(Stripe::PaymentMethod).to receive(:retrieve).with(platform_payment_method.id).and_call_original
+    expect(Stripe::SetupIntent).to receive(:create).and_call_original
+
+    checkout_payment = page.evaluate_script(<<~JS)
+      JSON.parse(document.querySelector("[data-page]").getAttribute("data-page")).props.checkout.checkout_payment
+    JS
+    expect(checkout_payment["integration"]).to eq("payment_element")
+    expect(checkout_payment["fallback_reason"]).to be_nil
+    expect(checkout_payment.dig("elements_options", "stripe_elements_mode")).to eq("setup")
+    expect(checkout_payment.dig("elements_options", "payment_method_creation")).to eq("manual")
+
+    check_out(product, payment_element: true)
+
+    new_purchase = Purchase.last
+    expect(new_purchase.preorder_authorization_successful?).to be(true)
+    expect(new_purchase.stripe_transaction_id).not_to be_present
+    expect(new_purchase.processor_setup_intent_id).to be_present
+    expect(new_purchase.credit_card.stripe_setup_intent_id).to be_present
+    expect(payment_element_payment_method_ids).to all(match(/\Apm_/))
+    expect(payment_element_payment_method_ids).not_to be_empty
+  end
+
+  it "allows the buyer to start a free-trial membership using the Payment Element SetupIntent mode" do
+    seller = create(:user)
+    MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id) ||
+      create(:merchant_account, user: nil, charge_processor_merchant_id: "acct_#{SecureRandom.hex(8)}")
+    product = create(
+      :membership_product_with_preset_tiered_pricing,
+      user: seller,
+      unique_permalink: "spefuturechargesetup#{SecureRandom.alphanumeric(12, chars: ("a".."z").to_a)}",
+      free_trial_enabled: true,
+      free_trial_duration_amount: 1,
+      free_trial_duration_unit: :week
+    )
+    tier = product.tiers.find_by!(name: "First Tier")
+    Feature.activate_user(Checkout::StripePaymentPresenter::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, product.user)
+
+    visit("/checkout?product=#{product.unique_permalink}&option=#{Rack::Utils.escape(tier.external_id)}")
+    within_cart_item(product.name) do
+      expect(page).to have_text("Tier: #{tier.name}")
+    end
+    expect(page).to have_text("one week free")
+    expect(page).to have_text("$3 monthly after")
+    expect(page).to have_text("Total US$0", normalize_ws: true)
+
+    # See the one-off Payment Element spec above: use the frontend-created Payment Method only to prove the
+    # Payment Element path ran, then swap in a known platform Payment Method for the backend Stripe call.
+    platform_payment_method = StripePaymentMethodHelper.success.with_zip_code("94107").to_stripejs_payment_method
+    payment_element_payment_method_ids = []
+    allow(StripeChargeablePaymentMethod).to receive(:new).and_wrap_original do |original, payment_method_id, *args, **kwargs|
+      payment_element_payment_method_ids << payment_method_id
+      original.call(platform_payment_method.id, *args, **kwargs)
+    end
+    expect(Stripe::PaymentMethod).to receive(:retrieve).with(platform_payment_method.id).and_call_original
+    expect(Stripe::SetupIntent).to receive(:create).and_call_original
+
+    checkout_payment = page.evaluate_script(<<~JS)
+      JSON.parse(document.querySelector("[data-page]").getAttribute("data-page")).props.checkout.checkout_payment
+    JS
+    expect(checkout_payment["integration"]).to eq("payment_element")
+    expect(checkout_payment["fallback_reason"]).to be_nil
+    expect(checkout_payment.dig("elements_options", "stripe_elements_mode")).to eq("setup")
+    expect(checkout_payment.dig("elements_options", "payment_method_creation")).to eq("manual")
+
+    check_out(product, payment_element: true)
+
+    original_purchase = Purchase.last
+    expect(original_purchase.not_charged?).to be(true)
+    expect(original_purchase.stripe_transaction_id).not_to be_present
+    expect(original_purchase.processor_setup_intent_id).to be_present
+    expect(original_purchase.subscription).to be_alive
+    expect(original_purchase.subscription.credit_card).to eq(original_purchase.credit_card)
+    expect(payment_element_payment_method_ids).to all(match(/\Apm_/))
+    expect(payment_element_payment_method_ids).not_to be_empty
+
+    travel_to(original_purchase.subscription.free_trial_ends_at + 1.day) do
+      expect do
+        original_purchase.subscription.charge!
+      end.to change { product.sales.successful.count }.by(1)
+    end
+  end
+
   describe "save credit card payment" do
     before :each do
       @buyer = create(:user)


### PR DESCRIPTION
Part of https://github.com/antiwork/gumroad/issues/5362

## What

Adds the setup-only Stripe Payment Element lane for flagged sellers while keeping the existing CardElement fallback available.

Eligible preorder and free-trial checkouts now receive `elements_options.mode: "setup"` from the server, mount Elements without an upfront amount, and continue submitting the Payment Element-created `stripe_payment_method_id` through Gumroad's existing SetupIntent-backed checkout path.

The lane stays narrow: setup mode is limited to single-seller setup-only carts with a positive future charge amount. Installments, mixed setup-plus-charged carts, reusable-card-only products, saved-card checkout, multi-seller carts, and zero-amount setup carts continue to use CardElement.

System coverage now exercises both setup-only paths:

- Preorder authorization uses Payment Element setup mode and stores a SetupIntent-backed purchase without an immediate charge.
- Free-trial membership checkout uses Payment Element setup mode, stores the trial subscription card, and successfully renews after the trial.

## Why

The first Payment Element rollout kept setup-only checkout on CardElement because those flows need a reusable payment method instead of an immediate PaymentIntent charge. This follow-up adds the narrow setup-mode lane now that the backend contract is clear: Payment Element still creates a card PaymentMethod in manual mode, and Rails remains responsible for creating the existing SetupIntent and future charge records.

Keeping this lane card-only and setup-only avoids pulling in ConfirmationTokens, client-confirmed SetupIntents, redirect methods, Link, or dynamic payment methods in this PR. It also preserves rollback behavior because the server can still return CardElement for every unsupported setup or reusable-payment case.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5610"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785337246&installation_id=134400930&pr_number=5610&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5610&signature=fcce2b607f8450b63e195cfe3781945f3ff59c4cd5735d0946c6ce01a450c5c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->