### PR TITLE
Hide soft-deleted reviews on the buyer's Library Reviews page

### DIFF
--- a/app/presenters/reviews_presenter.rb
+++ b/app/presenters/reviews_presenter.rb
@@ -9,7 +9,7 @@ class ReviewsPresenter
 
   def reviews_props
     {
-      reviews: user.product_reviews.includes(:editable_video, :purchase, link: [:user, :thumbnail_alive]).map do |review|
+      reviews: user.product_reviews.merge(ProductReview.alive).includes(:editable_video, :purchase, link: [:user, :thumbnail_alive]).map do |review|
         product = review.link
         ProductReviewPresenter.new(review).review_form_props.merge(
           id: review.external_id,

--- a/spec/presenters/reviews_presenter_spec.rb
+++ b/spec/presenters/reviews_presenter_spec.rb
@@ -133,6 +133,17 @@ describe ReviewsPresenter do
       end
     end
 
+    context "when the buyer's own review has been soft-deleted" do
+      let!(:deleted_review) do
+        purchase = create(:purchase, purchaser: user)
+        create(:product_review, purchase: purchase, link: purchase.link, deleted_at: 1.day.ago)
+      end
+
+      it "omits it from the reviews list" do
+        expect(presenter.reviews_props[:reviews].map { |r| r[:id] }).not_to include(deleted_review.external_id)
+      end
+    end
+
     context "when a purchase awaiting review is for a deleted product" do
       let!(:deleted_product) { create(:product, deleted_at: 1.day.ago) }
       let!(:purchase_on_deleted_product) { create(:purchase, purchaser: user, link: deleted_product) }


### PR DESCRIPTION
## What
A buyer's Library → **Reviews** ("Your reviews") page kept listing reviews the buyer had already **soft-deleted** (`deleted_at` set). The reviews were correctly gone from public product pages, but the buyer's own Reviews tab still showed all of them with their old star ratings, surviving a hard refresh and a full day of waiting.

## Why
`ReviewsPresenter#reviews_props` built the reviews list from `user.product_reviews` with no `.alive` scope:

```ruby
reviews: user.product_reviews.includes(...).map do |review|
```

`ProductReview` includes `Deletable` (which provides `scope :alive, -> { where(deleted_at: nil) }`), but the presenter never applied it — so soft-deleted reviews were returned to the buyer's Library page. The public product-page path filters correctly, which is why the reviews vanished publicly but not in the buyer's own Library.

## The fix
Scope the query to alive reviews. Both `purchases` and `product_reviews` carry a `deleted_at` column, so a bare `.alive` on the `has_many :through` join would be ambiguous SQL — this uses `.merge(ProductReview.alive)` to qualify it to the reviews table:

```ruby
reviews: user.product_reviews.merge(ProductReview.alive).includes(...).map do |review|
```

Adds a regression spec asserting a soft-deleted review is omitted from `reviews_props[:reviews]`.

## Verification
Root cause was reproduced at the code level and all three of the reporting buyer's reviews were independently confirmed `deleted_at`-set on live (audited, read-only) production data. Autoreview (Codex) run against the branch returned clean — no accepted/actionable findings. Local RSpec couldn't boot in the worktree (missing MaxMind GeoIP DB, an environment gap unrelated to this diff); CI will run the spec.

Fixes antiwork/gumroad-private#846

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5672"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785574958&installation_id=134400930&pr_number=5672&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5672&signature=f747b4953d0f2f472bc43d93b5b85b9df62495eae410f2ec95fb08db34eeb304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->