### PR TITLE
fix: record Stripe requirements.disabled_reason on stripe_risk suspensions

### DIFF
--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -968,7 +968,7 @@ module StripeMerchantAccountManager
       if %w(rejection_appeal supportability_rejection_appeal).include?(risk_requirement_category)
         # Account not supportable under Stripe supportability.
         # Suspend the account and inform the creator via email.
-        user.suspend_due_to_stripe_risk
+        user.suspend_due_to_stripe_risk(disabled_reason: requirements["disabled_reason"])
       else
         # Some info/verification is required by Stripe for supportability.
         # Send a Stripe remediation link to the creator via email so they can submit the info.

--- a/app/modules/user/risk.rb
+++ b/app/modules/user/risk.rb
@@ -39,17 +39,19 @@ module User::Risk
     end
   end
 
-  def suspend_due_to_stripe_risk
+  def suspend_due_to_stripe_risk(disabled_reason: nil)
     transaction do
       update!(tos_violation_reason: "Stripe reported high risk")
       suspend_for_tos_violation!(author_name: "stripe_risk", bulk: true, skip_generic_suspension_email: true) unless suspended?
       links.alive.find_each do |product|
         product.unpublish!(is_unpublished_by_admin: true)
       end
+      note = "Suspended because of high risk reported by Stripe"
+      note += " (Stripe requirements.disabled_reason: #{disabled_reason})" if disabled_reason.present?
       comments.create!(
         author_name: "stripe_risk",
         comment_type: Comment::COMMENT_TYPE_SUSPENSION_NOTE,
-        content: "Suspended because of high risk reported by Stripe"
+        content: note
       )
       ContactingCreatorMailer.suspended_due_to_stripe_risk(id).deliver_later
     end

--- a/spec/modules/user/risk_spec.rb
+++ b/spec/modules/user/risk_spec.rb
@@ -70,6 +70,20 @@ describe User::Risk do
         another_user.suspend_due_to_stripe_risk
       end.not_to have_enqueued_mail(ContactingCreatorMailer, :account_suspended)
     end
+
+    it "records a suspension note without the reason when disabled_reason is not provided" do
+      user.suspend_due_to_stripe_risk
+
+      note = user.comments.where(comment_type: Comment::COMMENT_TYPE_SUSPENSION_NOTE).last
+      expect(note.content).to eq("Suspended because of high risk reported by Stripe")
+    end
+
+    it "includes the Stripe requirements.disabled_reason in the suspension note when provided" do
+      user.suspend_due_to_stripe_risk(disabled_reason: "rejected.fraud")
+
+      note = user.comments.where(comment_type: Comment::COMMENT_TYPE_SUSPENSION_NOTE).last
+      expect(note.content).to eq("Suspended because of high risk reported by Stripe (Stripe requirements.disabled_reason: rejected.fraud)")
+    end
   end
 
 


### PR DESCRIPTION
## What

Stripe-driven account suspensions (authored by `stripe_risk`) previously collapsed **every** supportability rejection into one generic note — `"Suspended because of high risk reported by Stripe"` — discarding the actual `requirements.disabled_reason` Stripe sends on the triggering `account.updated` webhook.

This change threads that reason through: `User#suspend_due_to_stripe_risk` now takes an optional `disabled_reason:` and appends it to the suspension note when present, and the caller in `StripeMerchantAccountManager#handle_stripe_info_requirements` passes `requirements["disabled_reason"]`.

Resulting suspension note when Stripe supplies a reason:
```
Suspended because of high risk reported by Stripe (Stripe requirements.disabled_reason: rejected.fraud)
```

## Why

When Stripe rejects a connected account as unsupportable, the `account.updated` webhook carries two facets of the same decision:
- `requirements.currently_due` → `interv_….supportability_rejection_appeal.form` (the actionable requirement Gumroad branches on to suspend)
- `requirements.disabled_reason` → the actual reason, e.g. `rejected.fraud`, `rejected.terms_of_service`, `rejected.other`

Gumroad's code branches on the requirement field and never records the reason. So `rejected.fraud` (an affirmative fraud rejection Stripe will not reverse) and a benign `rejected.other` produced an identical, reason-less suspension note. A support/risk reviewer handling an appeal could not distinguish them without querying Stripe's API directly, which led appeals to be triaged on softer framing than the ground truth.

Recording `disabled_reason` in the note surfaces the real driver in-admin, at the moment of suspension, with no extra Stripe calls (the value is already in the webhook payload and is already persisted to `merchant_account.stripe_disabled_reason` a few lines earlier).

## Test plan

- `spec/modules/user/risk_spec.rb` — added two cases:
  - suspension note is unchanged (`"Suspended because of high risk reported by Stripe"`) when `disabled_reason` is not provided (backward compatibility)
  - suspension note includes the reason when provided (`rejected.fraud`)
- Backward compatible: `disabled_reason:` defaults to `nil`; the existing email + suspension + product-unpublish behavior is untouched.

Backend-only change; no UI impact.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5657"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785526345&installation_id=134400930&pr_number=5657&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5657&signature=ca483064f48f56a8067f50b447c7209243a68e2d63ffe861f7e7553f12a73b1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->