### PR TITLE
Use a flag for the purchase reassignment lock

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -570,6 +570,10 @@ class Purchase < ApplicationRecord
             29 => :is_commission_deposit_purchase,
             30 => :is_commission_completion_purchase,
             31 => :is_installment_payment,
+            # Temporary, per-purchase lock set by Trust & Safety during fraud review;
+            # blocks Purchase::ReassignByEmailService from moving the purchase between
+            # accounts. Not a buyer-level block (see is_buyer_blocked_by_admin).
+            32 => :is_reassignment_locked,
             :column => "flags",
             :flag_query_mode => :bit_operator,
             check_for_column: false

--- a/app/services/purchase/reassign_by_email_service.rb
+++ b/app/services/purchase/reassign_by_email_service.rb
@@ -48,7 +48,7 @@ class Purchase::ReassignByEmailService
       end
     end
 
-    if mutable_purchases.any? { |purchase| purchase.reassignment_locked_at.present? }
+    if mutable_purchases.any?(&:is_reassignment_locked?)
       return Result.new(success: false, reassigned_purchase_ids: [], reason: :locked, error_message: "One or more purchases are under review and cannot be reassigned")
     end
 

--- a/db/migrate/20261201000006_add_reassignment_locked_at_to_purchases.rb
+++ b/db/migrate/20261201000006_add_reassignment_locked_at_to_purchases.rb
@@ -1,7 +1,28 @@
 # frozen_string_literal: true
 
+# Intentionally a no-op.
+#
+# This originally added a `reassignment_locked_at` column to `purchases`. That
+# table is far too large for a deploy-time `ALTER TABLE`: db:migrate runs on the
+# critical path of every production deploy, and a plain ALTER on `purchases`
+# stalls behind the table's metadata lock (or falls back to a full rebuild),
+# hanging the deploy — which is what happened on the deploy that shipped this.
+#
+# The reassignment lock is now a FlagShihTzu flag on the existing `purchases.flags`
+# column (Purchase#is_reassignment_locked?), so no schema change is needed. This
+# migration stays as a no-op so the version records cleanly across environments.
+#
+# There is nothing to backfill into the flag: the ALTER was cancelled before it
+# committed in production (verified — the column and this migration version are
+# absent there) and the lock has no automated writer, so no purchase was ever
+# locked via the column. Every row therefore starts correctly unlocked (flag bit
+# defaults to 0). If some other environment did add the column, it is a harmless
+# unused nullable column, to be dropped out-of-band — never via a deploy-time
+# migration.
 class AddReassignmentLockedAtToPurchases < ActiveRecord::Migration[7.1]
-  def change
-    add_column :purchases, :reassignment_locked_at, :datetime
+  def up
+  end
+
+  def down
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1902,7 +1902,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_12_01_000006) do
     t.bigint "price_id"
     t.string "recommended_by"
     t.datetime "deleted_at", precision: nil
-    t.datetime "reassignment_locked_at"
     t.index ["affiliate_id", "created_at"], name: "index_purchases_on_affiliate_id_and_created_at"
     t.index ["browser_guid"], name: "index_purchases_on_browser_guid"
     t.index ["card_type", "card_visual", "created_at", "stripe_fingerprint"], name: "index_purchases_on_card_type_visual_date_fingerprint"

--- a/spec/services/purchase/reassign_by_email_service_spec.rb
+++ b/spec/services/purchase/reassign_by_email_service_spec.rb
@@ -132,7 +132,7 @@ describe Purchase::ReassignByEmailService do
 
       it "preloads subscriptions and original purchases before the guard checks recurring charges" do
         subscription = create(:subscription, user: buyer)
-        original_purchase = create(:purchase, email: "old_original@example.com", purchaser: buyer, is_original_subscription_purchase: true, subscription:, merchant_account:, reassignment_locked_at: Time.current)
+        original_purchase = create(:purchase, email: "old_original@example.com", purchaser: buyer, is_original_subscription_purchase: true, subscription:, merchant_account:, is_reassignment_locked: true)
         3.times { create(:purchase, email: from_email, purchaser: buyer, subscription:, merchant_account:) }
 
         subscription_selects = []
@@ -231,7 +231,7 @@ describe Purchase::ReassignByEmailService do
     context "when a matched purchase is reassignment-locked" do
       let!(:target_user) { create(:user, email: to_email) }
       let!(:unlocked_purchase) { create(:purchase, email: from_email, purchaser: buyer, merchant_account:) }
-      let!(:locked_purchase) { create(:purchase, email: from_email, purchaser: buyer, merchant_account:, reassignment_locked_at: Time.current) }
+      let!(:locked_purchase) { create(:purchase, email: from_email, purchaser: buyer, merchant_account:, is_reassignment_locked: true) }
 
       it "refuses the whole batch without mutating any purchase" do
         expect(CustomerMailer).not_to receive(:grouped_receipt)
@@ -355,7 +355,7 @@ describe Purchase::ReassignByEmailService do
 
       it "refuses the batch because a mutable purchase is locked" do
         subscription = create(:subscription, user: buyer)
-        original_purchase = create(:purchase, email: "old_original@example.com", purchaser: buyer, is_original_subscription_purchase: true, subscription:, merchant_account:, reassignment_locked_at: Time.current)
+        original_purchase = create(:purchase, email: "old_original@example.com", purchaser: buyer, is_original_subscription_purchase: true, subscription:, merchant_account:, is_reassignment_locked: true)
         recurring = create(:purchase, email: from_email, purchaser: buyer, subscription:, merchant_account:)
 
         result = described_class.new(from_email:, to_email:).perform


### PR DESCRIPTION
Follow-up to #5625

## What

Moves the purchase "reassignment lock" — the flag that blocks a purchase from being reassigned between accounts while it's under fraud review — off a new `reassignment_locked_at` column on the `purchases` table and onto an `is_reassignment_locked` boolean flag on the existing `purchases.flags` column. The original column-add migration becomes a no-op, and the reassignment guard now reads the flag in-memory.

## Why

`purchases` is one of our largest tables, and `db:migrate` runs on the critical path of every production deploy. Adding a column there is an `ALTER TABLE` that stalls the deploy — which is exactly what happened to the deploy shipping #5625. Storing the lock as a flag on the existing `flags` column needs no schema change, so there's nothing for the deploy to stall on, and it keeps #5625's fraud guards intact.

A flag fits because the lock is presence-only — the guard just checks whether it's set — and `purchases` already encodes ~31 such booleans this way. A separate side table was considered but rejected: it adds a table, a query on the hot path, and transition machinery for no benefit here. Nothing needs backfilling — the original migration was cancelled before it committed in production (verified: the column and migration version are absent there), and the lock has no automated writer, so no purchase was ever locked via the column.

## Test Results

`bin/test-confidence` reached 99% (safe to commit) — the reassignment service, `purchase`, `blockable`, and `searchable` specs pass. _(Attach a screenshot of the local run.)_

---

This PR was implemented with AI assistance using Claude Opus 4.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785448785&installation_id=134400930&pr_number=5629&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5629&signature=40eb33db34356975612ad47d81a3e65e83c3fa8804a6daf998bf1c869f2131df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->