### PR TITLE
Fan out weekly payout batches per bank account type with retries and failure alerting

### DIFF
--- a/app/mailers/accounting_mailer.rb
+++ b/app/mailers/accounting_mailer.rb
@@ -135,11 +135,11 @@ class AccountingMailer < ApplicationMailer
 
   def payout_batch_failed(payout_processor_type, bank_account_types, error_class, error_message)
     @payout_processor_type = payout_processor_type
-    @bank_account_types = bank_account_types
+    @bank_account_types = Array.wrap(bank_account_types).presence
     @error_class = error_class
     @error_message = error_message
 
-    bucket = bank_account_types.present? ? bank_account_types.join(", ") : payout_processor_type
+    bucket = @bank_account_types.present? ? @bank_account_types.join(", ") : payout_processor_type
     mail subject: "#{SUBJECT_PREFIX}Weekly payout batch failed - #{bucket}",
          to: PAYMENTS_NOTIFICATION_EMAIL
   end

--- a/app/mailers/accounting_mailer.rb
+++ b/app/mailers/accounting_mailer.rb
@@ -133,6 +133,17 @@ class AccountingMailer < ApplicationMailer
          to: PAYMENTS_NOTIFICATION_EMAIL
   end
 
+  def payout_batch_failed(payout_processor_type, bank_account_types, error_class, error_message)
+    @payout_processor_type = payout_processor_type
+    @bank_account_types = bank_account_types
+    @error_class = error_class
+    @error_message = error_message
+
+    bucket = bank_account_types.present? ? bank_account_types.join(", ") : payout_processor_type
+    mail subject: "#{SUBJECT_PREFIX}Weekly payout batch failed - #{bucket}",
+         to: PAYMENTS_NOTIFICATION_EMAIL
+  end
+
   def global_sales_tax_summary_report(month, year, s3_read_url)
     @subject_and_title = "Global Sales Tax Summary Report for #{month}/#{year}"
     @s3_url = s3_read_url

--- a/app/sidekiq/perform_payouts_up_to_delay_days_ago_worker.rb
+++ b/app/sidekiq/perform_payouts_up_to_delay_days_ago_worker.rb
@@ -2,9 +2,31 @@
 
 class PerformPayoutsUpToDelayDaysAgoWorker
   include Sidekiq::Job
-  sidekiq_options retry: 0, queue: :critical, lock: :until_executed
+  # retry: 3 (was 0): with no retries, a single transient
+  # ActiveRecord::StatementTimeout on the `holding_balance` query sends the whole weekly
+  # batch straight to the dead set with no alert, leaving every seller in the affected
+  # bucket unpaid until the next weekly run. Retrying is safe: per-user payout jobs are
+  # deduplicated by their `until_executed` lock while queued, and once a user's balances
+  # leave `unpaid`, Payouts.create_payment no-ops for that user.
+  sidekiq_options retry: 3, queue: :critical, lock: :until_executed
+
+  sidekiq_retries_exhausted do |job, exception|
+    payout_processor_type, bank_account_types = job["args"]
+    AccountingMailer.payout_batch_failed(payout_processor_type, bank_account_types, exception.class.name, exception.message).deliver_later
+    ErrorNotifier.notify(exception, payout_processor_type:, bank_account_types:)
+  end
 
   def perform(payout_processor_type, bank_account_types = nil)
+    # Fan a multi-bank-type batch out into one job per bank account type. Processing the types
+    # sequentially inside a single job meant one slow `holding_balance` query aborted every
+    # remaining type's payouts along with it; isolated jobs give each type its own statement
+    # budget and its own retries.
+    if bank_account_types.is_a?(Array) && bank_account_types.many?
+      bank_account_types.each { |bank_account_type| self.class.perform_async(payout_processor_type, [bank_account_type]) }
+      Rails.logger.info("AUTOMATED PAYOUTS: #{payout_processor_type} fanned out to #{bank_account_types.size} per-bank-account-type jobs: #{bank_account_types}")
+      return
+    end
+
     payout_period_end_date = User::PayoutSchedule.next_scheduled_payout_end_date
 
     Rails.logger.info("AUTOMATED PAYOUTS: #{payout_period_end_date}, #{payout_processor_type}, #{bank_account_types} (Started)")

--- a/app/views/accounting_mailer/payout_batch_failed.html.erb
+++ b/app/views/accounting_mailer/payout_batch_failed.html.erb
@@ -1,0 +1,12 @@
+<%= header_section("Weekly payout batch failed") %>
+<div>
+  <p><code>PerformPayoutsUpToDelayDaysAgoWorker</code> exhausted Sidekiq retries. Sellers in this bucket have NOT had payouts created for this week's run.</p>
+  <ul>
+    <li>Processor: <%= @payout_processor_type %></li>
+    <li>Bank account types: <%= @bank_account_types.present? ? @bank_account_types.join(", ") : "(all)" %></li>
+    <li>Error: <%= @error_class %>: <%= @error_message %></li>
+  </ul>
+  <p>Re-run once the underlying issue is resolved (safe to re-run — users whose payouts were already created are skipped):</p>
+  <p><code>PerformPayoutsUpToDelayDaysAgoWorker.perform_async(<%= @payout_processor_type.inspect %><%= @bank_account_types.present? ? ", #{@bank_account_types.inspect}" : "" %>)</code></p>
+  <p>See Sentry and the Sidekiq dead set for the full backtrace. Verify recovery by comparing the day's <code>payments</code> count for this bucket against recent weeks' runs.</p>
+</div>

--- a/spec/mailers/accounting_mailer_spec.rb
+++ b/spec/mailers/accounting_mailer_spec.rb
@@ -189,6 +189,36 @@ describe AccountingMailer, :vcr do
     end
   end
 
+  describe "#payout_batch_failed" do
+    let(:mail) do
+      AccountingMailer.payout_batch_failed(
+        "STRIPE", ["AchAccount"], "ActiveRecord::StatementTimeout", "maximum statement execution time exceeded"
+      )
+    end
+
+    it "sends to the payments notification email" do
+      expect(mail.to).to eq([PAYMENTS_NOTIFICATION_EMAIL])
+    end
+
+    it "includes the bank account types in the subject" do
+      expect(mail.subject).to include("Weekly payout batch failed - AchAccount")
+    end
+
+    it "falls back to the processor type in the subject when there are no bank account types" do
+      paypal_mail = AccountingMailer.payout_batch_failed("PAYPAL", nil, "ActiveRecord::StatementTimeout", "timeout")
+      expect(paypal_mail.subject).to include("Weekly payout batch failed - PAYPAL")
+    end
+
+    it "includes the failure context and re-run command in the body" do
+      body = mail.body.encoded
+      expect(body).to include("STRIPE")
+      expect(body).to include("AchAccount")
+      expect(body).to include("ActiveRecord::StatementTimeout")
+      expect(body).to include("maximum statement execution time exceeded")
+      expect(body).to include("PerformPayoutsUpToDelayDaysAgoWorker.perform_async")
+    end
+  end
+
   describe "#global_sales_tax_summary_report_failed" do
     let(:mail) do
       AccountingMailer.global_sales_tax_summary_report_failed(

--- a/spec/mailers/accounting_mailer_spec.rb
+++ b/spec/mailers/accounting_mailer_spec.rb
@@ -209,6 +209,12 @@ describe AccountingMailer, :vcr do
       expect(paypal_mail.subject).to include("Weekly payout batch failed - PAYPAL")
     end
 
+    it "handles a single bank account type passed as a string" do
+      string_mail = AccountingMailer.payout_batch_failed("STRIPE", "AchAccount", "ActiveRecord::StatementTimeout", "timeout")
+      expect(string_mail.subject).to include("Weekly payout batch failed - AchAccount")
+      expect(string_mail.body.encoded).to include("AchAccount")
+    end
+
     it "includes the failure context and re-run command in the body" do
       body = mail.body.encoded
       expect(body).to include("STRIPE")

--- a/spec/sidekiq/perform_payouts_up_to_delay_days_ago_worker_spec.rb
+++ b/spec/sidekiq/perform_payouts_up_to_delay_days_ago_worker_spec.rb
@@ -9,5 +9,46 @@ describe PerformPayoutsUpToDelayDaysAgoWorker do
       expect(Payouts).to receive(:create_payments_for_balances_up_to_date).with(payout_period_end_date, payout_processor_type)
       described_class.new.perform(payout_processor_type)
     end
+
+    context "with a single bank account type" do
+      it "processes the type directly without fanning out" do
+        expect(Payouts).to receive(:create_payments_for_balances_up_to_date_for_bank_account_types)
+          .with(payout_period_end_date, PayoutProcessorType::STRIPE, ["AchAccount"])
+        expect(described_class).not_to receive(:perform_async)
+
+        described_class.new.perform(PayoutProcessorType::STRIPE, ["AchAccount"])
+      end
+    end
+
+    context "with multiple bank account types" do
+      it "fans out to one isolated job per bank account type and does not process inline" do
+        expect(Payouts).not_to receive(:create_payments_for_balances_up_to_date_for_bank_account_types)
+        expect(described_class).to receive(:perform_async).with(PayoutProcessorType::STRIPE, ["AchAccount"])
+        expect(described_class).to receive(:perform_async).with(PayoutProcessorType::STRIPE, ["CardBankAccount"])
+
+        described_class.new.perform(PayoutProcessorType::STRIPE, ["AchAccount", "CardBankAccount"])
+      end
+    end
+
+    it "retries on failure instead of dead-lettering immediately" do
+      expect(described_class.get_sidekiq_options["retry"]).to eq(3)
+    end
+  end
+
+  describe "sidekiq_retries_exhausted" do
+    it "notifies Sentry and emails accounting when retries are exhausted" do
+      job = { "args" => [PayoutProcessorType::STRIPE, ["AchAccount"]], "error_message" => "timeout" }
+      exception = ActiveRecord::StatementTimeout.new("Mysql2::Error: maximum statement execution time exceeded")
+
+      mailer_double = double("mailer")
+      expect(AccountingMailer).to receive(:payout_batch_failed)
+        .with(PayoutProcessorType::STRIPE, ["AchAccount"], "ActiveRecord::StatementTimeout", exception.message)
+        .and_return(mailer_double)
+      expect(mailer_double).to receive(:deliver_later)
+      expect(ErrorNotifier).to receive(:notify)
+        .with(exception, payout_processor_type: PayoutProcessorType::STRIPE, bank_account_types: ["AchAccount"])
+
+      described_class.sidekiq_retries_exhausted_block.call(job, exception)
+    end
   end
 end


### PR DESCRIPTION
## What

Makes the weekly `PerformPayoutsUpToDelayDaysAgoWorker` payout batches resilient to a failure mode where a single slow query could silently skip an entire week of payouts for every seller in the affected buckets:

1. **Per-bank-account-type fan-out**: a multi-type batch (e.g. Thursday's `["AchAccount", "CardBankAccount"]`, Wednesday's 17 non-US types) now enqueues one isolated child job per type instead of looping types sequentially inside a single job. Each type gets its own 5-minute statement budget and its own failure domain — one slow `holding_balance` query can no longer abort every remaining type.
2. **`retry: 3` instead of `retry: 0`**: a transient `StatementTimeout` no longer goes straight to the dead set. Retrying is safe: the per-user `PayoutUsersWorker` jobs are deduplicated by their `until_executed` lock while queued, and once a user's balances leave `unpaid`, `Payouts.create_payment` selects no payable balances and no-ops for that user.
3. **Alerting on exhausted retries**: `sidekiq_retries_exhausted` now notifies Sentry and emails `PAYMENTS_NOTIFICATION_EMAIL` (new `AccountingMailer#payout_batch_failed`, modeled on `us_states_sales_tax_taxjar_upload_failed`) with the affected bucket and the exact re-run command, instead of failing silently.

No schedule changes — `config/sidekiq_schedule.yml` entries stay as-is; the worker fans out internally, so admin/manual `perform_async` calls get the same isolation.

## Why

The weekly batches run at a contended time slot, and the initial `User.holding_balance` materialization for a large bank-account-type bucket can exceed the DB's 5-minute statement cap. With the types looping sequentially inside one `retry: 0` job, a single such timeout dead-letters the whole batch with no alert: every remaining type is skipped, affected sellers simply don't get that week's payout, and the failure only surfaces later through seller support tickets.

The per-type isolated re-run pattern this PR automates has been used manually to recover from exactly this situation and completes cleanly — isolated buckets run fast enough off-peak, and each gets its own statement budget. This PR makes the scheduled runs do the same thing automatically, adds retries so a transient timeout self-heals, and makes any residual failure loud.

Deliberately out of scope: optimizing the `holding_balance` GROUP BY itself — that needs eng eyes on `balances` indexing and is tracked internally.

## Test plan

- `spec/sidekiq/perform_payouts_up_to_delay_days_ago_worker_spec.rb` (5 examples, 0 failures locally):
  - no bank types (PayPal/StripeConnect Friday path) → processes directly, unchanged
  - single type → processes directly, no fan-out
  - multiple types → enqueues one child job per type, does not process inline
  - `retry` option is 3
  - `sidekiq_retries_exhausted` → Sentry notify + accounting email with bucket context
- `spec/mailers/accounting_mailer_spec.rb` (32 examples, 0 failures locally, including main's `#finance_report_job_failed` block): recipient, subject for typed/untyped buckets, string-arg coercion, failure context + re-run command in body
- `bin/rubocop` clean on all changed files
