### PR TITLE
Fix NameError in client-confirm webhook lifecycle spec breaking CI on main

### DIFF
--- a/spec/business/payments/events/stripe/client_confirm_webhook_lifecycle_spec.rb
+++ b/spec/business/payments/events/stripe/client_confirm_webhook_lifecycle_spec.rb
@@ -47,7 +47,7 @@ describe "Client-confirmed PaymentIntent webhook lifecycle", :vcr do
       statement_description: seller.name_or_username,
       transfer_group: charge.id_with_prefix,
       idempotency_key: "deferred_intent_test_#{SecureRandom.hex}",
-      payment_method_types: Checkout::StripePaymentPresenter::CLIENT_CONFIRM_PAYMENT_METHOD_TYPES,
+      payment_method_types: Checkout::PaymentMethodResolver.new(sellers: [seller]).resolve.payment_method_types,
       currency: Checkout::StripePaymentPresenter::CLIENT_CONFIRM_CURRENCY
     )
     charge.update!(stripe_payment_intent_id: charge_intent.id)


### PR DESCRIPTION
## What

Fixes the spec that is failing a Test Fast shard on every `main` run: `spec/business/payments/events/stripe/client_confirm_webhook_lifecycle_spec.rb:50` references `Checkout::StripePaymentPresenter::CLIENT_CONFIRM_PAYMENT_METHOD_TYPES`, which no longer exists, so all 10 examples in the file raise `NameError`. The spec now derives `payment_method_types` from `Checkout::PaymentMethodResolver`, the same way production does.

## Why

Two PRs raced and landed a semantic conflict that Git could not catch:

- #5665 removed the `CLIENT_CONFIRM_PAYMENT_METHOD_TYPES` constant from the presenter, replacing it with the per-cart `Checkout::PaymentMethodResolver`.
- #5656 was written against the pre-#5665 tree and merged afterwards, carrying a spec that still referenced the deleted constant. Its own merge-to-main Tests run was cancelled, so the failure only surfaced on subsequent pushes (and on unrelated PRs like #5682, whose red `Test Fast 11` is this spec).

The fix mirrors `Order::PreparePaymentIntentService#payment_method_resolution`: resolve for the cart's single seller and use the resulting `payment_method_types`. For the spec's carts (single-seller, one-time, non-commission) the resolver returns `["card"]` — the exact value the deleted constant held — so the committed VCR cassettes still match and the recorded Stripe interactions replay unchanged. This also keeps the spec faithful to how the deferred intent is actually built, so it can't drift from production again if the launched method set widens.

## Before/After

Not user-facing — a one-line spec fix, no application code changed. Before: every example in the file fails with `NameError: uninitialized constant Checkout::StripePaymentPresenter::CLIENT_CONFIRM_PAYMENT_METHOD_TYPES` (see any recent `main` Tests run, e.g. [28605966353](https://github.com/antiwork/gumroad/actions/runs/28605966353)). After: all 10 examples pass.

## Test Results

```
$ bundle exec rspec spec/business/payments/events/stripe/client_confirm_webhook_lifecycle_spec.rb

Finished in 10.36 seconds (files took 7.68 seconds to load)
10 examples, 0 failures
```

Rubocop clean on the changed file.

---

AI disclosure: This PR was authored by Claude Code (Claude Fable 5). Prompts: "check https://github.com/antiwork/gumroad/pull/5682#issuecomment-4868478096 and check failing CI on main as well, i think we should fix".

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785606090&installation_id=134400930&pr_number=5685&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5685&signature=f5c715309260be5667e095e97c680b8ffc82ee224f2e166d499cf01fc239aaf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->