### PR TITLE
docs: exempt documentation- and skill-only PRs from the video requirement

### DIFF
--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -57,7 +57,7 @@ Evaluate readability and maintainability of new/modified code. See [references/r
 **Pass 4 — PR Structure**
 AI disclosure, description quality (explains _why_), before/after media, test results, appropriate size — all per CONTRIBUTING.md.
 
-**⛔ Media evidence is a BLOCKING check (CONTRIBUTING.md line 17 — a hard `Must`).** If the PR touches product/UI (any view, component, CSS, layout, mobile behavior, user-visible copy) and has **no before/after video or screenshots**, raise it as a **critical** finding at **confidence 95+** and set the Verdict to request-changes. Do NOT wave through a mobile/CSS/layout PR just because the prose description is clear — "the code looks right" is not a substitute for visual proof. A missing video on a non-visual change (no walkthrough) is at least an **important** finding.
+**⛔ Media evidence is a BLOCKING check (CONTRIBUTING.md line 17 — a hard `Must`).** If the PR touches product/UI (any view, component, CSS, layout, mobile behavior, user-visible copy) and has **no before/after video or screenshots**, raise it as a **critical** finding at **confidence 95+** and set the Verdict to request-changes. Do NOT wave through a mobile/CSS/layout PR just because the prose description is clear — "the code looks right" is not a substitute for visual proof. A missing video on a non-visual change (no walkthrough) is at least an **important** finding. This does not apply to PRs that only touch documentation or agent skill files — the diff itself is the reviewable artifact, so do not raise a missing-media finding for docs- or skill-only PRs.
 
 ### 4. Score and Filter
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Non-trivial PRs should follow this structure:
 
 - **What** — What this PR does. Concrete changes, not a list of files.
 - **Why** — Why this change exists and why this approach was chosen over alternatives. When other PRs or approaches exist for the same problem, name them and say why this one wins (fewer changes, right API, no backend/storage churn, etc.).
-- **Before/After** — Video is required for all PRs. For user-facing changes, show before/after with desktop and mobile, light and dark mode. For non-user-facing changes, include a short video walking through the relevant existing functionality.
+- **Before/After** — Video is required for all PRs, except PRs that only touch documentation or agent skill files, where the diff itself is the reviewable artifact. For user-facing changes, show before/after with desktop and mobile, light and dark mode. For non-user-facing changes, include a short video walking through the relevant existing functionality.
 - **Test Results** — Screenshot of tests passing locally.
 
 Store screenshots and videos in `qa-media/` using the naming convention `pr-<number>-<description>.<ext>`. Reference them in PR descriptions with raw GitHub URLs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,12 +12,13 @@ Explain the reasoning behind your changes, not just the change itself. Describe 
 ## Pull requests
 
 > ### ⛔ THE #1 RULE FOR ANY PRODUCT CHANGE: SHOW IT.
-> **Every PR that changes anything a user can see or experience MUST include before/after visual evidence — a video (preferred) or screenshots — covering desktop + mobile, light + dark where applicable.** This is the single most important requirement of a product PR, above code style, above everything. A "small" mobile/CSS/layout tweak is exactly the kind of change that needs a screenshot or clip — that is the whole point. Do NOT rationalize a visual change as too minor to capture. A product PR without media is not ready to review and should be sent back. Non-visual PRs still need a short walkthrough video (see below).
+>
+> **Every PR that changes anything a user can see or experience MUST include before/after visual evidence — a video (preferred) or screenshots — covering desktop + mobile, light + dark where applicable.** This is the single most important requirement of a product PR, above code style, above everything. A "small" mobile/CSS/layout tweak is exactly the kind of change that needs a screenshot or clip — that is the whole point. Do NOT rationalize a visual change as too minor to capture. A product PR without media is not ready to review and should be sent back. Non-visual PRs still need a short walkthrough video (see below) — **except PRs that only modify documentation or agent skill files, where the diff itself is the reviewable artifact and no video is required.**
 
 - Include an AI disclosure
 - Self-review (comment) on your code
 - Break up big 1k+ line PRs into smaller PRs (100 loc)
-- **Must**: Include a video for every PR. For user-facing changes, show before/after with light/dark mode and mobile/desktop. For non-user-facing changes, record a short walkthrough of the relevant existing functionality to demonstrate understanding and confirm nothing broke.
+- **Must**: Include a video for every PR. For user-facing changes, show before/after with light/dark mode and mobile/desktop. For non-user-facing changes, record a short walkthrough of the relevant existing functionality to demonstrate understanding and confirm nothing broke. Exception: PRs that only touch documentation or agent skill files need no video — the diff is the reviewable artifact.
 - Include updates to any tests, especially end-to-end tests!
 - Deploy the app to a preview URL and include QA steps
 


### PR DESCRIPTION
## What

Adds an explicit **documentation- and agent-skill-only exemption** to the before/after media requirement in `CONTRIBUTING.md` and the `review-pr` skill. Follow-up to #5649.

## Why

#5649 made before/after media the #1 requirement for product PRs and closed the loophole that let product changes skip it. In review, Greptile pointed out that the "Non-visual PRs still need a short walkthrough video" language is broad enough to technically sweep in pure documentation and agent-skill PRs — like #5649 itself. A screen recording of markdown rendering or symlink resolution proves nothing a reviewer can't verify directly from the diff, so requiring one for docs-only changes is friction without value and invites exactly the "prose can stand in for video" rationalization the policy is meant to prevent.

This carves out the narrow case cleanly:
- **CONTRIBUTING.md** — the #1-rule callout and the `Must` bullet now say the video requirement does not apply to PRs that only touch documentation or agent skill files; the diff is the reviewable artifact.
- **`.agents/skills/review-pr/SKILL.md`** — the blocking media-evidence check now explicitly excludes docs- and skill-only PRs, so the PR-review agent stays consistent with CONTRIBUTING.md and does not raise a missing-media finding on those PRs.

The walkthrough-video requirement is **unchanged** for all product/UI changes and all non-visual backend/refactor/config changes — the exemption is scoped strictly to `.md` docs and `.agents/skills/**`.

## Before / After

Not applicable — documentation- and agent-skill-only change (the exact category this PR exempts). No user-facing behavior changes; the diff across the two markdown files is the reviewable artifact.

## Test plan

- `npx prettier --check` passes on both changed files (`CONTRIBUTING.md` and `.agents/skills/review-pr/SKILL.md`).

## AI disclosure

Drafted with Hermes Agent (Claude). The exemption wording was written in response to the Greptile review on #5649; every change was verified against the current `origin/main` copy of both files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785516275&installation_id=134400930&pr_number=5655&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5655&signature=79693d1bbc6e88c7deff0ee8736fa40360e876cb68d5b3598e957929682a41ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
