### PR TITLE
fix: handle scalar asset_preview param (NoMethodError in AssetPreviewsController#create)

### DIFF
--- a/app/controllers/asset_previews_controller.rb
+++ b/app/controllers/asset_previews_controller.rb
@@ -7,6 +7,8 @@ class AssetPreviewsController < ApplicationController
   def create
     authorize AssetPreview
 
+    return render(json: { success: false, error: "Could not process your preview, please try again." }) unless params[:asset_preview].is_a?(ActionController::Parameters)
+
     asset_preview = @product.asset_previews.build
 
     if permitted_params[:signed_blob_id].present?

--- a/spec/controllers/asset_previews_controller_spec.rb
+++ b/spec/controllers/asset_previews_controller_spec.rb
@@ -47,6 +47,13 @@ describe AssetPreviewsController do
       expect(response.parsed_body["error"]).to eq("Could not process your preview, please try again.")
     end
 
+    it "returns a graceful error when asset_preview is a scalar instead of a hash" do
+      post(:create, params: { link_id: product.unique_permalink, asset_preview: "not-a-hash", format: :json })
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["success"]).to eq(false)
+      expect(response.parsed_body["error"]).to eq("Could not process your preview, please try again.")
+    end
+
     it "doesn't add a preview if there are too many previews" do
       stub_const("Link::MAX_PREVIEW_COUNT", 1)
       allow_any_instance_of(AssetPreview).to receive(:analyze_file).and_return(nil)

--- a/spec/controllers/asset_previews_controller_spec.rb
+++ b/spec/controllers/asset_previews_controller_spec.rb
@@ -54,6 +54,13 @@ describe AssetPreviewsController do
       expect(response.parsed_body["error"]).to eq("Could not process your preview, please try again.")
     end
 
+    it "returns a graceful error when asset_preview param is absent" do
+      post(:create, params: { link_id: product.unique_permalink, format: :json })
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["success"]).to eq(false)
+      expect(response.parsed_body["error"]).to eq("Could not process your preview, please try again.")
+    end
+
     it "doesn't add a preview if there are too many previews" do
       stub_const("Link::MAX_PREVIEW_COUNT", 1)
       allow_any_instance_of(AssetPreview).to receive(:analyze_file).and_return(nil)


### PR DESCRIPTION
## What

Guard `AssetPreviewsController#create` against a malformed `asset_preview` param. When the param arrives as a scalar string instead of a nested hash, the controller now returns the existing graceful JSON error instead of crashing with a 500.

## Why

A request that sent `asset_preview` as a scalar (e.g. `asset_preview=foo`) caused `params.require(:asset_preview)` to return a `String`, so the subsequent `.permit(:signed_blob_id, :url)` raised:

```
NoMethodError: undefined method 'permit' for an instance of String
  params.require(:asset_preview).permit(:signed_blob_id, :url)
```

This surfaced as an unhandled 500 (Sentry GUMROAD-XM, `NoMethodError`, unhandled). The fix returns early with the same `{ success: false, error: "Could not process your preview, please try again." }` payload the action already uses for other unprocessable inputs, so malformed clients get a clean response and the error stops paging.

## How

- Early `return` in `#create` when `params[:asset_preview]` is not an `ActionController::Parameters`. `authorize AssetPreview` still runs first, so `verify_authorized` stays satisfied.

## Test plan

Added a controller spec covering the scalar-param case:

```
it "returns a graceful error when asset_preview is a scalar instead of a hash"
```

Local run (`bundle exec rspec spec/controllers/asset_previews_controller_spec.rb`): the new spec and the other non-S3 specs pass. The remaining failures in this file are `Aws::S3::Errors::NoSuchBucket` from the local worktree lacking an S3 bucket (fixture/file-attach specs) — pre-existing environment limitation, unrelated to this change. CI has S3 configured and will exercise the full file.

## AI disclosure

Authored with Hermes Agent (Codex `gpt-5.5` autoreview gate: clean, "patch is correct"). Triaged from a Sentry `event_alert` webhook.

Not a UI change — no screenshots/video applicable.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785355353&installation_id=134400930&pr_number=5616&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5616&signature=f751b720224354f1386d80d3c8473cec597aea274be85c0b2593e0825601b82f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->