### PR TITLE
Fix two dark-mode gaps in marketing pages (follow-up to #5634)

### DIFF
--- a/app/views/home/about.html.erb
+++ b/app/views/home/about.html.erb
@@ -15,7 +15,7 @@
               type="text"
               name="query"
               placeholder="Search marketplace ..."
-              class="!bg-gray mr-8 rounded focus:outline-hidden focus:ring-2 focus:ring-accent focus:border-accent w-full! sm:w-64 text-xl! h-14! lg:h-16! border !border-dark-gray dark:!bg-dark-gray dark:!laceholder-white dark:border-gray-600 dark:text-white! font-[inherit]"
+              class="!bg-gray mr-8 rounded focus:outline-hidden focus:ring-2 focus:ring-accent focus:border-accent w-full! sm:w-64 text-xl! h-14! lg:h-16! border !border-dark-gray dark:!bg-dark-gray dark:!placeholder-white dark:border-gray-600 dark:text-white! font-[inherit]"
               style="padding-left: 2rem; padding-right: 5rem;"
             />
             <button

--- a/app/views/home/shared/_how_we_build.html.erb
+++ b/app/views/home/shared/_how_we_build.html.erb
@@ -4,7 +4,7 @@
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-10 gap-y-16 md:gap-y-20">
     <% cards.each do |card| %>
       <div class="relative">
-        <div class="absolute -top-8 sm:-top-10 left-6 w-16 h-16 sm:w-20 sm:h-20 rounded-xl flex items-center justify-center border-2 border-black bg-<%= card[:icon_bg] %> shadow-[4px_4px_0_0_#000]">
+        <div class="absolute -top-8 sm:-top-10 left-6 w-16 h-16 sm:w-20 sm:h-20 rounded-xl flex items-center justify-center border-2 border-black dark:border-white/35 bg-<%= card[:icon_bg] %> shadow-[4px_4px_0_0_#000] dark:shadow-[4px_4px_0_0_rgba(255,255,255,0.35)]">
           <%= image_tag card[:icon], alt: card[:title], class: "w-12 h-12" %>
         </div>
         <div class="bg-white dark:bg-dark-gray text-black dark:text-white rounded-2xl p-8 pt-12 sm:pt-14 h-full">


### PR DESCRIPTION
## What

Two dark-mode rendering fixes on the marketing pages, following up on #5634:

- **about.html.erb** — the marketplace search input had a misspelled Tailwind class `dark:!laceholder-white` (missing the `p`), which silently did nothing and left the placeholder text at the browser default color against the dark input surface. Corrected to `dark:!placeholder-white`.
- **_how_we_build.html.erb** — the floating icon badge above each card kept a hardcoded black `shadow-[4px_4px_0_0_#000]` and `border-black`, both of which become invisible against the newly-dark card surface in dark mode. Added `dark:border-white/35` and `dark:shadow-[4px_4px_0_0_rgba(255,255,255,0.35)]`, matching the convention already used in `_discovery_category.html.erb`.

## Why

These two gaps shipped with #5634. Both are visible-only-in-dark-mode defects: a placeholder that's hard to read and an icon badge whose outline/shadow disappears. No logic, data, or auth paths are touched — purely additive `dark:` styling.

## Test plan

- Both touched ERB templates pass `ERB.new(...).src` syntax check.
- Changes are additive `dark:` Tailwind variants only; light mode is unaffected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785466727&installation_id=134400930&pr_number=5636&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5636&signature=bb0b7811843682696d102cb2ab0791483554b582aa29c25ffdecf085d03559ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->