### PR TITLE
Guard near-zero Payment Element carts

### DIFF
--- a/app/javascript/components/Checkout/PaymentElementInput.tsx
+++ b/app/javascript/components/Checkout/PaymentElementInput.tsx
@@ -164,6 +164,9 @@ const StripePaymentElementProvider = ({
           focusBoxShadow: "none",
         },
         rules: {
+          ".Tab": {
+            display: "none",
+          },
           ".TabLabel": {
             fontSize: "1rem",
             fontWeight: "400",
@@ -171,6 +174,7 @@ const StripePaymentElementProvider = ({
           ".Input": {
             borderColor,
             boxShadow: "none",
+            minHeight: "3rem",
             padding: "0.75rem 1rem",
           },
           ".Input:focus": {

--- a/app/javascript/components/Checkout/PaymentElementInput.tsx
+++ b/app/javascript/components/Checkout/PaymentElementInput.tsx
@@ -164,9 +164,6 @@ const StripePaymentElementProvider = ({
           focusBoxShadow: "none",
         },
         rules: {
-          ".Tab": {
-            display: "none",
-          },
           ".TabLabel": {
             fontSize: "1rem",
             fontWeight: "400",
@@ -174,7 +171,6 @@ const StripePaymentElementProvider = ({
           ".Input": {
             borderColor,
             boxShadow: "none",
-            minHeight: "3rem",
             padding: "0.75rem 1rem",
           },
           ".Input:focus": {

--- a/app/javascript/components/Checkout/payment.test.ts
+++ b/app/javascript/components/Checkout/payment.test.ts
@@ -16,7 +16,8 @@ import {
   type State,
 } from "$app/components/Checkout/payment";
 
-const paymentElementMinimumPrice = getMinPriceCents("usd");
+const stripePaymentElementMinimumCharge = 50;
+const belowGumroadUsdMinimumPrice = getMinPriceCents("usd") - 1;
 
 const paymentElementConfig: CheckoutPaymentConfig = {
   integration: "payment_element",
@@ -248,7 +249,7 @@ describe("canUseStripePaymentElement", () => {
     ).toBe(false);
   });
 
-  it("falls back when loaded checkout total is below the Gumroad USD minimum", () => {
+  it("falls back when loaded checkout total is below the Stripe USD minimum charge amount", () => {
     expect(
       canUseStripePaymentElement(
         state({
@@ -260,7 +261,7 @@ describe("canUseStripePaymentElement", () => {
               shipping_rate_cents: 0,
               tax_cents: 0,
               tax_included_cents: 0,
-              subtotal: paymentElementMinimumPrice - 1,
+              subtotal: stripePaymentElementMinimumCharge - 1,
             },
           },
         }),
@@ -272,7 +273,7 @@ describe("canUseStripePaymentElement", () => {
     expect(canUseStripePaymentElement(state({ surcharges: { type: "pending" } }))).toBe(true);
   });
 
-  it("allows a loaded checkout total at the Gumroad USD minimum", () => {
+  it("allows a loaded checkout total below Gumroad's USD minimum when it meets Stripe's minimum charge amount", () => {
     expect(
       canUseStripePaymentElement(
         state({
@@ -284,7 +285,7 @@ describe("canUseStripePaymentElement", () => {
               shipping_rate_cents: 0,
               tax_cents: 0,
               tax_included_cents: 0,
-              subtotal: paymentElementMinimumPrice,
+              subtotal: belowGumroadUsdMinimumPrice,
             },
           },
         }),
@@ -292,7 +293,27 @@ describe("canUseStripePaymentElement", () => {
     ).toBe(true);
   });
 
-  it("recomputes eligibility when the loaded checkout total crosses below the Gumroad USD minimum", () => {
+  it("allows a loaded checkout total at the Stripe USD minimum charge amount", () => {
+    expect(
+      canUseStripePaymentElement(
+        state({
+          surcharges: {
+            type: "loaded",
+            result: {
+              vat_id_valid: false,
+              has_vat_id_input: false,
+              shipping_rate_cents: 0,
+              tax_cents: 0,
+              tax_included_cents: 0,
+              subtotal: stripePaymentElementMinimumCharge,
+            },
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("recomputes eligibility when the loaded checkout total crosses below the Stripe USD minimum charge amount", () => {
     const atMinimum = state({
       surcharges: {
         type: "loaded",
@@ -302,7 +323,7 @@ describe("canUseStripePaymentElement", () => {
           shipping_rate_cents: 0,
           tax_cents: 0,
           tax_included_cents: 0,
-          subtotal: paymentElementMinimumPrice,
+          subtotal: stripePaymentElementMinimumCharge,
         },
       },
     });
@@ -315,13 +336,13 @@ describe("canUseStripePaymentElement", () => {
           shipping_rate_cents: 0,
           tax_cents: 0,
           tax_included_cents: 0,
-          subtotal: paymentElementMinimumPrice - 1,
+          subtotal: stripePaymentElementMinimumCharge - 1,
         },
       },
     });
 
     expect(canUseStripePaymentElement(atMinimum)).toBe(true);
-    expect(getStripePaymentElementAmount(atMinimum)).toBe(paymentElementMinimumPrice);
+    expect(getStripePaymentElementAmount(atMinimum)).toBe(stripePaymentElementMinimumCharge);
     expect(canUseStripePaymentElement(belowMinimum)).toBe(false);
     expect(getStripePaymentElementAmount(belowMinimum)).toBeNull();
   });
@@ -417,7 +438,7 @@ describe("getStripePaymentElementAmount", () => {
     ).toBeNull();
   });
 
-  it("returns null when the loaded checkout total is below the Gumroad USD minimum", () => {
+  it("returns null when the loaded checkout total is below the Stripe USD minimum charge amount", () => {
     expect(
       getStripePaymentElementAmount(
         state({
@@ -429,7 +450,7 @@ describe("getStripePaymentElementAmount", () => {
               shipping_rate_cents: 0,
               tax_cents: 0,
               tax_included_cents: 0,
-              subtotal: paymentElementMinimumPrice - 1,
+              subtotal: stripePaymentElementMinimumCharge - 1,
             },
           },
         }),
@@ -437,7 +458,7 @@ describe("getStripePaymentElementAmount", () => {
     ).toBeNull();
   });
 
-  it("returns the loaded total when it meets the Gumroad USD minimum", () => {
+  it("returns a loaded total below Gumroad's USD minimum when it meets Stripe's minimum charge amount", () => {
     expect(
       getStripePaymentElementAmount(
         state({
@@ -449,12 +470,32 @@ describe("getStripePaymentElementAmount", () => {
               shipping_rate_cents: 0,
               tax_cents: 0,
               tax_included_cents: 0,
-              subtotal: paymentElementMinimumPrice,
+              subtotal: belowGumroadUsdMinimumPrice,
             },
           },
         }),
       ),
-    ).toBe(paymentElementMinimumPrice);
+    ).toBe(belowGumroadUsdMinimumPrice);
+  });
+
+  it("returns the loaded total when it meets the Stripe USD minimum charge amount", () => {
+    expect(
+      getStripePaymentElementAmount(
+        state({
+          surcharges: {
+            type: "loaded",
+            result: {
+              vat_id_valid: false,
+              has_vat_id_input: false,
+              shipping_rate_cents: 0,
+              tax_cents: 0,
+              tax_included_cents: 0,
+              subtotal: stripePaymentElementMinimumCharge,
+            },
+          },
+        }),
+      ),
+    ).toBe(stripePaymentElementMinimumCharge);
   });
 });
 

--- a/app/javascript/components/Checkout/payment.test.ts
+++ b/app/javascript/components/Checkout/payment.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 
+import { getMinPriceCents } from "$app/utils/currency";
+
 import {
   canUseStripePaymentElement,
   getStripePaymentElementAmount,
@@ -13,6 +15,8 @@ import {
   type Product,
   type State,
 } from "$app/components/Checkout/payment";
+
+const paymentElementMinimumPrice = getMinPriceCents("usd");
 
 const paymentElementConfig: CheckoutPaymentConfig = {
   integration: "payment_element",
@@ -243,6 +247,84 @@ describe("canUseStripePaymentElement", () => {
       ),
     ).toBe(false);
   });
+
+  it("falls back when loaded checkout total is below the Gumroad USD minimum", () => {
+    expect(
+      canUseStripePaymentElement(
+        state({
+          surcharges: {
+            type: "loaded",
+            result: {
+              vat_id_valid: false,
+              has_vat_id_input: false,
+              shipping_rate_cents: 0,
+              tax_cents: 0,
+              tax_included_cents: 0,
+              subtotal: paymentElementMinimumPrice - 1,
+            },
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps the Payment Element path selected while the final total is pending", () => {
+    expect(canUseStripePaymentElement(state({ surcharges: { type: "pending" } }))).toBe(true);
+  });
+
+  it("allows a loaded checkout total at the Gumroad USD minimum", () => {
+    expect(
+      canUseStripePaymentElement(
+        state({
+          surcharges: {
+            type: "loaded",
+            result: {
+              vat_id_valid: false,
+              has_vat_id_input: false,
+              shipping_rate_cents: 0,
+              tax_cents: 0,
+              tax_included_cents: 0,
+              subtotal: paymentElementMinimumPrice,
+            },
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("recomputes eligibility when the loaded checkout total crosses below the Gumroad USD minimum", () => {
+    const atMinimum = state({
+      surcharges: {
+        type: "loaded",
+        result: {
+          vat_id_valid: false,
+          has_vat_id_input: false,
+          shipping_rate_cents: 0,
+          tax_cents: 0,
+          tax_included_cents: 0,
+          subtotal: paymentElementMinimumPrice,
+        },
+      },
+    });
+    const belowMinimum = state({
+      surcharges: {
+        type: "loaded",
+        result: {
+          vat_id_valid: false,
+          has_vat_id_input: false,
+          shipping_rate_cents: 0,
+          tax_cents: 0,
+          tax_included_cents: 0,
+          subtotal: paymentElementMinimumPrice - 1,
+        },
+      },
+    });
+
+    expect(canUseStripePaymentElement(atMinimum)).toBe(true);
+    expect(getStripePaymentElementAmount(atMinimum)).toBe(paymentElementMinimumPrice);
+    expect(canUseStripePaymentElement(belowMinimum)).toBe(false);
+    expect(getStripePaymentElementAmount(belowMinimum)).toBeNull();
+  });
 });
 
 describe("requiresReusablePaymentMethod", () => {
@@ -333,6 +415,46 @@ describe("getStripePaymentElementAmount", () => {
         state({ checkoutPayment: futureChargePaymentElementConfig, products: [product({ isPreorder: true })] }),
       ),
     ).toBeNull();
+  });
+
+  it("returns null when the loaded checkout total is below the Gumroad USD minimum", () => {
+    expect(
+      getStripePaymentElementAmount(
+        state({
+          surcharges: {
+            type: "loaded",
+            result: {
+              vat_id_valid: false,
+              has_vat_id_input: false,
+              shipping_rate_cents: 0,
+              tax_cents: 0,
+              tax_included_cents: 0,
+              subtotal: paymentElementMinimumPrice - 1,
+            },
+          },
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("returns the loaded total when it meets the Gumroad USD minimum", () => {
+    expect(
+      getStripePaymentElementAmount(
+        state({
+          surcharges: {
+            type: "loaded",
+            result: {
+              vat_id_valid: false,
+              has_vat_id_input: false,
+              shipping_rate_cents: 0,
+              tax_cents: 0,
+              tax_included_cents: 0,
+              subtotal: paymentElementMinimumPrice,
+            },
+          },
+        }),
+      ),
+    ).toBe(paymentElementMinimumPrice);
   });
 });
 

--- a/app/javascript/components/Checkout/payment.test.ts
+++ b/app/javascript/components/Checkout/payment.test.ts
@@ -1,7 +1,5 @@
 import { describe, expect, it } from "vitest";
 
-import { getMinPriceCents } from "$app/utils/currency";
-
 import {
   canUseStripePaymentElement,
   getStripePaymentElementAmount,
@@ -15,9 +13,6 @@ import {
   type Product,
   type State,
 } from "$app/components/Checkout/payment";
-
-const stripePaymentElementMinimumCharge = 50;
-const belowGumroadUsdMinimumPrice = getMinPriceCents("usd") - 1;
 
 const paymentElementConfig: CheckoutPaymentConfig = {
   integration: "payment_element",
@@ -249,31 +244,11 @@ describe("canUseStripePaymentElement", () => {
     ).toBe(false);
   });
 
-  it("falls back when loaded checkout total is below the Stripe USD minimum charge amount", () => {
-    expect(
-      canUseStripePaymentElement(
-        state({
-          surcharges: {
-            type: "loaded",
-            result: {
-              vat_id_valid: false,
-              has_vat_id_input: false,
-              shipping_rate_cents: 0,
-              tax_cents: 0,
-              tax_included_cents: 0,
-              subtotal: stripePaymentElementMinimumCharge - 1,
-            },
-          },
-        }),
-      ),
-    ).toBe(false);
-  });
-
   it("keeps the Payment Element path selected while the final total is pending", () => {
     expect(canUseStripePaymentElement(state({ surcharges: { type: "pending" } }))).toBe(true);
   });
 
-  it("allows a loaded checkout total below Gumroad's USD minimum when it meets Stripe's minimum charge amount", () => {
+  it("allows a positive loaded checkout total when the server selected Payment Element", () => {
     expect(
       canUseStripePaymentElement(
         state({
@@ -285,66 +260,12 @@ describe("canUseStripePaymentElement", () => {
               shipping_rate_cents: 0,
               tax_cents: 0,
               tax_included_cents: 0,
-              subtotal: belowGumroadUsdMinimumPrice,
+              subtotal: 98,
             },
           },
         }),
       ),
     ).toBe(true);
-  });
-
-  it("allows a loaded checkout total at the Stripe USD minimum charge amount", () => {
-    expect(
-      canUseStripePaymentElement(
-        state({
-          surcharges: {
-            type: "loaded",
-            result: {
-              vat_id_valid: false,
-              has_vat_id_input: false,
-              shipping_rate_cents: 0,
-              tax_cents: 0,
-              tax_included_cents: 0,
-              subtotal: stripePaymentElementMinimumCharge,
-            },
-          },
-        }),
-      ),
-    ).toBe(true);
-  });
-
-  it("recomputes eligibility when the loaded checkout total crosses below the Stripe USD minimum charge amount", () => {
-    const atMinimum = state({
-      surcharges: {
-        type: "loaded",
-        result: {
-          vat_id_valid: false,
-          has_vat_id_input: false,
-          shipping_rate_cents: 0,
-          tax_cents: 0,
-          tax_included_cents: 0,
-          subtotal: stripePaymentElementMinimumCharge,
-        },
-      },
-    });
-    const belowMinimum = state({
-      surcharges: {
-        type: "loaded",
-        result: {
-          vat_id_valid: false,
-          has_vat_id_input: false,
-          shipping_rate_cents: 0,
-          tax_cents: 0,
-          tax_included_cents: 0,
-          subtotal: stripePaymentElementMinimumCharge - 1,
-        },
-      },
-    });
-
-    expect(canUseStripePaymentElement(atMinimum)).toBe(true);
-    expect(getStripePaymentElementAmount(atMinimum)).toBe(stripePaymentElementMinimumCharge);
-    expect(canUseStripePaymentElement(belowMinimum)).toBe(false);
-    expect(getStripePaymentElementAmount(belowMinimum)).toBeNull();
   });
 });
 
@@ -438,6 +359,26 @@ describe("getStripePaymentElementAmount", () => {
     ).toBeNull();
   });
 
+  it("returns null when the loaded checkout total is zero", () => {
+    expect(
+      getStripePaymentElementAmount(
+        state({
+          surcharges: {
+            type: "loaded",
+            result: {
+              vat_id_valid: false,
+              has_vat_id_input: false,
+              shipping_rate_cents: 0,
+              tax_cents: 0,
+              tax_included_cents: 0,
+              subtotal: 0,
+            },
+          },
+        }),
+      ),
+    ).toBeNull();
+  });
+
   it("returns null when the loaded checkout total is below the Stripe USD minimum charge amount", () => {
     expect(
       getStripePaymentElementAmount(
@@ -458,7 +399,7 @@ describe("getStripePaymentElementAmount", () => {
     ).toBeNull();
   });
 
-  it("returns a loaded total below Gumroad's USD minimum when it meets Stripe's minimum charge amount", () => {
+  it("returns a positive loaded total below Gumroad's USD minimum when the server selected Payment Element", () => {
     expect(
       getStripePaymentElementAmount(
         state({
@@ -470,32 +411,12 @@ describe("getStripePaymentElementAmount", () => {
               shipping_rate_cents: 0,
               tax_cents: 0,
               tax_included_cents: 0,
-              subtotal: belowGumroadUsdMinimumPrice,
+              subtotal: 98,
             },
           },
         }),
       ),
-    ).toBe(belowGumroadUsdMinimumPrice);
-  });
-
-  it("returns the loaded total when it meets the Stripe USD minimum charge amount", () => {
-    expect(
-      getStripePaymentElementAmount(
-        state({
-          surcharges: {
-            type: "loaded",
-            result: {
-              vat_id_valid: false,
-              has_vat_id_input: false,
-              shipping_rate_cents: 0,
-              tax_cents: 0,
-              tax_included_cents: 0,
-              subtotal: stripePaymentElementMinimumCharge,
-            },
-          },
-        }),
-      ),
-    ).toBe(stripePaymentElementMinimumCharge);
+    ).toBe(98);
   });
 });
 

--- a/app/javascript/components/Checkout/payment.test.ts
+++ b/app/javascript/components/Checkout/payment.test.ts
@@ -14,6 +14,8 @@ import {
   type State,
 } from "$app/components/Checkout/payment";
 
+const stripePaymentElementMinimumCharge = 50;
+
 const paymentElementConfig: CheckoutPaymentConfig = {
   integration: "payment_element",
   fallback_reason: null,
@@ -244,11 +246,31 @@ describe("canUseStripePaymentElement", () => {
     ).toBe(false);
   });
 
+  it("falls back when loaded checkout total is below Stripe's USD minimum charge amount", () => {
+    expect(
+      canUseStripePaymentElement(
+        state({
+          surcharges: {
+            type: "loaded",
+            result: {
+              vat_id_valid: false,
+              has_vat_id_input: false,
+              shipping_rate_cents: 0,
+              tax_cents: 0,
+              tax_included_cents: 0,
+              subtotal: 49,
+            },
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
   it("keeps the Payment Element path selected while the final total is pending", () => {
     expect(canUseStripePaymentElement(state({ surcharges: { type: "pending" } }))).toBe(true);
   });
 
-  it("allows a positive loaded checkout total when the server selected Payment Element", () => {
+  it("allows a loaded checkout total below Gumroad's USD minimum when Stripe can charge it", () => {
     expect(
       canUseStripePaymentElement(
         state({
@@ -379,7 +401,7 @@ describe("getStripePaymentElementAmount", () => {
     ).toBeNull();
   });
 
-  it("returns null when the loaded checkout total is below the Stripe USD minimum charge amount", () => {
+  it("returns null when the loaded checkout total is below Stripe's USD minimum charge amount", () => {
     expect(
       getStripePaymentElementAmount(
         state({

--- a/app/javascript/components/Checkout/payment.ts
+++ b/app/javascript/components/Checkout/payment.ts
@@ -213,7 +213,10 @@ export function canUseStripePaymentElement(state: State): state is StateWithPaym
     return canUseStripePaymentElementForFutureChargeSetup(state);
   }
 
-  if (state.surcharges.type === "loaded" && !isStripePaymentElementAmountAllowed(getTotalPrice(state))) return false;
+  if (state.surcharges.type === "loaded") {
+    const total = getTotalPrice(state);
+    if (total === null || total < STRIPE_PAYMENT_ELEMENT_MINIMUM_USD_CHARGE_CENTS) return false;
+  }
 
   return !state.products.some((product) => product.payInInstallments || product.hasFreeTrial || product.isPreorder);
 }
@@ -231,12 +234,7 @@ export function getStripePaymentElementAmount(state: State) {
   if (!canUseStripePaymentElement(state) || state.surcharges.type !== "loaded") return null;
   if (state.checkoutPayment.elements_options.stripe_elements_mode === STRIPE_ELEMENTS_MODE_FOR_SETUP_INTENT)
     return null;
-  const total = getTotalPrice(state);
-  return isStripePaymentElementAmountAllowed(total) ? total : null;
-}
-
-function isStripePaymentElementAmountAllowed(amount: number | null) {
-  return amount !== null && amount >= STRIPE_PAYMENT_ELEMENT_MINIMUM_USD_CHARGE_CENTS;
+  return getTotalPrice(state);
 }
 
 export function isProcessing(state: State) {

--- a/app/javascript/components/Checkout/payment.ts
+++ b/app/javascript/components/Checkout/payment.ts
@@ -7,6 +7,7 @@ import { PurchasePaymentMethod } from "$app/data/purchase";
 import { SavedCreditCard } from "$app/parsers/card";
 import { CustomFieldDescriptor, ProductNativeType } from "$app/parsers/product";
 import { assert } from "$app/utils/assert";
+import { getMinPriceCents } from "$app/utils/currency";
 import { isValidEmail } from "$app/utils/email";
 import { asyncVoid } from "$app/utils/promise";
 import { RecurrenceId } from "$app/utils/recurringPricing";
@@ -31,6 +32,9 @@ export const STRIPE_ELEMENTS_MODE_FOR_SETUP_INTENT = "setup";
 type StripeElementsModeForCheckout =
   | typeof STRIPE_ELEMENTS_MODE_FOR_PAYMENT_INTENT
   | typeof STRIPE_ELEMENTS_MODE_FOR_SETUP_INTENT;
+
+const STRIPE_PAYMENT_ELEMENT_CURRENCY = "usd";
+const STRIPE_PAYMENT_ELEMENT_MINIMUM_GUMROAD_PRICE_CENTS = getMinPriceCents(STRIPE_PAYMENT_ELEMENT_CURRENCY);
 
 export type PaymentElementConfig = {
   stripe_elements_mode: StripeElementsModeForCheckout;
@@ -211,7 +215,7 @@ export function canUseStripePaymentElement(state: State): state is StateWithPaym
     return canUseStripePaymentElementForFutureChargeSetup(state);
   }
 
-  if (state.surcharges.type === "loaded" && !getTotalPrice(state)) return false;
+  if (state.surcharges.type === "loaded" && !isStripePaymentElementAmountAllowed(getTotalPrice(state))) return false;
 
   return !state.products.some((product) => product.payInInstallments || product.hasFreeTrial || product.isPreorder);
 }
@@ -230,7 +234,11 @@ export function getStripePaymentElementAmount(state: State) {
   if (state.checkoutPayment.elements_options.stripe_elements_mode === STRIPE_ELEMENTS_MODE_FOR_SETUP_INTENT)
     return null;
   const total = getTotalPrice(state);
-  return total && total > 0 ? total : null;
+  return isStripePaymentElementAmountAllowed(total) ? total : null;
+}
+
+function isStripePaymentElementAmountAllowed(amount: number | null) {
+  return amount !== null && amount >= STRIPE_PAYMENT_ELEMENT_MINIMUM_GUMROAD_PRICE_CENTS;
 }
 
 export function isProcessing(state: State) {

--- a/app/javascript/components/Checkout/payment.ts
+++ b/app/javascript/components/Checkout/payment.ts
@@ -7,7 +7,6 @@ import { PurchasePaymentMethod } from "$app/data/purchase";
 import { SavedCreditCard } from "$app/parsers/card";
 import { CustomFieldDescriptor, ProductNativeType } from "$app/parsers/product";
 import { assert } from "$app/utils/assert";
-import { getMinPriceCents } from "$app/utils/currency";
 import { isValidEmail } from "$app/utils/email";
 import { asyncVoid } from "$app/utils/promise";
 import { RecurrenceId } from "$app/utils/recurringPricing";
@@ -33,8 +32,7 @@ type StripeElementsModeForCheckout =
   | typeof STRIPE_ELEMENTS_MODE_FOR_PAYMENT_INTENT
   | typeof STRIPE_ELEMENTS_MODE_FOR_SETUP_INTENT;
 
-const STRIPE_PAYMENT_ELEMENT_CURRENCY = "usd";
-const STRIPE_PAYMENT_ELEMENT_MINIMUM_GUMROAD_PRICE_CENTS = getMinPriceCents(STRIPE_PAYMENT_ELEMENT_CURRENCY);
+const STRIPE_PAYMENT_ELEMENT_MINIMUM_USD_CHARGE_CENTS = 50;
 
 export type PaymentElementConfig = {
   stripe_elements_mode: StripeElementsModeForCheckout;
@@ -238,7 +236,7 @@ export function getStripePaymentElementAmount(state: State) {
 }
 
 function isStripePaymentElementAmountAllowed(amount: number | null) {
-  return amount !== null && amount >= STRIPE_PAYMENT_ELEMENT_MINIMUM_GUMROAD_PRICE_CENTS;
+  return amount !== null && amount >= STRIPE_PAYMENT_ELEMENT_MINIMUM_USD_CHARGE_CENTS;
 }
 
 export function isProcessing(state: State) {

--- a/app/javascript/components/Checkout/payment.ts
+++ b/app/javascript/components/Checkout/payment.ts
@@ -213,6 +213,7 @@ export function canUseStripePaymentElement(state: State): state is StateWithPaym
     return canUseStripePaymentElementForFutureChargeSetup(state);
   }
 
+  // Rails chooses the initial lane, but discount/surcharge reloads can lower the final total before Elements updates.
   if (state.surcharges.type === "loaded") {
     const total = getTotalPrice(state);
     if (total === null || total < STRIPE_PAYMENT_ELEMENT_MINIMUM_USD_CHARGE_CENTS) return false;

--- a/app/javascript/utils/currency.ts
+++ b/app/javascript/utils/currency.ts
@@ -52,7 +52,7 @@ export const getShortCurrencySymbol = (code: CurrencyCode): string => {
   return currency.shortSymbol;
 };
 
-// Stripe will not accept payments below certain limits (e.g. $0.50 for USD), this is a way to query these minimum amounts
+// Gumroad's configured minimum sale amounts; these are kept at or above Stripe's processing floors.
 export const getMinPriceCents = (code: CurrencyCode): number => {
   const currency = findCurrencyByCode(code);
   return currency.minPriceCents;

--- a/app/presenters/checkout/stripe_payment_presenter.rb
+++ b/app/presenters/checkout/stripe_payment_presenter.rb
@@ -79,7 +79,7 @@ class Checkout::StripePaymentPresenter
       return nil if sellers.one? && setup_for_future_charges_without_charging?(items)
       return "setup_or_installment_flow" if items.any? { future_charge_setup_item?(_1) }
 
-      # Initial eligibility uses pre-tax item prices; the browser re-gates the final loaded total.
+      # Initial eligibility uses pre-tax item prices; the browser waits for the final loaded total.
       total_price_cents = items.sum { _1[:price_cents].to_i }
       return "not_charged" unless total_price_cents.positive?
       return "stripe_payment_element_amount_below_minimum" if total_price_cents < STRIPE_PAYMENT_ELEMENT_MINIMUM_USD_CHARGE_CENTS

--- a/app/presenters/checkout/stripe_payment_presenter.rb
+++ b/app/presenters/checkout/stripe_payment_presenter.rb
@@ -13,8 +13,10 @@ class Checkout::StripePaymentPresenter
   # not a selector for Gumroad's backend PaymentIntent/SetupIntent API path.
   STRIPE_ELEMENTS_MODE_FOR_PAYMENT_INTENT = "payment"
   STRIPE_ELEMENTS_MODE_FOR_SETUP_INTENT = "setup"
-  STRIPE_PAYMENT_ELEMENT_CURRENCY = Currency::USD
-  STRIPE_PAYMENT_ELEMENT_MINIMUM_GUMROAD_PRICE_CENTS = CURRENCY_CHOICES[STRIPE_PAYMENT_ELEMENT_CURRENCY][:min_price]
+  # Payment Element mounts with a charge amount up front, unlike CardElement, so keep carts
+  # below Stripe's USD charge floor on CardElement. This is intentionally lower than
+  # Gumroad's buyer-facing minimum so chargeable near-zero carts can still use Payment Element.
+  STRIPE_PAYMENT_ELEMENT_MINIMUM_USD_CHARGE_CENTS = 50
 
   attr_reader :cart, :add_products, :clear_cart, :saved_credit_card
 
@@ -80,7 +82,7 @@ class Checkout::StripePaymentPresenter
       # Initial eligibility uses pre-tax item prices; the browser re-gates the final loaded total.
       total_price_cents = items.sum { _1[:price_cents].to_i }
       return "not_charged" unless total_price_cents.positive?
-      return "stripe_payment_element_amount_below_minimum" if total_price_cents < STRIPE_PAYMENT_ELEMENT_MINIMUM_GUMROAD_PRICE_CENTS
+      return "stripe_payment_element_amount_below_minimum" if total_price_cents < STRIPE_PAYMENT_ELEMENT_MINIMUM_USD_CHARGE_CENTS
 
       nil
     end

--- a/app/presenters/checkout/stripe_payment_presenter.rb
+++ b/app/presenters/checkout/stripe_payment_presenter.rb
@@ -13,6 +13,8 @@ class Checkout::StripePaymentPresenter
   # not a selector for Gumroad's backend PaymentIntent/SetupIntent API path.
   STRIPE_ELEMENTS_MODE_FOR_PAYMENT_INTENT = "payment"
   STRIPE_ELEMENTS_MODE_FOR_SETUP_INTENT = "setup"
+  STRIPE_PAYMENT_ELEMENT_CURRENCY = Currency::USD
+  STRIPE_PAYMENT_ELEMENT_MINIMUM_GUMROAD_PRICE_CENTS = CURRENCY_CHOICES[STRIPE_PAYMENT_ELEMENT_CURRENCY][:min_price]
 
   attr_reader :cart, :add_products, :clear_cart, :saved_credit_card
 
@@ -74,7 +76,11 @@ class Checkout::StripePaymentPresenter
       return "setup_or_installment_flow" if items.any? { _1[:pay_in_installments] }
       return nil if sellers.one? && setup_for_future_charges_without_charging?(items)
       return "setup_or_installment_flow" if items.any? { future_charge_setup_item?(_1) }
-      return "not_charged" unless items.sum { _1[:price_cents].to_i }.positive?
+
+      # Initial eligibility uses pre-tax item prices; the browser re-gates the final loaded total.
+      total_price_cents = items.sum { _1[:price_cents].to_i }
+      return "not_charged" unless total_price_cents.positive?
+      return "stripe_payment_element_amount_below_minimum" if total_price_cents < STRIPE_PAYMENT_ELEMENT_MINIMUM_GUMROAD_PRICE_CENTS
 
       nil
     end

--- a/spec/presenters/checkout/stripe_payment_presenter_spec.rb
+++ b/spec/presenters/checkout/stripe_payment_presenter_spec.rb
@@ -192,24 +192,34 @@ describe Checkout::StripePaymentPresenter do
   it "falls back to CardElement when the charged checkout total is below the Payment Element minimum" do
     expect(
       stripe_payment_props(
-        add_products: [flagged_seller_product(price: described_class::STRIPE_PAYMENT_ELEMENT_MINIMUM_GUMROAD_PRICE_CENTS - 1)]
+        add_products: [flagged_seller_product(price: described_class::STRIPE_PAYMENT_ELEMENT_MINIMUM_USD_CHARGE_CENTS - 1)]
       )
     )
       .to eq(card_element_fallback("stripe_payment_element_amount_below_minimum"))
   end
 
+  it "selects Stripe Payment Element when the charged checkout total is below Gumroad's USD minimum but chargeable by Stripe" do
+    gumroad_minimum_price_cents = CURRENCY_CHOICES[Currency::USD][:min_price]
+
+    expect(
+      stripe_payment_props(
+        add_products: [flagged_seller_product(price: gumroad_minimum_price_cents - 1)]
+      )
+    ).to eq(payment_element_props)
+  end
+
   it "selects Stripe Payment Element for mixed free and paid products when the charged total meets the minimum" do
     seller = create(:user)
-    minimum_price_cents = described_class::STRIPE_PAYMENT_ELEMENT_MINIMUM_GUMROAD_PRICE_CENTS
+    minimum_charge_cents = described_class::STRIPE_PAYMENT_ELEMENT_MINIMUM_USD_CHARGE_CENTS
     free_product = create(:product, user: seller, price_cents: 0)
-    paid_product = create(:product, user: seller, price_cents: minimum_price_cents)
+    paid_product = create(:product, user: seller, price_cents: CURRENCY_CHOICES[Currency::USD][:min_price])
     Feature.activate_user(described_class::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, seller)
 
     expect(
       stripe_payment_props(
         add_products: [
           checkout_product_for(free_product, price: 0),
-          checkout_product_for(paid_product),
+          checkout_product_for(paid_product, price: minimum_charge_cents),
         ]
       )
     ).to eq(payment_element_props)
@@ -217,9 +227,9 @@ describe Checkout::StripePaymentPresenter do
 
   it "falls back to CardElement for mixed free and paid products when the charged total is below the minimum" do
     seller = create(:user)
-    minimum_price_cents = described_class::STRIPE_PAYMENT_ELEMENT_MINIMUM_GUMROAD_PRICE_CENTS
+    minimum_price_cents = described_class::STRIPE_PAYMENT_ELEMENT_MINIMUM_USD_CHARGE_CENTS
     free_product = create(:product, user: seller, price_cents: 0)
-    paid_product = create(:product, user: seller, price_cents: minimum_price_cents)
+    paid_product = create(:product, user: seller, price_cents: CURRENCY_CHOICES[Currency::USD][:min_price])
     Feature.activate_user(described_class::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, seller)
 
     expect(

--- a/spec/presenters/checkout/stripe_payment_presenter_spec.rb
+++ b/spec/presenters/checkout/stripe_payment_presenter_spec.rb
@@ -189,6 +189,49 @@ describe Checkout::StripePaymentPresenter do
       .to eq(card_element_fallback("setup_or_installment_flow"))
   end
 
+  it "falls back to CardElement when the charged checkout total is below the Payment Element minimum" do
+    expect(
+      stripe_payment_props(
+        add_products: [flagged_seller_product(price: described_class::STRIPE_PAYMENT_ELEMENT_MINIMUM_GUMROAD_PRICE_CENTS - 1)]
+      )
+    )
+      .to eq(card_element_fallback("stripe_payment_element_amount_below_minimum"))
+  end
+
+  it "selects Stripe Payment Element for mixed free and paid products when the charged total meets the minimum" do
+    seller = create(:user)
+    minimum_price_cents = described_class::STRIPE_PAYMENT_ELEMENT_MINIMUM_GUMROAD_PRICE_CENTS
+    free_product = create(:product, user: seller, price_cents: 0)
+    paid_product = create(:product, user: seller, price_cents: minimum_price_cents)
+    Feature.activate_user(described_class::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, seller)
+
+    expect(
+      stripe_payment_props(
+        add_products: [
+          checkout_product_for(free_product, price: 0),
+          checkout_product_for(paid_product),
+        ]
+      )
+    ).to eq(payment_element_props)
+  end
+
+  it "falls back to CardElement for mixed free and paid products when the charged total is below the minimum" do
+    seller = create(:user)
+    minimum_price_cents = described_class::STRIPE_PAYMENT_ELEMENT_MINIMUM_GUMROAD_PRICE_CENTS
+    free_product = create(:product, user: seller, price_cents: 0)
+    paid_product = create(:product, user: seller, price_cents: minimum_price_cents)
+    Feature.activate_user(described_class::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, seller)
+
+    expect(
+      stripe_payment_props(
+        add_products: [
+          checkout_product_for(free_product, price: 0),
+          checkout_product_for(paid_product, price: minimum_price_cents - 1),
+        ]
+      )
+    ).to eq(card_element_fallback("stripe_payment_element_amount_below_minimum"))
+  end
+
   it "ignores cart products when clear_cart is set" do
     cart = create(:cart, :guest)
     create(:cart_product, cart:, product: create(:product, user: create(:user)))

--- a/spec/requests/purchases/product/stripejs_purchase_spec.rb
+++ b/spec/requests/purchases/product/stripejs_purchase_spec.rb
@@ -137,7 +137,9 @@ describe("PurchaseScenario using StripeJs", type: :system, js: true) do
     MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id) ||
       create(:merchant_account, user: nil, charge_processor_merchant_id: "acct_#{SecureRandom.hex(8)}")
     near_zero_price_cents = Checkout::StripePaymentPresenter::STRIPE_PAYMENT_ELEMENT_MINIMUM_USD_CHARGE_CENTS + 10
-    product = create(:product_with_pdf_file, user: seller, name: "Near-zero guide", price_cents: near_zero_price_cents)
+    product = create(:product_with_pdf_file, user: seller, name: "Near-zero guide")
+    # Product creation enforces Gumroad's minimum; this synthetic checkout verifies Stripe's lower charge floor.
+    product.update_column(:price_cents, near_zero_price_cents)
     Feature.activate_user(Checkout::StripePaymentPresenter::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, seller)
 
     visit("/checkout?product=#{product.unique_permalink}")

--- a/spec/requests/purchases/product/stripejs_purchase_spec.rb
+++ b/spec/requests/purchases/product/stripejs_purchase_spec.rb
@@ -139,7 +139,8 @@ describe("PurchaseScenario using StripeJs", type: :system, js: true) do
     near_zero_price_cents = Checkout::StripePaymentPresenter::STRIPE_PAYMENT_ELEMENT_MINIMUM_USD_CHARGE_CENTS + 10
     product = create(:product_with_pdf_file, user: seller, name: "Near-zero guide")
     # Product creation enforces Gumroad's minimum; this synthetic checkout verifies Stripe's lower charge floor.
-    product.update_column(:price_cents, near_zero_price_cents)
+    product.default_price.update_column(:price_cents, near_zero_price_cents)
+    product.reload
     Feature.activate_user(Checkout::StripePaymentPresenter::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, seller)
 
     visit("/checkout?product=#{product.unique_permalink}")

--- a/spec/requests/purchases/product/stripejs_purchase_spec.rb
+++ b/spec/requests/purchases/product/stripejs_purchase_spec.rb
@@ -132,6 +132,43 @@ describe("PurchaseScenario using StripeJs", type: :system, js: true) do
     expect(payment_element_payment_method_ids).not_to be_empty
   end
 
+  it "allows the buyer to pay for a checkout below Gumroad's minimum but chargeable by Stripe using the Payment Element" do
+    seller = create(:user)
+    MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id) ||
+      create(:merchant_account, user: nil, charge_processor_merchant_id: "acct_#{SecureRandom.hex(8)}")
+    near_zero_price_cents = Checkout::StripePaymentPresenter::STRIPE_PAYMENT_ELEMENT_MINIMUM_USD_CHARGE_CENTS + 10
+    product = create(:product_with_pdf_file, user: seller, name: "Near-zero guide", price_cents: near_zero_price_cents)
+    Feature.activate_user(Checkout::StripePaymentPresenter::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, seller)
+
+    visit("/checkout?product=#{product.unique_permalink}")
+
+    expect(page).to have_current_path(checkout_path)
+    expect(page).to have_text("Near-zero guide")
+    expect(page).to have_text("Total US$0.60", normalize_ws: true)
+    checkout_payment = checkout_payment_props
+    expect(checkout_payment["integration"]).to eq("payment_element")
+    expect(checkout_payment["fallback_reason"]).to be_nil
+
+    platform_payment_method = StripePaymentMethodHelper.success.with_zip_code("94107").to_stripejs_payment_method
+    payment_element_payment_method_ids = []
+    allow(StripeChargeablePaymentMethod).to receive(:new).and_wrap_original do |original, payment_method_id, *args, **kwargs|
+      payment_element_payment_method_ids << payment_method_id
+      original.call(platform_payment_method.id, *args, **kwargs)
+    end
+    expect(Stripe::PaymentMethod).to receive(:retrieve).with(platform_payment_method.id).and_call_original
+    expect(Stripe::PaymentIntent).to receive(:create).and_call_original
+
+    expect do
+      check_out(product, payment_element: true)
+    end.to change { product.sales.successful.count }.by(1)
+
+    purchase = product.sales.successful.last
+    expect(purchase.price_cents).to eq(near_zero_price_cents)
+    expect(purchase.successful?).to be(true)
+    expect(payment_element_payment_method_ids).to all(match(/\Apm_/))
+    expect(payment_element_payment_method_ids).not_to be_empty
+  end
+
   it "renders Payment Element for a checkout total below Gumroad's minimum but chargeable by Stripe" do
     seller = create(:user)
     gumroad_minimum_amount_cents = CURRENCY_CHOICES[Currency::USD][:min_price]

--- a/spec/requests/purchases/product/stripejs_purchase_spec.rb
+++ b/spec/requests/purchases/product/stripejs_purchase_spec.rb
@@ -4,6 +4,12 @@ require("spec_helper")
 require "timeout"
 
 describe("PurchaseScenario using StripeJs", type: :system, js: true) do
+  def checkout_payment_props
+    page.evaluate_script(<<~JS)
+      JSON.parse(document.querySelector("[data-page]").getAttribute("data-page")).props.checkout.checkout_payment
+    JS
+  end
+
   it "uses a users saved cc if they have one" do
     previous_successful_sales_count = Purchase.successful.count
     link = create(:product, price_cents: 200)
@@ -61,9 +67,7 @@ describe("PurchaseScenario using StripeJs", type: :system, js: true) do
     expect(Stripe::PaymentMethod).to receive(:retrieve).with(platform_payment_method.id).and_call_original
     expect(Stripe::PaymentIntent).to receive(:create).and_call_original
 
-    checkout_payment = page.evaluate_script(<<~JS)
-      JSON.parse(document.querySelector("[data-page]").getAttribute("data-page")).props.checkout.checkout_payment
-    JS
+    checkout_payment = checkout_payment_props
     expect(checkout_payment["integration"]).to eq("payment_element")
     expect(checkout_payment["fallback_reason"]).to be_nil
 
@@ -81,6 +85,71 @@ describe("PurchaseScenario using StripeJs", type: :system, js: true) do
     expect(new_purchase.successful?).to be(true)
     expect(payment_element_payment_method_ids).to all(match(/\Apm_/))
     expect(payment_element_payment_method_ids).not_to be_empty
+  end
+
+  it "allows the buyer to pay for a mixed free and paid cart using the Payment Element" do
+    seller = create(:user)
+    MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id) ||
+      create(:merchant_account, user: nil, charge_processor_merchant_id: "acct_#{SecureRandom.hex(8)}")
+    payment_element_minimum_amount_cents = Checkout::StripePaymentPresenter::STRIPE_PAYMENT_ELEMENT_MINIMUM_GUMROAD_PRICE_CENTS
+    free_product = create(:product_with_pdf_file, user: seller, name: "Free bonus", price_cents: 0)
+    paid_product = create(:product_with_pdf_file, user: seller, name: "Paid guide", price_cents: payment_element_minimum_amount_cents)
+    Feature.activate_user(Checkout::StripePaymentPresenter::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, seller)
+    cart = create(:cart, :guest)
+    create(:cart_product, cart:, product: free_product, price: 0)
+    create(:cart_product, cart:, product: paid_product, price: payment_element_minimum_amount_cents)
+
+    visit checkout_path(cart_id: cart.secure_external_id(scope: "cart_login"))
+
+    expect(page).to have_current_path(checkout_path)
+    expect(page).to have_text("Free bonus")
+    expect(page).to have_text("Paid guide")
+    expect(page).to have_text("Total US$0.99", normalize_ws: true)
+    checkout_payment = checkout_payment_props
+    expect(checkout_payment["integration"]).to eq("payment_element")
+    expect(checkout_payment["fallback_reason"]).to be_nil
+
+    platform_payment_method = StripePaymentMethodHelper.success.with_zip_code("94107").to_stripejs_payment_method
+    payment_element_payment_method_ids = []
+    allow(StripeChargeablePaymentMethod).to receive(:new).and_wrap_original do |original, payment_method_id, *args, **kwargs|
+      payment_element_payment_method_ids << payment_method_id
+      original.call(platform_payment_method.id, *args, **kwargs)
+    end
+    expect(Stripe::PaymentMethod).to receive(:retrieve).with(platform_payment_method.id).and_call_original
+    expect(Stripe::PaymentIntent).to receive(:create).and_call_original
+
+    expect do
+      check_out(paid_product, payment_element: true)
+    end.to change { free_product.sales.successful.count }.by(1)
+
+    paid_purchase = paid_product.sales.successful.last
+    free_purchase = free_product.sales.successful.last
+    expect(paid_purchase.price_cents).to eq(payment_element_minimum_amount_cents)
+    expect(paid_purchase.successful?).to be(true)
+    expect(free_purchase.price_cents).to eq(0)
+    expect(free_purchase.successful?).to be(true)
+    expect(payment_element_payment_method_ids).to all(match(/\Apm_/))
+    expect(payment_element_payment_method_ids).not_to be_empty
+  end
+
+  it "renders CardElement fallback for a positive checkout total below the Payment Element minimum" do
+    seller = create(:user)
+    payment_element_minimum_amount_cents = Checkout::StripePaymentPresenter::STRIPE_PAYMENT_ELEMENT_MINIMUM_GUMROAD_PRICE_CENTS
+    product = create(:product_with_pdf_file, user: seller, name: "Near-zero guide", customizable_price: true, price_cents: 0)
+    Feature.activate_user(Checkout::StripePaymentPresenter::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, seller)
+    cart = create(:cart, :guest)
+    create(:cart_product, cart:, product:, price: payment_element_minimum_amount_cents - 1)
+
+    visit checkout_path(cart_id: cart.secure_external_id(scope: "cart_login"))
+
+    expect(page).to have_current_path(checkout_path)
+    expect(page).to have_text("Near-zero guide")
+    expect(page).to have_text("Total US$0.98", normalize_ws: true)
+    checkout_payment = checkout_payment_props
+    expect(checkout_payment["integration"]).to eq("card_element")
+    expect(checkout_payment["fallback_reason"]).to eq("stripe_payment_element_amount_below_minimum")
+    expect(page).to have_selector(:fieldset, "Card information")
+    expect(page).not_to have_selector("iframe[src*='elements-inner-payment']", wait: 0)
   end
 
   it "allows the buyer to pay for a recurring membership using the Payment Element reusable setup path" do
@@ -108,9 +177,7 @@ describe("PurchaseScenario using StripeJs", type: :system, js: true) do
       setup_intent
     end
 
-    checkout_payment = page.evaluate_script(<<~JS)
-      JSON.parse(document.querySelector("[data-page]").getAttribute("data-page")).props.checkout.checkout_payment
-    JS
+    checkout_payment = checkout_payment_props
     expect(checkout_payment["integration"]).to eq("payment_element")
     expect(checkout_payment["fallback_reason"]).to be_nil
 

--- a/spec/requests/purchases/product/stripejs_purchase_spec.rb
+++ b/spec/requests/purchases/product/stripejs_purchase_spec.rb
@@ -91,13 +91,13 @@ describe("PurchaseScenario using StripeJs", type: :system, js: true) do
     seller = create(:user)
     MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id) ||
       create(:merchant_account, user: nil, charge_processor_merchant_id: "acct_#{SecureRandom.hex(8)}")
-    payment_element_minimum_amount_cents = Checkout::StripePaymentPresenter::STRIPE_PAYMENT_ELEMENT_MINIMUM_GUMROAD_PRICE_CENTS
+    paid_product_price_cents = CURRENCY_CHOICES[Currency::USD][:min_price]
     free_product = create(:product_with_pdf_file, user: seller, name: "Free bonus", price_cents: 0)
-    paid_product = create(:product_with_pdf_file, user: seller, name: "Paid guide", price_cents: payment_element_minimum_amount_cents)
+    paid_product = create(:product_with_pdf_file, user: seller, name: "Paid guide", price_cents: paid_product_price_cents)
     Feature.activate_user(Checkout::StripePaymentPresenter::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, seller)
     cart = create(:cart, :guest)
     create(:cart_product, cart:, product: free_product, price: 0)
-    create(:cart_product, cart:, product: paid_product, price: payment_element_minimum_amount_cents)
+    create(:cart_product, cart:, product: paid_product, price: paid_product_price_cents)
 
     visit checkout_path(cart_id: cart.secure_external_id(scope: "cart_login"))
 
@@ -124,7 +124,7 @@ describe("PurchaseScenario using StripeJs", type: :system, js: true) do
 
     paid_purchase = paid_product.sales.successful.last
     free_purchase = free_product.sales.successful.last
-    expect(paid_purchase.price_cents).to eq(payment_element_minimum_amount_cents)
+    expect(paid_purchase.price_cents).to eq(paid_product_price_cents)
     expect(paid_purchase.successful?).to be(true)
     expect(free_purchase.price_cents).to eq(0)
     expect(free_purchase.successful?).to be(true)
@@ -132,9 +132,28 @@ describe("PurchaseScenario using StripeJs", type: :system, js: true) do
     expect(payment_element_payment_method_ids).not_to be_empty
   end
 
+  it "renders Payment Element for a checkout total below Gumroad's minimum but chargeable by Stripe" do
+    seller = create(:user)
+    gumroad_minimum_amount_cents = CURRENCY_CHOICES[Currency::USD][:min_price]
+    product = create(:product_with_pdf_file, user: seller, name: "Near-zero guide", customizable_price: true, price_cents: 0)
+    Feature.activate_user(Checkout::StripePaymentPresenter::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, seller)
+    cart = create(:cart, :guest)
+    create(:cart_product, cart:, product:, price: gumroad_minimum_amount_cents - 1)
+
+    visit checkout_path(cart_id: cart.secure_external_id(scope: "cart_login"))
+
+    expect(page).to have_current_path(checkout_path)
+    expect(page).to have_text("Near-zero guide")
+    expect(page).to have_text("Total US$0.98", normalize_ws: true)
+    checkout_payment = checkout_payment_props
+    expect(checkout_payment["integration"]).to eq("payment_element")
+    expect(checkout_payment["fallback_reason"]).to be_nil
+    expect(page).to have_selector("iframe[src*='elements-inner-payment']")
+  end
+
   it "renders CardElement fallback for a positive checkout total below the Payment Element minimum" do
     seller = create(:user)
-    payment_element_minimum_amount_cents = Checkout::StripePaymentPresenter::STRIPE_PAYMENT_ELEMENT_MINIMUM_GUMROAD_PRICE_CENTS
+    payment_element_minimum_amount_cents = Checkout::StripePaymentPresenter::STRIPE_PAYMENT_ELEMENT_MINIMUM_USD_CHARGE_CENTS
     product = create(:product_with_pdf_file, user: seller, name: "Near-zero guide", customizable_price: true, price_cents: 0)
     Feature.activate_user(Checkout::StripePaymentPresenter::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, seller)
     cart = create(:cart, :guest)
@@ -144,7 +163,7 @@ describe("PurchaseScenario using StripeJs", type: :system, js: true) do
 
     expect(page).to have_current_path(checkout_path)
     expect(page).to have_text("Near-zero guide")
-    expect(page).to have_text("Total US$0.98", normalize_ws: true)
+    expect(page).to have_text("Total US$0.49", normalize_ws: true)
     checkout_payment = checkout_payment_props
     expect(checkout_payment["integration"]).to eq("card_element")
     expect(checkout_payment["fallback_reason"]).to eq("stripe_payment_element_amount_below_minimum")


### PR DESCRIPTION
Part of #5362

## What

This PR tightens Payment Element eligibility for near-zero and mixed free-plus-paid carts.

Payment Element now stays selected only when Rails selects the Payment Element lane and the browser has either a pending total or a loaded total that meets Stripe's USD processor minimum. Pure-free checkouts and positive totals below Stripe's processor minimum fall back to CardElement from Rails, and the browser re-checks loaded totals so discount/surcharge updates cannot leave Payment Element mounted with a sub-minimum amount.

Existing product and checkout validation already normalizes or rejects buyer-entered pay-what-you-want amounts below Gumroad's configured minimum; the frontend guard is limited to Stripe's lower processor floor for the loaded checkout total.

The new coverage proves the boundary on both sides: frontend loaded-total handoff and fallback, server lane selection, a 60-cent Payment Element checkout charge, a mixed free-plus-paid checkout that completes through Payment Element, and a `$0.49` synthetic checkout that renders the CardElement fallback.

## Why

Phase 1 keeps Payment Element as a card-only UI path on top of Gumroad's existing backend `stripe_payment_method_id` flow. CardElement can render without knowing the amount, but Payment Element is initialized and updated with an amount, so the browser still waits for a loaded chargeable amount before mounting it.

The processor-minimum threshold belongs first in Rails, where checkout lane selection already has the cart items and can fall back to CardElement before the browser receives Payment Element props. The browser keeps a small loaded-total guard for post-render cart mutations, because discounts and surcharge reloads update the Payment Element amount without recomputing the Rails lane.

## Before/After


https://github.com/user-attachments/assets/44f68910-2e0d-4ac5-b61c-34d7cdf34837


Before:

- Payment Element amount eligibility either used Gumroad's 99-cent product minimum or trusted the initial Rails lane after the loaded total changed.
- Mixed free-plus-paid carts and sub-99-cent chargeable totals did not have end-to-end proof for the Payment Element path.

After:

- Buyer-entered PWYW amounts below Gumroad's product minimum continue to normalize or fail before checkout can charge them.
- `$0.49` synthetic carts fall back to CardElement with a specific fallback reason.
- Mixed free-plus-paid carts use Payment Element when Rails selects the Payment Element lane.
- A 60-cent checkout completes through Payment Element.
- The browser re-checks loaded totals against Stripe's processor floor before mounting or updating Payment Element.

---

This PR was implemented with AI assistance using GPT-5 Codex. All code was self-reviewed.

Prompts used:

- "Work on issue #5362 follow-up PR for near-zero and mixed free-plus-paid carts, read the plan, mark it WIP by rmarescu, and use tmp/engineering-handbook policies."
- "Add e2e test coverage. Use other PRs as inspiration"
- "Review and address Claude's findings from tmp/near-zero-mixed-cart-review.md"
- "Fix the bug where Payment Element used Gumroad's product minimum instead of Stripe's processor minimum."
- "Update the plan and PR description if needed."
- "Verify why `$0.95` normalizes to `$0.99`, simplify frontend amount handling, then commit, push, and update the PR description."

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785346016&installation_id=134400930&pr_number=5613&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5613&signature=7cbff52f62dafc15e1ba965286544d84dc4957730abcbfa7c2a4801ce9dfd724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
