### PR TITLE
Fix NameError in client-confirm webhook lifecycle spec (main is red)

### DIFF
--- a/spec/business/payments/events/stripe/client_confirm_webhook_lifecycle_spec.rb
+++ b/spec/business/payments/events/stripe/client_confirm_webhook_lifecycle_spec.rb
@@ -47,7 +47,7 @@ describe "Client-confirmed PaymentIntent webhook lifecycle", :vcr do
       statement_description: seller.name_or_username,
       transfer_group: charge.id_with_prefix,
       idempotency_key: "deferred_intent_test_#{SecureRandom.hex}",
-      payment_method_types: Checkout::StripePaymentPresenter::CLIENT_CONFIRM_PAYMENT_METHOD_TYPES,
+      payment_method_types: Checkout::PaymentMethodResolver::LAUNCHED_PAYMENT_METHOD_TYPES,
       currency: Checkout::StripePaymentPresenter::CLIENT_CONFIRM_CURRENCY
     )
     charge.update!(stripe_payment_intent_id: charge_intent.id)


### PR DESCRIPTION
## What

One-line fix: `spec/business/payments/events/stripe/client_confirm_webhook_lifecycle_spec.rb:50` references `Checkout::StripePaymentPresenter::CLIENT_CONFIRM_PAYMENT_METHOD_TYPES`, which is not defined anywhere. Replaced with `Checkout::PaymentMethodResolver::LAUNCHED_PAYMENT_METHOD_TYPES`.

## Why

Main has been red since #5656 merged. #5665 moved payment-method-type resolution out of the presenter into `Checkout::PaymentMethodResolver` (the presenter now reads `payment_method_resolver.resolve.payment_method_types`), but the spec added by #5656 still expected the presenter constant. Every example in the file raises `NameError`, failing the Test Fast shard on main and on every open PR (e.g. #5682).

## Which constant

`Checkout::PaymentMethodResolver::LAUNCHED_PAYMENT_METHOD_TYPES` is `["card"]` — the set the deferred PaymentIntent actually receives on the client-confirm path today. This is also the exact substitution @nyomanjyotisa's #5673 makes on its branch, so the two merge cleanly in either order.

## Test plan

- `ruby -c` passes on the spec.
- CI runs the file; it currently cannot even load, so any green run of Test Fast covering it is the proof.

Ref #5656, #5665. Unblocks #5682 and every other open PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785605906&installation_id=134400930&pr_number=5683&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5683&signature=4dd9438ad914931df2311f7271b0998a4edae5c11adeecba0dd7399d1b527c69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->