### PR TITLE
feat(checkout): launch Stripe Link on the client-confirm path (U9)

### DIFF
--- a/app/javascript/components/Checkout/payment.ts
+++ b/app/javascript/components/Checkout/payment.ts
@@ -42,11 +42,12 @@ export type PaymentElementConfig = {
   stripe_link_enabled: boolean;
 };
 // Client-confirm checkout mints a ConfirmationToken from the Payment Element, so it omits
-// payment_method_creation and stays in one-time payment mode.
+// payment_method_creation and stays in one-time payment mode. The method list is server-resolved
+// (card always; link per-seller) — the client never widens it.
 export type PaymentElementClientConfirmConfig = {
   stripe_elements_mode: typeof STRIPE_ELEMENTS_MODE_FOR_PAYMENT_INTENT;
   currency: "usd";
-  payment_method_types: ["card"];
+  payment_method_types: string[];
   stripe_link_enabled: boolean;
   stripe_connect_account_id: string | null;
 };

--- a/app/presenters/checkout/stripe_payment_presenter.rb
+++ b/app/presenters/checkout/stripe_payment_presenter.rb
@@ -119,7 +119,9 @@ class Checkout::StripePaymentPresenter
           stripe_elements_mode: STRIPE_ELEMENTS_MODE_FOR_PAYMENT_INTENT,
           currency: CLIENT_CONFIRM_CURRENCY,
           payment_method_types: resolution.payment_method_types,
-          stripe_link_enabled: sellers.all? { Feature.active?(STRIPE_PAYMENT_ELEMENT_LINK_FEATURE_NAME, _1) },
+          # Derived from the resolved method set (not a second flag read) so the Link toggle and the
+          # deferred intent's payment_method_types cannot drift.
+          stripe_link_enabled: resolution.stripe_link_enabled?,
           stripe_connect_account_id: resolution.stripe_connect_account_id,
         },
       }

--- a/app/services/checkout/payment_method_resolver.rb
+++ b/app/services/checkout/payment_method_resolver.rb
@@ -9,10 +9,10 @@
 #   - eligible_payment_method_types: the policy set the cart *could* use (the eligibility-by-product-type
 #     policy). This is the logged decision and what later units intersect with per-method launch/PPP gates.
 #   - payment_method_types: what Stripe actually receives on the client-confirmed path today. Only card
-#     is launched, because the other methods need machinery that isn't built yet: redirect methods need
-#     the server return page + allow_redirects, delayed-notification methods need the PaymentIntent
-#     webhook lifecycle, and inline wallets/Link need frontend verification. Widening
-#     LAUNCHED_PAYMENT_METHOD_TYPES is a later unit's job.
+#     is launched unconditionally; Link joins it per-seller behind :stripe_payment_element_link, reusing
+#     Lane A's flag so the two lanes launch Link together. The remaining methods need machinery that
+#     isn't built yet: redirect methods need allow_redirects enablement, and delayed-notification
+#     methods need pending UX. Widening the launched set further is a later unit's job.
 #
 # Handshake note: the deferred PaymentIntent's payment_method_types must equal the Payment Element's or
 # Stripe rejects the ConfirmationToken (which is payment_method_types-scoped, so it also can't be
@@ -29,13 +29,19 @@ class Checkout::PaymentMethodResolver
   ONE_TIME_PAYMENT_METHOD_TYPES = %w[card link klarna afterpay_clearpay affirm ideal bancontact cashapp].freeze
   # Afterpay/Clearpay and Affirm are one-time, buyer-present only, so a recurring lifecycle drops them.
   RECURRING_INELIGIBLE_PAYMENT_METHOD_TYPES = %w[afterpay_clearpay affirm].freeze
-  # Only card is launched on the client-confirmed path today; later units widen this (see class comment).
+  # Card is always launched on the client-confirmed path; later units widen this (see class comment).
   LAUNCHED_PAYMENT_METHOD_TYPES = %w[card].freeze
+  # Link launches per-seller behind Lane A's existing flag (see #launched_payment_method_types).
+  LINK_PAYMENT_METHOD_TYPE = "link"
   # Multi-seller and other Lane A carts keep Gumroad's existing card + PayPal set.
   LANE_A_PAYMENT_METHOD_TYPES = %w[card paypal].freeze
 
   Resolution = Data.define(:client_confirm_eligible, :payment_method_types, :eligible_payment_method_types, :fallback_reason, :stripe_connect_account_id) do
     def client_confirm_eligible? = client_confirm_eligible
+
+    # One source of truth for the Payment Element's Link toggle: Link renders iff the intent will
+    # accept a link-type payment method, so the Element and the deferred intent cannot drift.
+    def stripe_link_enabled? = Array(payment_method_types).include?(LINK_PAYMENT_METHOD_TYPE)
   end
 
   def initialize(sellers:, recurring: false, commission: false, setup_for_future: false)
@@ -53,7 +59,7 @@ class Checkout::PaymentMethodResolver
         client_confirm_eligible: reason.nil?,
         # Nil on Lane A carts: they never mount the client-confirmed Payment Element, so there is no
         # Stripe method list to hand them. Non-nil only when the cart confirms client-side.
-        payment_method_types: reason.nil? ? eligible & LAUNCHED_PAYMENT_METHOD_TYPES : nil,
+        payment_method_types: reason.nil? ? eligible & launched_payment_method_types : nil,
         eligible_payment_method_types: eligible,
         fallback_reason: reason,
         stripe_connect_account_id: reason.nil? ? stripe_connect_account_id : nil
@@ -92,6 +98,22 @@ class Checkout::PaymentMethodResolver
       methods = ONE_TIME_PAYMENT_METHOD_TYPES
       methods -= RECURRING_INELIGIBLE_PAYMENT_METHOD_TYPES if recurring
       methods
+    end
+
+    # The launched set is per-seller: Link requires the seller-scoped :stripe_payment_element_link
+    # flag (the same flag that gates Link on the server-confirm lane, so both lanes move together).
+    # PPP note: a Link payment method has no card country in the ConfirmationToken preview, so a
+    # PPP-discounted purchase paid via Link fails the existing card-country check (fails closed,
+    # buyer retries with a card). The PPP method matrix (U13) will gate Link out of PPP checkouts
+    # pre-render instead.
+    def launched_payment_method_types
+      return LAUNCHED_PAYMENT_METHOD_TYPES unless link_launched?
+
+      LAUNCHED_PAYMENT_METHOD_TYPES + [LINK_PAYMENT_METHOD_TYPE]
+    end
+
+    def link_launched?
+      sellers.one? && Feature.active?(Checkout::StripePaymentPresenter::STRIPE_PAYMENT_ELEMENT_LINK_FEATURE_NAME, sellers.first)
     end
 
     def log_decision(resolution)

--- a/spec/presenters/checkout/stripe_payment_presenter_spec.rb
+++ b/spec/presenters/checkout/stripe_payment_presenter_spec.rb
@@ -45,7 +45,8 @@ describe Checkout::StripePaymentPresenter do
       elements_options: {
         stripe_elements_mode: described_class::STRIPE_ELEMENTS_MODE_FOR_PAYMENT_INTENT,
         currency: "usd",
-        payment_method_types: ["card"],
+        # Link's launch widens the intent's method list itself — the toggle and the list move together.
+        payment_method_types: stripe_link_enabled ? %w[card link] : ["card"],
         stripe_link_enabled:,
         stripe_connect_account_id:,
       },

--- a/spec/services/checkout/payment_method_resolver_spec.rb
+++ b/spec/services/checkout/payment_method_resolver_spec.rb
@@ -38,6 +38,37 @@ describe Checkout::PaymentMethodResolver do
       it "returns an explicit list of method-type strings, never Stripe's automatic_payment_methods shape" do
         expect(resolve.payment_method_types).to be_an(Array).and(all(be_a(String)))
       end
+
+      it "does not report Link enabled without the Link flag" do
+        expect(resolve.stripe_link_enabled?).to be(false)
+      end
+    end
+
+    context "with the seller-scoped Link flag active" do
+      before { Feature.activate_user(Checkout::StripePaymentPresenter::STRIPE_PAYMENT_ELEMENT_LINK_FEATURE_NAME, seller) }
+
+      it "launches link alongside card so the Element and the deferred intent widen together" do
+        resolution = resolve
+
+        expect(resolution.payment_method_types).to eq(%w[card link])
+        expect(resolution.stripe_link_enabled?).to be(true)
+      end
+
+      it "keeps link out of the launched set for another (unflagged) seller" do
+        other = create(:user)
+
+        resolution = described_class.new(sellers: [other]).resolve
+
+        expect(resolution.payment_method_types).to eq(["card"])
+        expect(resolution.stripe_link_enabled?).to be(false)
+      end
+
+      it "still reports no methods and no Link on an ineligible cart" do
+        resolution = resolve(recurring: true)
+
+        expect(resolution.payment_method_types).to be_nil
+        expect(resolution.stripe_link_enabled?).to be(false)
+      end
     end
 
     context "with a recurring (subscription) lifecycle" do


### PR DESCRIPTION
Implements step 5 (plan unit U9) of #5640 — inline method expansion, first method: **Stripe Link** on the client-confirmed Intent path.

## What this does

Widens the resolver's launched set to `["card", "link"]` for sellers with the seller-scoped `:stripe_payment_element_link` flag — the **same flag that gates Link on the server-confirm lane** (#5614), so both lanes launch Link together per seller.

The key invariant (step 1: *the deferred PaymentIntent's `payment_method_types` must equal the Payment Element's*) now holds **by construction for Link too**:

- `Checkout::PaymentMethodResolver` owns the launch decision (`launched_payment_method_types`, per-seller)
- `Resolution#stripe_link_enabled?` derives the Element's Link toggle **from the resolved method list itself** — the presenter no longer does a second independent flag read, so the toggle and the intent's method list cannot drift
- `Order::PreparePaymentIntentService` already reads the same resolver (since #5665), so the deferred intent automatically carries `["card", "link"]` for flagged sellers — no changes needed there
- Frontend Link plumbing (`wallets.link: "auto"`, debounced contact prefill) is **reused unchanged** from #5614 per the issue's "verify, do not rebuild" mandate

## Why this closes a real gap (not just enablement)

Before this PR, a flagged seller's client-confirm checkout rendered the Link UI (`stripe_link_enabled` was an independent flag read) while the deferred intent stayed `["card"]` — a buyer who actually paid via Link would mint a `link`-type payment method against a card-only intent and **fail at the confirm handshake**. Deriving the toggle from the resolved list makes that state unrepresentable.

## Behavior

- Seller with Link flag + client-confirm flags → Element shows Link, intent accepts `["card", "link"]`
- Seller without Link flag → byte-for-byte unchanged (`["card"]`, no Link)
- Ineligible carts (recurring/commission/multi-seller/setup) → unchanged Lane A fallback, `stripe_link_enabled?` false
- **PPP note** (documented in the resolver): a Link payment method carries no `card.country` in the ConfirmationToken preview, so a PPP-discounted purchase paid via Link fails the existing card-country check — fails **closed** (buyer retries with a card). The PPP method matrix (U13/step 8) will gate Link out of PPP checkouts pre-render.

## Testing

- Resolver specs: Link launched with flag (`["card","link"]` + `stripe_link_enabled?`), unflagged seller stays card-only, ineligible carts report no Link, per-seller isolation
- Presenter specs: client-confirm props carry `["card","link"]` iff Link flag active (existing Link expectation updated — the toggle and list now move together)
- 56 examples, 0 failures locally (resolver + presenter suites)
- Manual test plan: posted as a comment below — covers this PR plus regression testing of all previously merged client-confirm work (#5635/#5656/#5665/#5664/#5673) on this preview, including country simulation via foreign-issued Stripe test cards and 3DS.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5691"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785628482&installation_id=134400930&pr_number=5691&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5691&signature=5df925c3f6da0c3152dfa3d9b44572b43be1b2dcd504c9691054703dcfff881e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->