### PR TITLE
Harden purchase reassignment against harvesting: dispute lock + payment-fingerprint guard

### DIFF
--- a/app/controllers/api/internal/admin/purchases_controller.rb
+++ b/app/controllers/api/internal/admin/purchases_controller.rb
@@ -119,9 +119,10 @@ class Api::Internal::Admin::PurchasesController < Api::Internal::Admin::BaseCont
   def reassign
     from_email = params[:from].to_s.strip.presence
     to_email = params[:to].to_s.strip.presence
+    confirmed_override = ActiveModel::Type::Boolean.new.cast(params[:confirmed_override])
 
     record_admin_write(action: "purchases.reassign") do
-      result = Purchase::ReassignByEmailService.new(from_email:, to_email:).perform
+      result = Purchase::ReassignByEmailService.new(from_email:, to_email:, confirmed_override:).perform
 
       unless result.success?
         return render json: { success: false, message: result.error_message }, status: status_for_reason(result.reason)
@@ -407,6 +408,8 @@ class Api::Internal::Admin::PurchasesController < Api::Internal::Admin::BaseCont
       when :missing_params then :bad_request
       when :not_found then :not_found
       when :no_changes then :unprocessable_entity
+      when :locked then :unprocessable_entity
+      when :fingerprint_anomaly then :unprocessable_entity
       end
     end
 end

--- a/app/controllers/api/internal/helper/base_controller.rb
+++ b/app/controllers/api/internal/helper/base_controller.rb
@@ -5,7 +5,7 @@ class Api::Internal::Helper::BaseController < Api::Internal::BaseController
 
   HELPER_ADMIN_AUDIT_REDACTED_PARAM_PATTERN = /password|secret|token|two_factor|otp|webhook_url|license_key|email/i
   HELPER_ADMIN_AUDIT_ACTION_REDACTED_PARAM_KEYS = {
-    "purchases.reassign" => %w[from to]
+    "purchases.reassign" => %w[from to from_email to_email]
   }.freeze
   HELPER_ADMIN_AUDIT_ACTIONS_ALLOWING_NULL_TARGET = %w[
     purchases.reassign
@@ -73,7 +73,9 @@ class Api::Internal::Helper::BaseController < Api::Internal::BaseController
 
       params_snapshot = helper_admin_audit_params_snapshot(action)
       helper_context = helper_admin_audit_context
-      params_snapshot["helper_reassign_result"] = helper_context if helper_context.present?
+      if helper_context.present?
+        params_snapshot["helper_reassign_result"] = redacted_helper_admin_audit_value(helper_context, action:)
+      end
 
       attributes = {
         actor_user_id: actor.id,

--- a/app/controllers/api/internal/helper/base_controller.rb
+++ b/app/controllers/api/internal/helper/base_controller.rb
@@ -71,6 +71,10 @@ class Api::Internal::Helper::BaseController < Api::Internal::BaseController
       actor = admin_api_token&.actor_user
       return if actor.blank? || admin_api_token.blank?
 
+      params_snapshot = helper_admin_audit_params_snapshot(action)
+      helper_context = helper_admin_audit_context
+      params_snapshot["helper_reassign_result"] = helper_context if helper_context.present?
+
       attributes = {
         actor_user_id: actor.id,
         admin_api_token_id: admin_api_token.id,
@@ -80,7 +84,7 @@ class Api::Internal::Helper::BaseController < Api::Internal::BaseController
         target_external_id: helper_admin_audit_target_external_id(target),
         route: request.path,
         http_method: request.request_method,
-        params_snapshot: helper_admin_audit_params_snapshot(action),
+        params_snapshot:,
         request_id: request.request_id,
         response_status: error.present? ? Rack::Utils.status_code(:internal_server_error) : response.status,
         error_class: error&.class&.name,
@@ -114,6 +118,10 @@ class Api::Internal::Helper::BaseController < Api::Internal::BaseController
 
     def helper_admin_audit_params_snapshot(action)
       redacted_helper_admin_audit_value(params.to_unsafe_h.except("controller", "action", "format"), action:)
+    end
+
+    def helper_admin_audit_context
+      @helper_admin_audit_context || {}
     end
 
     def redacted_helper_admin_audit_value(value, key: nil, action:)

--- a/app/controllers/api/internal/helper/base_controller.rb
+++ b/app/controllers/api/internal/helper/base_controller.rb
@@ -1,70 +1,22 @@
 # frozen_string_literal: true
 
 class Api::Internal::Helper::BaseController < Api::Internal::BaseController
+  include AfterCommitEverywhere
+
+  HELPER_ADMIN_AUDIT_REDACTED_PARAM_PATTERN = /password|secret|token|two_factor|otp|webhook_url|license_key|email/i
+  HELPER_ADMIN_AUDIT_ACTION_REDACTED_PARAM_KEYS = {
+    "purchases.reassign" => %w[from to]
+  }.freeze
+  HELPER_ADMIN_AUDIT_ACTIONS_ALLOWING_NULL_TARGET = %w[
+    purchases.reassign
+  ].freeze
+  HMAC_EXPIRATION = 1.minute
+
   skip_before_action :verify_authenticity_token
   before_action :verify_authorization_header!
   before_action :authorize_helper_token!
 
-  HELPER_AUDIT_REDACTED_PARAM_PATTERN = /password|secret|token|two_factor|otp|webhook_url|license_key|email/i
-  HELPER_AUDIT_ACTION_REDACTED_PARAM_KEYS = {
-    "purchases.reassign" => %w[from to]
-  }.freeze
-  HMAC_EXPIRATION = 1.minute
-
   private
-    def record_helper_audit_log(action:, confirmed_override:, result_reason:)
-      attributes = {
-        event: "helper_api_audit",
-        source: "helper_tools",
-        action:,
-        route: request.path,
-        http_method: request.request_method,
-        params_snapshot: helper_audit_params_snapshot(action),
-        confirmed_override:,
-        result_reason:,
-        request_id: request.request_id,
-        response_status: response.status,
-        created_at: Time.current.iso8601
-      }
-
-      Rails.logger.info(attributes.to_json)
-    rescue => e
-      handle_helper_audit_log_failure(e, attributes)
-    end
-
-    def helper_audit_params_snapshot(action)
-      redacted_helper_audit_value(params.to_unsafe_h.except("controller", "action", "format"), action:)
-    end
-
-    def redacted_helper_audit_value(value, key: nil, action:)
-      return "[REDACTED]" if helper_audit_redacted_param_key?(key, action:)
-
-      case value
-      when ActionController::Parameters
-        redacted_helper_audit_value(value.to_unsafe_h, key:, action:)
-      when Hash
-        value.to_h.each_with_object({}) do |(nested_key, nested_value), redacted|
-          redacted[nested_key] = redacted_helper_audit_value(nested_value, key: nested_key, action:)
-        end
-      when Array
-        value.map { redacted_helper_audit_value(_1, key:, action:) }
-      else
-        value
-      end
-    end
-
-    def helper_audit_redacted_param_key?(key, action:)
-      key.to_s.match?(HELPER_AUDIT_REDACTED_PARAM_PATTERN) ||
-        HELPER_AUDIT_ACTION_REDACTED_PARAM_KEYS.fetch(action, []).include?(key.to_s)
-    end
-
-    def handle_helper_audit_log_failure(error, attributes)
-      Rails.logger.error("Failed to record helper audit log for #{attributes[:action]}: #{error.class.name}: #{error.message}")
-      ErrorNotifier.notify(error) do |report|
-        report.add_metadata(:helper_audit_log, attributes.except(:params_snapshot))
-      end
-    end
-
     def authorize_hmac_signature!
       json = request.body.read.empty? ? nil : JSON.parse(request.body.read)
       query_params = json ? nil : request.query_parameters
@@ -92,5 +44,97 @@ class Api::Internal::Helper::BaseController < Api::Internal::BaseController
 
     def verify_authorization_header!
       render json: { success: false, message: "unauthenticated" }, status: :unauthorized if request.authorization.nil?
+    end
+
+    def record_helper_admin_write(action:, target: nil)
+      validate_helper_admin_audit_target!(action:, target:)
+
+      error = nil
+      begin
+        yield
+      rescue => e
+        error = e
+        raise
+      ensure
+        write_helper_admin_audit_log(action:, target:, error:)
+      end
+    end
+
+    def validate_helper_admin_audit_target!(action:, target:)
+      return if action.present? && (target.present? || HELPER_ADMIN_AUDIT_ACTIONS_ALLOWING_NULL_TARGET.include?(action))
+
+      raise ArgumentError, "admin write audit target is required for #{action.presence || "unknown action"}"
+    end
+
+    def write_helper_admin_audit_log(action:, target:, error:)
+      admin_api_token = AdminApiToken.legacy_admin_token
+      actor = admin_api_token&.actor_user
+      return if actor.blank? || admin_api_token.blank?
+
+      attributes = {
+        actor_user_id: actor.id,
+        admin_api_token_id: admin_api_token.id,
+        action:,
+        target_type: helper_admin_audit_target_type(target),
+        target_id: target&.id,
+        target_external_id: helper_admin_audit_target_external_id(target),
+        route: request.path,
+        http_method: request.request_method,
+        params_snapshot: helper_admin_audit_params_snapshot(action),
+        request_id: request.request_id,
+        response_status: error.present? ? Rack::Utils.status_code(:internal_server_error) : response.status,
+        error_class: error&.class&.name,
+        created_at: Time.current
+      }
+
+      after_commit do
+        AdminApiAuditLog.create!(attributes)
+      rescue => e
+        handle_helper_admin_audit_log_failure(e, attributes)
+      end
+    end
+
+    def helper_admin_audit_target_type(target)
+      target&.class&.base_class&.name
+    end
+
+    def helper_admin_audit_target_external_id(target)
+      return if target.blank?
+      return target.external_id.to_s if target.respond_to?(:external_id) && target.external_id.present?
+
+      target.external_id_numeric.to_s if target.respond_to?(:external_id_numeric) && target.external_id_numeric.present?
+    end
+
+    def handle_helper_admin_audit_log_failure(error, attributes)
+      Rails.logger.error("Failed to record admin audit log for #{attributes[:action]}: #{error.class.name}: #{error.message}")
+      ErrorNotifier.notify(error) do |report|
+        report.add_metadata(:admin_audit_log, attributes.except(:params_snapshot))
+      end
+    end
+
+    def helper_admin_audit_params_snapshot(action)
+      redacted_helper_admin_audit_value(params.to_unsafe_h.except("controller", "action", "format"), action:)
+    end
+
+    def redacted_helper_admin_audit_value(value, key: nil, action:)
+      return "[REDACTED]" if helper_admin_audit_redacted_param_key?(key, action:)
+
+      case value
+      when ActionController::Parameters
+        redacted_helper_admin_audit_value(value.to_unsafe_h, key:, action:)
+      when Hash
+        value.to_h.each_with_object({}) do |(nested_key, nested_value), redacted|
+          redacted[nested_key] = redacted_helper_admin_audit_value(nested_value, key: nested_key, action:)
+        end
+      when Array
+        value.map { redacted_helper_admin_audit_value(_1, key:, action:) }
+      else
+        value
+      end
+    end
+
+    def helper_admin_audit_redacted_param_key?(key, action:)
+      key.to_s.match?(HELPER_ADMIN_AUDIT_REDACTED_PARAM_PATTERN) ||
+        HELPER_ADMIN_AUDIT_ACTION_REDACTED_PARAM_KEYS.fetch(action, []).include?(key.to_s)
     end
 end

--- a/app/controllers/api/internal/helper/base_controller.rb
+++ b/app/controllers/api/internal/helper/base_controller.rb
@@ -5,9 +5,66 @@ class Api::Internal::Helper::BaseController < Api::Internal::BaseController
   before_action :verify_authorization_header!
   before_action :authorize_helper_token!
 
+  HELPER_AUDIT_REDACTED_PARAM_PATTERN = /password|secret|token|two_factor|otp|webhook_url|license_key|email/i
+  HELPER_AUDIT_ACTION_REDACTED_PARAM_KEYS = {
+    "purchases.reassign" => %w[from to]
+  }.freeze
   HMAC_EXPIRATION = 1.minute
 
   private
+    def record_helper_audit_log(action:, confirmed_override:, result_reason:)
+      attributes = {
+        event: "helper_api_audit",
+        source: "helper_tools",
+        action:,
+        route: request.path,
+        http_method: request.request_method,
+        params_snapshot: helper_audit_params_snapshot(action),
+        confirmed_override:,
+        result_reason:,
+        request_id: request.request_id,
+        response_status: response.status,
+        created_at: Time.current.iso8601
+      }
+
+      Rails.logger.info(attributes.to_json)
+    rescue => e
+      handle_helper_audit_log_failure(e, attributes)
+    end
+
+    def helper_audit_params_snapshot(action)
+      redacted_helper_audit_value(params.to_unsafe_h.except("controller", "action", "format"), action:)
+    end
+
+    def redacted_helper_audit_value(value, key: nil, action:)
+      return "[REDACTED]" if helper_audit_redacted_param_key?(key, action:)
+
+      case value
+      when ActionController::Parameters
+        redacted_helper_audit_value(value.to_unsafe_h, key:, action:)
+      when Hash
+        value.to_h.each_with_object({}) do |(nested_key, nested_value), redacted|
+          redacted[nested_key] = redacted_helper_audit_value(nested_value, key: nested_key, action:)
+        end
+      when Array
+        value.map { redacted_helper_audit_value(_1, key:, action:) }
+      else
+        value
+      end
+    end
+
+    def helper_audit_redacted_param_key?(key, action:)
+      key.to_s.match?(HELPER_AUDIT_REDACTED_PARAM_PATTERN) ||
+        HELPER_AUDIT_ACTION_REDACTED_PARAM_KEYS.fetch(action, []).include?(key.to_s)
+    end
+
+    def handle_helper_audit_log_failure(error, attributes)
+      Rails.logger.error("Failed to record helper audit log for #{attributes[:action]}: #{error.class.name}: #{error.message}")
+      ErrorNotifier.notify(error) do |report|
+        report.add_metadata(:helper_audit_log, attributes.except(:params_snapshot))
+      end
+    end
+
     def authorize_hmac_signature!
       json = request.body.read.empty? ? nil : JSON.parse(request.body.read)
       query_params = json ? nil : request.query_parameters

--- a/app/controllers/api/internal/helper/purchases_controller.rb
+++ b/app/controllers/api/internal/helper/purchases_controller.rb
@@ -83,21 +83,20 @@ class Api::Internal::Helper::PurchasesController < Api::Internal::Helper::BaseCo
     to_email = params[:to]
     confirmed_override = ActiveModel::Type::Boolean.new.cast(params[:confirmed_override])
 
-    result = Purchase::ReassignByEmailService.new(from_email:, to_email:, confirmed_override:).perform
+    record_helper_admin_write(action: "purchases.reassign") do
+      result = Purchase::ReassignByEmailService.new(from_email:, to_email:, confirmed_override:).perform
 
-    unless result.success?
-      render json: { success: false, message: result.error_message }, status: status_for_reason(result.reason)
-      record_helper_audit_log(action: "purchases.reassign", confirmed_override:, result_reason: result.reason) if confirmed_override
-      return
+      unless result.success?
+        return render json: { success: false, message: result.error_message }, status: status_for_reason(result.reason)
+      end
+
+      render json: {
+        success: true,
+        message: "Successfully reassigned #{result.count} purchases from #{from_email} to #{to_email}. Receipt sent to #{to_email}.",
+        count: result.count,
+        reassigned_purchase_ids: result.reassigned_purchase_ids
+      }
     end
-
-    render json: {
-      success: true,
-      message: "Successfully reassigned #{result.count} purchases from #{from_email} to #{to_email}. Receipt sent to #{to_email}.",
-      count: result.count,
-      reassigned_purchase_ids: result.reassigned_purchase_ids
-    }
-    record_helper_audit_log(action: "purchases.reassign", confirmed_override:, result_reason: result.reason) if confirmed_override
   end
 
   def auto_refund_purchase

--- a/app/controllers/api/internal/helper/purchases_controller.rb
+++ b/app/controllers/api/internal/helper/purchases_controller.rb
@@ -81,8 +81,9 @@ class Api::Internal::Helper::PurchasesController < Api::Internal::Helper::BaseCo
   def reassign_purchases
     from_email = params[:from]
     to_email = params[:to]
+    confirmed_override = ActiveModel::Type::Boolean.new.cast(params[:confirmed_override])
 
-    result = Purchase::ReassignByEmailService.new(from_email:, to_email:).perform
+    result = Purchase::ReassignByEmailService.new(from_email:, to_email:, confirmed_override:).perform
 
     unless result.success?
       return render json: { success: false, message: result.error_message }, status: status_for_reason(result.reason)
@@ -152,6 +153,8 @@ class Api::Internal::Helper::PurchasesController < Api::Internal::Helper::BaseCo
       when :missing_params then :bad_request
       when :not_found then :not_found
       when :no_changes then :unprocessable_entity
+      when :locked then :unprocessable_entity
+      when :fingerprint_anomaly then :unprocessable_entity
       end
     end
 end

--- a/app/controllers/api/internal/helper/purchases_controller.rb
+++ b/app/controllers/api/internal/helper/purchases_controller.rb
@@ -86,7 +86,9 @@ class Api::Internal::Helper::PurchasesController < Api::Internal::Helper::BaseCo
     result = Purchase::ReassignByEmailService.new(from_email:, to_email:, confirmed_override:).perform
 
     unless result.success?
-      return render json: { success: false, message: result.error_message }, status: status_for_reason(result.reason)
+      render json: { success: false, message: result.error_message }, status: status_for_reason(result.reason)
+      record_helper_audit_log(action: "purchases.reassign", confirmed_override:, result_reason: result.reason) if confirmed_override
+      return
     end
 
     render json: {
@@ -95,6 +97,7 @@ class Api::Internal::Helper::PurchasesController < Api::Internal::Helper::BaseCo
       count: result.count,
       reassigned_purchase_ids: result.reassigned_purchase_ids
     }
+    record_helper_audit_log(action: "purchases.reassign", confirmed_override:, result_reason: result.reason) if confirmed_override
   end
 
   def auto_refund_purchase

--- a/app/controllers/api/internal/helper/purchases_controller.rb
+++ b/app/controllers/api/internal/helper/purchases_controller.rb
@@ -85,6 +85,16 @@ class Api::Internal::Helper::PurchasesController < Api::Internal::Helper::BaseCo
 
     record_helper_admin_write(action: "purchases.reassign") do
       result = Purchase::ReassignByEmailService.new(from_email:, to_email:, confirmed_override:).perform
+      @helper_admin_audit_context = {
+        helper_actor: request.headers["X-Helper-Actor"].presence || "helper_tools",
+        from_email:,
+        to_email:,
+        confirmed_override:,
+        success: result.success?,
+        result_reason: result.reason,
+        reassigned_count: result.count,
+        reassigned_purchase_ids: result.reassigned_purchase_ids,
+      }
 
       unless result.success?
         return render json: { success: false, message: result.error_message }, status: status_for_reason(result.reason)

--- a/app/services/purchase/reassign_by_email_service.rb
+++ b/app/services/purchase/reassign_by_email_service.rb
@@ -96,8 +96,10 @@ class Purchase::ReassignByEmailService
       visual = purchase.card_visual.to_s.strip
       return nil if visual.blank?
 
-      last_four = visual.gsub(/[^0-9]/, "")[-4..]
-      return "card:#{last_four}" if last_four.present?
+      if ChargeableVisual.is_cc_visual(visual)
+        last_four = visual.gsub(/[^0-9]/, "")[-4..]
+        return "card:#{last_four}" if last_four.present?
+      end
 
       "other:#{visual.downcase}"
     end

--- a/app/services/purchase/reassign_by_email_service.rb
+++ b/app/services/purchase/reassign_by_email_service.rb
@@ -1,14 +1,20 @@
 # frozen_string_literal: true
 
 class Purchase::ReassignByEmailService
+  # Maximum number of distinct payment cards (by last-4) a single from_email batch
+  # may span before the reassignment is treated as a possible harvesting attempt
+  # and routed to manual review. 4+ distinct cards trips the guard.
+  MAX_DISTINCT_CARDS = 3
+
   Result = Struct.new(:success, :reassigned_purchase_ids, :error_message, :reason, keyword_init: true) do
     def success? = success
     def count = reassigned_purchase_ids.size
   end
 
-  def initialize(from_email:, to_email:)
+  def initialize(from_email:, to_email:, confirmed_override: false)
     @from_email = from_email
     @to_email = to_email
+    @confirmed_override = confirmed_override
   end
 
   def perform
@@ -23,6 +29,17 @@ class Purchase::ReassignByEmailService
     purchases = Purchase.where(email: @from_email).to_a
     if purchases.empty?
       return Result.new(success: false, reassigned_purchase_ids: [], reason: :not_found, error_message: "No purchases found for email: #{@from_email}")
+    end
+
+    if purchases.any? { |purchase| purchase.reassignment_locked_at.present? }
+      return Result.new(success: false, reassigned_purchase_ids: [], reason: :locked, error_message: "One or more purchases are under review and cannot be reassigned")
+    end
+
+    unless @confirmed_override
+      distinct_cards = purchases.map { |purchase| purchase.card_visual.to_s.gsub(/[^0-9]/, "")[-4..] }.compact.reject(&:blank?).uniq
+      if distinct_cards.size > MAX_DISTINCT_CARDS
+        return Result.new(success: false, reassigned_purchase_ids: [], reason: :fingerprint_anomaly, error_message: "This reassignment spans an unusual number of distinct payment methods and requires manual review")
+      end
     end
 
     purchase_id_set = purchases.map(&:id).to_set

--- a/app/services/purchase/reassign_by_email_service.rb
+++ b/app/services/purchase/reassign_by_email_service.rb
@@ -26,7 +26,7 @@ class Purchase::ReassignByEmailService
       return Result.new(success: false, reassigned_purchase_ids: [], reason: :no_changes, error_message: "from and to emails are the same")
     end
 
-    purchases = Purchase.where(email: @from_email).to_a
+    purchases = Purchase.where(email: @from_email).includes(subscription: :original_purchase).to_a
     if purchases.empty?
       return Result.new(success: false, reassigned_purchase_ids: [], reason: :not_found, error_message: "No purchases found for email: #{@from_email}")
     end
@@ -37,11 +37,15 @@ class Purchase::ReassignByEmailService
     # purchases that are not themselves matched by from_email but get reassigned
     # alongside a recurring charge.
     mutable_purchases = purchases.dup
+    mutable_purchase_id_set = purchase_id_set.dup
     purchases.each do |purchase|
       next unless purchase.subscription.present? && !purchase.is_original_subscription_purchase?
 
       original_purchase = purchase.original_purchase
-      mutable_purchases << original_purchase if original_purchase.present? && !purchase_id_set.include?(original_purchase.id)
+      if original_purchase.present? && !mutable_purchase_id_set.include?(original_purchase.id)
+        mutable_purchases << original_purchase
+        mutable_purchase_id_set.add(original_purchase.id)
+      end
     end
 
     if mutable_purchases.any? { |purchase| purchase.reassignment_locked_at.present? }
@@ -95,6 +99,7 @@ class Purchase::ReassignByEmailService
     def payment_fingerprint(purchase)
       visual = purchase.card_visual.to_s.strip
       return nil if visual.blank?
+      return "other:#{visual.downcase}" if visual.match?(/[\r\n]/)
 
       if ChargeableVisual.is_cc_visual(visual)
         last_four = visual.gsub(/[^0-9]/, "")[-4..]

--- a/app/services/purchase/reassign_by_email_service.rb
+++ b/app/services/purchase/reassign_by_email_service.rb
@@ -31,18 +31,30 @@ class Purchase::ReassignByEmailService
       return Result.new(success: false, reassigned_purchase_ids: [], reason: :not_found, error_message: "No purchases found for email: #{@from_email}")
     end
 
-    if purchases.any? { |purchase| purchase.reassignment_locked_at.present? }
+    purchase_id_set = purchases.map(&:id).to_set
+
+    # Every purchase this service may mutate, including original subscription
+    # purchases that are not themselves matched by from_email but get reassigned
+    # alongside a recurring charge.
+    mutable_purchases = purchases.dup
+    purchases.each do |purchase|
+      next unless purchase.subscription.present? && !purchase.is_original_subscription_purchase?
+
+      original_purchase = purchase.original_purchase
+      mutable_purchases << original_purchase if original_purchase.present? && !purchase_id_set.include?(original_purchase.id)
+    end
+
+    if mutable_purchases.any? { |purchase| purchase.reassignment_locked_at.present? }
       return Result.new(success: false, reassigned_purchase_ids: [], reason: :locked, error_message: "One or more purchases are under review and cannot be reassigned")
     end
 
     unless @confirmed_override
-      distinct_cards = purchases.map { |purchase| purchase.card_visual.to_s.gsub(/[^0-9]/, "")[-4..] }.compact.reject(&:blank?).uniq
-      if distinct_cards.size > MAX_DISTINCT_CARDS
+      distinct_fingerprints = mutable_purchases.map { |purchase| payment_fingerprint(purchase) }.compact.uniq
+      if distinct_fingerprints.size > MAX_DISTINCT_CARDS
         return Result.new(success: false, reassigned_purchase_ids: [], reason: :fingerprint_anomaly, error_message: "This reassignment spans an unusual number of distinct payment methods and requires manual review")
       end
     end
 
-    purchase_id_set = purchases.map(&:id).to_set
     target_user = User.alive.by_email(@to_email).first
     reassigned_purchase_ids = []
 
@@ -74,4 +86,19 @@ class Purchase::ReassignByEmailService
 
     Result.new(success: true, reassigned_purchase_ids: reassigned_purchase_ids, reason: nil, error_message: nil)
   end
+
+  private
+    # Returns a normalized, distinct payment-method signal for a purchase.
+    # Card purchases collapse to the card's last 4 digits; non-card processors
+    # (e.g. PayPal) store an email or other token in card_visual, so fall back to
+    # the normalized full visual rather than silently dropping it.
+    def payment_fingerprint(purchase)
+      visual = purchase.card_visual.to_s.strip
+      return nil if visual.blank?
+
+      last_four = visual.gsub(/[^0-9]/, "")[-4..]
+      return "card:#{last_four}" if last_four.present?
+
+      "other:#{visual.downcase}"
+    end
 end

--- a/db/migrate/20261201000006_add_reassignment_locked_at_to_purchases.rb
+++ b/db/migrate/20261201000006_add_reassignment_locked_at_to_purchases.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddReassignmentLockedAtToPurchases < ActiveRecord::Migration[7.1]
+  def change
+    add_column :purchases, :reassignment_locked_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_12_01_000005) do
+ActiveRecord::Schema[7.1].define(version: 2026_12_01_000006) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -1902,6 +1902,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_12_01_000005) do
     t.bigint "price_id"
     t.string "recommended_by"
     t.datetime "deleted_at", precision: nil
+    t.datetime "reassignment_locked_at"
     t.index ["affiliate_id", "created_at"], name: "index_purchases_on_affiliate_id_and_created_at"
     t.index ["browser_guid"], name: "index_purchases_on_browser_guid"
     t.index ["card_type", "card_visual", "created_at", "stripe_fingerprint"], name: "index_purchases_on_card_type_visual_date_fingerprint"

--- a/spec/controllers/api/internal/admin/purchases_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/purchases_controller_spec.rb
@@ -1235,6 +1235,16 @@ describe Api::Internal::Admin::PurchasesController do
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.parsed_body).to eq({ success: false, message: "from and to emails are the same" }.as_json)
     end
+
+    it "threads confirmed_override through to the service" do
+      expect(Purchase::ReassignByEmailService).to receive(:new)
+        .with(from_email:, to_email:, confirmed_override: true)
+        .and_call_original
+
+      post :reassign, params: { from: from_email, to: to_email, confirmed_override: "true" }
+
+      expect(response).to have_http_status(:ok)
+    end
   end
 
   describe "POST cancel_subscription" do

--- a/spec/controllers/api/internal/helper/purchases_controller_spec.rb
+++ b/spec/controllers/api/internal/helper/purchases_controller_spec.rb
@@ -66,27 +66,35 @@ describe Api::Internal::Helper::PurchasesController, :vcr do
         expect(response.parsed_body["message"]).to include("Receipt sent to #{to_email}")
       end
 
-      it "writes a helper audit log when confirmed_override bypasses the fingerprint anomaly guard" do
+      it "records an admin audit log when confirmed_override bypasses the fingerprint anomaly guard" do
+        legacy_admin_token = create(:admin_api_token, actor_user: admin_user)
+        stub_const("GUMROAD_ADMIN_ID", admin_user.id)
         extra_purchase = create(:purchase, email: from_email, purchaser: buyer, merchant_account: merchant_account)
         [purchase1, purchase2, purchase3, extra_purchase].zip(["**** **** **** 1111", "**** **** **** 2222", "**** **** **** 3333", "**** **** **** 4444"]).each do |purchase, card_visual|
           purchase.update_column(:card_visual, card_visual)
         end
-        allow(Rails.logger).to receive(:info).and_call_original
 
-        post :reassign_purchases, params: { from: from_email, to: to_email, confirmed_override: "true" }
+        expect do
+          post :reassign_purchases, params: { from: from_email, to: to_email, confirmed_override: "true" }
+        end.to change { AdminApiAuditLog.count }.by(1)
 
         expect(response).to have_http_status(:success)
         expect(response.parsed_body["success"]).to eq(true)
-        expect(Rails.logger).to have_received(:info).with(
-          a_string_including(
-            '"event":"helper_api_audit"',
-            '"action":"purchases.reassign"',
-            '"from":"[REDACTED]"',
-            '"to":"[REDACTED]"',
-            '"confirmed_override":true',
-            '"result_reason":null',
-            '"response_status":200'
-          )
+        expect(AdminApiAuditLog.last).to have_attributes(
+          action: "purchases.reassign",
+          target_type: nil,
+          target_id: nil,
+          actor_user_id: admin_user.id,
+          admin_api_token_id: legacy_admin_token.id,
+          route: request.path,
+          http_method: "POST",
+          response_status: 200,
+          error_class: nil
+        )
+        expect(AdminApiAuditLog.last.params_snapshot).to include(
+          "from" => "[REDACTED]",
+          "to" => "[REDACTED]",
+          "confirmed_override" => "true"
         )
       end
 

--- a/spec/controllers/api/internal/helper/purchases_controller_spec.rb
+++ b/spec/controllers/api/internal/helper/purchases_controller_spec.rb
@@ -66,6 +66,30 @@ describe Api::Internal::Helper::PurchasesController, :vcr do
         expect(response.parsed_body["message"]).to include("Receipt sent to #{to_email}")
       end
 
+      it "writes a helper audit log when confirmed_override bypasses the fingerprint anomaly guard" do
+        extra_purchase = create(:purchase, email: from_email, purchaser: buyer, merchant_account: merchant_account)
+        [purchase1, purchase2, purchase3, extra_purchase].zip(["**** **** **** 1111", "**** **** **** 2222", "**** **** **** 3333", "**** **** **** 4444"]).each do |purchase, card_visual|
+          purchase.update_column(:card_visual, card_visual)
+        end
+        allow(Rails.logger).to receive(:info).and_call_original
+
+        post :reassign_purchases, params: { from: from_email, to: to_email, confirmed_override: "true" }
+
+        expect(response).to have_http_status(:success)
+        expect(response.parsed_body["success"]).to eq(true)
+        expect(Rails.logger).to have_received(:info).with(
+          a_string_including(
+            '"event":"helper_api_audit"',
+            '"action":"purchases.reassign"',
+            '"from":"[REDACTED]"',
+            '"to":"[REDACTED]"',
+            '"confirmed_override":true',
+            '"result_reason":null',
+            '"response_status":200'
+          )
+        )
+      end
+
       it "updates original_purchase email for subscription purchases" do
         subscription = create(:subscription, user: buyer)
         original_purchase = create(:purchase, email: "old_original_purchase@example.com", purchaser: buyer, is_original_subscription_purchase: true, subscription: subscription, merchant_account: merchant_account)

--- a/spec/controllers/api/internal/helper/purchases_controller_spec.rb
+++ b/spec/controllers/api/internal/helper/purchases_controller_spec.rb
@@ -101,8 +101,8 @@ describe Api::Internal::Helper::PurchasesController, :vcr do
         )
         expect(audit_log.params_snapshot["helper_reassign_result"]).to include(
           "helper_actor" => "helper-operator@example.com",
-          "from_email" => from_email,
-          "to_email" => to_email,
+          "from_email" => "[REDACTED]",
+          "to_email" => "[REDACTED]",
           "confirmed_override" => true,
           "success" => true,
           "result_reason" => nil,

--- a/spec/controllers/api/internal/helper/purchases_controller_spec.rb
+++ b/spec/controllers/api/internal/helper/purchases_controller_spec.rb
@@ -74,6 +74,8 @@ describe Api::Internal::Helper::PurchasesController, :vcr do
           purchase.update_column(:card_visual, card_visual)
         end
 
+        request.headers["X-Helper-Actor"] = "helper-operator@example.com"
+
         expect do
           post :reassign_purchases, params: { from: from_email, to: to_email, confirmed_override: "true" }
         end.to change { AdminApiAuditLog.count }.by(1)
@@ -91,10 +93,21 @@ describe Api::Internal::Helper::PurchasesController, :vcr do
           response_status: 200,
           error_class: nil
         )
-        expect(AdminApiAuditLog.last.params_snapshot).to include(
+        audit_log = AdminApiAuditLog.last
+        expect(audit_log.params_snapshot).to include(
           "from" => "[REDACTED]",
           "to" => "[REDACTED]",
           "confirmed_override" => "true"
+        )
+        expect(audit_log.params_snapshot["helper_reassign_result"]).to include(
+          "helper_actor" => "helper-operator@example.com",
+          "from_email" => from_email,
+          "to_email" => to_email,
+          "confirmed_override" => true,
+          "success" => true,
+          "result_reason" => nil,
+          "reassigned_count" => 4,
+          "reassigned_purchase_ids" => match_array([purchase1.id, purchase2.id, purchase3.id, extra_purchase.id])
         )
       end
 

--- a/spec/services/purchase/reassign_by_email_service_spec.rb
+++ b/spec/services/purchase/reassign_by_email_service_spec.rb
@@ -255,5 +255,40 @@ describe Purchase::ReassignByEmailService do
         expect(result.count).to eq(3)
       end
     end
+
+    context "when purchases span too many distinct non-card payment methods" do
+      let!(:target_user) { create(:user, email: to_email) }
+
+      before do
+        ["paypal-a@example.com", "paypal-b@example.com", "paypal-c@example.com", "paypal-d@example.com"].each do |visual|
+          purchase = create(:purchase, email: from_email, purchaser: buyer, merchant_account:)
+          purchase.update_column(:card_visual, visual)
+        end
+      end
+
+      it "refuses with reason :fingerprint_anomaly for distinct non-card visuals" do
+        result = described_class.new(from_email:, to_email:).perform
+
+        expect(result.success?).to be(false)
+        expect(result.reason).to eq(:fingerprint_anomaly)
+      end
+    end
+
+    context "when a locked original subscription purchase is not in the matched set" do
+      let!(:target_user) { create(:user, email: to_email) }
+
+      it "refuses the batch because a mutable purchase is locked" do
+        subscription = create(:subscription, user: buyer)
+        original_purchase = create(:purchase, email: "old_original@example.com", purchaser: buyer, is_original_subscription_purchase: true, subscription:, merchant_account:, reassignment_locked_at: Time.current)
+        recurring = create(:purchase, email: from_email, purchaser: buyer, subscription:, merchant_account:)
+
+        result = described_class.new(from_email:, to_email:).perform
+
+        expect(result.success?).to be(false)
+        expect(result.reason).to eq(:locked)
+        expect(recurring.reload.email).to eq(from_email)
+        expect(original_purchase.reload.email).to eq("old_original@example.com")
+      end
+    end
   end
 end

--- a/spec/services/purchase/reassign_by_email_service_spec.rb
+++ b/spec/services/purchase/reassign_by_email_service_spec.rb
@@ -116,6 +116,46 @@ describe Purchase::ReassignByEmailService do
         expect(subscription.reload.user).to eq(target_user)
       end
 
+      it "checks a shared unmatched original purchase once for multiple recurring charges" do
+        subscription = create(:subscription, user: buyer)
+        original_purchase = create(:purchase, email: "old_original@example.com", purchaser: buyer, is_original_subscription_purchase: true, subscription:, merchant_account:)
+        create(:purchase, email: from_email, purchaser: buyer, subscription:, merchant_account:)
+        create(:purchase, email: from_email, purchaser: buyer, subscription:, merchant_account:)
+
+        service = described_class.new(from_email:, to_email:)
+        allow(service).to receive(:payment_fingerprint).and_call_original
+
+        service.perform
+
+        expect(service).to have_received(:payment_fingerprint).with(original_purchase).once
+      end
+
+      it "preloads subscriptions and original purchases before the guard checks recurring charges" do
+        subscription = create(:subscription, user: buyer)
+        original_purchase = create(:purchase, email: "old_original@example.com", purchaser: buyer, is_original_subscription_purchase: true, subscription:, merchant_account:, reassignment_locked_at: Time.current)
+        3.times { create(:purchase, email: from_email, purchaser: buyer, subscription:, merchant_account:) }
+
+        subscription_selects = []
+        original_purchase_selects = []
+        counter = lambda do |_name, _started, _finished, _unique_id, payload|
+          sql = payload[:sql]
+          next unless sql.start_with?("SELECT")
+
+          subscription_selects << sql if sql.match?(/FROM [`"]subscriptions[`"]/)
+          original_purchase_selects << sql if sql.match?(/FROM [`"]purchases[`"]/) && sql.match?(/[`"]purchases[`"]\.[`"]subscription_id[`"]/)
+        end
+
+        result = nil
+        ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
+          result = described_class.new(from_email:, to_email:).perform
+        end
+
+        expect(result.reason).to eq(:locked)
+        expect(original_purchase.reload.email).to eq("old_original@example.com")
+        expect(subscription_selects.size).to eq(1)
+        expect(original_purchase_selects.size).to eq(1)
+      end
+
       it "does not modify subscription.user when the original_purchase update fails" do
         subscription = create(:subscription, user: buyer)
         original_purchase = create(:purchase, email: "old_original@example.com", purchaser: buyer, is_original_subscription_purchase: true, subscription:, merchant_account:)
@@ -285,6 +325,24 @@ describe Purchase::ReassignByEmailService do
       end
 
       it "does not collapse numeric PayPal emails into a single card fingerprint" do
+        result = described_class.new(from_email:, to_email:).perform
+
+        expect(result.success?).to be(false)
+        expect(result.reason).to eq(:fingerprint_anomaly)
+      end
+    end
+
+    context "when non-card payment visuals contain a card-like line" do
+      let!(:target_user) { create(:user, email: to_email) }
+
+      before do
+        ["paypal-a@example.com", "paypal-b@example.com", "paypal-c@example.com", "paypal-d@example.com"].each do |visual|
+          purchase = create(:purchase, email: from_email, purchaser: buyer, merchant_account:)
+          purchase.update_column(:card_visual, "#{visual}\n**** **** **** 1234")
+        end
+      end
+
+      it "does not collapse the multi-line visuals into the same card fingerprint" do
         result = described_class.new(from_email:, to_email:).perform
 
         expect(result.success?).to be(false)

--- a/spec/services/purchase/reassign_by_email_service_spec.rb
+++ b/spec/services/purchase/reassign_by_email_service_spec.rb
@@ -187,5 +187,73 @@ describe Purchase::ReassignByEmailService do
         expect(purchase.purchaser_id).to be_nil
       end
     end
+
+    context "when a matched purchase is reassignment-locked" do
+      let!(:target_user) { create(:user, email: to_email) }
+      let!(:unlocked_purchase) { create(:purchase, email: from_email, purchaser: buyer, merchant_account:) }
+      let!(:locked_purchase) { create(:purchase, email: from_email, purchaser: buyer, merchant_account:, reassignment_locked_at: Time.current) }
+
+      it "refuses the whole batch without mutating any purchase" do
+        expect(CustomerMailer).not_to receive(:grouped_receipt)
+
+        result = described_class.new(from_email:, to_email:).perform
+
+        expect(result.success?).to be(false)
+        expect(result.reason).to eq(:locked)
+        expect(result.error_message).to eq("One or more purchases are under review and cannot be reassigned")
+        expect(result.reassigned_purchase_ids).to eq([])
+        expect(unlocked_purchase.reload.email).to eq(from_email)
+        expect(locked_purchase.reload.email).to eq(from_email)
+      end
+    end
+
+    context "when purchases span too many distinct cards" do
+      let!(:target_user) { create(:user, email: to_email) }
+
+      before do
+        ["**** **** **** 1111", "**** **** **** 2222", "**** **** **** 3333", "**** **** **** 4444"].each do |card_visual|
+          purchase = create(:purchase, email: from_email, purchaser: buyer, merchant_account:)
+          purchase.update_column(:card_visual, card_visual)
+        end
+      end
+
+      it "refuses with reason :fingerprint_anomaly and does not mutate purchases" do
+        expect(CustomerMailer).not_to receive(:grouped_receipt)
+
+        result = described_class.new(from_email:, to_email:).perform
+
+        expect(result.success?).to be(false)
+        expect(result.reason).to eq(:fingerprint_anomaly)
+        expect(result.error_message).to eq("This reassignment spans an unusual number of distinct payment methods and requires manual review")
+        expect(result.reassigned_purchase_ids).to eq([])
+        expect(Purchase.where(email: from_email).count).to eq(4)
+      end
+
+      it "allows the high-card-diversity move when confirmed_override is true" do
+        result = described_class.new(from_email:, to_email:, confirmed_override: true).perform
+
+        expect(result.success?).to be(true)
+        expect(result.count).to eq(4)
+        expect(Purchase.where(email: from_email).count).to eq(0)
+      end
+    end
+
+    context "when purchases use a normal one-to-two card library" do
+      let!(:target_user) { create(:user, email: to_email) }
+
+      before do
+        ["**** **** **** 1111", "**** **** **** 1111", "**** **** **** 2222"].each do |card_visual|
+          purchase = create(:purchase, email: from_email, purchaser: buyer, merchant_account:)
+          purchase.update_column(:card_visual, card_visual)
+        end
+      end
+
+      it "does not trip the fingerprint guard" do
+        result = described_class.new(from_email:, to_email:).perform
+
+        expect(result.success?).to be(true)
+        expect(result.count).to eq(3)
+      end
+    end
   end
 end

--- a/spec/services/purchase/reassign_by_email_service_spec.rb
+++ b/spec/services/purchase/reassign_by_email_service_spec.rb
@@ -274,6 +274,24 @@ describe Purchase::ReassignByEmailService do
       end
     end
 
+    context "when purchases span distinct non-card visuals containing digits" do
+      let!(:target_user) { create(:user, email: to_email) }
+
+      before do
+        ["buyer2024-a@example.com", "buyer2024-b@example.com", "buyer2024-c@example.com", "buyer2024-d@example.com"].each do |visual|
+          purchase = create(:purchase, email: from_email, purchaser: buyer, merchant_account:)
+          purchase.update_column(:card_visual, visual)
+        end
+      end
+
+      it "does not collapse numeric PayPal emails into a single card fingerprint" do
+        result = described_class.new(from_email:, to_email:).perform
+
+        expect(result.success?).to be(false)
+        expect(result.reason).to eq(:fingerprint_anomaly)
+      end
+    end
+
     context "when a locked original subscription purchase is not in the matched set" do
       let!(:target_user) { create(:user, email: to_email) }
 


### PR DESCRIPTION
## What

Adds two fraud-hardening guardrails to `Purchase::ReassignByEmailService`, the single chokepoint shared by the admin CLI reassign action and the Helper reassign flow:

- **Dispute/review lock.** A new nullable `purchases.reassignment_locked_at` column. If any purchase the service would mutate (including an original subscription purchase pulled in alongside a recurring charge) has `reassignment_locked_at` set, the entire batch is refused with reason `:locked` before any write. This prevents records from oscillating between accounts while under review.
- **Payment-fingerprint diversity guard.** Across the matched batch, the service counts distinct payment-method fingerprints. Masked card visuals collapse to the card's last four digits; non-card processor visuals (e.g. PayPal emails) are normalized and counted distinctly so they are not silently dropped. When the count exceeds `MAX_DISTINCT_CARDS` (3, so 4+ trips it), the reassignment is refused with reason `:fingerprint_anomaly` and routed to manual review. A human can deliberately approve a flagged move by passing `confirmed_override: true`, which is threaded through both controllers.

Both new reasons map to HTTP 422 in the admin and Helper controllers.

## Why

Implements recommended controls from gumroad-private issue #753, which documents an active purchase-harvesting fraud ring: a single requester funnels purchases from many unrelated buyers' emails into destination accounts via reassignment, and records oscillated between accounts because there was no lock. The dispute lock stops the oscillation; the fingerprint-diversity guard surfaces the harvesting pattern (one destination batch spanning many unrelated payment methods) for manual review.

## Test plan

- `bundle exec rspec spec/services/purchase/reassign_by_email_service_spec.rb` — 23 examples, 0 failures. New coverage: locked batch refusal (no mutation), locked original subscription purchase outside the matched set, high card-diversity refusal, `confirmed_override` bypass, normal 1–2 card library passing, distinct non-card visuals refusal, and numeric-bearing non-card visuals not collapsing into a single card fingerprint.
- `bundle exec rspec spec/controllers/api/internal/admin/purchases_controller_spec.rb -e "POST reassign"` — 10 examples, 0 failures, including a `confirmed_override` pass-through example.
- `bundle exec rspec spec/controllers/api/internal/helper/purchases_controller_spec.rb -e "reassign"` — 10 examples, 0 failures.
- `RAILS_ENV=test bundle exec rails db:migrate` applied the online DDL column add and regenerated `db/schema.rb`.

## Follow-up still needed

This change hardens the admin/Helper-mediated reassignment path only. A separate buyer-facing ownership-proof gate (card-last-4 / original-checkout fingerprint match) on the self-serve receipt-link claim flow is still required; that is a distinct code path not touched here and should be tracked as follow-up work.

Closes #753.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785425217&installation_id=134400930&pr_number=5625&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5625&signature=4ea72765b6a44ff30a75f827f1aae3daa3fe5a0ca36f3b5fef0dafa5a61c23f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->