### PR TITLE
ci: leave ci/green unset on cancelled/neutral/skipped runs

### DIFF
--- a/.github/workflows/ci-green.yml
+++ b/.github/workflows/ci-green.yml
@@ -48,8 +48,9 @@ jobs:
             # cancelled, neutral, skipped — leave the status unset so the
             # required check stays pending instead of flipping to failure.
             # A concurrency-cancel is moot (the head has already moved to a
-            # new SHA); a manual cancel/timeout on the current head should
-            # not require a manual re-trigger to unblock auto-merge.
+            # new SHA); a manual cancel on the current head should not require
+            # a manual re-trigger to unblock auto-merge. (timed_out is treated
+            # as a genuine failure above and is intentionally not covered here.)
             echo "Workflow conclusion is '$CONCLUSION'; not reporting ci/green."
             exit 0
           fi

--- a/.github/workflows/ci-green.yml
+++ b/.github/workflows/ci-green.yml
@@ -41,9 +41,17 @@ jobs:
           if [ "$CONCLUSION" = "success" ]; then
             STATE=success
             DESC="Test suite passed"
-          else
+          elif [ "$CONCLUSION" = "failure" ] || [ "$CONCLUSION" = "timed_out" ] || [ "$CONCLUSION" = "action_required" ]; then
             STATE=failure
             DESC="Test suite: $CONCLUSION"
+          else
+            # cancelled, neutral, skipped — leave the status unset so the
+            # required check stays pending instead of flipping to failure.
+            # A concurrency-cancel is moot (the head has already moved to a
+            # new SHA); a manual cancel/timeout on the current head should
+            # not require a manual re-trigger to unblock auto-merge.
+            echo "Workflow conclusion is '$CONCLUSION'; not reporting ci/green."
+            exit 0
           fi
           gh api "repos/${GITHUB_REPOSITORY}/statuses/${SHA}" \
             -f state="$STATE" \


### PR DESCRIPTION
## What

Follow-up to #5668. Refines the `ci/green` reporter so it only reports a **failure** status for genuine failure conclusions (`failure`, `timed_out`, `action_required`). For `cancelled`, `neutral`, and `skipped` runs it now leaves the status unset — the required check stays pending instead of flipping to `failure`.

## Why

The original `else → failure` branch treated every non-`success` conclusion as a failure, including `cancelled`. Greptile flagged the footgun on #5668:

- A **concurrency-cancel** (newer push arrived) is harmless — the PR head has already moved to a new SHA, so the stale `failure` doesn't matter.
- But a **manual cancel or timeout while the PR head is still at that SHA** flips the required `ci/green` check to `failure`, forcing the developer to manually re-trigger the workflow to unblock auto-merge.

Leaving the status unset for non-terminal conclusions keeps the check in its implicit "pending" state, which is the correct behavior — auto-merge keeps waiting rather than getting a false-negative.

## Test plan

- YAML validated (`yaml.safe_load`).
- Pure shell-conditional change in a `workflow_run` reporter; no application code touched.

🤖 AI disclosure: authored with Claude (Hermes Agent), addressing a Greptile P2 finding on #5668.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785565960&installation_id=134400930&pr_number=5671&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5671&signature=58acfcf4bdaf515cedd81648f23effd785f0223aa03ff864efc5ac7f07e01e34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->