### PR TITLE
Launch inline Link on the client-confirm checkout path (U9)

### DIFF
--- a/app/business/payments/charging/implementations/stripe/stripe_card_type.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_card_type.rb
@@ -18,7 +18,8 @@ class StripeCardType
     "discover" => CardType::DISCOVER,
     "jcb" => CardType::JCB,
     "diners" => CardType::DINERS_CLUB,
-    "unionpay" => CardType::UNION_PAY
+    "unionpay" => CardType::UNION_PAY,
+    "link" => CardType::LINK
   }.freeze
 
   def self.to_card_type(stripe_card_type)

--- a/app/business/payments/charging/implementations/stripe/stripe_charge.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge.rb
@@ -39,8 +39,22 @@ class StripeCharge < BaseProcessorCharge
       payment_method_details = stripe_charge[:payment_method_details]
       billing_details = stripe_charge[:billing_details]
       payment_card = payment_method_details[:card]
-      self.card_fingerprint = payment_card[:fingerprint]
       self.card_instance_id = stripe_charge[:payment_method]
+      # Inline non-card methods (e.g. Link on the client-confirmed path) carry no card block, so
+      # record what the method exposes instead of dereferencing a nil card.
+      if payment_card.nil?
+        method_type = payment_method_details[:type]
+        self.card_type = StripeCardType.to_new_card_type(method_type)
+        self.card_country = method_type.present? ? payment_method_details[method_type.to_sym]&.[](:country) : nil
+        self.card_zip_code = billing_details[:address][:postal_code] if billing_details.present?
+        # Inline wallets (e.g. Link) expose no card fingerprint, but paid purchases require a stable
+        # processor identifier (financial_transaction_validation wants stripe_fingerprint present).
+        # The PaymentMethod id is stable per funding instrument, so use it as the fingerprint.
+        self.card_fingerprint = stripe_charge[:payment_method]
+        return
+      end
+
+      self.card_fingerprint = payment_card[:fingerprint]
       self.card_last4 = payment_card[:last4]
       if payment_card[:brand].present?
         card_type = StripeCardType.to_new_card_type(payment_card[:brand])

--- a/app/javascript/components/Checkout/payment.ts
+++ b/app/javascript/components/Checkout/payment.ts
@@ -42,11 +42,13 @@ export type PaymentElementConfig = {
   stripe_link_enabled: boolean;
 };
 // Client-confirm checkout mints a ConfirmationToken from the Payment Element, so it omits
-// payment_method_creation and stays in one-time payment mode.
+// payment_method_creation and stays in one-time payment mode. The method list is
+// server-resolved (Checkout::PaymentMethodResolver) and must match the deferred intent's;
+// the browser never widens it. "link" is present iff stripe_link_enabled is true.
 export type PaymentElementClientConfirmConfig = {
   stripe_elements_mode: typeof STRIPE_ELEMENTS_MODE_FOR_PAYMENT_INTENT;
   currency: "usd";
-  payment_method_types: ["card"];
+  payment_method_types: ("card" | "link")[];
   stripe_link_enabled: boolean;
 };
 export type CheckoutPaymentConfig =

--- a/app/presenters/checkout/stripe_payment_presenter.rb
+++ b/app/presenters/checkout/stripe_payment_presenter.rb
@@ -101,14 +101,18 @@ class Checkout::StripePaymentPresenter
     end
 
     def client_confirm_props
+      payment_method_types = payment_method_resolver.resolve.payment_method_types
       {
         integration: STRIPE_PAYMENT_ELEMENT_CLIENT_CONFIRM_INTEGRATION,
         fallback_reason: nil,
         elements_options: {
           stripe_elements_mode: STRIPE_ELEMENTS_MODE_FOR_PAYMENT_INTENT,
           currency: CLIENT_CONFIRM_CURRENCY,
-          payment_method_types: payment_method_resolver.resolve.payment_method_types,
-          stripe_link_enabled: sellers.all? { Feature.active?(STRIPE_PAYMENT_ELEMENT_LINK_FEATURE_NAME, _1) },
+          payment_method_types:,
+          # Derived from the resolver's method list (not a second flag check) so the Element's Link
+          # config and the deferred intent's payment_method_types cannot drift: Stripe rejects a
+          # ConfirmationToken minted with Link against an intent whose method list omits it.
+          stripe_link_enabled: payment_method_types.include?(Checkout::PaymentMethodResolver::LINK_PAYMENT_METHOD_TYPE),
         },
       }
     end

--- a/app/presenters/receipt_presenter/payment_info.rb
+++ b/app/presenters/receipt_presenter/payment_info.rb
@@ -118,9 +118,18 @@ class ReceiptPresenter::PaymentInfo
       return if chargeable.successful_purchases.all?(&:is_free_trial_purchase?)
       return if orderable.card_type.blank? && orderable.card_visual.blank?
 
+      # Inline wallet methods (e.g. Link) carry a card_type but no card_visual (no last4), so
+      # render the method name alone rather than dereferencing a nil visual.
+      value =
+        if orderable.card_visual.present?
+          "#{orderable.card_type.upcase} *#{orderable.card_visual.delete('*').delete(' ')}"
+        else
+          orderable.card_type.upcase
+        end
+
       {
         label: "Payment method",
-        value: "#{orderable.card_type.upcase} *#{orderable.card_visual.delete('*').delete(' ')}"
+        value:
       }
     end
   end

--- a/app/presenters/receipt_presenter/payment_info.rb
+++ b/app/presenters/receipt_presenter/payment_info.rb
@@ -161,7 +161,7 @@ class ReceiptPresenter::PaymentInfo
 
     def credit_card_note
       return if orderable.card_type.blank?
-      return if orderable.card_type == CardType::PAYPAL
+      return if orderable.card_type.in?([CardType::PAYPAL, CardType::LINK])
 
       # TODO: Update when multiple charges per receipt are supported
       "The charge will be listed as GUMRD.COM* on your credit card statement."

--- a/app/services/checkout/payment_method_resolver.rb
+++ b/app/services/checkout/payment_method_resolver.rb
@@ -8,11 +8,12 @@
 # Two method sets are distinguished:
 #   - eligible_payment_method_types: the policy set the cart *could* use (the eligibility-by-product-type
 #     policy). This is the logged decision and what later units intersect with per-method launch/PPP gates.
-#   - payment_method_types: what Stripe actually receives on the client-confirmed path today. Only card
-#     is launched, because the other methods need machinery that isn't built yet: redirect methods need
-#     the server return page + allow_redirects, delayed-notification methods need the PaymentIntent
-#     webhook lifecycle, inline wallets/Link need frontend verification, and connected-account sellers
-#     need account-scoped Elements. Widening LAUNCHED_PAYMENT_METHOD_TYPES is a later unit's job.
+#   - payment_method_types: what Stripe actually receives on the client-confirmed path today. Card is
+#     always launched, and Link joins it per-seller behind the same :stripe_payment_element_link flag
+#     that ramps Link on Lane A, so one flag governs Link everywhere. The remaining methods need
+#     machinery that isn't built yet: redirect methods need the server return page + allow_redirects,
+#     delayed-notification methods need the PaymentIntent webhook lifecycle, and connected-account
+#     sellers need account-scoped Elements. Widening the launched set is a later unit's job.
 #
 # Handshake note: the deferred PaymentIntent's payment_method_types must equal the Payment Element's or
 # Stripe rejects the ConfirmationToken (which is payment_method_types-scoped, so it also can't be
@@ -29,8 +30,14 @@ class Checkout::PaymentMethodResolver
   ONE_TIME_PAYMENT_METHOD_TYPES = %w[card link klarna afterpay_clearpay affirm ideal bancontact cashapp].freeze
   # Afterpay/Clearpay and Affirm are one-time, buyer-present only, so a recurring lifecycle drops them.
   RECURRING_INELIGIBLE_PAYMENT_METHOD_TYPES = %w[afterpay_clearpay affirm].freeze
-  # Only card is launched on the client-confirmed path today; later units widen this (see class comment).
+  # Card is always launched on the client-confirmed path; later units widen this (see class comment).
   LAUNCHED_PAYMENT_METHOD_TYPES = %w[card].freeze
+  # Link is inline (non-redirect), so it needs none of the return-page/webhook machinery the other
+  # gated methods wait on. It launches per-seller behind Lane A's existing Link flag (#5614) so the
+  # rollout ramps once for both integrations. This resolver is the ONLY place that widens the
+  # client-confirm method list — the presenter derives the Element's Link config from this output.
+  LINK_PAYMENT_METHOD_TYPE = "link"
+  STRIPE_PAYMENT_ELEMENT_LINK_FEATURE_NAME = :stripe_payment_element_link
   # Multi-seller and other Lane A carts keep Gumroad's existing card + PayPal set.
   LANE_A_PAYMENT_METHOD_TYPES = %w[card paypal].freeze
 
@@ -53,7 +60,7 @@ class Checkout::PaymentMethodResolver
         client_confirm_eligible: reason.nil?,
         # Nil on Lane A carts: they never mount the client-confirmed Payment Element, so there is no
         # Stripe method list to hand them. Non-nil only when the cart confirms client-side.
-        payment_method_types: reason.nil? ? eligible & LAUNCHED_PAYMENT_METHOD_TYPES : nil,
+        payment_method_types: reason.nil? ? eligible & launched_payment_method_types : nil,
         eligible_payment_method_types: eligible,
         fallback_reason: reason
       )
@@ -74,6 +81,14 @@ class Checkout::PaymentMethodResolver
       return "commission" if commission
       return "setup_flow" if setup_for_future
       nil
+    end
+
+    # Order follows ONE_TIME_PAYMENT_METHOD_TYPES (the resolve intersection preserves the receiver's
+    # order), so card always renders as the first Payment Element tab.
+    def launched_payment_method_types
+      launched = LAUNCHED_PAYMENT_METHOD_TYPES
+      launched += [LINK_PAYMENT_METHOD_TYPE] if sellers.all? { Feature.active?(STRIPE_PAYMENT_ELEMENT_LINK_FEATURE_NAME, _1) }
+      launched
     end
 
     def eligible_method_policy

--- a/app/services/order/prepare_payment_intent_service.rb
+++ b/app/services/order/prepare_payment_intent_service.rb
@@ -101,11 +101,26 @@ class Order::PreparePaymentIntentService
     end
 
     def apply_previewed_card_country(preview)
-      card_country = preview.card&.country
+      country = previewed_country(preview)
       purchases_to_charge.each do |purchase|
-        purchase.card_country = card_country
+        purchase.card_country = country
         purchase.card_country_source = CARD_COUNTRY_SOURCE
       end
+    end
+
+    # Card carries country directly; inline wallet methods (e.g. Link) are non-card, so the card
+    # field is nil — fall back to the method-specific preview block's country. BOTH are Stripe-owned
+    # funding-source countries, safe to trust for PPP verification. We deliberately do NOT fall back
+    # to buyer-supplied billing_details: that is checkout-form input, so trusting it would let a buyer
+    # spoof the discounted country. When Stripe exposes no funding country the value stays nil and a
+    # PPP-discounted purchase fails closed. Uses [] access because a Stripe::StripeObject raises on a
+    # missing attribute reader but returns nil for an absent key.
+    def previewed_country(preview)
+      card_country = preview[:card]&.[](:country)
+      return card_country if card_country.present?
+
+      method_type = preview[:type]
+      method_type.present? ? preview[method_type.to_sym]&.[](:country) : nil
     end
 
     def block_purchasing_power_parity_mismatches

--- a/app/services/purchase/finalize_confirmed_charge_service.rb
+++ b/app/services/purchase/finalize_confirmed_charge_service.rb
@@ -53,7 +53,13 @@ class Purchase::FinalizeConfirmedChargeService < Purchase::BaseService
     # card_visual/type/country from the confirmed charge. Expiry, fingerprint, and
     # processor id are handled by #save_charge_data.
     def assign_confirmed_card_presentation(processor_charge)
-      return if processor_charge.card_last4.blank?
+      # Inline non-card methods (e.g. Link) expose no last4/visual, but still carry a
+      # card_type/country worth persisting for receipts and analytics.
+      if processor_charge.card_last4.blank?
+        purchase.card_type = processor_charge.card_type if processor_charge.card_type.present?
+        purchase.card_country = processor_charge.card_country if processor_charge.card_country.present?
+        return
+      end
 
       purchase.card_visual = ChargeableVisual.build_visual(processor_charge.card_last4, processor_charge.card_number_length)
       purchase.card_type = processor_charge.card_type

--- a/lib/utilities/card_type.rb
+++ b/lib/utilities/card_type.rb
@@ -10,4 +10,7 @@ class CardType
   DINERS_CLUB = "diners"
   PAYPAL = "paypal"
   UNION_PAY = "unionpay"
+  # Stripe Link is a wallet, not a card network; mirrors the PAYPAL precedent for
+  # non-card payment methods surfaced through card_type.
+  LINK = "link"
 end

--- a/spec/business/payments/charging/implementations/stripe/stripe_charge_spec.rb
+++ b/spec/business/payments/charging/implementations/stripe/stripe_charge_spec.rb
@@ -129,6 +129,44 @@ describe StripeCharge, :vcr do
     # zip_check_result will never be false since we do not create Charge object when an error is raised.
     # If the Stripe configuration changes in the future then a test should be added for this scenario.
 
+    describe "with a stripe charge paid with an inline non-card method (Link)" do
+      let(:stripe_charge_hash) do
+        {
+          id: "ch_test_link",
+          status: "succeeded",
+          refunded: false,
+          dispute: nil,
+          currency: Currency::USD,
+          amount: 1_00,
+          payment_method_details: { type: "link", link: { country: "US" } },
+          billing_details: { address: { postal_code: "94117" } },
+          payment_method: "pm_test_link",
+          outcome: { risk_level: "normal" },
+        }
+      end
+
+      let(:stripe_charge_balance_transaction) do
+        {
+          currency: Currency::USD,
+          amount: 1_00,
+          fee_details: [{ type: "stripe_fee", currency: Currency::USD, amount: 30 }],
+        }
+      end
+
+      let(:subject) { described_class.new(Stripe::Charge.construct_from(stripe_charge_hash), stripe_charge_balance_transaction, nil, nil, nil) }
+
+      it "records the method type and country without dereferencing a nil card block" do
+        expect(subject.card_type).to eq(CardType::LINK)
+        expect(subject.card_country).to eq("US")
+        expect(subject.card_instance_id).to eq("pm_test_link")
+        expect(subject.card_zip_code).to eq("94117")
+        expect(subject.card_last4).to be_nil
+        # Falls back to the PaymentMethod id so paid Link purchases satisfy the
+        # financial-transaction validation that requires a stable processor identifier.
+        expect(subject.card_fingerprint).to eq("pm_test_link")
+      end
+    end
+
     describe "with a destination charge but nil destination payment balance transaction" do
       let(:stripe_charge_hash) do
         {

--- a/spec/presenters/checkout/stripe_payment_presenter_spec.rb
+++ b/spec/presenters/checkout/stripe_payment_presenter_spec.rb
@@ -43,7 +43,9 @@ describe Checkout::StripePaymentPresenter do
       elements_options: {
         stripe_elements_mode: described_class::STRIPE_ELEMENTS_MODE_FOR_PAYMENT_INTENT,
         currency: "usd",
-        payment_method_types: ["card"],
+        # The Element's Link toggle and the intent's method list derive from the same resolver
+        # output, so they move together.
+        payment_method_types: stripe_link_enabled ? %w[card link] : ["card"],
         stripe_link_enabled:,
       },
     }

--- a/spec/presenters/receipt_presenter/payment_info_spec.rb
+++ b/spec/presenters/receipt_presenter/payment_info_spec.rb
@@ -797,6 +797,16 @@ describe ReceiptPresenter::PaymentInfo do
           expect(payment_info.payment_method_attribute).to be_nil
         end
       end
+
+      context "when the purchase was paid with an inline wallet method (no card visual)" do
+        before { purchase.update!(card_type: CardType::LINK, card_visual: nil) }
+
+        it "renders the method name alone without dereferencing a nil visual" do
+          expect(payment_info.payment_method_attribute).to eq(
+            { label: "Payment method", value: "LINK" }
+          )
+        end
+      end
     end
 
     describe "#today_membership_paid_until_attribute" do

--- a/spec/presenters/receipt_presenter/payment_info_spec.rb
+++ b/spec/presenters/receipt_presenter/payment_info_spec.rb
@@ -773,6 +773,14 @@ describe ReceiptPresenter::PaymentInfo do
           expect(payment_info.send(:credit_card_note)).to be_nil
         end
       end
+
+      context "when the card_type is link" do
+        before { purchase.update!(card_type: CardType::LINK) }
+
+        it "returns nil" do
+          expect(payment_info.send(:credit_card_note)).to be_nil
+        end
+      end
     end
 
     context "with a Purchase" do

--- a/spec/services/checkout/payment_method_resolver_spec.rb
+++ b/spec/services/checkout/payment_method_resolver_spec.rb
@@ -31,6 +31,21 @@ describe Checkout::PaymentMethodResolver do
         expect(resolution.eligible_payment_method_types).to include(*resolution.payment_method_types)
       end
 
+      context "when the seller has the Stripe Link flag enabled" do
+        before { Feature.activate_user(described_class::STRIPE_PAYMENT_ELEMENT_LINK_FEATURE_NAME, seller) }
+
+        it "launches Link alongside card, keeping card as the first Payment Element tab" do
+          resolution = resolve
+
+          expect(resolution.payment_method_types).to eq(%w[card link])
+          expect(resolution.eligible_payment_method_types).to include(*resolution.payment_method_types)
+        end
+
+        it "still gates the redirect and delayed-notification methods behind later units" do
+          expect(resolve.payment_method_types).not_to include("klarna", "afterpay_clearpay", "affirm", "ideal", "bancontact", "cashapp")
+        end
+      end
+
       it "returns an explicit list of method-type strings, never Stripe's automatic_payment_methods shape" do
         expect(resolve.payment_method_types).to be_an(Array).and(all(be_a(String)))
       end

--- a/spec/services/order/prepare_payment_intent_service_spec.rb
+++ b/spec/services/order/prepare_payment_intent_service_spec.rb
@@ -105,8 +105,9 @@ describe Order::PreparePaymentIntentService, :vcr do
 
     # The country that drives PPP verification must come from whichever preview block the chosen
     # method exposes: card carries it directly, inline wallets (Link) do not, so fall back to the
-    # method's typed block then billing details — otherwise a discounted Link purchase fails on a
-    # nil country even when the wallet's country matches the buyer's.
+    # method's typed block only — billing_details is intentionally excluded because it is
+    # buyer-supplied and spoofable. Without the typed-block fallback a discounted Link purchase
+    # fails on a nil country even when the wallet's country matches the buyer's.
     describe "previewed country extraction" do
       let(:service) { described_class.new(order: build_order.first, params: {}, confirmation_token: "ctoken_test") }
 

--- a/spec/services/order/prepare_payment_intent_service_spec.rb
+++ b/spec/services/order/prepare_payment_intent_service_spec.rb
@@ -103,6 +103,38 @@ describe Order::PreparePaymentIntentService, :vcr do
       end
     end
 
+    # The country that drives PPP verification must come from whichever preview block the chosen
+    # method exposes: card carries it directly, inline wallets (Link) do not, so fall back to the
+    # method's typed block then billing details — otherwise a discounted Link purchase fails on a
+    # nil country even when the wallet's country matches the buyer's.
+    describe "previewed country extraction" do
+      let(:service) { described_class.new(order: build_order.first, params: {}, confirmation_token: "ctoken_test") }
+
+      def preview_from(hash)
+        Stripe::StripeObject.construct_from(hash)
+      end
+
+      it "reads the country from the card block for a card preview" do
+        preview = preview_from(type: "card", card: { country: "US" })
+        expect(service.send(:previewed_country, preview)).to eq("US")
+      end
+
+      it "reads the country from the method-typed block for an inline wallet (Link) preview" do
+        preview = preview_from(type: "link", link: { country: "DE" }, card: nil)
+        expect(service.send(:previewed_country, preview)).to eq("DE")
+      end
+
+      it "does NOT trust buyer-supplied billing details (returns nil when only billing country is present)" do
+        preview = preview_from(type: "link", link: {}, billing_details: { address: { country: "FR" } })
+        expect(service.send(:previewed_country, preview)).to be_nil
+      end
+
+      it "returns nil when no Stripe-owned funding country is available" do
+        preview = preview_from(type: "link", link: {})
+        expect(service.send(:previewed_country, preview)).to be_nil
+      end
+    end
+
     context "when no confirmation token is supplied" do
       before { create(:merchant_account, user: seller) }
 
@@ -214,6 +246,28 @@ describe Order::PreparePaymentIntentService, :vcr do
 
         expect(create_args[:payment_method_types]).to eq(["card"])
         expect(create_args[:currency]).to eq(Checkout::StripePaymentPresenter::CLIENT_CONFIRM_CURRENCY)
+      end
+
+      # The presenter derives the Element's Link config from the same resolver output, so a
+      # Link-flagged seller's Payment Element and deferred intent both carry "link".
+      it "includes Link in the intent's payment_method_types when the seller has the Link flag" do
+        Feature.activate_user(Checkout::PaymentMethodResolver::STRIPE_PAYMENT_ELEMENT_LINK_FEATURE_NAME, seller)
+        order, params = build_order
+
+        preview = Stripe::StripeObject.construct_from(card: { country: "US" })
+        allow(Stripe::ConfirmationToken).to receive(:retrieve)
+          .and_return(Stripe::StripeObject.construct_from(payment_method_preview: preview))
+
+        charge_intent = instance_double(StripeChargeIntent, id: "pi_test", client_secret: "pi_test_secret")
+        create_args = nil
+        allow(StripeDeferredPaymentIntent).to receive(:create) do |**kwargs|
+          create_args = kwargs
+          charge_intent
+        end
+
+        described_class.new(order:, params:, confirmation_token: "ctoken_test").perform
+
+        expect(create_args[:payment_method_types]).to eq(%w[card link])
       end
 
       # A key built only from the (database-id-derived) external_id collides in Stripe test mode,


### PR DESCRIPTION
## What

Launches inline **Stripe Link** on the client-confirmed checkout path (Lane B) — plan unit **U9** of #5640. Card remains the always-launched method; Link joins it per-seller behind the existing `:stripe_payment_element_link` flag that already ramps Link on the server-confirm Payment Element (Lane A, #5614), so one flag governs Link on both integrations and there is no new rollout surface.

- **`Checkout::PaymentMethodResolver`** adds `"link"` to the launched set (beside the always-launched `"card"`) when every seller has the Link flag. It remains the single authority that widens the client-confirm method list; redirect and delayed-notification methods stay gated behind their later units. Card stays first in the list (first Payment Element tab).
- **`Checkout::StripePaymentPresenter`** derives the client-confirm Element's `stripe_link_enabled` from the resolver's method list rather than a separate flag check, so the Payment Element and the deferred PaymentIntent's `payment_method_types` cannot drift (Stripe rejects a Link `ConfirmationToken` against an intent whose method list omits `link`).
- **Non-card charge handling** — persisting a completed Link purchase, which has no card block:
  - `StripeCharge` tolerates an inline `payment_method_details` with no `card`, recording the method type and (Stripe-owned) country, and falls back to the `PaymentMethod` id as the fingerprint so `financial_transaction_validation` (which requires a stable processor identifier on paid purchases) is satisfied.
  - `CardType::LINK` + `StripeCardType` map the `"link"` method type.
  - `Purchase::FinalizeConfirmedChargeService` records `card_type`/`country` for a last4-less charge.
  - `ReceiptPresenter::PaymentInfo` renders the wallet method name alone instead of dereferencing a nil `card_visual`.

## Why

Unblocks the first inline non-card method on the client-confirmed path now that the method resolver (U8, #5665) is merged. Link is inline (no redirect / webhook lifecycle needed), so it is the cheapest expansion and reuses Lane A's already-shipped `stripe_link_enabled` / `paymentElementWallets` plumbing rather than rebuilding it. Apple/Google Pay in-element (the Express Checkout migration) remains deferred.

PPP is preserved and enforced pre-charge: the country that drives `validate_purchasing_power_parity` is read from whichever preview block the chosen method exposes — the card block for cards, the method-typed block for Link — **both Stripe-owned funding-source countries**. Buyer-supplied `billing_details` is deliberately NOT trusted as a fallback (it is checkout-form input, so trusting it would let a buyer spoof the discounted country); when Stripe exposes no funding country the value stays nil and a PPP-discounted purchase fails closed.

## Test plan

- `spec/services/checkout/payment_method_resolver_spec.rb` — Link joins the launched set only when the seller has the flag; card stays first; redirect/delayed methods stay gated.
- `spec/presenters/checkout/stripe_payment_presenter_spec.rb` — client-confirm props carry `payment_method_types: [card, link]` and `stripe_link_enabled: true` together (derived from one source).
- `spec/services/order/prepare_payment_intent_service_spec.rb` — the deferred intent includes `link` for a Link-flagged seller; `previewed_country` trusts card/method-block country, ignores buyer billing details, fails closed on none.
- `spec/business/.../stripe_charge_spec.rb` — an inline non-card (Link) charge records method type/country/fingerprint without dereferencing a nil card block.
- `spec/presenters/receipt_presenter/payment_info_spec.rb` — a wallet purchase with no visual renders the method name alone.
- `spec/services/purchase/finalize_confirmed_charge_service_spec.rb` — unchanged, still green.
- Full run of the above: **109 examples, 0 failures** locally.

autoreview: clean (Codex) — three money-path findings surfaced and fixed pre-merge (receipt nil-visual crash, PPP country for wallets, and the fingerprint requirement on the successful-purchase transition), then a clean re-review.

## Screenshots

No Gumroad-authored UI markup changes. The only frontend diff is a TypeScript type widening in `payment.ts` (`payment_method_types` gains `"link"`); the visible Link tab is rendered by Stripe's own Payment Element iframe from the `payment_method_types` config — identical mechanism to the already-shipped Lane A Link tab (#5614). A running-app capture requires a live Stripe session with both `stripe_payment_element_client_confirm` + `stripe_payment_element_link` flags on; happy to boot the preview and attach a real client-confirm-with-Link screenshot if you'd like it on the PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785606036&installation_id=134400930&pr_number=5684&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5684&signature=79f8374d1d21bdc053eeb6735a636c188e77eea8f03c840d601bd2a546e3e194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->