### PR TITLE
Report a single ci/green status from the real test run so auto-merge waits on tests

### DIFF
--- a/.github/workflows/ci-green.yml
+++ b/.github/workflows/ci-green.yml
@@ -1,0 +1,52 @@
+name: CI Green
+
+# Reports a single required commit status ("ci/green") that native auto-merge
+# can wait on. The Tests workflow runs the real suite on `push` events (and on
+# `pull_request_target` for FORK PRs only — internal PR-target runs are noops).
+# The main ruleset requires the ci/green status, and until it lands, a PR shows
+# as pending. This closes the gap where auto-merge fired instantly because the
+# internal PR check suite was all noop/skipped (see gumroad PR #5667).
+#
+# Why commit statuses and not a job inside tests.yml: skipped check runs SATISFY
+# required checks, so any job name the internal-PR noop run also emits would be
+# an instant-green loophole. A workflow_run-triggered reporter never attaches
+# check runs to the PR head SHA — it only sets the status via the API, and only
+# for runs that actually executed the suite.
+
+on:
+  workflow_run:
+    workflows: ["Tests"]
+    types: [completed]
+
+permissions:
+  statuses: write
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    # Real suite runs only: push events, or pull_request_target from a FORK
+    # (internal pull_request_target runs are noops and must not report).
+    if: >-
+      github.event.workflow_run.event == 'push' ||
+      (github.event.workflow_run.event == 'pull_request_target' &&
+       github.event.workflow_run.head_repository.full_name != github.repository)
+    steps:
+      - name: Set ci/green status on the tested commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          if [ "$CONCLUSION" = "success" ]; then
+            STATE=success
+            DESC="Test suite passed"
+          else
+            STATE=failure
+            DESC="Test suite: $CONCLUSION"
+          fi
+          gh api "repos/${GITHUB_REPOSITORY}/statuses/${SHA}" \
+            -f state="$STATE" \
+            -f context="ci/green" \
+            -f description="$DESC" \
+            -f target_url="$RUN_URL"


### PR DESCRIPTION
## What

Adds a small `workflow_run` reporter that stamps one commit status, `ci/green`, on the tested SHA whenever the **Tests** workflow completes a real run — `push` events, plus `pull_request_target` runs for fork PRs. Internal PR-target runs (which are deliberate noops) never report.

Follow-up once merged: add `ci/green` as a required status check on the `main` ruleset so native auto-merge actually waits for the suite.

## Why

PR #5667 merged 9 seconds after opening, before the test suite finished. Two things stacked:

1. The internal-PR `pull_request_target` run is a noop — every job skips — and skipped checks satisfy GitHub's merge readiness, so the PR read all-green immediately.
2. The `main` ruleset has **no required status checks**, so armed auto-merge had nothing to wait for.

Requiring the 68 matrix shard names directly would break whenever the matrix changes, and requiring any name the noop run also emits would be an instant-green loophole (skipped satisfies required). A single API-set commit status from the completed real run avoids both: until the suite finishes, `ci/green` simply doesn't exist on the SHA, so a required check shows pending and native auto-merge waits.

## Notes

- Fork PRs are covered via the non-noop `pull_request_target` branch of the condition.
- The existing `ci_gate` job stays — it's the fork-PR environment-approval gate, unrelated to this.
- No effect until the ruleset requires `ci/green`; rollout: merge this → add required check → new PRs wait on tests.

🤖 AI disclosure: authored with Claude (Hermes Agent), prompted by Sahil after #5667 merged before tests passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785565117&installation_id=134400930&pr_number=5668&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5668&signature=93ae0a630f8db759dbf30bbccbdff70dcafb2ee4a93659b97cc320b6ff071b16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->