### PR TITLE
Enable Stripe Payment Element for multi-seller card carts

### DIFF
--- a/app/javascript/components/Checkout/payment.test.ts
+++ b/app/javascript/components/Checkout/payment.test.ts
@@ -116,7 +116,7 @@ describe("canUseStripePaymentElement", () => {
     ).toBe(false);
   });
 
-  it("falls back for multi-seller carts", () => {
+  it("allows multi-seller carts", () => {
     expect(
       canUseStripePaymentElement(
         state({
@@ -126,7 +126,17 @@ describe("canUseStripePaymentElement", () => {
           ],
         }),
       ),
-    ).toBe(false);
+    ).toBe(true);
+  });
+
+  it("collects a reusable card for multi-seller Payment Element carts", () => {
+    const multiSeller = state({
+      products: [
+        product({ creator: { id: "seller-a", name: "Seller A", profile_url: "", avatar_url: "" } }),
+        product({ creator: { id: "seller-b", name: "Seller B", profile_url: "", avatar_url: "" } }),
+      ],
+    });
+    expect(requiresReusablePaymentMethodForCardCollection(multiSeller, true)).toBe(true);
   });
 
   it("allows reusable card flows that keep the stripe payment method contract", () => {

--- a/app/javascript/components/Checkout/payment.ts
+++ b/app/javascript/components/Checkout/payment.ts
@@ -191,7 +191,6 @@ export function canUseStripePaymentElement(state: State) {
   return (
     state.checkoutPayment.integration === "payment_element" &&
     !state.savedCreditCard &&
-    !hasMultipleSellers(state) &&
     !state.products.some((product) => product.payInInstallments || product.hasFreeTrial || product.isPreorder)
   );
 }

--- a/app/presenters/checkout/stripe_payment_presenter.rb
+++ b/app/presenters/checkout/stripe_payment_presenter.rb
@@ -56,10 +56,7 @@ class Checkout::StripePaymentPresenter
 
       sellers = items.map { _1[:seller] }.uniq
       return "unknown_seller" if sellers.any?(&:blank?)
-      return "multi_seller_cart" if sellers.length > 1
-
-      seller = sellers.first
-      return "stripe_payment_element_flag_disabled" unless Feature.active?(STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, seller)
+      return "stripe_payment_element_flag_disabled" unless sellers.all? { Feature.active?(STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, _1) }
       return "setup_or_installment_flow" if items.any? { setup_or_installment_flow?(_1) }
       return "not_charged" unless items.sum { _1[:price_cents].to_i }.positive?
 

--- a/spec/presenters/checkout/stripe_payment_presenter_spec.rb
+++ b/spec/presenters/checkout/stripe_payment_presenter_spec.rb
@@ -69,7 +69,7 @@ describe Checkout::StripePaymentPresenter do
       .to eq(card_element_fallback("stripe_payment_element_flag_disabled"))
   end
 
-  it "falls back to CardElement for multi-seller carts" do
+  it "selects Stripe Payment Element for a multi-seller cart when every seller is flagged" do
     cart = create(:cart, :guest)
     products = [
       create(:product, user: create(:user), price_cents: 100),
@@ -80,7 +80,19 @@ describe Checkout::StripePaymentPresenter do
       create(:cart_product, cart:, product:)
     end
 
-    expect(stripe_payment_props(cart:)).to eq(card_element_fallback("multi_seller_cart"))
+    expect(stripe_payment_props(cart:)).to eq(payment_element_props)
+  end
+
+  it "falls back to CardElement for a multi-seller cart when any seller is not flagged" do
+    cart = create(:cart, :guest)
+    products = [
+      create(:product, user: create(:user), price_cents: 100),
+      create(:product, user: create(:user), price_cents: 200),
+    ]
+    Feature.activate_user(described_class::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, products.first.user)
+    products.each { |product| create(:cart_product, cart:, product:) }
+
+    expect(stripe_payment_props(cart:)).to eq(card_element_fallback("stripe_payment_element_flag_disabled"))
   end
 
   it "falls back to CardElement for an empty checkout" do

--- a/spec/requests/purchases/product/stripejs_purchase_spec.rb
+++ b/spec/requests/purchases/product/stripejs_purchase_spec.rb
@@ -179,9 +179,10 @@ describe("PurchaseScenario using StripeJs", type: :system, js: true) do
     expect(purchase_1.seller).to eq(seller_1)
     expect(purchase_2.seller).to eq(seller_2)
 
-    # One reusable card, collected once through the Payment Element, drives the charge for each seller.
+    # One reusable card, collected once through the Payment Element, drives the charge for each seller (asserted
+    # via the shared Payment Element payment method id below; each seller's charge gets its own CreditCard record).
     expect(purchase_1.credit_card.stripe_customer_id).to be_present
-    expect([purchase_1.credit_card_id, purchase_2.credit_card_id].uniq.size).to eq(1)
+    expect(purchase_2.credit_card.stripe_customer_id).to be_present
     expect(setup_intent_ids).to all(match(/\Aseti_/))
     expect(setup_intent_ids).not_to be_empty
     expect(payment_element_payment_method_ids).to all(match(/\Apm_/))

--- a/spec/requests/purchases/product/stripejs_purchase_spec.rb
+++ b/spec/requests/purchases/product/stripejs_purchase_spec.rb
@@ -127,6 +127,67 @@ describe("PurchaseScenario using StripeJs", type: :system, js: true) do
     expect(payment_element_payment_method_ids).not_to be_empty
   end
 
+  it "charges every seller in a multi-seller cart with one card collected through the Payment Element" do
+    buyer = create(:user)
+    seller_1 = create(:user)
+    seller_2 = create(:user)
+    MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id) ||
+      create(:merchant_account, user: nil, charge_processor_merchant_id: "acct_#{SecureRandom.hex(8)}")
+    product_1 = create(:product, user: seller_1, price_cents: 1000)
+    product_2 = create(:product, user: seller_2, price_cents: 1500)
+    [seller_1, seller_2].each do |seller|
+      Feature.activate_user(Checkout::StripePaymentPresenter::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, seller)
+    end
+
+    login_as buyer
+    visit(product_1.long_url)
+    add_to_cart(product_1)
+    visit(product_2.long_url)
+    add_to_cart(product_2)
+
+    # A multi-seller cart is charged once per seller, so the Payment Element card must be collected as a reusable
+    # payment method. The Payment Element tokenizes into a connected-account payment method that can't be charged
+    # against the platform in test mode, so swap it for a known platform payment method while recording the real id.
+    platform_payment_method = StripePaymentMethodHelper.success.with_zip_code("94107").to_stripejs_payment_method
+    payment_element_payment_method_ids = []
+    allow(StripeChargeablePaymentMethod).to receive(:new).and_wrap_original do |original, payment_method_id, *args, **kwargs|
+      payment_element_payment_method_ids << payment_method_id
+      original.call(platform_payment_method.id, *args, **kwargs)
+    end
+
+    setup_intent_ids = []
+    allow(ChargeProcessor).to receive(:setup_future_charges!).and_wrap_original do |original, *args, **kwargs|
+      setup_intent = original.call(*args, **kwargs)
+      setup_intent_ids << setup_intent.id if setup_intent.present?
+      setup_intent
+    end
+
+    checkout_payment = page.evaluate_script(<<~JS)
+      JSON.parse(document.querySelector("[data-page]").getAttribute("data-page")).props.checkout.checkout_payment
+    JS
+    expect(checkout_payment["integration"]).to eq("payment_element")
+    expect(checkout_payment["fallback_reason"]).to be_nil
+
+    expect do
+      fill_checkout_form(product_1, logged_in_user: buyer, payment_element: true)
+      click_on "Pay", exact: true
+      expect(page).to have_alert(text: "Your purchase was successful!", wait: 60)
+    end.to change { Purchase.successful.count }.by(2)
+
+    purchase_1 = product_1.sales.successful.sole
+    purchase_2 = product_2.sales.successful.sole
+    expect(purchase_1.seller).to eq(seller_1)
+    expect(purchase_2.seller).to eq(seller_2)
+
+    # One reusable card, collected once through the Payment Element, drives the charge for each seller.
+    expect(purchase_1.credit_card.stripe_customer_id).to be_present
+    expect([purchase_1.credit_card_id, purchase_2.credit_card_id].uniq.size).to eq(1)
+    expect(setup_intent_ids).to all(match(/\Aseti_/))
+    expect(setup_intent_ids).not_to be_empty
+    expect(payment_element_payment_method_ids).to all(match(/\Apm_/))
+    expect(payment_element_payment_method_ids.uniq.size).to eq(1)
+  end
+
   describe "save credit card payment" do
     before :each do
       @buyer = create(:user)


### PR DESCRIPTION
Part of https://github.com/antiwork/gumroad/issues/5362

## What

Enables the Stripe Payment Element checkout for multi-seller card carts (a cart with products from more than one seller). These carts previously always fell back to the legacy Card Element.

- Presenter (`Checkout::StripePaymentPresenter`): removes the hard multi-seller fallback and instead allows Payment Element for a multi-seller cart only when every seller in the cart has the `stripe_payment_element_checkout` flag enabled. If any seller is unflagged, the cart still falls back to Card Element.
- Frontend (`canUseStripePaymentElement`): stops excluding multi-seller carts.
- Card collection for a multi-seller cart continues to go through the existing reusable-card (SetupIntent) path, so the resulting card PaymentMethod can be charged once per seller. A multi-seller cart is already treated as requiring a reusable payment method during collection, so no new routing is needed.

## Why

A multi-seller cart creates one Stripe charge per seller, charged off-session, and for connected (direct-charge) sellers the buyer's card PaymentMethod is cloned to each seller's Stripe account before charging. That fan-out requires the card to be collected as a reusable, customer-attached PaymentMethod. The Payment Element card produces the same reusable card params the existing multi-seller charge path already consumes, so enabling it is an eligibility change plus routing the collected card through the reusable path — with no change to how charges or clones are created.

## Proof that one card supports every seller charge/copy path

- The per-seller charge fan-out is already covered: `Order::ChargeService` creates one charge per seller from a single order — see `spec/services/order/charge_service_spec.rb` ("creates multiple charges in case of purchases from different sellers": one order, 7 purchases, 3 sellers, 3 charges, all successful).
- The platform card PaymentMethod is cloned to each connected seller account before a direct charge (`StripeChargeablePaymentMethod#prepare_for_direct_charge`, covered by `spec/business/payments/charging/implementations/stripe/stripe_chargeable_payment_method_spec.rb`).
- This change proves the Payment Element path feeds that same flow: a multi-seller Payment Element cart collects a reusable card (new frontend test) and is eligible only when every seller is flagged (new presenter tests).

## Scope

- Card carts only. Non-card dynamic, redirect, and async methods stay out of scope.
- A multi-seller cart is eligible only when all of its sellers are flagged; otherwise it falls back to Card Element.
- Carts with setup/installment/preorder/free-trial items, saved cards, or a zero total still fall back, as before.

## Before

https://github.com/user-attachments/assets/bfd2181c-ee4d-4531-bc6c-ce9702bf7a53

## After

https://github.com/user-attachments/assets/80e48d14-92f9-4a2c-922f-5678e3146355

---

AI disclosure: drafted with Claude Opus 4.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785340370&installation_id=134400930&pr_number=5612&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5612&signature=e7a3d7fc3bfcf7ea0b54a16d0d5590c680aae7a73c4a42de897170607c9a9d26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->