### PR TITLE
Add Payment Element mixed free-and-paid cart test coverage

### DIFF
--- a/app/javascript/components/Checkout/payment.test.ts
+++ b/app/javascript/components/Checkout/payment.test.ts
@@ -95,6 +95,14 @@ describe("canUseStripePaymentElement", () => {
     expect(canUseStripePaymentElement(state())).toBe(true);
   });
 
+  it("allows a mixed free-and-paid single-seller cart with a positive total", () => {
+    expect(
+      canUseStripePaymentElement(
+        state({ products: [product({ price: 0 }), product({ permalink: "product-b", price: 1_000 })] }),
+      ),
+    ).toBe(true);
+  });
+
   it("falls back when the server selected the Card Element integration", () => {
     expect(canUseStripePaymentElement(state({ checkoutPayment: cardElementConfig }))).toBe(false);
   });
@@ -179,5 +187,9 @@ describe("getStripePaymentElementAmount", () => {
 
   it("returns null until surcharges load", () => {
     expect(getStripePaymentElementAmount(state({ surcharges: { type: "pending" } }))).toBeNull();
+  });
+
+  it("returns null for an ineligible checkout even when surcharges are loaded", () => {
+    expect(getStripePaymentElementAmount(state({ checkoutPayment: cardElementConfig }))).toBeNull();
   });
 });

--- a/spec/presenters/checkout/stripe_payment_presenter_spec.rb
+++ b/spec/presenters/checkout/stripe_payment_presenter_spec.rb
@@ -128,6 +128,16 @@ describe Checkout::StripePaymentPresenter do
       .to eq(card_element_fallback("not_charged"))
   end
 
+  it "selects Stripe Payment Element for a mixed free-and-paid single-seller cart" do
+    seller = create(:user)
+    free_product = create(:product, user: seller, price_cents: 0)
+    paid_product = create(:product, user: seller, price_cents: 1234)
+    Feature.activate_user(described_class::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, seller)
+
+    add_products = [checkout_product_for(free_product, price: 0), checkout_product_for(paid_product)]
+    expect(stripe_payment_props(add_products:)).to eq(payment_element_props)
+  end
+
   it "ignores cart products when clear_cart is set" do
     cart = create(:cart, :guest)
     create(:cart_product, cart:, product: create(:product, user: create(:user)))


### PR DESCRIPTION
## What

Adds regression coverage for the Stripe Payment Element checkout eligibility path:

- Backend presenter: a mixed cart containing a free ($0) item and a paid item from the same seller selects Payment Element, confirming a zero-priced line item does not trigger the "not charged" CardElement fallback.
- Frontend: `canUseStripePaymentElement` allows a mixed free-and-paid cart with a positive total, and `getStripePaymentElementAmount` returns `null` for an ineligible checkout even when surcharges are loaded, so no amount is passed to Stripe for a non-Payment-Element checkout.

## Why

These cases were already handled correctly but were not covered by tests. The coverage locks the behavior so future changes to eligibility or amount calculation cannot silently regress mixed free-and-paid carts or feed Stripe an amount for an ineligible checkout.

---

AI disclosure: drafted with Claude Opus 4.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785338833&installation_id=134400930&pr_number=5611&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5611&signature=074dde3cb0c7493a8a0079d139d7ea5e78683d940d9c2f830425031b13c758dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->