### PR TITLE
Fix AI Agent 500: fall back to Walks Anthropic key when ANTHROPIC_API_KEY is unset

### DIFF
--- a/app/services/ai/anthropic_client.rb
+++ b/app/services/ai/anthropic_client.rb
@@ -127,10 +127,25 @@ class Ai::AnthropicClient
 
     def http
       HTTP.timeout(timeout).headers(
-        "x-api-key" => GlobalConfig.get("ANTHROPIC_API_KEY"),
+        "x-api-key" => api_key,
         "anthropic-version" => API_VERSION,
         "content-type" => "application/json",
       )
+    end
+
+    # The store agent's own Anthropic key. Falls back to the Walks synthesis key (already provisioned
+    # in production) when a dedicated ANTHROPIC_API_KEY hasn't been set yet, so the agent isn't dark
+    # on a missing config — otherwise every request goes out with a blank x-api-key and Anthropic
+    # rejects it with a 401 ("x-api-key header is required"), taking the whole feature down with the
+    # generic "Sorry, I ran into a problem" error. Remove the fallback once ANTHROPIC_API_KEY is set.
+    # Failing fast here with a clear message (rather than shipping a blank key upstream) keeps a future
+    # config gap legible instead of surfacing as a confusing upstream 401.
+    def api_key
+      key = GlobalConfig.get("ANTHROPIC_API_KEY").presence ||
+            GlobalConfig.get("WALKS_ANTHROPIC_API_KEY").presence
+      raise Error, "Anthropic API key is not configured (set ANTHROPIC_API_KEY)." if key.blank?
+
+      key
     end
 
     # Normalize a buffered Messages response into a Result. Content is an array of typed blocks; we

--- a/spec/services/ai/anthropic_client_spec.rb
+++ b/spec/services/ai/anthropic_client_spec.rb
@@ -54,6 +54,43 @@ describe Ai::AnthropicClient do
     end
   end
 
+  describe "API key resolution" do
+    it "uses ANTHROPIC_API_KEY when it is set" do
+      allow(GlobalConfig).to receive(:get).with("ANTHROPIC_API_KEY").and_return("sk-ant-dedicated")
+
+      stub = stub_request(:post, url)
+        .with(headers: { "x-api-key" => "sk-ant-dedicated" })
+        .to_return(status: 200, body: { "content" => [], "stop_reason" => "end_turn" }.to_json, headers: { "Content-Type" => "application/json" })
+
+      client.messages(system: "s", messages: [{ role: "user", content: "x" }])
+
+      expect(stub).to have_been_requested
+    end
+
+    it "falls back to WALKS_ANTHROPIC_API_KEY when ANTHROPIC_API_KEY is blank" do
+      allow(GlobalConfig).to receive(:get).with("ANTHROPIC_API_KEY").and_return("")
+      allow(GlobalConfig).to receive(:get).with("WALKS_ANTHROPIC_API_KEY").and_return("sk-ant-walks")
+
+      stub = stub_request(:post, url)
+        .with(headers: { "x-api-key" => "sk-ant-walks" })
+        .to_return(status: 200, body: { "content" => [], "stop_reason" => "end_turn" }.to_json, headers: { "Content-Type" => "application/json" })
+
+      client.messages(system: "s", messages: [{ role: "user", content: "x" }])
+
+      expect(stub).to have_been_requested
+    end
+
+    it "raises a clear error (no blank-key request) when both keys are missing" do
+      allow(GlobalConfig).to receive(:get).with("ANTHROPIC_API_KEY").and_return("")
+      allow(GlobalConfig).to receive(:get).with("WALKS_ANTHROPIC_API_KEY").and_return(nil)
+      request = stub_request(:post, url)
+
+      expect { client.messages(system: "s", messages: [{ role: "user", content: "x" }]) }
+        .to raise_error(described_class::Error, /not configured/i)
+      expect(request).not_to have_been_requested
+    end
+  end
+
   describe "#stream_messages" do
     # Build a raw Anthropic SSE body from a list of [event, data] pairs.
     def sse(*events)


### PR DESCRIPTION
## What

The store Agent's `Ai::AnthropicClient` reads `GlobalConfig.get("ANTHROPIC_API_KEY")`, which is **blank in production**. Every request went out with an empty `x-api-key` header and Anthropic rejected it with:

```
401 Unauthorized — "x-api-key header is required"
```

That took the entire Agent feature down behind the generic "Sorry, I ran into a problem" message and flooded Sentry (500+ events, escalating). Root cause is a missing prod config value, not a logic bug, but the client also failed unhelpfully by shipping a blank key upstream instead of failing fast.

Fixes antiwork/gumroad-private#827.

## Change

- **Stopgap fallback:** when `ANTHROPIC_API_KEY` is absent, use the already-provisioned `WALKS_ANTHROPIC_API_KEY` so the Agent comes back online immediately. When a dedicated `ANTHROPIC_API_KEY` is later set in prod it takes precedence automatically, and this fallback can be removed (noted in a code comment).
- **Fail fast:** if both keys are missing, raise a clear `"Anthropic API key is not configured"` error before making the request, so a future config gap is legible instead of a confusing upstream 401.

## Why not just set the key in AWS?

The prod env value lives in deploy infra outside this repo, and provisioning a dedicated `ANTHROPIC_API_KEY` there is still the right long-term fix. This fallback is explicitly temporary. Shipping it restores the feature now without waiting on a config change, and self-heals once the dedicated key lands.

## Tests

Added coverage in `spec/services/ai/anthropic_client_spec.rb`:
- uses `ANTHROPIC_API_KEY` when set
- falls back to `WALKS_ANTHROPIC_API_KEY` when it's blank
- raises a clear error and makes no request when both are missing

```
10 examples, 0 failures
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785528825&installation_id=134400930&pr_number=5660&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5660&signature=5a43d4884722aa83cac132760b2f00f53709dabb9d0f4b684249408e037717a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->