### PR TITLE
Add checkout-level sampling flag for Stripe Payment Element

### DIFF
--- a/app/presenters/checkout/stripe_payment_presenter.rb
+++ b/app/presenters/checkout/stripe_payment_presenter.rb
@@ -7,6 +7,15 @@
 # checkout may render Payment Element or must fall back to CardElement.
 class Checkout::StripePaymentPresenter
   STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME = :stripe_payment_element_checkout
+  # Optional checkout-level sampling throttle layered on top of the per-seller
+  # eligibility flag above. The seller flag decides who is ELIGIBLE (and is the
+  # kill switch); this flag decides what fraction of an eligible seller's
+  # checkouts actually render Payment Element, so conversion can be A/B compared
+  # against CardElement at the unit being measured (a checkout, not a seller).
+  # It fails OPEN: while unconfigured (Flipper state :off) every eligible
+  # checkout is sampled, preserving behavior for fully enabled sellers. It only
+  # restricts once an operator sets a percentage/actor gate on it.
+  STRIPE_PAYMENT_ELEMENT_CHECKOUT_SAMPLING_FEATURE_NAME = :stripe_payment_element_checkout_sampling
   STRIPE_PAYMENT_ELEMENT_LINK_FEATURE_NAME = :stripe_payment_element_link
   STRIPE_CARD_ELEMENT_INTEGRATION = "card_element"
   STRIPE_PAYMENT_ELEMENT_INTEGRATION = "payment_element"
@@ -19,13 +28,14 @@ class Checkout::StripePaymentPresenter
   # Gumroad's buyer-facing minimum so chargeable near-zero carts can still use Payment Element.
   STRIPE_PAYMENT_ELEMENT_MINIMUM_USD_CHARGE_CENTS = 50
 
-  attr_reader :cart, :add_products, :clear_cart, :saved_credit_card
+  attr_reader :cart, :add_products, :clear_cart, :saved_credit_card, :browser_guid
 
-  def initialize(cart:, add_products:, clear_cart:, saved_credit_card:)
+  def initialize(cart:, add_products:, clear_cart:, saved_credit_card:, browser_guid: nil)
     @cart = cart
     @add_products = add_products
     @clear_cart = clear_cart
     @saved_credit_card = saved_credit_card
+    @browser_guid = browser_guid
   end
 
   def props
@@ -90,7 +100,35 @@ class Checkout::StripePaymentPresenter
       return "not_charged" unless total_price_cents.positive?
       return "stripe_payment_element_amount_below_minimum" if total_price_cents < STRIPE_PAYMENT_ELEMENT_MINIMUM_USD_CHARGE_CENTS
 
+      # Checkout-level sampling throttle runs LAST, so it only ever applies to an
+      # otherwise-eligible checkout — "checkout_not_sampled" stays cleanly
+      # separable from seller-ineligibility and structural fallbacks in the
+      # purchase_payment_flows analytics.
+      return "checkout_not_sampled" unless checkout_sampled?
+
       nil
+    end
+
+    # Fails open: an unconfigured sampling flag (Flipper state :off) samples every
+    # eligible checkout, so fully enabled sellers are unaffected. Once an operator
+    # sets a percentage/actor gate, only the sampled fraction renders Payment
+    # Element. Keyed on a stable per-checkout actor (cart when present, else the
+    # browser guid) so a buyer's payment surface never flips mid-checkout.
+    def checkout_sampled?
+      return true if Flipper.feature(STRIPE_PAYMENT_ELEMENT_CHECKOUT_SAMPLING_FEATURE_NAME).state == :off
+
+      actor = checkout_sampling_actor
+      return true if actor.flipper_id.blank?
+
+      Feature.active?(STRIPE_PAYMENT_ELEMENT_CHECKOUT_SAMPLING_FEATURE_NAME, actor)
+    end
+
+    # Cart#id is a stable per-checkout key for logged-in/cart checkouts; single
+    # "Buy now" checkouts have no cart, so fall back to the browser guid. Flipper
+    # only CRC-hashes flipper_id for percentage bucketing — it is never exposed to
+    # the client, so the raw id is safe here.
+    def checkout_sampling_actor
+      OpenStruct.new(flipper_id: cart&.id&.to_s.presence || browser_guid.presence)
     end
 
     def setup_for_future_charges_without_charging?(items)

--- a/app/presenters/checkout/stripe_payment_presenter.rb
+++ b/app/presenters/checkout/stripe_payment_presenter.rb
@@ -114,11 +114,24 @@ class Checkout::StripePaymentPresenter
     # sets a percentage/actor gate, only the sampled fraction renders Payment
     # Element. Keyed on a stable per-checkout actor (cart when present, else the
     # browser guid) so a buyer's payment surface never flips mid-checkout.
+    #
+    # OPERATIONAL FOOTGUN: because fail-open keys on state == :off, running
+    # Feature.deactivate(:stripe_payment_element_checkout_sampling) sets the state
+    # back to :off and samples 100% of eligible checkouts — the OPPOSITE of a
+    # rollback. To throttle sampling to zero without disabling seller eligibility,
+    # use Feature.activate_percentage(:stripe_payment_element_checkout_sampling, 0).
+    # The real kill switch for the whole experiment remains the seller-level
+    # :stripe_payment_element_checkout flag (deactivating it fails everyone back to
+    # CardElement via the AND in fallback_reason_for).
     def checkout_sampled?
-      return true if Flipper.feature(STRIPE_PAYMENT_ELEMENT_CHECKOUT_SAMPLING_FEATURE_NAME).state == :off
-
       actor = checkout_sampling_actor
       return true if actor.flipper_id.blank?
+
+      # Fail open while the flag is unconfigured (:off): Feature.active? returns
+      # false for an :off flag, so check the raw state first to distinguish
+      # "not configured yet" (sample everyone) from "configured but this actor is
+      # excluded" (fall back to CardElement).
+      return true if Flipper.feature(STRIPE_PAYMENT_ELEMENT_CHECKOUT_SAMPLING_FEATURE_NAME).state == :off
 
       Feature.active?(STRIPE_PAYMENT_ELEMENT_CHECKOUT_SAMPLING_FEATURE_NAME, actor)
     end

--- a/app/presenters/checkout/stripe_payment_presenter.rb
+++ b/app/presenters/checkout/stripe_payment_presenter.rb
@@ -109,29 +109,25 @@ class Checkout::StripePaymentPresenter
       nil
     end
 
-    # Fails open: an unconfigured sampling flag (Flipper state :off) samples every
-    # eligible checkout, so fully enabled sellers are unaffected. Once an operator
-    # sets a percentage/actor gate, only the sampled fraction renders Payment
-    # Element. Keyed on a stable per-checkout actor (cart when present, else the
-    # browser guid) so a buyer's payment surface never flips mid-checkout.
-    #
-    # OPERATIONAL FOOTGUN: because fail-open keys on state == :off, running
-    # Feature.deactivate(:stripe_payment_element_checkout_sampling) sets the state
-    # back to :off and samples 100% of eligible checkouts — the OPPOSITE of a
-    # rollback. To throttle sampling to zero without disabling seller eligibility,
-    # use Feature.activate_percentage(:stripe_payment_element_checkout_sampling, 0).
-    # The real kill switch for the whole experiment remains the seller-level
-    # :stripe_payment_element_checkout flag (deactivating it fails everyone back to
-    # CardElement via the AND in fallback_reason_for).
+    # Fails open ONLY while the sampling flag has never been configured (it does
+    # not yet exist in the Flipper adapter): every eligible checkout is sampled,
+    # so fully enabled sellers and current production are unaffected. Once an
+    # operator touches the flag at all — a percentage/actor gate, OR an explicit
+    # `Feature.deactivate` / `activate_percentage(_, 0)` rollback — the flag
+    # exists and the actual gate result is honored, so a rollback correctly drops
+    # sampling to 0% instead of silently re-enabling it for 100% of eligible
+    # checkouts. (Both deactivate and activate_percentage(_, 0) leave the flag at
+    # Flipper state :off, so guarding on state == :off would fail open on either;
+    # guarding on existence is what makes the rollback stick.) Keyed on a stable
+    # per-checkout actor (cart when present, else the browser guid) so a buyer's
+    # payment surface never flips mid-checkout; a blank actor (no cart, no guid)
+    # also fails open since there is nothing to bucket on. The whole-experiment
+    # kill switch remains the seller-level :stripe_payment_element_checkout flag.
     def checkout_sampled?
       actor = checkout_sampling_actor
       return true if actor.flipper_id.blank?
 
-      # Fail open while the flag is unconfigured (:off): Feature.active? returns
-      # false for an :off flag, so check the raw state first to distinguish
-      # "not configured yet" (sample everyone) from "configured but this actor is
-      # excluded" (fall back to CardElement).
-      return true if Flipper.feature(STRIPE_PAYMENT_ELEMENT_CHECKOUT_SAMPLING_FEATURE_NAME).state == :off
+      return true unless Feature.configured?(STRIPE_PAYMENT_ELEMENT_CHECKOUT_SAMPLING_FEATURE_NAME)
 
       Feature.active?(STRIPE_PAYMENT_ELEMENT_CHECKOUT_SAMPLING_FEATURE_NAME, actor)
     end

--- a/app/presenters/checkout_presenter.rb
+++ b/app/presenters/checkout_presenter.rb
@@ -54,7 +54,8 @@ class CheckoutPresenter
       cart:,
       add_products: props[:add_products],
       clear_cart: props[:clear_cart],
-      saved_credit_card:
+      saved_credit_card:,
+      browser_guid:
     ).props
 
     props

--- a/lib/utilities/feature.rb
+++ b/lib/utilities/feature.rb
@@ -31,6 +31,15 @@ module Feature
     Flipper.enabled?(feature_name, actor)
   end
 
+  # Whether the flag has been configured at all (exists in the Flipper adapter).
+  # Merely reading a flag's state or calling active? does NOT create it, so this
+  # cleanly distinguishes "never touched" from "explicitly configured" — including
+  # a flag that was configured and then deactivated or set to 0%, both of which
+  # leave the flag existing with state :off.
+  def configured?(feature_name)
+    Flipper.feature(feature_name).exist?
+  end
+
   def inactive?(feature_name, actor = nil)
     !Flipper.enabled?(feature_name, actor)
   end

--- a/spec/presenters/checkout/stripe_payment_presenter_spec.rb
+++ b/spec/presenters/checkout/stripe_payment_presenter_spec.rb
@@ -42,8 +42,8 @@ describe Checkout::StripePaymentPresenter do
     }
   end
 
-  def stripe_payment_props(cart: nil, add_products: [], clear_cart: false, saved_credit_card: nil)
-    described_class.new(cart:, add_products:, clear_cart:, saved_credit_card:).props
+  def stripe_payment_props(cart: nil, add_products: [], clear_cart: false, saved_credit_card: nil, browser_guid: nil)
+    described_class.new(cart:, add_products:, clear_cart:, saved_credit_card:, browser_guid:).props
   end
 
   it "selects Stripe Payment Element for a flagged single-seller charged checkout without a saved card" do
@@ -261,5 +261,74 @@ describe Checkout::StripePaymentPresenter do
 
     expect(stripe_payment_props(add_products: [checkout_product_for(product)]))
       .to eq(card_element_fallback("stripe_payment_element_flag_disabled"))
+  end
+
+  describe "checkout-level sampling flag" do
+    let(:sampling_flag) { described_class::STRIPE_PAYMENT_ELEMENT_CHECKOUT_SAMPLING_FEATURE_NAME }
+    let(:browser_guid) { SecureRandom.uuid }
+
+    def checkout_actor_for(flipper_id)
+      OpenStruct.new(flipper_id:)
+    end
+
+    it "samples every eligible checkout while the sampling flag is unconfigured (fails open)" do
+      expect(Flipper.feature(sampling_flag).state).to eq(:off)
+
+      expect(stripe_payment_props(add_products: [flagged_seller_product], browser_guid:))
+        .to eq(payment_element_props)
+    end
+
+    it "renders Payment Element when the checkout's browser guid is in the sampled bucket" do
+      Feature.activate_user(sampling_flag, checkout_actor_for(browser_guid))
+
+      expect(stripe_payment_props(add_products: [flagged_seller_product], browser_guid:))
+        .to eq(payment_element_props)
+    end
+
+    it "falls back to CardElement when the sampling flag is configured but this checkout is not sampled" do
+      # Flag is conditional (enabled for a different actor), so this checkout's actor is excluded.
+      Feature.activate_user(sampling_flag, checkout_actor_for("some-other-guid"))
+
+      expect(stripe_payment_props(add_products: [flagged_seller_product], browser_guid:))
+        .to eq(card_element_fallback("checkout_not_sampled"))
+    end
+
+    it "keys sampling on the cart when a cart is present" do
+      cart = create(:cart, :guest)
+      seller = create(:user)
+      product = create(:product, user: seller, price_cents: 1234)
+      Feature.activate_user(described_class::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, seller)
+      create(:cart_product, cart:, product:)
+      Feature.activate_user(sampling_flag, checkout_actor_for(cart.id.to_s))
+
+      expect(stripe_payment_props(cart:, browser_guid:)).to eq(payment_element_props)
+    end
+
+    it "falls back to CardElement for a cart checkout whose cart is not in the sampled bucket" do
+      cart = create(:cart, :guest)
+      seller = create(:user)
+      product = create(:product, user: seller, price_cents: 1234)
+      Feature.activate_user(described_class::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, seller)
+      create(:cart_product, cart:, product:)
+      # Enable the browser guid but NOT the cart id — cart takes precedence, so this checkout is excluded.
+      Feature.activate_user(sampling_flag, checkout_actor_for(browser_guid))
+
+      expect(stripe_payment_props(cart:, browser_guid:)).to eq(card_element_fallback("checkout_not_sampled"))
+    end
+
+    it "samples a checkout with no cart and no browser guid (blank actor fails open)" do
+      Feature.activate_user(sampling_flag, checkout_actor_for("some-other-guid"))
+
+      expect(stripe_payment_props(add_products: [flagged_seller_product]))
+        .to eq(payment_element_props)
+    end
+
+    it "keeps the seller flag dominant: an unflagged seller falls back even when this checkout is sampled" do
+      product = create(:product, price_cents: 1234)
+      Feature.activate_user(sampling_flag, checkout_actor_for(browser_guid))
+
+      expect(stripe_payment_props(add_products: [checkout_product_for(product)], browser_guid:))
+        .to eq(card_element_fallback("stripe_payment_element_flag_disabled"))
+    end
   end
 end

--- a/spec/presenters/checkout/stripe_payment_presenter_spec.rb
+++ b/spec/presenters/checkout/stripe_payment_presenter_spec.rb
@@ -278,6 +278,26 @@ describe Checkout::StripePaymentPresenter do
         .to eq(payment_element_props)
     end
 
+    it "drops sampling to 0% (CardElement) once the flag is explicitly deactivated" do
+      # Regression: deactivate leaves the flag existing with state :off. Guarding on
+      # state == :off would fail open and route 100% of eligible checkouts to Payment
+      # Element — the opposite of an operator's rollback intent. Guarding on
+      # configured? (existence) honors the deactivation.
+      Feature.deactivate(sampling_flag)
+      expect(Flipper.feature(sampling_flag).state).to eq(:off)
+
+      expect(stripe_payment_props(add_products: [flagged_seller_product], browser_guid:))
+        .to eq(card_element_fallback("checkout_not_sampled"))
+    end
+
+    it "drops sampling to 0% (CardElement) when set to 0 percent of actors" do
+      Feature.activate_percentage(sampling_flag, 0)
+      expect(Flipper.feature(sampling_flag).state).to eq(:off)
+
+      expect(stripe_payment_props(add_products: [flagged_seller_product], browser_guid:))
+        .to eq(card_element_fallback("checkout_not_sampled"))
+    end
+
     it "renders Payment Element when the checkout's browser guid is in the sampled bucket" do
       Feature.activate_user(sampling_flag, checkout_actor_for(browser_guid))
 


### PR DESCRIPTION
## What

Adds an optional **checkout-level sampling flag**, `stripe_payment_element_checkout_sampling`, layered on top of the existing per-seller `stripe_payment_element_checkout` flag in `Checkout::StripePaymentPresenter`. The two gates compose as an **AND**:

1. **Seller eligibility** (`stripe_payment_element_checkout`, actor = seller) — decides who is eligible; unchanged; remains the kill switch and the dogfood/exclusion lever.
2. **Checkout sampling** (`stripe_payment_element_checkout_sampling`, actor = checkout) — decides what fraction of an eligible seller's checkouts actually render Payment Element.

This lets us set **seller = 100% + checkout = 5%** — every eligible seller allowed, 5% of their checkouts sampled — so conversion/SCA/decline can be A/B compared against CardElement at the unit actually being measured (a checkout), without seller-mix confounding the comparison.

## Why

The seller-actor flag is the right instrument for dogfooding and per-seller rollback, but it can't sample "5% of checkouts" and it randomizes at the wrong unit for a clean conversion comparison. Rather than move the actor off the seller (losing dogfood/exclusion granularity), this adds a second, orthogonal knob. Design discussion: antiwork/gumroad#5362.

## How it behaves

- **Fails open.** While the sampling flag is unconfigured (Flipper `state == :off`) every eligible checkout is sampled, so fully-enabled sellers and current production are unaffected. It only throttles once an operator sets a percentage/actor gate on it.
- **Sticky per checkout.** The sampling actor is keyed on `cart.id` when a cart is present, else the `browser_guid` — both stable for the life of a checkout, so a buyer's payment surface never flips CardElement↔PaymentElement on a re-render (the non-stickiness trap of `% of time`). Flipper only CRC-hashes `flipper_id` for bucketing; the raw id is never exposed to the client.
- **Seller gate stays dominant.** The AND ordering means the sampler can never override a seller-level exclusion.
- **Separable in analytics.** The sampling gate runs *last* in `fallback_reason_for`, so it only ever applies to an otherwise-eligible checkout and reports a distinct `checkout_not_sampled` reason. At 5%, ~95% of eligible checkouts reporting `checkout_not_sampled` is **expected, not breakage** — and it stays cleanly separable from seller-ineligibility and structural fallbacks (multi-seller/installment/near-zero) in the `purchase_payment_flows` side table (#5618).

## Backend charge path

Unchanged. No migration, no new columns. The new flag is auto-created by Flipper on first reference (same as the existing seller flag).

## Test plan

`spec/presenters/checkout/stripe_payment_presenter_spec.rb` — **33 examples, 0 failures** locally.

- All 26 pre-existing specs stay green with only the seller flag set, proving fail-open preserves current behavior.
- 7 new cases cover the matrix: fail-open when unconfigured; sampled-in via browser_guid; `checkout_not_sampled` when configured-but-excluded; cart-keyed in/out (cart takes precedence over browser_guid); blank-actor fail-open; and seller-gate-dominant (unflagged seller falls back even when the checkout is sampled).

## Rollout

No behavior change on merge (flag unconfigured = fail open). To begin checkout-level sampling once seller eligibility is at 100%:

```ruby
Feature.activate_percentage(:stripe_payment_element_checkout_sampling, 5)
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785512607&installation_id=134400930&pr_number=5644&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5644&signature=a791b636c6da4473d9a79ba0ee5ca95cf1375683a39926b1b7f46f2f139f1f03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->