### PR TITLE
Show "Purchase again" after a paid product is discounted to $0

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -1147,7 +1147,7 @@ class Purchase < ApplicationRecord
     json = {
       created_at: purchase.created_at,
       should_show_receipt: !purchase.is_test_purchase? && purchase.successful_and_not_reversed?(include_gift: true),
-      was_paid: purchase.present? && purchase.paid?,
+      was_paid: purchase.present? && (purchase.paid? || purchase.offer_code_id.present?),
       show_view_content_button_on_product_page: purchase.show_view_content_button_on_product_page?,
       is_recurring_billing: link.is_recurring_billing,
       is_physical: link.is_physical,

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -4323,6 +4323,15 @@ describe Link, :vcr do
           end
         end
 
+        context "when the user's previous purchase was a paid product discounted to $0 by an offer code" do
+          let!(:offer_code) { create(:offer_code, products: [product], amount_cents: nil, amount_percentage: 100) }
+          let!(:purchase) { create(:free_purchase, link: product, purchaser: user, offer_code:) }
+
+          it "marks the purchase as paid" do
+            expect(product.purchase_info_for_product_page(user, nil)[:was_paid]).to eq(true)
+          end
+        end
+
         context "when the user has a previous gift sender purchase" do
           let!(:purchase) { create(:purchase, link: product, purchaser: user, is_gift_sender_purchase: true) }
 


### PR DESCRIPTION
## What

On the product page, the CTA stays **"I want this!"** for a buyer who has already purchased the product, when that purchase was a **paid product discounted to $0 by an offer code** (e.g. a 100%-off discount code). It should read **"Purchase again"**.

`Purchase#paid?` is `price_cents > 0`, and a fully-discounted purchase stores `price_cents = 0`, so `purchase_info[:was_paid]` came back `false` and the CTA never flipped — even though the buyer genuinely owns the product and their library and receipts reflect it.

The fix treats a purchase as "paid" for CTA purposes when money changed hands **or** an offer code was applied:

```ruby
was_paid: purchase.present? && (purchase.paid? || purchase.offer_code_id.present?),
```

## Why

PR #5520 intentionally gated "Purchase again" on `paid?` so that a **free-product acquisition** falls through to "I want this!". That change conflated *"money changed hands"* with *"this is a free product"* — two things that diverge exactly when a discount code zeroes out the price of a **paid** product.

`offer_code_id` is read straight off the column, so the CTA stays correct even if the seller later deletes the code. A genuine free acquisition still has no offer code and `price_cents == 0`, so it keeps showing "I want this!" — #5520's behavior is preserved.

Reported (internal): antiwork/gumroad-private#815. The same report also alleged a "random discount percentage per page load"; that part is not reproducible — the discount percentage is a validated, static integer column read deterministically. The real, reproducible defect is this CTA regression that the 100%-off purchase triggers.

---

AI disclosure: implemented with Claude Opus 4.8 (1M context) in Claude Code.
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785509329&installation_id=134400930&pr_number=5641&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5641&signature=5e00d82d0caaa09d3ef2b90c8be65b0004c040486f18d80c6b5a3d74d076df2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->