### PR TITLE
Record processor-initiated partial refunds from the charge.refund.updated webhook

### DIFF
--- a/app/models/concerns/charge/refundable.rb
+++ b/app/models/concerns/charge/refundable.rb
@@ -21,7 +21,27 @@ module Charge::Refundable
       # Stripe reports refunded_amount_cents in the charge currency, which for
       # buyer-presentment charges is the buyer's currency, not canonical USD.
       expected_refunded_amount_cents = refundable.presentment_refundable_amount_cents || refundable.refundable_amount_cents
-      return unless event.extras[:refunded_amount_cents] == expected_refunded_amount_cents
+      refunded_amount_cents = event.extras[:refunded_amount_cents].to_i
+      return unless refunded_amount_cents > 0 && refunded_amount_cents <= expected_refunded_amount_cents
+
+      # A partial charge-level refund on a combined charge with multiple purchases
+      # cannot be reliably attributed: a proportional split across all purchases may
+      # not match the intent of a dashboard refund aimed at a single purchase. Surface
+      # it loudly instead of recording a possibly-wrong split or dropping it silently.
+      if refunded_amount_cents < expected_refunded_amount_cents && refundable.charged_purchases.size > 1
+        ErrorNotifier.notify(
+          "Processor-initiated partial refund on a combined charge with multiple purchases cannot be attributed automatically",
+          context: {
+            stripe_refund_id:,
+            stripe_charge_id:,
+            refundable_type: refundable.class.name,
+            refundable_id: refundable.id,
+            refunded_amount_cents:,
+            expected_refunded_amount_cents:,
+          }
+        )
+        return
+      end
 
       charge_refund = StripeChargeProcessor.new.get_refund(stripe_refund_id, merchant_account: refundable.merchant_account)
       refundable.charged_purchases.each do |purchase|

--- a/spec/models/concerns/charge/refundable_spec.rb
+++ b/spec/models/concerns/charge/refundable_spec.rb
@@ -56,11 +56,50 @@ describe Charge::Refundable do
         expect(refund.presentment_amount_cents).to eq(13_50)
       end
 
-      it "does not treat the canonical USD amount as a full refund" do
-        purchase.handle_event_refund_updated!(build_event(refunded_amount_cents: 10_00))
+      it "records a partial processor-initiated refund with a derived canonical amount" do
+        stub_stripe_refund(presentment_cents: 4_50)
+
+        purchase.handle_event_refund_updated!(build_event(refunded_amount_cents: 4_50))
+
+        purchase.reload
+        expect(purchase.stripe_refunded?).to be(false)
+        expect(purchase.stripe_partially_refunded?).to be(true)
+        refund = purchase.refunds.last
+        expect(refund.presentment_currency).to eq(Currency::CAD)
+        expect(refund.presentment_amount_cents).to eq(4_50)
+        # 4_50 / 13_50 of the canonical 10_00, allocated by largest remainder
+        expect(refund.total_transaction_cents).to eq(3_33)
+      end
+
+      it "records repeated partial refunds until the presentment total is exhausted" do
+        stub_stripe_refund(presentment_cents: 4_50)
+        purchase.handle_event_refund_updated!(build_event(refunded_amount_cents: 4_50))
+
+        stub_stripe_refund(presentment_cents: 9_00)
+        purchase.handle_event_refund_updated!(build_event(refunded_amount_cents: 9_00))
+
+        purchase.reload
+        expect(purchase.stripe_refunded?).to be(true)
+        expect(purchase.refunds.sum { _1.presentment_amount_cents.to_i }).to eq(13_50)
+        expect(purchase.refunds.sum(:total_transaction_cents)).to eq(10_00)
+      end
+
+      it "ignores amounts above the presentment total" do
+        purchase.handle_event_refund_updated!(build_event(refunded_amount_cents: 14_00))
 
         expect(purchase.reload.refunds).to be_empty
         expect(purchase.stripe_refunded?).to be(false)
+      end
+
+      it "does not treat the canonical USD amount as a full refund" do
+        stub_stripe_refund(presentment_cents: 10_00)
+
+        purchase.handle_event_refund_updated!(build_event(refunded_amount_cents: 10_00))
+
+        purchase.reload
+        expect(purchase.stripe_refunded?).to be(false)
+        expect(purchase.stripe_partially_refunded?).to be(true)
+        expect(purchase.refunds.last.presentment_amount_cents).to eq(10_00)
       end
     end
 
@@ -73,6 +112,84 @@ describe Charge::Refundable do
         purchase.reload
         expect(purchase.stripe_refunded?).to be(true)
         expect(purchase.refunds.last.total_transaction_cents).to eq(10_00)
+      end
+
+      it "records a partial processor-initiated refund" do
+        stub_stripe_refund(presentment_cents: 3_00, currency: Currency::USD)
+
+        purchase.handle_event_refund_updated!(build_event(refunded_amount_cents: 3_00))
+
+        purchase.reload
+        expect(purchase.stripe_refunded?).to be(false)
+        expect(purchase.stripe_partially_refunded?).to be(true)
+        expect(purchase.refunds.last.total_transaction_cents).to eq(3_00)
+      end
+
+      it "records repeated partial refunds until the charge is fully refunded" do
+        stub_stripe_refund(presentment_cents: 3_00, currency: Currency::USD)
+        purchase.handle_event_refund_updated!(build_event(refunded_amount_cents: 3_00))
+
+        stub_stripe_refund(presentment_cents: 7_00, currency: Currency::USD)
+        purchase.handle_event_refund_updated!(build_event(refunded_amount_cents: 7_00))
+
+        purchase.reload
+        expect(purchase.stripe_refunded?).to be(true)
+        expect(purchase.refunds.sum(:total_transaction_cents)).to eq(10_00)
+      end
+
+      it "ignores zero and over-refundable amounts" do
+        purchase.handle_event_refund_updated!(build_event(refunded_amount_cents: 0))
+        purchase.handle_event_refund_updated!(build_event(refunded_amount_cents: 11_00))
+
+        expect(purchase.reload.refunds).to be_empty
+        expect(purchase.stripe_refunded?).to be(false)
+        expect(purchase.stripe_partially_refunded?).to be(false)
+      end
+    end
+
+    describe "combined charges with multiple purchases" do
+      let(:purchase_one) { create(:purchase, price_cents: 10_00, total_transaction_cents: 10_00, is_part_of_combined_charge: true) }
+      let(:purchase_two) { create(:purchase, price_cents: 5_00, total_transaction_cents: 5_00, is_part_of_combined_charge: true) }
+      let!(:charge) do
+        create(:charge,
+               processor_transaction_id: "ch_refundable_#{SecureRandom.hex(6)}",
+               amount_cents: 15_00,
+               purchases: [purchase_one, purchase_two])
+      end
+
+      def build_charge_event(refunded_amount_cents:)
+        event = ChargeEvent.new
+        event.charge_processor_id = StripeChargeProcessor.charge_processor_id
+        event.charge_id = charge.processor_transaction_id
+        event.refund_id = "re_refundable_#{SecureRandom.hex(6)}"
+        event.type = ChargeEvent::TYPE_CHARGE_REFUND_UPDATED
+        event.extras = { refund_status: "succeeded", refunded_amount_cents:, refund_reason: nil }
+        event
+      end
+
+      it "notifies and skips partial refunds instead of silently dropping them" do
+        expect(ErrorNotifier).to receive(:notify).with(
+          "Processor-initiated partial refund on a combined charge with multiple purchases cannot be attributed automatically",
+          context: hash_including(refundable_type: "Charge",
+                                  refundable_id: charge.id,
+                                  refunded_amount_cents: 5_00,
+                                  expected_refunded_amount_cents: 15_00)
+        )
+        expect_any_instance_of(StripeChargeProcessor).not_to receive(:get_refund)
+
+        charge.handle_event_refund_updated!(build_charge_event(refunded_amount_cents: 5_00))
+
+        expect(purchase_one.reload.refunds).to be_empty
+        expect(purchase_two.reload.refunds).to be_empty
+      end
+
+      it "still records full refunds across all purchases" do
+        stub_stripe_refund(presentment_cents: 15_00, currency: Currency::USD)
+
+        charge.handle_event_refund_updated!(build_charge_event(refunded_amount_cents: 15_00))
+
+        expect(purchase_one.reload.stripe_refunded?).to be(true)
+        expect(purchase_two.reload.stripe_refunded?).to be(true)
       end
     end
   end

--- a/spec/models/purchase/purchase_refunds_spec.rb
+++ b/spec/models/purchase/purchase_refunds_spec.rb
@@ -187,11 +187,18 @@ describe "PurchaseRefunds", :vcr do
         end
 
         it "does not treat canonical USD cents as a full presentment refund" do
-          expect_any_instance_of(StripeChargeProcessor).not_to receive(:get_refund)
+          canonical_cents = @purchase.total_transaction_cents
+          charge_refund = build_presentment_charge_refund(presentment_cents: canonical_cents)
+          expect_any_instance_of(StripeChargeProcessor).to receive(:get_refund).and_return(charge_refund)
 
-          @purchase.handle_event_refund_updated!(build_refund_updated_event(refunded_amount_cents: @purchase.total_transaction_cents))
+          @purchase.handle_event_refund_updated!(build_refund_updated_event(refunded_amount_cents: canonical_cents))
 
-          expect(@purchase.reload.refunds).to be_empty
+          # The amount is in the charge (presentment) currency, so it's a valid
+          # partial refund of that many presentment cents — never a full refund.
+          @purchase.reload
+          expect(@purchase.stripe_refunded).to be(false)
+          expect(@purchase.stripe_partially_refunded).to be(true)
+          expect(@purchase.refunds.last.presentment_amount_cents).to eq(canonical_cents)
         end
       end
     end


### PR DESCRIPTION
## What

The `charge.refund.updated` webhook handler (`Charge::Refundable#handle_event_refund_updated!`) only recorded processor-initiated refunds when the refund amount exactly equaled the full refundable total:

```ruby
return unless event.extras[:refunded_amount_cents] == expected_refunded_amount_cents
```

Stripe's refund `amount` is the amount of *that* refund, so a partial refund issued from the Stripe dashboard (with no app-side `Refund` row) failed the equality check and was silently dropped — no refund records, stale purchase refund state, books diverging from Stripe.

This PR relaxes the gate to `0 < refunded_amount_cents <= expected_refunded_amount_cents`:

- **Single-purchase charges (Charge with one purchase, or bare Purchase):** the refund's own flow of funds goes to `refund_purchase!`, whose partial paths already exist — canonical partials via `build_partial_refund`, and buyer-presentment partials via the #5689 derivation (`Purchase::PresentmentRefund.from_presentment_amount`, which allocates against *remaining* balances so repeated partials reconcile exactly).
- **Combined charges with multiple purchases:** a partial charge-level refund cannot be attributed automatically (a proportional split may not match the intent of a dashboard refund aimed at one purchase), so it notifies via `ErrorNotifier` with full context and skips — loudly surfaced instead of silently dropped.
- **Full refunds:** behavior unchanged (regression specs green).

## Why

Processor-initiated partial refunds are real money movements that Gumroad's books currently never see. This gate has been full-refund-only since the initial commit and was flagged on #5689 (which deliberately kept full-only semantics for the presentment fix).

Fixes antiwork/gumroad-private#863

## Test plan

- `spec/models/concerns/charge/refundable_spec.rb` — new coverage: canonical partial, repeated canonical partials to exhaustion, zero/over-refundable amounts ignored, presentment partial with derived canonical amount (4.50 CAD of 13.50 CAD → 3.33 USD of 10.00 by largest remainder), repeated presentment partials reconciling to exact totals, amounts above presentment total ignored, combined-charge partial notify+skip, combined-charge full refund still records across all purchases.
- `spec/models/purchase/purchase_refunds_spec.rb` — updated the "canonical USD cents on a presentment purchase" expectation: under the new gate it's a valid *partial* refund of that many presentment cents (still never treated as full).
- Locally: `bin/rspec spec/models/concerns/charge/refundable_spec.rb spec/models/purchase/purchase_refunds_spec.rb spec/services/purchase/presentment_refund_spec.rb spec/models/concerns/purchase/charge_events_handler_spec.rb` → 173 examples, 0 failures. Rubocop clean.

autoreview: clean (Codex, 0 findings)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5695"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785680426&installation_id=134400930&pr_number=5695&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5695&signature=75cbdb7ee6c03cc0c595cd8f8c54fbb025d7b129a9f8a0e85be085895699f242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->