### PR TITLE
Launch Cash App Pay and ACH Direct Debit on the client-confirmed checkout path for US buyers

### DIFF
--- a/app/javascript/components/Checkout/payment.ts
+++ b/app/javascript/components/Checkout/payment.ts
@@ -42,11 +42,14 @@ export type PaymentElementConfig = {
   stripe_link_enabled: boolean;
 };
 // Client-confirm checkout mints a ConfirmationToken from the Payment Element, so it omits
-// payment_method_creation and stays in one-time payment mode.
+// payment_method_creation and stays in one-time payment mode. The launched method set is
+// server-resolved (card everywhere, plus us_bank_account/ACH for US buyers), so this is a
+// string list, not a fixed ["card"] tuple — the frontend must not widen it, but it must accept
+// whatever the resolver launched.
 export type PaymentElementClientConfirmConfig = {
   stripe_elements_mode: typeof STRIPE_ELEMENTS_MODE_FOR_PAYMENT_INTENT;
   currency: "usd";
-  payment_method_types: ["card"];
+  payment_method_types: string[];
   stripe_link_enabled: boolean;
 };
 export type CheckoutPaymentConfig =

--- a/app/models/concerns/purchase/charge_events_handler.rb
+++ b/app/models/concerns/purchase/charge_events_handler.rb
@@ -125,8 +125,9 @@ module Purchase::ChargeEventsHandler
     # A client-confirm charge (card SCA drop-off, or a delayed-notification method like ACH whose
     # debit later fails) transitions its still-in_progress purchases to failed so the buyer is
     # returned to a resubmittable cart. The intent funds one charge, so every purchase in the group
-    # fails together. mark_failed! is a no-op on an already-terminal purchase, so a re-delivered
-    # webhook is safe.
+    # fails together. The in_progress? guard below is what makes a re-delivered webhook safe:
+    # mark_failed! only defines the in_progress -> failed transition, so calling it on an
+    # already-terminal purchase would raise AASM::InvalidTransition.
     if client_confirmed_charge?
       charged_purchases.each { |purchase| purchase.mark_failed! if purchase.in_progress? }
       return

--- a/app/models/concerns/purchase/charge_events_handler.rb
+++ b/app/models/concerns/purchase/charge_events_handler.rb
@@ -122,6 +122,16 @@ module Purchase::ChargeEventsHandler
   def handle_event_failed!(event)
     handle_event_informational!(event)
 
+    # A client-confirm charge (card SCA drop-off, or a delayed-notification method like ACH whose
+    # debit later fails) transitions its still-in_progress purchases to failed so the buyer is
+    # returned to a resubmittable cart. The intent funds one charge, so every purchase in the group
+    # fails together. mark_failed! is a no-op on an already-terminal purchase, so a re-delivered
+    # webhook is safe.
+    if client_confirmed_charge?
+      charged_purchases.each { |purchase| purchase.mark_failed! if purchase.in_progress? }
+      return
+    end
+
     charged_purchases.each do |purchase|
       if purchase.in_progress? && purchase.is_an_off_session_charge_on_indian_card?
         if purchase.subscription.present?

--- a/app/presenters/checkout/stripe_payment_presenter.rb
+++ b/app/presenters/checkout/stripe_payment_presenter.rb
@@ -103,7 +103,18 @@ class Checkout::StripePaymentPresenter
         recurring: items.any? { _1[:recurrence].present? },
         commission: items.any? { _1[:native_type] == Link::NATIVE_TYPE_COMMISSION },
         setup_for_future: setup_for_future_charges_without_charging?(items),
+        buyer_country:,
       )
+    end
+
+    # GeoIP-detected country (never the user's profile country) so the resolver's US-locked-method
+    # gate keys on the same basis as Order::PreparePaymentIntentService, which derives it from the
+    # purchase's ip_country (also GeoIP). Keeping them identical preserves the Element↔intent
+    # method-set invariant: Stripe rejects a ConfirmationToken whose types don't match the intent's.
+    def buyer_country
+      return @buyer_country if defined?(@buyer_country)
+
+      @buyer_country = Compliance::Countries.find_by_name(GeoIp.lookup(ip).try(:country_name))&.alpha2
     end
 
     def client_confirm_props

--- a/app/services/checkout/payment_method_resolver.rb
+++ b/app/services/checkout/payment_method_resolver.rb
@@ -30,10 +30,11 @@ class Checkout::PaymentMethodResolver
   ONE_TIME_PAYMENT_METHOD_TYPES = %w[card link klarna afterpay_clearpay affirm ideal bancontact cashapp us_bank_account].freeze
   # Afterpay/Clearpay and Affirm are one-time, buyer-present only, so a recurring lifecycle drops them.
   RECURRING_INELIGIBLE_PAYMENT_METHOD_TYPES = %w[afterpay_clearpay affirm].freeze
-  # Launched on the client-confirmed path: card everywhere, plus ACH Direct Debit for US buyers
-  # (region-gated below). Cash App Pay (redirect) and the EUR methods stay gated until their machinery
-  # (server return page / buyer-currency FX) ships.
-  LAUNCHED_PAYMENT_METHOD_TYPES = %w[card us_bank_account].freeze
+  # Launched on the client-confirmed path: card everywhere, plus the US-locked first-launch methods
+  # (region-gated below) — Cash App Pay (redirect; confirms via the #5664 return page) and ACH Direct
+  # Debit (delayed-notification; settles via the PaymentIntent webhook lifecycle). The EUR methods
+  # (iDEAL/Bancontact/SEPA) stay gated until buyer-currency FX lands.
+  LAUNCHED_PAYMENT_METHOD_TYPES = %w[card cashapp us_bank_account].freeze
   # Methods that only work for US buyers on USD PaymentIntents. ACH Direct Debit debits a US bank
   # account; Cash App Pay is US-locked. These are dropped from the launched set unless GeoIP ∈ {US}.
   US_LOCKED_PAYMENT_METHOD_TYPES = %w[us_bank_account cashapp].freeze

--- a/app/services/checkout/payment_method_resolver.rb
+++ b/app/services/checkout/payment_method_resolver.rb
@@ -25,12 +25,19 @@
 # Stripe with the wrong method list.
 class Checkout::PaymentMethodResolver
   # Buyer-present single-seller dynamic set. Apple Pay / Google Pay ride on "card" in the Payment
-  # Element, so they are not separate types here.
-  ONE_TIME_PAYMENT_METHOD_TYPES = %w[card link klarna afterpay_clearpay affirm ideal bancontact cashapp].freeze
+  # Element, so they are not separate types here. us_bank_account (ACH Direct Debit) is a
+  # delayed-notification method: it settles asynchronously via the PaymentIntent webhook lifecycle.
+  ONE_TIME_PAYMENT_METHOD_TYPES = %w[card link klarna afterpay_clearpay affirm ideal bancontact cashapp us_bank_account].freeze
   # Afterpay/Clearpay and Affirm are one-time, buyer-present only, so a recurring lifecycle drops them.
   RECURRING_INELIGIBLE_PAYMENT_METHOD_TYPES = %w[afterpay_clearpay affirm].freeze
-  # Only card is launched on the client-confirmed path today; later units widen this (see class comment).
-  LAUNCHED_PAYMENT_METHOD_TYPES = %w[card].freeze
+  # Launched on the client-confirmed path: card everywhere, plus ACH Direct Debit for US buyers
+  # (region-gated below). Cash App Pay (redirect) and the EUR methods stay gated until their machinery
+  # (server return page / buyer-currency FX) ships.
+  LAUNCHED_PAYMENT_METHOD_TYPES = %w[card us_bank_account].freeze
+  # Methods that only work for US buyers on USD PaymentIntents. ACH Direct Debit debits a US bank
+  # account; Cash App Pay is US-locked. These are dropped from the launched set unless GeoIP ∈ {US}.
+  US_LOCKED_PAYMENT_METHOD_TYPES = %w[us_bank_account cashapp].freeze
+  US_ALPHA2 = "US"
   # Multi-seller and other Lane A carts keep Gumroad's existing card + PayPal set.
   LANE_A_PAYMENT_METHOD_TYPES = %w[card paypal].freeze
 
@@ -38,11 +45,12 @@ class Checkout::PaymentMethodResolver
     def client_confirm_eligible? = client_confirm_eligible
   end
 
-  def initialize(sellers:, recurring: false, commission: false, setup_for_future: false)
+  def initialize(sellers:, recurring: false, commission: false, setup_for_future: false, buyer_country: nil)
     @sellers = sellers
     @recurring = recurring
     @commission = commission
     @setup_for_future = setup_for_future
+    @buyer_country = buyer_country
   end
 
   def resolve
@@ -53,7 +61,7 @@ class Checkout::PaymentMethodResolver
         client_confirm_eligible: reason.nil?,
         # Nil on Lane A carts: they never mount the client-confirmed Payment Element, so there is no
         # Stripe method list to hand them. Non-nil only when the cart confirms client-side.
-        payment_method_types: reason.nil? ? eligible & LAUNCHED_PAYMENT_METHOD_TYPES : nil,
+        payment_method_types: reason.nil? ? launched_method_set(eligible) : nil,
         eligible_payment_method_types: eligible,
         fallback_reason: reason
       )
@@ -63,7 +71,7 @@ class Checkout::PaymentMethodResolver
   end
 
   private
-    attr_reader :sellers, :recurring, :commission, :setup_for_future
+    attr_reader :sellers, :recurring, :commission, :setup_for_future, :buyer_country
 
     # The client-confirm cart-shape gates (single-seller, non-connect, one-time), owned here and applied
     # as an ordered set of reasons so a blocked cart records *why* it stayed on Lane A.
@@ -84,12 +92,24 @@ class Checkout::PaymentMethodResolver
       methods
     end
 
+    # What Stripe actually receives: the eligible policy set intersected with the launched set, then
+    # region-gated. A US-locked method (ACH now, Cash App later) is only offered when the buyer's
+    # GeoIP country is US, so a non-US buyer never sees a method they can't complete. When the buyer
+    # country is unknown (nil), US-locked methods are dropped to fail safe. Card always survives.
+    def launched_method_set(eligible)
+      launched = eligible & LAUNCHED_PAYMENT_METHOD_TYPES
+      return launched if buyer_country == US_ALPHA2
+
+      launched - US_LOCKED_PAYMENT_METHOD_TYPES
+    end
+
     def log_decision(resolution)
       launch_gated_out = resolution.eligible_payment_method_types - Array(resolution.payment_method_types)
       Rails.logger.info(
         "[#{self.class.name}] client_confirm_eligible=#{resolution.client_confirm_eligible} " \
         "seller_ids=#{sellers.map { _1&.id }} recurring=#{recurring} commission=#{commission} " \
-        "setup_for_future=#{setup_for_future} fallback_reason=#{resolution.fallback_reason.inspect} " \
+        "setup_for_future=#{setup_for_future} buyer_country=#{buyer_country.inspect} " \
+        "fallback_reason=#{resolution.fallback_reason.inspect} " \
         "eligible=#{resolution.eligible_payment_method_types} enabled=#{resolution.payment_method_types.inspect} " \
         "launch_gated_out=#{launch_gated_out}"
       )

--- a/app/services/order/prepare_payment_intent_service.rb
+++ b/app/services/order/prepare_payment_intent_service.rb
@@ -209,8 +209,18 @@ class Order::PreparePaymentIntentService
       @payment_method_resolution ||= Checkout::PaymentMethodResolver.new(
         sellers: [seller],
         recurring: purchases_to_charge.any? { _1.link.is_recurring_billing? },
-        commission: purchases_to_charge.any? { _1.link.native_type == Link::NATIVE_TYPE_COMMISSION }
+        commission: purchases_to_charge.any? { _1.link.native_type == Link::NATIVE_TYPE_COMMISSION },
+        buyer_country: buyer_country_alpha2
       ).resolve
+    end
+
+    # The buyer's country as an alpha2, derived from server-owned GeoIP data (ip_country, a country
+    # name set at order creation) — never a client-supplied field. Must key on the same location basis
+    # the presenter used so the deferred intent's US-locked methods (ACH) match the Payment Element's;
+    # a divergence fails closed at Stripe (the payment_method_types-scoped ConfirmationToken is rejected)
+    # rather than charging with the wrong method list.
+    def buyer_country_alpha2
+      Compliance::Countries.find_by_name(purchases_to_charge.first.ip_country)&.alpha2
     end
 
     # Persist the mapping before responding so a webhook arriving before the browser returns can

--- a/spec/business/payments/events/stripe/client_confirm_webhook_lifecycle_spec.rb
+++ b/spec/business/payments/events/stripe/client_confirm_webhook_lifecycle_spec.rb
@@ -171,6 +171,10 @@ describe "Client-confirmed PaymentIntent webhook lifecycle", :vcr do
       # resubmittable cart, so the client-confirmed charge's in_progress purchases are marked failed.
       deliver_webhook(payment_intent_event("payment_intent.payment_failed", charge, event_id: "evt_pf_failed"))
       expect(purchase.reload).to be_failed
+      # payment_failed is deliberately NOT recorded in ProcessedStripeEvent: recording is scoped to
+      # PAYMENT_INTENT_LIFECYCLE_EVENTS (processing/succeeded), where it gates exactly-once
+      # fulfillment. The failed path's idempotency is the in_progress? guard in the handler.
+      expect(ProcessedStripeEvent.processed?("evt_pf_failed")).to be(false)
     end
 
     it "is a no-op when the purchase already reached a terminal state (re-delivered payment_failed)" do
@@ -182,6 +186,9 @@ describe "Client-confirmed PaymentIntent webhook lifecycle", :vcr do
 
       deliver_webhook(payment_intent_event("payment_intent.payment_failed", charge, event_id: "evt_pf_terminal"))
       expect(purchase.reload).to be_successful
+      # Not recorded (see above) — a re-delivery is safe because the in_progress? guard skips
+      # terminal purchases, not because the event is deduplicated.
+      expect(ProcessedStripeEvent.processed?("evt_pf_terminal")).to be(false)
     end
   end
 

--- a/spec/business/payments/events/stripe/client_confirm_webhook_lifecycle_spec.rb
+++ b/spec/business/payments/events/stripe/client_confirm_webhook_lifecycle_spec.rb
@@ -47,7 +47,9 @@ describe "Client-confirmed PaymentIntent webhook lifecycle", :vcr do
       statement_description: seller.name_or_username,
       transfer_group: charge.id_with_prefix,
       idempotency_key: "deferred_intent_test_#{SecureRandom.hex}",
-      payment_method_types: Checkout::StripePaymentPresenter::CLIENT_CONFIRM_PAYMENT_METHOD_TYPES,
+      # Matches the resolver's launched set for a non-US test buyer (ip 0.0.0.0 → no country → card
+      # only). Kept as an explicit list so the recorded Stripe cassettes stay stable.
+      payment_method_types: ["card"],
       currency: Checkout::StripePaymentPresenter::CLIENT_CONFIRM_CURRENCY
     )
     charge.update!(stripe_payment_intent_id: charge_intent.id)
@@ -157,7 +159,7 @@ describe "Client-confirmed PaymentIntent webhook lifecycle", :vcr do
   end
 
   context "payment_intent.processing then payment_intent.payment_failed for a client-confirmed charge" do
-    it "leaves the purchase in progress; payment_failed is outside the new lifecycle scope" do
+    it "keeps the purchase in progress while processing, then fails it to a resubmittable state on payment_failed" do
       seller = create(:user)
       charge = create(:charge, seller:, client_confirmed: true, stripe_payment_intent_id: "pi_proc_fail")
       purchase = create(:purchase_in_progress, link: create(:product, user: seller), seller:)
@@ -167,9 +169,21 @@ describe "Client-confirmed PaymentIntent webhook lifecycle", :vcr do
       expect(purchase.reload).to be_in_progress
       expect(ProcessedStripeEvent.processed?("evt_pf_processing")).to be(true)
 
+      # A delayed-notification method (ACH) whose debit later fails must return the buyer to a
+      # resubmittable cart, so the client-confirmed charge's in_progress purchases are marked failed.
       deliver_webhook(payment_intent_event("payment_intent.payment_failed", charge, event_id: "evt_pf_failed"))
-      expect(purchase.reload).to be_in_progress
-      expect(ProcessedStripeEvent.processed?("evt_pf_failed")).to be(false)
+      expect(purchase.reload).to be_failed
+    end
+
+    it "is a no-op when the purchase already reached a terminal state (re-delivered payment_failed)" do
+      seller = create(:user)
+      charge = create(:charge, seller:, client_confirmed: true, stripe_payment_intent_id: "pi_fail_terminal")
+      purchase = create(:purchase, link: create(:product, user: seller), seller:)
+      charge.purchases << purchase
+      expect(purchase).to be_successful
+
+      deliver_webhook(payment_intent_event("payment_intent.payment_failed", charge, event_id: "evt_pf_terminal"))
+      expect(purchase.reload).to be_successful
     end
   end
 

--- a/spec/presenters/checkout/stripe_payment_presenter_spec.rb
+++ b/spec/presenters/checkout/stripe_payment_presenter_spec.rb
@@ -348,14 +348,14 @@ describe Checkout::StripePaymentPresenter do
         .to eq(payment_element_client_confirm_props)
     end
 
-    it "launches ACH Direct Debit alongside card for a US buyer" do
+    it "launches Cash App Pay and ACH Direct Debit alongside card for a US buyer" do
       stub_geoip_country("104.28.0.1", "United States")
 
       expect(stripe_payment_props(add_products: [confirm_flagged_seller_product], ip: "104.28.0.1"))
-        .to eq(payment_element_client_confirm_props(payment_method_types: %w[card us_bank_account]))
+        .to eq(payment_element_client_confirm_props(payment_method_types: %w[card cashapp us_bank_account]))
     end
 
-    it "offers card only for a non-US buyer (ACH is US-locked)" do
+    it "offers card only for a non-US buyer (Cash App/ACH are US-locked)" do
       stub_geoip_country("2.2.2.2", "United Kingdom")
 
       expect(stripe_payment_props(add_products: [confirm_flagged_seller_product], ip: "2.2.2.2"))

--- a/spec/presenters/checkout/stripe_payment_presenter_spec.rb
+++ b/spec/presenters/checkout/stripe_payment_presenter_spec.rb
@@ -37,7 +37,7 @@ describe Checkout::StripePaymentPresenter do
     { integration: described_class::STRIPE_CARD_ELEMENT_INTEGRATION, fallback_reason: reason, disable_wallets: false, elements_options: nil }
   end
 
-  def payment_element_client_confirm_props(stripe_link_enabled: false)
+  def payment_element_client_confirm_props(stripe_link_enabled: false, payment_method_types: ["card"])
     {
       integration: described_class::STRIPE_PAYMENT_ELEMENT_CLIENT_CONFIRM_INTEGRATION,
       fallback_reason: nil,
@@ -45,7 +45,7 @@ describe Checkout::StripePaymentPresenter do
       elements_options: {
         stripe_elements_mode: described_class::STRIPE_ELEMENTS_MODE_FOR_PAYMENT_INTENT,
         currency: "usd",
-        payment_method_types: ["card"],
+        payment_method_types:,
         stripe_link_enabled:,
       },
     }
@@ -66,8 +66,12 @@ describe Checkout::StripePaymentPresenter do
     }
   end
 
-  def stripe_payment_props(cart: nil, add_products: [], clear_cart: false, saved_credit_card: nil)
-    described_class.new(cart:, add_products:, clear_cart:, saved_credit_card:).props
+  def stripe_payment_props(cart: nil, add_products: [], clear_cart: false, saved_credit_card: nil, ip: nil)
+    described_class.new(cart:, add_products:, clear_cart:, saved_credit_card:, ip:).props
+  end
+
+  def stub_geoip_country(ip, country_name)
+    allow(GeoIp).to receive(:lookup).with(ip).and_return(double(country_name:))
   end
 
   it "selects Stripe Payment Element for a flagged single-seller charged checkout without a saved card" do
@@ -342,6 +346,27 @@ describe Checkout::StripePaymentPresenter do
     it "selects the confirm integration for a single-seller one-time card cart with both flags" do
       expect(stripe_payment_props(add_products: [confirm_flagged_seller_product]))
         .to eq(payment_element_client_confirm_props)
+    end
+
+    it "launches ACH Direct Debit alongside card for a US buyer" do
+      stub_geoip_country("104.28.0.1", "United States")
+
+      expect(stripe_payment_props(add_products: [confirm_flagged_seller_product], ip: "104.28.0.1"))
+        .to eq(payment_element_client_confirm_props(payment_method_types: %w[card us_bank_account]))
+    end
+
+    it "offers card only for a non-US buyer (ACH is US-locked)" do
+      stub_geoip_country("2.2.2.2", "United Kingdom")
+
+      expect(stripe_payment_props(add_products: [confirm_flagged_seller_product], ip: "2.2.2.2"))
+        .to eq(payment_element_client_confirm_props(payment_method_types: ["card"]))
+    end
+
+    it "offers card only when the buyer's country cannot be resolved" do
+      allow(GeoIp).to receive(:lookup).and_return(nil)
+
+      expect(stripe_payment_props(add_products: [confirm_flagged_seller_product], ip: "0.0.0.0"))
+        .to eq(payment_element_client_confirm_props(payment_method_types: ["card"]))
     end
 
     it "keeps server-confirm Payment Element when only the base flag is enabled" do

--- a/spec/services/checkout/payment_method_resolver_spec.rb
+++ b/spec/services/checkout/payment_method_resolver_spec.rb
@@ -26,12 +26,12 @@ describe Checkout::PaymentMethodResolver do
       it "enables the launched methods on Stripe for a US buyer, gating the rest behind later units" do
         resolution = resolve(buyer_country: "US")
 
-        expect(resolution.payment_method_types).to eq(%w[card us_bank_account])
+        expect(resolution.payment_method_types).to eq(%w[card cashapp us_bank_account])
         # The launched set is always a subset of the eligible policy set.
         expect(resolution.eligible_payment_method_types).to include(*resolution.payment_method_types)
       end
 
-      it "drops US-locked methods (ACH) for a non-US buyer, leaving card only" do
+      it "drops US-locked methods (Cash App/ACH) for a non-US buyer, leaving card only" do
         expect(resolve(buyer_country: "GB").payment_method_types).to eq(["card"])
       end
 
@@ -116,14 +116,14 @@ describe Checkout::PaymentMethodResolver do
       )
     end
 
-    it "logs the buyer country and the ACH launch for a US buyer" do
+    it "logs the buyer country and the US-locked method launch for a US buyer" do
       resolver = described_class.new(sellers: [seller], buyer_country: "US")
       allow(Rails.logger).to receive(:info)
 
       resolver.resolve
 
       expect(Rails.logger).to have_received(:info).with(
-        a_string_matching(/buyer_country="US".*enabled=\["card", "us_bank_account"\]/)
+        a_string_matching(/buyer_country="US".*enabled=\["card", "cashapp", "us_bank_account"\]/)
       )
     end
 

--- a/spec/services/checkout/payment_method_resolver_spec.rb
+++ b/spec/services/checkout/payment_method_resolver_spec.rb
@@ -5,8 +5,8 @@ require "spec_helper"
 describe Checkout::PaymentMethodResolver do
   let(:seller) { create(:user) }
 
-  def resolve(sellers: [seller], **opts)
-    described_class.new(sellers:, **opts).resolve
+  def resolve(sellers: [seller], buyer_country: "US", **opts)
+    described_class.new(sellers:, buyer_country:, **opts).resolve
   end
 
   describe "#resolve" do
@@ -20,15 +20,23 @@ describe Checkout::PaymentMethodResolver do
 
       it "resolves the full inline dynamic method set as eligible" do
         expect(resolve.eligible_payment_method_types)
-          .to eq(%w[card link klarna afterpay_clearpay affirm ideal bancontact cashapp])
+          .to eq(%w[card link klarna afterpay_clearpay affirm ideal bancontact cashapp us_bank_account])
       end
 
-      it "enables only the launched card method on Stripe, gating the rest behind later units" do
-        resolution = resolve
+      it "enables the launched methods on Stripe for a US buyer, gating the rest behind later units" do
+        resolution = resolve(buyer_country: "US")
 
-        expect(resolution.payment_method_types).to eq(["card"])
+        expect(resolution.payment_method_types).to eq(%w[card us_bank_account])
         # The launched set is always a subset of the eligible policy set.
         expect(resolution.eligible_payment_method_types).to include(*resolution.payment_method_types)
+      end
+
+      it "drops US-locked methods (ACH) for a non-US buyer, leaving card only" do
+        expect(resolve(buyer_country: "GB").payment_method_types).to eq(["card"])
+      end
+
+      it "drops US-locked methods when the buyer country is unknown, failing safe to card only" do
+        expect(resolve(buyer_country: nil).payment_method_types).to eq(["card"])
       end
 
       it "returns an explicit list of method-type strings, never Stripe's automatic_payment_methods shape" do
@@ -105,6 +113,17 @@ describe Checkout::PaymentMethodResolver do
 
       expect(Rails.logger).to have_received(:info).with(
         a_string_matching(/client_confirm_eligible=true.*enabled=\["card"\].*launch_gated_out=/)
+      )
+    end
+
+    it "logs the buyer country and the ACH launch for a US buyer" do
+      resolver = described_class.new(sellers: [seller], buyer_country: "US")
+      allow(Rails.logger).to receive(:info)
+
+      resolver.resolve
+
+      expect(Rails.logger).to have_received(:info).with(
+        a_string_matching(/buyer_country="US".*enabled=\["card", "us_bank_account"\]/)
       )
     end
 

--- a/spec/services/order/prepare_payment_intent_service_spec.rb
+++ b/spec/services/order/prepare_payment_intent_service_spec.rb
@@ -216,9 +216,9 @@ describe Order::PreparePaymentIntentService, :vcr do
         expect(create_args[:currency]).to eq(Checkout::StripePaymentPresenter::CLIENT_CONFIRM_CURRENCY)
       end
 
-      # The launched set must equal the Payment Element's for the buyer's country, so ACH Direct Debit
-      # (us_bank_account) rides the deferred intent only when the server-owned ip_country is the US.
-      it "launches ACH Direct Debit for a US buyer, matching the Payment Element's method set" do
+      # The launched set must equal the Payment Element's for the buyer's country, so Cash App Pay and
+      # ACH Direct Debit ride the deferred intent only when the server-owned ip_country is the US.
+      it "launches Cash App Pay and ACH Direct Debit for a US buyer, matching the Payment Element's method set" do
         order, params = build_order
         order.purchases.each { _1.update!(ip_country: "United States") }
 
@@ -235,7 +235,7 @@ describe Order::PreparePaymentIntentService, :vcr do
 
         described_class.new(order:, params:, confirmation_token: "ctoken_us").perform
 
-        expect(create_args[:payment_method_types]).to eq(%w[card us_bank_account])
+        expect(create_args[:payment_method_types]).to eq(%w[card cashapp us_bank_account])
       end
 
       # A key built only from the (database-id-derived) external_id collides in Stripe test mode,

--- a/spec/services/order/prepare_payment_intent_service_spec.rb
+++ b/spec/services/order/prepare_payment_intent_service_spec.rb
@@ -196,7 +196,7 @@ describe Order::PreparePaymentIntentService, :vcr do
     context "the deferred intent method/currency contract" do
       before { create(:merchant_account, user: seller, charge_processor_merchant_id: "acct_test") }
 
-      it "creates the intent with the resolver's launched payment_method_types and currency" do
+      it "creates the intent with only card for a buyer whose country cannot be resolved (US-locked methods dropped)" do
         order, params = build_order
 
         preview = Stripe::StripeObject.construct_from(card: { country: "US" })
@@ -214,6 +214,28 @@ describe Order::PreparePaymentIntentService, :vcr do
 
         expect(create_args[:payment_method_types]).to eq(["card"])
         expect(create_args[:currency]).to eq(Checkout::StripePaymentPresenter::CLIENT_CONFIRM_CURRENCY)
+      end
+
+      # The launched set must equal the Payment Element's for the buyer's country, so ACH Direct Debit
+      # (us_bank_account) rides the deferred intent only when the server-owned ip_country is the US.
+      it "launches ACH Direct Debit for a US buyer, matching the Payment Element's method set" do
+        order, params = build_order
+        order.purchases.each { _1.update!(ip_country: "United States") }
+
+        preview = Stripe::StripeObject.construct_from(card: { country: "US" })
+        allow(Stripe::ConfirmationToken).to receive(:retrieve)
+          .and_return(Stripe::StripeObject.construct_from(payment_method_preview: preview))
+
+        charge_intent = instance_double(StripeChargeIntent, id: "pi_test", client_secret: "pi_test_secret")
+        create_args = nil
+        allow(StripeDeferredPaymentIntent).to receive(:create) do |**kwargs|
+          create_args = kwargs
+          charge_intent
+        end
+
+        described_class.new(order:, params:, confirmation_token: "ctoken_us").perform
+
+        expect(create_args[:payment_method_types]).to eq(%w[card us_bank_account])
       end
 
       # A key built only from the (database-id-derived) external_id collides in Stripe test mode,


### PR DESCRIPTION
## What

Launches **Cash App Pay (`cashapp`)** and **ACH Direct Debit (`us_bank_account`)** on the client-confirmed Intent path (Lane B) for US buyers — #5640 step 7 (plan unit U11)'s first redirect method and first delayed-notification method. Cash App Pay confirms via the #5664 return page (merged); ACH exercises the `processing` → webhook-driven fulfillment lifecycle that #5656 (step 2) established.

- `Checkout::PaymentMethodResolver`: adds `us_bank_account` to the eligible one-time set and widens `LAUNCHED_PAYMENT_METHOD_TYPES` to `card, cashapp, us_bank_account`. A new `US_LOCKED_PAYMENT_METHOD_TYPES` gate drops both US-locked methods unless the buyer's GeoIP country is US; an unresolvable country fails safe to card-only. The gate decision (`buyer_country`) is logged with every resolution.
- `Checkout::StripePaymentPresenter`: derives `buyer_country` from the request `ip` (GeoIP) and threads it into the resolver, so the Payment Element only offers ACH to US buyers.
- `Order::PreparePaymentIntentService`: derives the same `buyer_country` from the purchase's server-owned `ip_country` (also GeoIP) and threads it into its resolver call, keeping the deferred PaymentIntent's `payment_method_types` equal to the Payment Element's — the step-1 invariant. Both sides key on the same GeoIP basis; any residual mismatch fails closed at Stripe (a `payment_method_types`-scoped ConfirmationToken is rejected against a mismatched intent) rather than charging with the wrong method list.
- `Purchase::ChargeEventsHandler#handle_event_failed!`: a `payment_intent.payment_failed` webhook for a client-confirmed charge now marks its still-`in_progress` purchases failed, returning the buyer to a resubmittable cart — the retry state for an ACH debit that fails after `processing`. Idempotent on terminal purchases; the existing Indian off-session branch is untouched.
- Frontend: `PaymentElementClientConfirmConfig.payment_method_types` widens from the `["card"]` tuple to `string[]` (the server-resolved set; the frontend cannot widen it).

No new confirm machinery is needed for either method: both ride the existing two-step + `stripe.confirmPayment({ redirect: "if_required" })` flow. Cash App Pay navigates to the #5664 return page (`Checkout::ReturnsController#show` → finalize on `succeeded`, pending page on `processing`); ACH resolves inline, reports `processing`, and fulfills exactly-once via the `payment_intent.succeeded` webhook. The EUR methods (iDEAL/Bancontact/SEPA) stay gated until buyer-currency FX lands.

## Why

#5640's step 7 launches the first local methods on the client-confirmed path, USD-native by design so a US team can test end-to-end. Cash App Pay (redirect, confirms immediately) proves the #5664 return page; ACH Direct Debit (delayed-notification) proves the webhook lifecycle: buyer authorizes inline, the intent goes `processing`, and the webhook lifecycle (#5656) is the source of truth for fulfillment — pending UX at finalize (`processing` line items) and abandonment-worker sparing of `processing` intents already shipped in steps 1–2. What was missing was the method itself, the US region gate, and a failure path that doesn't strand the purchase `in_progress` until abandonment.

Everything stays behind `:stripe_payment_element_checkout` AND `:stripe_payment_element_client_confirm` (seller-scoped, off by default): with the flags off, checkout behavior is unchanged, and even with them on, non-US buyers see exactly today's card-only Element.

Also fixes the client-confirm webhook lifecycle spec's reference to `Checkout::StripePaymentPresenter::CLIENT_CONFIRM_PAYMENT_METHOD_TYPES`, a constant removed when #5665 introduced the resolver (the spec merged from a branch cut before that rename).

## Test plan

- `spec/services/checkout/payment_method_resolver_spec.rb` (15 examples): US buyer gets `card, cashapp, us_bank_account`; non-US and unknown-country buyers get `card` only; eligible-set/logging/memoization coverage updated.
- `spec/presenters/checkout/stripe_payment_presenter_spec.rb` (38 examples): ACH offered for a US GeoIP, card-only for UK GeoIP and unresolvable IP; all pre-existing contexts unchanged.
- `spec/services/order/prepare_payment_intent_service_spec.rb` (11 examples): deferred intent carries `card, cashapp, us_bank_account` when `ip_country` is United States, card-only otherwise — proving both sides of the invariant resolve identically.
- `spec/requests/checkout/returns_spec.rb` (14 examples, from #5664): the return page Cash App Pay lands on — succeeded/processing/failed branches — green against the widened launched set.
- `spec/business/payments/events/stripe/client_confirm_webhook_lifecycle_spec.rb` (11 examples): `processing` keeps the purchase pending, a subsequent `payment_failed` marks it failed (resubmittable), a re-delivered `payment_failed` on a terminal purchase is a no-op; the existing exactly-once `succeeded` coverage still passes.
- `spec/models/concerns/purchase/charge_events_handler_spec.rb` (29 examples) and `spec/presenters/checkout_presenter_spec.rb` (44 examples) green.
- Frontend: `vitest` (45 tests across payment/client-confirm/order suites), `tsc --noEmit` (no new errors), `eslint`, `prettier` all clean. `rubocop` clean on all touched Ruby files.

No UI change with the flags off (default); with flags on, the only UI difference is Stripe's Payment Element rendering its native Cash App Pay and ACH tabs for US buyers, driven entirely by the server-resolved `payment_method_types`.

Part of #5640 (step 7 / U11).

## After


https://github.com/user-attachments/assets/11719fbe-38dd-4bac-84d1-d50fc9fcaea1


https://github.com/user-attachments/assets/9ef44043-f706-48bf-b646-c8efe7f0821a

