### PR TITLE
Fire seller analytics on custom HTML landing pages

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1013,6 +1013,7 @@ class LinksController < ApplicationController
             <meta property="og:type" content="product">
             <meta property="og:url" content="#{canonical}">
             #{og_image_tag}
+            #{custom_html_analytics_head(product)}
             <style>html,body{margin:0;padding:0;height:100%;overflow:hidden}iframe{display:block;width:100%;height:100%;border:0}</style>
           </head>
           <body>
@@ -1054,6 +1055,51 @@ class LinksController < ApplicationController
             #{can_preview_custom_html? ? custom_html_live_reload_script(version_src: "/l/#{product.unique_permalink}/landing/version", nonce:) : ""}
           </body>
         </html>
+      HTML
+    end
+
+    # Custom HTML pages bypass the React product page, so the seller's analytics
+    # (Google Analytics, Facebook/TikTok pixels, and raw third-party snippets)
+    # never load. We inject them into the trusted wrapper — never the sandboxed
+    # landing iframe, whose strict CSP (connect-src 'none', no Google host in
+    # script-src) blocks them by design. The wrapper runs under the global site
+    # CSP, which allowlists those hosts, and the `custom_html_analytics` entry
+    # point reuses the same tracking modules the standard product page uses.
+    #
+    # The entry point fires the same events the standard product page would
+    # (product view + "I want this" on buy click) so switching to a custom page
+    # keeps the same analytics event names. begin_checkout and purchase stay on
+    # the standard checkout and receipt pages the buy button navigates to, which
+    # already fire them — firing them here too would double-count.
+    def custom_html_analytics_head(product)
+      return "" unless analytics_enabled?(seller: product.user)
+
+      analytics = product.analytics_data
+      has_product_third_party_analytics = product.has_third_party_analytics?("product")
+      has_configured_pixel = analytics.values_at(:google_analytics_id, :facebook_pixel_id, :tiktok_pixel_id).any?(&:present?)
+      return "" unless has_configured_pixel || has_product_third_party_analytics
+
+      props = {
+        seller_id: product.user.external_id,
+        analytics:,
+        has_product_third_party_analytics:,
+        third_party_analytics_domain: THIRD_PARTY_ANALYTICS_DOMAIN,
+        permalink: product.unique_permalink,
+        name: product.name,
+      }
+
+      # All three enabled flags are "true" (not per-pixel): this block only renders
+      # when analytics_enabled?, and the frontend gates each pixel on its own
+      # configured id — mirroring PageMeta::Analytics#set_analytics_meta_tags, which
+      # the wrapper's layout-less document can't accumulate. The props JSON goes in a
+      # double-quoted attribute, so ERB::Util.h (which escapes ") is the right escape
+      # here — json_escape would leave quotes intact and break out of the attribute.
+      <<~HTML.strip
+        <meta property="gr:google_analytics:enabled" content="true">
+        <meta property="gr:fb_pixel:enabled" content="true">
+        <meta property="gr:tiktok_pixel:enabled" content="true">
+        <meta name="gr:custom-html-analytics" content="#{ERB::Util.h(props.to_json)}">
+        #{helpers.vite_typescript_tag("custom_html_analytics")}
       HTML
     end
 end

--- a/app/javascript/entrypoints/custom_html_analytics.ts
+++ b/app/javascript/entrypoints/custom_html_analytics.ts
@@ -1,0 +1,55 @@
+import typia from "typia";
+
+import { AnalyticsData } from "$app/parsers/product";
+import { startTrackingForSeller, trackProductEvent } from "$app/utils/user_analytics";
+
+import { addThirdPartyAnalytics } from "$app/components/useAddThirdPartyAnalytics";
+
+// A custom HTML landing page renders as a bare wrapper document that embeds the
+// seller's HTML in a sandboxed, opaque-origin iframe. Neither layer loads the
+// React product page, so the seller's analytics — which normally fire from the
+// product component — never run. This entry point runs only on the trusted
+// wrapper (same-origin gumroad.com, under the global CSP that allowlists Google
+// Analytics and the pixels) and fires the same events the standard product page
+// does, so switching to a custom page keeps the same analytics event names:
+//   - "viewed" on load (GA page_view + view_item, Facebook/TikTok ViewContent)
+//   - "iwantthis" on buy click (GA add_to_cart, Facebook InitiateCheckout)
+// begin_checkout and purchase are intentionally NOT fired here: the buy button
+// navigates to the standard /checkout (which fires begin_checkout) and then the
+// receipt page (which fires purchase), so firing them here would double-count.
+const configElement = document.querySelector('meta[name="gr:custom-html-analytics"]');
+if (configElement) {
+  const props = typia.assert<{
+    seller_id: string;
+    analytics: AnalyticsData;
+    has_product_third_party_analytics: boolean;
+    third_party_analytics_domain: string;
+    permalink: string;
+    name: string;
+  }>(JSON.parse(configElement.getAttribute("content") ?? ""));
+
+  startTrackingForSeller(props.seller_id, props.analytics);
+  trackProductEvent(props.seller_id, { permalink: props.permalink, action: "viewed", product_name: props.name });
+  if (props.has_product_third_party_analytics)
+    addThirdPartyAnalytics({
+      domain: props.third_party_analytics_domain,
+      permalink: props.permalink,
+      location: "product",
+    });
+
+  // The seller's buy control lives inside the sandboxed iframe; clicking it posts
+  // a "gumroad:checkout" message to this wrapper (see custom_html_wrapper_document),
+  // which then navigates to checkout. That message is the custom page's equivalent
+  // of the product page's "I want this" CTA, so mirror its add_to_cart tracking.
+  // We re-check origin/source exactly like the wrapper's navigation handler so a
+  // message from anything but the sandboxed (opaque-origin) iframe is ignored.
+  const landingFrame = document.querySelector<HTMLIFrameElement>("#gumroad-landing-frame");
+  window.addEventListener("message", (event) => {
+    if (event.source !== landingFrame?.contentWindow || event.origin !== "null") return;
+    const data: unknown = event.data;
+    const isCheckout =
+      data === "gumroad:checkout" || (typia.is<{ type: string }>(data) && data.type === "gumroad:checkout");
+    if (!isCheckout) return;
+    trackProductEvent(props.seller_id, { permalink: props.permalink, action: "iwantthis", product_name: props.name });
+  });
+}

--- a/spec/requests/products/show/custom_html_analytics_spec.rb
+++ b/spec/requests/products/show/custom_html_analytics_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# A custom HTML landing page renders as a bare wrapper document that embeds the
+# seller's HTML in a sandboxed, opaque-origin iframe. That bypasses the React
+# product page which normally fires the seller's analytics, so the wrapper has to
+# re-inject the tracking itself. These specs verify it does — and only in the
+# trusted wrapper, only when the seller has analytics configured and enabled.
+describe "Custom HTML landing page analytics", type: :request do
+  let(:seller) { create(:user, username: "analyticsseller", google_analytics_id: "G-ABC123") }
+  let(:product) { create(:product, user: seller, custom_html: "<main><h1>Custom landing</h1></main>") }
+
+  before do
+    Feature.activate_user(:custom_html_pages, seller)
+    # analytics_enabled? only tracks in production/staging, matching the rest of the app.
+    allow(Rails.env).to receive(:production?).and_return(true)
+    # Resolving the Vite manifest for a real build is infra, not what we're testing —
+    # assert the entry point is requested by name and stub the tag it renders.
+    allow_any_instance_of(ActionView::Base).to receive(:vite_typescript_tag)
+      .with("custom_html_analytics").and_return(%(<script src="/custom_html_analytics.js"></script>).html_safe)
+  end
+
+  # Request the canonical subdomain URL directly: in production mode the apex
+  # /l/:permalink 302-redirects to the seller's subdomain, which would swallow
+  # the rendered body.
+  def get_wrapper
+    get product.long_url
+  end
+
+  def analytics_props(body)
+    content = body[/<meta name="gr:custom-html-analytics" content="([^"]*)"/, 1]
+    content && JSON.parse(CGI.unescapeHTML(content))
+  end
+
+  it "injects the enabled meta tags, seller props, and analytics entry point into the wrapper head" do
+    get_wrapper
+
+    expect(response).to be_successful
+    expect(response.body).to include('<meta property="gr:google_analytics:enabled" content="true">')
+    expect(response.body).to include('<meta property="gr:fb_pixel:enabled" content="true">')
+    expect(response.body).to include('<meta property="gr:tiktok_pixel:enabled" content="true">')
+    expect(response.body).to include('src="/custom_html_analytics.js"')
+
+    props = analytics_props(response.body)
+    expect(props).to include(
+      "seller_id" => seller.external_id,
+      "permalink" => product.unique_permalink,
+      "name" => product.name,
+      "third_party_analytics_domain" => THIRD_PARTY_ANALYTICS_DOMAIN,
+      "has_product_third_party_analytics" => false,
+    )
+    expect(props["analytics"]).to include("google_analytics_id" => "G-ABC123")
+  end
+
+  it "does not inject analytics into the sandboxed landing iframe, whose CSP would block them" do
+    get "#{product.long_url}/landing/embed"
+
+    expect(response.body).not_to include("gr:custom-html-analytics")
+    expect(response.body).not_to include("gr:google_analytics:enabled")
+  end
+
+  context "when the seller has no analytics configured" do
+    let(:seller) { create(:user, username: "noanalytics") }
+
+    it "omits the analytics block so the wrapper stays minimal" do
+      get_wrapper
+
+      expect(response.body).not_to include("gr:custom-html-analytics")
+      expect(response.body).not_to include("gr:google_analytics:enabled")
+    end
+  end
+
+  context "when the seller disabled third-party analytics" do
+    before { seller.update!(disable_third_party_analytics: true) }
+
+    it "omits the analytics block" do
+      get_wrapper
+
+      expect(response.body).not_to include("gr:custom-html-analytics")
+    end
+  end
+
+  context "when the seller has only a raw third-party analytics snippet (no pixel ids)" do
+    let(:seller) { create(:user, username: "snippetseller") }
+
+    before { ThirdPartyAnalytic.create!(user: seller, analytics_code: "<script>1</script>", location: "product") }
+
+    it "injects the block so the entry point loads the snippet iframe" do
+      get_wrapper
+
+      props = analytics_props(response.body)
+      expect(props["has_product_third_party_analytics"]).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
Ref #5642

## What
Custom HTML product landing pages render as a bare wrapper document + a sandboxed, opaque-origin iframe, so they never load the React product page that fires the seller's Google Analytics and Facebook/TikTok pixels. A seller who switches to a custom page silently loses all analytics. This injects the tracking into the **trusted wrapper** (same-origin, under the global CSP that already allowlists the analytics hosts) via a small Vite entry point that reuses the same tracking modules the standard product page uses.

## Why
Analytics is a primary reason sellers reach for custom pages, and the feature quietly broke it. Injecting in the wrapper — never the sandboxed iframe (whose strict `connect-src 'none'` CSP blocks GA by design) — restores it without weakening the sandbox.

**Event parity** — switching to a custom page keeps the same event names:
- `viewed` on load, `iwantthis` on buy click (mirrors the standard page's "I want this" CTA)
- `begin_checkout` and `purchase` are left to the checkout/receipt pages the buy button navigates to, so nothing is double-counted (verified: `?wanted=true` server-redirects to `/checkout` without rendering the product page).

---
🤖 AI disclosure: implemented with Claude Opus 4.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5658"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785527707&installation_id=134400930&pr_number=5658&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5658&signature=2b24e5fcbcf91c5021fc5a1ab70ac855b66890781c5ecb3684f2ed3135e39917"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->