### PR TITLE
Derive canonical refund amounts for processor-initiated presentment refunds

### DIFF
--- a/app/models/concerns/charge/chargeable.rb
+++ b/app/models/concerns/charge/chargeable.rb
@@ -64,6 +64,17 @@ module Charge::Chargeable
     is_a?(Charge) ? purchases.successful.sum(&:total_transaction_cents) : total_transaction_cents
   end
 
+  # Full refundable amount in the buyer-presentment currency, or nil for canonical
+  # charges. Stripe denominates charge.refund.updated amounts in the charge currency,
+  # so buyer-presentment refunds must be compared against this, not canonical USD cents.
+  def presentment_refundable_amount_cents
+    if is_a?(Charge)
+      charge_presentment&.presentment_total_cents
+    else
+      purchase_presentment&.presentment_total_cents
+    end
+  end
+
   def purchaser
     is_a?(Charge) ? order.purchaser : super
   end

--- a/app/models/concerns/charge/refundable.rb
+++ b/app/models/concerns/charge/refundable.rb
@@ -18,7 +18,10 @@ module Charge::Refundable
       stripe_charge_id = event.charge_id
       refundable = Charge.find_by(processor_transaction_id: stripe_charge_id) || Purchase.find_by(stripe_transaction_id: stripe_charge_id)
       return unless refundable.present?
-      return unless event.extras[:refunded_amount_cents] == refundable.refundable_amount_cents
+      # Stripe reports refunded_amount_cents in the charge currency, which for
+      # buyer-presentment charges is the buyer's currency, not canonical USD.
+      expected_refunded_amount_cents = refundable.presentment_refundable_amount_cents || refundable.refundable_amount_cents
+      return unless event.extras[:refunded_amount_cents] == expected_refunded_amount_cents
 
       charge_refund = StripeChargeProcessor.new.get_refund(stripe_refund_id, merchant_account: refundable.merchant_account)
       refundable.charged_purchases.each do |purchase|

--- a/app/modules/purchase/refundable.rb
+++ b/app/modules/purchase/refundable.rb
@@ -211,8 +211,19 @@ class Purchase
   # For buyer-presentment purchases, flow_of_funds.issued_amount is in the buyer's currency,
   # so callers must pass canonical_gross_refund_cents (the canonical USD gross refund) for the
   # canonical refund/balance records, plus the presentment_refund snapshot to persist on the refund.
+  # Direct callers that only have the processor flow of funds (refund webhooks, settlement
+  # declines) get the canonical amount + snapshot derived from the presentment amount; if no
+  # consistent derivation is possible the refund fails closed rather than booking buyer-currency
+  # cents as canonical USD.
   def refund_purchase!(flow_of_funds, refunding_user_id, stripe_refund = nil, is_for_fraud = false,
                        canonical_gross_refund_cents: nil, presentment_refund: nil)
+    if buyer_presentment? && canonical_gross_refund_cents.nil?
+      derived = derive_presentment_refund_from_flow_of_funds(flow_of_funds)
+      return false if derived.blank?
+
+      canonical_gross_refund_cents = derived.canonical_gross_refund_cents
+      presentment_refund ||= derived.presentment_refund
+    end
     funds_refunded = canonical_gross_refund_cents || flow_of_funds.issued_amount.cents.abs
     partially_refunded_previously = self.stripe_partially_refunded
     ActiveRecord::Base.transaction do
@@ -386,6 +397,33 @@ class Purchase
       }
     )
     true
+  end
+
+  # Derives the canonical refund amount + presentment snapshot for a refund that arrived with
+  # only a buyer-currency flow of funds (refund webhooks, settlement declines). Returns nil —
+  # and notifies — when the flow of funds is not in the presentment currency or no consistent
+  # derivation is possible, so the caller fails closed.
+  def derive_presentment_refund_from_flow_of_funds(flow_of_funds)
+    issued_amount = flow_of_funds&.issued_amount
+    derived = if issued_amount&.currency.to_s.downcase == purchase_presentment.presentment_currency.to_s.downcase
+      Purchase::PresentmentRefund.from_presentment_amount(purchase: self,
+                                                          presentment_amount_cents: issued_amount.cents.abs)
+    end
+    return derived if derived.present?
+
+    errors.add :base, BUYER_PRESENTMENT_REFUND_ERROR_MESSAGE
+    ErrorNotifier.notify(
+      "Buyer-presentment refund blocked: cannot derive canonical amount from flow of funds",
+      context: {
+        purchase_id: id,
+        purchase_external_id: external_id,
+        charge_id: charge&.id,
+        purchase_presentment_id: purchase_presentment.id,
+        flow_of_funds_issued_currency: issued_amount&.currency,
+        flow_of_funds_issued_cents: issued_amount&.cents,
+      }
+    )
+    nil
   end
 
   def formatted_refund_state

--- a/app/services/purchase/presentment_refund.rb
+++ b/app/services/purchase/presentment_refund.rb
@@ -49,10 +49,13 @@ class Purchase::PresentmentRefund
     canonical_gross_refund_cents = if presentment_amount_cents == remaining_presentment_cents
       purchase.gross_amount_refundable_cents
     else
+      # Allocate against the REMAINING presentment/canonical balances (not the original
+      # totals) so repeated partial refunds cannot exhaust the canonical refundable amount
+      # through rounding before the presentment charge is fully refunded.
       refunded_share = Charge.allocate_by_largest_remainder(
-        purchase.total_transaction_cents,
-        [presentment_amount_cents, presentment.presentment_total_cents - presentment_amount_cents],
-        presentment.presentment_total_cents
+        purchase.gross_amount_refundable_cents,
+        [presentment_amount_cents, remaining_presentment_cents - presentment_amount_cents],
+        remaining_presentment_cents
       ).first
       [refunded_share, purchase.gross_amount_refundable_cents].min
     end

--- a/app/services/purchase/presentment_refund.rb
+++ b/app/services/purchase/presentment_refund.rb
@@ -42,7 +42,14 @@ class Purchase::PresentmentRefund
     presentment_amount_cents = presentment_amount_cents.to_i
     return nil if presentment.blank? || presentment_amount_cents <= 0 || presentment.presentment_total_cents.to_i <= 0
 
-    refunded_presentment_cents = purchase.refunds.sum { _1.presentment_amount_cents.to_i }
+    # A prior refund without a presentment snapshot makes the remaining presentment
+    # balance unknowable (its canonical cents already reduced gross_amount_refundable_cents
+    # but consumed zero presentment cents here), so fail closed rather than allocate the
+    # new refund against a skewed balance.
+    prior_refunds = purchase.refunds.to_a
+    return nil if prior_refunds.any? { _1.presentment_amount_cents.to_i <= 0 }
+
+    refunded_presentment_cents = prior_refunds.sum { _1.presentment_amount_cents.to_i }
     remaining_presentment_cents = presentment.presentment_total_cents - refunded_presentment_cents
     return nil if presentment_amount_cents > remaining_presentment_cents
 

--- a/app/services/purchase/presentment_refund.rb
+++ b/app/services/purchase/presentment_refund.rb
@@ -30,6 +30,41 @@ class Purchase::PresentmentRefund
     presentment_shipping_cents
   ].freeze
 
+  DerivedRefund = Struct.new(:canonical_gross_refund_cents, :presentment_refund, keyword_init: true)
+
+  # Inverse mapping for refunds initiated at the processor (e.g. Stripe dashboard refunds
+  # arriving via webhook, settlement declines): given the buyer-presentment amount that was
+  # actually refunded, derive the canonical (USD) gross refund cents for the canonical
+  # refund/balance records plus the presentment snapshot to persist on the refund.
+  # Returns nil when no consistent derivation is possible, so callers fail closed.
+  def self.from_presentment_amount(purchase:, presentment_amount_cents:)
+    presentment = purchase.purchase_presentment
+    presentment_amount_cents = presentment_amount_cents.to_i
+    return nil if presentment.blank? || presentment_amount_cents <= 0 || presentment.presentment_total_cents.to_i <= 0
+
+    refunded_presentment_cents = purchase.refunds.sum { _1.presentment_amount_cents.to_i }
+    remaining_presentment_cents = presentment.presentment_total_cents - refunded_presentment_cents
+    return nil if presentment_amount_cents > remaining_presentment_cents
+
+    canonical_gross_refund_cents = if presentment_amount_cents == remaining_presentment_cents
+      purchase.gross_amount_refundable_cents
+    else
+      refunded_share = Charge.allocate_by_largest_remainder(
+        purchase.total_transaction_cents,
+        [presentment_amount_cents, presentment.presentment_total_cents - presentment_amount_cents],
+        presentment.presentment_total_cents
+      ).first
+      [refunded_share, purchase.gross_amount_refundable_cents].min
+    end
+    return nil if canonical_gross_refund_cents <= 0
+
+    presentment_refund = new(purchase:, canonical_gross_refund_cents:)
+                           .result_for_presentment_amount(presentment_amount_cents)
+    return nil if presentment_refund.blank?
+
+    DerivedRefund.new(canonical_gross_refund_cents:, presentment_refund:)
+  end
+
   attr_reader :purchase, :canonical_gross_refund_cents
 
   def initialize(purchase:, canonical_gross_refund_cents:)
@@ -47,6 +82,20 @@ class Purchase::PresentmentRefund
       amount_cents = partial_presentment_amount_cents
       build_result(amount_cents:,
                    component_cents: allocate_components(amount_cents))
+    end
+  end
+
+  # Builds a snapshot for a refund whose presentment amount is already known exactly
+  # (processor-initiated refunds); the components are allocated to match that amount.
+  def result_for_presentment_amount(presentment_amount_cents)
+    return nil if purchase_presentment.blank? || presentment_amount_cents.to_i <= 0
+
+    if presentment_amount_cents == remaining_presentment_amount_cents
+      build_result(amount_cents: presentment_amount_cents,
+                   component_cents: remaining_component_cents)
+    else
+      build_result(amount_cents: presentment_amount_cents,
+                   component_cents: allocate_components(presentment_amount_cents))
     end
   end
 

--- a/spec/models/concerns/charge/refundable_spec.rb
+++ b/spec/models/concerns/charge/refundable_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Charge::Refundable do
+  describe "#handle_event_refund_updated!" do
+    let(:purchase) do
+      create(:purchase,
+             price_cents: 10_00,
+             total_transaction_cents: 10_00,
+             stripe_transaction_id: "ch_refundable_#{SecureRandom.hex(6)}")
+    end
+
+    def build_event(refunded_amount_cents:)
+      event = ChargeEvent.new
+      event.charge_processor_id = StripeChargeProcessor.charge_processor_id
+      event.charge_id = purchase.stripe_transaction_id
+      event.refund_id = "re_refundable_#{SecureRandom.hex(6)}"
+      event.type = ChargeEvent::TYPE_CHARGE_REFUND_UPDATED
+      event.extras = { refund_status: "succeeded", refunded_amount_cents:, refund_reason: nil }
+      event
+    end
+
+    def stub_stripe_refund(presentment_cents:, currency: Currency::CAD)
+      stripe_refund = double("stripe_refund", status: "succeeded", id: "re_refundable_#{SecureRandom.hex(6)}")
+      charge_refund = ChargeRefund.new
+      charge_refund.charge_processor_id = StripeChargeProcessor.charge_processor_id
+      charge_refund.id = stripe_refund.id
+      charge_refund.flow_of_funds = FlowOfFunds.build_simple_flow_of_funds(currency, -presentment_cents)
+      charge_refund.instance_variable_set(:@refund, stripe_refund)
+      allow_any_instance_of(StripeChargeProcessor).to receive(:get_refund).and_return(charge_refund)
+      charge_refund
+    end
+
+    describe "buyer-presentment purchases" do
+      before do
+        create(:purchase_presentment,
+               purchase:,
+               presentment_currency: Currency::CAD,
+               presentment_price_cents: 13_50,
+               presentment_gumroad_tax_cents: 0,
+               presentment_total_cents: 13_50)
+        purchase.association(:purchase_presentment).reset
+      end
+
+      it "records the refund when Stripe reports the full presentment amount" do
+        stub_stripe_refund(presentment_cents: 13_50)
+
+        purchase.handle_event_refund_updated!(build_event(refunded_amount_cents: 13_50))
+
+        purchase.reload
+        expect(purchase.stripe_refunded?).to be(true)
+        refund = purchase.refunds.last
+        expect(refund.total_transaction_cents).to eq(10_00)
+        expect(refund.presentment_currency).to eq(Currency::CAD)
+        expect(refund.presentment_amount_cents).to eq(13_50)
+      end
+
+      it "does not treat the canonical USD amount as a full refund" do
+        purchase.handle_event_refund_updated!(build_event(refunded_amount_cents: 10_00))
+
+        expect(purchase.reload.refunds).to be_empty
+        expect(purchase.stripe_refunded?).to be(false)
+      end
+    end
+
+    describe "canonical purchases" do
+      it "records the refund when Stripe reports the full canonical amount" do
+        stub_stripe_refund(presentment_cents: 10_00, currency: Currency::USD)
+
+        purchase.handle_event_refund_updated!(build_event(refunded_amount_cents: 10_00))
+
+        purchase.reload
+        expect(purchase.stripe_refunded?).to be(true)
+        expect(purchase.refunds.last.total_transaction_cents).to eq(10_00)
+      end
+    end
+  end
+end

--- a/spec/models/purchase/purchase_refunds_spec.rb
+++ b/spec/models/purchase/purchase_refunds_spec.rb
@@ -115,6 +115,53 @@ describe "PurchaseRefunds", :vcr do
         expect(ErrorNotifier).to have_received(:notify).with("Buyer-presentment refund blocked: no presentment refund amount computable",
                                                              context: hash_including(purchase_id: @purchase.id))
       end
+
+      describe "direct refund_purchase! calls (processor-initiated refunds)" do
+        it "derives the canonical amount and snapshot from a presentment flow of funds" do
+          presentment_total = @purchase.purchase_presentment.presentment_total_cents
+          stripe_refund = double("stripe_refund", status: "succeeded", id: "re_direct_#{SecureRandom.hex(6)}")
+          flow_of_funds = FlowOfFunds.build_simple_flow_of_funds(Currency::CAD, -presentment_total)
+
+          expect(@purchase.refund_purchase!(flow_of_funds, @user.id, stripe_refund)).to be_truthy
+
+          @purchase.reload
+          refund = @purchase.refunds.last
+          expect(@purchase.stripe_refunded).to be(true)
+          expect(refund.total_transaction_cents).to eq(@purchase.total_transaction_cents)
+          expect(refund.presentment_currency).to eq(Currency::CAD)
+          expect(refund.presentment_amount_cents).to eq(presentment_total)
+          balance_transaction = refund.balance_transactions.where(user: @user).last
+          expect(balance_transaction.issued_amount_currency).to eq(Currency::USD)
+          expect(balance_transaction.issued_amount_gross_cents).to eq(-1 * @purchase.total_transaction_cents)
+        end
+
+        it "derives a proportional canonical amount for a partial presentment flow of funds" do
+          presentment_total = @purchase.purchase_presentment.presentment_total_cents
+          presentment_partial = presentment_total / 2
+          stripe_refund = double("stripe_refund", status: "succeeded", id: "re_direct_#{SecureRandom.hex(6)}")
+          flow_of_funds = FlowOfFunds.build_simple_flow_of_funds(Currency::CAD, -presentment_partial)
+
+          expect(@purchase.refund_purchase!(flow_of_funds, @user.id, stripe_refund)).to be_truthy
+
+          @purchase.reload
+          refund = @purchase.refunds.last
+          expect(@purchase.stripe_partially_refunded).to be(true)
+          expect(refund.presentment_amount_cents).to eq(presentment_partial)
+          expect(refund.total_transaction_cents).to eq(@purchase.total_transaction_cents / 2)
+        end
+
+        it "fails closed when the flow of funds is not in the presentment currency" do
+          allow(ErrorNotifier).to receive(:notify)
+          stripe_refund = double("stripe_refund", status: "succeeded", id: "re_direct_#{SecureRandom.hex(6)}")
+          flow_of_funds = FlowOfFunds.build_simple_flow_of_funds(Currency::USD, -@purchase.total_transaction_cents)
+
+          expect(@purchase.refund_purchase!(flow_of_funds, @user.id, stripe_refund)).to be(false)
+          expect(@purchase.errors[:base]).to include(Purchase::Refundable::BUYER_PRESENTMENT_REFUND_ERROR_MESSAGE)
+          expect(ErrorNotifier).to have_received(:notify).with("Buyer-presentment refund blocked: cannot derive canonical amount from flow of funds",
+                                                               context: hash_including(purchase_id: @purchase.id))
+          expect(@purchase.reload.refunds).to be_empty
+        end
+      end
     end
 
     it "updates refund status" do

--- a/spec/models/purchase/purchase_refunds_spec.rb
+++ b/spec/models/purchase/purchase_refunds_spec.rb
@@ -162,6 +162,38 @@ describe "PurchaseRefunds", :vcr do
           expect(@purchase.reload.refunds).to be_empty
         end
       end
+
+      describe "charge.refund.updated webhook (handle_event_refund_updated!)" do
+        def build_refund_updated_event(refunded_amount_cents:)
+          event = ChargeEvent.new
+          event.type = ChargeEvent::TYPE_CHARGE_REFUND_UPDATED
+          event.refund_id = "re_webhook_#{SecureRandom.hex(6)}"
+          event.charge_id = @purchase.stripe_transaction_id
+          event.extras = { refund_status: "succeeded", refunded_amount_cents:, refund_reason: nil }
+          event
+        end
+
+        it "matches the full refunded amount against the presentment total, not canonical USD cents" do
+          presentment_total = @purchase.purchase_presentment.presentment_total_cents
+          charge_refund = build_presentment_charge_refund(presentment_cents: presentment_total)
+          expect_any_instance_of(StripeChargeProcessor).to receive(:get_refund).and_return(charge_refund)
+
+          @purchase.handle_event_refund_updated!(build_refund_updated_event(refunded_amount_cents: presentment_total))
+
+          @purchase.reload
+          expect(@purchase.stripe_refunded).to be(true)
+          expect(@purchase.refunds.last.presentment_amount_cents).to eq(presentment_total)
+          expect(@purchase.refunds.last.total_transaction_cents).to eq(@purchase.total_transaction_cents)
+        end
+
+        it "does not treat canonical USD cents as a full presentment refund" do
+          expect_any_instance_of(StripeChargeProcessor).not_to receive(:get_refund)
+
+          @purchase.handle_event_refund_updated!(build_refund_updated_event(refunded_amount_cents: @purchase.total_transaction_cents))
+
+          expect(@purchase.reload.refunds).to be_empty
+        end
+      end
     end
 
     it "updates refund status" do

--- a/spec/services/purchase/presentment_refund_spec.rb
+++ b/spec/services/purchase/presentment_refund_spec.rb
@@ -145,6 +145,13 @@ describe Purchase::PresentmentRefund do
       expect(final.presentment_refund.presentment_amount_cents).to eq(1)
     end
 
+    it "returns nil when a prior refund has no presentment snapshot" do
+      refund = build(:refund, purchase:, total_transaction_cents: 40, amount_cents: 40)
+      purchase.refunds << refund
+
+      expect(described_class.from_presentment_amount(purchase:, presentment_amount_cents: 54)).to be_nil
+    end
+
     it "returns nil for a non-positive presentment amount" do
       expect(described_class.from_presentment_amount(purchase:, presentment_amount_cents: 0)).to be_nil
     end

--- a/spec/services/purchase/presentment_refund_spec.rb
+++ b/spec/services/purchase/presentment_refund_spec.rb
@@ -119,6 +119,32 @@ describe Purchase::PresentmentRefund do
       expect(described_class.from_presentment_amount(purchase:, presentment_amount_cents: 100)).to be_nil
     end
 
+    it "allocates repeated partials against remaining balances so the final presentment cent stays recordable" do
+      purchase.purchase_presentment.update!(presentment_price_cents: 101,
+                                            presentment_tip_cents: 0,
+                                            presentment_seller_tax_cents: 0,
+                                            presentment_gumroad_tax_cents: 0,
+                                            presentment_total_cents: 101)
+      purchase.association(:purchase_presentment).reset
+
+      first = described_class.from_presentment_amount(purchase:, presentment_amount_cents: 50)
+      expect(first.canonical_gross_refund_cents).to eq(50)
+      first_refund = build(:refund, purchase:, total_transaction_cents: 50, amount_cents: 50)
+      first.presentment_refund.json_data.each { |key, value| first_refund.public_send("#{key}=", value) }
+      purchase.refunds << first_refund
+
+      second = described_class.from_presentment_amount(purchase:, presentment_amount_cents: 50)
+      expect(second.canonical_gross_refund_cents).to be < 50
+      second_refund = build(:refund, purchase:, total_transaction_cents: second.canonical_gross_refund_cents, amount_cents: second.canonical_gross_refund_cents)
+      second.presentment_refund.json_data.each { |key, value| second_refund.public_send("#{key}=", value) }
+      purchase.refunds << second_refund
+
+      final = described_class.from_presentment_amount(purchase:, presentment_amount_cents: 1)
+      expect(final).to be_present
+      expect(final.canonical_gross_refund_cents).to eq(100 - 50 - second.canonical_gross_refund_cents)
+      expect(final.presentment_refund.presentment_amount_cents).to eq(1)
+    end
+
     it "returns nil for a non-positive presentment amount" do
       expect(described_class.from_presentment_amount(purchase:, presentment_amount_cents: 0)).to be_nil
     end

--- a/spec/services/purchase/presentment_refund_spec.rb
+++ b/spec/services/purchase/presentment_refund_spec.rb
@@ -79,4 +79,48 @@ describe Purchase::PresentmentRefund do
     expect(result.presentment_gumroad_tax_cents).to eq(12)
     expect(result.presentment_shipping_cents).to eq(0)
   end
+
+  describe ".from_presentment_amount" do
+    it "returns nil for canonical purchases" do
+      purchase.purchase_presentment.destroy!
+      purchase.association(:purchase_presentment).reset
+
+      expect(described_class.from_presentment_amount(purchase:, presentment_amount_cents: 135)).to be_nil
+    end
+
+    it "derives the full canonical refund when the presentment amount equals the remaining total" do
+      derived = described_class.from_presentment_amount(purchase:, presentment_amount_cents: 135)
+
+      expect(derived.canonical_gross_refund_cents).to eq(purchase.gross_amount_refundable_cents)
+      expect(derived.presentment_refund.presentment_amount_cents).to eq(135)
+      expect(derived.presentment_refund.currency).to eq(Currency::CAD)
+    end
+
+    it "derives a proportional canonical refund for a partial presentment amount" do
+      derived = described_class.from_presentment_amount(purchase:, presentment_amount_cents: 54)
+
+      expect(derived.canonical_gross_refund_cents).to eq(40)
+      expect(derived.presentment_refund.presentment_amount_cents).to eq(54)
+      expect([
+        derived.presentment_refund.presentment_price_cents,
+        derived.presentment_refund.presentment_tip_cents,
+        derived.presentment_refund.presentment_seller_tax_cents,
+        derived.presentment_refund.presentment_gumroad_tax_cents,
+        derived.presentment_refund.presentment_shipping_cents,
+      ].sum).to eq(54)
+    end
+
+    it "returns nil when the presentment amount exceeds the remaining presentment cents" do
+      refund = build(:refund, purchase:, total_transaction_cents: 40, amount_cents: 40)
+      refund.presentment_currency = Currency::CAD
+      refund.presentment_amount_cents = 54
+      purchase.refunds << refund
+
+      expect(described_class.from_presentment_amount(purchase:, presentment_amount_cents: 100)).to be_nil
+    end
+
+    it "returns nil for a non-positive presentment amount" do
+      expect(described_class.from_presentment_amount(purchase:, presentment_amount_cents: 0)).to be_nil
+    end
+  end
 end

--- a/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/buyer-presentment_purchases/charge_refund_updated_webhook_handle_event_refund_updated_/does_not_treat_canonical_USD_cents_as_a_full_presentment_refund.yml
+++ b/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/buyer-presentment_purchases/charge_refund_updated_webhook_handle_event_refund_updated_/does_not_treat_canonical_USD_cents_as_a_full_presentment_refund.yml
@@ -1,0 +1,660 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_dk7VNL0xRku7O1","request_duration_ms":526}}'
+      Idempotency-Key:
+      - 724b708b-aa74-4afa-9e3c-aeff417ba316
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 23:04:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=6RzF2YHK_JU8SOnRyPH0EaHhO8BsoPWchODNhibADpxJvdn2a_c8oU-ZSIz9r0lnML72JPDXt3_7eMqp;
+        report-to csp
+      Idempotency-Key:
+      - 724b708b-aa74-4afa-9e3c-aeff417ba316
+      Original-Request:
+      - req_IczJ788d0V0pne
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=6RzF2YHK_JU8SOnRyPH0EaHhO8BsoPWchODNhibADpxJvdn2a_c8oU-ZSIz9r0lnML72JPDXt3_7eMqp&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=6RzF2YHK_JU8SOnRyPH0EaHhO8BsoPWchODNhibADpxJvdn2a_c8oU-ZSIz9r0lnML72JPDXt3_7eMqp&t=1"
+      Request-Id:
+      - req_IczJ788d0V0pne
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1Totf9IBOqvOFDrfvJOItX9n",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783033495,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Thu, 02 Jul 2026 23:04:55 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1Totf9IBOqvOFDrfvJOItX9n
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_IczJ788d0V0pne","request_duration_ms":198}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 23:04:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=6RzF2YHK_JU8SOnRyPH0EaHhO8BsoPWchODNhibADpxJvdn2a_c8oU-ZSIz9r0lnML72JPDXt3_7eMqp;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=6RzF2YHK_JU8SOnRyPH0EaHhO8BsoPWchODNhibADpxJvdn2a_c8oU-ZSIz9r0lnML72JPDXt3_7eMqp&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=6RzF2YHK_JU8SOnRyPH0EaHhO8BsoPWchODNhibADpxJvdn2a_c8oU-ZSIz9r0lnML72JPDXt3_7eMqp&t=1"
+      Request-Id:
+      - req_vX5W0xlSZFxZWU
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1Totf9IBOqvOFDrfvJOItX9n",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783033495,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Thu, 02 Jul 2026 23:04:55 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=You+bought+http%3A%2F%2Fedgar47700ff729.test.gumroad.com%3A31337%2Fl%2Fm%21&metadata[purchase]=3D4kUFY7t7YTkz3H4Dt9Gg%3D%3D&transfer_group=584&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1Totf9IBOqvOFDrfvJOItX9n&statement_descriptor_suffix=edgar47700ff729
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_vX5W0xlSZFxZWU","request_duration_ms":152}}'
+      Idempotency-Key:
+      - 0b742aaf-a079-4f0b-9022-f21a5c46f3ae
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 23:04:56 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1639'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=6RzF2YHK_JU8SOnRyPH0EaHhO8BsoPWchODNhibADpxJvdn2a_c8oU-ZSIz9r0lnML72JPDXt3_7eMqp;
+        report-to csp
+      Idempotency-Key:
+      - 0b742aaf-a079-4f0b-9022-f21a5c46f3ae
+      Original-Request:
+      - req_FFWgUxk0w6tzHC
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=6RzF2YHK_JU8SOnRyPH0EaHhO8BsoPWchODNhibADpxJvdn2a_c8oU-ZSIz9r0lnML72JPDXt3_7eMqp&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=6RzF2YHK_JU8SOnRyPH0EaHhO8BsoPWchODNhibADpxJvdn2a_c8oU-ZSIz9r0lnML72JPDXt3_7eMqp&t=1"
+      Request-Id:
+      - req_FFWgUxk0w6tzHC
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3Totf9IBOqvOFDrf0glm2V8d",
+          "object": "payment_intent",
+          "amount": 100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 100,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3Totf9IBOqvOFDrf0glm2V8d_secret_2hSYKRupAjd5Kqh71auub6oSJ",
+          "confirmation_method": "automatic",
+          "created": 1783033495,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgar47700ff729.test.gumroad.com:31337/l/m!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3Totf9IBOqvOFDrf0oS0x4FL",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "3D4kUFY7t7YTkz3H4Dt9Gg=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1Totf9IBOqvOFDrfvJOItX9n",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar47700ff729",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "584"
+        }
+  recorded_at: Thu, 02 Jul 2026 23:04:56 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3Totf9IBOqvOFDrf0oS0x4FL?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_FFWgUxk0w6tzHC","request_duration_ms":822}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 23:04:56 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3793'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=6RzF2YHK_JU8SOnRyPH0EaHhO8BsoPWchODNhibADpxJvdn2a_c8oU-ZSIz9r0lnML72JPDXt3_7eMqp;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=6RzF2YHK_JU8SOnRyPH0EaHhO8BsoPWchODNhibADpxJvdn2a_c8oU-ZSIz9r0lnML72JPDXt3_7eMqp&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=6RzF2YHK_JU8SOnRyPH0EaHhO8BsoPWchODNhibADpxJvdn2a_c8oU-ZSIz9r0lnML72JPDXt3_7eMqp&t=1"
+      Request-Id:
+      - req_qnvRM3w4LrTneM
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3Totf9IBOqvOFDrf0oS0x4FL",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3Totf9IBOqvOFDrf0Bl3sfQ5",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1783555200,
+            "balance_type": "payments",
+            "created": 1783033495,
+            "currency": "usd",
+            "description": "You bought http://edgar47700ff729.test.gumroad.com:31337/l/m!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3Totf9IBOqvOFDrf0oS0x4FL",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR47700FF72",
+          "captured": true,
+          "created": 1783033495,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar47700ff729.test.gumroad.com:31337/l/m!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "3D4kUFY7t7YTkz3H4Dt9Gg=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 16,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3Totf9IBOqvOFDrf0glm2V8d",
+          "payment_method": "pm_1Totf9IBOqvOFDrfvJOItX9n",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "225590",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKJjdm9IGMgaCg5COeX46LBZH9RntJg6bJXwu6XKzdMB1wSgK1qyd6qH4p6ajvN9GSkJ75Yp9f7Z_q_wr",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar47700ff729",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "584"
+        }
+  recorded_at: Thu, 02 Jul 2026 23:04:56 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/buyer-presentment_purchases/charge_refund_updated_webhook_handle_event_refund_updated_/matches_the_full_refunded_amount_against_the_presentment_total_not_canonical_USD_cents.yml
+++ b/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/buyer-presentment_purchases/charge_refund_updated_webhook_handle_event_refund_updated_/matches_the_full_refunded_amount_against_the_presentment_total_not_canonical_USD_cents.yml
@@ -1,0 +1,660 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_EAVWhuQuA8jiuO","request_duration_ms":0}}'
+      Idempotency-Key:
+      - ed4db737-a093-4df7-92c2-7d423612caae
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 23:04:52 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=6RzF2YHK_JU8SOnRyPH0EaHhO8BsoPWchODNhibADpxJvdn2a_c8oU-ZSIz9r0lnML72JPDXt3_7eMqp;
+        report-to csp
+      Idempotency-Key:
+      - ed4db737-a093-4df7-92c2-7d423612caae
+      Original-Request:
+      - req_ZgWl4MlcCIvWmH
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=6RzF2YHK_JU8SOnRyPH0EaHhO8BsoPWchODNhibADpxJvdn2a_c8oU-ZSIz9r0lnML72JPDXt3_7eMqp&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=6RzF2YHK_JU8SOnRyPH0EaHhO8BsoPWchODNhibADpxJvdn2a_c8oU-ZSIz9r0lnML72JPDXt3_7eMqp&t=1"
+      Request-Id:
+      - req_ZgWl4MlcCIvWmH
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1Totf6IBOqvOFDrfoISlwFW1",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783033492,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Thu, 02 Jul 2026 23:04:52 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1Totf6IBOqvOFDrfoISlwFW1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_ZgWl4MlcCIvWmH","request_duration_ms":256}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 23:04:52 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=6RzF2YHK_JU8SOnRyPH0EaHhO8BsoPWchODNhibADpxJvdn2a_c8oU-ZSIz9r0lnML72JPDXt3_7eMqp;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=6RzF2YHK_JU8SOnRyPH0EaHhO8BsoPWchODNhibADpxJvdn2a_c8oU-ZSIz9r0lnML72JPDXt3_7eMqp&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=6RzF2YHK_JU8SOnRyPH0EaHhO8BsoPWchODNhibADpxJvdn2a_c8oU-ZSIz9r0lnML72JPDXt3_7eMqp&t=1"
+      Request-Id:
+      - req_IBteVoE8MU3Yg6
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1Totf6IBOqvOFDrfoISlwFW1",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783033492,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Thu, 02 Jul 2026 23:04:52 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=You+bought+http%3A%2F%2Fedgare69a8efa25.test.gumroad.com%3A31337%2Fl%2Fj%21&metadata[purchase]=89_yTWoQ7_Lc0uPDgrNiig%3D%3D&transfer_group=583&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1Totf6IBOqvOFDrfoISlwFW1&statement_descriptor_suffix=edgare69a8efa25
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_IBteVoE8MU3Yg6","request_duration_ms":161}}'
+      Idempotency-Key:
+      - 339dcafc-1f98-4053-ad3a-da998788b04c
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 23:04:54 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1639'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=6RzF2YHK_JU8SOnRyPH0EaHhO8BsoPWchODNhibADpxJvdn2a_c8oU-ZSIz9r0lnML72JPDXt3_7eMqp;
+        report-to csp
+      Idempotency-Key:
+      - 339dcafc-1f98-4053-ad3a-da998788b04c
+      Original-Request:
+      - req_OSFLccdW24pPsM
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=6RzF2YHK_JU8SOnRyPH0EaHhO8BsoPWchODNhibADpxJvdn2a_c8oU-ZSIz9r0lnML72JPDXt3_7eMqp&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=6RzF2YHK_JU8SOnRyPH0EaHhO8BsoPWchODNhibADpxJvdn2a_c8oU-ZSIz9r0lnML72JPDXt3_7eMqp&t=1"
+      Request-Id:
+      - req_OSFLccdW24pPsM
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3Totf7IBOqvOFDrf13ten9oe",
+          "object": "payment_intent",
+          "amount": 100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 100,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3Totf7IBOqvOFDrf13ten9oe_secret_rQRRIZnvHPZc6wuAiKSjywIrg",
+          "confirmation_method": "automatic",
+          "created": 1783033493,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgare69a8efa25.test.gumroad.com:31337/l/j!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3Totf7IBOqvOFDrf1Uk0YDBn",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "89_yTWoQ7_Lc0uPDgrNiig=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1Totf6IBOqvOFDrfoISlwFW1",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgare69a8efa25",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "583"
+        }
+  recorded_at: Thu, 02 Jul 2026 23:04:54 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3Totf7IBOqvOFDrf1Uk0YDBn?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_OSFLccdW24pPsM","request_duration_ms":1247}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 23:04:54 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3793'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=6RzF2YHK_JU8SOnRyPH0EaHhO8BsoPWchODNhibADpxJvdn2a_c8oU-ZSIz9r0lnML72JPDXt3_7eMqp;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=6RzF2YHK_JU8SOnRyPH0EaHhO8BsoPWchODNhibADpxJvdn2a_c8oU-ZSIz9r0lnML72JPDXt3_7eMqp&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=6RzF2YHK_JU8SOnRyPH0EaHhO8BsoPWchODNhibADpxJvdn2a_c8oU-ZSIz9r0lnML72JPDXt3_7eMqp&t=1"
+      Request-Id:
+      - req_dk7VNL0xRku7O1
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3Totf7IBOqvOFDrf1Uk0YDBn",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3Totf7IBOqvOFDrf1YOHmS2D",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1783555200,
+            "balance_type": "payments",
+            "created": 1783033493,
+            "currency": "usd",
+            "description": "You bought http://edgare69a8efa25.test.gumroad.com:31337/l/j!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3Totf7IBOqvOFDrf1Uk0YDBn",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGARE69A8EFA2",
+          "captured": true,
+          "created": 1783033493,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgare69a8efa25.test.gumroad.com:31337/l/j!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "89_yTWoQ7_Lc0uPDgrNiig=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 51,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3Totf7IBOqvOFDrf13ten9oe",
+          "payment_method": "pm_1Totf6IBOqvOFDrfoISlwFW1",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "962176",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKJbdm9IGMgZbk6aN4cY6LBZkB29mhy2VdEpjW-4Lre-NtG5ZrBVhxXICtI7zIhF10wsMFuxeeOtRqiS7",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgare69a8efa25",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "583"
+        }
+  recorded_at: Thu, 02 Jul 2026 23:04:54 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/buyer-presentment_purchases/direct_refund_purchase_calls_processor-initiated_refunds_/derives_a_proportional_canonical_amount_for_a_partial_presentment_flow_of_funds.yml
+++ b/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/buyer-presentment_purchases/direct_refund_purchase_calls_processor-initiated_refunds_/derives_a_proportional_canonical_amount_for_a_partial_presentment_flow_of_funds.yml
@@ -1,0 +1,660 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_P3IDgQgHMZ77i4","request_duration_ms":322}}'
+      Idempotency-Key:
+      - 07710531-b40d-4e09-9c32-db123dc75468
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 22:58:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI;
+        report-to csp
+      Idempotency-Key:
+      - 07710531-b40d-4e09-9c32-db123dc75468
+      Original-Request:
+      - req_du3YkfwuB6FS6g
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI&t=1"
+      Request-Id:
+      - req_du3YkfwuB6FS6g
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TotZCIBOqvOFDrfBiL6LPnQ",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783033126,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Thu, 02 Jul 2026 22:58:46 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TotZCIBOqvOFDrfBiL6LPnQ
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_du3YkfwuB6FS6g","request_duration_ms":173}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 22:58:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI&t=1"
+      Request-Id:
+      - req_obgFhD2X9fC79C
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TotZCIBOqvOFDrfBiL6LPnQ",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783033126,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Thu, 02 Jul 2026 22:58:46 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=You+bought+http%3A%2F%2Fedgar79c39e9417.test.gumroad.com%3A31337%2Fl%2Fy%21&metadata[purchase]=FXikrf1Adkuch_KlgB1x4g%3D%3D&transfer_group=379&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1TotZCIBOqvOFDrfBiL6LPnQ&statement_descriptor_suffix=edgar79c39e9417
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_obgFhD2X9fC79C","request_duration_ms":172}}'
+      Idempotency-Key:
+      - e4b26af4-815b-4274-8d86-aebc6e444841
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 22:58:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1639'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI;
+        report-to csp
+      Idempotency-Key:
+      - e4b26af4-815b-4274-8d86-aebc6e444841
+      Original-Request:
+      - req_DXWTllhYXY0t1K
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI&t=1"
+      Request-Id:
+      - req_DXWTllhYXY0t1K
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3TotZCIBOqvOFDrf1dM2GOfa",
+          "object": "payment_intent",
+          "amount": 100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 100,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3TotZCIBOqvOFDrf1dM2GOfa_secret_f71bs5Ko98TGaOXLcpqq60Qoh",
+          "confirmation_method": "automatic",
+          "created": 1783033126,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgar79c39e9417.test.gumroad.com:31337/l/y!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3TotZCIBOqvOFDrf1hJOFain",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "FXikrf1Adkuch_KlgB1x4g=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1TotZCIBOqvOFDrfBiL6LPnQ",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar79c39e9417",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "379"
+        }
+  recorded_at: Thu, 02 Jul 2026 22:58:47 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TotZCIBOqvOFDrf1hJOFain?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_DXWTllhYXY0t1K","request_duration_ms":868}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 22:58:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3793'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI&t=1"
+      Request-Id:
+      - req_a7waPEcme2KUje
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TotZCIBOqvOFDrf1hJOFain",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TotZCIBOqvOFDrf1fYdmGTE",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1783555200,
+            "balance_type": "payments",
+            "created": 1783033126,
+            "currency": "usd",
+            "description": "You bought http://edgar79c39e9417.test.gumroad.com:31337/l/y!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3TotZCIBOqvOFDrf1hJOFain",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR79C39E941",
+          "captured": true,
+          "created": 1783033126,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar79c39e9417.test.gumroad.com:31337/l/y!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "FXikrf1Adkuch_KlgB1x4g=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 24,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TotZCIBOqvOFDrf1dM2GOfa",
+          "payment_method": "pm_1TotZCIBOqvOFDrfBiL6LPnQ",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "560742",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKKfam9IGMgYFfjs8kFU6LBYDTmv_EmTDW05Oi9x-87f391zqnmrsJGYWoEbTrWRPORqMDHqAJKngABw7",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar79c39e9417",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "379"
+        }
+  recorded_at: Thu, 02 Jul 2026 22:58:47 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/buyer-presentment_purchases/direct_refund_purchase_calls_processor-initiated_refunds_/derives_the_canonical_amount_and_snapshot_from_a_presentment_flow_of_funds.yml
+++ b/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/buyer-presentment_purchases/direct_refund_purchase_calls_processor-initiated_refunds_/derives_the_canonical_amount_and_snapshot_from_a_presentment_flow_of_funds.yml
@@ -1,0 +1,660 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_7u3kQjjwsJdKru","request_duration_ms":0}}'
+      Idempotency-Key:
+      - 501938dc-df13-40e0-903b-359b54dd4678
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 22:58:43 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI;
+        report-to csp
+      Idempotency-Key:
+      - 501938dc-df13-40e0-903b-359b54dd4678
+      Original-Request:
+      - req_PeDB310pDVszGu
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI&t=1"
+      Request-Id:
+      - req_PeDB310pDVszGu
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TotZ9IBOqvOFDrfYnPLx4Uj",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783033123,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Thu, 02 Jul 2026 22:58:43 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TotZ9IBOqvOFDrfYnPLx4Uj
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_PeDB310pDVszGu","request_duration_ms":294}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 22:58:44 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI&t=1"
+      Request-Id:
+      - req_osV1Ya4LA540vi
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TotZ9IBOqvOFDrfYnPLx4Uj",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783033123,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Thu, 02 Jul 2026 22:58:44 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=You+bought+http%3A%2F%2Fedgar63bbd23c13.test.gumroad.com%3A31337%2Fl%2Fn%21&metadata[purchase]=HcwgaF7MKAKnqzZKs3121Q%3D%3D&transfer_group=378&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1TotZ9IBOqvOFDrfYnPLx4Uj&statement_descriptor_suffix=edgar63bbd23c13
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_osV1Ya4LA540vi","request_duration_ms":145}}'
+      Idempotency-Key:
+      - 93490fc2-36b4-40b9-88bf-60d9dad37801
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 22:58:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1639'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI;
+        report-to csp
+      Idempotency-Key:
+      - 93490fc2-36b4-40b9-88bf-60d9dad37801
+      Original-Request:
+      - req_Rr67n6Jref8bhm
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI&t=1"
+      Request-Id:
+      - req_Rr67n6Jref8bhm
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3TotZAIBOqvOFDrf1d79T9IZ",
+          "object": "payment_intent",
+          "amount": 100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 100,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3TotZAIBOqvOFDrf1d79T9IZ_secret_xITqp2f4TuNA0oUdavKWFcYGX",
+          "confirmation_method": "automatic",
+          "created": 1783033124,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgar63bbd23c13.test.gumroad.com:31337/l/n!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3TotZAIBOqvOFDrf15JNQuVD",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "HcwgaF7MKAKnqzZKs3121Q=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1TotZ9IBOqvOFDrfYnPLx4Uj",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar63bbd23c13",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "378"
+        }
+  recorded_at: Thu, 02 Jul 2026 22:58:45 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TotZAIBOqvOFDrf15JNQuVD?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_Rr67n6Jref8bhm","request_duration_ms":878}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 22:58:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3793'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI&t=1"
+      Request-Id:
+      - req_P3IDgQgHMZ77i4
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TotZAIBOqvOFDrf15JNQuVD",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TotZAIBOqvOFDrf1sZLCXqi",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1783555200,
+            "balance_type": "payments",
+            "created": 1783033124,
+            "currency": "usd",
+            "description": "You bought http://edgar63bbd23c13.test.gumroad.com:31337/l/n!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3TotZAIBOqvOFDrf15JNQuVD",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR63BBD23C1",
+          "captured": true,
+          "created": 1783033124,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar63bbd23c13.test.gumroad.com:31337/l/n!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "HcwgaF7MKAKnqzZKs3121Q=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 11,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TotZAIBOqvOFDrf1d79T9IZ",
+          "payment_method": "pm_1TotZ9IBOqvOFDrfYnPLx4Uj",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "111372",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKKXam9IGMgYHg92IuV86LBZZOU5N5fTzZ5iXg9By0P4BDRNy5VHktIkEdMWmDQzBfQ-Wnir6jsYKya0k",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar63bbd23c13",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "378"
+        }
+  recorded_at: Thu, 02 Jul 2026 22:58:45 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/buyer-presentment_purchases/direct_refund_purchase_calls_processor-initiated_refunds_/fails_closed_when_the_flow_of_funds_is_not_in_the_presentment_currency.yml
+++ b/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/buyer-presentment_purchases/direct_refund_purchase_calls_processor-initiated_refunds_/fails_closed_when_the_flow_of_funds_is_not_in_the_presentment_currency.yml
@@ -1,0 +1,660 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_a7waPEcme2KUje","request_duration_ms":325}}'
+      Idempotency-Key:
+      - f3c4fcdb-6f37-4b76-870c-4b943a460c96
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 22:58:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI;
+        report-to csp
+      Idempotency-Key:
+      - f3c4fcdb-6f37-4b76-870c-4b943a460c96
+      Original-Request:
+      - req_s66aiq5IbkVXjt
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI&t=1"
+      Request-Id:
+      - req_s66aiq5IbkVXjt
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TotZEIBOqvOFDrfzBDY7TFS",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783033128,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Thu, 02 Jul 2026 22:58:48 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TotZEIBOqvOFDrfzBDY7TFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_s66aiq5IbkVXjt","request_duration_ms":177}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 22:58:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI&t=1"
+      Request-Id:
+      - req_oFJSDyf8ak1JvQ
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TotZEIBOqvOFDrfzBDY7TFS",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783033128,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Thu, 02 Jul 2026 22:58:48 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=You+bought+http%3A%2F%2Fedgar0866ee4b21.test.gumroad.com%3A31337%2Fl%2Fe%21&metadata[purchase]=ZFQLZ-T-3Dsi1dXG7GqCpw%3D%3D&transfer_group=380&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1TotZEIBOqvOFDrfzBDY7TFS&statement_descriptor_suffix=edgar0866ee4b21
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_oFJSDyf8ak1JvQ","request_duration_ms":161}}'
+      Idempotency-Key:
+      - a2d45c40-0465-4c96-9916-e6a7589103e9
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 22:58:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1639'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI;
+        report-to csp
+      Idempotency-Key:
+      - a2d45c40-0465-4c96-9916-e6a7589103e9
+      Original-Request:
+      - req_fJre2niFitecDG
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI&t=1"
+      Request-Id:
+      - req_fJre2niFitecDG
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3TotZEIBOqvOFDrf08vzMLaR",
+          "object": "payment_intent",
+          "amount": 100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 100,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3TotZEIBOqvOFDrf08vzMLaR_secret_90WHiSSgOt7iTaqL8dxxU4iYT",
+          "confirmation_method": "automatic",
+          "created": 1783033128,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgar0866ee4b21.test.gumroad.com:31337/l/e!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3TotZEIBOqvOFDrf0vW56MVC",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "ZFQLZ-T-3Dsi1dXG7GqCpw=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1TotZEIBOqvOFDrfzBDY7TFS",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar0866ee4b21",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "380"
+        }
+  recorded_at: Thu, 02 Jul 2026 22:58:49 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TotZEIBOqvOFDrf0vW56MVC?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_fJre2niFitecDG","request_duration_ms":1064}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Sahils-MacBook-Pro-2.local 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27
+        20:39:42 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"Sahils-MacBook-Pro-2.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 02 Jul 2026 22:58:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3792'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=P_jMvbjdn27JuTqubnM0vc4e_U8Sea8OASUSTrBcsIoL9mycsp2IXyEBcNMg6OWwWAU12K1fpg76g3TI&t=1"
+      Request-Id:
+      - req_EAVWhuQuA8jiuO
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TotZEIBOqvOFDrf0vW56MVC",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TotZEIBOqvOFDrf0pJavEHN",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1783555200,
+            "balance_type": "payments",
+            "created": 1783033128,
+            "currency": "usd",
+            "description": "You bought http://edgar0866ee4b21.test.gumroad.com:31337/l/e!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3TotZEIBOqvOFDrf0vW56MVC",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR0866EE4B2",
+          "captured": true,
+          "created": 1783033128,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar0866ee4b21.test.gumroad.com:31337/l/e!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "ZFQLZ-T-3Dsi1dXG7GqCpw=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 2,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TotZEIBOqvOFDrf08vzMLaR",
+          "payment_method": "pm_1TotZEIBOqvOFDrfzBDY7TFS",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "875953",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKKnam9IGMgY-0_iYFto6LBZjTtp_UQSL68Tx5o6xkWiAs8v_8s-ne6FHQljf0n3CvbV_re2fmRBCBW89",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar0866ee4b21",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "380"
+        }
+  recorded_at: Thu, 02 Jul 2026 22:58:49 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## What

Follow-up to #5687 (merged before Greptile's review landed), fixing the P1 it raised plus a related webhook gate bug: direct callers of `refund_purchase!` — the `charge.refund.updated` webhook (`Charge::Refundable#handle_event_refund_updated!`), settlement declines (`Purchase::ChargeEventsHandler`), and the PayPal processor — pass only the processor flow of funds, which for buyer-presentment purchases is denominated in the buyer's currency.

Three fixes:

1. **`refund_purchase!` derives canonical amounts for presentment purchases.** When a buyer-presentment purchase gets a direct call without `canonical_gross_refund_cents:`, the new `Purchase::PresentmentRefund.from_presentment_amount` inverse-maps the buyer-currency flow-of-funds amount to canonical USD gross refund cents (largest-remainder allocation, clamped to remaining amounts) plus the presentment snapshot. If the flow of funds isn't in the presentment currency or no consistent derivation exists, the refund fails closed with an `ErrorNotifier` notification instead of booking buyer-currency cents as canonical USD.
2. **`charge.refund.updated` full-refund gate compares presentment cents.** Stripe reports `refunded_amount_cents` in the charge currency; comparing it against canonical `refundable_amount_cents` never matched for presentment charges, silently dropping full processor refunds before the derivation path could even run. The gate now compares against the presentment total when one exists.
3. **Partial derivations allocate against remaining balances** (not original totals), so rounding across repeated partial refunds can't exhaust the canonical refundable amount while a final presentment cent is still outstanding.

PayPal purchases are unaffected — `purchase_presentment` only exists on the Stripe PaymentIntent presentment path, so `buyer_presentment?` is false and the existing fallback behavior is unchanged.

## Why

Without this, a processor-initiated CAD/EUR refund would record buyer-currency cents as canonical USD in the refund row and skip the presentment snapshot — so refunded presentment cents look like zero to later allocations, which can over-refund (Greptile P1 on #5687, review 4621594687).

## Test plan

Ran locally:

- `bundle exec rspec spec/services/purchase/presentment_refund_spec.rb` — 10 examples, 0 failures (5 new `.from_presentment_amount` examples incl. the repeated-partials rounding regression)
- `bundle exec rspec spec/models/purchase/purchase_refunds_spec.rb -e "buyer-presentment purchases"` — 9 examples, 0 failures (3 new direct-call examples, 2 new webhook-gate examples)
- `bundle exec rspec spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb` `charge.refund.updated` examples — 4 examples, 0 failures
- `bundle exec rubocop` on all touched files — no offenses

Autoreview (Codex, branch mode vs origin/main): clean after fixing one accepted P1 (partial allocation against remaining balances, commit 3).

## AI disclosure

Authored by an AI agent (Claude via Hermes) end to end: analysis, code, specs, local test runs, and Codex autoreview iteration.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5689"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785625861&installation_id=134400930&pr_number=5689&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5689&signature=b5defb818af76c44e7d4c2c30e2c888161988f60f5756b20221754a3a6f3f33f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->