### PR TITLE
Prevent draft products leaking in custom profile page data

### DIFF
--- a/app/services/pages/profile_data.rb
+++ b/app/services/pages/profile_data.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Pages::ProfileData
-  CACHE_VERSION = "v1"
+  CACHE_VERSION = "v2"
   MAX_ITEMS = 100
   DESCRIPTION_LIMIT = 200
 
@@ -30,7 +30,7 @@ class Pages::ProfileData
   end
 
   def self.products(seller)
-    seller.products.alive.not_archived.includes(:thumbnail_alive).order(created_at: :desc).limit(MAX_ITEMS).map do |product|
+    seller.products.alive.not_archived.not_draft.includes(:thumbnail_alive).order(created_at: :desc).limit(MAX_ITEMS).map do |product|
       {
         name: product.name,
         url: product.long_url,

--- a/spec/services/pages/profile_data_spec.rb
+++ b/spec/services/pages/profile_data_spec.rb
@@ -34,5 +34,15 @@ describe Pages::ProfileData do
         expect(Pages::ProfileData.build(seller.reload)[:pages]).to eq([{ name: "Shop" }])
       end
     end
+
+    it "does not expose draft products in the public profile data payload" do
+      published_product = create(:product, user: seller, name: "Published product", draft: false)
+      draft_product = create(:product, user: seller, name: "Draft product", draft: true)
+
+      products = Pages::ProfileData.build(seller)[:products]
+
+      expect(products.pluck(:name)).to include(published_product.name)
+      expect(products.pluck(:name)).not_to include(draft_product.name)
+    end
   end
 end


### PR DESCRIPTION
## Summary

Fixes a high-severity information disclosure found during the automated security review of PR #5571.

`Pages::ProfileData.products` powers the public `gumroad-data` JSON injected into custom profile page iframes. It selected `seller.products.alive.not_archived`, but `Link.alive` does not exclude drafts. As a result, any seller with a custom profile page could unintentionally expose draft product names, public URLs, prices, types, thumbnails, and sanitized descriptions in the public profile page payload.

## Security impact

Draft products are not intended to be publicly discoverable. Exposing them through the profile custom page payload can leak unreleased product metadata and product URLs to anonymous visitors.

## Fix

- Filter the profile data product list with `not_draft` before serializing it.
- Bump the `Pages::ProfileData` cache version so any cached payloads generated before this fix are not reused.
- Add a regression spec proving draft products are omitted while published products remain present.

## Verification

- `ruby -S bundle exec rspec spec/services/pages/profile_data_spec.rb`
- `ruby -S bundle exec rubocop app/services/pages/profile_data.rb spec/services/pages/profile_data_spec.rb`

Note: `pnpm format app/services/pages/profile_data.rb spec/services/pages/profile_data_spec.rb` was attempted per repo guidance, but the repository is currently configured with `packageManager: npm@10.8.2`, so pnpm refused to run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785420423&installation_id=134400930&pr_number=5624&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5624&signature=fba7be10204945b0cc5dbba1a734b3111312b62db18e71c1b6d87073a022c830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->