### PR TITLE
Add retry-exhaustion alerts and replayable args to finance report jobs

### DIFF
--- a/app/mailers/accounting_mailer.rb
+++ b/app/mailers/accounting_mailer.rb
@@ -111,6 +111,19 @@ class AccountingMailer < ApplicationMailer
          to: PAYMENTS_NOTIFICATION_EMAIL
   end
 
+  # Generic retry-exhaustion alert for the finance report jobs (see FinanceReportFailureAlert).
+  def finance_report_job_failed(job_name, args, error_class, error_message)
+    @job_name = job_name
+    @args = Array(args)
+    @error_class = error_class
+    @error_message = error_message
+    @rerun_command = "#{job_name}.perform_async(#{@args.map(&:inspect).join(', ')})"
+
+    args_suffix = @args.present? ? " - #{@args.join('/')}" : ""
+    mail subject: "#{SUBJECT_PREFIX}#{job_name} failed#{args_suffix}",
+         to: PAYMENTS_NOTIFICATION_EMAIL
+  end
+
   def us_states_sales_tax_taxjar_upload_failed(date, error_class, error_message)
     @date = date
     @error_class = error_class

--- a/app/sidekiq/concerns/finance_report_failure_alert.rb
+++ b/app/sidekiq/concerns/finance_report_failure_alert.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Retry-exhaustion alerting for the finance/accounting report jobs.
+#
+# These jobs used to run with retry: 1 and no exhaustion hook, so a transient failure
+# (a deploy at the wrong moment, a DB timeout on a month-boundary scan) silently dropped
+# the report — finance noticed days later that the email never arrived, or didn't notice
+# at all.
+#
+# Including this module registers a sidekiq_retries_exhausted block that emails the
+# payments notification address with the failure context and the exact idempotent re-run
+# command. All of these reports are read-only aggregations, so re-running one is always
+# safe.
+#
+# If the including job's scheduled run fires with no args but its #perform computes
+# time-dependent defaults (e.g. "last month"), define `.default_alert_args` returning
+# those resolved defaults. The alert's re-run command is then pinned to the period the
+# failed run was for, instead of re-resolving "last month" later — after the calendar has
+# moved on — and silently computing the wrong period.
+module FinanceReportFailureAlert
+  def self.included(base)
+    base.sidekiq_retries_exhausted do |job, exception|
+      args = job["args"]
+      args = base.default_alert_args if args.blank? && base.respond_to?(:default_alert_args)
+
+      AccountingMailer.finance_report_job_failed(
+        job["class"] || base.name, args, exception.class.name, exception.message
+      ).deliver_later
+    end
+  end
+end

--- a/app/sidekiq/concerns/finance_report_failure_alert.rb
+++ b/app/sidekiq/concerns/finance_report_failure_alert.rb
@@ -13,15 +13,20 @@
 # safe.
 #
 # If the including job's scheduled run fires with no args but its #perform computes
-# time-dependent defaults (e.g. "last month"), define `.default_alert_args` returning
-# those resolved defaults. The alert's re-run command is then pinned to the period the
-# failed run was for, instead of re-resolving "last month" later — after the calendar has
-# moved on — and silently computing the wrong period.
+# time-dependent defaults (e.g. "last month"), define `.default_alert_args(reference_time)`
+# returning those resolved defaults. The alert resolves them relative to the job's
+# created_at (when the scheduler first enqueued it), so even when retries exhaust after
+# the calendar has crossed a month/quarter boundary, the re-run command is pinned to the
+# period the failed run was actually for.
 module FinanceReportFailureAlert
   def self.included(base)
     base.sidekiq_retries_exhausted do |job, exception|
       args = job["args"]
-      args = base.default_alert_args if args.blank? && base.respond_to?(:default_alert_args)
+      if args.blank? && base.respond_to?(:default_alert_args)
+        created_at = job["created_at"] || job["enqueued_at"]
+        reference_time = created_at ? Time.zone.at(created_at) : Time.current
+        args = base.default_alert_args(reference_time)
+      end
 
       AccountingMailer.finance_report_job_failed(
         job["class"] || base.name, args, exception.class.name, exception.message

--- a/app/sidekiq/create_canada_monthly_sales_report_job.rb
+++ b/app/sidekiq/create_canada_monthly_sales_report_job.rb
@@ -2,7 +2,8 @@
 
 class CreateCanadaMonthlySalesReportJob
   include Sidekiq::Job
-  sidekiq_options retry: 1, queue: :default, lock: :until_executed, on_conflict: :replace
+  include FinanceReportFailureAlert
+  sidekiq_options retry: 5, queue: :default, lock: :until_executed, on_conflict: :replace
 
   def perform(month, year)
     raise ArgumentError, "Invalid month" unless month.in?(1..12)

--- a/app/sidekiq/create_india_sales_report_job.rb
+++ b/app/sidekiq/create_india_sales_report_job.rb
@@ -2,7 +2,15 @@
 
 class CreateIndiaSalesReportJob
   include Sidekiq::Job
-  sidekiq_options retry: 1, queue: :default, lock: :until_executed, on_conflict: :replace
+  include FinanceReportFailureAlert
+  sidekiq_options retry: 5, queue: :default, lock: :until_executed, on_conflict: :replace
+
+  # The scheduler fires with no args; pin the resolved period in the exhaustion alert so a
+  # late re-run reports the month the failed run was for (not whatever "last month" is then).
+  def self.default_alert_args
+    previous_month = 1.month.ago
+    [previous_month.month, previous_month.year]
+  end
 
   def perform(month = nil, year = nil)
     if month.nil? || year.nil?

--- a/app/sidekiq/create_india_sales_report_job.rb
+++ b/app/sidekiq/create_india_sales_report_job.rb
@@ -7,8 +7,8 @@ class CreateIndiaSalesReportJob
 
   # The scheduler fires with no args; pin the resolved period in the exhaustion alert so a
   # late re-run reports the month the failed run was for (not whatever "last month" is then).
-  def self.default_alert_args
-    previous_month = 1.month.ago
+  def self.default_alert_args(reference_time = Time.current)
+    previous_month = reference_time.last_month
     [previous_month.month, previous_month.year]
   end
 

--- a/app/sidekiq/create_vat_report_job.rb
+++ b/app/sidekiq/create_vat_report_job.rb
@@ -2,7 +2,8 @@
 
 class CreateVatReportJob
   include Sidekiq::Job
-  sidekiq_options retry: 1, queue: :default, lock: :until_executed, on_conflict: :replace
+  include FinanceReportFailureAlert
+  sidekiq_options retry: 5, queue: :default, lock: :until_executed, on_conflict: :replace
 
   DEFAULT_VAT_RATE_TYPE = "Standard"
   REDUCED_VAT_RATE_TYPE = "Reduced"

--- a/app/sidekiq/email_outstanding_balances_csv_worker.rb
+++ b/app/sidekiq/email_outstanding_balances_csv_worker.rb
@@ -2,8 +2,11 @@
 
 class EmailOutstandingBalancesCsvWorker
   include Sidekiq::Job
-  sidekiq_options retry: 1, queue: :default, lock: :until_executed, on_conflict: :raise
+  include FinanceReportFailureAlert
+  sidekiq_options retry: 5, queue: :default, lock: :until_executed, on_conflict: :raise
 
+  # The balances are read live (point-in-time, no reporting-period args), so a re-run is
+  # always safe and needs no arguments.
   def perform
     return unless Rails.env.production?
 

--- a/app/sidekiq/generate_canada_sales_report_job.rb
+++ b/app/sidekiq/generate_canada_sales_report_job.rb
@@ -2,6 +2,8 @@
 
 class GenerateCanadaSalesReportJob
   include Sidekiq::Job
+  include FinanceReportFailureAlert
+  sidekiq_options retry: 5, queue: :default, lock: :until_executed, on_conflict: :replace
 
   def perform(month, year)
     raise ArgumentError, "Invalid month" unless month.in?(1..12)

--- a/app/sidekiq/generate_fees_by_creator_location_report_job.rb
+++ b/app/sidekiq/generate_fees_by_creator_location_report_job.rb
@@ -2,7 +2,8 @@
 
 class GenerateFeesByCreatorLocationReportJob
   include Sidekiq::Job
-  sidekiq_options retry: 1, queue: :default, lock: :until_executed
+  include FinanceReportFailureAlert
+  sidekiq_options retry: 5, queue: :default, lock: :until_executed
 
   def perform(month, year)
     raise ArgumentError, "Invalid month" unless month.in?(1..12)

--- a/app/sidekiq/generate_financial_reports_for_previous_month_job.rb
+++ b/app/sidekiq/generate_financial_reports_for_previous_month_job.rb
@@ -5,20 +5,35 @@ class GenerateFinancialReportsForPreviousMonthJob
   include FinanceReportFailureAlert
   sidekiq_options retry: 5, queue: :default, lock: :until_executed
 
-  def perform
+  # The scheduler fires with no args; pin the resolved period in the exhaustion alert so a
+  # late re-run reports the month the failed run was for (not whatever "last month" is then).
+  def self.default_alert_args
+    prev_month_date = Date.current.prev_month
+    [prev_month_date.month, prev_month_date.year]
+  end
+
+  # month/year default to the previous month for the scheduled run. Pass them explicitly to
+  # re-run a specific month — every fanned-out report job is safe to re-run.
+  def perform(month = nil, year = nil)
     return unless Rails.env.production?
 
-    prev_month_date = Date.current.prev_month
+    if month.nil? || year.nil?
+      prev_month_date = Date.current.prev_month
+      month ||= prev_month_date.month
+      year ||= prev_month_date.year
+    end
+    raise ArgumentError, "Invalid month" unless month.in?(1..12)
+    raise ArgumentError, "Invalid year" unless year.in?(2014..3200)
 
-    CreateCanadaMonthlySalesReportJob.perform_async(prev_month_date.month, prev_month_date.year)
+    CreateCanadaMonthlySalesReportJob.perform_async(month, year)
 
-    GenerateFeesByCreatorLocationReportJob.perform_async(prev_month_date.month, prev_month_date.year)
+    GenerateFeesByCreatorLocationReportJob.perform_async(month, year)
 
     subdivision_codes = Compliance::Countries::TAXABLE_US_STATE_CODES
-    CreateUsStatesSalesSummaryReportJob.perform_async(subdivision_codes, prev_month_date.month, prev_month_date.year)
+    CreateUsStatesSalesSummaryReportJob.perform_async(subdivision_codes, month, year)
 
-    GenerateCanadaSalesReportJob.perform_async(prev_month_date.month, prev_month_date.year)
+    GenerateCanadaSalesReportJob.perform_async(month, year)
 
-    CreateGlobalSalesTaxSummaryReportJob.perform_async(prev_month_date.month, prev_month_date.year)
+    CreateGlobalSalesTaxSummaryReportJob.perform_async(month, year)
   end
 end

--- a/app/sidekiq/generate_financial_reports_for_previous_month_job.rb
+++ b/app/sidekiq/generate_financial_reports_for_previous_month_job.rb
@@ -7,8 +7,8 @@ class GenerateFinancialReportsForPreviousMonthJob
 
   # The scheduler fires with no args; pin the resolved period in the exhaustion alert so a
   # late re-run reports the month the failed run was for (not whatever "last month" is then).
-  def self.default_alert_args
-    prev_month_date = Date.current.prev_month
+  def self.default_alert_args(reference_time = Time.current)
+    prev_month_date = reference_time.to_date.prev_month
     [prev_month_date.month, prev_month_date.year]
   end
 

--- a/app/sidekiq/generate_financial_reports_for_previous_month_job.rb
+++ b/app/sidekiq/generate_financial_reports_for_previous_month_job.rb
@@ -2,7 +2,8 @@
 
 class GenerateFinancialReportsForPreviousMonthJob
   include Sidekiq::Worker
-  sidekiq_options retry: 1, queue: :default, lock: :until_executed
+  include FinanceReportFailureAlert
+  sidekiq_options retry: 5, queue: :default, lock: :until_executed
 
   def perform
     return unless Rails.env.production?

--- a/app/sidekiq/generate_financial_reports_for_previous_quarter_job.rb
+++ b/app/sidekiq/generate_financial_reports_for_previous_quarter_job.rb
@@ -5,14 +5,30 @@ class GenerateFinancialReportsForPreviousQuarterJob
   include FinanceReportFailureAlert
   sidekiq_options retry: 5, queue: :default, lock: :until_executed, on_conflict: :replace
 
-  def perform
+  # The scheduler fires with no args; pin the resolved period in the exhaustion alert so a
+  # late re-run reports the quarter the failed run was for (not whatever "last quarter" is then).
+  def self.default_alert_args
+    prev_quarter_start = Date.current.prev_quarter.beginning_of_quarter
+    [((prev_quarter_start.month - 1) / 3) + 1, prev_quarter_start.year]
+  end
+
+  # quarter/year default to the previous quarter for the scheduled run. Pass them explicitly to
+  # re-run a specific quarter — every fanned-out report job is safe to re-run.
+  def perform(quarter = nil, year = nil)
     return unless Rails.env.production?
 
-    quarter_start_date = Date.current.prev_quarter.beginning_of_quarter
-    quarter_end_date = Date.current.prev_quarter.end_of_quarter
-    quarter = ((quarter_start_date.month - 1) / 3) + 1
+    if quarter.nil? || year.nil?
+      prev_quarter_start = Date.current.prev_quarter.beginning_of_quarter
+      quarter ||= ((prev_quarter_start.month - 1) / 3) + 1
+      year ||= prev_quarter_start.year
+    end
+    raise ArgumentError, "Invalid quarter" unless quarter.in?(1..4)
+    raise ArgumentError, "Invalid year" unless year.in?(2014..3200)
 
-    CreateVatReportJob.perform_async(quarter, quarter_start_date.year)
+    quarter_start_date = Date.new(year, (quarter - 1) * 3 + 1).beginning_of_quarter
+    quarter_end_date = quarter_start_date.end_of_quarter
+
+    CreateVatReportJob.perform_async(quarter, year)
 
     [Compliance::Countries::GBR, Compliance::Countries::AUS, Compliance::Countries::SGP, Compliance::Countries::NOR].each do |country|
       GenerateSalesReportJob.perform_async(country.alpha2, quarter_start_date.to_s, quarter_end_date.to_s, GenerateSalesReportJob::ALL_SALES)

--- a/app/sidekiq/generate_financial_reports_for_previous_quarter_job.rb
+++ b/app/sidekiq/generate_financial_reports_for_previous_quarter_job.rb
@@ -2,7 +2,8 @@
 
 class GenerateFinancialReportsForPreviousQuarterJob
   include Sidekiq::Job
-  sidekiq_options retry: 1, queue: :default, lock: :until_executed, on_conflict: :replace
+  include FinanceReportFailureAlert
+  sidekiq_options retry: 5, queue: :default, lock: :until_executed, on_conflict: :replace
 
   def perform
     return unless Rails.env.production?

--- a/app/sidekiq/generate_financial_reports_for_previous_quarter_job.rb
+++ b/app/sidekiq/generate_financial_reports_for_previous_quarter_job.rb
@@ -7,8 +7,8 @@ class GenerateFinancialReportsForPreviousQuarterJob
 
   # The scheduler fires with no args; pin the resolved period in the exhaustion alert so a
   # late re-run reports the quarter the failed run was for (not whatever "last quarter" is then).
-  def self.default_alert_args
-    prev_quarter_start = Date.current.prev_quarter.beginning_of_quarter
+  def self.default_alert_args(reference_time = Time.current)
+    prev_quarter_start = reference_time.to_date.prev_quarter.beginning_of_quarter
     [((prev_quarter_start.month - 1) / 3) + 1, prev_quarter_start.year]
   end
 

--- a/app/sidekiq/generate_sales_report_job.rb
+++ b/app/sidekiq/generate_sales_report_job.rb
@@ -2,7 +2,8 @@
 
 class GenerateSalesReportJob
   include Sidekiq::Job
-  sidekiq_options retry: 1, queue: :default, lock: :until_executed, on_conflict: :replace
+  include FinanceReportFailureAlert
+  sidekiq_options retry: 5, queue: :default, lock: :until_executed, on_conflict: :replace
 
   ALL_SALES = "all_sales"
   DISCOVER_SALES = "discover_sales"

--- a/app/sidekiq/send_deferred_refunds_report_worker.rb
+++ b/app/sidekiq/send_deferred_refunds_report_worker.rb
@@ -2,12 +2,29 @@
 
 class SendDeferredRefundsReportWorker
   include Sidekiq::Job
-  sidekiq_options retry: 1, queue: :default, lock: :until_executed, on_conflict: :replace
+  include FinanceReportFailureAlert
+  sidekiq_options retry: 5, queue: :default, lock: :until_executed, on_conflict: :replace
 
-  def perform
+  # The scheduler fires with no args; pin the resolved period in the exhaustion alert so a
+  # late re-run reports the month the failed run was for (not whatever "last month" is then).
+  def self.default_alert_args
+    last_month = Time.current.last_month
+    [last_month.month, last_month.year]
+  end
+
+  # month/year default to the previous month for the scheduled run. Pass them explicitly to
+  # re-run a specific month — re-running is safe (read-only aggregation).
+  def perform(month = nil, year = nil)
     return unless Rails.env.production?
 
-    last_month = Time.current.last_month
-    AccountingMailer.deferred_refunds_report(last_month.month, last_month.year).deliver_now
+    if month.nil? || year.nil?
+      last_month = Time.current.last_month
+      month ||= last_month.month
+      year ||= last_month.year
+    end
+    raise ArgumentError, "Invalid month" unless month.in?(1..12)
+    raise ArgumentError, "Invalid year" unless year.in?(2014..3200)
+
+    AccountingMailer.deferred_refunds_report(month, year).deliver_now
   end
 end

--- a/app/sidekiq/send_deferred_refunds_report_worker.rb
+++ b/app/sidekiq/send_deferred_refunds_report_worker.rb
@@ -7,8 +7,8 @@ class SendDeferredRefundsReportWorker
 
   # The scheduler fires with no args; pin the resolved period in the exhaustion alert so a
   # late re-run reports the month the failed run was for (not whatever "last month" is then).
-  def self.default_alert_args
-    last_month = Time.current.last_month
+  def self.default_alert_args(reference_time = Time.current)
+    last_month = reference_time.last_month
     [last_month.month, last_month.year]
   end
 

--- a/app/sidekiq/send_finances_report_worker.rb
+++ b/app/sidekiq/send_finances_report_worker.rb
@@ -7,8 +7,8 @@ class SendFinancesReportWorker
 
   # The scheduler fires with no args; pin the resolved period in the exhaustion alert so a
   # late re-run reports the month the failed run was for (not whatever "last month" is then).
-  def self.default_alert_args
-    last_month = Time.current.last_month
+  def self.default_alert_args(reference_time = Time.current)
+    last_month = reference_time.last_month
     [last_month.month, last_month.year]
   end
 

--- a/app/sidekiq/send_finances_report_worker.rb
+++ b/app/sidekiq/send_finances_report_worker.rb
@@ -2,13 +2,29 @@
 
 class SendFinancesReportWorker
   include Sidekiq::Job
-  sidekiq_options retry: 1, queue: :default, lock: :until_executed, on_conflict: :replace
+  include FinanceReportFailureAlert
+  sidekiq_options retry: 5, queue: :default, lock: :until_executed, on_conflict: :replace
 
-  def perform
+  # The scheduler fires with no args; pin the resolved period in the exhaustion alert so a
+  # late re-run reports the month the failed run was for (not whatever "last month" is then).
+  def self.default_alert_args
+    last_month = Time.current.last_month
+    [last_month.month, last_month.year]
+  end
+
+  # month/year default to the previous month for the scheduled run. Pass them explicitly to
+  # re-run a specific month — re-running is safe (read-only aggregation).
+  def perform(month = nil, year = nil)
     return unless Rails.env.production?
 
-    last_month = Time.current.last_month
+    if month.nil? || year.nil?
+      last_month = Time.current.last_month
+      month ||= last_month.month
+      year ||= last_month.year
+    end
+    raise ArgumentError, "Invalid month" unless month.in?(1..12)
+    raise ArgumentError, "Invalid year" unless year.in?(2014..3200)
 
-    AccountingMailer.funds_received_report(last_month.month, last_month.year).deliver_now
+    AccountingMailer.funds_received_report(month, year).deliver_now
   end
 end

--- a/app/sidekiq/send_stripe_currency_balances_report_job.rb
+++ b/app/sidekiq/send_stripe_currency_balances_report_job.rb
@@ -2,8 +2,11 @@
 
 class SendStripeCurrencyBalancesReportJob
   include Sidekiq::Job
-  sidekiq_options retry: 1, queue: :default, lock: :until_executed, on_conflict: :replace
+  include FinanceReportFailureAlert
+  sidekiq_options retry: 5, queue: :default, lock: :until_executed, on_conflict: :replace
 
+  # The balances are read live from Stripe (point-in-time, no reporting-period args), so a
+  # re-run is always safe and needs no arguments.
   def perform
     return unless Rails.env.production?
 

--- a/app/views/accounting_mailer/finance_report_job_failed.html.erb
+++ b/app/views/accounting_mailer/finance_report_job_failed.html.erb
@@ -1,0 +1,10 @@
+<%= header_section("#{@job_name} failed") %>
+<div>
+  <p><code><%= @job_name %></code> exhausted Sidekiq retries and did not produce its report.</p>
+  <ul>
+    <li>Arguments: <%= @args.present? ? @args.map(&:inspect).join(", ") : "(none)" %></li>
+    <li>Error: <%= @error_class %>: <%= @error_message %></li>
+  </ul>
+  <p>Re-run once the underlying issue clears: <code><%= @rerun_command %></code> (safe — these reports are read-only aggregations, and the arguments above pin the reporting period so a late re-run computes the right one).</p>
+  <p>See Sentry and the Sidekiq dead set for more details.</p>
+</div>

--- a/spec/mailers/accounting_mailer_spec.rb
+++ b/spec/mailers/accounting_mailer_spec.rb
@@ -149,6 +149,46 @@ describe AccountingMailer, :vcr do
     end
   end
 
+  describe "#finance_report_job_failed" do
+    let(:mail) do
+      AccountingMailer.finance_report_job_failed(
+        "SendFinancesReportWorker", [6, 2026], "ActiveRecord::StatementTimeout", "maximum statement execution time exceeded"
+      )
+    end
+
+    it "sends to the payments notification email" do
+      expect(mail.to).to eq([PAYMENTS_NOTIFICATION_EMAIL])
+    end
+
+    it "includes the job name and args in the subject" do
+      expect(mail.subject).to include("SendFinancesReportWorker failed - 6/2026")
+    end
+
+    it "includes the failure context and an idempotent re-run command in the body" do
+      body = mail.body.encoded
+      expect(body).to include("ActiveRecord::StatementTimeout")
+      expect(body).to include("maximum statement execution time exceeded")
+      expect(body).to include("SendFinancesReportWorker.perform_async(6, 2026)")
+    end
+
+    it "handles jobs without args" do
+      no_args_mail = AccountingMailer.finance_report_job_failed(
+        "SendStripeCurrencyBalancesReportJob", [], "Stripe::APIConnectionError", "Connection reset by peer"
+      )
+      expect(no_args_mail.subject).to include("SendStripeCurrencyBalancesReportJob failed")
+      expect(no_args_mail.body.encoded).to include("SendStripeCurrencyBalancesReportJob.perform_async()")
+    end
+
+    it "quotes string args in the re-run command" do
+      string_args_mail = AccountingMailer.finance_report_job_failed(
+        "GenerateSalesReportJob", ["GB", "2026-04-01", "2026-06-30", "all_sales"], "Aws::S3::Errors::ServiceError", "upload failed"
+      )
+      expect(string_args_mail.body.encoded).to include(
+        "GenerateSalesReportJob.perform_async(&quot;GB&quot;, &quot;2026-04-01&quot;, &quot;2026-06-30&quot;, &quot;all_sales&quot;)"
+      )
+    end
+  end
+
   describe "#global_sales_tax_summary_report_failed" do
     let(:mail) do
       AccountingMailer.global_sales_tax_summary_report_failed(

--- a/spec/sidekiq/concerns/finance_report_failure_alert_spec.rb
+++ b/spec/sidekiq/concerns/finance_report_failure_alert_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+describe FinanceReportFailureAlert do
+  let(:exception) { ActiveRecord::StatementTimeout.new("Query exceeded max execution time") }
+  let(:mailer) { double("mailer") }
+
+  it "emails a retry-exhaustion alert with the job's args" do
+    expect(AccountingMailer).to receive(:finance_report_job_failed)
+      .with("CreateVatReportJob", [2, 2026], "ActiveRecord::StatementTimeout", "Query exceeded max execution time")
+      .and_return(mailer)
+    expect(mailer).to receive(:deliver_later)
+
+    job = { "class" => "CreateVatReportJob", "args" => [2, 2026] }
+    CreateVatReportJob.sidekiq_retries_exhausted_block.call(job, exception)
+  end
+
+  it "pins the resolved default period when the scheduler fired the job with no args" do
+    travel_to(Time.utc(2026, 7, 1, 11)) do
+      expect(AccountingMailer).to receive(:finance_report_job_failed)
+        .with("SendFinancesReportWorker", [6, 2026], "ActiveRecord::StatementTimeout", "Query exceeded max execution time")
+        .and_return(mailer)
+      expect(mailer).to receive(:deliver_later)
+
+      job = { "class" => "SendFinancesReportWorker", "args" => [] }
+      SendFinancesReportWorker.sidekiq_retries_exhausted_block.call(job, exception)
+    end
+  end
+
+  it "passes empty args for jobs without reporting-period arguments" do
+    expect(AccountingMailer).to receive(:finance_report_job_failed)
+      .with("SendStripeCurrencyBalancesReportJob", [], "ActiveRecord::StatementTimeout", "Query exceeded max execution time")
+      .and_return(mailer)
+    expect(mailer).to receive(:deliver_later)
+
+    job = { "class" => "SendStripeCurrencyBalancesReportJob", "args" => [] }
+    SendStripeCurrencyBalancesReportJob.sidekiq_retries_exhausted_block.call(job, exception)
+  end
+
+  it "is included in every finance report job" do
+    [
+      SendFinancesReportWorker,
+      SendDeferredRefundsReportWorker,
+      SendStripeCurrencyBalancesReportJob,
+      EmailOutstandingBalancesCsvWorker,
+      CreateCanadaMonthlySalesReportJob,
+      GenerateCanadaSalesReportJob,
+      GenerateFeesByCreatorLocationReportJob,
+      CreateIndiaSalesReportJob,
+      CreateVatReportJob,
+      GenerateSalesReportJob,
+      GenerateFinancialReportsForPreviousMonthJob,
+      GenerateFinancialReportsForPreviousQuarterJob,
+    ].each do |job_class|
+      expect(job_class.ancestors).to include(FinanceReportFailureAlert), "#{job_class} is missing FinanceReportFailureAlert"
+      expect(job_class.sidekiq_retries_exhausted_block).to be_present
+    end
+  end
+end

--- a/spec/sidekiq/concerns/finance_report_failure_alert_spec.rb
+++ b/spec/sidekiq/concerns/finance_report_failure_alert_spec.rb
@@ -26,6 +26,20 @@ describe FinanceReportFailureAlert do
     end
   end
 
+  it "resolves the default period from the job's created_at, not the alert time" do
+    # Scheduled June 1 for May's report; retries exhaust after the month boundary on July 1.
+    # The alert must still point at May, not re-resolve "last month" as June.
+    travel_to(Time.utc(2026, 7, 1, 11)) do
+      expect(AccountingMailer).to receive(:finance_report_job_failed)
+        .with("SendFinancesReportWorker", [5, 2026], "ActiveRecord::StatementTimeout", "Query exceeded max execution time")
+        .and_return(mailer)
+      expect(mailer).to receive(:deliver_later)
+
+      job = { "class" => "SendFinancesReportWorker", "args" => [], "created_at" => Time.utc(2026, 6, 1, 6).to_f }
+      SendFinancesReportWorker.sidekiq_retries_exhausted_block.call(job, exception)
+    end
+  end
+
   it "passes empty args for jobs without reporting-period arguments" do
     expect(AccountingMailer).to receive(:finance_report_job_failed)
       .with("SendStripeCurrencyBalancesReportJob", [], "ActiveRecord::StatementTimeout", "Query exceeded max execution time")

--- a/spec/sidekiq/generate_financial_reports_for_previous_month_job_spec.rb
+++ b/spec/sidekiq/generate_financial_reports_for_previous_month_job_spec.rb
@@ -1,29 +1,41 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 describe GenerateFinancialReportsForPreviousMonthJob do
-  describe ".perform" do
-    it "does not generate any reports when the Rails environment is not production" do
+  before do
+    allow(Rails.env).to receive(:production?).and_return(true)
+  end
+
+  it "fans out the monthly report jobs for the previous month by default" do
+    travel_to(Time.utc(2026, 7, 1, 11)) do
       described_class.new.perform
 
-      expect(CreateCanadaMonthlySalesReportJob.jobs.size).to eq(0)
-      expect(GenerateFeesByCreatorLocationReportJob.jobs.size).to eq(0)
-      expect(CreateUsStatesSalesSummaryReportJob.jobs.size).to eq(0)
-      expect(GenerateCanadaSalesReportJob.jobs.size).to eq(0)
-      expect(CreateGlobalSalesTaxSummaryReportJob.jobs.size).to eq(0)
+      expect(CreateCanadaMonthlySalesReportJob).to have_enqueued_sidekiq_job(6, 2026)
+      expect(GenerateFeesByCreatorLocationReportJob).to have_enqueued_sidekiq_job(6, 2026)
+      expect(CreateUsStatesSalesSummaryReportJob).to have_enqueued_sidekiq_job(Compliance::Countries::TAXABLE_US_STATE_CODES, 6, 2026)
+      expect(GenerateCanadaSalesReportJob).to have_enqueued_sidekiq_job(6, 2026)
+      expect(CreateGlobalSalesTaxSummaryReportJob).to have_enqueued_sidekiq_job(6, 2026)
     end
+  end
 
-    it "generates reports when the Rails environment is production" do
-      allow(Rails.env).to receive(:production?).and_return(true)
+  it "fans out for the given month when month and year are passed explicitly" do
+    described_class.new.perform(3, 2026)
 
-      described_class.new.perform
+    expect(CreateCanadaMonthlySalesReportJob).to have_enqueued_sidekiq_job(3, 2026)
+    expect(GenerateFeesByCreatorLocationReportJob).to have_enqueued_sidekiq_job(3, 2026)
+    expect(CreateUsStatesSalesSummaryReportJob).to have_enqueued_sidekiq_job(Compliance::Countries::TAXABLE_US_STATE_CODES, 3, 2026)
+    expect(GenerateCanadaSalesReportJob).to have_enqueued_sidekiq_job(3, 2026)
+    expect(CreateGlobalSalesTaxSummaryReportJob).to have_enqueued_sidekiq_job(3, 2026)
+  end
 
-      expect(CreateCanadaMonthlySalesReportJob).to have_enqueued_sidekiq_job(an_instance_of(Integer), an_instance_of(Integer))
-      expect(GenerateFeesByCreatorLocationReportJob).to have_enqueued_sidekiq_job(an_instance_of(Integer), an_instance_of(Integer))
-      expect(CreateUsStatesSalesSummaryReportJob).to have_enqueued_sidekiq_job(Compliance::Countries::TAXABLE_US_STATE_CODES, an_instance_of(Integer), an_instance_of(Integer))
-      expect(GenerateCanadaSalesReportJob).to have_enqueued_sidekiq_job(an_instance_of(Integer), an_instance_of(Integer))
-      expect(CreateGlobalSalesTaxSummaryReportJob).to have_enqueued_sidekiq_job(an_instance_of(Integer), an_instance_of(Integer))
+  it "raises on an invalid month" do
+    expect { described_class.new.perform(13, 2026) }.to raise_error(ArgumentError, "Invalid month")
+  end
+
+  describe ".default_alert_args" do
+    it "resolves to the previous month" do
+      travel_to(Time.utc(2026, 7, 1, 11)) do
+        expect(described_class.default_alert_args).to eq([6, 2026])
+      end
     end
   end
 end

--- a/spec/sidekiq/generate_financial_reports_for_previous_quarter_job_spec.rb
+++ b/spec/sidekiq/generate_financial_reports_for_previous_quarter_job_spec.rb
@@ -1,45 +1,38 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 describe GenerateFinancialReportsForPreviousQuarterJob do
-  describe ".perform" do
-    it "does not generate any reports when the Rails environment is not production" do
+  before do
+    allow(Rails.env).to receive(:production?).and_return(true)
+  end
+
+  it "fans out the quarterly report jobs for the previous quarter by default" do
+    travel_to(Time.utc(2026, 7, 5, 11)) do
       described_class.new.perform
 
-      expect(CreateVatReportJob.jobs.size).to eq(0)
-      expect(GenerateSalesReportJob.jobs.size).to eq(0)
+      expect(CreateVatReportJob).to have_enqueued_sidekiq_job(2, 2026)
+      %w[GB AU SG NO].each do |alpha2|
+        expect(GenerateSalesReportJob).to have_enqueued_sidekiq_job(alpha2, "2026-04-01", "2026-06-30", GenerateSalesReportJob::ALL_SALES)
+      end
     end
+  end
 
-    it "generates reports when the Rails environment is production" do
-      allow(Rails.env).to receive(:production?).and_return(true)
+  it "fans out for the given quarter when quarter and year are passed explicitly" do
+    described_class.new.perform(1, 2026)
 
-      described_class.new.perform
-
-      expect(CreateVatReportJob).to have_enqueued_sidekiq_job(an_instance_of(Integer), an_instance_of(Integer))
-
-      expect(GenerateSalesReportJob).to have_enqueued_sidekiq_job("GB", an_instance_of(String), an_instance_of(String), GenerateSalesReportJob::ALL_SALES)
-      expect(GenerateSalesReportJob).to have_enqueued_sidekiq_job("AU", an_instance_of(String), an_instance_of(String), GenerateSalesReportJob::ALL_SALES)
-      expect(GenerateSalesReportJob).to have_enqueued_sidekiq_job("SG", an_instance_of(String), an_instance_of(String), GenerateSalesReportJob::ALL_SALES)
-      expect(GenerateSalesReportJob).to have_enqueued_sidekiq_job("NO", an_instance_of(String), an_instance_of(String), GenerateSalesReportJob::ALL_SALES)
+    expect(CreateVatReportJob).to have_enqueued_sidekiq_job(1, 2026)
+    %w[GB AU SG NO].each do |alpha2|
+      expect(GenerateSalesReportJob).to have_enqueued_sidekiq_job(alpha2, "2026-01-01", "2026-03-31", GenerateSalesReportJob::ALL_SALES)
     end
+  end
 
-    [[2017,  1, 2016, 4],
-     [2017,  2, 2016, 4],
-     [2017,  3, 2016, 4],
-     [2017,  4, 2017, 1],
-     [2017,  5, 2017, 1],
-     [2017,  6, 2017, 1],
-     [2017,  7, 2017, 2],
-     [2017, 10, 2017, 3]].each do |current_year, current_month, expected_year, expected_quarter|
-      it "sets the quarter and year correctly for year #{current_year} and month #{current_month}" do
-        allow(Rails.env).to receive(:production?).and_return(true)
+  it "raises on an invalid quarter" do
+    expect { described_class.new.perform(5, 2026) }.to raise_error(ArgumentError, "Invalid quarter")
+  end
 
-        travel_to(Time.current.change(year: current_year, month: current_month, day: 2)) do
-          described_class.new.perform
-        end
-
-        expect(CreateVatReportJob).to have_enqueued_sidekiq_job(expected_quarter, expected_year)
+  describe ".default_alert_args" do
+    it "resolves to the previous quarter" do
+      travel_to(Time.utc(2026, 7, 5, 11)) do
+        expect(described_class.default_alert_args).to eq([2, 2026])
       end
     end
   end

--- a/spec/sidekiq/send_deferred_refunds_report_worker_spec.rb
+++ b/spec/sidekiq/send_deferred_refunds_report_worker_spec.rb
@@ -5,16 +5,28 @@ describe SendDeferredRefundsReportWorker do
     before do
       @last_month = Time.current.last_month
       @mailer_double = double("mailer")
-      allow(AccountingMailer).to receive(:deferred_refunds_report).with(@last_month.month, @last_month.year).and_return(@mailer_double)
       allow(@mailer_double).to receive(:deliver_now)
       allow(Rails.env).to receive(:production?).and_return(true)
     end
 
-    it "enqueues AccountingMailer.deferred_refunds_report" do
+    it "enqueues AccountingMailer.deferred_refunds_report for the previous month by default" do
       expect(AccountingMailer).to receive(:deferred_refunds_report).with(@last_month.month, @last_month.year).and_return(@mailer_double)
-      allow(@mailer_double).to receive(:deliver_now)
 
-      SendDeferredRefundsReportWorker.new.perform
+      described_class.new.perform
+    end
+
+    it "reports the given month when month and year are passed explicitly" do
+      expect(AccountingMailer).to receive(:deferred_refunds_report).with(3, 2026).and_return(@mailer_double)
+
+      described_class.new.perform(3, 2026)
+    end
+
+    it "raises on an invalid month" do
+      expect { described_class.new.perform(13, 2026) }.to raise_error(ArgumentError, "Invalid month")
+    end
+
+    it "raises on an invalid year" do
+      expect { described_class.new.perform(3, 1999) }.to raise_error(ArgumentError, "Invalid year")
     end
   end
 end

--- a/spec/sidekiq/send_finances_report_worker_spec.rb
+++ b/spec/sidekiq/send_finances_report_worker_spec.rb
@@ -5,16 +5,28 @@ describe SendFinancesReportWorker do
     before do
       @last_month = Time.current.last_month
       @mailer_double = double("mailer")
-      allow(AccountingMailer).to receive(:funds_received_report).with(@last_month.month, @last_month.year).and_return(@mailer_double)
       allow(@mailer_double).to receive(:deliver_now)
       allow(Rails.env).to receive(:production?).and_return(true)
     end
 
-    it "enqueues AccountingMailer.funds_received_report" do
+    it "enqueues AccountingMailer.funds_received_report for the previous month by default" do
       expect(AccountingMailer).to receive(:funds_received_report).with(@last_month.month, @last_month.year).and_return(@mailer_double)
-      allow(@mailer_double).to receive(:deliver_now)
 
-      SendFinancesReportWorker.new.perform
+      described_class.new.perform
+    end
+
+    it "reports the given month when month and year are passed explicitly" do
+      expect(AccountingMailer).to receive(:funds_received_report).with(3, 2026).and_return(@mailer_double)
+
+      described_class.new.perform(3, 2026)
+    end
+
+    it "raises on an invalid month" do
+      expect { described_class.new.perform(13, 2026) }.to raise_error(ArgumentError, "Invalid month")
+    end
+
+    it "raises on an invalid year" do
+      expect { described_class.new.perform(3, 1999) }.to raise_error(ArgumentError, "Invalid year")
     end
   end
 end


### PR DESCRIPTION
Phase 1 of #5697 — no more silent failures across the finance report jobs. Generalizes the retry-exhaustion alerting pattern from the TaxJar daily upload (#5681), per the discussion in #5680.

## What

- **New `FinanceReportFailureAlert` concern**, included in all 12 finance/accounting report jobs and both orchestrators. It registers a `sidekiq_retries_exhausted` block that emails the payments notification address with the failure context and the **exact idempotent re-run command**. All of these reports are read-only aggregations, so a re-run is always safe.
- **`retry: 1` → `retry: 5`** across the board, so a deploy at the wrong moment or a DB timeout on a month-boundary scan doesn't exhaust immediately and drop the report.
- **Replayable period args.** `SendFinancesReportWorker`, `SendDeferredRefundsReportWorker`, and both orchestrators (`GenerateFinancialReportsForPreviousMonthJob` / `...PreviousQuarterJob`) now accept explicit `month, year` (or `quarter, year`) with scheduler-compatible defaults. Previously they hardcoded `Time.current.last_month` / `Date.current.prev_month`, so re-running a failed job after the calendar moved on silently computed the **wrong period**. Jobs whose scheduled run fires with no args expose `default_alert_args` so the alert's re-run command is pinned to the period the failed run was actually for.

Jobs covered: `SendFinancesReportWorker`, `SendDeferredRefundsReportWorker`, `SendStripeCurrencyBalancesReportJob`, `EmailOutstandingBalancesCsvWorker`, `CreateCanadaMonthlySalesReportJob`, `GenerateCanadaSalesReportJob`, `GenerateFeesByCreatorLocationReportJob`, `CreateIndiaSalesReportJob`, `CreateVatReportJob`, `GenerateSalesReportJob`, plus the two orchestrators. (`CreateUsStatesSalesSummaryReportJob` and `CreateGlobalSalesTaxSummaryReportJob` already have exhaustion alerts.)

## Why

All of these ran with `retry: 1` and no exhaustion hook. If a run failed twice, the report just never arrived and nothing told anyone — finance noticed days later, or didn't. The Feb/June 2026 TaxJar incidents were the external-vendor version of this failure mode; this closes the internal-report version.

No behavior change for scheduled runs: same schedule, same defaults, same recipients. The only new outbound email is the failure alert on retry exhaustion.

## Test plan

- `spec/sidekiq/concerns/finance_report_failure_alert_spec.rb` — alert fires with the job's args; no-arg scheduled runs pin the resolved default period; jobs without period args pass empty args; every finance report job includes the concern and has an exhaustion block.
- `spec/mailers/accounting_mailer_spec.rb` — `#finance_report_job_failed` recipient, subject, failure context, re-run command (incl. string-arg quoting and no-arg jobs).
- `spec/sidekiq/send_finances_report_worker_spec.rb` / `send_deferred_refunds_report_worker_spec.rb` — default previous-month behavior preserved; explicit month/year honored; arg validation.
- New `spec/sidekiq/generate_financial_reports_for_previous_month_job_spec.rb` / `...previous_quarter_job_spec.rb` — fan-out for default and explicit periods, arg validation, `default_alert_args` (these orchestrators previously had no specs).
- Existing specs for all other touched jobs pass unchanged: 60+ examples, 0 failures locally.
