### PR TITLE
Block automatic production deploys midnight-6am ET (overnight cron window)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -638,6 +638,21 @@ jobs:
               exit 0
             fi
 
+            # Deploy window block: no automatic production deploys between
+            # midnight and 6am ET. All the important nightly crons (report
+            # generation, payout runs, monthly closes) run in that window, and
+            # deploys recycle worker pods mid-run — long-running Sidekiq jobs
+            # (e.g. GenerateCanadaSalesReportJob, 1-2h) have been silently
+            # killed twice this way. A build landing in the window stays
+            # blocked in Buildkite; it can still be shipped manually by
+            # clicking require-approval, or it deploys with the next
+            # in-window push.
+            ET_HOUR=$(TZ=America/New_York date +%-H)
+            if [ "$ET_HOUR" -lt 6 ]; then
+              echo "Inside overnight cron window (midnight-6am ET; current hour: $ET_HOUR). Skipping auto-unblock; deploy stays blocked until manually approved or next in-window push."
+              exit 0
+            fi
+
             echo "Looking for Buildkite build for commit $COMMIT_SHA on pipeline $ORG_SLUG/$PIPELINE_SLUG..."
             # Fetch builds for the specific commit, including jobs
             BUILD_DATA=$(curl -s -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -643,10 +643,15 @@ jobs:
             # generation, payout runs, monthly closes) run in that window, and
             # deploys recycle worker pods mid-run — long-running Sidekiq jobs
             # (e.g. GenerateCanadaSalesReportJob, 1-2h) have been silently
-            # killed twice this way. A build landing in the window stays
-            # blocked in Buildkite; it can still be shipped manually by
-            # clicking require-approval, or it deploys with the next
-            # in-window push.
+            # killed twice this way. This gates on DEPLOY time (when this
+            # unblock job runs), not on when the commit landed on main — a
+            # push at 5:30am whose tests finish at 6:15am deploys normally,
+            # because the deploy itself happens outside the window. A build
+            # whose unblock falls inside the window stays blocked in
+            # Buildkite; it can still be shipped manually by clicking
+            # require-approval, or its changes ship with the next in-window
+            # push (whose build at HEAD includes them) — the stale blocked
+            # build is queue noise, not a shipping gap.
             ET_HOUR=$(TZ=America/New_York date +%-H)
             if [ "$ET_HOUR" -lt 6 ]; then
               echo "Inside overnight cron window (midnight-6am ET; current hour: $ET_HOUR). Skipping auto-unblock; deploy stays blocked until manually approved or next in-window push."


### PR DESCRIPTION
## What

Adds a deploy-window block to the `unblock_deployment_from_buildkite` job in `tests.yml`: between **midnight and 6am ET**, the job skips the automatic Buildkite `require-approval` unblock, so builds whose auto-unblock would fire in that window (i.e. whose deploy would land during it) stay parked at the existing manual gate instead of deploying to production.

## Why

All the important nightly crons run in that window — report generation, payout runs, monthly closes. A production deploy recycles worker pods mid-run, and long-running Sidekiq jobs die silently (no error metadata, no retry, no alert).

This is not theoretical: `GenerateCanadaSalesReportJob` (1-2h runtime) was killed this exact way **twice in 48 hours** — once by the 2026-07-01 deploy train (12 releases that day) and again by v2026.07.02.3/.4 landing mid-run. Both times the June Canada fees report simply never materialized and nobody was alerted. Ref #5680.

## How it works

- The unblock job already skips outside Mon-Fri business constraints via its secret gate; this adds an hour check: `TZ=America/New_York date +%-H` < 6 → exit 0 with a clear log line (`Inside overnight cron window (midnight-6am ET...)`).
- Skipping cleanly is `exit 0` (job shows success), matching the existing "not set to true" skip semantics — no red workflows from an intentional window.
- DST-safe (IANA zone, not a fixed UTC offset).

## Escape hatches (unchanged)

- Urgent overnight ship: click the `require-approval` step in Buildkite manually.
- Otherwise the blocked build deploys with the next in-window push to main.

## Testing

- YAML validated; hour-boundary logic verified: 0→blocked, 5→blocked, 6→allowed, 23→allowed.
- Durable fix for the underlying job fragility (checkpointed/resumable report generation) is tracked separately in #5680 — this window block removes the recurring cause while that lands.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785681700&installation_id=134400930&pr_number=5696&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5696&signature=cbd21895d803261204d690a306261d04f924119d4bace4b83e37dd126dd12b1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
