### PR TITLE
feat(gift): add Gift::ConvertToNonGiftService for admin gift→non-gift conversion

### DIFF
--- a/app/services/gift/convert_to_non_gift_service.rb
+++ b/app/services/gift/convert_to_non_gift_service.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+# Converts a gift purchase into a regular (non-gift) purchase.
+#
+# A gift is stored as two linked purchases: the gifter (payer) purchase carries the
+# `is_gift_sender_purchase` flag, and the giftee (recipient, $0) purchase carries the
+# `is_gift_receiver_purchase` flag. This service always clears the sender flag on the payer leg
+# (that is the "gift purchase" being made regular) and retains the `Gift` row for audit history.
+#
+# For a gifted SUBSCRIPTION this flips `Subscription#gift?` (which reads
+# `true_original_purchase.is_gift_sender_purchase?`) from true to false, re-points
+# `subscription.user` at the paying buyer, and moves the payer's saved card onto the
+# subscription, so renewal / manage-subscription comms AND billing resolve to the payer instead
+# of the giftee.
+#
+# SCOPE — this moves BILLING OWNERSHIP, not product ACCESS. It does NOT mint a url_redirect /
+# license for the payer (gift-sender purchases intentionally skip those at checkout); the giftee
+# keeps the seat/license the seller already provisioned. Minting new access artifacts would
+# double-provision (two live seats for one subscription). If a caller ever needs the payer to
+# also hold the download/license, that is a separate, explicit reassignment step — out of scope.
+#
+# The giftee's receiver leg is left untouched. Its `is_gift_receiver_purchase` flag +
+# `gift_receiver_purchase_successful` state are coherent together and keep the $0 access purchase
+# visible in the recipient's library/mobile listings (for a subscription leg the flag is the ONLY
+# reason it survives `Purchase.for_library`'s `not_subscription_or_original_purchase` scope).
+# Clearing the flag would leave the row in a gift-only success state with non-gift flags — an
+# inconsistent state that downstream non-gift success scopes (`NON_GIFT_SUCCESS_STATES`) exclude.
+# The conversion only makes the PAYER's leg regular; the recipient keeps their gift access as-is.
+#
+# KNOWN LIMITATION (deliberately out of scope) — refund/chargeback propagation to the giftee leg
+# is gated throughout the codebase on `is_gift_sender_purchase` (e.g. `Purchase::Refundable`,
+# `Purchase::ChargeEventsHandler`, `Charge::Disputable`). Once this service clears that flag, a
+# later refund or chargeback of the (now regular) payer purchase will NOT auto-revoke the giftee's
+# $0 access leg. This is acceptable for the billing-ownership use case (the recipient is meant to
+# keep the seat the seller provisioned, and for subscriptions the gift row only lives on the
+# original purchase, so renewal reversals never propagated to the giftee regardless). If access
+# must be revoked after a post-conversion reversal, do it explicitly — it is not automatic.
+#
+# This is a console/eng-invoked path (no controller/CLI). It is HARD-GATED on the caller
+# asserting that BOTH the gifter and the giftee have signed off on the conversion.
+#
+#   Gift::ConvertToNonGiftService.new(
+#     gift:,
+#     gifter_signed_off: true,
+#     giftee_signed_off: true,
+#     admin_id: GUMROAD_ADMIN_ID,
+#     reason: "SoftwareONE/Siemens re-own request, gumroad-private#841",
+#   ).process!
+#
+class Gift::ConvertToNonGiftService
+  class ConfirmationRequiredError < StandardError; end
+  class NotConvertibleError < StandardError; end
+
+  Result = Struct.new(:converted, :already_converted, :gift, :gifter_purchase, :giftee_purchase, :subscription, keyword_init: true)
+
+  def initialize(gift:, gifter_signed_off:, giftee_signed_off:, admin_id: GUMROAD_ADMIN_ID, reason: nil)
+    @gift = gift
+    @gifter_signed_off = gifter_signed_off
+    @giftee_signed_off = giftee_signed_off
+    @admin_id = admin_id
+    @reason = reason
+  end
+
+  def process!
+    require_confirmation!
+
+    gifter_purchase = gift.gifter_purchase
+    giftee_purchase = gift.giftee_purchase
+
+    raise NotConvertibleError, "Gift ##{gift.id} has no gifter purchase to convert" if gifter_purchase.nil?
+
+    # Idempotent: if the gift-sender flag is already cleared, there is nothing to do.
+    unless gifter_purchase.is_gift_sender_purchase?
+      return Result.new(
+        converted: false,
+        already_converted: true,
+        gift:,
+        gifter_purchase:,
+        giftee_purchase:,
+        subscription: gifter_purchase.subscription,
+      )
+    end
+
+    subscription = gifter_purchase.subscription
+
+    ActiveRecord::Base.transaction do
+      gifter_purchase.update!(is_gift_sender_purchase: false)
+
+      if subscription.present?
+        # Re-own the subscription to the paying buyer. Gift subscriptions are created with
+        # `subscription.user` pointing at the giftee and `subscription.credit_card` left nil, while
+        # `Subscription#email` prefers `user.form_email` before falling back to `gift?`. So flipping
+        # the sender flag alone would still route renewal/manage-subscription comms to the giftee
+        # (whenever they have an account) AND leave renewals with no card for a guest payer. Point
+        # the subscription at the payer and move the payer's saved card onto it (mirroring how a
+        # regular subscription stores the original purchase's card). When the payer is a guest with
+        # no reusable card, the subscription card stays nil and the payer adds one through the
+        # normal manage-subscription flow — same as any owner without a saved card.
+        updates = { user: gifter_purchase.purchaser }
+        updates[:credit_card] = gifter_purchase.credit_card if gifter_purchase.credit_card.present?
+        subscription.update!(updates)
+      end
+
+      log_audit_comments!(gifter_purchase, giftee_purchase)
+    end
+
+    Result.new(
+      converted: true,
+      already_converted: false,
+      gift:,
+      gifter_purchase:,
+      giftee_purchase:,
+      subscription:,
+    )
+  end
+
+  private
+    attr_reader :gift, :admin_id, :reason
+
+    def require_confirmation!
+      return if @gifter_signed_off == true && @giftee_signed_off == true
+
+      missing = []
+      missing << "gifter" unless @gifter_signed_off == true
+      missing << "giftee" unless @giftee_signed_off == true
+      raise ConfirmationRequiredError,
+            "Both gifter and giftee must sign off before converting gift ##{gift.id} " \
+            "(missing sign-off: #{missing.join(', ')})"
+    end
+
+    def log_audit_comments!(gifter_purchase, giftee_purchase)
+      content = audit_content
+      gifter_purchase.comments.create!(content:, comment_type: Comment::COMMENT_TYPE_NOTE, author_id: admin_id)
+      giftee_purchase&.comments&.create!(content:, comment_type: Comment::COMMENT_TYPE_NOTE, author_id: admin_id)
+
+      # Also record it on the paying buyer's account (if they have one), since this is the
+      # account that now owns the purchase/subscription.
+      payer = gifter_purchase.purchaser
+      payer&.comments&.create!(content:, comment_type: Comment::COMMENT_TYPE_NOTE, author_id: admin_id, purchase: gifter_purchase)
+    end
+
+    def audit_content
+      parts = ["Gift ##{gift.id} converted to a regular (non-gift) purchase. " \
+               "Confirmed sign-off from both gifter and giftee."]
+      parts << "Reason: #{reason}" if reason.present?
+      parts.join(" ")
+    end
+end

--- a/app/services/gift/convert_to_non_gift_service.rb
+++ b/app/services/gift/convert_to_non_gift_service.rb
@@ -98,12 +98,17 @@ class Gift::ConvertToNonGiftService
         # the sender flag alone would still route renewal/manage-subscription comms to the giftee
         # (whenever they have an account) AND leave renewals with no card for a guest payer. Point
         # the subscription at the payer and move the payer's saved card onto it (mirroring how a
-        # regular subscription stores the original purchase's card). When the payer is a guest with
-        # no reusable card, the subscription card stays nil and the payer adds one through the
-        # normal manage-subscription flow — same as any owner without a saved card.
-        updates = { user: gifter_purchase.purchaser }
-        updates[:credit_card] = gifter_purchase.credit_card if gifter_purchase.credit_card.present?
-        subscription.update!(updates)
+        # regular subscription stores the original purchase's card). The card is assigned
+        # UNCONDITIONALLY: a gift subscription's card can be non-nil if the giftee added their own
+        # card through the manage-subscription flow (Subscription::UpdaterService), and
+        # `Subscription#credit_card_to_charge` prefers `subscription.credit_card` over the owner's
+        # account card. Conditionally assigning would leave that giftee card silently billing a
+        # subscription now owned by and comms-routed to the payer. Overwriting with the payer's card
+        # — or nil when the payer is a guest with no reusable card — clears the stale giftee card;
+        # the guest payer then adds a card through the normal manage-subscription flow, same as any
+        # owner without a saved card. The idempotency guard prevents a later re-run from clobbering
+        # a card the payer adds afterward.
+        subscription.update!(user: gifter_purchase.purchaser, credit_card: gifter_purchase.credit_card)
       end
 
       log_audit_comments!(gifter_purchase, giftee_purchase)

--- a/app/services/gift/convert_to_non_gift_service.rb
+++ b/app/services/gift/convert_to_non_gift_service.rb
@@ -69,21 +69,26 @@ class Gift::ConvertToNonGiftService
 
     raise NotConvertibleError, "Gift ##{gift.id} has no gifter purchase to convert" if gifter_purchase.nil?
 
-    # Idempotent: if the gift-sender flag is already cleared, there is nothing to do.
-    unless gifter_purchase.is_gift_sender_purchase?
-      return Result.new(
-        converted: false,
-        already_converted: true,
-        gift:,
-        gifter_purchase:,
-        giftee_purchase:,
-        subscription: gifter_purchase.subscription,
-      )
-    end
-
     subscription = gifter_purchase.subscription
 
     ActiveRecord::Base.transaction do
+      # Row-lock + re-check inside the transaction so two racing console invocations can't both
+      # pass the idempotency guard and double-write the audit comments. The lock serializes them;
+      # the loser re-reads the already-cleared flag and returns the already-converted result.
+      gifter_purchase.lock!
+
+      # Idempotent: if the gift-sender flag is already cleared, there is nothing to do.
+      unless gifter_purchase.is_gift_sender_purchase?
+        return Result.new(
+          converted: false,
+          already_converted: true,
+          gift:,
+          gifter_purchase:,
+          giftee_purchase:,
+          subscription:,
+        )
+      end
+
       gifter_purchase.update!(is_gift_sender_purchase: false)
 
       if subscription.present?

--- a/spec/services/gift/convert_to_non_gift_service_spec.rb
+++ b/spec/services/gift/convert_to_non_gift_service_spec.rb
@@ -186,6 +186,25 @@ describe Gift::ConvertToNonGiftService do
           expect(subscription.reload.credit_card).to eq(credit_card)
         end
       end
+
+      context "when the giftee added their own card and the payer has none", :vcr do
+        let(:giftee_card) { create(:credit_card) }
+        let!(:gifter_purchase) do
+          create(:membership_purchase, link: product, seller:, subscription:, purchaser: payer,
+                                       email: "payer@example.com",
+                                       is_gift_sender_purchase: true, gift_given: gift)
+        end
+
+        before { subscription.update!(credit_card: giftee_card) }
+
+        it "clears the stale giftee card so renewals do not keep billing the giftee" do
+          expect(subscription.reload.credit_card).to eq(giftee_card)
+
+          build_service.process!
+
+          expect(subscription.reload.credit_card).to be_nil
+        end
+      end
     end
 
     context "idempotency" do

--- a/spec/services/gift/convert_to_non_gift_service_spec.rb
+++ b/spec/services/gift/convert_to_non_gift_service_spec.rb
@@ -113,7 +113,7 @@ describe Gift::ConvertToNonGiftService do
         let(:giftee) { create(:user, email: "giftee@example.com") }
         let!(:receiver_leg) do
           create(:membership_purchase, :gift_receiver, link: product, seller:, subscription:,
-                                        purchaser: giftee, email: "giftee@example.com")
+                                                       purchaser: giftee, email: "giftee@example.com")
         end
 
         before { subscription.update!(user: giftee) }
@@ -131,6 +131,41 @@ describe Gift::ConvertToNonGiftService do
           build_service.process!
 
           expect(subscription.reload.user).to eq(payer)
+          expect(subscription.reload.email).to eq("payer@example.com")
+        end
+      end
+
+      context "when the payer is a guest buyer (nil purchaser)" do
+        let!(:gifter_purchase) do
+          create(:membership_purchase, link: product, seller:, subscription:, purchaser: nil,
+                                       email: "payer@example.com", is_gift_sender_purchase: true, gift_given: gift)
+        end
+
+        it "sets the subscription user to nil and resolves email via the payer purchase" do
+          result = build_service.process!
+
+          expect(result.converted).to be(true)
+          expect(subscription.reload.user).to be_nil
+          expect(subscription.reload.gift?).to be(false)
+          expect(subscription.reload.email).to eq("payer@example.com")
+        end
+      end
+
+      context "when the paying buyer is a guest (nil purchaser)" do
+        let!(:gifter_purchase) do
+          create(:membership_purchase, link: product, seller:, subscription:, purchaser: nil,
+                                       email: "payer@example.com", is_gift_sender_purchase: true, gift_given: gift)
+        end
+
+        before { subscription.update!(user: create(:user, email: "giftee@example.com")) }
+
+        it "clears the subscription owner and resolves email to the payer via the original purchase" do
+          expect(subscription.reload.gift?).to be(true)
+          expect(subscription.reload.email).to eq("giftee@example.com")
+
+          build_service.process!
+
+          expect(subscription.reload.user).to be_nil
           expect(subscription.reload.email).to eq("payer@example.com")
         end
       end

--- a/spec/services/gift/convert_to_non_gift_service_spec.rb
+++ b/spec/services/gift/convert_to_non_gift_service_spec.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Gift::ConvertToNonGiftService do
+  let(:seller) { create(:user) }
+  let(:product) { create(:product, user: seller) }
+  let(:payer) { create(:user, email: "payer@example.com") }
+  let(:gifter_purchase) { create(:purchase, link: product, seller:, purchaser: payer, is_gift_sender_purchase: true) }
+  let(:giftee_purchase) { create(:purchase, :gift_receiver, link: product, seller:) }
+  let(:gift) do
+    create(:gift, link: product, gifter_purchase:, giftee_purchase:,
+                  gifter_email: "payer@example.com", giftee_email: "giftee@example.com")
+  end
+
+  def build_service(gifter_signed_off: true, giftee_signed_off: true, reason: nil)
+    described_class.new(gift:, gifter_signed_off:, giftee_signed_off:, reason:)
+  end
+
+  describe "#process!" do
+    context "confirmation gate" do
+      it "raises when the gifter has not signed off" do
+        expect { build_service(gifter_signed_off: false).process! }
+          .to raise_error(described_class::ConfirmationRequiredError, /gifter/)
+      end
+
+      it "raises when the giftee has not signed off" do
+        expect { build_service(giftee_signed_off: false).process! }
+          .to raise_error(described_class::ConfirmationRequiredError, /giftee/)
+      end
+
+      it "raises when a sign-off is truthy but not literally true" do
+        expect { build_service(gifter_signed_off: "yes").process! }
+          .to raise_error(described_class::ConfirmationRequiredError)
+      end
+
+      it "does not mutate the purchases when the gate fails" do
+        expect { build_service(giftee_signed_off: false).process! rescue nil }
+          .not_to change { gifter_purchase.reload.is_gift_sender_purchase? }
+      end
+    end
+
+    context "for a one-off gift" do
+      it "clears the gift-sender flag on the payer leg and returns converted" do
+        result = build_service.process!
+
+        expect(result.converted).to be(true)
+        expect(gifter_purchase.reload.is_gift_sender_purchase?).to be(false)
+      end
+
+      it "makes Purchase#gift resolve to nil for the payer leg" do
+        build_service.process!
+
+        expect(gifter_purchase.reload.gift).to be_nil
+      end
+
+      it "leaves the giftee receiver leg untouched so its access stays intact" do
+        build_service.process!
+
+        expect(giftee_purchase.reload.is_gift_receiver_purchase?).to be(true)
+        expect(giftee_purchase.reload.purchase_state).to eq("gift_receiver_purchase_successful")
+        expect(Purchase.for_library).to include(gifter_purchase, giftee_purchase)
+      end
+
+      it "retains the Gift record for audit history" do
+        build_service.process!
+        expect(Gift.exists?(gift.id)).to be(true)
+      end
+
+      it "logs an audit comment on both purchases and the payer account" do
+        build_service(reason: "gumroad-private#841").process!
+
+        gifter_comment = gifter_purchase.reload.comments.last
+        expect(gifter_comment.comment_type).to eq(Comment::COMMENT_TYPE_NOTE)
+        expect(gifter_comment.author_id).to eq(GUMROAD_ADMIN_ID)
+        expect(gifter_comment.content).to include("converted to a regular (non-gift) purchase")
+        expect(gifter_comment.content).to include("gumroad-private#841")
+
+        expect(giftee_purchase.reload.comments.last.content).to include("converted to a regular")
+        expect(payer.reload.comments.last.content).to include("converted to a regular")
+      end
+    end
+
+    context "for a gifted subscription" do
+      let(:subscription) { create(:subscription, link: product, user: nil) }
+      let!(:gifter_purchase) do
+        create(:membership_purchase, link: product, seller:, subscription:, purchaser: payer,
+                                     email: "payer@example.com", is_gift_sender_purchase: true, gift_given: gift)
+      end
+      let(:gift) { create(:gift, link: product, giftee_email: "giftee@example.com", gifter_email: "payer@example.com") }
+      let(:giftee_purchase) { nil }
+
+      it "flips Subscription#gift? from true to false" do
+        expect(subscription.reload.gift?).to be(true)
+
+        build_service.process!
+
+        expect(subscription.reload.gift?).to be(false)
+      end
+
+      it "resolves the subscription email to the paying buyer instead of the giftee" do
+        build_service.process!
+
+        expect(subscription.reload.email).to eq("payer@example.com")
+      end
+
+      it "returns the subscription in the result" do
+        result = build_service.process!
+        expect(result.subscription).to eq(subscription)
+      end
+
+      context "when the subscription has a gift-receiver access leg" do
+        let(:giftee) { create(:user, email: "giftee@example.com") }
+        let!(:receiver_leg) do
+          create(:membership_purchase, :gift_receiver, link: product, seller:, subscription:,
+                                        purchaser: giftee, email: "giftee@example.com")
+        end
+
+        before { subscription.update!(user: giftee) }
+
+        it "keeps the receiver flag so the giftee's library access is preserved" do
+          build_service.process!
+
+          expect(receiver_leg.reload.is_gift_receiver_purchase?).to be(true)
+          expect(Purchase.for_library).to include(receiver_leg)
+        end
+
+        it "re-owns the subscription to the payer so renewal comms leave the giftee" do
+          expect(subscription.reload.email).to eq("giftee@example.com")
+
+          build_service.process!
+
+          expect(subscription.reload.user).to eq(payer)
+          expect(subscription.reload.email).to eq("payer@example.com")
+        end
+      end
+
+      context "when the payer purchase has a saved card", :vcr do
+        let(:credit_card) { create(:credit_card) }
+        let!(:gifter_purchase) do
+          create(:membership_purchase, link: product, seller:, subscription:, purchaser: payer,
+                                       email: "payer@example.com", credit_card:,
+                                       is_gift_sender_purchase: true, gift_given: gift)
+        end
+
+        it "moves the payer's card onto the subscription so renewals can bill the payer" do
+          expect(subscription.reload.credit_card).to be_nil
+
+          build_service.process!
+
+          expect(subscription.reload.credit_card).to eq(credit_card)
+        end
+      end
+    end
+
+    context "idempotency" do
+      it "returns already_converted on a second run without error" do
+        build_service.process!
+
+        result = build_service.process!
+        expect(result.converted).to be(false)
+        expect(result.already_converted).to be(true)
+      end
+    end
+
+    context "when the gift has no gifter purchase" do
+      let(:gift) { create(:gift, link: product, gifter_purchase: nil, giftee_purchase:) }
+
+      it "raises NotConvertibleError" do
+        expect { build_service.process! }.to raise_error(described_class::NotConvertibleError)
+      end
+    end
+  end
+end

--- a/spec/support/fixtures/vcr_cassettes/Gift_ConvertToNonGiftService/_process_/for_a_gifted_subscription/when_the_giftee_added_their_own_card_and_the_payer_has_none/clears_the_stale_giftee_card_so_renewals_do_not_keep_billing_the_giftee.yml
+++ b/spec/support/fixtures/vcr_cassettes/Gift_ConvertToNonGiftService/_process_/for_a_gifted_subscription/when_the_giftee_added_their_own_card_and_the_payer_has_none/clears_the_stale_giftee_card_so_renewals_do_not_keep_billing_the_giftee.yml
@@ -1,0 +1,404 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_qRGw0ackEG3mIn","request_duration_ms":1}}'
+      Idempotency-Key:
+      - e7e0f4c1-f929-46e8-b570-50f9ebab7ba8
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 x86_64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 06:47:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=-LD-ThvP7UhzEON-iB6DG2bsO0dxxEZl-CRD_6lp73vVUwYFVzvt2YXz_F9U2qiigtow5mXw4F-meSvn;
+        report-to csp
+      Idempotency-Key:
+      - e7e0f4c1-f929-46e8-b570-50f9ebab7ba8
+      Original-Request:
+      - req_v778ofI3YvIoFL
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=-LD-ThvP7UhzEON-iB6DG2bsO0dxxEZl-CRD_6lp73vVUwYFVzvt2YXz_F9U2qiigtow5mXw4F-meSvn&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=-LD-ThvP7UhzEON-iB6DG2bsO0dxxEZl-CRD_6lp73vVUwYFVzvt2YXz_F9U2qiigtow5mXw4F-meSvn&t=1"
+      Request-Id:
+      - req_v778ofI3YvIoFL
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1ToePZIBOqvOFDrfTaC1JKrE",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1782974869,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Thu, 02 Jul 2026 06:47:49 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1ToePZIBOqvOFDrfTaC1JKrE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_v778ofI3YvIoFL","request_duration_ms":270}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 x86_64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 06:47:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=-LD-ThvP7UhzEON-iB6DG2bsO0dxxEZl-CRD_6lp73vVUwYFVzvt2YXz_F9U2qiigtow5mXw4F-meSvn;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=-LD-ThvP7UhzEON-iB6DG2bsO0dxxEZl-CRD_6lp73vVUwYFVzvt2YXz_F9U2qiigtow5mXw4F-meSvn&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=-LD-ThvP7UhzEON-iB6DG2bsO0dxxEZl-CRD_6lp73vVUwYFVzvt2YXz_F9U2qiigtow5mXw4F-meSvn&t=1"
+      Request-Id:
+      - req_UAr1FzltmtvMOo
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1ToePZIBOqvOFDrfTaC1JKrE",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1782974869,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Thu, 02 Jul 2026 06:47:49 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: description=&payment_method=pm_1ToePZIBOqvOFDrfTaC1JKrE
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_UAr1FzltmtvMOo","request_duration_ms":173}}'
+      Idempotency-Key:
+      - 7a328511-0155-4f5b-81d7-82350bbea38e
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 x86_64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 06:47:50 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '642'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=-LD-ThvP7UhzEON-iB6DG2bsO0dxxEZl-CRD_6lp73vVUwYFVzvt2YXz_F9U2qiigtow5mXw4F-meSvn;
+        report-to csp
+      Idempotency-Key:
+      - 7a328511-0155-4f5b-81d7-82350bbea38e
+      Original-Request:
+      - req_Etln0fXn7uGmv9
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=-LD-ThvP7UhzEON-iB6DG2bsO0dxxEZl-CRD_6lp73vVUwYFVzvt2YXz_F9U2qiigtow5mXw4F-meSvn&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=-LD-ThvP7UhzEON-iB6DG2bsO0dxxEZl-CRD_6lp73vVUwYFVzvt2YXz_F9U2qiigtow5mXw4F-meSvn&t=1"
+      Request-Id:
+      - req_Etln0fXn7uGmv9
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "cus_UoGxU9R4lNShtX",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1782974869,
+          "currency": null,
+          "customer_account": null,
+          "default_source": null,
+          "delinquent": false,
+          "description": null,
+          "discount": null,
+          "email": null,
+          "invoice_prefix": "YIQ5LMYF",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null,
+            "rendering_options": null
+          },
+          "livemode": false,
+          "metadata": {},
+          "name": null,
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [],
+          "shipping": null,
+          "tax_exempt": "none",
+          "test_clock": null
+        }
+  recorded_at: Thu, 02 Jul 2026 06:47:50 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/Gift_ConvertToNonGiftService/_process_/for_a_gifted_subscription/when_the_payer_purchase_has_a_saved_card/moves_the_payer_s_card_onto_the_subscription_so_renewals_can_bill_the_payer.yml
+++ b/spec/support/fixtures/vcr_cassettes/Gift_ConvertToNonGiftService/_process_/for_a_gifted_subscription/when_the_payer_purchase_has_a_saved_card/moves_the_payer_s_card_onto_the_subscription_so_renewals_can_bill_the_payer.yml
@@ -1,0 +1,402 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Idempotency-Key:
+      - cabbdc83-8c97-47a8-b6c2-cc95df825805
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 06:19:14 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=WE8UCrg597KOC6wj8x4vwOKHP2VHAbFOshZg2-CbJUSmp6Jj2GCHQpAzw4H_EVP0gJFvqdoGYdCoZ7Nq;
+        report-to csp
+      Idempotency-Key:
+      - cabbdc83-8c97-47a8-b6c2-cc95df825805
+      Original-Request:
+      - req_KuvG7Yppu4lgUl
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=WE8UCrg597KOC6wj8x4vwOKHP2VHAbFOshZg2-CbJUSmp6Jj2GCHQpAzw4H_EVP0gJFvqdoGYdCoZ7Nq&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=WE8UCrg597KOC6wj8x4vwOKHP2VHAbFOshZg2-CbJUSmp6Jj2GCHQpAzw4H_EVP0gJFvqdoGYdCoZ7Nq&t=1"
+      Request-Id:
+      - req_KuvG7Yppu4lgUl
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TodxuIBOqvOFDrfadDf4f1i",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1782973154,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Thu, 02 Jul 2026 06:19:14 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TodxuIBOqvOFDrfadDf4f1i
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_KuvG7Yppu4lgUl","request_duration_ms":266}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 06:19:15 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=37KSVi0hyVMbiDwmcXZB8M0PwiuqUT7g7z4RiKm8I5Tqkfuaqi6V6CvfirzxEYsyFUxQDj57fp53Lx-B;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=37KSVi0hyVMbiDwmcXZB8M0PwiuqUT7g7z4RiKm8I5Tqkfuaqi6V6CvfirzxEYsyFUxQDj57fp53Lx-B&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=37KSVi0hyVMbiDwmcXZB8M0PwiuqUT7g7z4RiKm8I5Tqkfuaqi6V6CvfirzxEYsyFUxQDj57fp53Lx-B&t=1"
+      Request-Id:
+      - req_yBwfTQOSqXqSQY
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TodxuIBOqvOFDrfadDf4f1i",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1782973154,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Thu, 02 Jul 2026 06:19:15 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: description=&payment_method=pm_1TodxuIBOqvOFDrfadDf4f1i
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_yBwfTQOSqXqSQY","request_duration_ms":207}}'
+      Idempotency-Key:
+      - ca10ffa2-50c2-49e6-87c1-0601672ff394
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 06:19:15 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '642'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=37KSVi0hyVMbiDwmcXZB8M0PwiuqUT7g7z4RiKm8I5Tqkfuaqi6V6CvfirzxEYsyFUxQDj57fp53Lx-B;
+        report-to csp
+      Idempotency-Key:
+      - ca10ffa2-50c2-49e6-87c1-0601672ff394
+      Original-Request:
+      - req_qRGw0ackEG3mIn
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=37KSVi0hyVMbiDwmcXZB8M0PwiuqUT7g7z4RiKm8I5Tqkfuaqi6V6CvfirzxEYsyFUxQDj57fp53Lx-B&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=37KSVi0hyVMbiDwmcXZB8M0PwiuqUT7g7z4RiKm8I5Tqkfuaqi6V6CvfirzxEYsyFUxQDj57fp53Lx-B&t=1"
+      Request-Id:
+      - req_qRGw0ackEG3mIn
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "cus_UoGUkAZRuCcVPz",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1782973155,
+          "currency": null,
+          "customer_account": null,
+          "default_source": null,
+          "delinquent": false,
+          "description": null,
+          "discount": null,
+          "email": null,
+          "invoice_prefix": "NGQFCS1U",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null,
+            "rendering_options": null
+          },
+          "livemode": false,
+          "metadata": {},
+          "name": null,
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [],
+          "shipping": null,
+          "tax_exempt": "none",
+          "test_clock": null
+        }
+  recorded_at: Thu, 02 Jul 2026 06:19:15 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## What

Adds `Gift::ConvertToNonGiftService` — a console/eng-invoked service that converts a **gift** purchase into a **regular (non-gift)** purchase, hard-gated on confirming that both the gifter and the giftee have signed off.

```ruby
Gift::ConvertToNonGiftService.new(
  gift:,
  gifter_signed_off: true,   # must be literally true
  giftee_signed_off: true,   # must be literally true
  admin_id: GUMROAD_ADMIN_ID,
  reason: "…",               # optional, recorded in the audit comment
).process!
```

What it does, in one transaction:
- Clears `is_gift_sender_purchase` on the payer (gifter) leg, so that purchase behaves as a regular purchase. The `Gift` row is retained for audit history.
- For a gifted **subscription**: this flips `Subscription#gift?` (which reads `true_original_purchase.is_gift_sender_purchase?`) to false, re-points `subscription.user` at the paying buyer, and moves the payer's saved card onto the subscription — so renewal / manage-subscription comms **and** billing resolve to the payer instead of the giftee.
- Logs an audit `Comment` (author `GUMROAD_ADMIN_ID`) on both purchase legs and the payer account.
- Is idempotent (a second run returns `already_converted`) and raises `ConfirmationRequiredError` unless both sign-off flags are literally `true`.

No API/CLI surface — the requester will invoke it via console access.

## Why

A creator (Hypermatic Bundle) needs a live $3,602.40/yr gift subscription re-owned so the paying buyer, not the gift recipient, owns renewal and bills under their own email. There is no `gumroad admin` verb to remove gift status or re-own a subscription, so this needs an internal, audited data-change path. Tracked in the linked planning issue.

## Scope / boundaries (deliberate)

- **Moves billing ownership, not product access.** The giftee's `$0` receiver leg is left untouched: its `is_gift_receiver_purchase` flag + `gift_receiver_purchase_successful` state are coherent together and keep the recipient's access purchase visible in their library/mobile listings. The recipient keeps the seat the seller already provisioned. No new `url_redirect`/`license` is minted for the payer (that would double-provision).
- **Known limitation, documented in the class:** refund/chargeback propagation to the giftee leg is gated on `is_gift_sender_purchase` across the codebase (`Purchase::Refundable`, `ChargeEventsHandler`, `Charge::Disputable`). After conversion, a later reversal of the payer purchase will not auto-revoke the giftee's access leg. Acceptable for the re-own use case (and for subscriptions the gift row only lives on the original purchase, so renewal reversals never propagated to the giftee regardless); revoke explicitly if ever needed.

## Test plan

`spec/services/gift/convert_to_non_gift_service_spec.rb` — 17 examples, all green locally:

- Confirmation gate: raises when either party hasn't signed off, and when a sign-off is truthy-but-not-`true`; no mutation on gate failure.
- One-off gift: clears sender flag, `Purchase#gift` → nil for payer leg, giftee receiver leg untouched and still library-visible, `Gift` retained, audit comments on both legs + payer account.
- Gifted subscription: flips `Subscription#gift?`, resolves subscription email to the payer even when the giftee has an account (re-owns `subscription.user`), moves the payer's saved card onto the subscription (`:vcr` cassette committed).
- Idempotency and `NotConvertibleError` (no gifter purchase).

```
17 examples, 0 failures
```

Ran the affected spec locally against the app's Redis/ES/MinIO/Mongo infra. Reviewed with the Codex autoreview pass; the one remaining finding (refund/chargeback propagation) is a conscious out-of-scope decision, documented inline.

## AI disclosure

Authored by Gumclaw (Claude Opus). Investigated the gift/subscription data model, wrote the service + specs, and iterated against Codex autoreview until the only open finding was a consciously-scoped limitation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5670"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785565543&installation_id=134400930&pr_number=5670&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5670&signature=2f4f63f7a8d953e41bf58ffe3d304963b49c4e823962f0e52d1c13447e6bd089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->