### PR TITLE
docs(pr-description): make RULE #0 media check a loud halt (follow-up to #5649)

### DIFF
--- a/.agents/skills/pr-description/SKILL.md
+++ b/.agents/skills/pr-description/SKILL.md
@@ -21,6 +21,15 @@ Generate a concise, high-quality PR description from the current branch and its 
 - **Non-user-facing change** (pure backend/refactor/config): a **short walkthrough video** of the relevant existing functionality is still required to demonstrate nothing broke.
 - If you do not yet have the media, the PR is NOT ready. Capture it first (boot the app, take the screenshots/video, store under `qa-media/pr-<number>-<desc>.<ext>`, reference via raw GitHub URL) — do NOT emit a description with an empty or deleted Before/After section for a product change.
 
+### ⛔ Prerequisite check — run this BEFORE generating any description
+
+This is a text-generation skill: the agent running it often has **no** running app or screenshot/video capture tooling. That is exactly the situation the rule exists to catch — do NOT rationalize past it. Before writing a single line of the description:
+
+1. Decide whether the change is a product/user-facing change (see the bullets above).
+2. If it is, ask: **can I actually capture the required media right now** (is the app bootable, is capture tooling available)?
+   - **YES** → capture the media first, then generate the description with the real media embedded.
+   - **NO** → **HALT.** Do NOT generate a description with a placeholder, an empty Before/After section, or a prose-only substitute. Instead, output a one-line stop message telling the human exactly what to capture and where to store it (`qa-media/pr-<number>-<desc>.<ext>`), and let them capture it before you proceed. Failing loudly here is the whole point — a description that silently omits the media is worse than no description.
+
 **The Before/After section below is NOT deletable for product changes.** The only case where it may be omitted is a genuinely non-visual change, and even then a walkthrough video goes in its place. When in doubt: include media.
 
 ## Workflow

--- a/.agents/skills/pr-description/SKILL.md
+++ b/.agents/skills/pr-description/SKILL.md
@@ -19,7 +19,7 @@ Generate a concise, high-quality PR description from the current branch and its 
 
 - **Any product/UI change** (a view, component, CSS, layout, mobile behavior, copy a user sees, a button, spacing, colors — anything a user could perceive): a **before/after VIDEO or screenshots are REQUIRED**, showing **desktop + mobile, light + dark** where applicable. A mobile-layout or CSS tweak is exactly the kind of change that MUST have visual proof — that is the whole point of the rule. "Minor layout fix" is NOT an exemption; it is the primary target.
 - **Non-user-facing change** (pure backend/refactor/config): a **short walkthrough video** of the relevant existing functionality is still required to demonstrate nothing broke.
-- If you do not yet have the media, the PR is NOT ready. Capture it first (boot the app, take the screenshots/video, store under `qa-media/pr-<number>-<desc>.<ext>`, reference via raw GitHub URL) — do NOT emit a description with an empty or deleted Before/After section for a product change.
+- If you do not yet have the media, the PR is NOT ready — do NOT emit a description with an empty or deleted Before/After section for a product change. **Run the prerequisite check below before proceeding**; it decides whether you may capture the media now or must HALT and hand the capture step back to a human.
 
 ### ⛔ Prerequisite check — run this BEFORE generating any description
 


### PR DESCRIPTION
## What

Reframes RULE #0 in the `pr-description` skill so the media-evidence requirement is enforced as an explicit **prerequisite gate that halts**, rather than an inline "capture it first" action step.

## Why

Follow-up to #5649. Greptile flagged (P2) that RULE #0 was unenforceable in practice: `pr-description` is a text-generation skill, and the agent running it usually has no running app or screenshot/video capture tooling. The old wording ("Capture it first — boot the app, take the screenshots…") is an action step the agent physically can't perform in-skill, so it would hit the requirement and rationalise past it — the exact loophole #5649 set out to close.

This change turns that inline action into a numbered prerequisite check the agent runs *before* generating any description:
- Product/user-facing change + can't capture media right now → **HALT** with a one-line message telling the human what to capture and where (`qa-media/pr-<number>-<desc>.<ext>`), instead of emitting a description with a placeholder, empty Before/After section, or prose-only substitute.
- Can capture → capture first, then generate with real media embedded.

The skill now fails loudly instead of silently degrading.

## Before/After

Not applicable — docs/skills-only change, no user-facing product surface. No app to film; the diff is the single SKILL.md edit above.

## Test plan

No code paths changed. Verified the `.claude/skills/pr-description` entry is a symlink to `.agents/skills/pr-description` (per AGENTS.md), so editing `.agents/skills` propagates to both.

## AI disclosure

Drafted by an AI agent (Claude, via Hermes) in response to the Greptile review on #5649. Change scoped to a single markdown skill file; reviewed against the current file on `main` before editing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785516029&installation_id=134400930&pr_number=5651&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5651&signature=f20b4b7b265f56b61eae1b84e692bf9433401e95856969bb838515ffbd469dc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->