### PR TITLE
Stop default CC on internal notifications

### DIFF
--- a/app/mailers/internal_notification_mailer.rb
+++ b/app/mailers/internal_notification_mailer.rb
@@ -14,8 +14,9 @@ class InternalNotificationMailer < ApplicationMailer
     recipient = CHAT_ROOMS.dig(room_name.to_sym, :email)
     return if recipient.blank?
 
-    # CC Gumclaw on every internal notification, in addition to the room's own recipient,
-    # so it ingests the full stream. Skip if it's already the room's recipient (no dup).
+    # Optional global CC. Keep it explicit-config only because internal
+    # notifications can carry sensitive risk/payments/payouts data.
+    # Skip if it's already the room's recipient (no dup).
     always_cc = INTERNAL_NOTIFICATION_ALWAYS_CC.presence
     cc = (always_cc && always_cc != recipient) ? always_cc : nil
 

--- a/config/initializers/chat_rooms.rb
+++ b/config/initializers/chat_rooms.rb
@@ -3,10 +3,11 @@
 INTERNAL_NOTIFICATION_EMAIL = GlobalConfig.get("INTERNAL_NOTIFICATION_EMAIL", "hi@gumroad.com")
 PAYMENTS_NOTIFICATION_EMAIL = GlobalConfig.get("PAYMENTS_NOTIFICATION_EMAIL", "hi@gumroad.com")
 
-# Address CC'd on EVERY internal notification (all CHAT_ROOMS), in addition to each
-# room's own recipient. Lets Gumclaw ingest the full internal-notification stream
-# (risk alerts, payments, payouts, etc.) alongside the existing human recipients.
-INTERNAL_NOTIFICATION_ALWAYS_CC = GlobalConfig.get("INTERNAL_NOTIFICATION_ALWAYS_CC", "gumclaw@gumroad.com")
+# Optional address CC'd on every internal notification. This is intentionally
+# disabled by default: internal notifications can include sensitive risk,
+# payments, and payouts data, so a broad secondary recipient must be enabled
+# explicitly via configuration rather than hard-coded in source.
+INTERNAL_NOTIFICATION_ALWAYS_CC = GlobalConfig.get("INTERNAL_NOTIFICATION_ALWAYS_CC", nil)
 
 CHAT_ROOMS = {
   announcements: { email: INTERNAL_NOTIFICATION_EMAIL },

--- a/spec/mailers/internal_notification_mailer_spec.rb
+++ b/spec/mailers/internal_notification_mailer_spec.rb
@@ -4,10 +4,6 @@ require "spec_helper"
 
 describe InternalNotificationMailer do
   describe "#notify" do
-    # Use the "risk" room, which maps to INTERNAL_NOTIFICATION_EMAIL — a recipient
-    # that is intentionally distinct from INTERNAL_NOTIFICATION_ALWAYS_CC. This keeps
-    # the `to` and `cc` assertions below meaningful even if PAYMENTS_NOTIFICATION_EMAIL
-    # and the always-CC address ever resolve to the same value in a shared config.
     subject(:mail) do
       described_class.notify(
         room_name: "risk",
@@ -20,12 +16,16 @@ describe InternalNotificationMailer do
       expect(mail.to).to eq([INTERNAL_NOTIFICATION_EMAIL])
     end
 
-    it "CCs Gumclaw on every notification in addition to the room recipient" do
-      # The mailer dedups the CC when it equals the room's own recipient, so this
-      # assertion is only meaningful while the two addresses are distinct. Assert the
-      # prerequisite explicitly rather than relying on it implicitly.
-      expect(INTERNAL_NOTIFICATION_ALWAYS_CC).not_to eq(mail.to.first)
-      expect(mail.cc).to eq([INTERNAL_NOTIFICATION_ALWAYS_CC])
+    it "does not CC an additional recipient by default" do
+      expect(mail.cc).to be_nil
+    end
+
+    context "when a global CC address is explicitly configured" do
+      before { stub_const("INTERNAL_NOTIFICATION_ALWAYS_CC", "audit@example.com") }
+
+      it "CCs the configured recipient in addition to the room recipient" do
+        expect(mail.cc).to eq(["audit@example.com"])
+      end
     end
 
     it "sets the subject with room name and sender" do
@@ -66,17 +66,20 @@ describe InternalNotificationMailer do
         expect(mail.to).to be_nil
       end
 
-      it "does not CC Gumclaw when the room has no recipient" do
+      it "does not CC the configured global recipient when the room has no recipient" do
         expect(mail.cc).to be_nil
       end
     end
 
-    context "when the room recipient IS the always-CC address" do
-      before { stub_const("CHAT_ROOMS", CHAT_ROOMS.merge(gumclaw_room: { email: INTERNAL_NOTIFICATION_ALWAYS_CC })) }
+    context "when the room recipient IS the configured always-CC address" do
+      before do
+        stub_const("INTERNAL_NOTIFICATION_ALWAYS_CC", "audit@example.com")
+        stub_const("CHAT_ROOMS", CHAT_ROOMS.merge(audit_room: { email: INTERNAL_NOTIFICATION_ALWAYS_CC }))
+      end
 
       subject(:mail) do
         described_class.notify(
-          room_name: "gumclaw_room",
+          room_name: "audit_room",
           sender: "Test",
           message_text: "No duplicate"
         )

--- a/spec/mailers/internal_notification_mailer_spec.rb
+++ b/spec/mailers/internal_notification_mailer_spec.rb
@@ -66,8 +66,17 @@ describe InternalNotificationMailer do
         expect(mail.to).to be_nil
       end
 
-      it "does not CC the configured global recipient when the room has no recipient" do
+      it "does not CC when the room has no recipient" do
         expect(mail.cc).to be_nil
+      end
+
+      context "even when a global CC address is configured" do
+        before { stub_const("INTERNAL_NOTIFICATION_ALWAYS_CC", "audit@example.com") }
+
+        it "does not CC the configured recipient" do
+          expect(mail.to).to be_nil
+          expect(mail.cc).to be_nil
+        end
       end
     end
 


### PR DESCRIPTION
## Summary
- remove the hard-coded default `gumclaw@gumroad.com` CC from all internal notification emails
- keep `INTERNAL_NOTIFICATION_ALWAYS_CC` available as an explicit opt-in configuration value
- update mailer specs to verify the default has no extra recipient and configured CC still deduplicates correctly

## Security impact
Internal notifications can include sensitive risk, payments, and payouts information. A hard-coded global CC address caused every room notification to be copied to an additional mailbox by default, expanding the recipient set without an explicit production configuration decision.

This change makes the broad CC opt-in only, reducing accidental sensitive-data exposure while preserving the operational escape hatch via `INTERNAL_NOTIFICATION_ALWAYS_CC`.

## Tests
- `ruby -c config/initializers/chat_rooms.rb`
- `ruby -c app/mailers/internal_notification_mailer.rb`
- `ruby -c spec/mailers/internal_notification_mailer_spec.rb`
- `bundle exec rspec spec/mailers/internal_notification_mailer_spec.rb`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785593178&installation_id=134400930&pr_number=5675&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5675&signature=d96b62fda69d4034d02fcb173dedc1e42dfc2c4c4047855786a3b9c70a8c17ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->