### PR TITLE
Accept Zengin corporate-abbreviation symbols in JP bank account holder names

### DIFF
--- a/app/javascript/components/Settings/PaymentsPage/BankAccountSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/BankAccountSection.tsx
@@ -956,7 +956,7 @@ const BankAccountSection = ({
     // are accepted here and normalized server-side (JapanBankAccount).
     const isKatakanaOnly =
       /^(?=.*[\p{Script=Katakana}])[\p{Script=Katakana}ー・\uFF65-\uFF9F\u3000 0-9().\-/０-９（）．－／]+$/u.test(name);
-    const isLatinOnly = /^(?=.*[A-Za-z])[A-Za-z 0-9().\-/]+$/u.test(name);
+    const isLatinOnly = /^(?=.*[A-Za-z])[A-Za-z 0-9().\-/０-９（）．－／]+$/u.test(name);
     if (isKatakanaOnly || isLatinOnly) return null;
     return "Use either katakana or Latin letters — not both.";
   })();

--- a/app/javascript/components/Settings/PaymentsPage/BankAccountSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/BankAccountSection.tsx
@@ -950,8 +950,13 @@ const BankAccountSection = ({
     if (!holderNameTouched) return null;
     const name = bankAccount?.account_holder_full_name?.trim() ?? "";
     if (name === "") return null;
-    const isKatakanaOnly = /^[\p{Script=Katakana}ー・\uFF65-\uFF9F\u3000 ]+$/u.test(name);
-    const isLatinOnly = /^[A-Za-z ]+$/u.test(name);
+    // Zengin-format account names also allow digits and the symbols ( ) . - / —
+    // Japanese corporate accounts are registered with an entity-type abbreviation
+    // and a parenthesis, e.g. カ)～ (株式会社), ド)～ (合同会社). Full-width variants
+    // are accepted here and normalized server-side (JapanBankAccount).
+    const isKatakanaOnly =
+      /^(?=.*[\p{Script=Katakana}])[\p{Script=Katakana}ー・\uFF65-\uFF9F\u3000 0-9().\-/０-９（）．－／]+$/u.test(name);
+    const isLatinOnly = /^(?=.*[A-Za-z])[A-Za-z 0-9().\-/]+$/u.test(name);
     if (isKatakanaOnly || isLatinOnly) return null;
     return "Use either katakana or Latin letters — not both.";
   })();

--- a/app/models/japan_bank_account.rb
+++ b/app/models/japan_bank_account.rb
@@ -14,11 +14,23 @@ class JapanBankAccount < BankAccount
   ACCOUNT_NUMBER_FORMAT_REGEX = /\A[0-9]{4,8}\z/
   private_constant :ACCOUNT_NUMBER_FORMAT_REGEX
 
-  KATAKANA_NAME_FORMAT_REGEX = /\A[\p{Katakana}ー・\uFF65-\uFF9F\u3000]+\z/
+  # Zengin-format account names allow katakana, digits, and the symbols ( ) . - /
+  # (plus space). Japanese corporate accounts are registered with the entity-type
+  # abbreviation and a parenthesis — e.g. カ)～ (株式会社), ド)～ (合同会社) — so the
+  # symbol set is required, not optional. Full-width variants are normalized to the
+  # half-width forms Zengin/Stripe expect (see stripped_fields transform below).
+  ZENGIN_SYMBOLS_AND_DIGITS = "0-9().\\-\\/"
+  private_constant :ZENGIN_SYMBOLS_AND_DIGITS
+
+  KATAKANA_NAME_FORMAT_REGEX = /\A(?=.*[\p{Katakana}\uFF66-\uFF9F])[\p{Katakana}ー・\uFF65-\uFF9F\u3000#{ZENGIN_SYMBOLS_AND_DIGITS}]+\z/
   private_constant :KATAKANA_NAME_FORMAT_REGEX
 
-  LATIN_NAME_FORMAT_REGEX = /\A[A-Za-z ]+\z/
+  LATIN_NAME_FORMAT_REGEX = /\A(?=.*[A-Za-z])[A-Za-z #{ZENGIN_SYMBOLS_AND_DIGITS}]+\z/
   private_constant :LATIN_NAME_FORMAT_REGEX
+
+  # Full-width digits/symbols → the half-width equivalents Zengin uses.
+  FULL_WIDTH_TO_HALF_WIDTH = ["０-９（）．－／", "0-9().-/"].freeze
+  private_constant :FULL_WIDTH_TO_HALF_WIDTH
 
   alias_attribute :bank_code, :bank_number
 
@@ -26,8 +38,15 @@ class JapanBankAccount < BankAccount
                   remove_duplicate_spaces: false,
                   nilify_blanks: false,
                   transform: ->(value) {
-                    full_width = value.tr(" ", "　")
-                    KATAKANA_NAME_FORMAT_REGEX.match?(full_width) ? full_width : value
+                    normalized = value.tr(*FULL_WIDTH_TO_HALF_WIDTH)
+                    full_width = normalized.tr(" ", "　")
+                    if KATAKANA_NAME_FORMAT_REGEX.match?(full_width)
+                      full_width
+                    elsif LATIN_NAME_FORMAT_REGEX.match?(normalized)
+                      normalized
+                    else
+                      value
+                    end
                   }
 
   validate :validate_bank_code

--- a/spec/models/japan_bank_account_spec.rb
+++ b/spec/models/japan_bank_account_spec.rb
@@ -110,6 +110,36 @@ describe JapanBankAccount do
       expect(account.account_holder_full_name).to eq("Masashi Haruna")
     end
 
+    it "accepts Zengin corporate-abbreviation names with parentheses (the incident case)" do
+      expect(build(:japan_bank_account, account_holder_full_name: "ド)エイチケー")).to be_valid
+      expect(build(:japan_bank_account, account_holder_full_name: "カ)テスト")).to be_valid
+      expect(build(:japan_bank_account, account_holder_full_name: "エイチケー(ド")).to be_valid
+      expect(build(:japan_bank_account, account_holder_full_name: "ﾄﾞ)ｴｲﾁｹｰ")).to be_valid
+    end
+
+    it "accepts Zengin digits and symbols alongside katakana or Latin letters" do
+      expect(build(:japan_bank_account, account_holder_full_name: "テスト2ゴウ")).to be_valid
+      expect(build(:japan_bank_account, account_holder_full_name: "シャ)テスト.コー-1/2")).to be_valid
+      expect(build(:japan_bank_account, account_holder_full_name: "HK LLC.")).to be_valid
+      expect(build(:japan_bank_account, account_holder_full_name: "Test-Co / 2")).to be_valid
+    end
+
+    it "normalizes full-width parentheses, digits, and symbols to the half-width forms Zengin uses" do
+      account = build(:japan_bank_account, account_holder_full_name: "ド）エイチケー")
+      expect(account).to be_valid
+      expect(account.account_holder_full_name).to eq("ド)エイチケー")
+
+      account = build(:japan_bank_account, account_holder_full_name: "テスト２ゴウ")
+      expect(account).to be_valid
+      expect(account.account_holder_full_name).to eq("テスト2ゴウ")
+    end
+
+    it "rejects names that are only digits or symbols with no katakana or Latin letters" do
+      expect(build(:japan_bank_account, account_holder_full_name: ")")).to_not be_valid
+      expect(build(:japan_bank_account, account_holder_full_name: "123")).to_not be_valid
+      expect(build(:japan_bank_account, account_holder_full_name: "().-/")).to_not be_valid
+    end
+
     it "rejects scripts outside the two allowed variants" do
       expect(build(:japan_bank_account, account_holder_full_name: "Haruna マサシ")).to_not be_valid
       expect(build(:japan_bank_account, account_holder_full_name: "春奈 正志")).to_not be_valid


### PR DESCRIPTION
Ref antiwork/gumroad-private/issues/869

## What

Japanese corporate bank accounts are registered under the standard Zengin abbreviation form — e.g. `カ)` for 株式会社 (KK), `ド)` for 合同会社 (GK), `ユ)` for 有限会社 (YK) — but the JP holder-name validation only accepted *pure* katakana or *pure* Latin letters. The parenthesis isn't in either character class, so **every Japanese business seller's official account name failed** with "Use either katakana or Latin letters — not both.", blocking payout setup.

This PR extends both the model (`JapanBankAccount`) and client (`BankAccountSection.tsx`) regexes to the Zengin account-name symbol set — digits `0-9` and `( ) . - /` — in both the katakana and Latin branches, while requiring at least one katakana/Latin character so symbol-only or digit-only names are still rejected. Full-width digits/symbols (`（）．－／０-９`) are normalized at the model layer to the half-width forms Zengin/Stripe expect — the same approach #4961 took for ASCII→full-width spaces on this field.

## Why

The Zengin charset for account names allows half/full-width katakana, digits, uppercase Latin, and `( ) . - /`. The corporate-abbreviation form with the parenthesis is not an edge case — it is the *required* registered account name for JP corporations, so the old validation locked out effectively all JP business (KK/GK/YK) sellers. Reported by a real seller whose registered name `ド)エイチケー` was rejected in both katakana and Latin attempts (see the private issue for ticket/user details).

## Test plan

- `spec/models/japan_bank_account_spec.rb` — new examples covering:
  - the incident name `ド)エイチケー`, `カ)テスト`, suffix form `エイチケー(ド`, half-width katakana `ﾄﾞ)ｴｲﾁｹｰ`
  - digits/symbols alongside katakana (`テスト2ゴウ`, `シャ)テスト.コー-1/2`) and Latin (`HK LLC.`, `Test-Co / 2`)
  - full-width → half-width normalization (`ド）エイチケー` → `ド)エイチケー`, `テスト２ゴウ` → `テスト2ゴウ`)
  - rejection of symbol-only/digit-only names and unchanged rejection of mixed scripts, hiragana, kanji
- Ran locally: `bundle exec rspec spec/models/japan_bank_account_spec.rb` → **21 examples, 0 failures**; `spec/services/update_payout_method_spec.rb` → **14 examples, 0 failures**. Rubocop and eslint clean; tsc has no new errors.
- Client regexes verified against the same case table in Node (accepts `ド)エイチケー`, `ド）エイチケー`, `ﾄﾞ)ｴｲﾁｹｰ`; rejects `)`, `ド)HK`, `はるな`).

Stripe's own guidance requires the entity-type abbreviation in the registered account name ("For corporate entities, include the entity type (such as カ) before the business name in Katakana" — [Stripe support](https://support.stripe.com/questions/can-i-receive-payouts-to-japan-post-bank)), so the extended set is what Stripe's JP external-account API expects to receive. If Stripe still rejects a specific name on sync, the existing `incorrect_account_holder_name` handling (seller email notification) covers it.

No UI layout changes — only the client-side validation regex behind the existing inline error message.

---

This PR was implemented with AI assistance using Claude Fable 5.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785679954&installation_id=134400930&pr_number=5694&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5694&signature=1634cb92c06d1eda0747fb43ef87c3713ac1ea508401e63eb47e5320584d17bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->