### PR TITLE
docs: update resubscribe step in help article for new confirmation page

### DIFF
--- a/app/views/help_center/articles/contents/_211-im-not-receiving-updates.html.erb
+++ b/app/views/help_center/articles/contents/_211-im-not-receiving-updates.html.erb
@@ -8,7 +8,7 @@
   </ul>
   <p>Then click “Unsubscribe” in the receipt’s footer.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/624c282f56ed31630f6ed9a5/file-XzaFg8H3IH.png" %></figure>
-  <p>Click “here” on the next page to resubscribe.</p>
+  <p>Click “here” on the next page, then click the “Resubscribe” button to confirm. You will start receiving the creator’s posts and updates again.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/624c2856309f633fb1e2a5e5/file-LLT2yZTxUt.png" %></figure>
   <h3>Check your Library</h3>
   <p>To see all of your product updates, <a href="https://gumroad.com/signup">create a Gumroad account</a> with the same email as your purchases (if you don't have an account already).</p>


### PR DESCRIPTION
## What

Updates the "I'm not receiving updates" help article (`211-im-not-receiving-updates`) to reflect the new resubscribe confirmation step.

## Why

PR #5688 changed the resubscribe flow: clicking the resubscribe link no longer re-opts the buyer in immediately. The link now lands on a confirmation page, and the buyer must click a "Resubscribe" button to confirm. The article previously said clicking "here" resubscribes directly, which is now inaccurate.

## Changes

- `_211-im-not-receiving-updates.html.erb`: one line — the resubscribe step now mentions the confirmation button.

No `articles.yml` changes (title/description unchanged). No article removals. No policy/pricing/tax/payout wording touched.

## Test plan

- Copy-only change to an article body partial; slug and YAML entry untouched, so help-center integrity specs are unaffected. CI runs the full suite.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785628047&installation_id=134400930&pr_number=5690&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5690&signature=857fc7275a9e4474078afb50fa0f31a3f21df27015de5d2bc36f66f969ce5b94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->