### PR TITLE
Upload TaxJar sales tax daily instead of monthly

### DIFF
--- a/app/business/sales_tax/taxjar/us_state_sales_tax_uploader.rb
+++ b/app/business/sales_tax/taxjar/us_state_sales_tax_uploader.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+# Shared selection + per-purchase TaxJar order-transaction logic for US state sales tax.
+#
+# Both the monthly summary report (CreateUsStatesSalesSummaryReportJob, which now only
+# summarizes and does NOT push) and the daily uploader (UploadUsStatesSalesTaxToTaxjarJob,
+# which pushes each day's orders to TaxJar) share this class so the purchase selection,
+# state-assignment, ZIP resolution, dollar amounts, and retry/rescue behavior stay identical.
+class UsStateSalesTaxUploader
+  # Groups the taxable US purchase ids created in [starts_at, ends_at] by subdivision code,
+  # exactly as the original monthly job did. Raises ArgumentError on an invalid subdivision code.
+  def self.grouped_purchase_ids_by_state(subdivision_codes:, starts_at:, ends_at:)
+    subdivisions = subdivisions_for(subdivision_codes)
+
+    Purchase.successful
+      .not_fully_refunded
+      .not_chargedback_or_chargedback_reversed
+      .where.not(stripe_transaction_id: nil)
+      .where("purchases.created_at BETWEEN ? AND ?", starts_at, ends_at)
+      .where("(country = 'United States') OR ((country IS NULL OR country = 'United States') AND ip_country = 'United States')")
+      .where(charge_processor_id: [nil, *ChargeProcessor.charge_processor_ids])
+      .pluck(:id, :zip_code, :ip_address)
+      .each_with_object({}) do |purchase_attributes, result|
+        id, zip_code, ip_address = purchase_attributes
+
+        subdivisions.each do |subdivision|
+          if zip_code.present?
+            if subdivision.code == UsZipCodes.identify_state_code(zip_code)
+              result[subdivision.code] ||= []
+              result[subdivision.code] << id
+            end
+          elsif subdivision.code == GeoIp.lookup(ip_address)&.region_name
+            result[subdivision.code] ||= []
+            result[subdivision.code] << id
+          end
+        end
+      end
+  end
+
+  def self.subdivisions_for(subdivision_codes)
+    subdivision_codes.map do |code|
+      Compliance::Countries::USA.subdivisions[code].tap { |value| raise ArgumentError, "Invalid subdivision code" unless value }
+    end
+  end
+
+  def initialize(taxjar_api: TaxjarApi.new, push_to_taxjar: true)
+    @taxjar_api = taxjar_api
+    @push_to_taxjar = push_to_taxjar
+  end
+
+  # Resolves the purchase's ZIP for the given subdivision, optionally creates the TaxJar order
+  # transaction (idempotent — an already-imported order is caught and skipped), and returns the
+  # purchase's contribution to the summary totals. Returns nil when the purchase cannot be
+  # assigned a ZIP for this subdivision (skipped, exactly as the monthly job skipped it).
+  def upload(purchase:, subdivision:)
+    zip_code = purchase.zip_code if purchase.zip_code.present? && subdivision.code == UsZipCodes.identify_state_code(purchase.zip_code)
+    unless zip_code
+      geo_ip = GeoIp.lookup(purchase.ip_address)
+      zip_code = geo_ip&.postal_code if subdivision.code == geo_ip&.region_name
+    end
+
+    return unless zip_code
+
+    price_cents = purchase.price_cents_net_of_refunds
+    shipping_cents = purchase.shipping_cents
+    gumroad_tax_cents = purchase.gumroad_tax_cents_net_of_refunds
+
+    if @push_to_taxjar
+      price_dollars = price_cents / 100.0
+      unit_price_dollars = price_dollars / purchase.quantity
+      shipping_dollars = shipping_cents / 100.0
+      amount_dollars = price_dollars + shipping_dollars
+      sales_tax_dollars = gumroad_tax_cents / 100.0
+
+      destination = {
+        country: Compliance::Countries::USA.alpha2,
+        state: subdivision.code,
+        zip: zip_code
+      }
+
+      push_transaction(
+        purchase:,
+        destination:,
+        quantity: purchase.quantity,
+        product_tax_code: Link::NATIVE_TYPES_TO_TAX_CODE[purchase.link.native_type],
+        amount_dollars:,
+        shipping_dollars:,
+        sales_tax_dollars:,
+        unit_price_dollars:
+      )
+    end
+
+    {
+      gmv_cents: purchase.total_cents_net_of_refunds,
+      tax_cents: gumroad_tax_cents
+    }
+  end
+
+  private
+    def push_transaction(purchase:, destination:, quantity:, product_tax_code:, amount_dollars:, shipping_dollars:, sales_tax_dollars:, unit_price_dollars:)
+      retries = 0
+      begin
+        @taxjar_api.create_order_transaction(
+          transaction_id: purchase.external_id,
+          transaction_date: purchase.created_at.iso8601,
+          destination:,
+          quantity:,
+          product_tax_code:,
+          amount_dollars:,
+          shipping_dollars:,
+          sales_tax_dollars:,
+          unit_price_dollars:
+        )
+      rescue Taxjar::Error::GatewayTimeout, *TaxjarErrors::SERVER => e
+        retries += 1
+        if retries < 3
+          Rails.logger.info("UsStateSalesTaxUploader: TaxJar error for purchase with external ID #{purchase.external_id}. Retry attempt #{retries}/3. #{e.class}: #{e.message}")
+          sleep(1)
+          retry
+        else
+          Rails.logger.error("UsStateSalesTaxUploader: TaxJar error for purchase with external ID #{purchase.external_id} after 3 retry attempts. #{e.class}: #{e.message}")
+          raise
+        end
+      rescue Taxjar::Error::UnprocessableEntity => e
+        Rails.logger.info("UsStateSalesTaxUploader: Purchase with external ID #{purchase.external_id} was already created as a TaxJar transaction. #{e.class}: #{e.message}")
+      rescue Taxjar::Error::BadRequest => e
+        ErrorNotifier.notify(e)
+        Rails.logger.info("UsStateSalesTaxUploader: Failed to create TaxJar transaction for purchase with external ID #{purchase.external_id}. #{e.class}: #{e.message}")
+      end
+    end
+end

--- a/app/mailers/accounting_mailer.rb
+++ b/app/mailers/accounting_mailer.rb
@@ -111,6 +111,15 @@ class AccountingMailer < ApplicationMailer
          to: PAYMENTS_NOTIFICATION_EMAIL
   end
 
+  def us_states_sales_tax_taxjar_upload_failed(date, error_class, error_message)
+    @date = date
+    @error_class = error_class
+    @error_message = error_message
+
+    mail subject: "#{SUBJECT_PREFIX}[TaxJar] US States Sales Tax daily upload failed - #{date}",
+         to: PAYMENTS_NOTIFICATION_EMAIL
+  end
+
   def global_sales_tax_summary_report(month, year, s3_read_url)
     @subject_and_title = "Global Sales Tax Summary Report for #{month}/#{year}"
     @s3_url = s3_read_url

--- a/app/sidekiq/create_us_states_sales_summary_report_job.rb
+++ b/app/sidekiq/create_us_states_sales_summary_report_job.rb
@@ -11,17 +11,14 @@ class CreateUsStatesSalesSummaryReportJob
     ).deliver_later
   end
 
-  attr_reader :taxjar_api
-
-  def perform(subdivision_codes, month, year, push_to_taxjar: true)
+  # push_to_taxjar defaults to false: TaxJar order transactions are now uploaded DAILY by
+  # UploadUsStatesSalesTaxToTaxjarJob, so the monthly run only summarizes. Pass true to also
+  # (idempotently) push — used for manual backfill / re-push of a month.
+  def perform(subdivision_codes, month, year, push_to_taxjar = false)
     raise ArgumentError, "Invalid month" unless month.in?(1..12)
     raise ArgumentError, "Invalid year" unless year.in?(2014..3200)
 
-    @taxjar_api = TaxjarApi.new
-    @push_to_taxjar = push_to_taxjar
-    subdivisions = subdivision_codes.map do |code|
-      Compliance::Countries::USA.subdivisions[code].tap { |value| raise ArgumentError, "Invalid subdivision code" unless value }
-    end
+    uploader = UsStateSalesTaxUploader.new(push_to_taxjar:)
 
     row_headers = [
       "State",
@@ -30,31 +27,11 @@ class CreateUsStatesSalesSummaryReportJob
       "Sales tax collected"
     ]
 
-    purchase_ids_by_state = Purchase.successful
-      .not_fully_refunded
-      .not_chargedback_or_chargedback_reversed
-      .where.not(stripe_transaction_id: nil)
-      .where("purchases.created_at BETWEEN ? AND ?",
-             Date.new(year, month).beginning_of_month.beginning_of_day,
-             Date.new(year, month).end_of_month.end_of_day)
-      .where("(country = 'United States') OR ((country IS NULL OR country = 'United States') AND ip_country = 'United States')")
-      .where(charge_processor_id: [nil, *ChargeProcessor.charge_processor_ids])
-      .pluck(:id, :zip_code, :ip_address)
-      .each_with_object({}) do |purchase_attributes, result|
-        id, zip_code, ip_address = purchase_attributes
-
-        subdivisions.each do |subdivision|
-          if zip_code.present?
-            if subdivision.code == UsZipCodes.identify_state_code(zip_code)
-              result[subdivision.code] ||= []
-              result[subdivision.code] << id
-            end
-          elsif subdivision.code == GeoIp.lookup(ip_address)&.region_name
-            result[subdivision.code] ||= []
-            result[subdivision.code] << id
-          end
-        end
-      end
+    purchase_ids_by_state = UsStateSalesTaxUploader.grouped_purchase_ids_by_state(
+      subdivision_codes:,
+      starts_at: Date.new(year, month).beginning_of_month.beginning_of_day,
+      ends_at: Date.new(year, month).end_of_month.end_of_day
+    )
 
     begin
       temp_file = Tempfile.new
@@ -71,63 +48,12 @@ class CreateUsStatesSalesSummaryReportJob
         purchase_ids.each do |id|
           purchase = Purchase.find(id)
 
-          zip_code = purchase.zip_code if purchase.zip_code.present? && subdivision.code == UsZipCodes.identify_state_code(purchase.zip_code)
-          unless zip_code
-            geo_ip = GeoIp.lookup(purchase.ip_address)
-            zip_code = geo_ip&.postal_code if subdivision.code == geo_ip&.region_name
-          end
+          totals = uploader.upload(purchase:, subdivision:)
+          next unless totals
 
-          next unless zip_code
-
-          price_cents = purchase.price_cents_net_of_refunds
-          shipping_cents = purchase.shipping_cents
-          gumroad_tax_cents = purchase.gumroad_tax_cents_net_of_refunds
-
-          price_dollars = price_cents / 100.0
-          unit_price_dollars = price_dollars / purchase.quantity
-          shipping_dollars = shipping_cents / 100.0
-          amount_dollars = price_dollars + shipping_dollars
-          sales_tax_dollars = gumroad_tax_cents / 100.0
-
-          destination = {
-            country: Compliance::Countries::USA.alpha2,
-            state: subdivision.code,
-            zip: zip_code
-          }
-
-          retries = 0
-          begin
-            if @push_to_taxjar
-              taxjar_api.create_order_transaction(transaction_id: purchase.external_id,
-                                                  transaction_date: purchase.created_at.iso8601,
-                                                  destination:,
-                                                  quantity: purchase.quantity,
-                                                  product_tax_code: Link::NATIVE_TYPES_TO_TAX_CODE[purchase.link.native_type],
-                                                  amount_dollars:,
-                                                  shipping_dollars:,
-                                                  sales_tax_dollars:,
-                                                  unit_price_dollars:)
-            end
-          rescue Taxjar::Error::GatewayTimeout, *TaxjarErrors::SERVER => e
-            retries += 1
-            if retries < 3
-              Rails.logger.info("CreateUsStatesSalesSummaryReportJob: TaxJar error for purchase with external ID #{purchase.external_id}. Retry attempt #{retries}/3. #{e.class}: #{e.message}")
-              sleep(1)
-              retry
-            else
-              Rails.logger.error("CreateUsStatesSalesSummaryReportJob: TaxJar error for purchase with external ID #{purchase.external_id} after 3 retry attempts. #{e.class}: #{e.message}")
-              raise
-            end
-          rescue Taxjar::Error::UnprocessableEntity => e
-            Rails.logger.info("CreateUsStatesSalesSummaryReportJob: Purchase with external ID #{purchase.external_id} was already created as a TaxJar transaction. #{e.class}: #{e.message}")
-          rescue Taxjar::Error::BadRequest => e
-            ErrorNotifier.notify(e)
-            Rails.logger.info("CreateUsStatesSalesSummaryReportJob: Failed to create TaxJar transaction for purchase with external ID #{purchase.external_id}. #{e.class}: #{e.message}")
-          end
-
-          gmv_cents += purchase.total_cents_net_of_refunds
+          gmv_cents += totals[:gmv_cents]
           order_count += 1
-          tax_collected_cents += gumroad_tax_cents
+          tax_collected_cents += totals[:tax_cents]
         end
 
         temp_file.write([
@@ -153,42 +79,4 @@ class CreateUsStatesSalesSummaryReportJob
       temp_file.close
     end
   end
-
-  private
-    def fetch_taxjar_info(purchase:, subdivision:, zip_code:, price_cents:)
-      return unless @push_to_taxjar
-
-      origin = {
-        country: GumroadAddress::COUNTRY.alpha2,
-        state: GumroadAddress::STATE,
-        zip: GumroadAddress::ZIP
-      }
-
-      destination = {
-        country: Compliance::Countries::USA.alpha2,
-        state: subdivision.code,
-        zip: zip_code
-      }
-
-      nexus_address = {
-        country: Compliance::Countries::USA.alpha2,
-        state: subdivision.code
-      }
-
-      product_tax_code = Link::NATIVE_TYPES_TO_TAX_CODE[purchase.link.native_type]
-      quantity = purchase.quantity
-      unit_price_dollars = price_cents / 100.0 / quantity
-      shipping_dollars = purchase.shipping_cents / 100.0
-
-      begin
-        taxjar_api.calculate_tax_for_order(origin:,
-                                           destination:,
-                                           nexus_address:,
-                                           quantity:,
-                                           product_tax_code:,
-                                           unit_price_dollars:,
-                                           shipping_dollars:)
-      rescue Taxjar::Error::NotFound, Taxjar::Error::BadRequest
-      end
-    end
 end

--- a/app/sidekiq/upload_us_states_sales_tax_to_taxjar_job.rb
+++ b/app/sidekiq/upload_us_states_sales_tax_to_taxjar_job.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# Uploads a single day's taxable US-state order transactions to TaxJar.
+#
+# Runs DAILY (see config/sidekiq_schedule.yml) so the volume pushed per run is ~1/30th of the
+# old month-end bulk push. This is what prevents the recurring month-end failure mode where the
+# whole-month push timed out / died mid-run on a transient TaxJar/DNS error and left TaxJar with a
+# partial (or zero) month right before its auto-filing window — see the Feb & June 2026 incidents.
+#
+# The per-purchase selection, ZIP resolution, dollar amounts, and retry/rescue behavior are shared
+# with the monthly summary job via UsStateSalesTaxUploader, so daily and monthly stay identical.
+# TaxJar order creation is idempotent (an already-imported order is caught and skipped), so a retry
+# or an overlap with a manual month re-push is safe.
+class UploadUsStatesSalesTaxToTaxjarJob
+  include Sidekiq::Job
+  sidekiq_options retry: 5, queue: :default, lock: :until_executed
+
+  sidekiq_retries_exhausted do |job, exception|
+    date = job["args"].first
+    AccountingMailer.us_states_sales_tax_taxjar_upload_failed(
+      date, exception.class.name, exception.message
+    ).deliver_later
+  end
+
+  # date: an ISO8601 date string (defaults to yesterday). Uploads every taxable US order created
+  # on that calendar day (UTC) to TaxJar.
+  def perform(date = Date.yesterday.iso8601)
+    return unless Rails.env.production?
+
+    day = Date.parse(date.to_s)
+    subdivision_codes = Compliance::Countries::TAXABLE_US_STATE_CODES
+
+    uploader = UsStateSalesTaxUploader.new(push_to_taxjar: true)
+    subdivisions_by_code = UsStateSalesTaxUploader.subdivisions_for(subdivision_codes)
+      .index_by(&:code)
+
+    purchase_ids_by_state = UsStateSalesTaxUploader.grouped_purchase_ids_by_state(
+      subdivision_codes:,
+      starts_at: day.beginning_of_day,
+      ends_at: day.end_of_day
+    )
+
+    uploaded_count = 0
+    purchase_ids_by_state.each do |subdivision_code, purchase_ids|
+      subdivision = subdivisions_by_code[subdivision_code]
+
+      purchase_ids.each do |id|
+        purchase = Purchase.find(id)
+        totals = uploader.upload(purchase:, subdivision:)
+        uploaded_count += 1 if totals
+      end
+    end
+
+    Rails.logger.info("UploadUsStatesSalesTaxToTaxjarJob: uploaded #{uploaded_count} order transactions to TaxJar for #{day.iso8601}")
+  end
+end

--- a/app/sidekiq/upload_us_states_sales_tax_to_taxjar_job.rb
+++ b/app/sidekiq/upload_us_states_sales_tax_to_taxjar_job.rb
@@ -16,7 +16,10 @@ class UploadUsStatesSalesTaxToTaxjarJob
   sidekiq_options retry: 5, queue: :default, lock: :until_executed
 
   sidekiq_retries_exhausted do |job, exception|
-    date = job["args"].first
+    # The scheduler fires with no args (see config/sidekiq_schedule.yml), so job["args"].first is
+    # nil for a scheduled run. Mirror #perform's default so the alert email's re-run command is
+    # actionable instead of "perform_async(\"\")".
+    date = job["args"].first || Date.yesterday.iso8601
     AccountingMailer.us_states_sales_tax_taxjar_upload_failed(
       date, exception.class.name, exception.message
     ).deliver_later

--- a/app/views/accounting_mailer/us_states_sales_tax_taxjar_upload_failed.html.erb
+++ b/app/views/accounting_mailer/us_states_sales_tax_taxjar_upload_failed.html.erb
@@ -1,0 +1,10 @@
+<%= header_section("US States Sales Tax daily upload failed - #{@date}") %>
+<div>
+  <p><code>UploadUsStatesSalesTaxToTaxjarJob</code> exhausted Sidekiq retries and did not upload the day's order transactions to TaxJar.</p>
+  <ul>
+    <li>Date: <%= @date %></li>
+    <li>Error: <%= @error_class %>: <%= @error_message %></li>
+  </ul>
+  <p>Re-run the day once TaxJar is reachable: <code>UploadUsStatesSalesTaxToTaxjarJob.perform_async("<%= @date %>")</code> (idempotent — already-imported orders are skipped).</p>
+  <p>See Sentry and the Sidekiq dead set for more details.</p>
+</div>

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -381,6 +381,10 @@ monthly_financial_reports:
   cron: "0 1 1 * *" # UTC 01:00 on 1st of every month
   class: GenerateFinancialReportsForPreviousMonthJob
   description: Generate financial reports for the previous month
+upload_us_states_sales_tax_to_taxjar:
+  cron: "0 3 * * *" # UTC 03:00 every day (uploads the previous day's orders)
+  class: UploadUsStatesSalesTaxToTaxjarJob
+  description: Upload the previous day's taxable US-state order transactions to TaxJar
 delete_old_sent_email_info_records:
   cron: "0 1 1 * *" # UTC 01:00 on 1st of every month
   class: DeleteOldSentEmailInfoRecordsJob

--- a/spec/sidekiq/create_us_states_sales_summary_report_job_spec.rb
+++ b/spec/sidekiq/create_us_states_sales_summary_report_job_spec.rb
@@ -79,7 +79,7 @@ describe CreateUsStatesSalesSummaryReportJob do
       expect(s3_bucket_double).to receive(:object).ordered.and_return(@s3_object)
       expect_any_instance_of(TaxjarApi).to receive(:create_order_transaction).exactly(8).times.and_call_original
 
-      described_class.new.perform(subdivision_codes, month, year)
+      described_class.new.perform(subdivision_codes, month, year, true)
 
       expect(InternalNotificationWorker).to have_enqueued_sidekiq_job("payments", "US Sales Tax Summary Report", anything, "green")
 
@@ -118,9 +118,9 @@ describe CreateUsStatesSalesSummaryReportJob do
         end
         original.call(**kwargs)
       end
-      allow_any_instance_of(described_class).to receive(:sleep)
+      allow_any_instance_of(UsStateSalesTaxUploader).to receive(:sleep)
 
-      expect { described_class.new.perform(subdivision_codes, month, year) }.not_to raise_error
+      expect { described_class.new.perform(subdivision_codes, month, year, true) }.not_to raise_error
 
       expect(InternalNotificationWorker).to have_enqueued_sidekiq_job("payments", "US Sales Tax Summary Report", anything, "green")
     end
@@ -129,7 +129,7 @@ describe CreateUsStatesSalesSummaryReportJob do
       expect(s3_bucket_double).to receive(:object).ordered.and_return(@s3_object)
       expect_any_instance_of(TaxjarApi).not_to receive(:create_order_transaction)
 
-      described_class.new.perform(subdivision_codes, month, year, push_to_taxjar: false)
+      described_class.new.perform(subdivision_codes, month, year)
 
       expect(InternalNotificationWorker).to have_enqueued_sidekiq_job("payments", "US Sales Tax Summary Report", anything, "green")
 

--- a/spec/sidekiq/upload_us_states_sales_tax_to_taxjar_job_spec.rb
+++ b/spec/sidekiq/upload_us_states_sales_tax_to_taxjar_job_spec.rb
@@ -31,6 +31,19 @@ describe UploadUsStatesSalesTaxToTaxjarJob do
 
       described_class.sidekiq_retries_exhausted_block.call(job, exception)
     end
+
+    it "falls back to yesterday's date when the scheduler fired the job with no args" do
+      job = { "args" => [] }
+      exception = HTTP::ConnectionError.new("failed to connect: getaddrinfo")
+      mailer = double("mailer")
+
+      expect(AccountingMailer).to receive(:us_states_sales_tax_taxjar_upload_failed)
+        .with(Date.yesterday.iso8601, "HTTP::ConnectionError", "failed to connect: getaddrinfo")
+        .and_return(mailer)
+      expect(mailer).to receive(:deliver_later)
+
+      described_class.sidekiq_retries_exhausted_block.call(job, exception)
+    end
   end
 
   describe "uploading a day's orders", :vcr do

--- a/spec/sidekiq/upload_us_states_sales_tax_to_taxjar_job_spec.rb
+++ b/spec/sidekiq/upload_us_states_sales_tax_to_taxjar_job_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe UploadUsStatesSalesTaxToTaxjarJob do
+  before do
+    allow(Rails.env).to receive(:production?).and_return(true)
+  end
+
+  it "is configured with retry: 5" do
+    expect(described_class.sidekiq_options["retry"]).to eq(5)
+  end
+
+  it "does nothing when the Rails environment is not production" do
+    allow(Rails.env).to receive(:production?).and_return(false)
+    expect_any_instance_of(TaxjarApi).not_to receive(:create_order_transaction)
+
+    described_class.new.perform("2022-08-10")
+  end
+
+  describe "sidekiq_retries_exhausted" do
+    it "emails payments notification with the failure context" do
+      job = { "args" => ["2026-06-15"] }
+      exception = HTTP::ConnectionError.new("failed to connect: getaddrinfo")
+      mailer = double("mailer")
+
+      expect(AccountingMailer).to receive(:us_states_sales_tax_taxjar_upload_failed)
+        .with("2026-06-15", "HTTP::ConnectionError", "failed to connect: getaddrinfo")
+        .and_return(mailer)
+      expect(mailer).to receive(:deliver_later)
+
+      described_class.sidekiq_retries_exhausted_block.call(job, exception)
+    end
+  end
+
+  describe "uploading a day's orders", :vcr do
+    before do
+      travel_to(Time.find_zone("UTC").local(2022, 8, 10)) do
+        product = create(:product, price_cents: 100_00, native_type: "digital")
+
+        @purchase_wa = create(:purchase_in_progress, link: product, was_product_recommended: true, country: "United States", zip_code: "98121") # King County, Washington
+        @purchase_wi = create(:purchase_in_progress, link: product, was_product_recommended: true, country: "United States", zip_code: "53703") # Madison, Wisconsin
+
+        Purchase.in_progress.find_each do |purchase|
+          purchase.chargeable = create(:chargeable)
+          purchase.process!
+          purchase.update_balance_and_mark_successful!
+        end
+      end
+    end
+
+    it "uploads the given day's taxable US-state order transactions to TaxJar" do
+      uploaded_transaction_ids = []
+      allow_any_instance_of(TaxjarApi).to receive(:create_order_transaction) do |_instance, **kwargs|
+        uploaded_transaction_ids << kwargs[:transaction_id]
+        {}
+      end
+
+      described_class.new.perform("2022-08-10")
+
+      expect(uploaded_transaction_ids).to match_array([@purchase_wa.external_id, @purchase_wi.external_id])
+    end
+
+    it "does not upload orders created on a different day" do
+      expect_any_instance_of(TaxjarApi).not_to receive(:create_order_transaction)
+
+      described_class.new.perform("2022-08-11")
+    end
+
+    it "retries and completes when TaxJar raises a transient connection error" do
+      raised = false
+      allow_any_instance_of(TaxjarApi).to receive(:create_order_transaction) do |_instance, **_kwargs|
+        unless raised
+          raised = true
+          raise HTTP::ConnectionError, "failed to connect: Connection reset by peer - SSL_connect"
+        end
+        {}
+      end
+      allow_any_instance_of(UsStateSalesTaxUploader).to receive(:sleep)
+
+      expect { described_class.new.perform("2022-08-10") }.not_to raise_error
+    end
+
+    it "defaults to uploading yesterday's orders" do
+      travel_to(Time.find_zone("UTC").local(2022, 8, 11, 3)) do
+        uploaded_transaction_ids = []
+        allow_any_instance_of(TaxjarApi).to receive(:create_order_transaction) do |_instance, **kwargs|
+          uploaded_transaction_ids << kwargs[:transaction_id]
+          {}
+        end
+
+        described_class.new.perform
+
+        expect(uploaded_transaction_ids).to match_array([@purchase_wa.external_id, @purchase_wi.external_id])
+      end
+    end
+  end
+end

--- a/spec/support/fixtures/vcr_cassettes/UploadUsStatesSalesTaxToTaxjarJob/uploading_a_day_s_orders/defaults_to_uploading_yesterday_s_orders.yml
+++ b/spec/support/fixtures/vcr_cassettes/UploadUsStatesSalesTaxToTaxjarJob/uploading_a_day_s_orders/defaults_to_uploading_yesterday_s_orders.yml
@@ -1,0 +1,1421 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_XqDsLM2nO2dU54","request_duration_ms":314}}'
+      Idempotency-Key:
+      - c17f9c52-4a1a-4ca4-85f8-47ae35e36955
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 15:44:59 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa;
+        report-to csp
+      Idempotency-Key:
+      - c17f9c52-4a1a-4ca4-85f8-47ae35e36955
+      Original-Request:
+      - req_u59ZiaA2SrwrKK
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"
+      Request-Id:
+      - req_u59ZiaA2SrwrKK
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TomnPIBOqvOFDrf4PSX3qNF",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783007099,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TomnPIBOqvOFDrf4PSX3qNF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_u59ZiaA2SrwrKK","request_duration_ms":205}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 15:44:59 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"
+      Request-Id:
+      - req_4Rz6AZKj0QaMrC
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TomnPIBOqvOFDrf4PSX3qNF",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783007099,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.sandbox.taxjar.com/v2/taxes
+    body:
+      encoding: UTF-8
+      string: '{"from_country":"US","from_state":"CA","from_zip":"94104","to_country":"US","to_state":"WA","to_zip":"98121","shipping":0.0,"line_items":[{"quantity":1,"unit_price":100.0,"discount":0,"product_tax_code":"31000"}],"nexus_addresses":[{"country":"US","state":"WA"}]}'
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version
+        25.5.0: Mon Apr 27 20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031
+        arm64; ruby 3.4.3-p32; OpenSSL 3.6.2 7 Apr 2026) taxjar-ruby/3.0.4'
+      Authorization:
+      - 'Bearer '
+      X-Api-Version:
+      - '2022-01-24'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+      Host:
+      - api.sandbox.taxjar.com
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '90'
+      Connection:
+      - close
+      Date:
+      - Thu, 02 Jul 2026 15:44:59 GMT
+      X-Amzn-Trace-Id:
+      - Root=1-6a46877b-419100ff6a6906aa20ed6b89
+      X-Amzn-Requestid:
+      - 4b9c06d7-252b-4402-a2e6-796915cf3729
+      X-Amz-Apigw-Id:
+      - f4obYHRnIAMEVCQ=
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 a00c6c8eb0312a56ca49e4663e1ea3d4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - JFK50-P9
+      X-Amz-Cf-Id:
+      - Lk38C7EODy2EG6Va0ef0A_NPGt8cvIHjezX9S99ZPJHiTiZU-BgriA==
+    body:
+      encoding: UTF-8
+      string: '{"detail":"Not authorized for route ''POST /v2/taxes''","status":401,"error":"Unauthorized"}'
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=10000&currency=usd&description=You+bought+http%3A%2F%2Fedgardcc060574.test.gumroad.com%3A31337%2Fl%2Fv%21&metadata[purchase]=tKDJVeTSb2eXbAmGaaVsTw%3D%3D&transfer_group=8&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1TomnPIBOqvOFDrf4PSX3qNF&statement_descriptor_suffix=edgardcc060574
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_4Rz6AZKj0QaMrC","request_duration_ms":150}}'
+      Idempotency-Key:
+      - 9c1c169b-e333-45ad-a029-a1dca237fa99
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 15:45:00 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1639'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa;
+        report-to csp
+      Idempotency-Key:
+      - 9c1c169b-e333-45ad-a029-a1dca237fa99
+      Original-Request:
+      - req_dD15dkAd8eFPPh
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"
+      Request-Id:
+      - req_dD15dkAd8eFPPh
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3TomnPIBOqvOFDrf04dsnEVB",
+          "object": "payment_intent",
+          "amount": 10000,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 10000,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3TomnPIBOqvOFDrf04dsnEVB_secret_QoRAtvaTJqqYYVJ4IXAMAmtp3",
+          "confirmation_method": "automatic",
+          "created": 1783007099,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgardcc060574.test.gumroad.com:31337/l/v!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3TomnPIBOqvOFDrf05pBhfEG",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "tKDJVeTSb2eXbAmGaaVsTw=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1TomnPIBOqvOFDrf4PSX3qNF",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgardcc060574",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "8"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TomnPIBOqvOFDrf05pBhfEG?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_dD15dkAd8eFPPh","request_duration_ms":1125}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 15:45:01 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3801'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"
+      Request-Id:
+      - req_D260XDcgrWBEs4
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TomnPIBOqvOFDrf05pBhfEG",
+          "object": "charge",
+          "amount": 10000,
+          "amount_captured": 10000,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TomnPIBOqvOFDrf0q1xSapC",
+            "object": "balance_transaction",
+            "amount": 10000,
+            "available_on": 1783555200,
+            "balance_type": "payments",
+            "created": 1783007100,
+            "currency": "usd",
+            "description": "You bought http://edgardcc060574.test.gumroad.com:31337/l/v!",
+            "exchange_rate": null,
+            "fee": 320,
+            "fee_details": [
+              {
+                "amount": 320,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 9680,
+            "reporting_category": "charge",
+            "source": "ch_3TomnPIBOqvOFDrf05pBhfEG",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGARDCC060574",
+          "captured": true,
+          "created": 1783007100,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgardcc060574.test.gumroad.com:31337/l/v!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "tKDJVeTSb2eXbAmGaaVsTw=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 0,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TomnPIBOqvOFDrf04dsnEVB",
+          "payment_method": "pm_1TomnPIBOqvOFDrf4PSX3qNF",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 10000,
+              "authorization_code": "200135",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 10000,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKP2OmtIGMgZMH5eTdWk6LBZ6fq0s_7EhO2jCOhnzGe-QwALfa_8Ut4mpReOCCKxQT_uqesfqAQWecLFJ",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgardcc060574",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "8"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_D260XDcgrWBEs4","request_duration_ms":655}}'
+      Idempotency-Key:
+      - a74c16ac-5985-443f-8098-0fe5d949a5c3
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 15:45:01 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa;
+        report-to csp
+      Idempotency-Key:
+      - a74c16ac-5985-443f-8098-0fe5d949a5c3
+      Original-Request:
+      - req_8xkrDOhClh03Uu
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"
+      Request-Id:
+      - req_8xkrDOhClh03Uu
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TomnRIBOqvOFDrfZUA0YxQe",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783007101,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TomnRIBOqvOFDrfZUA0YxQe
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_8xkrDOhClh03Uu","request_duration_ms":221}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 15:45:01 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"
+      Request-Id:
+      - req_aqYY5hevKQ3EGs
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TomnRIBOqvOFDrfZUA0YxQe",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783007101,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.sandbox.taxjar.com/v2/taxes
+    body:
+      encoding: UTF-8
+      string: '{"from_country":"US","from_state":"CA","from_zip":"94104","to_country":"US","to_state":"WI","to_zip":"53703","shipping":0.0,"line_items":[{"quantity":1,"unit_price":100.0,"discount":0,"product_tax_code":"31000"}],"nexus_addresses":[{"country":"US","state":"WI"}]}'
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version
+        25.5.0: Mon Apr 27 20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031
+        arm64; ruby 3.4.3-p32; OpenSSL 3.6.2 7 Apr 2026) taxjar-ruby/3.0.4'
+      Authorization:
+      - 'Bearer '
+      X-Api-Version:
+      - '2022-01-24'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+      Host:
+      - api.sandbox.taxjar.com
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '90'
+      Connection:
+      - close
+      Date:
+      - Thu, 02 Jul 2026 15:45:02 GMT
+      X-Amzn-Trace-Id:
+      - Root=1-6a46877e-65ccb49d7ddaf2b22a3fd903
+      X-Amzn-Requestid:
+      - 99b9f586-e130-49df-ad89-76ec4d86c4e0
+      X-Amz-Apigw-Id:
+      - f4obwHv4IAMEf9Q=
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 fbc6aba81adda3753f540e18b975899c.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - JFK50-P9
+      X-Amz-Cf-Id:
+      - UuLtR8Rm6jMBInQHA3HE87odQily5DbnIu30ZzOSJLYESrCYjN99Gw==
+    body:
+      encoding: UTF-8
+      string: '{"detail":"Not authorized for route ''POST /v2/taxes''","status":401,"error":"Unauthorized"}'
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=10000&currency=usd&description=You+bought+http%3A%2F%2Fedgardcc060574.test.gumroad.com%3A31337%2Fl%2Fv%21&metadata[purchase]=9V1cJ4Q_KG1jiFcpM49gVA%3D%3D&transfer_group=9&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1TomnRIBOqvOFDrfZUA0YxQe&statement_descriptor_suffix=edgardcc060574
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_aqYY5hevKQ3EGs","request_duration_ms":172}}'
+      Idempotency-Key:
+      - 296c107a-de2c-41a2-81be-cc60ccba001c
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 15:45:03 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1639'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa;
+        report-to csp
+      Idempotency-Key:
+      - 296c107a-de2c-41a2-81be-cc60ccba001c
+      Original-Request:
+      - req_cwATB0h2rUFeHE
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"
+      Request-Id:
+      - req_cwATB0h2rUFeHE
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3TomnSIBOqvOFDrf1s7iEwXB",
+          "object": "payment_intent",
+          "amount": 10000,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 10000,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3TomnSIBOqvOFDrf1s7iEwXB_secret_2IvWq0TdOaGnoRUY7agB6fes2",
+          "confirmation_method": "automatic",
+          "created": 1783007102,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgardcc060574.test.gumroad.com:31337/l/v!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3TomnSIBOqvOFDrf1fKmiWG3",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "9V1cJ4Q_KG1jiFcpM49gVA=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1TomnRIBOqvOFDrfZUA0YxQe",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgardcc060574",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "9"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TomnSIBOqvOFDrf1fKmiWG3?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_cwATB0h2rUFeHE","request_duration_ms":1087}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 15:45:03 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3802'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"
+      Request-Id:
+      - req_MKdPvRFW6EMBWB
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TomnSIBOqvOFDrf1fKmiWG3",
+          "object": "charge",
+          "amount": 10000,
+          "amount_captured": 10000,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TomnSIBOqvOFDrf1FZ5Poqp",
+            "object": "balance_transaction",
+            "amount": 10000,
+            "available_on": 1783555200,
+            "balance_type": "payments",
+            "created": 1783007102,
+            "currency": "usd",
+            "description": "You bought http://edgardcc060574.test.gumroad.com:31337/l/v!",
+            "exchange_rate": null,
+            "fee": 320,
+            "fee_details": [
+              {
+                "amount": 320,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 9680,
+            "reporting_category": "charge",
+            "source": "ch_3TomnSIBOqvOFDrf1fKmiWG3",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGARDCC060574",
+          "captured": true,
+          "created": 1783007102,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgardcc060574.test.gumroad.com:31337/l/v!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "9V1cJ4Q_KG1jiFcpM49gVA=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 33,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TomnSIBOqvOFDrf1s7iEwXB",
+          "payment_method": "pm_1TomnRIBOqvOFDrfZUA0YxQe",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 10000,
+              "authorization_code": "716531",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 10000,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKP-OmtIGMgZFnHpPpo06LBaiBsgb6I1ayIKzAZW9F7PmSrqWKV_WwSgHc6VZeLflR6fLfSU2bR0pgqQ0",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgardcc060574",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "9"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/UploadUsStatesSalesTaxToTaxjarJob/uploading_a_day_s_orders/does_not_upload_orders_created_on_a_different_day.yml
+++ b/spec/support/fixtures/vcr_cassettes/UploadUsStatesSalesTaxToTaxjarJob/uploading_a_day_s_orders/does_not_upload_orders_created_on_a_different_day.yml
@@ -1,0 +1,1421 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_aS7ekwxT6ioXM5","request_duration_ms":353}}'
+      Idempotency-Key:
+      - 94ecb22c-fbc1-496c-a6b3-1f39f33001fc
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 15:44:51 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa;
+        report-to csp
+      Idempotency-Key:
+      - 94ecb22c-fbc1-496c-a6b3-1f39f33001fc
+      Original-Request:
+      - req_oRGDlcdDcO5iuq
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"
+      Request-Id:
+      - req_oRGDlcdDcO5iuq
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TomnHIBOqvOFDrfim399cYk",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783007091,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TomnHIBOqvOFDrfim399cYk
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_oRGDlcdDcO5iuq","request_duration_ms":201}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 15:44:52 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"
+      Request-Id:
+      - req_yKjYl4Pr696l95
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TomnHIBOqvOFDrfim399cYk",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783007091,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.sandbox.taxjar.com/v2/taxes
+    body:
+      encoding: UTF-8
+      string: '{"from_country":"US","from_state":"CA","from_zip":"94104","to_country":"US","to_state":"WA","to_zip":"98121","shipping":0.0,"line_items":[{"quantity":1,"unit_price":100.0,"discount":0,"product_tax_code":"31000"}],"nexus_addresses":[{"country":"US","state":"WA"}]}'
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version
+        25.5.0: Mon Apr 27 20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031
+        arm64; ruby 3.4.3-p32; OpenSSL 3.6.2 7 Apr 2026) taxjar-ruby/3.0.4'
+      Authorization:
+      - 'Bearer '
+      X-Api-Version:
+      - '2022-01-24'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+      Host:
+      - api.sandbox.taxjar.com
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '90'
+      Connection:
+      - close
+      Date:
+      - Thu, 02 Jul 2026 15:44:52 GMT
+      X-Amzn-Trace-Id:
+      - Root=1-6a468774-5b6227112307445f7d7ab445
+      X-Amzn-Requestid:
+      - 318e070d-ba42-4673-be03-669b13a26eab
+      X-Amz-Apigw-Id:
+      - f4oaNHNXIAMEWtw=
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 2f77ee6d00910cc9164b3833771289c2.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - JFK50-P9
+      X-Amz-Cf-Id:
+      - gW8mP8JYac06my1CScnKD4xUyHh5Wql5WBMdWA6-iX9d-HKQrGwsyw==
+    body:
+      encoding: UTF-8
+      string: '{"detail":"Not authorized for route ''POST /v2/taxes''","status":401,"error":"Unauthorized"}'
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=10000&currency=usd&description=You+bought+http%3A%2F%2Fedgar137dc25f2.test.gumroad.com%3A31337%2Fl%2Fx%21&metadata[purchase]=rZRIoAk5W2qtGOs_qEd9IA%3D%3D&transfer_group=4&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1TomnHIBOqvOFDrfim399cYk&statement_descriptor_suffix=edgar137dc25f2
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_yKjYl4Pr696l95","request_duration_ms":160}}'
+      Idempotency-Key:
+      - 5c29e7e6-9aac-4da9-b089-16dd167ce369
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 15:44:53 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1639'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa;
+        report-to csp
+      Idempotency-Key:
+      - 5c29e7e6-9aac-4da9-b089-16dd167ce369
+      Original-Request:
+      - req_bTxIVCwFBt7GlU
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"
+      Request-Id:
+      - req_bTxIVCwFBt7GlU
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3TomnIIBOqvOFDrf0ujCnaIo",
+          "object": "payment_intent",
+          "amount": 10000,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 10000,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3TomnIIBOqvOFDrf0ujCnaIo_secret_8N1KuEwUaSyGEwlc5XdeSsYEk",
+          "confirmation_method": "automatic",
+          "created": 1783007092,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgar137dc25f2.test.gumroad.com:31337/l/x!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3TomnIIBOqvOFDrf0pvboV9q",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "rZRIoAk5W2qtGOs_qEd9IA=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1TomnHIBOqvOFDrfim399cYk",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar137dc25f2",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "4"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TomnIIBOqvOFDrf0pvboV9q?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_bTxIVCwFBt7GlU","request_duration_ms":902}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 15:44:53 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3802'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"
+      Request-Id:
+      - req_izRyg2YEnFzw53
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TomnIIBOqvOFDrf0pvboV9q",
+          "object": "charge",
+          "amount": 10000,
+          "amount_captured": 10000,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TomnIIBOqvOFDrf01fdo8JL",
+            "object": "balance_transaction",
+            "amount": 10000,
+            "available_on": 1783555200,
+            "balance_type": "payments",
+            "created": 1783007092,
+            "currency": "usd",
+            "description": "You bought http://edgar137dc25f2.test.gumroad.com:31337/l/x!",
+            "exchange_rate": null,
+            "fee": 320,
+            "fee_details": [
+              {
+                "amount": 320,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 9680,
+            "reporting_category": "charge",
+            "source": "ch_3TomnIIBOqvOFDrf0pvboV9q",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR137DC25F2",
+          "captured": true,
+          "created": 1783007092,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar137dc25f2.test.gumroad.com:31337/l/x!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "rZRIoAk5W2qtGOs_qEd9IA=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 44,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TomnIIBOqvOFDrf0ujCnaIo",
+          "payment_method": "pm_1TomnHIBOqvOFDrfim399cYk",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 10000,
+              "authorization_code": "999162",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 10000,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKPWOmtIGMgbLCPeABKw6LBZCwlfJdy3bMiNzuC4G449Ow05bVJn7L2QCaLPzyZjDKuxhqYNThgS1ALU1",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar137dc25f2",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "4"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_izRyg2YEnFzw53","request_duration_ms":304}}'
+      Idempotency-Key:
+      - e3c2c979-a725-425a-947b-25df2d285e88
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 15:44:53 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa;
+        report-to csp
+      Idempotency-Key:
+      - e3c2c979-a725-425a-947b-25df2d285e88
+      Original-Request:
+      - req_SP279HuStllLdK
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"
+      Request-Id:
+      - req_SP279HuStllLdK
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TomnJIBOqvOFDrfYwo53XIF",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783007093,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TomnJIBOqvOFDrfYwo53XIF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_SP279HuStllLdK","request_duration_ms":192}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 15:44:53 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"
+      Request-Id:
+      - req_aHBSN4VihWuUeR
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TomnJIBOqvOFDrfYwo53XIF",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783007093,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.sandbox.taxjar.com/v2/taxes
+    body:
+      encoding: UTF-8
+      string: '{"from_country":"US","from_state":"CA","from_zip":"94104","to_country":"US","to_state":"WI","to_zip":"53703","shipping":0.0,"line_items":[{"quantity":1,"unit_price":100.0,"discount":0,"product_tax_code":"31000"}],"nexus_addresses":[{"country":"US","state":"WI"}]}'
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version
+        25.5.0: Mon Apr 27 20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031
+        arm64; ruby 3.4.3-p32; OpenSSL 3.6.2 7 Apr 2026) taxjar-ruby/3.0.4'
+      Authorization:
+      - 'Bearer '
+      X-Api-Version:
+      - '2022-01-24'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+      Host:
+      - api.sandbox.taxjar.com
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '90'
+      Connection:
+      - close
+      Date:
+      - Thu, 02 Jul 2026 15:44:54 GMT
+      X-Amzn-Trace-Id:
+      - Root=1-6a468776-77a3690b367c8e4f1d273777
+      X-Amzn-Requestid:
+      - 18c376a6-d9af-43ab-826e-ca0145919e23
+      X-Amz-Apigw-Id:
+      - f4oagF1gIAMEQSw=
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 82ea6125c245bf5c3d91bf07bf2aab4c.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - JFK50-P9
+      X-Amz-Cf-Id:
+      - ijWhVUEhR8BRNBwTR2iO0WXgEV5VQk3jIbD7vAd-tVCZ18506gkl0g==
+    body:
+      encoding: UTF-8
+      string: '{"detail":"Not authorized for route ''POST /v2/taxes''","status":401,"error":"Unauthorized"}'
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=10000&currency=usd&description=You+bought+http%3A%2F%2Fedgar137dc25f2.test.gumroad.com%3A31337%2Fl%2Fx%21&metadata[purchase]=qP2s9UXyL7CqmGpuynmLZg%3D%3D&transfer_group=5&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1TomnJIBOqvOFDrfYwo53XIF&statement_descriptor_suffix=edgar137dc25f2
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_aHBSN4VihWuUeR","request_duration_ms":162}}'
+      Idempotency-Key:
+      - f629c801-f69f-4c0f-9c11-300f9c835f90
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 15:44:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1639'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa;
+        report-to csp
+      Idempotency-Key:
+      - f629c801-f69f-4c0f-9c11-300f9c835f90
+      Original-Request:
+      - req_Dva6PcsMz3rPCS
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"
+      Request-Id:
+      - req_Dva6PcsMz3rPCS
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3TomnKIBOqvOFDrf0DENadtt",
+          "object": "payment_intent",
+          "amount": 10000,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 10000,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3TomnKIBOqvOFDrf0DENadtt_secret_iJHzrpPioRhPnyqARS5Y6NVhq",
+          "confirmation_method": "automatic",
+          "created": 1783007094,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgar137dc25f2.test.gumroad.com:31337/l/x!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3TomnKIBOqvOFDrf0q2uShi7",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "qP2s9UXyL7CqmGpuynmLZg=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1TomnJIBOqvOFDrfYwo53XIF",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar137dc25f2",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "5"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TomnKIBOqvOFDrf0q2uShi7?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_Dva6PcsMz3rPCS","request_duration_ms":1027}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 15:44:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3802'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"
+      Request-Id:
+      - req_v2P4lwtFvaQVel
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TomnKIBOqvOFDrf0q2uShi7",
+          "object": "charge",
+          "amount": 10000,
+          "amount_captured": 10000,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TomnKIBOqvOFDrf0tYj1kOy",
+            "object": "balance_transaction",
+            "amount": 10000,
+            "available_on": 1783555200,
+            "balance_type": "payments",
+            "created": 1783007094,
+            "currency": "usd",
+            "description": "You bought http://edgar137dc25f2.test.gumroad.com:31337/l/x!",
+            "exchange_rate": null,
+            "fee": 320,
+            "fee_details": [
+              {
+                "amount": 320,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 9680,
+            "reporting_category": "charge",
+            "source": "ch_3TomnKIBOqvOFDrf0q2uShi7",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR137DC25F2",
+          "captured": true,
+          "created": 1783007094,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar137dc25f2.test.gumroad.com:31337/l/x!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "qP2s9UXyL7CqmGpuynmLZg=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 31,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TomnKIBOqvOFDrf0DENadtt",
+          "payment_method": "pm_1TomnJIBOqvOFDrfYwo53XIF",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 10000,
+              "authorization_code": "098344",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 10000,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKPeOmtIGMgYJYI76ZQs6LBZPzvCab7SU5v6E8p2PEZvwLwjIhpUFyLGQ4DlVhdMkMGaa_HIcLRLdtfHu",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar137dc25f2",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "5"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/UploadUsStatesSalesTaxToTaxjarJob/uploading_a_day_s_orders/retries_and_completes_when_TaxJar_raises_a_transient_connection_error.yml
+++ b/spec/support/fixtures/vcr_cassettes/UploadUsStatesSalesTaxToTaxjarJob/uploading_a_day_s_orders/retries_and_completes_when_TaxJar_raises_a_transient_connection_error.yml
@@ -1,0 +1,1421 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_v2P4lwtFvaQVel","request_duration_ms":322}}'
+      Idempotency-Key:
+      - 6f3e9d6c-dd6f-4d89-9f76-5b9d561b8fc7
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 15:44:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa;
+        report-to csp
+      Idempotency-Key:
+      - 6f3e9d6c-dd6f-4d89-9f76-5b9d561b8fc7
+      Original-Request:
+      - req_sj5EZf13lSIeC6
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"
+      Request-Id:
+      - req_sj5EZf13lSIeC6
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TomnLIBOqvOFDrfgK3mX53E",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783007095,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TomnLIBOqvOFDrfgK3mX53E
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_sj5EZf13lSIeC6","request_duration_ms":253}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 15:44:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"
+      Request-Id:
+      - req_CObTNH2Ji2IuBp
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TomnLIBOqvOFDrfgK3mX53E",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783007095,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.sandbox.taxjar.com/v2/taxes
+    body:
+      encoding: UTF-8
+      string: '{"from_country":"US","from_state":"CA","from_zip":"94104","to_country":"US","to_state":"WA","to_zip":"98121","shipping":0.0,"line_items":[{"quantity":1,"unit_price":100.0,"discount":0,"product_tax_code":"31000"}],"nexus_addresses":[{"country":"US","state":"WA"}]}'
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version
+        25.5.0: Mon Apr 27 20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031
+        arm64; ruby 3.4.3-p32; OpenSSL 3.6.2 7 Apr 2026) taxjar-ruby/3.0.4'
+      Authorization:
+      - 'Bearer '
+      X-Api-Version:
+      - '2022-01-24'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+      Host:
+      - api.sandbox.taxjar.com
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '90'
+      Connection:
+      - close
+      Date:
+      - Thu, 02 Jul 2026 15:44:56 GMT
+      X-Amzn-Trace-Id:
+      - Root=1-6a468778-24401faf6fded8df7bbe080b
+      X-Amzn-Requestid:
+      - 65124887-fa8c-409a-bf58-65327f25ea06
+      X-Amz-Apigw-Id:
+      - f4oa1EebIAMEJJw=
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 db8ed9452856968607345e917396a2bc.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - JFK50-P9
+      X-Amz-Cf-Id:
+      - WJ5y_eDYq7-yHDqBP73wJxgY6G4xT-aRGjrfve02KauoCip9zSUthQ==
+    body:
+      encoding: UTF-8
+      string: '{"detail":"Not authorized for route ''POST /v2/taxes''","status":401,"error":"Unauthorized"}'
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=10000&currency=usd&description=You+bought+http%3A%2F%2Fedgar317621193.test.gumroad.com%3A31337%2Fl%2Fu%21&metadata[purchase]=OKW5T4NMBrWG_MhdAf9kiQ%3D%3D&transfer_group=6&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1TomnLIBOqvOFDrfgK3mX53E&statement_descriptor_suffix=edgar317621193
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_CObTNH2Ji2IuBp","request_duration_ms":179}}'
+      Idempotency-Key:
+      - 5eb19a67-78c4-4eb8-9eac-830e2612840a
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 15:44:57 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1639'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa;
+        report-to csp
+      Idempotency-Key:
+      - 5eb19a67-78c4-4eb8-9eac-830e2612840a
+      Original-Request:
+      - req_kHHPaLDPHXVGQb
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"
+      Request-Id:
+      - req_kHHPaLDPHXVGQb
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3TomnMIBOqvOFDrf1QZMlhwO",
+          "object": "payment_intent",
+          "amount": 10000,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 10000,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3TomnMIBOqvOFDrf1QZMlhwO_secret_tdT2ahfuKqpncpg1ZnnxpqkAx",
+          "confirmation_method": "automatic",
+          "created": 1783007096,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgar317621193.test.gumroad.com:31337/l/u!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3TomnMIBOqvOFDrf1K4YlRFn",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "OKW5T4NMBrWG_MhdAf9kiQ=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1TomnLIBOqvOFDrfgK3mX53E",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar317621193",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "6"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TomnMIBOqvOFDrf1K4YlRFn?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_kHHPaLDPHXVGQb","request_duration_ms":929}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 15:44:57 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3802'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"
+      Request-Id:
+      - req_kwr9RcEpClPrPQ
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TomnMIBOqvOFDrf1K4YlRFn",
+          "object": "charge",
+          "amount": 10000,
+          "amount_captured": 10000,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TomnMIBOqvOFDrf1hOd9iEo",
+            "object": "balance_transaction",
+            "amount": 10000,
+            "available_on": 1783555200,
+            "balance_type": "payments",
+            "created": 1783007096,
+            "currency": "usd",
+            "description": "You bought http://edgar317621193.test.gumroad.com:31337/l/u!",
+            "exchange_rate": null,
+            "fee": 320,
+            "fee_details": [
+              {
+                "amount": 320,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 9680,
+            "reporting_category": "charge",
+            "source": "ch_3TomnMIBOqvOFDrf1K4YlRFn",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR317621193",
+          "captured": true,
+          "created": 1783007096,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar317621193.test.gumroad.com:31337/l/u!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "OKW5T4NMBrWG_MhdAf9kiQ=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 21,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TomnMIBOqvOFDrf1QZMlhwO",
+          "payment_method": "pm_1TomnLIBOqvOFDrfgK3mX53E",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 10000,
+              "authorization_code": "528588",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 10000,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKPmOmtIGMgaImsr8RIw6LBbtupxAkpKLSKQaYAivIkvGNYu0LyX82XiRH4m_CFH8KSKQDGWr2hway1d4",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar317621193",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "6"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_kwr9RcEpClPrPQ","request_duration_ms":198}}'
+      Idempotency-Key:
+      - 247a3789-2abc-4514-8b8e-daec2f4b54c6
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 15:44:57 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa;
+        report-to csp
+      Idempotency-Key:
+      - 247a3789-2abc-4514-8b8e-daec2f4b54c6
+      Original-Request:
+      - req_KWw30RiVdGTftI
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"
+      Request-Id:
+      - req_KWw30RiVdGTftI
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TomnNIBOqvOFDrf2fol6MNt",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783007097,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TomnNIBOqvOFDrf2fol6MNt
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_KWw30RiVdGTftI","request_duration_ms":206}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 15:44:57 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"
+      Request-Id:
+      - req_yGNTBIrUvGbLjS
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TomnNIBOqvOFDrf2fol6MNt",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783007097,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.sandbox.taxjar.com/v2/taxes
+    body:
+      encoding: UTF-8
+      string: '{"from_country":"US","from_state":"CA","from_zip":"94104","to_country":"US","to_state":"WI","to_zip":"53703","shipping":0.0,"line_items":[{"quantity":1,"unit_price":100.0,"discount":0,"product_tax_code":"31000"}],"nexus_addresses":[{"country":"US","state":"WI"}]}'
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version
+        25.5.0: Mon Apr 27 20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031
+        arm64; ruby 3.4.3-p32; OpenSSL 3.6.2 7 Apr 2026) taxjar-ruby/3.0.4'
+      Authorization:
+      - 'Bearer '
+      X-Api-Version:
+      - '2022-01-24'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+      Host:
+      - api.sandbox.taxjar.com
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '90'
+      Connection:
+      - close
+      Date:
+      - Thu, 02 Jul 2026 15:44:57 GMT
+      X-Amzn-Trace-Id:
+      - Root=1-6a468779-5348b9577c58c3977a8bfa20
+      X-Amzn-Requestid:
+      - c42f238e-3549-43db-b477-4eba1f8d8418
+      X-Amz-Apigw-Id:
+      - f4obFE7wIAMEivw=
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 e3e31445c00bbce77f755b563c056d44.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - JFK50-P9
+      X-Amz-Cf-Id:
+      - iiROyfigSKNYyH4iEnKjKyFgjFaTa2-1uKDzHlwTkuCLx15k_Kg_MQ==
+    body:
+      encoding: UTF-8
+      string: '{"detail":"Not authorized for route ''POST /v2/taxes''","status":401,"error":"Unauthorized"}'
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=10000&currency=usd&description=You+bought+http%3A%2F%2Fedgar317621193.test.gumroad.com%3A31337%2Fl%2Fu%21&metadata[purchase]=y8TaBjObeFjYTCZgPWOozw%3D%3D&transfer_group=7&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1TomnNIBOqvOFDrf2fol6MNt&statement_descriptor_suffix=edgar317621193
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_yGNTBIrUvGbLjS","request_duration_ms":165}}'
+      Idempotency-Key:
+      - c94dd59b-9176-4a65-b6f8-552daa940d92
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 15:44:58 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1639'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa;
+        report-to csp
+      Idempotency-Key:
+      - c94dd59b-9176-4a65-b6f8-552daa940d92
+      Original-Request:
+      - req_D4x2BaNx2gmd3S
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"
+      Request-Id:
+      - req_D4x2BaNx2gmd3S
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3TomnNIBOqvOFDrf08hbUAEs",
+          "object": "payment_intent",
+          "amount": 10000,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 10000,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3TomnNIBOqvOFDrf08hbUAEs_secret_BKy3CCHJ9pldwIFhWi4A8i5Bf",
+          "confirmation_method": "automatic",
+          "created": 1783007097,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgar317621193.test.gumroad.com:31337/l/u!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3TomnNIBOqvOFDrf0hAq1i73",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "y8TaBjObeFjYTCZgPWOozw=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1TomnNIBOqvOFDrf2fol6MNt",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar317621193",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "7"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TomnNIBOqvOFDrf0hAq1i73?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_D4x2BaNx2gmd3S","request_duration_ms":858}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 15:44:58 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3802'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"
+      Request-Id:
+      - req_XqDsLM2nO2dU54
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TomnNIBOqvOFDrf0hAq1i73",
+          "object": "charge",
+          "amount": 10000,
+          "amount_captured": 10000,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TomnNIBOqvOFDrf0xwZs5gU",
+            "object": "balance_transaction",
+            "amount": 10000,
+            "available_on": 1783555200,
+            "balance_type": "payments",
+            "created": 1783007098,
+            "currency": "usd",
+            "description": "You bought http://edgar317621193.test.gumroad.com:31337/l/u!",
+            "exchange_rate": null,
+            "fee": 320,
+            "fee_details": [
+              {
+                "amount": 320,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 9680,
+            "reporting_category": "charge",
+            "source": "ch_3TomnNIBOqvOFDrf0hAq1i73",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR317621193",
+          "captured": true,
+          "created": 1783007098,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar317621193.test.gumroad.com:31337/l/u!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "y8TaBjObeFjYTCZgPWOozw=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 24,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TomnNIBOqvOFDrf08hbUAEs",
+          "payment_method": "pm_1TomnNIBOqvOFDrf2fol6MNt",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 10000,
+              "authorization_code": "200636",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 10000,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKPqOmtIGMgbGEzzrT-I6LBYaa_wsX3thcVPuf_q3zSNnBNOvhVcjdVhFsxKGCBjEH62Zhg5EHbSIiYC_",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar317621193",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "7"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/UploadUsStatesSalesTaxToTaxjarJob/uploading_a_day_s_orders/uploads_the_given_day_s_taxable_US-state_order_transactions_to_TaxJar.yml
+++ b/spec/support/fixtures/vcr_cassettes/UploadUsStatesSalesTaxToTaxjarJob/uploading_a_day_s_orders/uploads_the_given_day_s_taxable_US-state_order_transactions_to_TaxJar.yml
@@ -1,0 +1,1419 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Idempotency-Key:
+      - 53e6a9b2-a1af-48f5-999c-0b5de3657187
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 15:44:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=uUjMXNn4eOpvReIe8i-8Fsd1ENCg7tyON9XgAvugQI2T_zkI42s7gMRfKsWAydEll4aI_JL_CXeCoevt;
+        report-to csp
+      Idempotency-Key:
+      - 53e6a9b2-a1af-48f5-999c-0b5de3657187
+      Original-Request:
+      - req_I4HVXAn3dRy2Gv
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=uUjMXNn4eOpvReIe8i-8Fsd1ENCg7tyON9XgAvugQI2T_zkI42s7gMRfKsWAydEll4aI_JL_CXeCoevt&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=uUjMXNn4eOpvReIe8i-8Fsd1ENCg7tyON9XgAvugQI2T_zkI42s7gMRfKsWAydEll4aI_JL_CXeCoevt&t=1"
+      Request-Id:
+      - req_I4HVXAn3dRy2Gv
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TomnCIBOqvOFDrfMdX0TbgO",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783007087,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TomnCIBOqvOFDrfMdX0TbgO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_I4HVXAn3dRy2Gv","request_duration_ms":254}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 15:44:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"
+      Request-Id:
+      - req_w25SzkzSELmqFb
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TomnCIBOqvOFDrfMdX0TbgO",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783007087,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.sandbox.taxjar.com/v2/taxes
+    body:
+      encoding: UTF-8
+      string: '{"from_country":"US","from_state":"CA","from_zip":"94104","to_country":"US","to_state":"WA","to_zip":"98121","shipping":0.0,"line_items":[{"quantity":1,"unit_price":100.0,"discount":0,"product_tax_code":"31000"}],"nexus_addresses":[{"country":"US","state":"WA"}]}'
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version
+        25.5.0: Mon Apr 27 20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031
+        arm64; ruby 3.4.3-p32; OpenSSL 3.6.2 7 Apr 2026) taxjar-ruby/3.0.4'
+      Authorization:
+      - 'Bearer '
+      X-Api-Version:
+      - '2022-01-24'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+      Host:
+      - api.sandbox.taxjar.com
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '90'
+      Connection:
+      - close
+      Date:
+      - Thu, 02 Jul 2026 15:44:47 GMT
+      X-Amzn-Trace-Id:
+      - Root=1-6a46876f-7eb3d3fe3fe13e9d2ac73664
+      X-Amzn-Requestid:
+      - dbebc877-4ef5-41ad-b29c-f010dfe04ee6
+      X-Amz-Apigw-Id:
+      - f4oZfGgwIAMEENQ=
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 2f77ee6d00910cc9164b3833771289c2.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - JFK50-P9
+      X-Amz-Cf-Id:
+      - deVAkGBhiq2TgaYVFUFiFt_ApH0Ry9f7gZgHHl-MaJdr3FUAS_1c3g==
+    body:
+      encoding: UTF-8
+      string: '{"detail":"Not authorized for route ''POST /v2/taxes''","status":401,"error":"Unauthorized"}'
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=10000&currency=usd&description=You+bought+http%3A%2F%2Fedgar9aaf7ec01.test.gumroad.com%3A31337%2Fl%2Fe%21&metadata[purchase]=7-RrdvIoUS_D2srgUHAytg%3D%3D&transfer_group=2&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1TomnCIBOqvOFDrfMdX0TbgO&statement_descriptor_suffix=edgar9aaf7ec01
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_w25SzkzSELmqFb","request_duration_ms":231}}'
+      Idempotency-Key:
+      - 3eb09a7e-68f3-495d-a1d7-ed81ea3bd0d6
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 15:44:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1639'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa;
+        report-to csp
+      Idempotency-Key:
+      - 3eb09a7e-68f3-495d-a1d7-ed81ea3bd0d6
+      Original-Request:
+      - req_0boOGOnbB27wtv
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"
+      Request-Id:
+      - req_0boOGOnbB27wtv
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3TomnDIBOqvOFDrf0fDrLNUV",
+          "object": "payment_intent",
+          "amount": 10000,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 10000,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3TomnDIBOqvOFDrf0fDrLNUV_secret_cVeFzDCb5yCGWdwThz9Rg9rH1",
+          "confirmation_method": "automatic",
+          "created": 1783007087,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgar9aaf7ec01.test.gumroad.com:31337/l/e!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3TomnDIBOqvOFDrf0UUYvCtn",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "7-RrdvIoUS_D2srgUHAytg=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1TomnCIBOqvOFDrfMdX0TbgO",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar9aaf7ec01",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "2"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TomnDIBOqvOFDrf0UUYvCtn?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_0boOGOnbB27wtv","request_duration_ms":931}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 15:44:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3802'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"
+      Request-Id:
+      - req_8wudP9VrvH7UHv
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TomnDIBOqvOFDrf0UUYvCtn",
+          "object": "charge",
+          "amount": 10000,
+          "amount_captured": 10000,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TomnDIBOqvOFDrf0K9cnbgG",
+            "object": "balance_transaction",
+            "amount": 10000,
+            "available_on": 1783555200,
+            "balance_type": "payments",
+            "created": 1783007087,
+            "currency": "usd",
+            "description": "You bought http://edgar9aaf7ec01.test.gumroad.com:31337/l/e!",
+            "exchange_rate": null,
+            "fee": 320,
+            "fee_details": [
+              {
+                "amount": 320,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 9680,
+            "reporting_category": "charge",
+            "source": "ch_3TomnDIBOqvOFDrf0UUYvCtn",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR9AAF7EC01",
+          "captured": true,
+          "created": 1783007087,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar9aaf7ec01.test.gumroad.com:31337/l/e!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "7-RrdvIoUS_D2srgUHAytg=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 64,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TomnDIBOqvOFDrf0fDrLNUV",
+          "payment_method": "pm_1TomnCIBOqvOFDrfMdX0TbgO",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 10000,
+              "authorization_code": "775757",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 10000,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKPCOmtIGMgZftC3q59U6LBYXEHG9feuYR3AdI7T3XWOAx5vqJBvLutKLB4bHRQFiISIa3ZYqoSxLHekT",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar9aaf7ec01",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "2"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_8wudP9VrvH7UHv","request_duration_ms":326}}'
+      Idempotency-Key:
+      - ef10026f-b751-4e92-a770-d42bac7241a2
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 15:44:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa;
+        report-to csp
+      Idempotency-Key:
+      - ef10026f-b751-4e92-a770-d42bac7241a2
+      Original-Request:
+      - req_Rah4PqktWzn1z5
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"
+      Request-Id:
+      - req_Rah4PqktWzn1z5
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TomnFIBOqvOFDrfXTwuEOJz",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783007089,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TomnFIBOqvOFDrfXTwuEOJz
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_Rah4PqktWzn1z5","request_duration_ms":191}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 15:44:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"
+      Request-Id:
+      - req_ya6wfQ3mH8PKr4
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TomnFIBOqvOFDrfXTwuEOJz",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783007089,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.sandbox.taxjar.com/v2/taxes
+    body:
+      encoding: UTF-8
+      string: '{"from_country":"US","from_state":"CA","from_zip":"94104","to_country":"US","to_state":"WI","to_zip":"53703","shipping":0.0,"line_items":[{"quantity":1,"unit_price":100.0,"discount":0,"product_tax_code":"31000"}],"nexus_addresses":[{"country":"US","state":"WI"}]}'
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version
+        25.5.0: Mon Apr 27 20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031
+        arm64; ruby 3.4.3-p32; OpenSSL 3.6.2 7 Apr 2026) taxjar-ruby/3.0.4'
+      Authorization:
+      - 'Bearer '
+      X-Api-Version:
+      - '2022-01-24'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+      Host:
+      - api.sandbox.taxjar.com
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '90'
+      Connection:
+      - close
+      Date:
+      - Thu, 02 Jul 2026 15:44:49 GMT
+      X-Amzn-Trace-Id:
+      - Root=1-6a468771-459eecdc2950b7fa73f5b51e
+      X-Amzn-Requestid:
+      - 1d485425-c02e-44ba-9949-da2a2739b8c6
+      X-Amz-Apigw-Id:
+      - f4oZ0FBaIAMETeQ=
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 10ba2918c339c40dc987fef4e0ca1954.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - JFK50-P9
+      X-Amz-Cf-Id:
+      - eOpRYhjxiUowf9jyGRLmOW719lx3SVZi5IUYb5U3dupMBfypHLG1RA==
+    body:
+      encoding: UTF-8
+      string: '{"detail":"Not authorized for route ''POST /v2/taxes''","status":401,"error":"Unauthorized"}'
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=10000&currency=usd&description=You+bought+http%3A%2F%2Fedgar9aaf7ec01.test.gumroad.com%3A31337%2Fl%2Fe%21&metadata[purchase]=Dpy_wNcsAa0jANXMy2eF3w%3D%3D&transfer_group=3&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1TomnFIBOqvOFDrfXTwuEOJz&statement_descriptor_suffix=edgar9aaf7ec01
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_ya6wfQ3mH8PKr4","request_duration_ms":158}}'
+      Idempotency-Key:
+      - 9103668b-ce76-4186-a740-9fcfbc535711
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 15:44:51 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1639'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa;
+        report-to csp
+      Idempotency-Key:
+      - 9103668b-ce76-4186-a740-9fcfbc535711
+      Original-Request:
+      - req_HlCKX2kQmmK9Q1
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"
+      Request-Id:
+      - req_HlCKX2kQmmK9Q1
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3TomnFIBOqvOFDrf0Sv7mUep",
+          "object": "payment_intent",
+          "amount": 10000,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 10000,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3TomnFIBOqvOFDrf0Sv7mUep_secret_eseN1VK7YeNQxBKrfKEo1uTLu",
+          "confirmation_method": "automatic",
+          "created": 1783007089,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgar9aaf7ec01.test.gumroad.com:31337/l/e!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3TomnFIBOqvOFDrf0nBd7xpq",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "Dpy_wNcsAa0jANXMy2eF3w=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1TomnFIBOqvOFDrfXTwuEOJz",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar9aaf7ec01",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "3"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TomnFIBOqvOFDrf0nBd7xpq?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_HlCKX2kQmmK9Q1","request_duration_ms":1328}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 15:44:51 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=xfEFxyZK04mlGwtXFU11xvstcA5eRC3IKsA5F6UxEn8Bytcn1CEEI6aGs8PZtJt9UP7LjbuHhN2xImQa&t=1"
+      Request-Id:
+      - req_aS7ekwxT6ioXM5
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TomnFIBOqvOFDrf0nBd7xpq",
+          "object": "charge",
+          "amount": 10000,
+          "amount_captured": 10000,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TomnFIBOqvOFDrf087c3ZKv",
+            "object": "balance_transaction",
+            "amount": 10000,
+            "available_on": 1783555200,
+            "balance_type": "payments",
+            "created": 1783007090,
+            "currency": "usd",
+            "description": "You bought http://edgar9aaf7ec01.test.gumroad.com:31337/l/e!",
+            "exchange_rate": null,
+            "fee": 320,
+            "fee_details": [
+              {
+                "amount": 320,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 9680,
+            "reporting_category": "charge",
+            "source": "ch_3TomnFIBOqvOFDrf0nBd7xpq",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR9AAF7EC01",
+          "captured": true,
+          "created": 1783007090,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar9aaf7ec01.test.gumroad.com:31337/l/e!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "Dpy_wNcsAa0jANXMy2eF3w=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 37,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TomnFIBOqvOFDrf0Sv7mUep",
+          "payment_method": "pm_1TomnFIBOqvOFDrfXTwuEOJz",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 10000,
+              "authorization_code": "491801",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 10000,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKPOOmtIGMgb3c1eRP0Q6LBbc5NQIq0TlOKXo4DIxXB8mEx6hdZHZKSOhvKb369fwXO7iUvUFxX5-v7hz",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar9aaf7ec01",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "3"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## What

Moves the TaxJar sales-tax **upload** from a single month-end push to a **daily** job.

- Adds `UploadUsStatesSalesTaxToTaxjarJob`, scheduled daily (03:00 UTC), which uploads the **previous day's** taxable US-state order transactions to TaxJar.
- `CreateUsStatesSalesSummaryReportJob` (run monthly by `GenerateFinancialReportsForPreviousMonthJob`) **no longer pushes to TaxJar by default** — it now only produces the summary CSV. It still accepts an opt-in `push_to_taxjar` flag for a manual month re-push / backfill.
- Extracts the shared purchase-selection, ZIP resolution, dollar-amount, and TaxJar retry/rescue logic into `UsStateSalesTaxUploader` so the daily and monthly paths stay byte-for-byte identical.
- Adds a dedicated retry-exhaustion alert (`AccountingMailer#us_states_sales_tax_taxjar_upload_failed`) to the payments notification email, including the exact idempotent re-run command for the affected day.

Closes #5680.

## Why

Today the entire prior month is pushed to TaxJar in one state-by-state run at month-end, immediately before TaxJar's auto-filing window. A single transient failure part-way through (a DNS/connection error, a timeout) leaves TaxJar with a **partial or zero month** for the states not yet reached — exactly when auto-filing then submits returns. This has caused real incidents: a Feb 2026 silent-zero that required amended returns across states, and a June 2026 partial upload after a mid-run `getaddrinfo` DNS crash.

Uploading daily means each run carries only ~1 day of orders, so a transient failure costs at most one day (auto-retried, and safe to re-run), and the failure blast radius no longer coincides with the auto-filing window. TaxJar order creation is already idempotent (already-imported orders are caught and skipped), so retries and any overlap with a manual month re-push are safe.

## Test plan

- `UploadUsStatesSalesTaxToTaxjarJob` spec: uploads only the target day's taxable US orders; skips other days; retries and completes on a transient connection error; defaults to yesterday; no-ops outside production; retry-exhaustion sends the failure email. **5 examples + fast cases green locally.**
- `CreateUsStatesSalesSummaryReportJob` spec: updated so the default run does **not** push to TaxJar; the explicit `push_to_taxjar: true` path still pushes all transactions. **8 examples green locally.**
- `GenerateFinancialReportsForPreviousMonthJob` spec unchanged and green (the monthly enqueue still passes the taxable state codes).

No UI changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785599603&installation_id=134400930&pr_number=5681&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5681&signature=50503fb34685383d52398ff54d24689442b6361b4b0076ec0b30ac382806bf49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->