### PR TITLE
test: make internal notification CC prerequisite explicit

### DIFF
--- a/spec/mailers/internal_notification_mailer_spec.rb
+++ b/spec/mailers/internal_notification_mailer_spec.rb
@@ -17,6 +17,10 @@ describe InternalNotificationMailer do
     end
 
     it "CCs Gumclaw on every notification in addition to the room recipient" do
+      # The mailer dedups the CC when it equals the room's own recipient, so this
+      # assertion is only meaningful while the two addresses are distinct. Assert the
+      # prerequisite explicitly rather than relying on it implicitly.
+      expect(INTERNAL_NOTIFICATION_ALWAYS_CC).not_to eq(mail.to.first)
       expect(mail.cc).to eq([INTERNAL_NOTIFICATION_ALWAYS_CC])
     end
 


### PR DESCRIPTION
## What

Adds an explicit precondition to the `InternalNotificationMailer` CC test that was added in #5650.

## Why

`InternalNotificationMailer#notify` dedups the always-CC address when it equals the room's own recipient (no self-CC). The `payments` room maps to `PAYMENTS_NOTIFICATION_EMAIL`, so the CC assertion only holds while `PAYMENTS_NOTIFICATION_EMAIL != INTERNAL_NOTIFICATION_ALWAYS_CC`. If both `GlobalConfig` values are ever resolved to the same address (e.g. both overridden in a shared staging config), the dedup guard suppresses the CC and the expectation would silently fail with an unhelpful message.

This asserts the inequality prerequisite up front so the test fails clearly if that invariant is ever broken, rather than relying on it implicitly. Flagged by Greptile on #5650.

## Test plan

```
bundle exec rspec spec/mailers/internal_notification_mailer_spec.rb
=> 8 examples, 0 failures
bundle exec rubocop spec/mailers/internal_notification_mailer_spec.rb
=> 1 file inspected, no offenses detected
```

Not a UI change — spec-only, no visual evidence applicable.

## AI disclosure

Authored with Hermes Agent (Claude). Change is a test-only precondition; verified locally with the commands above.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785516165&installation_id=134400930&pr_number=5652&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5652&signature=1c5c0a97a6536e807100b100b2da51f3dcc74b39f37156ebead0b5883d9b8579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->