### PR TITLE
Fix embedded review cards erroring when product reviews are disabled

### DIFF
--- a/app/controllers/product_reviews_controller.rb
+++ b/app/controllers/product_reviews_controller.rb
@@ -35,9 +35,6 @@ class ProductReviewsController < ApplicationController
       .includes(:response, purchase: :purchaser, link: :user)
       .find_by_external_id!(permitted_params[:id])
 
-    product = review.link
-    return head :forbidden unless product.display_product_reviews || current_seller == product.user
-
     render json: {
       review: ProductReviewPresenter.new(review).product_review_props
     }

--- a/app/javascript/components/TiptapExtensions/ReviewCard.tsx
+++ b/app/javascript/components/TiptapExtensions/ReviewCard.tsx
@@ -8,7 +8,6 @@ import { assertResponseError } from "$app/utils/request";
 
 import { useCurrentSeller } from "$app/components/CurrentSeller";
 import { Review } from "$app/components/Review";
-import { showAlert } from "$app/components/server-components/Alert";
 import { Skeleton } from "$app/components/Skeleton";
 import { createInsertCommand } from "$app/components/TiptapExtensions/utils";
 
@@ -59,6 +58,7 @@ export const ReviewCard = Node.create({
 const ReviewCardNodeView = ({ node, selected, editor }: NodeViewProps) => {
   const reviewId = typia.assert<string>(node.attrs.reviewId ?? "");
   const [review, setReview] = React.useState<ReviewType | null>(null);
+  const [failedToLoad, setFailedToLoad] = React.useState(false);
   const isEditable = editor.isEditable;
   const seller = useCurrentSeller();
 
@@ -69,7 +69,7 @@ const ReviewCardNodeView = ({ node, selected, editor }: NodeViewProps) => {
         setReview(review);
       } catch (error) {
         assertResponseError(error);
-        showAlert(error.message, "error");
+        setFailedToLoad(true);
       }
     };
 
@@ -103,7 +103,7 @@ const ReviewCardNodeView = ({ node, selected, editor }: NodeViewProps) => {
             hideResponse
           />
         </article>
-      ) : (
+      ) : failedToLoad ? null : (
         <Skeleton className="h-32" />
       )}
     </NodeViewWrapper>

--- a/spec/controllers/product_reviews_controller_spec.rb
+++ b/spec/controllers/product_reviews_controller_spec.rb
@@ -320,17 +320,22 @@ describe ProductReviewsController do
       end
     end
 
-    context "when product reviews are hidden" do
+    context "when the product page reviews section is disabled" do
       before { product.update!(display_product_reviews: false) }
 
-      it "returns forbidden" do
+      it "still returns the review so creator-embedded testimonial cards render" do
         get :show, params: { id: review.external_id }
-        expect(response).to have_http_status(:forbidden)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["review"].deep_symbolize_keys).to eq(
+          ProductReviewPresenter.new(review).product_review_props
+        )
       end
 
-      it "allows product owner to view the review" do
+      it "returns the review for the product owner" do
         sign_in product.user
         get :show, params: { id: review.external_id }
+
         expect(response).to be_successful
       end
     end


### PR DESCRIPTION
## What

Content pages that embed `reviewCard` testimonials showed a red "Something went wrong." error toast for entitled buyers whenever the underlying product had its reviews section turned off. The page shell and other content rendered fine — only the embedded review blocks failed.

## Why

Each embedded `reviewCard` fetches `GET /product_reviews/:id` when it renders. `ProductReviewsController#show` returned **403 Forbidden** unless the product had `display_product_reviews` enabled (or the viewer was the seller). But `#show` is only ever called by embedded review cards, so gating it on the **public product-page** reviews toggle blocked testimonials the creator deliberately embedded into their content. `ReviewCard` then escalated each failed fetch into a page-level error toast — the generic `ResponseError` message is literally "Something went wrong."

Two changes:

- **`ProductReviewsController#show`** — drop the `display_product_reviews` gate. The query stays scoped to `.alive.visible_on_product_page` and is fetched by an unguessable external id, and the response uses the same public `ProductReviewPresenter` already used on product pages. So a review the creator embedded is viewable by anyone who can already see the content embedding it. Since `#show` serves only embedded cards, this gate was the bug (its previous 403 behavior was updated in the spec accordingly).
- **`ReviewCard`** — degrade gracefully when a review can't load: collapse the card instead of firing an error toast (and stop spinning a perpetual skeleton).

Fixes antiwork/gumroad-private#804

---

**AI disclosure:** Implemented with Claude Opus 4.8 via Claude Code.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5637"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785501454&installation_id=134400930&pr_number=5637&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5637&signature=5ef77038ada9e0168feceffa243840a9bb44e36f12f35d853e1a5e8fdaacc785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->