### PR TITLE
Fix embedded-video fullscreen button (preserve allowfullscreen in client sanitizer)

### DIFF
--- a/app/javascript/utils/sanitize.ts
+++ b/app/javascript/utils/sanitize.ts
@@ -15,6 +15,6 @@ export const sanitizeHtml = (dirtyHtml: string): string => {
 
   return DOMPurify.sanitize(dirtyHtml, {
     ADD_TAGS: ["iframe"],
-    ADD_ATTR: ["src", "allow", "width", "height", "title", "sandbox"],
+    ADD_ATTR: ["src", "allow", "allowfullscreen", "width", "height", "title", "sandbox"],
   });
 };


### PR DESCRIPTION
## What

Adds `"allowfullscreen"` to the `ADD_ATTR` allowlist in the client-side `sanitizeHtml` (`app/javascript/utils/sanitize.ts`) so DOMPurify preserves it on embedded-media iframes.

## Why

Embedded Vimeo/YouTube videos in product/download content were missing the fullscreen button on the customer-facing page, even when fullscreen was enabled on the source.

Root cause (confirmed against live code): a creator adds a video via the rich-content editor's media embed, which calls iframely and gets back a Vimeo/YouTube `<iframe>` carrying both `allow="... fullscreen ..."` and the boolean `allowfullscreen` attribute. On the customer download page the node is re-rendered via `dangerouslySetInnerHTML={{ __html: sanitizeHtml(node.attrs.html) }}`. The client sanitizer allowlisted `allow` but **not** `allowfullscreen`, and DOMPurify's default attribute allowlist excludes both — so `allowfullscreen` was stripped on render. Browsers only expose the player's fullscreen control when the embedding iframe carries `allowfullscreen`, so the button disappeared.

The server-side page sanitizer (`app/services/ai/page_sanitizer.rb`) already lists `allowfullscreen` in its `ALLOWED_ATTRIBUTES`, and `spec/services/ai/page_sanitizer_spec.rb` asserts it's preserved. This PR brings the out-of-sync client embed sanitizer in line.

## Before / After

Both panels below are the **actual** output of the repo's DOMPurify (`node_modules/dompurify`) run against a real iframely-style YouTube embed, using the exact `ADD_ATTR` allowlist from `app/javascript/utils/sanitize.ts` — **before** (`main`) vs **after** (this PR). The embed carries both `allow="… fullscreen"` and the boolean `allowfullscreen`.

![Before/after: embedded video fullscreen button](https://raw.githubusercontent.com/gumclaw/gumroad/pr5663-media/media/pr5663-fullscreen-before-after.png)

| | Allowlist | Sanitized iframe | Fullscreen control |
|---|---|---|---|
| **Before** (`main`) | `["src","allow","width","height","title","sandbox"]` | `allowfullscreen` **stripped** (`…allow="…fullscreen" sandbox=…`) | ❌ hidden |
| **After** (#5663) | `[…,"allowfullscreen"]` | `allowfullscreen=""` **preserved** (`…allow="…fullscreen" allowfullscreen="" sandbox=…`) | ✅ shown |

Browsers only expose the player's fullscreen control when the embedding iframe still carries `allowfullscreen` after sanitization — which is exactly what the right-hand panel restores.

## Test plan / verification

- `autoreview` (Codex/gpt-5.5): **clean — no accepted/actionable findings** (correctness 0.88).
- The parallel server-side path already has a preserving-`allowfullscreen` assertion in `page_sanitizer_spec.rb`.
- A client-side regression test was **not** added: the vitest suite runs in `environment: "node"` with no jsdom/testing-library, and `sanitizeHtml` requires `window` + a DOM, so a shipping test would mean standing up a jsdom harness — a bigger, riskier change than this one-line allowlist fix. Flagging for the reviewer in case you'd prefer to add that harness separately.

## Root cause / rung

Confirmed — see antiwork/gumroad-private#832 for the full investigation.

---
Draft fix filed by Gumclaw from support ticket investigation gumroad-private#832.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785530667&installation_id=134400930&pr_number=5663&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5663&signature=de1ebc811ad9ea77df7afcfd4fcd0848ac0ddfd82448e0bb00176ffb39a24694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
