### PR TITLE
Store reassignment lock in a side table instead of a purchases column

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -120,6 +120,7 @@ class Purchase < ApplicationRecord
   has_one :purchasing_power_parity_info, dependent: :destroy
   has_one :upsell_purchase, dependent: :destroy
   has_one :purchase_refund_policy, dependent: :destroy
+  has_one :purchase_reassignment_lock, dependent: :destroy
   has_one :order_purchase, dependent: :destroy
   has_one :order, through: :order_purchase, dependent: :destroy
   has_one :charge_purchase, dependent: :destroy

--- a/app/models/purchase_reassignment_lock.rb
+++ b/app/models/purchase_reassignment_lock.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Marks a purchase as under review so Purchase::ReassignByEmailService refuses to
+# move it between accounts. Lives in its own table rather than as a column on the
+# (too-large-to-alter) purchases table; a row's presence is the lock.
+class PurchaseReassignmentLock < ApplicationRecord
+  belongs_to :purchase
+
+  validates :purchase, uniqueness: true
+end

--- a/app/services/onetime/backfill_purchase_reassignment_locks.rb
+++ b/app/services/onetime/backfill_purchase_reassignment_locks.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Onetime
+  # Migrates legacy reassignment locks that were stored on the now-removed
+  # `purchases.reassignment_locked_at` column into the `purchase_reassignment_locks`
+  # table that Purchase::ReassignByEmailService now reads.
+  #
+  # Run this manually during rollout in any environment where the original
+  # AddReassignmentLockedAtToPurchases migration actually added the column before it
+  # was reduced to a no-op. Where the column was never added (e.g. the production
+  # deploy that stalled on the ALTER), this is a no-op — the early return skips the
+  # scan entirely. Idempotent and safe to re-run.
+  #
+  #   Onetime::BackfillPurchaseReassignmentLocks.process
+  class BackfillPurchaseReassignmentLocks
+    BATCH_SIZE = 1_000
+    LEGACY_COLUMN = "reassignment_locked_at"
+
+    def self.process(batch_size: BATCH_SIZE)
+      new.process(batch_size:)
+    end
+
+    def process(batch_size: BATCH_SIZE)
+      unless Purchase.column_names.include?(LEGACY_COLUMN)
+        puts "#{LEGACY_COLUMN} column not present; nothing to backfill."
+        return
+      end
+
+      migrated = 0
+      Purchase.where.not(LEGACY_COLUMN => nil).in_batches(of: batch_size) do |batch|
+        ReplicaLagWatcher.watch
+        ids = batch.ids
+        already_locked = PurchaseReassignmentLock.where(purchase_id: ids).pluck(:purchase_id)
+        new_ids = ids - already_locked
+        next if new_ids.empty?
+
+        now = Time.current
+        PurchaseReassignmentLock.insert_all(new_ids.map { |purchase_id| { purchase_id:, created_at: now, updated_at: now } })
+        migrated += new_ids.size
+        puts "Backfilled #{new_ids.size} locks (running total: #{migrated})"
+      end
+
+      puts "Done. Backfilled #{migrated} purchase reassignment locks."
+    end
+  end
+end

--- a/app/services/purchase/reassign_by_email_service.rb
+++ b/app/services/purchase/reassign_by_email_service.rb
@@ -48,7 +48,7 @@ class Purchase::ReassignByEmailService
       end
     end
 
-    if mutable_purchases.any? { |purchase| purchase.reassignment_locked_at.present? }
+    if reassignment_locked?(mutable_purchases)
       return Result.new(success: false, reassigned_purchase_ids: [], reason: :locked, error_message: "One or more purchases are under review and cannot be reassigned")
     end
 
@@ -92,6 +92,19 @@ class Purchase::ReassignByEmailService
   end
 
   private
+    # A purchase is locked if it has a row in purchase_reassignment_locks. While the
+    # legacy purchases.reassignment_locked_at column is still being retired (removed
+    # from the schema, dropped out-of-band), also honor a lock left on that column so
+    # an already-locked purchase can't slip through before the data is moved over by
+    # Onetime::BackfillPurchaseReassignmentLocks. has_attribute? makes the legacy
+    # check a no-op wherever the column never existed, and it self-removes once the
+    # column is gone.
+    def reassignment_locked?(purchases)
+      return true if PurchaseReassignmentLock.where(purchase_id: purchases.map(&:id)).exists?
+
+      purchases.any? { |purchase| purchase.has_attribute?(:reassignment_locked_at) && purchase[:reassignment_locked_at].present? }
+    end
+
     # Returns a normalized, distinct payment-method signal for a purchase.
     # Card purchases collapse to the card's last 4 digits; non-card processors
     # (e.g. PayPal) store an email or other token in card_visual, so fall back to

--- a/db/migrate/20261201000006_add_reassignment_locked_at_to_purchases.rb
+++ b/db/migrate/20261201000006_add_reassignment_locked_at_to_purchases.rb
@@ -1,7 +1,30 @@
 # frozen_string_literal: true
 
+# Intentionally a no-op.
+#
+# This originally added a `reassignment_locked_at` column to `purchases`. That
+# table is far too large for a deploy-time `ALTER TABLE`: db:migrate runs on the
+# critical path of every production deploy (gr_deploy -> wait_for_db_migrate
+# blocks until it finishes), and a plain ALTER on `purchases` either stalls
+# behind the table's metadata lock or falls back to a full-table rebuild,
+# hanging the deploy and risking a query pileup on a table written by every sale.
+#
+# The reassignment lock now lives in its own `purchase_reassignment_locks` table
+# (see CreatePurchaseReassignmentLocks / PurchaseReassignmentLock), per the rule
+# that the `users` and `purchases` tables must not take schema changes. This
+# migration stays so the version records cleanly across environments; it
+# performs no work.
+#
+# If an earlier deploy already added the column in some environment, the
+# reassignment guard keeps honoring locks stored on it (Purchase::ReassignByEmailService
+# dual-reads during the transition), so nothing slips through. Run
+# Onetime::BackfillPurchaseReassignmentLocks to move those locks into the new
+# table; afterward the column is a harmless unused nullable column that can be
+# dropped out-of-band — never via a deploy-time migration.
 class AddReassignmentLockedAtToPurchases < ActiveRecord::Migration[7.1]
-  def change
-    add_column :purchases, :reassignment_locked_at, :datetime
+  def up
+  end
+
+  def down
   end
 end

--- a/db/migrate/20261201000007_create_purchase_reassignment_locks.rb
+++ b/db/migrate/20261201000007_create_purchase_reassignment_locks.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class CreatePurchaseReassignmentLocks < ActiveRecord::Migration[7.1]
+  def change
+    create_table :purchase_reassignment_locks do |t|
+      t.references :purchase, index: { unique: true }, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_12_01_000006) do
+ActiveRecord::Schema[7.1].define(version: 2026_12_01_000007) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -1777,6 +1777,13 @@ ActiveRecord::Schema[7.1].define(version: 2026_12_01_000006) do
     t.index ["purchase_id"], name: "index_purchase_offer_code_discounts_on_purchase_id", unique: true
   end
 
+  create_table "purchase_reassignment_locks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "purchase_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["purchase_id"], name: "index_purchase_reassignment_locks_on_purchase_id", unique: true
+  end
+
   create_table "purchase_refund_policies", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "purchase_id", null: false
     t.string "title", null: false
@@ -1902,7 +1909,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_12_01_000006) do
     t.bigint "price_id"
     t.string "recommended_by"
     t.datetime "deleted_at", precision: nil
-    t.datetime "reassignment_locked_at"
     t.index ["affiliate_id", "created_at"], name: "index_purchases_on_affiliate_id_and_created_at"
     t.index ["browser_guid"], name: "index_purchases_on_browser_guid"
     t.index ["card_type", "card_visual", "created_at", "stripe_fingerprint"], name: "index_purchases_on_card_type_visual_date_fingerprint"

--- a/spec/models/purchase_reassignment_lock_spec.rb
+++ b/spec/models/purchase_reassignment_lock_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe PurchaseReassignmentLock do
+  describe "associations" do
+    it "belongs to a purchase" do
+      lock = build(:purchase_reassignment_lock)
+      expect(lock.purchase).to be_present
+    end
+  end
+
+  describe "validations" do
+    it "requires a purchase" do
+      lock = build(:purchase_reassignment_lock, purchase: nil)
+      expect(lock).not_to be_valid
+      expect(lock.errors).to include(:purchase)
+    end
+
+    it "allows only one lock per purchase" do
+      purchase = create(:free_purchase)
+      create(:purchase_reassignment_lock, purchase:)
+
+      duplicate = build(:purchase_reassignment_lock, purchase:)
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors).to include(:purchase)
+    end
+  end
+end

--- a/spec/services/onetime/backfill_purchase_reassignment_locks_spec.rb
+++ b/spec/services/onetime/backfill_purchase_reassignment_locks_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Onetime::BackfillPurchaseReassignmentLocks do
+  describe ".process" do
+    # In every environment past this change the legacy `reassignment_locked_at`
+    # column is gone (the migration that added it is now a no-op), so the task
+    # must short-circuit rather than query a column that doesn't exist.
+    context "when the legacy reassignment_locked_at column is absent" do
+      it "makes no changes and does not raise" do
+        create(:free_purchase)
+
+        expect { described_class.process }.not_to change(PurchaseReassignmentLock, :count)
+      end
+    end
+  end
+end

--- a/spec/services/purchase/reassign_by_email_service_spec.rb
+++ b/spec/services/purchase/reassign_by_email_service_spec.rb
@@ -132,7 +132,8 @@ describe Purchase::ReassignByEmailService do
 
       it "preloads subscriptions and original purchases before the guard checks recurring charges" do
         subscription = create(:subscription, user: buyer)
-        original_purchase = create(:purchase, email: "old_original@example.com", purchaser: buyer, is_original_subscription_purchase: true, subscription:, merchant_account:, reassignment_locked_at: Time.current)
+        original_purchase = create(:purchase, email: "old_original@example.com", purchaser: buyer, is_original_subscription_purchase: true, subscription:, merchant_account:)
+        create(:purchase_reassignment_lock, purchase: original_purchase)
         3.times { create(:purchase, email: from_email, purchaser: buyer, subscription:, merchant_account:) }
 
         subscription_selects = []
@@ -231,7 +232,11 @@ describe Purchase::ReassignByEmailService do
     context "when a matched purchase is reassignment-locked" do
       let!(:target_user) { create(:user, email: to_email) }
       let!(:unlocked_purchase) { create(:purchase, email: from_email, purchaser: buyer, merchant_account:) }
-      let!(:locked_purchase) { create(:purchase, email: from_email, purchaser: buyer, merchant_account:, reassignment_locked_at: Time.current) }
+      let!(:locked_purchase) do
+        create(:purchase, email: from_email, purchaser: buyer, merchant_account:).tap do |purchase|
+          create(:purchase_reassignment_lock, purchase:)
+        end
+      end
 
       it "refuses the whole batch without mutating any purchase" do
         expect(CustomerMailer).not_to receive(:grouped_receipt)
@@ -355,7 +360,8 @@ describe Purchase::ReassignByEmailService do
 
       it "refuses the batch because a mutable purchase is locked" do
         subscription = create(:subscription, user: buyer)
-        original_purchase = create(:purchase, email: "old_original@example.com", purchaser: buyer, is_original_subscription_purchase: true, subscription:, merchant_account:, reassignment_locked_at: Time.current)
+        original_purchase = create(:purchase, email: "old_original@example.com", purchaser: buyer, is_original_subscription_purchase: true, subscription:, merchant_account:)
+        create(:purchase_reassignment_lock, purchase: original_purchase)
         recurring = create(:purchase, email: from_email, purchaser: buyer, subscription:, merchant_account:)
 
         result = described_class.new(from_email:, to_email:).perform

--- a/spec/support/factories/purchase_reassignment_locks.rb
+++ b/spec/support/factories/purchase_reassignment_locks.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :purchase_reassignment_lock do
+    purchase
+  end
+end


### PR DESCRIPTION
Follow-up to #5625

## What

Moves the purchase "reassignment lock" — the flag that blocks a purchase from being reassigned between accounts while it's under fraud review — off a new column on the `purchases` table and into a dedicated `purchase_reassignment_locks` table. The migration that added the column is reduced to a no-op, and the reassignment guard now reads the new table.

## Why

`purchases` is one of our largest tables, and `db:migrate` runs on the critical path of every production deploy. Adding a column there is a plain `ALTER TABLE` that stalls the deploy — it waits on the table's lock and can fall back to a full-table rebuild. That's exactly what happened: the deploy shipping #5625 hung on this migration. Our standing rule is that `users`/`purchases` don't take schema changes, so the lock belongs in its own table.

To make the switch safe to roll out, the guard still honors a lock left on the old column wherever it already exists — a query-free check (it reuses the already-loaded purchase rows) that becomes a no-op once the column is gone. This means a previously-locked purchase can't slip through before `Onetime::BackfillPurchaseReassignmentLocks` copies the old locks into the new table. After the backfill, the orphaned column can be dropped out-of-band (never via a deploy migration).

## Test Results

`bin/test-confidence` reached 99% (safe to commit). The new model, service, and onetime specs pass, along with the reassignment service spec, `purchase_spec`, and factory linting. _(Attach screenshot of the local run.)_

---

This PR was implemented with AI assistance using Claude Opus 4.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785445507&installation_id=134400930&pr_number=5628&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5628&signature=f5185e1d66524678e83f22b655ea1b5a3db4d6f621ccf2b05af2b33619d77e9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->