### PR TITLE
[Option A] Fire seller analytics on custom HTML profile pages

### DIFF
--- a/app/controllers/third_party_analytics_controller.rb
+++ b/app/controllers/third_party_analytics_controller.rb
@@ -2,7 +2,7 @@
 
 class ThirdPartyAnalyticsController < ApplicationController
   before_action { opt_out_of_header(:csp) } # Turn off CSP for this controller
-  before_action :fetch_product
+  before_action :fetch_product, except: :profile
 
   OVERRIDE_WINDOW_ACTIONS_CODE = "<script type=\"text/javascript\">
 try { window.alert = function() {}; } catch(error) { }
@@ -46,6 +46,22 @@ try { window.onabort = null; } catch(error) { }
     end
 
     render layout: false
+  end
+
+  # Serves the seller's universal snippets for the custom HTML profile page
+  # (#5676), which has no product to key the index action on. Only location
+  # "all" ("run everywhere") applies: "product" and "receipt" universal
+  # snippets target those surfaces, and a profile is neither. Product-scoped
+  # snippets never load here. The $VALUE/$CURRENCY/$ORDER purchase
+  # substitutions don't apply — there is no purchase on a profile view.
+  def profile
+    user = User.alive.find_by(username: params[:username]) || e404
+    @third_party_analytics = OVERRIDE_WINDOW_ACTIONS_CODE
+    user_snippets = user.third_party_analytics.universal.alive.where(location: "all").pluck(:analytics_code)
+    @third_party_analytics += user_snippets.join("\n") if user_snippets.present?
+    @third_party_analytics += OVERRIDE_ON_CLOSE_CODE
+
+    render :index, layout: false
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -259,6 +259,7 @@ class UsersController < ApplicationController
             <meta property="og:type" content="profile">
             <meta property="og:url" content="#{canonical}">
             #{og_image_tag}
+            #{profile_custom_html_analytics_head(user)}
             <style>html,body{margin:0;padding:0;height:100%;overflow:hidden}iframe{display:block;width:100%;height:100%;border:0}</style>
           </head>
           <body>
@@ -271,6 +272,59 @@ class UsersController < ApplicationController
             #{live_reload}
           </body>
         </html>
+      HTML
+    end
+
+    # A custom HTML profile bypasses the React profile page, so the seller's
+    # account-scoped analytics (Google Analytics, Facebook/TikTok pixels,
+    # universal raw snippets) never load — the gap #5658 closed for custom
+    # product landing pages, on the profile surface (#5676). Like the product
+    # version, the tracking goes into this trusted wrapper only: the sandboxed
+    # landing iframe's strict CSP blocks the analytics hosts by design, while
+    # the wrapper runs under the global site CSP, which allowlists them.
+    #
+    # Unlike a product page, a profile has no permalink, name, or buy action, so
+    # the entry point only bootstraps the pixels and fires a seller GA page_view
+    # — no view_item/ViewContent/add_to_cart, which are product-shaped events a
+    # standard profile page doesn't fire either.
+    def profile_custom_html_analytics_head(user)
+      return "" unless analytics_enabled?(seller: user)
+
+      # Same shape as Link#analytics_data, which is sourced entirely from the
+      # user — the profile just reads the account fields directly.
+      analytics = {
+        google_analytics_id: user.google_analytics_id,
+        facebook_pixel_id: user.facebook_pixel_id,
+        tiktok_pixel_id: user.tiktok_pixel_id,
+        free_sales: !user.skip_free_sale_analytics?,
+      }
+      # Only location "all" ("run everywhere") snippets apply here: "product" and
+      # "receipt" universal snippets target those surfaces, and a profile is neither.
+      has_universal_third_party_analytics = user.third_party_analytics.universal.alive.where(location: "all").exists?
+      has_configured_pixel = analytics.values_at(:google_analytics_id, :facebook_pixel_id, :tiktok_pixel_id).any?(&:present?)
+      return "" unless has_configured_pixel || has_universal_third_party_analytics
+
+      props = {
+        seller_id: user.external_id,
+        analytics:,
+        # The snippet endpoint for products is keyed on a permalink, which a
+        # profile doesn't have, so the profile variant is keyed on the username
+        # and the URL is built here rather than with Routes on the frontend.
+        third_party_analytics_url: has_universal_third_party_analytics ? profile_third_party_analytics_url(username: user.username, host: THIRD_PARTY_ANALYTICS_DOMAIN) : nil,
+      }
+
+      # All three enabled flags are "true" (not per-pixel): this block only renders
+      # when analytics_enabled?, and the frontend gates each pixel on its own
+      # configured id — mirroring PageMeta::Analytics#set_analytics_meta_tags, which
+      # the wrapper's layout-less document can't accumulate. The props JSON goes in a
+      # double-quoted attribute, so ERB::Util.h (which escapes ") is the right escape
+      # here — json_escape would leave quotes intact and break out of the attribute.
+      <<~HTML.strip
+        <meta property="gr:google_analytics:enabled" content="true">
+        <meta property="gr:fb_pixel:enabled" content="true">
+        <meta property="gr:tiktok_pixel:enabled" content="true">
+        <meta name="gr:custom-html-profile-analytics" content="#{ERB::Util.h(props.to_json)}">
+        #{helpers.vite_typescript_tag("custom_html_profile_analytics")}
       HTML
     end
 

--- a/app/javascript/data/google_analytics.ts
+++ b/app/javascript/data/google_analytics.ts
@@ -103,6 +103,15 @@ export function trackProductEvent(config: AnalyticsConfig | undefined, data: Pro
   }
 }
 
+// A bare page_view for surfaces with no product to attach (the custom HTML
+// profile page). Product surfaces get their page_view from trackProductEvent,
+// which sends it alongside the product-shaped event for the action.
+export function trackPageView(config: AnalyticsConfig) {
+  if (!shouldTrack() || !config.googleAnalyticsId || typeof gtag === "undefined") return;
+
+  logSellerEvent(config.id, "page_view", { page: window.location.pathname + window.location.search });
+}
+
 export function startTrackingForSeller(data: AnalyticsConfig) {
   if (!shouldTrack() || !data.googleAnalyticsId) return;
   if (typeof gtag === "undefined") loadGoogleAnalyticsScript();

--- a/app/javascript/entrypoints/custom_html_profile_analytics.ts
+++ b/app/javascript/entrypoints/custom_html_profile_analytics.ts
@@ -1,0 +1,43 @@
+import typia from "typia";
+
+import { AnalyticsData } from "$app/parsers/product";
+import { startTrackingForSeller, trackSellerPageView } from "$app/utils/user_analytics";
+
+// A custom HTML profile page renders as a bare wrapper document that embeds the
+// seller's HTML in a sandboxed, opaque-origin iframe. Neither layer loads the
+// React profile page, so the seller's account-scoped analytics never run. This
+// entry point runs only on the trusted wrapper (same-origin gumroad.com, under
+// the global CSP that allowlists Google Analytics and the pixels) — the profile
+// counterpart of custom_html_analytics.ts (#5658).
+//
+// A profile has no permalink, product name, or buy action, so unlike the
+// product entry point this one only bootstraps the pixels and fires a seller GA
+// page_view — no view_item/ViewContent and no checkout-message listener. That
+// matches the standard profile page, which fires no product-shaped events of
+// its own either (only an embedded featured product does, and a custom HTML
+// profile has none).
+const configElement = document.querySelector('meta[name="gr:custom-html-profile-analytics"]');
+if (configElement) {
+  const props = typia.assert<{
+    seller_id: string;
+    analytics: AnalyticsData;
+    third_party_analytics_url: string | null;
+  }>(JSON.parse(configElement.getAttribute("content") ?? ""));
+
+  startTrackingForSeller(props.seller_id, props.analytics);
+  trackSellerPageView(props.seller_id);
+
+  // Universal ("run everywhere") raw snippets load in a hidden iframe on the
+  // cookie-less third-party analytics domain, like addThirdPartyAnalytics does
+  // for products — but that helper builds a product-permalink URL, so the
+  // wrapper receives the profile-keyed URL from the backend instead. The
+  // wrapper document has no stylesheet, so hide the iframe inline.
+  if (props.third_party_analytics_url) {
+    const iframe = document.createElement("iframe");
+    iframe.style.display = "none";
+    iframe.setAttribute("sandbox", "allow-scripts allow-same-origin");
+    iframe.ariaLabel = "Third-party analytics";
+    iframe.setAttribute("src", props.third_party_analytics_url);
+    document.body.appendChild(iframe);
+  }
+}

--- a/app/javascript/utils/user_analytics.ts
+++ b/app/javascript/utils/user_analytics.ts
@@ -71,6 +71,16 @@ export function startTrackingForSeller(id: string, data: AnalyticsData) {
   TikTokPixel.startTrackingForSeller(config);
 }
 
+// Fires the seller's GA page_view on pages with no product context (the custom
+// HTML profile page). GA only: TikTok already sends its page event when the
+// pixel bootstraps in startTrackingForSeller, and the Facebook pixel is only
+// ever sent product-shaped events in this codebase.
+export function trackSellerPageView(id: string) {
+  const config = configs.get(id);
+  if (!config) return;
+  GoogleAnalytics.trackPageView(config);
+}
+
 export function trackProductEvent(id: string | undefined, data: ProductAnalyticsEvent) {
   const config = id ? configs.get(id) : undefined;
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,8 @@ Rails.application.routes.draw do
 
   # third party analytics (near the top to matches constraint first)
   constraints(host: /#{THIRD_PARTY_ANALYTICS_DOMAIN}/o) do
+    # Two path segments, so it can never shadow a product permalink matched by /:link_id below.
+    get "/profile/:username", to: "third_party_analytics#profile", as: :profile_third_party_analytics
     get "/:link_id", to: "third_party_analytics#index", as: :third_party_analytics
     get "/(*path)", to: "application#e404_page"
   end

--- a/spec/controllers/third_party_analytics_controller_spec.rb
+++ b/spec/controllers/third_party_analytics_controller_spec.rb
@@ -77,4 +77,38 @@ describe ThirdPartyAnalyticsController do
       expect { get :index, params: { link_id: @product.unique_permalink, purchase_id: "@purchase.external_id" } }.to raise_error(ActionController::RoutingError)
     end
   end
+
+  # Serves the custom HTML profile page (#5676), which has no product to key
+  # the index action on. Only universal snippets marked "all" apply — a profile
+  # is neither a product page nor a receipt.
+  describe "profile" do
+    it "includes only the seller's universal run-everywhere snippets" do
+      get :profile, params: { username: @seller.username }
+
+      expect(response.body).to include @global_user_snippet.analytics_code
+      expect(response.body).to_not include @global_product_snippet.analytics_code
+      expect(response.body).to_not include @product_user_snippet.analytics_code
+      expect(response.body).to_not include @receipt_user_snippet.analytics_code
+      expect(response.body).to_not include @product_product_snippet.analytics_code
+      expect(response.body).to_not include @receipt_product_snippet.analytics_code
+    end
+
+    it "excludes deleted snippets" do
+      @global_user_snippet.mark_deleted
+
+      get :profile, params: { username: @seller.username }
+
+      expect(response.body).to_not include @global_user_snippet.analytics_code
+    end
+
+    it "raises an e404 for an unknown username" do
+      expect { get :profile, params: { username: "nosuchuser" } }.to raise_error(ActionController::RoutingError)
+    end
+
+    it "raises an e404 for a deleted user" do
+      @seller.update_columns(deleted_at: Time.current)
+
+      expect { get :profile, params: { username: @seller.username } }.to raise_error(ActionController::RoutingError)
+    end
+  end
 end

--- a/spec/requests/users/show/custom_html_analytics_spec.rb
+++ b/spec/requests/users/show/custom_html_analytics_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# A custom HTML profile page renders as a bare wrapper document that embeds the
+# seller's HTML in a sandboxed, opaque-origin iframe. That bypasses the React
+# profile page, so the wrapper has to inject the seller's account-scoped
+# analytics itself — the profile counterpart of the custom product landing page
+# fix (#5658). These specs verify it does, and only in the trusted wrapper,
+# only when the seller has analytics configured and enabled.
+describe "Custom HTML profile page analytics", type: :request do
+  let(:seller) { create(:user, username: "analyticsprofile", google_analytics_id: "G-ABC123") }
+  let!(:custom_domain) { create(:custom_domain, user: seller, domain: "seller.example.com") }
+
+  before do
+    seller.update!(custom_html: "<main><h1>Custom profile</h1></main>")
+    Feature.activate_user(:custom_html_pages, seller)
+    # analytics_enabled? only tracks in production/staging, matching the rest of the app.
+    allow(Rails.env).to receive(:production?).and_return(true)
+    # Resolving the Vite manifest for a real build is infra, not what we're testing —
+    # assert the entry point is requested by name and stub the tag it renders.
+    allow_any_instance_of(ActionView::Base).to receive(:vite_typescript_tag)
+      .with("custom_html_profile_analytics").and_return(%(<script src="/custom_html_profile_analytics.js"></script>).html_safe)
+  end
+
+  def analytics_props(body)
+    content = body[/<meta name="gr:custom-html-profile-analytics" content="([^"]*)"/, 1]
+    content && JSON.parse(CGI.unescapeHTML(content))
+  end
+
+  it "injects the enabled meta tags, seller props, and analytics entry point into the wrapper head" do
+    get "http://seller.example.com/"
+
+    expect(response).to be_successful
+    expect(response.body).to include('<meta property="gr:google_analytics:enabled" content="true">')
+    expect(response.body).to include('<meta property="gr:fb_pixel:enabled" content="true">')
+    expect(response.body).to include('<meta property="gr:tiktok_pixel:enabled" content="true">')
+    expect(response.body).to include('src="/custom_html_profile_analytics.js"')
+
+    props = analytics_props(response.body)
+    expect(props).to include(
+      "seller_id" => seller.external_id,
+      "third_party_analytics_url" => nil,
+    )
+    expect(props["analytics"]).to include("google_analytics_id" => "G-ABC123")
+  end
+
+  it "does not inject analytics into the sandboxed landing iframe, whose CSP would block them" do
+    get "http://seller.example.com/landing/embed"
+
+    expect(response).to be_successful
+    expect(response.body).not_to include("gr:custom-html-profile-analytics")
+    expect(response.body).not_to include("gr:google_analytics:enabled")
+  end
+
+  context "when the seller has no analytics configured" do
+    let(:seller) { create(:user, username: "noanalytics") }
+
+    it "omits the analytics block so the wrapper stays minimal" do
+      get "http://seller.example.com/"
+
+      expect(response).to be_successful
+      expect(response.body).not_to include("gr:custom-html-profile-analytics")
+      expect(response.body).not_to include("gr:google_analytics:enabled")
+    end
+  end
+
+  context "when the seller disabled third-party analytics" do
+    before { seller.update!(disable_third_party_analytics: true) }
+
+    it "omits the analytics block" do
+      get "http://seller.example.com/"
+
+      expect(response.body).not_to include("gr:custom-html-profile-analytics")
+    end
+  end
+
+  context "when the seller has only a universal run-everywhere snippet (no pixel ids)" do
+    let(:seller) { create(:user, username: "snippetprofile") }
+
+    before { ThirdPartyAnalytic.create!(user: seller, analytics_code: "<script>1</script>", location: "all") }
+
+    it "injects the block with the profile snippet URL so the entry point loads the snippet iframe" do
+      get "http://seller.example.com/"
+
+      props = analytics_props(response.body)
+      expect(props["third_party_analytics_url"]).to eq(
+        "http://#{THIRD_PARTY_ANALYTICS_DOMAIN}/profile/#{seller.username}"
+      )
+    end
+  end
+
+  context "when the seller's universal snippets target only product or receipt pages" do
+    let(:seller) { create(:user, username: "productsnippet") }
+
+    before { ThirdPartyAnalytic.create!(user: seller, analytics_code: "<script>1</script>", location: "product") }
+
+    it "omits the analytics block — a profile is neither surface" do
+      get "http://seller.example.com/"
+
+      expect(response.body).not_to include("gr:custom-html-profile-analytics")
+    end
+  end
+end


### PR DESCRIPTION
## What (Option A of #5676 — custom profile pages only)

Fires the seller's configured analytics (Google Analytics, Facebook Pixel, TikTok Pixel, and universal "run everywhere" raw snippets) on **custom HTML profile pages**. This mirrors the already-merged custom-**product**-page fix (#5658) on the profile surface.

**This is one of two candidate PRs for #5676 — see the issue's open questions.** This one is the narrow, low-blast-radius option:
- **Option A (this PR):** custom HTML profile pages only.
- **Option B (sibling PR):** all profile pages, standard + custom.

## Why

Custom HTML profile pages render as a bare wrapper document + a sandboxed, opaque-origin iframe, so they never load the React profile page and none of the seller's analytics run. A seller who switches their profile to custom HTML silently loses tracking. Pasting the snippet into their own HTML doesn't work either — the sanitizer strips it and the landing iframe's strict CSP (`connect-src 'none'`, no Google hosts) blocks it by design, and that must not change.

## How

Analytics is injected into the **trusted wrapper** only (same-origin `gumroad.com`, under the global site CSP that allowlists `*.googletagmanager.com` / `*.google-analytics.com`) — never the sandboxed iframe.

- `users_controller.rb`: new `profile_custom_html_analytics_head(user)` mirroring `custom_html_analytics_head`, injected into the profile wrapper `<head>`. Keyed off the seller's **account-scoped** GA/pixel config (`User#google_analytics_id` / `facebook_pixel_id` / `tiktok_pixel_id`).
- `app/javascript/entrypoints/custom_html_profile_analytics.ts`: new sibling entrypoint (the product entrypoint is untouched). Bootstraps the pixels + fires a seller GA `page_view` only — **no** `view_item`/`ViewContent`/`add_to_cart`/checkout events, because a profile has no permalink, product name, or buy action.
- `trackSellerPageView` / `trackPageView`: new additive helpers in the shared analytics utils; existing product/checkout callers are unchanged.
- Universal (`location: "all"`) raw snippets: served via a new `third_party_analytics#profile` action keyed on `username` (products key on permalink, which a profile lacks). Route is two-segment so it can't shadow a product permalink.

## Event parity

A profile has no buy button, so it fires page-view + pixel init only — matching what a standard profile page fires today (no product-shaped e-commerce events). Note: seller analytics currently fire on **no** profile page at all (see issue) — so this is net-new tracking on the custom profile surface, deliberately scoped to match standard-profile behavior.

## Tests

- New: `spec/requests/users/show/custom_html_analytics_spec.rb` (6 request) + `third_party_analytics_controller_spec.rb` profile cases (11 controller) — all pass locally.
- Regression: product custom-HTML analytics, profile custom-HTML, users-controller custom-HTML — 42 examples, 0 failures locally.
- rubocop / tsc / eslint / prettier clean (only pre-existing global `vite/client` tsc error, identical on main).
- The only local failures (`spec/requests/products/third_party_analytics_spec.rb` Capybara checkout flows) fail identically on unmodified main — pre-existing env issue, not from this change. CI is the authoritative gate.

Ref #5676

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785596154&installation_id=134400930&pr_number=5677&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5677&signature=81dc788238990bf62a91caaf185dbe1c1ce3428727897c9ab1a080fc488ec011"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->