### PR TITLE
Show proposed changes as a structured confirmation card

### DIFF
--- a/app/javascript/components/Agent/AgentChat.tsx
+++ b/app/javascript/components/Agent/AgentChat.tsx
@@ -111,28 +111,45 @@ const ProposedActionCard = ({
   onConfirm: () => void;
   onDismiss: () => void;
 }) => (
-  <div className="flex flex-col gap-2 rounded-2xl border border-dashed p-4">
-    <strong>Proposed change</strong>
-    <span className="break-words">{action.summary}</span>
-    {status === "applied" ? (
-      <span role="status" className="text-green">
-        Applied
-      </span>
-    ) : status === "dismissed" ? (
-      <span role="status" className="text-muted">
-        Dismissed
-      </span>
-    ) : (
-      <div className="flex gap-2">
-        <Button color="accent" disabled={isPending} onClick={onConfirm}>
-          {isApplying ? "Applying…" : "Confirm"}
-        </Button>
-        <Button disabled={isPending} onClick={onDismiss}>
-          Dismiss
-        </Button>
-      </div>
-    )}
-  </div>
+  // Same solid card treatment as the object cards (Card = rounded border-border + a divider), with the
+  // actions in a divided footer — secondary on the left, primary (Confirm) on the right.
+  <Card>
+    <CardContent className="flex-col items-stretch gap-2">
+      <strong>{action.title ?? "Proposed change"}</strong>
+      {action.fields && action.fields.length > 0 ? (
+        <DefinitionList className="text-sm">
+          {action.fields.map((field) => (
+            <React.Fragment key={field.label}>
+              <dt className="text-muted">{field.label}</dt>
+              <dd className="break-words">{field.value}</dd>
+            </React.Fragment>
+          ))}
+        </DefinitionList>
+      ) : (
+        <span className="break-words">{action.summary}</span>
+      )}
+    </CardContent>
+    <CardContent className="justify-end gap-2">
+      {status === "applied" ? (
+        <span role="status" className="mr-auto text-green">
+          Applied
+        </span>
+      ) : status === "dismissed" ? (
+        <span role="status" className="mr-auto text-muted">
+          Dismissed
+        </span>
+      ) : (
+        <>
+          <Button disabled={isPending} onClick={onDismiss}>
+            Dismiss
+          </Button>
+          <Button color="accent" disabled={isPending} onClick={onConfirm}>
+            {isApplying ? "Applying…" : "Confirm"}
+          </Button>
+        </>
+      )}
+    </CardContent>
+  </Card>
 );
 
 export const AgentChat = ({ greeting, suggestions }: Props) => {
@@ -303,9 +320,9 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
         aria-label="Conversation"
         role="log"
       >
-        {/* mt-auto fills the chat from the bottom (like a messenger): a short conversation sits just
-            above the composer, and the margin collapses once the content is tall enough to scroll. */}
-        <div className="mx-auto mt-auto flex w-full max-w-2xl flex-col gap-4 p-4 md:p-8">
+        {/* Content starts at the top and grows downward; the effect below keeps the newest line in
+            view as the conversation gets long enough to scroll. */}
+        <div className="mx-auto flex w-full max-w-2xl flex-col gap-4 p-4 md:p-8">
           {messages.map((message, index) => {
             const isUser = message.role === "user";
             // A pending proposed change reads as the confirmation card alone — suppress the objects the

--- a/app/javascript/data/agent.ts
+++ b/app/javascript/data/agent.ts
@@ -18,6 +18,11 @@ export type ProposedAction = {
   type: "api_write";
   params: Record<string, unknown>;
   summary: string;
+  // The operation being proposed (e.g. "Delete a discount code."), shown as the card heading.
+  title?: string;
+  // Humanized label/value rows for the confirmation card. Optional so older/streamed payloads without
+  // them still validate; the card falls back to `summary` when absent.
+  fields?: { label: string; value: string }[];
 };
 
 type SendMessageResponse =

--- a/app/services/ai/store_agent_service.rb
+++ b/app/services/ai/store_agent_service.rb
@@ -481,11 +481,11 @@ class Ai::StoreAgentService
       return value.to_json unless value.is_a?(String) || value.is_a?(Numeric) || value == true || value == false
       case key.to_s
       when "price", "amount_cents", "minimum_amount_cents"
-        # Format real numbers (and numeric strings) in the currency's own subunit (JPY has none, so
-        # 1000 -> ¥1,000, not ¥10). A blank value falls through to "(blank)" via the caller rather than
-        # formatting as $0; booleans / unknown currency show raw — so we never imply a wrong amount.
-        formattable = value.is_a?(Numeric) || (value.is_a?(String) && value.strip.present?)
-        currency && formattable ? MoneyFormatter.format(value.to_i, currency, no_cents_if_whole: true) : value.to_s
+        # Format real cents in the currency's own subunit (JPY has none, so 1000 -> ¥1,000, not ¥10).
+        # Anything that isn't a number/digit-string — a blank, a boolean, or a hallucinated "free" —
+        # shows raw (and blanks become "(blank)" via the caller), so the card never coerces a non-amount
+        # into $0 or implies a wrong amount.
+        currency && numeric_cents?(value) ? MoneyFormatter.format(value.to_i, currency, no_cents_if_whole: true) : value.to_s
       else
         # Show the full value — this is the safety boundary, so never truncate what will be applied.
         value.to_s
@@ -494,14 +494,21 @@ class Ai::StoreAgentService
 
     # "20% off" for a percentage code; for a fixed-amount one the value is cents in the target's
     # currency. Non-scalar (untrusted) input is JSON-encoded rather than formatted, so a hallucinated
-    # object can't raise; an unknown currency shows the raw cents rather than a wrong symbol.
+    # object can't raise; a non-numeric or unknown-currency amount shows raw rather than a wrong symbol.
     def discount_amount(amount, offer_type, currency)
       return nil if amount.nil?
       return amount.to_json unless amount.is_a?(String) || amount.is_a?(Numeric)
       return nil if amount.to_s.strip.blank?
       return "#{amount}% off" if offer_type.to_s == "percent"
+      return amount.to_s unless numeric_cents?(amount)
       formatted = currency ? MoneyFormatter.format(amount.to_i, currency, no_cents_if_whole: true) : amount.to_s
       "#{formatted} off" if formatted.present?
+    end
+
+    # A value we can safely render as money: a number, or a string of digits (cents). Anything else
+    # (a blank, a hallucinated "free") is shown raw instead of coercing to $0.
+    def numeric_cents?(value)
+      value.is_a?(Numeric) || (value.is_a?(String) && value.match?(/\A-?\d+\z/))
     end
 
     # The seller's product for the write's path id (external id or permalink), or nil. Names the target

--- a/app/services/ai/store_agent_service.rb
+++ b/app/services/ai/store_agent_service.rb
@@ -101,8 +101,11 @@ class Ai::StoreAgentService
     %<writes>s
   PROMPT
 
-  ProposedAction = Struct.new(:type, :params, :summary, keyword_init: true) do
-    def as_json(*) = { type:, params:, summary: }
+  ProposedAction = Struct.new(:type, :params, :summary, :title, :fields, keyword_init: true) do
+    # `title` names the operation (the endpoint's own summary) so the card always states what will
+    # happen — important for destructive writes. `fields` are humanized detail rows; `summary` is the
+    # one-line fallback the card shows when there are no fields.
+    def as_json(*) = { type:, params:, summary:, title:, fields: fields || [] }
   end
 
   def initialize(seller:, pundit_user:)
@@ -393,6 +396,9 @@ class Ai::StoreAgentService
         # Everything the executor needs to replay the exact same call after the creator confirms.
         params: { "endpoint" => endpoint.id, "path_params" => path_params, "params" => body },
         summary:,
+        # The operation itself (e.g. "Delete a discount code."), shown as the card's heading.
+        title: endpoint.summary,
+        fields: write_fields(endpoint, path_params, body),
       )
       [{ proposed: true, summary: }, action]
     end
@@ -404,6 +410,118 @@ class Ai::StoreAgentService
       detail = path_params.merge(body).map { |k, v| "#{k}: #{v}" }.join(", ")
       parts << "(#{detail})" if detail.present?
       parts.join(" ")
+    end
+
+    # Friendlier labels for a couple of offer-code body keys; everything else is humanized generically.
+    OFFER_CODE_LABELS = { "name" => "Code", "max_purchase_count" => "Max uses" }.freeze
+    # Shown for a body key the model set to blank/null, so a "clear this field" mutation stays visible
+    # rather than silently dropping off the card while still executing.
+    BLANK_VALUE = "(blank)"
+
+    # Humanized label/value rows for the confirmation card. EVERY path param and body key is
+    # represented, so the card never hides a proposed mutation or the record it targets. A few are
+    # rendered nicely — the discount amount + type as one row, cents as currency, and product ids as
+    # names — but nothing is dropped. Values are coerced to strings (non-scalar tool output is
+    # JSON-encoded rather than formatted), so a hallucinated array/object can't raise here.
+    def write_fields(endpoint, path_params, body)
+      body = body.dup
+      offer_code = endpoint.id.include?("offer_code")
+      product = target_product(endpoint, path_params)
+      # Amounts apply in the target resource's currency. Use the product's; for a new product fall back
+      # to the requested or seller currency; leave it unknown elsewhere (e.g. a sale's currency on a
+      # refund) so we never stamp a wrong symbol on the card.
+      # The currency amounts will actually save in. Only product create/update persist a requested
+      # price_currency_type, so only honor it there (a discount/refund ignores it and uses the product
+      # or sale currency); then the existing product's, the seller's for a brand-new product, else
+      # unknown (e.g. a sale on a refund) so we don't stamp a wrong symbol.
+      honors_requested_currency = endpoint.id.in?(%w[create_product update_product])
+      currency = (honors_requested_currency ? requested_currency(body) : nil) ||
+                 product&.price_currency_type ||
+                 (seller.currency_type if endpoint.id == "create_product")
+
+      # Target identity (path params are validated non-blank) — names the record being changed.
+      rows = path_params.filter_map { |key, value| preview_field(path_label(endpoint, key), path_value(endpoint, key, value, product)) }
+
+      # Body keys are intentional mutations, so each gets a row even when blank (a blank renders as
+      # "(blank)") — otherwise a destructive clear like description: "" would execute invisibly. The
+      # discount amount + type collapse into one readable row; both are still represented.
+      if body.key?("amount_off") || body.key?("offer_type")
+        rows << { label: "Discount", value: discount_amount(body.delete("amount_off"), body.delete("offer_type"), currency).presence || BLANK_VALUE }
+      end
+      body.each { |key, value| rows << { label: field_label(key, offer_code:), value: display_value(key, value, currency).presence || BLANK_VALUE } }
+      rows << { label: "Max uses", value: "Unlimited" } if endpoint.id == "create_offer_code" && !body.key?("max_purchase_count")
+
+      rows
+    end
+
+    def path_label(endpoint, key)
+      return "Applies to" if key.to_s == "link_id"
+      return "Product" if key.to_s == "id" && endpoint.id.include?("product")
+      return "Discount code" if key.to_s == "id" && endpoint.id.include?("offer_code")
+      key.to_s.humanize
+    end
+
+    # A path id displays as "name (id)" when it points at a resolvable product — the name for the
+    # seller to recognize, the raw id (which is what's replayed) so a destructive write still names the
+    # exact record even when two products share a name. Otherwise it's just the id.
+    def path_value(endpoint, key, value, product)
+      points_at_product = key.to_s == "link_id" || (key.to_s == "id" && endpoint.id.include?("product"))
+      name = product&.name if points_at_product
+      name.present? ? "#{name} (#{value})" : display_value(key, value)
+    end
+
+    def field_label(key, offer_code:)
+      (offer_code && OFFER_CODE_LABELS[key.to_s]) || key.to_s.humanize
+    end
+
+    # Cents keys -> currency when known (else the raw integer, so we never imply the wrong currency);
+    # description -> truncated; non-scalar (untrusted) -> JSON; else a string.
+    def display_value(key, value, currency = nil)
+      return nil if value.nil?
+      return value.to_json unless value.is_a?(String) || value.is_a?(Numeric) || value == true || value == false
+      case key.to_s
+      when "price", "amount_cents", "minimum_amount_cents"
+        # Format real numbers (and numeric strings) in the currency's own subunit (JPY has none, so
+        # 1000 -> ¥1,000, not ¥10). A blank value falls through to "(blank)" via the caller rather than
+        # formatting as $0; booleans / unknown currency show raw — so we never imply a wrong amount.
+        formattable = value.is_a?(Numeric) || (value.is_a?(String) && value.strip.present?)
+        currency && formattable ? MoneyFormatter.format(value.to_i, currency, no_cents_if_whole: true) : value.to_s
+      else
+        # Show the full value — this is the safety boundary, so never truncate what will be applied.
+        value.to_s
+      end
+    end
+
+    # "20% off" for a percentage code; for a fixed-amount one the value is cents in the target's
+    # currency. Non-scalar (untrusted) input is JSON-encoded rather than formatted, so a hallucinated
+    # object can't raise; an unknown currency shows the raw cents rather than a wrong symbol.
+    def discount_amount(amount, offer_type, currency)
+      return nil if amount.nil?
+      return amount.to_json unless amount.is_a?(String) || amount.is_a?(Numeric)
+      return nil if amount.to_s.strip.blank?
+      return "#{amount}% off" if offer_type.to_s == "percent"
+      formatted = currency ? MoneyFormatter.format(amount.to_i, currency, no_cents_if_whole: true) : amount.to_s
+      "#{formatted} off" if formatted.present?
+    end
+
+    # The seller's product for the write's path id (external id or permalink), or nil. Names the target
+    # and supplies the currency the confirmed amounts will use. One cheap lookup, only when proposing.
+    def target_product(endpoint, path_params)
+      external_id = path_params["link_id"] || (endpoint.id.include?("product") ? path_params["id"] : nil)
+      return nil if external_id.to_s.strip.blank?
+      seller.links.find_by_external_id(external_id) || seller.links.find_by(unique_permalink: external_id)
+    end
+
+    # A valid currency this write itself sets (product writes accept price_currency_type), or nil.
+    # Guards an invalid/untrusted value from reaching the formatter.
+    def requested_currency(body)
+      requested = body["price_currency_type"].to_s.downcase.presence
+      requested if CURRENCY_CHOICES.key?(requested)
+    end
+
+    def preview_field(label, value)
+      stringified = value.to_s.strip
+      { label:, value: stringified } if stringified.present?
     end
 
     # Tool-call inputs are supposed to be JSON objects; a hallucinating model can emit an array or

--- a/spec/services/ai/store_agent_service_spec.rb
+++ b/spec/services/ai/store_agent_service_spec.rb
@@ -195,6 +195,97 @@ describe Ai::StoreAgentService do
           ),
         )
         expect(result[:proposed_action][:summary]).to be_present
+        expect(result[:proposed_action][:fields]).to include(
+          { label: "Code", value: "LAUNCH" },
+          { label: "Discount", value: "20% off" },
+        )
+      end
+
+      it "builds preview fields from untrusted tool values without raising on a non-scalar" do
+        allow(client).to receive(:messages).and_return(
+          tool_result("api_write", {
+                        "endpoint" => "update_product",
+                        "path_params" => { "id" => "prod_1" },
+                        "params" => { "price" => { "unexpected" => "object" } },
+                      }),
+          text_result("Prepared the change."),
+        )
+
+        result = nil
+        expect { result = service.respond(messages: [{ role: "user", content: "update it" }]) }.not_to raise_error
+        # The malformed value is shown (JSON-encoded), never dropped or crashed on.
+        expect(result[:proposed_action][:fields]).to include({ label: "Price", value: "{\"unexpected\":\"object\"}" })
+      end
+
+      it "shows a long field value in full rather than truncating what will be applied" do
+        long_description = "a" * 200
+        allow(client).to receive(:messages).and_return(
+          tool_result("api_write", {
+                        "endpoint" => "update_product",
+                        "path_params" => { "id" => "prod_1" },
+                        "params" => { "description" => long_description },
+                      }),
+          text_result("Prepared."),
+        )
+
+        result = service.respond(messages: [{ role: "user", content: "update the description" }])
+        expect(result[:proposed_action][:fields]).to include({ label: "Description", value: long_description })
+      end
+
+      it "previews a blank money value as (blank), not $0" do
+        allow(client).to receive(:messages).and_return(
+          tool_result("api_write", {
+                        "endpoint" => "create_product",
+                        "path_params" => {},
+                        "params" => { "name" => "P", "price" => "" },
+                      }),
+          text_result("Prepared."),
+        )
+
+        result = service.respond(messages: [{ role: "user", content: "make a product with no price yet" }])
+        expect(result[:proposed_action][:fields]).to include({ label: "Price", value: "(blank)" })
+      end
+
+      it "does not crash when a money param is a boolean" do
+        allow(client).to receive(:messages).and_return(
+          tool_result("api_write", {
+                        "endpoint" => "create_product",
+                        "path_params" => {},
+                        "params" => { "name" => "P", "price" => true },
+                      }),
+          text_result("Prepared."),
+        )
+
+        result = nil
+        expect { result = service.respond(messages: [{ role: "user", content: "make a product" }]) }.not_to raise_error
+        expect(result[:proposed_action][:fields]).to include({ label: "Price", value: "true" })
+      end
+
+      it "does not crash formatting a fixed discount whose amount is a non-scalar" do
+        allow(client).to receive(:messages).and_return(
+          tool_result("api_write", {
+                        "endpoint" => "create_offer_code",
+                        "path_params" => { "link_id" => "prod_1" },
+                        "params" => { "name" => "X", "amount_off" => { "unexpected" => "object" } },
+                      }),
+          text_result("Prepared."),
+        )
+
+        expect { service.respond(messages: [{ role: "user", content: "make a code" }]) }.not_to raise_error
+      end
+
+      it "keeps a body field the model set to blank visible (so a clear isn't hidden)" do
+        allow(client).to receive(:messages).and_return(
+          tool_result("api_write", {
+                        "endpoint" => "update_product",
+                        "path_params" => { "id" => "prod_1" },
+                        "params" => { "description" => "" },
+                      }),
+          text_result("Prepared."),
+        )
+
+        result = service.respond(messages: [{ role: "user", content: "clear the description" }])
+        expect(result[:proposed_action][:fields]).to include({ label: "Description", value: "(blank)" })
       end
 
       it "rejects a READ endpoint sent to api_write (nudges to api_read)" do

--- a/spec/services/ai/store_agent_service_spec.rb
+++ b/spec/services/ai/store_agent_service_spec.rb
@@ -246,6 +246,20 @@ describe Ai::StoreAgentService do
         expect(result[:proposed_action][:fields]).to include({ label: "Price", value: "(blank)" })
       end
 
+      it "shows a non-numeric money value raw instead of coercing it to $0" do
+        allow(client).to receive(:messages).and_return(
+          tool_result("api_write", {
+                        "endpoint" => "create_product",
+                        "path_params" => {},
+                        "params" => { "name" => "P", "price" => "free" },
+                      }),
+          text_result("Prepared."),
+        )
+
+        result = service.respond(messages: [{ role: "user", content: "make it free" }])
+        expect(result[:proposed_action][:fields]).to include({ label: "Price", value: "free" })
+      end
+
       it "does not crash when a money param is a boolean" do
         allow(client).to receive(:messages).and_return(
           tool_result("api_write", {


### PR DESCRIPTION
Follow-up to #5591 (conversational Agent dashboard tab).

## What

When the store Agent proposes a change, it now renders as a **structured confirmation card** instead of a raw summary line:

- The operation is the heading (e.g. "Update a product's fields"), followed by humanized rows: the target product (named, with its id), the discount as one "20% off" / "$5 off" row, and money in the resource's own currency.
- Reuses the shared `Card` (solid border, divided footer) with the actions right-aligned — secondary on the left, primary **Confirm** on the right.

Because this card is the safety boundary before an LLM-proposed write executes, it never hides or misstates what will be applied: every supplied field is shown (blanks as `(blank)` so a clear is visible, long values in full), amounts use the currency the write actually persists and respect single-unit currencies like JPY, and untrusted tool values are coerced (non-scalars JSON-encoded) so a malformed payload can't crash the preview. The card is display-only — the payload the executor replays is unchanged, and the chat falls back to the plain summary when structured fields are absent.

Also: the conversation now starts at the top instead of being pinned to the bottom.

## Why

The previous card dumped the endpoint description plus raw params (`Update a product's fields (id: Xq94…, price: 1900)`) — hard to read and easy to misread right before confirming a real store mutation. A labeled, complete preview lets the seller see exactly what will change. Formatting stops at *display*: the confirmed request is byte-for-byte the same, so the card can't widen what the agent is allowed to do.

---

This PR was implemented with AI assistance using Claude Opus 4.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785449249&installation_id=134400930&pr_number=5630&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5630&signature=6cbe4cf3060cd39c5ad5bf6d82afc128c2c88c2a366cb88693ab66389844891c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->