### PR TITLE
Fix dark-mode button hover shadow to render black, matching light mode

### DIFF
--- a/app/javascript/components/Button.tsx
+++ b/app/javascript/components/Button.tsx
@@ -22,7 +22,11 @@ export const brandNames = [
 export type BrandName = (typeof brandNames)[number];
 
 export const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 cursor-pointer border border-border rounded text-current font-[inherit] no-underline transition-transform hover:-translate-1 hover:shadow active:translate-0 active:shadow-none data-[state=open]:translate-0! data-[state=open]:shadow-none!",
+  // Hover drop-shadow is pinned to black (var(--color-black)) in BOTH light and dark mode.
+  // The default `shadow` token resolves to `currentColor`, which flips to near-white in dark
+  // mode (text color becomes rgb(221 221 221)) and renders a strange white button shadow.
+  // Matching light mode's black keeps the neobrutalist look consistent across color schemes.
+  "inline-flex items-center justify-center gap-2 cursor-pointer border border-border rounded text-current font-[inherit] no-underline transition-transform hover:-translate-1 hover:shadow-[0.25rem_0.25rem_0_var(--color-black)] active:translate-0 active:shadow-none data-[state=open]:translate-0! data-[state=open]:shadow-none!",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## What

Pins the button hover drop-shadow to **black** in both light and dark mode.

`Button.tsx` previously used the Tailwind `hover:shadow` utility, whose `--shadow` token resolves to `0.25rem 0.25rem 0 currentColor`. A button's `currentColor` is `text-current` → `rgb(var(--color))`, which is black (`0 0 0`) in light mode but flips to near-white (`221 221 221`) under `@media (prefers-color-scheme: dark)` (see `_definitions.scss`). The result: on hover, dark-mode buttons cast a **white** drop-shadow, which looks out of place against the neobrutalist hard-shadow style.

The fix replaces `hover:shadow` with an explicit `hover:shadow-[0.25rem_0.25rem_0_var(--color-black)]`, so the hover shadow is the same black offset shadow in both color schemes. Geometry (offset/size) is unchanged; only the color is pinned. `active:shadow-none`, `data-[state=open]:shadow-none`, and the disabled `hover:shadow-none` paths are untouched.

## Why

In dark mode the hover shadow rendered white, which looks strange and inconsistent with light mode. The shadow should match light mode (black) regardless of color scheme. This is a presentation-only fix scoped to the shared `Button` component, so every button across the app inherits the corrected hover shadow.

## Test plan

- CI: Lint JS/TS + Build images.
- Manual: hover any button in light mode (shadow unchanged — black) and in dark mode (`prefers-color-scheme: dark`); the hover shadow is now black instead of white.
- Before/after screenshots on light + dark mode attached below.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5617"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785359395&installation_id=134400930&pr_number=5617&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5617&signature=9e6a20b31e29b55c5d907b007f808ede4efff4078ec92be8acb059a6b167bb89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->