### PR TITLE
[Option B] Fire seller analytics on all profile pages (standard + custom)

### DIFF
--- a/app/controllers/third_party_analytics_controller.rb
+++ b/app/controllers/third_party_analytics_controller.rb
@@ -2,7 +2,7 @@
 
 class ThirdPartyAnalyticsController < ApplicationController
   before_action { opt_out_of_header(:csp) } # Turn off CSP for this controller
-  before_action :fetch_product
+  before_action :fetch_product, except: :profile
 
   OVERRIDE_WINDOW_ACTIONS_CODE = "<script type=\"text/javascript\">
 try { window.alert = function() {}; } catch(error) { }
@@ -46,6 +46,23 @@ try { window.onabort = null; } catch(error) { }
     end
 
     render layout: false
+  end
+
+  # Serves the seller's universal raw snippets for the profile page (#5676),
+  # which has no product to hang the permalink-based index action on. Only
+  # "all"-located universal snippets run here: "product"/"receipt" scope a
+  # snippet to the purchase flow, and there is no purchase context for the
+  # $VALUE/$CURRENCY/$ORDER substitutions either.
+  def profile
+    user = User.alive.find_by(username: params[:username])
+    return e404 if user.nil?
+
+    @third_party_analytics = OVERRIDE_WINDOW_ACTIONS_CODE
+    snippets = user.third_party_analytics.universal.alive.where(location: "all").pluck(:analytics_code)
+    @third_party_analytics += snippets.join("\n") if snippets.present?
+    @third_party_analytics += OVERRIDE_ON_CLOSE_CODE
+
+    render :index, layout: false
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -259,6 +259,7 @@ class UsersController < ApplicationController
             <meta property="og:type" content="profile">
             <meta property="og:url" content="#{canonical}">
             #{og_image_tag}
+            #{profile_custom_html_analytics_head(user)}
             <style>html,body{margin:0;padding:0;height:100%;overflow:hidden}iframe{display:block;width:100%;height:100%;border:0}</style>
           </head>
           <body>
@@ -271,6 +272,47 @@ class UsersController < ApplicationController
             #{live_reload}
           </body>
         </html>
+      HTML
+    end
+
+    # Mirrors LinksController#custom_html_analytics_head for the profile wrapper:
+    # a custom profile bypasses the Inertia profile page, so the seller's
+    # analytics would otherwise never load (#5676). The tracking runs only in
+    # this trusted same-origin wrapper — the global CSP allowlists the analytics
+    # hosts — never in the sandboxed landing iframe, whose strict CSP blocks
+    # them by design. The payload carries no permalink/name, which routes the
+    # shared custom_html_analytics entry point down its profile branch:
+    # page-view + pixel init + universal snippets only, no product events and no
+    # checkout listener, because a profile has no buy affordance.
+    def profile_custom_html_analytics_head(user)
+      return "" unless analytics_enabled?(seller: user)
+
+      analytics = user.analytics_data
+      # Universal snippets scoped to "product"/"receipt" belong to the purchase
+      # flow; only "all" runs on the profile. The snippet iframe URL is
+      # username-based, so it's only offered when a username exists.
+      has_universal_third_party_analytics =
+        user.username.present? && user.third_party_analytics.universal.alive.where(location: "all").exists?
+      has_configured_pixel = analytics.values_at(:google_analytics_id, :facebook_pixel_id, :tiktok_pixel_id).any?(&:present?)
+      return "" unless has_configured_pixel || has_universal_third_party_analytics
+
+      props = {
+        seller_id: user.external_id,
+        analytics:,
+        has_universal_third_party_analytics:,
+        third_party_analytics_domain: THIRD_PARTY_ANALYTICS_DOMAIN,
+        username: user.username,
+      }
+
+      # All three enabled flags are "true" (not per-pixel), and the props JSON is
+      # escaped with ERB::Util.h because it sits in a double-quoted attribute —
+      # same rationale as LinksController#custom_html_analytics_head.
+      <<~HTML.strip
+        <meta property="gr:google_analytics:enabled" content="true">
+        <meta property="gr:fb_pixel:enabled" content="true">
+        <meta property="gr:tiktok_pixel:enabled" content="true">
+        <meta name="gr:custom-html-analytics" content="#{ERB::Util.h(props.to_json)}">
+        #{helpers.vite_typescript_tag("custom_html_analytics")}
       HTML
     end
 

--- a/app/javascript/components/useAddThirdPartyAnalytics.ts
+++ b/app/javascript/components/useAddThirdPartyAnalytics.ts
@@ -31,3 +31,24 @@ export function addThirdPartyAnalytics({
   );
   document.body.appendChild(iframe);
 }
+
+// Profile-page variant: the profile has no product, so the seller's universal
+// ("all products", location "all") snippets load through the username-based
+// endpoint instead of the permalink-based one.
+type ProfileOptions = { username: string };
+
+export function useAddProfileThirdPartyAnalytics() {
+  const { thirdPartyAnalyticsDomain } = useDomains();
+
+  return (options: ProfileOptions) => addProfileThirdPartyAnalytics({ ...options, domain: thirdPartyAnalyticsDomain });
+}
+
+export function addProfileThirdPartyAnalytics({ domain, username }: ProfileOptions & { domain: string }) {
+  const iframe = document.createElement("iframe");
+  iframe.classList.add("hidden");
+  iframe.setAttribute("sandbox", "allow-scripts allow-same-origin");
+  iframe.ariaLabel = "Third-party analytics";
+  iframe.dataset.username = username;
+  iframe.setAttribute("src", Routes.profile_third_party_analytics_url(username, { host: domain }));
+  document.body.appendChild(iframe);
+}

--- a/app/javascript/data/facebook_pixel.ts
+++ b/app/javascript/data/facebook_pixel.ts
@@ -39,6 +39,15 @@ export function trackProductEvent(config: AnalyticsConfig, data: FacebookProduct
   }
 }
 
+// startTrackingForSeller only inits the pixel — on product pages the first
+// event is ViewContent. A profile has no product, so it fires the standard
+// PageView instead.
+export function trackProfilePageView(config: AnalyticsConfig) {
+  if (!shouldTrack() || !config.facebookPixelId || typeof fbq === "undefined") return;
+
+  fbq("trackSingle", config.facebookPixelId, "PageView", {});
+}
+
 export function startTrackingForSeller(data: FacebookPixelConfig) {
   if (!shouldTrack() || !data.facebookPixelId || initializedPixels.has(data.facebookPixelId)) return;
 

--- a/app/javascript/data/google_analytics.ts
+++ b/app/javascript/data/google_analytics.ts
@@ -103,6 +103,18 @@ export function trackProductEvent(config: AnalyticsConfig | undefined, data: Pro
   }
 }
 
+// The seller's GA config is registered with send_page_view: false (see
+// startTrackingForSeller), so a profile view — which has no product "viewed"
+// event to piggyback on — needs this explicit page_view.
+export function trackProfilePageView(config: AnalyticsConfig) {
+  if (!shouldTrack() || !config.googleAnalyticsId || typeof gtag === "undefined") return;
+
+  logSellerEvent(config.id, "page_view", {
+    page: window.location.pathname + window.location.search,
+    title: "viewed profile",
+  });
+}
+
 export function startTrackingForSeller(data: AnalyticsConfig) {
   if (!shouldTrack() || !data.googleAnalyticsId) return;
   if (typeof gtag === "undefined") loadGoogleAnalyticsScript();

--- a/app/javascript/entrypoints/custom_html_analytics.ts
+++ b/app/javascript/entrypoints/custom_html_analytics.ts
@@ -1,55 +1,81 @@
 import typia from "typia";
 
 import { AnalyticsData } from "$app/parsers/product";
-import { startTrackingForSeller, trackProductEvent } from "$app/utils/user_analytics";
+import { startTrackingForSeller, trackProductEvent, trackProfilePageView } from "$app/utils/user_analytics";
 
-import { addThirdPartyAnalytics } from "$app/components/useAddThirdPartyAnalytics";
+import { addProfileThirdPartyAnalytics, addThirdPartyAnalytics } from "$app/components/useAddThirdPartyAnalytics";
+
+type SharedProps = {
+  seller_id: string;
+  analytics: AnalyticsData;
+  third_party_analytics_domain: string;
+};
+
+// Emitted by LinksController#custom_html_analytics_head for a custom product
+// landing page.
+type ProductProps = SharedProps & {
+  has_product_third_party_analytics: boolean;
+  permalink: string;
+  name: string;
+};
+
+// Emitted by UsersController#profile_custom_html_analytics_head for a custom
+// profile landing page, which has no product: no permalink/name and no
+// checkout bridge, only the seller's universal snippets.
+type ProfileProps = SharedProps & {
+  has_universal_third_party_analytics: boolean;
+  username: string;
+};
 
 // A custom HTML landing page renders as a bare wrapper document that embeds the
 // seller's HTML in a sandboxed, opaque-origin iframe. Neither layer loads the
-// React product page, so the seller's analytics — which normally fire from the
-// product component — never run. This entry point runs only on the trusted
+// React product/profile page, so the seller's analytics — which normally fire
+// from those components — never run. This entry point runs only on the trusted
 // wrapper (same-origin gumroad.com, under the global CSP that allowlists Google
-// Analytics and the pixels) and fires the same events the standard product page
-// does, so switching to a custom page keeps the same analytics event names:
+// Analytics and the pixels) and fires the same events the standard page does.
+//
+// For a product landing page, that keeps the same analytics event names:
 //   - "viewed" on load (GA page_view + view_item, Facebook/TikTok ViewContent)
 //   - "iwantthis" on buy click (GA add_to_cart, Facebook InitiateCheckout)
 // begin_checkout and purchase are intentionally NOT fired here: the buy button
 // navigates to the standard /checkout (which fires begin_checkout) and then the
 // receipt page (which fires purchase), so firing them here would double-count.
+//
+// For a profile landing page, only a page view fires — a profile has no buy
+// affordance, so there are no product or e-commerce events.
 const configElement = document.querySelector('meta[name="gr:custom-html-analytics"]');
 if (configElement) {
-  const props = typia.assert<{
-    seller_id: string;
-    analytics: AnalyticsData;
-    has_product_third_party_analytics: boolean;
-    third_party_analytics_domain: string;
-    permalink: string;
-    name: string;
-  }>(JSON.parse(configElement.getAttribute("content") ?? ""));
+  const props = typia.assert<ProductProps | ProfileProps>(JSON.parse(configElement.getAttribute("content") ?? ""));
 
   startTrackingForSeller(props.seller_id, props.analytics);
-  trackProductEvent(props.seller_id, { permalink: props.permalink, action: "viewed", product_name: props.name });
-  if (props.has_product_third_party_analytics)
-    addThirdPartyAnalytics({
-      domain: props.third_party_analytics_domain,
-      permalink: props.permalink,
-      location: "product",
-    });
 
-  // The seller's buy control lives inside the sandboxed iframe; clicking it posts
-  // a "gumroad:checkout" message to this wrapper (see custom_html_wrapper_document),
-  // which then navigates to checkout. That message is the custom page's equivalent
-  // of the product page's "I want this" CTA, so mirror its add_to_cart tracking.
-  // We re-check origin/source exactly like the wrapper's navigation handler so a
-  // message from anything but the sandboxed (opaque-origin) iframe is ignored.
-  const landingFrame = document.querySelector<HTMLIFrameElement>("#gumroad-landing-frame");
-  window.addEventListener("message", (event) => {
-    if (event.source !== landingFrame?.contentWindow || event.origin !== "null") return;
-    const data: unknown = event.data;
-    const isCheckout =
-      data === "gumroad:checkout" || (typia.is<{ type: string }>(data) && data.type === "gumroad:checkout");
-    if (!isCheckout) return;
-    trackProductEvent(props.seller_id, { permalink: props.permalink, action: "iwantthis", product_name: props.name });
-  });
+  if ("permalink" in props) {
+    trackProductEvent(props.seller_id, { permalink: props.permalink, action: "viewed", product_name: props.name });
+    if (props.has_product_third_party_analytics)
+      addThirdPartyAnalytics({
+        domain: props.third_party_analytics_domain,
+        permalink: props.permalink,
+        location: "product",
+      });
+
+    // The seller's buy control lives inside the sandboxed iframe; clicking it posts
+    // a "gumroad:checkout" message to this wrapper (see custom_html_wrapper_document),
+    // which then navigates to checkout. That message is the custom page's equivalent
+    // of the product page's "I want this" CTA, so mirror its add_to_cart tracking.
+    // We re-check origin/source exactly like the wrapper's navigation handler so a
+    // message from anything but the sandboxed (opaque-origin) iframe is ignored.
+    const landingFrame = document.querySelector<HTMLIFrameElement>("#gumroad-landing-frame");
+    window.addEventListener("message", (event) => {
+      if (event.source !== landingFrame?.contentWindow || event.origin !== "null") return;
+      const data: unknown = event.data;
+      const isCheckout =
+        data === "gumroad:checkout" || (typia.is<{ type: string }>(data) && data.type === "gumroad:checkout");
+      if (!isCheckout) return;
+      trackProductEvent(props.seller_id, { permalink: props.permalink, action: "iwantthis", product_name: props.name });
+    });
+  } else {
+    trackProfilePageView(props.seller_id);
+    if (props.has_universal_third_party_analytics)
+      addProfileThirdPartyAnalytics({ domain: props.third_party_analytics_domain, username: props.username });
+  }
 }

--- a/app/javascript/pages/Users/Show.tsx
+++ b/app/javascript/pages/Users/Show.tsx
@@ -2,12 +2,39 @@ import { usePage } from "@inertiajs/react";
 import * as React from "react";
 import typia from "typia";
 
-import { Profile } from "$app/components/Profile";
+import { AnalyticsData } from "$app/parsers/product";
+import { startTrackingForSeller, trackProfilePageView } from "$app/utils/user_analytics";
 
-type ShowPageProps = React.ComponentProps<typeof Profile>;
+import { Profile } from "$app/components/Profile";
+import { useAddProfileThirdPartyAnalytics } from "$app/components/useAddThirdPartyAnalytics";
+import { useRunOnce } from "$app/components/useRunOnce";
+
+type SellerAnalytics = {
+  seller_id: string;
+  analytics: AnalyticsData;
+  has_universal_third_party_analytics: boolean;
+  username: string | null;
+};
+
+type ShowPageProps = React.ComponentProps<typeof Profile> & { seller_analytics: SellerAnalytics };
 
 function UsersShow() {
   const profileProps = typia.assert<ShowPageProps>(usePage().props);
+  const addProfileThirdPartyAnalytics = useAddProfileThirdPartyAnalytics();
+
+  // The seller's analytics never fired on the profile: startTrackingForSeller
+  // is otherwise only called from product/checkout surfaces (#5676). Tracking
+  // fires here — the public page — rather than inside the Profile component,
+  // which the profile editor also renders as a preview. Page-view + pixel init
+  // only: a profile has no buy action, so no e-commerce events. Enablement is
+  // still gated by the gr:*:enabled meta tags inside the tracking modules.
+  useRunOnce(() => {
+    const { seller_id, analytics, has_universal_third_party_analytics, username } = profileProps.seller_analytics;
+    startTrackingForSeller(seller_id, analytics);
+    trackProfilePageView(seller_id);
+    if (has_universal_third_party_analytics && username != null) addProfileThirdPartyAnalytics({ username });
+  });
+
   return <Profile {...profileProps} />;
 }
 

--- a/app/javascript/utils/user_analytics.ts
+++ b/app/javascript/utils/user_analytics.ts
@@ -71,6 +71,20 @@ export function startTrackingForSeller(id: string, data: AnalyticsData) {
   TikTokPixel.startTrackingForSeller(config);
 }
 
+// Page-view-only tracking for profile pages, which have no product to attach
+// the usual "viewed" event to. TikTok is intentionally absent: its
+// startTrackingForSeller already fires ttq.page() on init, so firing it here
+// too would double-count — while GA registers the seller config with
+// send_page_view: false and Facebook only inits the pixel, so both need an
+// explicit page view.
+export function trackProfilePageView(id: string) {
+  const config = configs.get(id);
+  if (!config) return;
+
+  GoogleAnalytics.trackProfilePageView(config);
+  FacebookPixel.trackProfilePageView(config);
+}
+
 export function trackProductEvent(id: string | undefined, data: ProductAnalyticsEvent) {
   const config = id ? configs.get(id) : undefined;
 

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1121,12 +1121,7 @@ class Link < ApplicationRecord
   end
 
   def analytics_data
-    {
-      google_analytics_id: user.google_analytics_id,
-      facebook_pixel_id: user.facebook_pixel_id,
-      tiktok_pixel_id: user.tiktok_pixel_id,
-      free_sales: !user.skip_free_sale_analytics?,
-    }
+    user.analytics_data
   end
 
   def has_multiple_variants?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -621,6 +621,19 @@ class User < ApplicationRecord
     name.presence || username
   end
 
+  # Account-scoped pixel configuration in the shape the frontend's
+  # startTrackingForSeller expects. Link#analytics_data delegates here: the
+  # pixel ids live on the account, not the product, so profile surfaces (which
+  # have no product) can boot the same tracking.
+  def analytics_data
+    {
+      google_analytics_id:,
+      facebook_pixel_id:,
+      tiktok_pixel_id:,
+      free_sales: !skip_free_sale_analytics?,
+    }
+  end
+
   def custom_html=(value)
     if value.blank?
       page.custom_html = nil if page.present?

--- a/app/presenters/profile_presenter.rb
+++ b/app/presenters/profile_presenter.rb
@@ -27,7 +27,7 @@ class ProfilePresenter
     # to /profile, so the public component no longer renders the owner/editing shape. The real viewer
     # is still passed through, so "you own this", "already following this wishlist", and currency
     # reflect them (including the seller viewing their own page).
-    shared_profile_props(seller_custom_domain_url:, request:, editing: false).merge(creator_profile:)
+    shared_profile_props(seller_custom_domain_url:, request:, editing: false).merge(creator_profile:, seller_analytics:)
   end
 
   def profile_settings_props(request:)
@@ -72,6 +72,24 @@ class ProfilePresenter
 
     def profile_sections_presenter
       ProfileSectionsPresenter.new(seller:, query: seller.seller_profile_sections.on_profile)
+    end
+
+    # Seller GA/pixels never fired on the profile: startTrackingForSeller is only
+    # called from product/checkout surfaces (#5676). These props let Users/Show
+    # boot the account-scoped tracking. Enablement (production-only, seller's
+    # disable_third_party_analytics flag) stays with the gr:*:enabled meta tags
+    # the frontend already gates on — this only supplies the ids. Universal raw
+    # snippets are limited to location "all": "product"/"receipt" scope a snippet
+    # to the purchase flow, which a profile is not. The snippet iframe URL is
+    # username-based, so it's only offered when a username exists.
+    def seller_analytics
+      {
+        seller_id: seller.external_id,
+        analytics: seller.analytics_data,
+        has_universal_third_party_analytics:
+          seller.username.present? && seller.third_party_analytics.universal.alive.where(location: "all").exists?,
+        username: seller.username,
+      }
     end
 
     def can_edit_profile?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,8 @@ Rails.application.routes.draw do
 
   # third party analytics (near the top to matches constraint first)
   constraints(host: /#{THIRD_PARTY_ANALYTICS_DOMAIN}/o) do
+    # Two segments, so it can't shadow the single-segment permalink route below.
+    get "/profile/:username", to: "third_party_analytics#profile", as: :profile_third_party_analytics
     get "/:link_id", to: "third_party_analytics#index", as: :third_party_analytics
     get "/(*path)", to: "application#e404_page"
   end

--- a/spec/controllers/third_party_analytics_controller_spec.rb
+++ b/spec/controllers/third_party_analytics_controller_spec.rb
@@ -77,4 +77,35 @@ describe ThirdPartyAnalyticsController do
       expect { get :index, params: { link_id: @product.unique_permalink, purchase_id: "@purchase.external_id" } }.to raise_error(ActionController::RoutingError)
     end
   end
+
+  describe "profile" do
+    it "includes only universal snippets scoped to all pages" do
+      get :profile, params: { username: @seller.username }
+
+      expect(response.body).to include @global_user_snippet.analytics_code
+      expect(response.body).to_not include @global_product_snippet.analytics_code
+      expect(response.body).to_not include @product_user_snippet.analytics_code
+      expect(response.body).to_not include @product_product_snippet.analytics_code
+      expect(response.body).to_not include @receipt_user_snippet.analytics_code
+      expect(response.body).to_not include @receipt_product_snippet.analytics_code
+    end
+
+    it "excludes deleted snippets" do
+      @global_user_snippet.mark_deleted!
+
+      get :profile, params: { username: @seller.username }
+
+      expect(response.body).to_not include @global_user_snippet.analytics_code
+    end
+
+    it "raises an e404 if the user does not exist" do
+      expect { get :profile, params: { username: "nonexistent" } }.to raise_error(ActionController::RoutingError)
+    end
+
+    it "raises an e404 if the user is deleted" do
+      @seller.update_columns(deleted_at: Time.current)
+
+      expect { get :profile, params: { username: @seller.username } }.to raise_error(ActionController::RoutingError)
+    end
+  end
 end

--- a/spec/presenters/profile_presenter_spec.rb
+++ b/spec/presenters/profile_presenter_spec.rb
@@ -79,7 +79,18 @@ describe ProfilePresenter do
         {
           **sections_presenter.props(request:, pundit_user:, seller_custom_domain_url: nil),
           bio: "Bio",
-          tabs: encrypted_tabs
+          tabs: encrypted_tabs,
+          seller_analytics: {
+            seller_id: seller.external_id,
+            analytics: {
+              google_analytics_id: nil,
+              facebook_pixel_id: nil,
+              tiktok_pixel_id: nil,
+              free_sales: true,
+            },
+            has_universal_third_party_analytics: false,
+            username: seller.username,
+          }
         }
       )
     end
@@ -140,7 +151,9 @@ describe ProfilePresenter do
           custom_html_pages_enabled: false,
           has_custom_landing_page: false,
           username: seller.username,
-          **described_class.new(pundit_user: SellerContext.logged_out, seller:).profile_props(request:, seller_custom_domain_url: nil),
+          # seller_analytics is only added to the public profile_props — the settings
+          # editor never boots visitor tracking.
+          **described_class.new(pundit_user: SellerContext.logged_out, seller:).profile_props(request:, seller_custom_domain_url: nil).except(:seller_analytics),
         }
       )
       expect(props[:profile_settings]).not_to have_key(:username)

--- a/spec/requests/profile_analytics_spec.rb
+++ b/spec/requests/profile_analytics_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Seller GA/pixels never fired on any profile surface: startTrackingForSeller is
+# only called from product/checkout/mobile. The standard Inertia profile page
+# now receives account-scoped analytics props so the frontend can boot the
+# tracking, and the custom HTML profile wrapper re-injects it the same way the
+# custom product landing page does — only ever in the trusted wrapper, never in
+# the sandboxed opaque-origin iframe.
+describe "Profile page analytics", type: :request do
+  let(:seller) { create(:user, username: "analyticsseller", google_analytics_id: "G-ABC123") }
+
+  describe "standard (Inertia) profile page" do
+    def seller_analytics_props
+      get "#{seller.subdomain_with_protocol}/", headers: { "X-Inertia" => "true" }
+      expect(response).to be_successful
+      JSON.parse(response.body).dig("props", "seller_analytics")
+    end
+
+    it "includes the seller's account-scoped analytics props" do
+      expect(seller_analytics_props).to eq(
+        "seller_id" => seller.external_id,
+        "analytics" => {
+          "google_analytics_id" => "G-ABC123",
+          "facebook_pixel_id" => nil,
+          "tiktok_pixel_id" => nil,
+          "free_sales" => true,
+        },
+        "has_universal_third_party_analytics" => false,
+        "username" => "analyticsseller",
+      )
+    end
+
+    it "flags universal third-party snippets scoped to all pages" do
+      ThirdPartyAnalytic.create!(user: seller, analytics_code: "<script>1</script>", location: "all")
+
+      expect(seller_analytics_props["has_universal_third_party_analytics"]).to eq(true)
+    end
+
+    it "does not flag snippets scoped to the purchase flow" do
+      ThirdPartyAnalytic.create!(user: seller, analytics_code: "<script>1</script>", location: "product")
+
+      expect(seller_analytics_props["has_universal_third_party_analytics"]).to eq(false)
+    end
+  end
+
+  describe "custom HTML profile page" do
+    before do
+      seller.update!(custom_html: "<main><h1>Custom profile</h1></main>")
+      Feature.activate_user(:custom_html_pages, seller)
+      # analytics_enabled? only tracks in production/staging, matching the rest of the app.
+      allow(Rails.env).to receive(:production?).and_return(true)
+      # Resolving the Vite manifest for a real build is infra, not what we're testing —
+      # assert the entry point is requested by name and stub the tag it renders.
+      allow_any_instance_of(ActionView::Base).to receive(:vite_typescript_tag)
+        .with("custom_html_analytics").and_return(%(<script src="/custom_html_analytics.js"></script>).html_safe)
+    end
+
+    def get_wrapper
+      get "#{seller.subdomain_with_protocol}/"
+    end
+
+    def analytics_props(body)
+      content = body[/<meta name="gr:custom-html-analytics" content="([^"]*)"/, 1]
+      content && JSON.parse(CGI.unescapeHTML(content))
+    end
+
+    it "injects the enabled meta tags, seller props, and analytics entry point into the wrapper head" do
+      get_wrapper
+
+      expect(response).to be_successful
+      expect(response.body).to include('<meta property="gr:google_analytics:enabled" content="true">')
+      expect(response.body).to include('<meta property="gr:fb_pixel:enabled" content="true">')
+      expect(response.body).to include('<meta property="gr:tiktok_pixel:enabled" content="true">')
+      expect(response.body).to include('src="/custom_html_analytics.js"')
+
+      props = analytics_props(response.body)
+      expect(props).to include(
+        "seller_id" => seller.external_id,
+        "username" => "analyticsseller",
+        "third_party_analytics_domain" => THIRD_PARTY_ANALYTICS_DOMAIN,
+        "has_universal_third_party_analytics" => false,
+      )
+      expect(props["analytics"]).to include("google_analytics_id" => "G-ABC123")
+      # The profile payload carries no product fields — their absence routes the
+      # shared custom_html_analytics entry point down its page-view-only branch
+      # (no product events, no checkout listener).
+      expect(props).not_to have_key("permalink")
+      expect(props).not_to have_key("name")
+    end
+
+    it "does not inject analytics into the sandboxed landing iframe, whose CSP would block them" do
+      get "#{seller.subdomain_with_protocol}/landing/embed"
+
+      expect(response.body).not_to include("gr:custom-html-analytics")
+      expect(response.body).not_to include("gr:google_analytics:enabled")
+    end
+
+    context "when the seller has no analytics configured" do
+      let(:seller) { create(:user, username: "noanalytics") }
+
+      it "omits the analytics block so the wrapper stays minimal" do
+        get_wrapper
+
+        expect(response.body).not_to include("gr:custom-html-analytics")
+        expect(response.body).not_to include("gr:google_analytics:enabled")
+      end
+    end
+
+    context "when the seller disabled third-party analytics" do
+      before { seller.update!(disable_third_party_analytics: true) }
+
+      it "omits the analytics block" do
+        get_wrapper
+
+        expect(response.body).not_to include("gr:custom-html-analytics")
+      end
+    end
+
+    context "when the seller has only a universal raw snippet (no pixel ids)" do
+      let(:seller) { create(:user, username: "snippetseller") }
+
+      before { ThirdPartyAnalytic.create!(user: seller, analytics_code: "<script>1</script>", location: "all") }
+
+      it "injects the block so the entry point loads the snippet iframe" do
+        get_wrapper
+
+        props = analytics_props(response.body)
+        expect(props["has_universal_third_party_analytics"]).to eq(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What (Option B of #5676 — all profile pages)

Fires the seller's configured analytics (Google Analytics, Facebook Pixel, TikTok Pixel, universal "run everywhere" raw snippets) on **every profile page — standard Inertia profile AND custom HTML profile.**

**This is one of two candidate PRs for #5676 — see the issue's open questions.** This is the broader option:
- **Option A (sibling PR #5677):** custom HTML profile pages only.
- **Option B (this PR):** all profile pages, standard + custom.

## Why

Seller analytics fire on **no** profile page today — `startTrackingForSeller` (the only thing that boots seller GA/FB/TikTok pixels) is called from product, checkout, and mobile, but never from any profile surface. A seller who sets a GA id expects it to track their profile; it doesn't. This wires it up everywhere a profile renders.

> ⚠️ **Scope note for reviewers:** because the standard profile never tracked, this turns on seller GA/pixels for **every existing profile that has a GA id configured** — a behavior change for all such sellers, not just custom-page users. That is the deliberate difference from Option A and the crux of open question #2 on the issue.

## How

- **Standard profile** (`ProfilePresenter#profile_props` → Inertia `Users/Show`): new `seller_analytics` props (account-scoped ids + universal-snippet flag). `Users/Show.tsx` boots `startTrackingForSeller` + `trackProfilePageView` via `useRunOnce`, on the **public** page only (not the editor preview). Page-view + pixel init only — no e-commerce events.
- **Custom HTML profile** (`users_controller.rb`): `profile_custom_html_analytics_head` injected into the trusted wrapper (same-origin, under the global CSP that allowlists the analytics hosts), never the sandboxed iframe.
- **Shared entrypoint** `custom_html_analytics.ts` generalized to a `ProductProps | ProfileProps` discriminated union. The product branch (`"permalink" in props`) is **behaviorally unchanged** — same `viewed`/`iwantthis`/checkout-listener logic; the profile branch is a new `else` firing page-view + universal snippets only.
- **`analytics_data` moved to `User`** (`Link#analytics_data` now delegates) — the pixel ids are account-scoped, so profile surfaces with no product can boot the same tracking.
- **Universal snippets:** new `third_party_analytics#profile` action keyed on `username` (products key on permalink); route ordered so it can't shadow a product permalink.

## Enablement / safety

Enablement still flows through the existing `gr:*:enabled` meta tags the tracking modules already gate on (production-only + the seller's `disable_third_party_analytics` flag). This PR only supplies the ids. The sandboxed landing iframe's sandbox/CSP is untouched.

## Tests

- New `spec/requests/profile_analytics_spec.rb` + `profile_presenter_spec.rb` + `third_party_analytics_controller_spec.rb` profile cases.
- Product custom-HTML analytics regression specs pass (product branch unchanged).
- Ruby syntax verified on all changed files. Full RSpec suite needs Elasticsearch via a `before(:suite)` hook — CI is the authoritative test gate; please confirm green before merge.

Ref #5676

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785596701&installation_id=134400930&pr_number=5678&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5678&signature=3126f2874baa847321659923ecb4c61e7d2c7e4002f5e3ac464454996fe2c1a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->