### PR TITLE
CC gumclaw@gumroad.com on every internal notification

### DIFF
--- a/app/mailers/internal_notification_mailer.rb
+++ b/app/mailers/internal_notification_mailer.rb
@@ -14,8 +14,14 @@ class InternalNotificationMailer < ApplicationMailer
     recipient = CHAT_ROOMS.dig(room_name.to_sym, :email)
     return if recipient.blank?
 
+    # CC Gumclaw on every internal notification, in addition to the room's own recipient,
+    # so it ingests the full stream. Skip if it's already the room's recipient (no dup).
+    always_cc = INTERNAL_NOTIFICATION_ALWAYS_CC.presence
+    cc = (always_cc && always_cc != recipient) ? always_cc : nil
+
     mail(
       to: recipient,
+      cc: cc,
       subject: "#{SUBJECT_PREFIX}[#{room_name}] #{sender}"
     )
   end

--- a/config/initializers/chat_rooms.rb
+++ b/config/initializers/chat_rooms.rb
@@ -3,6 +3,11 @@
 INTERNAL_NOTIFICATION_EMAIL = GlobalConfig.get("INTERNAL_NOTIFICATION_EMAIL", "hi@gumroad.com")
 PAYMENTS_NOTIFICATION_EMAIL = GlobalConfig.get("PAYMENTS_NOTIFICATION_EMAIL", "hi@gumroad.com")
 
+# Address CC'd on EVERY internal notification (all CHAT_ROOMS), in addition to each
+# room's own recipient. Lets Gumclaw ingest the full internal-notification stream
+# (risk alerts, payments, payouts, etc.) alongside the existing human recipients.
+INTERNAL_NOTIFICATION_ALWAYS_CC = GlobalConfig.get("INTERNAL_NOTIFICATION_ALWAYS_CC", "gumclaw@gumroad.com")
+
 CHAT_ROOMS = {
   announcements: { email: INTERNAL_NOTIFICATION_EMAIL },
   awards: { email: INTERNAL_NOTIFICATION_EMAIL },

--- a/spec/mailers/internal_notification_mailer_spec.rb
+++ b/spec/mailers/internal_notification_mailer_spec.rb
@@ -16,6 +16,10 @@ describe InternalNotificationMailer do
       expect(mail.to).to eq([INTERNAL_NOTIFICATION_EMAIL])
     end
 
+    it "CCs Gumclaw on every notification in addition to the room recipient" do
+      expect(mail.cc).to eq([INTERNAL_NOTIFICATION_ALWAYS_CC])
+    end
+
     it "sets the subject with room name and sender" do
       expect(mail.subject).to eq("[test] [payments] VAT Reporting")
     end
@@ -52,6 +56,27 @@ describe InternalNotificationMailer do
 
       it "returns a null mail" do
         expect(mail.to).to be_nil
+      end
+
+      it "does not CC Gumclaw when the room has no recipient" do
+        expect(mail.cc).to be_nil
+      end
+    end
+
+    context "when the room recipient IS the always-CC address" do
+      before { stub_const("CHAT_ROOMS", CHAT_ROOMS.merge(gumclaw_room: { email: INTERNAL_NOTIFICATION_ALWAYS_CC })) }
+
+      subject(:mail) do
+        described_class.notify(
+          room_name: "gumclaw_room",
+          sender: "Test",
+          message_text: "No duplicate"
+        )
+      end
+
+      it "does not duplicate the address into CC" do
+        expect(mail.to).to eq([INTERNAL_NOTIFICATION_ALWAYS_CC])
+        expect(mail.cc).to be_nil
       end
     end
   end


### PR DESCRIPTION
## What

Every internal notification sent via `InternalNotificationMailer` (all `CHAT_ROOMS` — risk, payments, payouts, announcements, awards, migrations, internals_log) now **CCs gumclaw@gumroad.com in addition to the room's existing recipient**. Existing human recipients are unchanged; Gumclaw is simply added alongside.

- `config/initializers/chat_rooms.rb`: new `INTERNAL_NOTIFICATION_ALWAYS_CC` (GlobalConfig, default `gumclaw@gumroad.com`), matching the existing `INTERNAL_NOTIFICATION_EMAIL` pattern.
- `app/mailers/internal_notification_mailer.rb`: add it as `cc:` on the single `mail()` call, so it applies to every room at once. Guarded to avoid duplicating the address when a room's own recipient already is it, and unknown rooms (blank recipient) still send nothing.

## Why

Gumclaw should ingest the full internal-notification stream (e.g. the new #risk card-testing alerts from #5639, plus payments/payouts/migrations) so it can act on them, without changing where those notifications already go. A single CC at the mailer layer covers every current and future room rather than editing each room's recipient. Making it a `GlobalConfig` value keeps it overridable per environment.

Builds on #5639 (which routes card-testing detections to #risk instead of pausing payouts) — this ensures Gumclaw receives that stream and every other internal notification.

## Before/After

Non-user-facing change (internal mailer routing — no rendered surface). Walkthrough: after this change, any `InternalNotificationWorker.perform_async(room, …)` / `InternalNotificationMailer.notify` call delivers to the room's recipient **with gumclaw@gumroad.com on CC**. Verified via the mailer spec below.

## Test Results

`spec/mailers/internal_notification_mailer_spec.rb` — added cases for: CC present on a normal room, no CC duplication when the room recipient already is the always-CC address, and no CC on an unrecognized room. **8 examples, 0 failures** locally.

---

This PR was authored by Gumclaw (Claude Opus 4.8).

Prompts used:
- "All internal notifications should go to gumclaw@gumroad.com as well as existing recipients."

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785515843&installation_id=134400930&pr_number=5650&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5650&signature=d02aa7ab7e9cd24ebf14599f87340c8d0dbc24f606ed9d0271e00025f06ab035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->