### PR TITLE
Don't auto-pause seller payouts on card-testing bursts; notify #risk instead

### DIFF
--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -237,6 +237,17 @@ module Purchase::Blockable
         # post to the #risk room (relayed to Telegram) for a human/agent to review, and leave
         # payouts untouched. A genuine self-funding seller is caught by the risk-queue review
         # flow (per-card buyer spread + seller-IP intersection), not by this blunt volume trip.
+        #
+        # Dedup guard: this runs on EVERY failed purchase, so once the cumulative volume crosses
+        # the threshold every subsequent failure in the same window would re-fire. Skip if we've
+        # already flagged this seller within the watch window — one comment + one #risk post per
+        # burst, not one per failed charge.
+        return if seller.comments.where(
+          comment_type: Comment::COMMENT_TYPE_ON_PROBATION,
+          author_name: User::SYSTEM_PAYOUT_PAUSE_COMMENT_AUTHORS[:recent_failed_purchases],
+          created_at: failed_seller_purchases_watch_minutes.minutes.ago..
+        ).exists?
+
         failed_price_amount = MoneyFormatter.format(failed_price_cents, :usd, no_cents_if_whole: true, symbol: true)
 
         seller.comments.create(

--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -230,13 +230,25 @@ module Purchase::Blockable
 
       failed_price_cents = failed_seller_purchases.sum(:price_cents)
       if failed_price_cents > max_seller_failed_purchases_price_cents
-        seller.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_SYSTEM)
-
+        # NOTE (2026-07-01, Sahil): do NOT pause the seller's payouts here. A failed-purchase
+        # burst is almost always an EXTERNAL card-tester spraying stolen cards at a popular
+        # checkout — the seller is the VICTIM, and freezing their money is a terrible UX that
+        # punishes the wrong party. Keep the detection, but make it purely INFORMATIONAL:
+        # post to the #risk room (relayed to Telegram) for a human/agent to review, and leave
+        # payouts untouched. A genuine self-funding seller is caught by the risk-queue review
+        # flow (per-card buyer spread + seller-IP intersection), not by this blunt volume trip.
         failed_price_amount = MoneyFormatter.format(failed_price_cents, :usd, no_cents_if_whole: true, symbol: true)
+
         seller.comments.create(
-          content: "Payouts paused due to high volume of failed purchases (#{failed_price_amount} USD in #{failed_seller_purchases_watch_minutes} minutes).",
+          content: "High volume of failed purchases (#{failed_price_amount} USD in #{failed_seller_purchases_watch_minutes} minutes) — flagged for review (payouts NOT paused).",
           comment_type: Comment::COMMENT_TYPE_ON_PROBATION,
           author_name: User::SYSTEM_PAYOUT_PAUSE_COMMENT_AUTHORS[:recent_failed_purchases]
+        )
+
+        InternalNotificationWorker.perform_async(
+          "risk",
+          "Card-testing watch",
+          "Seller #{seller.username || seller.external_id} (#{seller.email}) had #{failed_price_amount} in failed purchases in #{failed_seller_purchases_watch_minutes} minutes. Payouts were NOT paused — review for genuine self-funding vs. an external card-testing spray. Admin: #{seller.external_id}"
         )
       end
     end

--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -206,7 +206,7 @@ module Purchase::Blockable
       block_buyer!
     end
 
-    def pause_payouts_for_seller_based_on_recent_failures!
+    def flag_seller_based_on_recent_failures!
       return if Feature.inactive?(:block_seller_based_on_recent_failures)
       return if IGNORED_ERROR_CODES.include?(error_code)
       return if seller.verified?

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -222,7 +222,7 @@ class Purchase < ApplicationRecord
     after_transition any => :failed, :do => :ban_fraudulent_buyer_browser_guid!
     after_transition any => :failed, :do => :ban_card_testers!
     after_transition any => :failed, :do => :block_purchases_on_product!, if: lambda { |purchase| purchase.price_cents.nonzero? && !purchase.is_recurring_subscription_charge }
-    after_transition any => :failed, :do => :pause_payouts_for_seller_based_on_recent_failures!, if: lambda { |purchase| purchase.price_cents.nonzero? }
+    after_transition any => :failed, :do => :flag_seller_based_on_recent_failures!, if: lambda { |purchase| purchase.price_cents.nonzero? }
     after_transition any => :failed, :do => :ban_buyer_on_fraud_related_error_code!
     after_transition any => :failed, :do => :suspend_buyer_on_fraudulent_card_decline!
     after_transition any => :failed, :do => :send_failure_email

--- a/spec/models/concerns/purchase/blockable_spec.rb
+++ b/spec/models/concerns/purchase/blockable_spec.rb
@@ -629,6 +629,22 @@ describe Purchase::Blockable do
           expect(job["args"][2]).to include("failed purchases")
           expect(job["args"][2]).to include("NOT paused")
         end
+
+        it "flags and notifies only once per watch window despite repeated failures" do
+          create_list(:failed_purchase, 5, link: product, price_cents: 250)
+
+          expect do
+            purchase.mark_failed!
+          end.to change { InternalNotificationWorker.jobs.size }.by(1)
+             .and change { seller.comments.where(comment_type: Comment::COMMENT_TYPE_ON_PROBATION).count }.by(1)
+
+          # A subsequent failure in the same window must NOT re-fire the comment or the #risk post.
+          another_purchase = create(:purchase, link: product, purchase_state: "in_progress")
+          expect do
+            another_purchase.mark_failed!
+          end.to not_change { InternalNotificationWorker.jobs.size }
+             .and not_change { seller.comments.where(comment_type: Comment::COMMENT_TYPE_ON_PROBATION).count }
+        end
       end
 
       context "when error code is ignored" do

--- a/spec/models/concerns/purchase/blockable_spec.rb
+++ b/spec/models/concerns/purchase/blockable_spec.rb
@@ -608,13 +608,26 @@ describe Purchase::Blockable do
       end
 
       context "when seller is not verified" do
-        it "pauses payouts when threshold is exceeded" do
+        it "does NOT pause payouts even when threshold is exceeded (informational only)" do
           expect(seller.verified?).to be(false)
           create_list(:failed_purchase, 5, link: product, price_cents: 250)
           purchase.mark_failed!
 
-          expect(seller.reload.payouts_paused_internally).to be(true)
-          expect(seller.payouts_paused_by_source).to eq(User::PAYOUT_PAUSE_SOURCE_SYSTEM)
+          expect(seller.reload.payouts_paused_internally).to be(false)
+          expect(seller.payouts_paused_by_source).to be_nil
+        end
+
+        it "enqueues a #risk notification when threshold is exceeded" do
+          create_list(:failed_purchase, 5, link: product, price_cents: 250)
+
+          expect do
+            purchase.mark_failed!
+          end.to change { InternalNotificationWorker.jobs.size }.by(1)
+
+          job = InternalNotificationWorker.jobs.last
+          expect(job["args"][0]).to eq("risk")
+          expect(job["args"][2]).to include("failed purchases")
+          expect(job["args"][2]).to include("NOT paused")
         end
       end
 
@@ -655,12 +668,15 @@ describe Purchase::Blockable do
         let(:newer_product) { create(:product, user: newer_seller) }
         let!(:newer_purchase) { create(:purchase, link: newer_product, purchase_state: "in_progress") }
 
-        it "pauses payouts for the seller when threshold is exceeded" do
+        it "does NOT pause payouts but flags for review when threshold is exceeded" do
           create_list(:failed_purchase, 5, link: newer_product, price_cents: 250)
-          newer_purchase.mark_failed!
 
-          expect(newer_seller.reload.payouts_paused_internally).to be(true)
-          expect(newer_seller.payouts_paused_by_source).to eq(User::PAYOUT_PAUSE_SOURCE_SYSTEM)
+          expect do
+            newer_purchase.mark_failed!
+          end.to change { InternalNotificationWorker.jobs.size }.by(1)
+
+          expect(newer_seller.reload.payouts_paused_internally).to be(false)
+          expect(newer_seller.payouts_paused_by_source).to be_nil
         end
       end
 
@@ -675,30 +691,32 @@ describe Purchase::Blockable do
       end
 
       context "when total failed amount is above threshold" do
-        it "pauses payouts internally" do
+        it "does NOT pause payouts internally (informational only)" do
           create_list(:failed_purchase, 5, link: product, price_cents: 250)
           purchase.mark_failed!
 
-          expect(seller.reload.payouts_paused_internally).to be(true)
-          expect(seller.payouts_paused_by_source).to eq(User::PAYOUT_PAUSE_SOURCE_SYSTEM)
+          expect(seller.reload.payouts_paused_internally).to be(false)
+          expect(seller.payouts_paused_by_source).to be_nil
         end
 
-        it "creates a comment with the failed amount" do
+        it "creates a review comment with the failed amount (no pause)" do
           create_list(:failed_purchase, 5, link: product, price_cents: 250)
           purchase.mark_failed!
 
           comment = seller.comments.last
-          expect(comment.content).to eq("Payouts paused due to high volume of failed purchases ($13.50 USD in 60 minutes).")
+          expect(comment.content).to eq("High volume of failed purchases ($13.50 USD in 60 minutes) — flagged for review (payouts NOT paused).")
           expect(comment.comment_type).to eq(Comment::COMMENT_TYPE_ON_PROBATION)
           expect(comment.author_name).to eq("pause_payouts_for_seller_based_on_recent_failures")
         end
 
         context "when some purchases are outside the watch window" do
-          it "does not pause payouts internally" do
+          it "does not flag or comment" do
             travel_to Time.current do
               create_list(:failed_purchase, 2, link: product, price_cents: 250)
               create_list(:failed_purchase, 3, link: product, price_cents: 250, created_at: 61.minutes.ago)
-              purchase.mark_failed!
+              expect do
+                purchase.mark_failed!
+              end.not_to change { InternalNotificationWorker.jobs.size }
               expect(seller.reload.payouts_paused_internally).to be(false)
               expect(seller.payouts_paused_by_source).to be nil
             end
@@ -713,7 +731,7 @@ describe Purchase::Blockable do
         end
 
         context "when total failed amount is below default threshold" do
-          it "does not pause payouts internally" do
+          it "does not flag the seller" do
             # default max amount is $2000
             create_list(:failed_purchase, 5, link: product, price_cents: 200_00)
             purchase.mark_failed!
@@ -724,13 +742,16 @@ describe Purchase::Blockable do
         end
 
         context "when total failed amount is above default threshold" do
-          it "pauses payouts internally" do
+          it "flags for review but does NOT pause payouts" do
             # default max amount is $2000
             create_list(:failed_purchase, 11, link: product, price_cents: 200_00)
-            purchase.mark_failed!
 
-            expect(seller.reload.payouts_paused_internally).to be(true)
-            expect(seller.payouts_paused_by_source).to eq(User::PAYOUT_PAUSE_SOURCE_SYSTEM)
+            expect do
+              purchase.mark_failed!
+            end.to change { InternalNotificationWorker.jobs.size }.by(1)
+
+            expect(seller.reload.payouts_paused_internally).to be(false)
+            expect(seller.payouts_paused_by_source).to be_nil
           end
         end
       end

--- a/spec/models/concerns/purchase/blockable_spec.rb
+++ b/spec/models/concerns/purchase/blockable_spec.rb
@@ -570,7 +570,7 @@ describe Purchase::Blockable do
       end
     end
 
-    describe "pause payouts for seller internally based on recent failures" do
+    describe "flag seller based on recent failures (informational, no payout pause)" do
       let(:seller) { create(:user) }
       let(:product) { create(:product, user: seller) }
       let!(:purchase) { create(:purchase, link: product, purchase_state: "in_progress") }


### PR DESCRIPTION
## Why
A failed-purchase burst on a seller's checkout is almost always an **external card-tester** spraying stolen cards at a popular product. The seller is the **victim** — and `pause_payouts_for_seller_based_on_recent_failures!` freezes *their* money as a result. That's a terrible UX: it hit compliant, long-tenured sellers with clean, diverse buyer bases and generated a stream of "why are my payouts paused?" tickets (gumroad-private #809 empathic01: 679 unique buyers / 418 cards / 2 CBs on $22k; #810 arcturiansignal: 0 CB / 0 EFW, already compliant; #816).

Per Sahil: we shouldn't auto-pause payouts for card-testing at all — make it purely informational.

## What
In `Purchase::Blockable#pause_payouts_for_seller_based_on_recent_failures!`:
- **Removed** the `payouts_paused_internally: true` write. Payouts are never frozen by this path anymore.
- **Kept** the detection and the audit comment (reworded: "flagged for review (payouts NOT paused)").
- **Added** an `InternalNotificationWorker` post to the existing `#risk` room (relayed to the Telegram risk topic) so a human/agent can review the burst.

Genuine self-funding sellers are still caught precisely by the risk-queue review flow (per-card buyer spread + seller-login-IP ∩ buyer-IP), which is the right tool — not this blunt failed-volume trip that punishes victims.

## Tests
Updated `blockable_spec.rb` to assert the new behavior (no pause, review comment, `#risk` notification enqueued on threshold breach; silent below threshold / outside watch window / verified / >2yr). **14 examples, 0 failures** locally.

## Note
The method name `pause_payouts_for_seller_based_on_recent_failures!` is now a slight misnomer (it notifies, doesn't pause) — left as-is to keep the diff focused and preserve the `SYSTEM_PAYOUT_PAUSE_COMMENT_AUTHORS` key; happy to rename in a follow-up if preferred.

Fixes the root cause behind gumroad-private #809, #810, #816.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785507819&installation_id=134400930&pr_number=5639&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5639&signature=78c69e3e570ff002d72846c4aa73b3ae49eb121d6782c94588d4ed8a9a6924ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->