### PR TITLE
Require POST confirmation for purchase resubscribe endpoint

### DIFF
--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -116,9 +116,16 @@ class PurchasesController < ApplicationController
 
   def subscribe
     (@purchase = Purchase.find_by_external_id(params[:id])) || e404
+
+    # GET renders a confirmation page; the state change only happens on POST.
+    # Mail clients and security scanners prefetch GET links in emails, which used to
+    # silently re-opt buyers back into a creator's emails after they unsubscribed.
+    return unless request.post?
+
     Purchase.where(email: @purchase.email, seller_id: @purchase.seller_id, can_contact: false).find_each do |purchase|
       purchase.update!(can_contact: true)
     end
+    @subscribed = true
   end
 
   def charge_preorder

--- a/app/views/purchases/subscribe.html.erb
+++ b/app/views/purchases/subscribe.html.erb
@@ -1,8 +1,18 @@
 <main class="grid divide-y divide-border bg-background border border-border rounded mx-auto my-4 h-min max-w-md w-[calc(100%-2rem)]">
-  <header class="flex flex-col gap-4 p-4 text-center">
-    <h2>The creator can now contact you.</h2>
-    <p>You will start receiving posts again. They will appear in your email inbox as well as in your Gumroad library, if you have an account. If you have missed an important update, you can email the creator to receive it.</p>
-  </header>
+  <% if @subscribed %>
+    <header class="flex flex-col gap-4 p-4 text-center">
+      <h2>The creator can now contact you.</h2>
+      <p>You will start receiving posts again. They will appear in your email inbox as well as in your Gumroad library, if you have an account. If you have missed an important update, you can email the creator to receive it.</p>
+    </header>
+  <% else %>
+    <header class="flex flex-col gap-4 p-4 text-center">
+      <h2>Resubscribe to this creator's emails?</h2>
+      <p>You previously unsubscribed from this creator's emails. Click the button below to start receiving their posts and updates again.</p>
+    </header>
+    <%= form_tag(subscribe_purchase_path(@purchase.external_id), method: "post", class: "flex flex-col gap-4 p-4") do %>
+      <%= button_tag "Resubscribe", type: "submit", class: "inline-flex items-center justify-center gap-2 cursor-pointer border border-border rounded font-[inherit] no-underline transition-transform hover:-translate-1 hover:shadow active:translate-0 active:shadow-none disabled:opacity-30 disabled:hover:translate-0 disabled:hover:shadow-none px-4 py-3 text-base leading-snug bg-primary text-primary-foreground hover:bg-accent hover:text-accent-foreground w-full", name: nil %>
+    <% end %>
+  <% end %>
 </main>
 <% content_for :footer do %>
   <%= default_footer_content %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -710,6 +710,7 @@ Rails.application.routes.draw do
         get :receipt
         get :confirm_receipt_email
         get :subscribe
+        post :subscribe
         get :unsubscribe
         post :confirm
         post :change_can_contact

--- a/spec/controllers/purchases_controller_spec.rb
+++ b/spec/controllers/purchases_controller_spec.rb
@@ -1370,16 +1370,24 @@ describe PurchasesController, :vcr do
     describe "subscribe" do
       it "404s on bad subscribe" do
         expect { get :subscribe, params: { id: "notreal" } }.to raise_error(ActionController::RoutingError)
+        expect { post :subscribe, params: { id: "notreal" } }.to raise_error(ActionController::RoutingError)
+      end
+
+      it "does not change can_contact on GET and renders a confirmation page" do
+        purchase = create(:purchase, can_contact: false)
+        get :subscribe, params: { id: purchase.external_id }
+        expect(response).to be_successful
+        expect(purchase.reload.can_contact).to eq false
       end
 
       it "only sets can_contact to true" do
         purchase = create(:purchase, can_contact: false)
-        get :subscribe, params: { id: purchase.external_id }
+        post :subscribe, params: { id: purchase.external_id }
         expect(response).to be_successful
         expect(purchase.reload.can_contact).to eq true
 
         purchase2 = create(:purchase, can_contact: true)
-        get :subscribe, params: { id: purchase2.external_id }
+        post :subscribe, params: { id: purchase2.external_id }
         expect(response).to be_successful
         expect(purchase2.reload.can_contact).to eq true
       end
@@ -1387,7 +1395,7 @@ describe PurchasesController, :vcr do
       it "sets can_contact to true for all purchases" do
         purchase = create(:purchase, can_contact: true)
         purchase2 = create(:purchase, seller_id: purchase.seller.id, link: create(:product, user: purchase.seller), email: purchase.email, can_contact: true)
-        get :subscribe, params: { id: purchase.external_id }
+        post :subscribe, params: { id: purchase.external_id }
         expect(response).to be_successful
         expect(purchase.reload.can_contact).to eq true
         expect(purchase2.reload.can_contact).to eq true


### PR DESCRIPTION
## What

`GET /purchases/:id/subscribe` no longer mutates state. It now renders a confirmation page with a Resubscribe button; the actual `can_contact: true` flip only happens on an explicit `POST` to the same path.

## Why

The subscribe endpoint was an unauthenticated GET that immediately re-opted a buyer into a creator's emails for every purchase matching that email + seller, with no confirmation step. Mail clients and email security scanners prefetch GET links inside emails, so a buyer who unsubscribed could be silently re-subscribed just by their mail client scanning an old email containing the resubscribe link. We confirmed this pattern on production data: repeated `can_contact` false→true flips with no user action, each seconds before/after a link-prefetch burst.

The unsubscribe flow already received the confirmation-gate treatment (secure redirect + email confirmation); this brings the resubscribe flow in line. Safe-method semantics: GET is now side-effect free, the state change requires a POST (with the standard Rails CSRF token in the form).

Fixes antiwork/gumroad-private#860

## Screenshots

No "before" UI existed — GET previously flipped the flag and rendered the success message directly.

**After — GET confirmation page:**

| Desktop (1280px) | Mobile (375px) |
|---|---|
| ![get-desktop](https://i.ibb.co/vvLzj7yz/pr-resubscribe-shot-get.png) | ![get-mobile](https://i.ibb.co/5Xp72MLT/pr-resubscribe-shot-get-mobile.png) |

**After — POST success page (unchanged copy from the old page):**

![post-success](https://i.ibb.co/sJPdsH6z/pr-resubscribe-shot-post.png)

## Changes

- `PurchasesController#subscribe`: `return unless request.post?` before the `can_contact` update; sets `@subscribed` for the view.
- `config/routes.rb`: added `post :subscribe` alongside the existing `get :subscribe` (existing emailed links keep working — they now land on the confirmation page instead of silently resubscribing).
- `app/views/purchases/subscribe.html.erb`: renders a confirmation form on GET, the existing success message after POST.
- Specs updated: GET no longer changes `can_contact`; POST performs the resubscribe for all purchases from the same seller + email.

## Test plan

- `bundle exec rspec spec/controllers/purchases_controller_spec.rb -e subscribe` — **18 examples, 0 failures** locally (clean worktree at this PR's commit). Same command on `origin/main`: 17 examples, 0 failures — the PR adds one example (GET no longer mutates) and rewrites the other two for the GET/POST split, no regressions.
- Manual: visit `/purchases/<external_id>/subscribe` for an unsubscribed purchase → confirmation page renders, `can_contact` unchanged. Click Resubscribe → success page renders, `can_contact` true on all of the buyer's purchases from that seller. Prefetching the GET URL (curl) does not change state.

## Notes

- Autoreview (Codex engine, branch mode vs origin/main): clean — "no accepted/actionable findings", overall "patch is correct (0.86)".
- The linked issue also asks to verify blast audience queries honor `can_contact` at delivery time. That's handled separately: `AudienceMember` membership is recalculated on every `can_contact` change (`Purchase::AudienceMember#update_audience_member_details`), and workflow sends re-check `sale.can_contact?` at send time. The observed deliveries coincided with the buyer being re-opted in by this GET endpoint before the blast query ran, which this PR fixes.

## AI Disclosure

Authored by Gumclaw (Claude via Hermes Agent): investigation, code, specs, screenshots, and this description. Verified locally as described above.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785624376&installation_id=134400930&pr_number=5688&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5688&signature=d2ffa0051894b0564daa67469dd04a7981dd2d6eee247d399f2cc6bf8c00ec36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
