### PR TITLE
Help center: update file size limit 16 GB → 20 GB

### DIFF
--- a/app/models/help_center/articles.yml
+++ b/app/models/help_center/articles.yml
@@ -498,7 +498,7 @@
 - id: 289
   slug: "289-file-size-limits-on-gumroad"
   title: "File size limits"
-  description: "In this article: 16 GB File size limit 250 MB limit Download All button How to zip your files Mac PC Your file size limit depends on how you’ve decided to price"
+  description: "In this article: 20 GB File size limit 250 MB limit Download All button How to zip your files Mac PC Your file size limit depends on how you’ve decided to price"
   category_id: <%= HelpCenter::Category::ADD_A_PRODUCT.id %>
 - id: 290
   slug: "290-facebook-domain-verification"

--- a/app/views/help_center/articles/contents/_289-file-size-limits-on-gumroad.html.erb
+++ b/app/views/help_center/articles/contents/_289-file-size-limits-on-gumroad.html.erb
@@ -1,7 +1,7 @@
 <div>
   <p>In this article:</p>
   <ul>
-    <li><a href="#16-GB-File-size-limit-nBMbC" target="_self">16 GB File size limit</a></li>
+    <li><a href="#16-GB-File-size-limit-nBMbC" target="_self">20 GB File size limit</a></li>
     <li><a href="#250-MB-File-size-limit-g_EnM" target="_self">250 MB limit</a></li>
     <li><a href="#Download-All-button--rvoOs" target="_self">Download All button</a></li>
     <li><a href="#How-to-zip-your-files-JUly-" target="_self">How to zip your files</a>
@@ -12,9 +12,9 @@
     </li>
   </ul>
   <br>
-  <p>Your file size limit depends on how you’ve decided to price your product. Free products have a file size limit of 250 MB. Products priced higher than $1 have a file size limit of 16 GB.</p>
-  <h3 id="16-GB-File-size-limit-nBMbC">16 GB File size limit</h3>
-  <p>If you price your product at any number greater than $0.99, the largest single file that you can upload to a product is 16 GB in size. We rarely see anyone upload files larger than 5GB, so that shouldn't be an issue for the vast majority of creators. Remember, you can add as many files as you want to each product.</p>
+  <p>Your file size limit depends on how you’ve decided to price your product. Free products have a file size limit of 250 MB. Products priced higher than $1 have a file size limit of 20 GB.</p>
+  <h3 id="16-GB-File-size-limit-nBMbC">20 GB File size limit</h3>
+  <p>If you price your product at any number greater than $0.99, the largest single file that you can upload to a product is 20 GB in size. We rarely see anyone upload files larger than 5GB, so that shouldn't be an issue for the vast majority of creators. Remember, you can add as many files as you want to each product.</p>
   <h3 id="250-MB-File-size-limit-g_EnM">250 MB limit</h3>
   <p>If you price your product at $0, then the max <i>product</i> size can be 250 MB. In other words, if you're using our <a href="133-pay-what-you-want-pricing">Pay What You Want</a> feature, and setting the lowest possible price to be $0, then the max cumulative size of all your files can be 250 MB.</p>
   <h3 id="Download-All-button--rvoOs">Download All button </h3>


### PR DESCRIPTION
## What

Updates help center article **289 – File size limits** from **16 GB → 20 GB** (article body + YAML `description`).

## Why

The product file uploader (`app/javascript/components/useConfigureEvaporate.ts`) enforces `MAX_FILE_SIZE = 20 GB` — a flat, ungated constant (no plan/tier/feature-flag gate, same for every creator on any paid product > $0.99). The help center still said 16 GB, so creators were told a lower limit than the product actually allows. No 16 GB constant remains anywhere in the codebase.

Verified 20 GB is available to **everyone** (not plan-gated) before writing it as a blanket fact. Free-product limit (250 MB) is unchanged.

## Changes
- `_289-file-size-limits-on-gumroad.html.erb` — TOC label, intro sentence, section heading, and body text 16 GB → 20 GB. **Anchor IDs preserved** (`#16-GB-File-size-limit-nBMbC` kept intact so external/in-page links don't break).
- `articles.yml` — `description` snippet 16 GB → 20 GB.

Integrity checks: YAML parses, 124 articles intact, slug↔body-file consistent, no leftover "16 GB", anchors preserved. Autoreview clean (0.93).

---
## 🧪 FIRST-RUN TRIAL — please review before this goes autonomous

@michellelarney — **this is the first-run trial of the merged-PR → help-center auto-sync automation** we set up today. I found this drift by scanning the volatile/high-stakes articles against live code (the 16→20 GB gap).

Per our agreement: I opened the PR but did **not** auto-merge this one. Please take a look and confirm it's working the way you want. Once you give the thumbs up, the pipeline flips to fully autonomous (edit + ship on its own) for future doc updates.

Filed by Gumclaw (help-center doc-sync).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785514603&installation_id=134400930&pr_number=5648&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5648&signature=18b5e65093ec5a506276139011713b241c1183761ad6de7695d75db5c06e06ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->