### PR TITLE
docs: seller analytics now fire on profile pages (help article)

### DIFF
--- a/app/views/help_center/articles/contents/_174-third-party-analytics.html.erb
+++ b/app/views/help_center/articles/contents/_174-third-party-analytics.html.erb
@@ -130,7 +130,7 @@
   <p><b>Troubleshoot</b></p>
   <p>If you don't see events going through, try turning off your browser extensions or ad-blockers as they can block TikTok Pixel requests. You can also use the <a href="https://chromewebstore.google.com/detail/tiktok-pixel-helper/aelgobmabdmlfmiblddjfnjodalhidnn" target="_blank">TikTok Pixel Helper Chrome extension</a> to verify your setup.</p>
   <h3 id="Snippets-j1elc">Snippets</h3>
-  <p>You can add snippets provided by services like Google, Facebook, Twitter, and others to track conversions, set up retargeting, and measure ad performance. This code will be triggered based on your Location selection - on a product page, after a purchase is completed, or both.</p>
+  <p>You can add snippets provided by services like Google, Facebook, Twitter, and others to track conversions, set up retargeting, and measure ad performance. This code will be triggered based on your Location selection - on a product page, after a purchase is completed, on your Gumroad profile page, or a combination of these.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/64816ecd7f8c2575e354488b/file-TUF4ntqLfY.png" %></figure>
   <p>These third-party services will provide you with a block of code to insert between &lt;head&gt; and &lt;/head&gt; on your website. Copy that block of code and paste it into the code box. Additionally, you can include your own custom JavaScript in a snippet. For example, the following snippet will log “Hello Gumroad!” to the browser console:</p>
   <pre>&lt;script&gt;console.log(“Hello Gumroad!”);&lt;/script&gt; </pre>

--- a/app/views/help_center/articles/contents/_174-third-party-analytics.html.erb
+++ b/app/views/help_center/articles/contents/_174-third-party-analytics.html.erb
@@ -31,6 +31,7 @@
     <li>purchase: A purchase. </li>
   </ul>
   <p>The three pageviews are for the same actions and are titled accordingly.</p>
+  <p>Your Google Analytics, Meta Pixel, and TikTok Pixel also record a page view when someone visits your Gumroad profile page (both the standard profile and a custom HTML profile). A profile has no checkout, so only the page view fires there, not the add to cart or purchase events.</p>
   <p>Once the setup is complete, the data usually appears quickly on GA’s Realtime dashboard even if the "Data Streams" table suggests that no data has been received in the last 48 hours.</p>
   <p>You’ll see the Google Analytics conversion events in the Events tab of the Reports page.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/64816b6a1211660f0912d4da/file-Rai50RULAo.png" %></figure>
@@ -133,7 +134,7 @@
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/64816ecd7f8c2575e354488b/file-TUF4ntqLfY.png" %></figure>
   <p>These third-party services will provide you with a block of code to insert between &lt;head&gt; and &lt;/head&gt; on your website. Copy that block of code and paste it into the code box. Additionally, you can include your own custom JavaScript in a snippet. For example, the following snippet will log “Hello Gumroad!” to the browser console:</p>
   <pre>&lt;script&gt;console.log(“Hello Gumroad!”);&lt;/script&gt; </pre>
-  <p>The ‘Location’ field controls where the snippet runs. If you select ‘Product page’, the snippet will run on the product page. If you select ‘Receipt’, it will run after a successful purchase. If you select ‘All pages’, it will run on the product page, and after a successful purchase of the product.</p>
+  <p>The ‘Location’ field controls where the snippet runs. If you select ‘Product page’, the snippet will run on the product page. If you select ‘Receipt’, it will run after a successful purchase. If you select ‘All pages’, it will run on the product page, after a successful purchase of the product, and on your Gumroad profile page (both the standard profile and a custom HTML profile).</p>
   <p>The 'Products' field determines the specific products to which the snippet is applicable. If ‘All Products’ is selected, the snippet will apply to all of your products.</p>
   <p>Some services allow you to include the sale's value, currency, and/or order number. We can enter those values for you if you add $VALUE, $CURRENCY, and $ORDER in place of the set price, currency, and order number, respectively. </p>
   <p>For example, if the URL reads:</p>


### PR DESCRIPTION
## What

Updates the **Third-party analytics** help article ([174-third-party-analytics](https://help.gumroad.com/help/article/174-third-party-analytics)) to reflect that seller-configured analytics now fire on profile pages.

## Why

Triggered by merged PR #5679 (fires seller analytics on all profile pages, standard + custom — Option B of #5676). Before that change, `startTrackingForSeller` only ran on product / checkout / mobile surfaces, so the help article's description of where tracking fires was complete. Now Google Analytics, Meta Pixel, and TikTok Pixel record a page view on the seller's profile too, and `All pages` snippets run there — so the article was describing the tracking surface incorrectly.

## Changes

`app/views/help_center/articles/contents/_174-third-party-analytics.html.erb`:
- Added a note under the Google Analytics section that GA / Meta Pixel / TikTok Pixel now record a page view on the profile page (standard + custom HTML), and that only the page view fires there (no add to cart / purchase, since a profile has no checkout).
- Updated the Snippets `Location` description: `All pages` now also runs on the seller's profile page, in addition to the product page and receipt.

No `articles.yml` metadata change — the title/description/category are unchanged.

## Test plan

- Manual integrity check (the checks the help-center specs guard): slug `174-third-party-analytics` has both the `articles.yml` entry and the `_174-...html.erb` body file, no stale `All pages` wording remains, anchor IDs preserved.
- Full RSpec suite can't bootstrap in the local worktree (system bundler vs rbenv Ruby mismatch); CI will run `spec/requests/help_center_spec.rb` and the help-center model/presenter specs.
- ERB body is not Prettier-formatted (no ERB parser); only content changed.

No policy / pricing / tax / payout wording touched. No article removals.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785600633&installation_id=134400930&pr_number=5682&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5682&signature=eafa68b28fa318a0c86330d78daef7dfaa01a552c0541b9c18e74aee97e8eac6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->