### PR TITLE
Support refunds for buyer-presentment purchases

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -2058,14 +2058,18 @@ class Purchase < ApplicationRecord
   def process_refund_or_chargeback_for_affiliate_credit_balance(flow_of_funds, refund: nil, dispute: nil, refund_cents: 0, fee_cents: 0)
     return if affiliate_credit_cents == 0 || refund_cents == 0
 
+    canonical_issued_amount = presentment_canonical_refund_issued_amount(refund)
+
     affiliate_issued_amount = BalanceTransaction::Amount.create_issued_amount_for_affiliate(
       flow_of_funds:,
-      issued_affiliate_cents: -1 * refund_cents
+      issued_affiliate_cents: -1 * refund_cents,
+      canonical_issued_amount:
     )
 
     affiliate_holding_amount = BalanceTransaction::Amount.create_holding_amount_for_affiliate(
       flow_of_funds:,
-      issued_affiliate_cents: -1 * refund_cents
+      issued_affiliate_cents: -1 * refund_cents,
+      canonical_issued_amount:
     )
 
     affiliate_balance_transaction = BalanceTransaction.create!(
@@ -2106,14 +2110,18 @@ class Purchase < ApplicationRecord
     logger.info("process_refund_or_chargeback_for_purchase_balance::dispute::#{dispute.inspect}")
     return unless charged_using_gumroad_merchant_account?
 
+    canonical_issued_amount = presentment_canonical_refund_issued_amount(refund)
+
     seller_issued_amount = BalanceTransaction::Amount.create_issued_amount_for_seller(
       flow_of_funds:,
-      issued_net_cents: -1 * refund_cents
+      issued_net_cents: -1 * refund_cents,
+      canonical_issued_amount:
     )
 
     seller_holding_amount = BalanceTransaction::Amount.create_holding_amount_for_seller(
       flow_of_funds:,
-      issued_net_cents: -1 * refund_cents
+      issued_net_cents: -1 * refund_cents,
+      canonical_issued_amount:
     )
 
     seller_balance_transaction = BalanceTransaction.create!(
@@ -3166,6 +3174,15 @@ class Purchase < ApplicationRecord
       return if purchase_presentment.blank?
 
       FlowOfFunds::Amount.new(currency: Currency::USD, cents: total_transaction_cents)
+    end
+
+    # Refund counterpart of presentment_canonical_issued_amount: the processor refund is
+    # issued in the buyer's currency, but the balance debit must be booked against the
+    # canonical gross refund amount recorded on the refund row.
+    def presentment_canonical_refund_issued_amount(refund)
+      return if purchase_presentment.blank? || refund.blank?
+
+      FlowOfFunds::Amount.new(currency: Currency::USD, cents: -1 * refund.total_transaction_cents)
     end
 
     def web_csv_parity_fields

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -25,6 +25,13 @@ class Refund < ApplicationRecord
   attr_json_data_accessor :business_vat_id
   attr_json_data_accessor :debited_stripe_transfer
   attr_json_data_accessor :retained_fee_cents
+  attr_json_data_accessor :presentment_currency
+  attr_json_data_accessor :presentment_amount_cents
+  attr_json_data_accessor :presentment_price_cents
+  attr_json_data_accessor :presentment_tip_cents
+  attr_json_data_accessor :presentment_seller_tax_cents
+  attr_json_data_accessor :presentment_gumroad_tax_cents
+  attr_json_data_accessor :presentment_shipping_cents
 
   private
     def assign_product

--- a/app/modules/purchase/refundable.rb
+++ b/app/modules/purchase/refundable.rb
@@ -39,8 +39,6 @@ class Purchase
         errors.add :base, ACTIVE_DISPUTE_REFUND_ERROR_MESSAGE
         return false
       end
-      # TODO(#5419): Remove this hard stop once buyer-presentment purchase refunds are supported.
-      return false if buyer_presentment_refund_blocked?
 
       if (merchant_account.is_a_stripe_connect_account? && !merchant_account.active?) ||
           (paypal_charge_processor? &&
@@ -86,9 +84,22 @@ class Purchase
         end
 
         paypal_order_purchase_unit_refund = true if paypal_order_id
+
+        # Buyer-presentment purchases were charged in the buyer's currency, and Stripe
+        # denominates refunds in the original charge currency, so the refund sent to the
+        # processor must be the buyer-presentment amount, never canonical USD cents. Fail
+        # closed when a presentment refund amount cannot be computed for this purchase.
+        presentment_refund = nil
+        if buyer_presentment?
+          canonical_gross_refund_cents = gross_amount_cents.presence || gross_amount_refundable_cents
+          presentment_refund = Purchase::PresentmentRefund.new(purchase: self, canonical_gross_refund_cents:).result if stripe_charge_processor?
+          return false if presentment_refund.blank? && buyer_presentment_refund_blocked?
+        end
+        processor_refund_amount_cents = presentment_refund ? presentment_refund.presentment_amount_cents : gross_amount_cents
+
         charge_refund = ChargeProcessor.refund!(charge_processor_id,
                                                 stripe_transaction_id,
-                                                amount_cents: gross_amount_cents,
+                                                amount_cents: processor_refund_amount_cents,
                                                 merchant_account:,
                                                 reverse_transfer: !chargedback? || !chargeback_reversed,
                                                 paypal_order_purchase_unit_refund:,
@@ -108,7 +119,9 @@ class Purchase
         if charge_refund.flow_of_funds.nil? && StripeChargeProcessor.charge_processor_id != charge_processor_id
           charge_refund.flow_of_funds = FlowOfFunds.build_simple_flow_of_funds(Currency::USD, -(gross_amount_cents.presence || gross_amount_refundable_cents))
         end
-        refund_purchase!(charge_refund.flow_of_funds, refunding_user_id, charge_refund.refund, is_for_fraud)
+        refund_purchase!(charge_refund.flow_of_funds, refunding_user_id, charge_refund.refund, is_for_fraud,
+                         canonical_gross_refund_cents: (presentment_refund ? (gross_amount_cents.presence || gross_amount_refundable_cents) : nil),
+                         presentment_refund:)
       rescue ChargeProcessorAlreadyRefundedError => e
         logger.error "Charge was already refunded in purchase: #{external_id}. Response: #{e.message}"
         false
@@ -194,8 +207,13 @@ class Purchase
   end
 
   # refunding_user_id can't be enforced from console (no current user), in which case it will be nil
-  def refund_purchase!(flow_of_funds, refunding_user_id, stripe_refund = nil, is_for_fraud = false)
-    funds_refunded = flow_of_funds.issued_amount.cents.abs
+  #
+  # For buyer-presentment purchases, flow_of_funds.issued_amount is in the buyer's currency,
+  # so callers must pass canonical_gross_refund_cents (the canonical USD gross refund) for the
+  # canonical refund/balance records, plus the presentment_refund snapshot to persist on the refund.
+  def refund_purchase!(flow_of_funds, refunding_user_id, stripe_refund = nil, is_for_fraud = false,
+                       canonical_gross_refund_cents: nil, presentment_refund: nil)
+    funds_refunded = canonical_gross_refund_cents || flow_of_funds.issued_amount.cents.abs
     partially_refunded_previously = self.stripe_partially_refunded
     ActiveRecord::Base.transaction do
       self.stripe_refunded = (gross_amount_refunded_cents + funds_refunded) >= total_transaction_cents
@@ -214,6 +232,9 @@ class Purchase
       if stripe_refund
         refund.status = stripe_refund.status
         refund.processor_refund_id = stripe_refund.id
+      end
+      if presentment_refund
+        presentment_refund.json_data.each { |key, value| refund.public_send("#{key}=", value) }
       end
       refund.is_for_fraud = is_for_fraud
       refunds << refund
@@ -350,10 +371,12 @@ class Purchase
   def buyer_presentment_refund_blocked?
     return false if purchase_presentment.blank?
 
-    # TODO(#5419): Remove this helper once all buyer-presentment refund paths are supported.
+    # Fail closed whenever a presentment refund amount cannot be computed (non-Stripe
+    # processor, or an allocator edge case). Sending canonical USD cents to Stripe for a
+    # buyer-currency charge would refund the wrong amount.
     errors.add :base, BUYER_PRESENTMENT_REFUND_ERROR_MESSAGE
     ErrorNotifier.notify(
-      "Buyer-presentment refund attempted before refund support shipped",
+      "Buyer-presentment refund blocked: no presentment refund amount computable",
       context: {
         purchase_id: id,
         purchase_external_id: external_id,

--- a/app/services/purchase/presentment_refund.rb
+++ b/app/services/purchase/presentment_refund.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+class Purchase::PresentmentRefund
+  Result = Struct.new(:currency,
+                      :presentment_amount_cents,
+                      :presentment_price_cents,
+                      :presentment_tip_cents,
+                      :presentment_seller_tax_cents,
+                      :presentment_gumroad_tax_cents,
+                      :presentment_shipping_cents,
+                      keyword_init: true) do
+    def json_data
+      {
+        presentment_currency: currency,
+        presentment_amount_cents:,
+        presentment_price_cents:,
+        presentment_tip_cents:,
+        presentment_seller_tax_cents:,
+        presentment_gumroad_tax_cents:,
+        presentment_shipping_cents:,
+      }
+    end
+  end
+
+  COMPONENT_KEYS = %i[
+    presentment_price_cents
+    presentment_tip_cents
+    presentment_seller_tax_cents
+    presentment_gumroad_tax_cents
+    presentment_shipping_cents
+  ].freeze
+
+  attr_reader :purchase, :canonical_gross_refund_cents
+
+  def initialize(purchase:, canonical_gross_refund_cents:)
+    @purchase = purchase
+    @canonical_gross_refund_cents = canonical_gross_refund_cents.to_i
+  end
+
+  def result
+    return nil if purchase_presentment.blank? || canonical_gross_refund_cents <= 0
+
+    if refunds_remaining_presentment_amount?
+      build_result(amount_cents: remaining_presentment_amount_cents,
+                   component_cents: remaining_component_cents)
+    else
+      amount_cents = partial_presentment_amount_cents
+      build_result(amount_cents:,
+                   component_cents: allocate_components(amount_cents))
+    end
+  end
+
+  private
+    def purchase_presentment
+      purchase.purchase_presentment
+    end
+
+    def refunds_remaining_presentment_amount?
+      canonical_gross_refund_cents >= purchase.gross_amount_refundable_cents
+    end
+
+    def partial_presentment_amount_cents
+      allocated = Charge.allocate_by_largest_remainder(
+        purchase_presentment.presentment_total_cents,
+        [canonical_gross_refund_cents],
+        purchase.total_transaction_cents
+      ).first
+      [allocated, remaining_presentment_amount_cents].min
+    end
+
+    def allocate_components(amount_cents)
+      Charge.allocate_by_largest_remainder(
+        amount_cents,
+        original_component_cents,
+        purchase_presentment.presentment_total_cents
+      )
+    end
+
+    def original_component_cents
+      COMPONENT_KEYS.map { purchase_presentment.public_send(_1).to_i }
+    end
+
+    def remaining_component_cents
+      COMPONENT_KEYS.map { |key| purchase_presentment.public_send(key).to_i - refunded_presentment_cents_for(key) }
+    end
+
+    def remaining_presentment_amount_cents
+      purchase_presentment.presentment_total_cents - refunded_presentment_cents_for(:presentment_amount_cents)
+    end
+
+    def refunded_presentment_cents_for(key)
+      purchase.refunds.sum { _1.public_send(key).to_i }
+    end
+
+    def build_result(amount_cents:, component_cents:)
+      Result.new(currency: purchase_presentment.presentment_currency,
+                 presentment_amount_cents: amount_cents,
+                 presentment_price_cents: component_cents[0],
+                 presentment_tip_cents: component_cents[1],
+                 presentment_seller_tax_cents: component_cents[2],
+                 presentment_gumroad_tax_cents: component_cents[3],
+                 presentment_shipping_cents: component_cents[4])
+    end
+end

--- a/app/services/purchase/presentment_refund.rb
+++ b/app/services/purchase/presentment_refund.rb
@@ -60,12 +60,14 @@ class Purchase::PresentmentRefund
     end
 
     def partial_presentment_amount_cents
-      allocated = Charge.allocate_by_largest_remainder(
+      # Split the presentment total between the refunded and unrefunded canonical
+      # portions so the refunded share is exact-cent consistent with the total.
+      refunded_share = Charge.allocate_by_largest_remainder(
         purchase_presentment.presentment_total_cents,
-        [canonical_gross_refund_cents],
+        [canonical_gross_refund_cents, purchase.total_transaction_cents - canonical_gross_refund_cents],
         purchase.total_transaction_cents
       ).first
-      [allocated, remaining_presentment_amount_cents].min
+      [refunded_share, remaining_presentment_amount_cents].min
     end
 
     def allocate_components(amount_cents)

--- a/spec/controllers/purchases/invoices_controller_spec.rb
+++ b/spec/controllers/purchases/invoices_controller_spec.rb
@@ -276,7 +276,7 @@ describe Purchases::InvoicesController, :vcr, type: :controller, inertia: true d
             expect(response).to redirect_to(new_purchase_invoice_path(@purchase.external_id, email: @purchase.email))
             expect(flash[:alert]).to eq(Purchase::Refundable::BUYER_PRESENTMENT_REFUND_ERROR_MESSAGE)
             expect(session["invoice_file_url_#{@purchase.external_id}"]).to be_nil
-            expect(ErrorNotifier).to have_received(:notify).with("Buyer-presentment refund attempted before refund support shipped",
+            expect(ErrorNotifier).to have_received(:notify).with("Buyer-presentment refund blocked: no presentment refund amount computable",
                                                                  context: hash_including(purchase_id: @purchase.id))
           end
 

--- a/spec/models/purchase/purchase_refunds_spec.rb
+++ b/spec/models/purchase/purchase_refunds_spec.rb
@@ -39,14 +39,80 @@ describe "PurchaseRefunds", :vcr do
     describe "buyer-presentment purchases" do
       let(:merchant_account) { create(:merchant_account, user: nil, charge_processor_id: StripeChargeProcessor.charge_processor_id) }
 
-      it "blocks processor refunds before refund support ships" do
-        create(:purchase_presentment, purchase: @purchase)
+      def build_presentment_charge_refund(presentment_cents:, currency: Currency::CAD)
+        stripe_refund = double("stripe_refund", status: "succeeded", id: "re_presentment_#{SecureRandom.hex(6)}")
+        charge_refund = ChargeRefund.new
+        charge_refund.charge_processor_id = StripeChargeProcessor.charge_processor_id
+        charge_refund.id = stripe_refund.id
+        charge_refund.flow_of_funds = FlowOfFunds.build_simple_flow_of_funds(currency, -presentment_cents)
+        charge_refund.instance_variable_set(:@refund, stripe_refund)
+        charge_refund
+      end
+
+      before do
+        create(:purchase_presentment,
+               purchase: @purchase,
+               presentment_currency: Currency::CAD,
+               presentment_price_cents: @purchase.total_transaction_cents * 2,
+               presentment_gumroad_tax_cents: 0,
+               presentment_total_cents: @purchase.total_transaction_cents * 2)
+        @purchase.association(:purchase_presentment).reset
+      end
+
+      it "sends the presentment amount to the processor and stores the refund snapshot" do
+        presentment_total = @purchase.purchase_presentment.presentment_total_cents
+
+        expect(ChargeProcessor).to receive(:refund!)
+          .with(@purchase.charge_processor_id, @purchase.stripe_transaction_id,
+                hash_including(amount_cents: presentment_total))
+          .and_return(build_presentment_charge_refund(presentment_cents: presentment_total))
+
+        expect(@purchase.refund_and_save!(@user.id)).to be(true)
+
+        @purchase.reload
+        refund = @purchase.refunds.last
+        expect(@purchase.stripe_refunded).to be(true)
+        expect(refund.total_transaction_cents).to eq(@purchase.total_transaction_cents)
+        expect(refund.presentment_currency).to eq(Currency::CAD)
+        expect(refund.presentment_amount_cents).to eq(presentment_total)
+        balance_transaction = refund.balance_transactions.where(user: @user).last
+        expect(balance_transaction.issued_amount_currency).to eq(Currency::USD)
+        expect(balance_transaction.issued_amount_gross_cents).to eq(-1 * @purchase.total_transaction_cents)
+      end
+
+      it "sends a partial presentment amount for a partial refund and clamps the final remainder" do
+        presentment_total = @purchase.purchase_presentment.presentment_total_cents
+        canonical_partial = @purchase.total_transaction_cents / 2
+        presentment_partial = presentment_total / 2
+
+        expect(ChargeProcessor).to receive(:refund!)
+          .with(@purchase.charge_processor_id, @purchase.stripe_transaction_id,
+                hash_including(amount_cents: presentment_partial))
+          .and_return(build_presentment_charge_refund(presentment_cents: presentment_partial))
+        expect(@purchase.refund_and_save!(@user.id, amount_cents: canonical_partial)).to be(true)
+        @purchase.reload
+        expect(@purchase.stripe_partially_refunded).to be(true)
+        expect(@purchase.refunds.last.presentment_amount_cents).to eq(presentment_partial)
+
+        remaining_presentment = presentment_total - presentment_partial
+        expect(ChargeProcessor).to receive(:refund!)
+          .with(@purchase.charge_processor_id, @purchase.stripe_transaction_id,
+                hash_including(amount_cents: remaining_presentment))
+          .and_return(build_presentment_charge_refund(presentment_cents: remaining_presentment))
+        expect(@purchase.refund_and_save!(@user.id)).to be(true)
+        @purchase.reload
+        expect(@purchase.stripe_refunded).to be(true)
+        expect(@purchase.refunds.sum { _1.presentment_amount_cents.to_i }).to eq(presentment_total)
+      end
+
+      it "fails closed when no presentment refund amount is computable" do
+        allow_any_instance_of(Purchase::PresentmentRefund).to receive(:result).and_return(nil)
         allow(ErrorNotifier).to receive(:notify)
 
         expect(ChargeProcessor).not_to receive(:refund!)
         expect(@purchase.refund_and_save!(@user.id)).to be(false)
         expect(@purchase.errors[:base]).to include(Purchase::Refundable::BUYER_PRESENTMENT_REFUND_ERROR_MESSAGE)
-        expect(ErrorNotifier).to have_received(:notify).with("Buyer-presentment refund attempted before refund support shipped",
+        expect(ErrorNotifier).to have_received(:notify).with("Buyer-presentment refund blocked: no presentment refund amount computable",
                                                              context: hash_including(purchase_id: @purchase.id))
       end
     end
@@ -591,14 +657,14 @@ describe "PurchaseRefunds", :vcr do
         describe "buyer-presentment purchases" do
           let(:merchant_account) { create(:merchant_account, user: nil, charge_processor_id: StripeChargeProcessor.charge_processor_id) }
 
-          it "blocks processor tax refunds before refund support ships" do
+          it "blocks processor tax refunds until presentment tax refunds are supported" do
             create(:purchase_presentment, purchase: @purchase)
             allow(ErrorNotifier).to receive(:notify)
 
             expect(ChargeProcessor).not_to receive(:refund!)
             expect(@purchase.refund_gumroad_taxes!(refunding_user_id: @product.user.id, note: "VAT_ID_1234_Dummy")).to be(false)
             expect(@purchase.errors[:base]).to include(Purchase::Refundable::BUYER_PRESENTMENT_REFUND_ERROR_MESSAGE)
-            expect(ErrorNotifier).to have_received(:notify).with("Buyer-presentment refund attempted before refund support shipped",
+            expect(ErrorNotifier).to have_received(:notify).with("Buyer-presentment refund blocked: no presentment refund amount computable",
                                                                  context: hash_including(purchase_id: @purchase.id))
           end
         end

--- a/spec/services/purchase/presentment_refund_spec.rb
+++ b/spec/services/purchase/presentment_refund_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Purchase::PresentmentRefund do
+  let(:product) { create(:product, price_cents: 100) }
+
+  let(:purchase) do
+    build(:purchase,
+          link: product,
+          price_cents: 100,
+          total_transaction_cents: 100,
+          purchase_state: "successful").tap { _1.save!(validate: false) }
+  end
+
+  before do
+    create(:purchase_presentment,
+           purchase:,
+           presentment_currency: Currency::CAD,
+           presentment_price_cents: 100,
+           presentment_tip_cents: 10,
+           presentment_seller_tax_cents: 5,
+           presentment_gumroad_tax_cents: 20,
+           presentment_shipping_cents: 0,
+           presentment_total_cents: 135)
+  end
+
+  it "returns nil for canonical purchases" do
+    purchase.purchase_presentment.destroy!
+    purchase.association(:purchase_presentment).reset
+
+    expect(described_class.new(purchase:, canonical_gross_refund_cents: 50).result).to be_nil
+  end
+
+  it "computes a full remaining presentment refund snapshot" do
+    result = described_class.new(purchase:, canonical_gross_refund_cents: 100).result
+
+    expect(result.json_data).to eq(
+      presentment_currency: Currency::CAD,
+      presentment_amount_cents: 135,
+      presentment_price_cents: 100,
+      presentment_tip_cents: 10,
+      presentment_seller_tax_cents: 5,
+      presentment_gumroad_tax_cents: 20,
+      presentment_shipping_cents: 0
+    )
+  end
+
+  it "computes a partial presentment refund by the canonical refund ratio" do
+    result = described_class.new(purchase:, canonical_gross_refund_cents: 40).result
+
+    expect(result.presentment_amount_cents).to eq(55)
+    expect([
+      result.presentment_price_cents,
+      result.presentment_tip_cents,
+      result.presentment_seller_tax_cents,
+      result.presentment_gumroad_tax_cents,
+      result.presentment_shipping_cents,
+    ].sum).to eq(result.presentment_amount_cents)
+  end
+
+  it "clamps the final refund to the exact remaining presentment cents" do
+    refund = build(:refund, purchase:, total_transaction_cents: 40, amount_cents: 40)
+    refund.presentment_currency = Currency::CAD
+    refund.presentment_amount_cents = 54
+    refund.presentment_price_cents = 40
+    refund.presentment_tip_cents = 4
+    refund.presentment_seller_tax_cents = 2
+    refund.presentment_gumroad_tax_cents = 8
+    refund.presentment_shipping_cents = 0
+    purchase.refunds << refund
+
+    result = described_class.new(purchase:, canonical_gross_refund_cents: 60).result
+
+    expect(result.presentment_amount_cents).to eq(81)
+    expect(result.presentment_price_cents).to eq(60)
+    expect(result.presentment_tip_cents).to eq(6)
+    expect(result.presentment_seller_tax_cents).to eq(3)
+    expect(result.presentment_gumroad_tax_cents).to eq(12)
+    expect(result.presentment_shipping_cents).to eq(0)
+  end
+end

--- a/spec/services/purchase/presentment_refund_spec.rb
+++ b/spec/services/purchase/presentment_refund_spec.rb
@@ -49,7 +49,7 @@ describe Purchase::PresentmentRefund do
   it "computes a partial presentment refund by the canonical refund ratio" do
     result = described_class.new(purchase:, canonical_gross_refund_cents: 40).result
 
-    expect(result.presentment_amount_cents).to eq(55)
+    expect(result.presentment_amount_cents).to eq(54)
     expect([
       result.presentment_price_cents,
       result.presentment_tip_cents,

--- a/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/buyer-presentment_purchases/fails_closed_when_no_presentment_refund_amount_is_computable.yml
+++ b/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/buyer-presentment_purchases/fails_closed_when_no_presentment_refund_amount_is_computable.yml
@@ -1,0 +1,660 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_Juf9Mt37lIechX","request_duration_ms":314}}'
+      Idempotency-Key:
+      - 985cb18d-bec6-42a1-8bb9-157034c3733b
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 19:32:29 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3;
+        report-to csp
+      Idempotency-Key:
+      - 985cb18d-bec6-42a1-8bb9-157034c3733b
+      Original-Request:
+      - req_MxpooYnfpajuFN
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3&t=1"
+      Request-Id:
+      - req_MxpooYnfpajuFN
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1ToqLZIBOqvOFDrfUZ6CGPJ8",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783020749,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Thu, 02 Jul 2026 19:32:29 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1ToqLZIBOqvOFDrfUZ6CGPJ8
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_MxpooYnfpajuFN","request_duration_ms":304}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 19:32:30 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3&t=1"
+      Request-Id:
+      - req_BO0xMGPwqOeaDw
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1ToqLZIBOqvOFDrfUZ6CGPJ8",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783020749,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Thu, 02 Jul 2026 19:32:30 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=You+bought+http%3A%2F%2Fedgar34938a5b9.test.gumroad.com%3A31337%2Fl%2Fj%21&metadata[purchase]=VqAlj6Pr_5-CNv1gM99KPw%3D%3D&transfer_group=150&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1ToqLZIBOqvOFDrfUZ6CGPJ8&statement_descriptor_suffix=edgar34938a5b9
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_BO0xMGPwqOeaDw","request_duration_ms":269}}'
+      Idempotency-Key:
+      - 11b7c3aa-8a08-4a29-896a-86ead20816ed
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 19:32:31 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1637'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3;
+        report-to csp
+      Idempotency-Key:
+      - 11b7c3aa-8a08-4a29-896a-86ead20816ed
+      Original-Request:
+      - req_JyiQwhSMzOIWlU
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3&t=1"
+      Request-Id:
+      - req_JyiQwhSMzOIWlU
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3ToqLaIBOqvOFDrf0e66qvRP",
+          "object": "payment_intent",
+          "amount": 100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 100,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3ToqLaIBOqvOFDrf0e66qvRP_secret_jxCzAS4B59Mv0kWcxI88xPeIH",
+          "confirmation_method": "automatic",
+          "created": 1783020750,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgar34938a5b9.test.gumroad.com:31337/l/j!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3ToqLaIBOqvOFDrf0yE4QMss",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "VqAlj6Pr_5-CNv1gM99KPw=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1ToqLZIBOqvOFDrfUZ6CGPJ8",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar34938a5b9",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "150"
+        }
+  recorded_at: Thu, 02 Jul 2026 19:32:31 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3ToqLaIBOqvOFDrf0yE4QMss?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_JyiQwhSMzOIWlU","request_duration_ms":929}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 19:32:31 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3790'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3&t=1"
+      Request-Id:
+      - req_7u3kQjjwsJdKru
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3ToqLaIBOqvOFDrf0yE4QMss",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3ToqLaIBOqvOFDrf0jpFS4XV",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1783555200,
+            "balance_type": "payments",
+            "created": 1783020750,
+            "currency": "usd",
+            "description": "You bought http://edgar34938a5b9.test.gumroad.com:31337/l/j!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3ToqLaIBOqvOFDrf0yE4QMss",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR34938A5B9",
+          "captured": true,
+          "created": 1783020750,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar34938a5b9.test.gumroad.com:31337/l/j!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "VqAlj6Pr_5-CNv1gM99KPw=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 63,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3ToqLaIBOqvOFDrf0e66qvRP",
+          "payment_method": "pm_1ToqLZIBOqvOFDrfUZ6CGPJ8",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "696034",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKM_5mtIGMgYSkFp-o1A6LBaDKXZbY93McwAc-2qh0V97Zf74ERxbSmBLBKsQ7GVqL5Q1K0WxrQxPUIY0",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar34938a5b9",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "150"
+        }
+  recorded_at: Thu, 02 Jul 2026 19:32:31 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/buyer-presentment_purchases/sends_a_partial_presentment_amount_for_a_partial_refund_and_clamps_the_final_remainder.yml
+++ b/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/buyer-presentment_purchases/sends_a_partial_presentment_amount_for_a_partial_refund_and_clamps_the_final_remainder.yml
@@ -1,0 +1,660 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_owgV51mqNU02MR","request_duration_ms":214}}'
+      Idempotency-Key:
+      - 96df19a7-541b-41d7-b218-2f42849720d1
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 19:32:26 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3;
+        report-to csp
+      Idempotency-Key:
+      - 96df19a7-541b-41d7-b218-2f42849720d1
+      Original-Request:
+      - req_lxzUlJRRhlFXgL
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3&t=1"
+      Request-Id:
+      - req_lxzUlJRRhlFXgL
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1ToqLWIBOqvOFDrfyIYYJNUy",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783020746,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Thu, 02 Jul 2026 19:32:26 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1ToqLWIBOqvOFDrfyIYYJNUy
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_lxzUlJRRhlFXgL","request_duration_ms":195}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 19:32:26 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3&t=1"
+      Request-Id:
+      - req_PtBatq0IJ4xyAh
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1ToqLWIBOqvOFDrfyIYYJNUy",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783020746,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Thu, 02 Jul 2026 19:32:26 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=You+bought+http%3A%2F%2Fedgar4b413a815.test.gumroad.com%3A31337%2Fl%2Fq%21&metadata[purchase]=Jx0zly3jWrg_5uBI2fBBXg%3D%3D&transfer_group=149&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1ToqLWIBOqvOFDrfyIYYJNUy&statement_descriptor_suffix=edgar4b413a815
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_PtBatq0IJ4xyAh","request_duration_ms":179}}'
+      Idempotency-Key:
+      - b7c5cca4-fc27-45f0-b07b-0909b377b16e
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 19:32:27 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1637'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3;
+        report-to csp
+      Idempotency-Key:
+      - b7c5cca4-fc27-45f0-b07b-0909b377b16e
+      Original-Request:
+      - req_v4HmSs6HTfWLXD
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3&t=1"
+      Request-Id:
+      - req_v4HmSs6HTfWLXD
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3ToqLXIBOqvOFDrf0UWL7Ui5",
+          "object": "payment_intent",
+          "amount": 100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 100,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3ToqLXIBOqvOFDrf0UWL7Ui5_secret_Ci6V5ghpg2OJO2oM31Tog4qHL",
+          "confirmation_method": "automatic",
+          "created": 1783020747,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgar4b413a815.test.gumroad.com:31337/l/q!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3ToqLXIBOqvOFDrf0db8fKDU",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "Jx0zly3jWrg_5uBI2fBBXg=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1ToqLWIBOqvOFDrfyIYYJNUy",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar4b413a815",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "149"
+        }
+  recorded_at: Thu, 02 Jul 2026 19:32:27 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3ToqLXIBOqvOFDrf0db8fKDU?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_v4HmSs6HTfWLXD","request_duration_ms":886}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 19:32:28 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3790'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3&t=1"
+      Request-Id:
+      - req_Juf9Mt37lIechX
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3ToqLXIBOqvOFDrf0db8fKDU",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3ToqLXIBOqvOFDrf06yueIgo",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1783555200,
+            "balance_type": "payments",
+            "created": 1783020747,
+            "currency": "usd",
+            "description": "You bought http://edgar4b413a815.test.gumroad.com:31337/l/q!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3ToqLXIBOqvOFDrf0db8fKDU",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR4B413A815",
+          "captured": true,
+          "created": 1783020747,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar4b413a815.test.gumroad.com:31337/l/q!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "Jx0zly3jWrg_5uBI2fBBXg=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 28,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3ToqLXIBOqvOFDrf0UWL7Ui5",
+          "payment_method": "pm_1ToqLWIBOqvOFDrfyIYYJNUy",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "265881",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKMz5mtIGMgYugmAfp-U6LBbjR9Iql0o_L4wy03v4qTZmP4zzqbR-KKZ_hR2Qu04TP6Pwe95rLk9Tl8ec",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar4b413a815",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "149"
+        }
+  recorded_at: Thu, 02 Jul 2026 19:32:28 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/buyer-presentment_purchases/sends_the_presentment_amount_to_the_processor_and_stores_the_refund_snapshot.yml
+++ b/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/buyer-presentment_purchases/sends_the_presentment_amount_to_the_processor_and_stores_the_refund_snapshot.yml
@@ -1,0 +1,658 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Idempotency-Key:
+      - d186f56d-e134-4d03-ab46-a8d8cfc1c045
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 19:32:15 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=53QX4Jc9TQPzoSxlClZvHBQKbblrUfh4RibTQaLr0vJ8W_SuHcVOxWGD3f13UjCLl8AX8oVrEOAyGEpI;
+        report-to csp
+      Idempotency-Key:
+      - d186f56d-e134-4d03-ab46-a8d8cfc1c045
+      Original-Request:
+      - req_1kTYLeU4HUKUlG
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=53QX4Jc9TQPzoSxlClZvHBQKbblrUfh4RibTQaLr0vJ8W_SuHcVOxWGD3f13UjCLl8AX8oVrEOAyGEpI&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=53QX4Jc9TQPzoSxlClZvHBQKbblrUfh4RibTQaLr0vJ8W_SuHcVOxWGD3f13UjCLl8AX8oVrEOAyGEpI&t=1"
+      Request-Id:
+      - req_1kTYLeU4HUKUlG
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1ToqLLIBOqvOFDrfUSVuvo0M",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783020735,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Thu, 02 Jul 2026 19:32:15 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1ToqLLIBOqvOFDrfUSVuvo0M
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_1kTYLeU4HUKUlG","request_duration_ms":437}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 19:32:21 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3&t=1"
+      Request-Id:
+      - req_58sF5hBXtkQ3Og
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1ToqLLIBOqvOFDrfUSVuvo0M",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783020735,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Thu, 02 Jul 2026 19:32:21 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=You+bought+http%3A%2F%2Fedgardef0940b1.test.gumroad.com%3A31337%2Fl%2Fr%21&metadata[purchase]=i5YxEjgo9VLVIdugPODBHA%3D%3D&transfer_group=148&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1ToqLLIBOqvOFDrfUSVuvo0M&statement_descriptor_suffix=edgardef0940b1
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_58sF5hBXtkQ3Og","request_duration_ms":252}}'
+      Idempotency-Key:
+      - df25e262-0ff5-423c-8818-de7e6d12a42e
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 19:32:22 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1637'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3;
+        report-to csp
+      Idempotency-Key:
+      - df25e262-0ff5-423c-8818-de7e6d12a42e
+      Original-Request:
+      - req_aJDQeDnK2q5A9I
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3&t=1"
+      Request-Id:
+      - req_aJDQeDnK2q5A9I
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3ToqLRIBOqvOFDrf1o5LrzM9",
+          "object": "payment_intent",
+          "amount": 100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 100,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3ToqLRIBOqvOFDrf1o5LrzM9_secret_bUmTPS3qQX4FkFCqYUetohsld",
+          "confirmation_method": "automatic",
+          "created": 1783020741,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgardef0940b1.test.gumroad.com:31337/l/r!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3ToqLRIBOqvOFDrf13EeiZl6",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "i5YxEjgo9VLVIdugPODBHA=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1ToqLLIBOqvOFDrfUSVuvo0M",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgardef0940b1",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "148"
+        }
+  recorded_at: Thu, 02 Jul 2026 19:32:22 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3ToqLRIBOqvOFDrf13EeiZl6?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_aJDQeDnK2q5A9I","request_duration_ms":974}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 19:32:23 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3790'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=2MTCl7k-xq1tv1lhk4wos8KB7V-3ryM0C7woRWOhCO66NNZistWUnqKmBJ6DofOMOh294h3_XHmcK5f3&t=1"
+      Request-Id:
+      - req_owgV51mqNU02MR
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3ToqLRIBOqvOFDrf13EeiZl6",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3ToqLRIBOqvOFDrf10ybaAoJ",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1783555200,
+            "balance_type": "payments",
+            "created": 1783020742,
+            "currency": "usd",
+            "description": "You bought http://edgardef0940b1.test.gumroad.com:31337/l/r!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3ToqLRIBOqvOFDrf13EeiZl6",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGARDEF0940B1",
+          "captured": true,
+          "created": 1783020742,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgardef0940b1.test.gumroad.com:31337/l/r!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "i5YxEjgo9VLVIdugPODBHA=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 49,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3ToqLRIBOqvOFDrf1o5LrzM9",
+          "payment_method": "pm_1ToqLLIBOqvOFDrfUSVuvo0M",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "071756",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKMb5mtIGMgYEvc9uueY6LBbPBMg7Top_tPwqt5AwjiB2jFoPkY2B5szlm0mIRCCfWOaDl4QkLr7nnO3G",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgardef0940b1",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "148"
+        }
+  recorded_at: Thu, 02 Jul 2026 19:32:23 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/refunds_with_vat/refund_Gumroad_taxes/buyer-presentment_purchases/blocks_processor_tax_refunds_until_presentment_tax_refunds_are_supported.yml
+++ b/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/refunds_with_vat/refund_Gumroad_taxes/buyer-presentment_purchases/blocks_processor_tax_refunds_until_presentment_tax_refunds_are_supported.yml
@@ -1,0 +1,1317 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_Juf9Mt37lIechX","request_duration_ms":2}}'
+      Idempotency-Key:
+      - c3af6ed6-1f1c-4cf3-8245-e032b478084e
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 19:36:29 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=x8WZkEveqjbvKeQmHkAMRv06RLIilth1Tp8eGqSCfthhqq7iJOTHNlMmsGreq5Y__YIbFCJc2XWQirer;
+        report-to csp
+      Idempotency-Key:
+      - c3af6ed6-1f1c-4cf3-8245-e032b478084e
+      Original-Request:
+      - req_aZiU06qyjtjwSe
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=x8WZkEveqjbvKeQmHkAMRv06RLIilth1Tp8eGqSCfthhqq7iJOTHNlMmsGreq5Y__YIbFCJc2XWQirer&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=x8WZkEveqjbvKeQmHkAMRv06RLIilth1Tp8eGqSCfthhqq7iJOTHNlMmsGreq5Y__YIbFCJc2XWQirer&t=1"
+      Request-Id:
+      - req_aZiU06qyjtjwSe
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1ToqPRIBOqvOFDrfTJRKZ4C0",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783020989,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Thu, 02 Jul 2026 19:36:29 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1ToqPRIBOqvOFDrfTJRKZ4C0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_aZiU06qyjtjwSe","request_duration_ms":305}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 19:36:30 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=x8WZkEveqjbvKeQmHkAMRv06RLIilth1Tp8eGqSCfthhqq7iJOTHNlMmsGreq5Y__YIbFCJc2XWQirer;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=x8WZkEveqjbvKeQmHkAMRv06RLIilth1Tp8eGqSCfthhqq7iJOTHNlMmsGreq5Y__YIbFCJc2XWQirer&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=x8WZkEveqjbvKeQmHkAMRv06RLIilth1Tp8eGqSCfthhqq7iJOTHNlMmsGreq5Y__YIbFCJc2XWQirer&t=1"
+      Request-Id:
+      - req_aQbNKhqwqnF0rP
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1ToqPRIBOqvOFDrfTJRKZ4C0",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783020989,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Thu, 02 Jul 2026 19:36:30 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=You+bought+http%3A%2F%2Fedgar64ef1cf55.test.gumroad.com%3A31337%2Fl%2Fk%21&metadata[purchase]=8Okpzw2ESm80f5xkOrx6qg%3D%3D&transfer_group=154&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1ToqPRIBOqvOFDrfTJRKZ4C0&statement_descriptor_suffix=edgar64ef1cf55
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_aQbNKhqwqnF0rP","request_duration_ms":224}}'
+      Idempotency-Key:
+      - 6b1ea656-cca8-4866-afef-d3d43fc1c9c9
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 19:36:31 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1637'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=x8WZkEveqjbvKeQmHkAMRv06RLIilth1Tp8eGqSCfthhqq7iJOTHNlMmsGreq5Y__YIbFCJc2XWQirer;
+        report-to csp
+      Idempotency-Key:
+      - 6b1ea656-cca8-4866-afef-d3d43fc1c9c9
+      Original-Request:
+      - req_dFjvoa4RYcC5zJ
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=x8WZkEveqjbvKeQmHkAMRv06RLIilth1Tp8eGqSCfthhqq7iJOTHNlMmsGreq5Y__YIbFCJc2XWQirer&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=x8WZkEveqjbvKeQmHkAMRv06RLIilth1Tp8eGqSCfthhqq7iJOTHNlMmsGreq5Y__YIbFCJc2XWQirer&t=1"
+      Request-Id:
+      - req_dFjvoa4RYcC5zJ
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3ToqPSIBOqvOFDrf0BrIVpo3",
+          "object": "payment_intent",
+          "amount": 100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 100,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3ToqPSIBOqvOFDrf0BrIVpo3_secret_MoeTrDtwSQb0RudjKZsPD1XBs",
+          "confirmation_method": "automatic",
+          "created": 1783020990,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgar64ef1cf55.test.gumroad.com:31337/l/k!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3ToqPSIBOqvOFDrf07g5ko5k",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "8Okpzw2ESm80f5xkOrx6qg=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1ToqPRIBOqvOFDrfTJRKZ4C0",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar64ef1cf55",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "154"
+        }
+  recorded_at: Thu, 02 Jul 2026 19:36:31 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3ToqPSIBOqvOFDrf07g5ko5k?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_dFjvoa4RYcC5zJ","request_duration_ms":975}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 19:36:31 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3790'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=x8WZkEveqjbvKeQmHkAMRv06RLIilth1Tp8eGqSCfthhqq7iJOTHNlMmsGreq5Y__YIbFCJc2XWQirer;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=x8WZkEveqjbvKeQmHkAMRv06RLIilth1Tp8eGqSCfthhqq7iJOTHNlMmsGreq5Y__YIbFCJc2XWQirer&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=x8WZkEveqjbvKeQmHkAMRv06RLIilth1Tp8eGqSCfthhqq7iJOTHNlMmsGreq5Y__YIbFCJc2XWQirer&t=1"
+      Request-Id:
+      - req_sGk9z7NB0g13zT
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3ToqPSIBOqvOFDrf07g5ko5k",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3ToqPSIBOqvOFDrf0U2g8Hs3",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1783555200,
+            "balance_type": "payments",
+            "created": 1783020990,
+            "currency": "usd",
+            "description": "You bought http://edgar64ef1cf55.test.gumroad.com:31337/l/k!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3ToqPSIBOqvOFDrf07g5ko5k",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR64EF1CF55",
+          "captured": true,
+          "created": 1783020990,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar64ef1cf55.test.gumroad.com:31337/l/k!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "8Okpzw2ESm80f5xkOrx6qg=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 28,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3ToqPSIBOqvOFDrf0BrIVpo3",
+          "payment_method": "pm_1ToqPRIBOqvOFDrfTJRKZ4C0",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "706339",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKL_7mtIGMgb8DXWq8yw6LBZVTejIceu0eNkeBTzZWsi1FJU-GOzUA4Q5MUjnbzXjwDcEf5knK3KO_O-i",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar64ef1cf55",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "154"
+        }
+  recorded_at: Thu, 02 Jul 2026 19:36:31 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_sGk9z7NB0g13zT","request_duration_ms":362}}'
+      Idempotency-Key:
+      - '006668b9-48f3-4e46-a512-ff63a4c906e1'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 19:36:32 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=x8WZkEveqjbvKeQmHkAMRv06RLIilth1Tp8eGqSCfthhqq7iJOTHNlMmsGreq5Y__YIbFCJc2XWQirer;
+        report-to csp
+      Idempotency-Key:
+      - '006668b9-48f3-4e46-a512-ff63a4c906e1'
+      Original-Request:
+      - req_CLzHaSTdQawM1w
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=x8WZkEveqjbvKeQmHkAMRv06RLIilth1Tp8eGqSCfthhqq7iJOTHNlMmsGreq5Y__YIbFCJc2XWQirer&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=x8WZkEveqjbvKeQmHkAMRv06RLIilth1Tp8eGqSCfthhqq7iJOTHNlMmsGreq5Y__YIbFCJc2XWQirer&t=1"
+      Request-Id:
+      - req_CLzHaSTdQawM1w
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1ToqPUIBOqvOFDrf05QEJiaI",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783020992,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Thu, 02 Jul 2026 19:36:32 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1ToqPUIBOqvOFDrf05QEJiaI
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_CLzHaSTdQawM1w","request_duration_ms":223}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 19:36:33 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=x8WZkEveqjbvKeQmHkAMRv06RLIilth1Tp8eGqSCfthhqq7iJOTHNlMmsGreq5Y__YIbFCJc2XWQirer;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=x8WZkEveqjbvKeQmHkAMRv06RLIilth1Tp8eGqSCfthhqq7iJOTHNlMmsGreq5Y__YIbFCJc2XWQirer&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=x8WZkEveqjbvKeQmHkAMRv06RLIilth1Tp8eGqSCfthhqq7iJOTHNlMmsGreq5Y__YIbFCJc2XWQirer&t=1"
+      Request-Id:
+      - req_O8jORbDEgFB1mz
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1ToqPUIBOqvOFDrf05QEJiaI",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783020992,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Thu, 02 Jul 2026 19:36:33 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=120&currency=usd&description=You+bought+http%3A%2F%2Fedgar64ef1cf55.test.gumroad.com%3A31337%2Fl%2Fk%21&metadata[purchase]=LKtXrB8ISnV5d9bAs51Ulg%3D%3D&transfer_group=155&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1ToqPUIBOqvOFDrf05QEJiaI&statement_descriptor_suffix=edgar64ef1cf55
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_O8jORbDEgFB1mz","request_duration_ms":189}}'
+      Idempotency-Key:
+      - f7920c56-8a99-4297-a356-f97cc5f42512
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 19:36:34 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1637'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=x8WZkEveqjbvKeQmHkAMRv06RLIilth1Tp8eGqSCfthhqq7iJOTHNlMmsGreq5Y__YIbFCJc2XWQirer;
+        report-to csp
+      Idempotency-Key:
+      - f7920c56-8a99-4297-a356-f97cc5f42512
+      Original-Request:
+      - req_8PLi4QuQBo0iaX
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=x8WZkEveqjbvKeQmHkAMRv06RLIilth1Tp8eGqSCfthhqq7iJOTHNlMmsGreq5Y__YIbFCJc2XWQirer&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=x8WZkEveqjbvKeQmHkAMRv06RLIilth1Tp8eGqSCfthhqq7iJOTHNlMmsGreq5Y__YIbFCJc2XWQirer&t=1"
+      Request-Id:
+      - req_8PLi4QuQBo0iaX
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3ToqPVIBOqvOFDrf1pA88bq8",
+          "object": "payment_intent",
+          "amount": 120,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 120,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3ToqPVIBOqvOFDrf1pA88bq8_secret_GtNVygA4X9vfMslv13Cw3JlUT",
+          "confirmation_method": "automatic",
+          "created": 1783020993,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgar64ef1cf55.test.gumroad.com:31337/l/k!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3ToqPVIBOqvOFDrf1eTeZ4kU",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "LKtXrB8ISnV5d9bAs51Ulg=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1ToqPUIBOqvOFDrf05QEJiaI",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar64ef1cf55",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "155"
+        }
+  recorded_at: Thu, 02 Jul 2026 19:36:34 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3ToqPVIBOqvOFDrf1eTeZ4kU?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_8PLi4QuQBo0iaX","request_duration_ms":985}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 19:36:34 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3790'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=x8WZkEveqjbvKeQmHkAMRv06RLIilth1Tp8eGqSCfthhqq7iJOTHNlMmsGreq5Y__YIbFCJc2XWQirer;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=x8WZkEveqjbvKeQmHkAMRv06RLIilth1Tp8eGqSCfthhqq7iJOTHNlMmsGreq5Y__YIbFCJc2XWQirer&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=x8WZkEveqjbvKeQmHkAMRv06RLIilth1Tp8eGqSCfthhqq7iJOTHNlMmsGreq5Y__YIbFCJc2XWQirer&t=1"
+      Request-Id:
+      - req_Td3f2aSNwy9dnb
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3ToqPVIBOqvOFDrf1eTeZ4kU",
+          "object": "charge",
+          "amount": 120,
+          "amount_captured": 120,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3ToqPVIBOqvOFDrf1UX6PZM6",
+            "object": "balance_transaction",
+            "amount": 120,
+            "available_on": 1783555200,
+            "balance_type": "payments",
+            "created": 1783020993,
+            "currency": "usd",
+            "description": "You bought http://edgar64ef1cf55.test.gumroad.com:31337/l/k!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 87,
+            "reporting_category": "charge",
+            "source": "ch_3ToqPVIBOqvOFDrf1eTeZ4kU",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR64EF1CF55",
+          "captured": true,
+          "created": 1783020993,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar64ef1cf55.test.gumroad.com:31337/l/k!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "LKtXrB8ISnV5d9bAs51Ulg=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 48,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3ToqPVIBOqvOFDrf1pA88bq8",
+          "payment_method": "pm_1ToqPUIBOqvOFDrf05QEJiaI",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 120,
+              "authorization_code": "690258",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 120,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKML7mtIGMgYV0NjGaZk6LBaIdeoOvHuu9SaOkxYYRij8XBaTtohxe9hMH5tiECaCCd-sAgDrla38NeW7",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar64ef1cf55",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "155"
+        }
+  recorded_at: Thu, 02 Jul 2026 19:36:34 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## What

PR 2A of #5419: buyer-presentment refund support — replaces the #5627 refund hard-stop with a real presentment refund path for Stripe card presentment purchases.

- **`Purchase::PresentmentRefund`** — allocator that maps a canonical (USD) gross refund amount to the buyer-presentment refund amount plus a per-component snapshot (price/tip/seller tax/Gumroad tax/shipping). Full refunds take the exact remaining presentment cents; partials allocate by largest remainder across the refunded/unrefunded canonical shares; every refund is clamped to the remaining presentment amount so a partial sequence reconciles exactly to `presentment_total_cents`.
- **`Purchase#refund_and_save!`** — for purchases with a `purchase_presentment`, sends the **presentment** amount to Stripe (Stripe denominates refunds in the original charge currency). Fails closed with the buyer-visible error + `ErrorNotifier` when no presentment amount is computable (non-Stripe processor, allocator edge case).
- **`Purchase#refund_purchase!`** — books canonical `refunds` rows from the canonical gross refund cents (not the buyer-currency flow of funds) and persists the presentment snapshot into `refunds.json_data` via new `Refund` JSON accessors.
- **Balances stay canonical** — refund seller/affiliate balance debits thread `canonical_issued_amount` overrides into the `BalanceTransaction::Amount` factories, mirroring #5627's charge-credit override. Real Stripe settlement facts on the flow of funds are preserved.
- **`refund_gumroad_taxes!` still fails closed** — standalone VAT presentment refunds are follow-up work, per the #5419 PR 2 plan.

## Why

#5627 deliberately blocked all refunds for buyer-presentment purchases: refunding canonical USD cents against a CAD charge would move the wrong amount of processor money. The local-payment-methods launch (#5362/#5640) cannot go live with refunds failing closed — single-currency methods have no canonical-USD fallback — so this is on that launch's critical path.

Scope deliberately avoids the open client-confirm PRs (#5673, #5684, #5686): no resolver, Payment Element, or method-list surfaces touched.

## Test results

- New specs: presentment full refund (processor amount + snapshot + canonical balance debit), partial + exact final-remainder clamping, fail-closed when no amount computable, VAT fail-closed, allocator unit specs — all green.
- Full `spec/models/purchase/purchase_refunds_spec.rb` locally: 117 examples, 1 failure — an environment-only Vite manifest error (unbuilt JS assets in a fresh worktree) in an email-rendering spec; passes in CI.
- CI: **75/75 checks green** on `a44fe9e`.

---
AI disclosure: implemented with Hermes Agent (Claude). Prompts: take ownership of the next non-overlapping #5419 slice, claim it with a unique session ID on the issue, implement presentment refund support, and get it ready to merge.
