### PR TITLE
Fix Niger (NE) IBAN validation rejecting valid account numbers

### DIFF
--- a/app/models/niger_bank_account.rb
+++ b/app/models/niger_bank_account.rb
@@ -3,7 +3,20 @@
 class NigerBankAccount < BankAccount
   BANK_ACCOUNT_TYPE = "NE"
 
-  validate :validate_account_number, if: -> { Rails.env.production? }
+  # Niger IBAN: NE + 2 check digits + 5-char bank code + 19-digit account number = 28 chars
+  # (same XOF/BCEAO structure as Côte d'Ivoire). Note a Niger IBAN contains "NE" twice — once
+  # as the country code and once inside the bank code.
+  #
+  # We validate the structure ourselves instead of delegating to Ibandit's per-field
+  # `*_format` regexes: in Ibandit 1.26.1 the NE structure has `bank_code_format` and
+  # `account_number_format` set to `nil`, which compile to `/\A\z/` (matches only the empty
+  # string), so every structurally-valid NE IBAN is rejected as "format is invalid". We still
+  # use Ibandit's working country-code / check-digit / length / character checks for the parts
+  # of the standard it validates correctly. Same fix as Côte d'Ivoire (#471) and Sweden (#775).
+  IBAN_FORMAT_REGEX = /\ANE[0-9]{2}[A-Z0-9]{5}[0-9]{19}\z/
+  private_constant :IBAN_FORMAT_REGEX
+
+  validate :validate_account_number
 
   def bank_account_type
     BANK_ACCOUNT_TYPE
@@ -30,7 +43,17 @@ class NigerBankAccount < BankAccount
 
   private
     def validate_account_number
-      return if Ibandit::IBAN.new(account_number_decrypted).valid?
+      decrypted = account_number_decrypted
+      if decrypted.blank?
+        errors.add :base, "The account number is invalid."
+        return
+      end
+      iban = Ibandit::IBAN.new(decrypted)
+      return if IBAN_FORMAT_REGEX.match?(iban.iban) &&
+                iban.valid_country_code? &&
+                iban.valid_check_digits? &&
+                iban.valid_length? &&
+                iban.valid_characters?
       errors.add :base, "The account number is invalid."
     end
 end

--- a/app/models/niger_bank_account.rb
+++ b/app/models/niger_bank_account.rb
@@ -7,12 +7,13 @@ class NigerBankAccount < BankAccount
   # (same XOF/BCEAO structure as Côte d'Ivoire). Note a Niger IBAN contains "NE" twice — once
   # as the country code and once inside the bank code.
   #
-  # We validate the structure ourselves instead of delegating to Ibandit's per-field
-  # `*_format` regexes: in Ibandit 1.26.1 the NE structure has `bank_code_format` and
-  # `account_number_format` set to `nil`, which compile to `/\A\z/` (matches only the empty
-  # string), so every structurally-valid NE IBAN is rejected as "format is invalid". We still
-  # use Ibandit's working country-code / check-digit / length / character checks for the parts
-  # of the standard it validates correctly. Same fix as Côte d'Ivoire (#471) and Sweden (#775).
+  # We validate the NE-specific BBAN structure ourselves because Ibandit 1.26.1 has no
+  # `:NE` structure entry (`Ibandit.structures[:NE]` is nil). Without that entry,
+  # `Ibandit::IBAN#valid?` cannot run the per-field format checks and rejects every
+  # structurally-valid NE IBAN as "format is invalid". The regex supplies those missing
+  # Niger field checks; the standalone Ibandit predicates below still cover the standard
+  # country-code, mod-97 check-digit, length, and allowed-character checks. Same fix as
+  # Côte d'Ivoire (#471) and Sweden (#775).
   IBAN_FORMAT_REGEX = /\ANE[0-9]{2}[A-Z0-9]{5}[0-9]{19}\z/
   private_constant :IBAN_FORMAT_REGEX
 

--- a/app/models/niger_bank_account.rb
+++ b/app/models/niger_bank_account.rb
@@ -12,8 +12,8 @@ class NigerBankAccount < BankAccount
   # `Ibandit::IBAN#valid?` cannot run the per-field format checks and rejects every
   # structurally-valid NE IBAN as "format is invalid". The regex supplies those missing
   # Niger field checks; the standalone Ibandit predicates below still cover the standard
-  # country-code, mod-97 check-digit, length, and allowed-character checks. Same fix as
-  # Côte d'Ivoire (#471) and Sweden (#775).
+  # country-code, mod-97 check-digit, length, and allowed-character checks. Same approach as
+  # CoteDIvoireBankAccount (#471).
   IBAN_FORMAT_REGEX = /\ANE[0-9]{2}[A-Z0-9]{5}[0-9]{19}\z/
   private_constant :IBAN_FORMAT_REGEX
 

--- a/app/models/niger_bank_account.rb
+++ b/app/models/niger_bank_account.rb
@@ -7,13 +7,12 @@ class NigerBankAccount < BankAccount
   # (same XOF/BCEAO structure as Côte d'Ivoire). Note a Niger IBAN contains "NE" twice — once
   # as the country code and once inside the bank code.
   #
-  # We validate the NE-specific BBAN structure ourselves because Ibandit 1.26.1 has no
-  # `:NE` structure entry (`Ibandit.structures[:NE]` is nil). Without that entry,
-  # `Ibandit::IBAN#valid?` cannot run the per-field format checks and rejects every
-  # structurally-valid NE IBAN as "format is invalid". The regex supplies those missing
-  # Niger field checks; the standalone Ibandit predicates below still cover the standard
-  # country-code, mod-97 check-digit, length, and allowed-character checks. Same approach as
-  # CoteDIvoireBankAccount (#471).
+  # We validate the structure ourselves instead of delegating to Ibandit's full `valid?`:
+  # Ibandit 1.26.1 has an NE entry (`Ibandit.structures["NE"]`) with length metadata, but
+  # it is missing the per-field format regexes that `valid?` requires. Those nil formats
+  # compile to `/\A\z/`, so valid NE IBANs are rejected as "format is invalid". Ibandit's
+  # country-code, check-digit, length, and character checks still validate correctly here.
+  # Same family of Ibandit bundled-data workaround as Côte d'Ivoire (#471) and Sweden (#775).
   IBAN_FORMAT_REGEX = /\ANE[0-9]{2}[A-Z0-9]{5}[0-9]{19}\z/
   private_constant :IBAN_FORMAT_REGEX
 

--- a/spec/models/niger_bank_account_spec.rb
+++ b/spec/models/niger_bank_account_spec.rb
@@ -33,35 +33,35 @@ describe NigerBankAccount do
 
   describe "#validate_account_number" do
     it "allows a valid 28-character NE IBAN" do
-      ba = build(:niger_bank_account, account_number: "NE58NE0380100100130305000268")
+      ba = build(:niger_bank_account, account_number: "NE08NE0001234567890123456789")
       expect(ba).to be_valid
     end
 
     it "allows a valid NE IBAN entered with spaces and lowercase" do
-      ba = build(:niger_bank_account, account_number: "ne58 ne03 8010 0100 1303 0500 0268")
+      ba = build(:niger_bank_account, account_number: "ne08 ne00 0123 4567 8901 2345 6789")
       expect(ba).to be_valid
     end
 
     it "rejects an IBAN with invalid check digits" do
-      ba = build(:niger_bank_account, account_number: "NE00NE0380100100130305000268")
+      ba = build(:niger_bank_account, account_number: "NE00NE0001234567890123456789")
       expect(ba).not_to be_valid
       expect(ba.errors.full_messages).to include("The account number is invalid.")
     end
 
     it "rejects an IBAN with the wrong country code" do
-      ba = build(:niger_bank_account, account_number: "GB58NE0380100100130305000268")
+      ba = build(:niger_bank_account, account_number: "GB08NE0001234567890123456789")
       expect(ba).not_to be_valid
       expect(ba.errors.full_messages).to include("The account number is invalid.")
     end
 
     it "rejects an IBAN that is too short" do
-      ba = build(:niger_bank_account, account_number: "NE58NE038010010013030500026")
+      ba = build(:niger_bank_account, account_number: "NE08NE000123456789012345678")
       expect(ba).not_to be_valid
       expect(ba.errors.full_messages).to include("The account number is invalid.")
     end
 
     it "rejects an account number with a non-digit in the account portion" do
-      ba = build(:niger_bank_account, account_number: "NE58NE038010010013030500026X")
+      ba = build(:niger_bank_account, account_number: "NE08NE000123456789012345678X")
       expect(ba).not_to be_valid
       expect(ba.errors.full_messages).to include("The account number is invalid.")
     end

--- a/spec/models/niger_bank_account_spec.rb
+++ b/spec/models/niger_bank_account_spec.rb
@@ -30,4 +30,46 @@ describe NigerBankAccount do
       expect(create(:niger_bank_account).routing_number).to be nil
     end
   end
+
+  describe "#validate_account_number" do
+    it "allows a valid 28-character NE IBAN" do
+      ba = build(:niger_bank_account, account_number: "NE58NE0380100100130305000268")
+      expect(ba).to be_valid
+    end
+
+    it "allows a valid NE IBAN entered with spaces and lowercase" do
+      ba = build(:niger_bank_account, account_number: "ne58 ne03 8010 0100 1303 0500 0268")
+      expect(ba).to be_valid
+    end
+
+    it "rejects an IBAN with invalid check digits" do
+      ba = build(:niger_bank_account, account_number: "NE00NE0380100100130305000268")
+      expect(ba).not_to be_valid
+      expect(ba.errors.full_messages).to include("The account number is invalid.")
+    end
+
+    it "rejects an IBAN with the wrong country code" do
+      ba = build(:niger_bank_account, account_number: "GB58NE0380100100130305000268")
+      expect(ba).not_to be_valid
+      expect(ba.errors.full_messages).to include("The account number is invalid.")
+    end
+
+    it "rejects an IBAN that is too short" do
+      ba = build(:niger_bank_account, account_number: "NE58NE038010010013030500026")
+      expect(ba).not_to be_valid
+      expect(ba.errors.full_messages).to include("The account number is invalid.")
+    end
+
+    it "rejects an account number with a non-digit in the account portion" do
+      ba = build(:niger_bank_account, account_number: "NE58NE038010010013030500026X")
+      expect(ba).not_to be_valid
+      expect(ba.errors.full_messages).to include("The account number is invalid.")
+    end
+
+    it "rejects a blank account number" do
+      ba = build(:niger_bank_account, account_number: "")
+      expect(ba).not_to be_valid
+      expect(ba.errors.full_messages).to include("The account number is invalid.")
+    end
+  end
 end


### PR DESCRIPTION
## What

Fixes Niger (`NE`) bank-account IBAN validation, which rejected every structurally-valid Niger IBAN with "The account number is invalid." Niger is a bank-payout-only (XOF) country with no PayPal option, so affected sellers had no working payout path.

## Why / root cause

`NigerBankAccount#validate_account_number` delegated to `Ibandit::IBAN.new(...).valid?`. In Ibandit 1.26.1, `Ibandit.structures` uses string country-code keys: `Ibandit.structures["NE"]` exists with NE length/field metadata, while the symbol lookup `Ibandit.structures[:NE]` returns `nil`. The NE structure is incomplete because it lacks the per-field `bank_code_format` / `account_number_format` regex values that `valid?` requires, so valid Niger IBANs are rejected as "format is invalid."

Reproduced locally (ibandit 1.26.1, Ruby 3.4.3) with a synthetic example IBAN:

```ruby
Ibandit.structures["NE"].slice(:total_length, :bank_code_length, :account_number_length)
# => { total_length: 28, bank_code_length: 5, account_number_length: 19 }
Ibandit.structures[:NE] # => nil # symbol lookup only

iban = Ibandit::IBAN.new("NE08NE0001234567890123456789")
iban.valid?               # => false
iban.errors               # => { bank_code: "format is invalid", account_number: "format is invalid" }
iban.valid_country_code?  # => true
iban.valid_length?        # => true
iban.valid_check_digits?  # => true
iban.valid_characters?    # => true
```

## Fix

Replace the Ibandit `valid?` delegation with an explicit structure regex (same XOF/BCEAO shape as Côte d'Ivoire — `NE` + 2 check digits + 5-char bank code + 19-digit account number = 28 chars) plus Ibandit's still-working country-code / check-digit / length / character checks. Mirrors `CoteDIvoireBankAccount` for the missing per-field format regexes.

## Test plan / verification

- Added 7 validation specs to `spec/models/niger_bank_account_spec.rb` using a **synthetic** structurally-valid NE IBAN (`NE08NE0001234567890123456789`): valid 28-char IBAN, valid spaced+lowercase IBAN, and rejection of bad check digits / wrong country code / too-short / non-digit-in-account / blank. No real seller account number is committed.
- `bundle exec rspec spec/models/niger_bank_account_spec.rb` → **12 examples, 0 failures** locally. The 7 new validation tests fail on the old broken delegation (RED→GREEN).
- `bin/test-confidence` → **99% confidence, 5 tests passed** locally.
- **autoreview (Codex/gpt-5.5): clean** — no accepted/actionable findings.

## Tracking

Resolves the payout-path block reported in the internal tracker (gumroad-private#792). Same direct manual-regex approach as the **Côte d'Ivoire** fix (#471) and related to the broader Ibandit bundled-data gap family as **Sweden** (#775), though Niger does not use the shared `IbanBankAccount` SEPA concern. Worth a follow-up audit of the other XOF/BCEAO countries (Benin, Gabon, etc.) for the same latent bug.

---
Opened as a **draft** for engineer review/merge. Filed by Gumclaw.
