### PR TITLE
Apply the PPP method matrix to the client-confirmed checkout path (U13)

### DIFF
--- a/app/presenters/checkout/stripe_payment_presenter.rb
+++ b/app/presenters/checkout/stripe_payment_presenter.rb
@@ -104,7 +104,19 @@ class Checkout::StripePaymentPresenter
         commission: items.any? { _1[:native_type] == Link::NATIVE_TYPE_COMMISSION },
         setup_for_future: setup_for_future_charges_without_charging?(items),
         buyer_country:,
+        ppp_discounted: ppp_verification_applies?,
       )
+    end
+
+    # U13 PPP method matrix input. True when any item offers a PPP discount for this buyer's GeoIP
+    # country AND the seller enforces PPP payment verification — the case where prepare will run the
+    # funding-country check and a non-verifiable method would fail closed. Keyed on discount
+    # AVAILABILITY (ppp_details for this ip), the same server-owned basis
+    # Order::PreparePaymentIntentService recomputes from the purchase's ip_country, so the Payment
+    # Element and the deferred intent gate identically (the step-1 method-set invariant).
+    def ppp_verification_applies?
+      items.any? { _1[:ppp_discounted] } &&
+        sellers.none? { _1&.purchasing_power_parity_payment_verification_disabled? }
     end
 
     # GeoIP-detected country (never the user's profile country) so the resolver's US-locked-method
@@ -185,7 +197,8 @@ class Checkout::StripePaymentPresenter
           is_preorder: product.is_in_preorder_state,
           has_free_trial: product.free_trial_enabled,
           native_type: product.native_type,
-          buyer_currency_display: buyer_currency_display_props(product:, price_cents: cart_product.price, ip:)
+          buyer_currency_display: buyer_currency_display_props(product:, price_cents: cart_product.price, ip:),
+          ppp_discounted: product.ppp_details(ip).present?
         )
       end
     end
@@ -204,12 +217,13 @@ class Checkout::StripePaymentPresenter
           is_preorder: product[:is_preorder],
           has_free_trial: product[:free_trial].present?,
           native_type: product[:native_type],
-          buyer_currency_display: product[:buyer_currency_display]
+          buyer_currency_display: product[:buyer_currency_display],
+          ppp_discounted: product[:ppp_details].present?
         )
       end
     end
 
-    def item(seller:, price_cents:, recurrence:, pay_in_installments:, is_preorder:, has_free_trial:, native_type:, buyer_currency_display:)
+    def item(seller:, price_cents:, recurrence:, pay_in_installments:, is_preorder:, has_free_trial:, native_type:, buyer_currency_display:, ppp_discounted: false)
       {
         seller:,
         price_cents:,
@@ -219,6 +233,7 @@ class Checkout::StripePaymentPresenter
         has_free_trial:,
         native_type:,
         buyer_currency_display:,
+        ppp_discounted:,
       }
     end
 end

--- a/app/services/checkout/payment_method_resolver.rb
+++ b/app/services/checkout/payment_method_resolver.rb
@@ -44,6 +44,19 @@ class Checkout::PaymentMethodResolver
   # account; Cash App Pay is US-locked. These are dropped from the launched set unless GeoIP ∈ {US}.
   US_LOCKED_PAYMENT_METHOD_TYPES = %w[us_bank_account cashapp].freeze
   US_ALPHA2 = "US"
+  # PPP method matrix (U13). On a PPP-discounted checkout, only methods whose funding country is
+  # verifiable pre-charge (card/wallets via card.country, and later sepa_debit.country) or whose
+  # region lock matches the discount country (Cash App Pay / ACH are US-locked, so US-only) may be
+  # offered. Methods with NO Stripe-owned funding country (Klarna/Afterpay/Affirm/PayPal/Link) are
+  # gated out on PPP checkouts: their preview yields nil country, so a PPP purchase would always
+  # fail closed at prepare — don't render a method that cannot complete.
+  # sepa_debit is wired but dormant until SEPA launches post-FX.
+  PPP_VERIFIABLE_PAYMENT_METHOD_TYPES = %w[card sepa_debit].freeze
+  # US-locked methods double as region-locked entries: allowed on a PPP checkout only when the
+  # buyer's (GeoIP) country — the basis of the discount — is the lock country. The resolver's US
+  # region gate already enforces buyer_country == US for these, so on a PPP checkout they stay
+  # offered exactly when the discount country is the lock country.
+  PPP_REGION_LOCKED_PAYMENT_METHOD_TYPES = US_LOCKED_PAYMENT_METHOD_TYPES
   # Multi-seller and other Lane A carts keep Gumroad's existing card + PayPal set.
   LANE_A_PAYMENT_METHOD_TYPES = %w[card paypal].freeze
 
@@ -51,12 +64,13 @@ class Checkout::PaymentMethodResolver
     def client_confirm_eligible? = client_confirm_eligible
   end
 
-  def initialize(sellers:, recurring: false, commission: false, setup_for_future: false, buyer_country: nil)
+  def initialize(sellers:, recurring: false, commission: false, setup_for_future: false, buyer_country: nil, ppp_discounted: false)
     @sellers = sellers
     @recurring = recurring
     @commission = commission
     @setup_for_future = setup_for_future
     @buyer_country = buyer_country
+    @ppp_discounted = ppp_discounted
   end
 
   def resolve
@@ -78,7 +92,7 @@ class Checkout::PaymentMethodResolver
   end
 
   private
-    attr_reader :sellers, :recurring, :commission, :setup_for_future, :buyer_country
+    attr_reader :sellers, :recurring, :commission, :setup_for_future, :buyer_country, :ppp_discounted
 
     # The client-confirm cart-shape gates (single-seller, non-connect, one-time), owned here and applied
     # as an ordered set of reasons so a blocked cart records *why* it stayed on Lane A.
@@ -117,15 +131,25 @@ class Checkout::PaymentMethodResolver
     end
 
     # What Stripe actually receives: the eligible policy set intersected with the launched set, then
-    # region-gated. A US-locked method (ACH, Cash App Pay) is only offered when the buyer's GeoIP
-    # country is US, so a non-US buyer never sees a method they can't complete. When the buyer
-    # country is unknown (nil), US-locked methods are dropped to fail safe. Card always survives,
+    # region-gated, then PPP-gated. A US-locked method (ACH, Cash App Pay) is only offered when the
+    # buyer's GeoIP country is US, so a non-US buyer never sees a method they can't complete. When the
+    # buyer country is unknown (nil), US-locked methods are dropped to fail safe. Card always survives,
     # and Link (inline, not US-locked) is unaffected by the region gate.
     def launched_method_set(eligible)
       launched = eligible & launched_payment_method_types
-      return launched if buyer_country == US_ALPHA2
+      launched -= US_LOCKED_PAYMENT_METHOD_TYPES unless buyer_country == US_ALPHA2
+      launched = ppp_method_matrix(launched) if ppp_discounted
+      launched
+    end
 
-      launched - US_LOCKED_PAYMENT_METHOD_TYPES
+    # U13: a PPP-discounted checkout only offers methods the pre-charge country check can verify
+    # (card/wallets, later sepa_debit) or whose region lock matches the buyer's country (Cash App
+    # Pay / ACH — already region-gated above, so surviving entries match by construction). Methods
+    # with no Stripe-owned funding country (Link today; Klarna/Afterpay/Affirm/PayPal when they
+    # launch) are dropped: `previewed_country` would return nil and the purchase would fail closed
+    # at prepare anyway — never render a method that cannot complete the discounted purchase.
+    def ppp_method_matrix(launched)
+      launched & (PPP_VERIFIABLE_PAYMENT_METHOD_TYPES + PPP_REGION_LOCKED_PAYMENT_METHOD_TYPES)
     end
 
     def log_decision(resolution)
@@ -134,6 +158,7 @@ class Checkout::PaymentMethodResolver
         "[#{self.class.name}] client_confirm_eligible=#{resolution.client_confirm_eligible} " \
         "seller_ids=#{sellers.map { _1&.id }} recurring=#{recurring} commission=#{commission} " \
         "setup_for_future=#{setup_for_future} buyer_country=#{buyer_country.inspect} " \
+        "ppp_discounted=#{ppp_discounted} " \
         "fallback_reason=#{resolution.fallback_reason.inspect} " \
         "eligible=#{resolution.eligible_payment_method_types} enabled=#{resolution.payment_method_types.inspect} " \
         "launch_gated_out=#{launch_gated_out} stripe_connect_account_id=#{resolution.stripe_connect_account_id.inspect}"

--- a/app/services/order/prepare_payment_intent_service.rb
+++ b/app/services/order/prepare_payment_intent_service.rb
@@ -113,10 +113,14 @@ class Order::PreparePaymentIntentService
     end
 
     # Card carries country directly; inline wallet methods (e.g. Link) are non-card, so the card
-    # field is nil — fall back to the method-specific preview block's country. BOTH are Stripe-owned
-    # funding-source countries, safe to trust for PPP verification. We deliberately do NOT fall back
-    # to buyer-supplied billing_details: that is checkout-form input, so trusting it would let a buyer
-    # spoof the discounted country. When Stripe exposes no funding country the value stays nil and a
+    # field is nil — fall back to the method-specific preview block's country (this generic read is
+    # also the sepa_debit.country hook: it activates untouched when SEPA launches post-FX). BOTH are
+    # Stripe-owned funding-source countries, safe to trust for PPP verification. US-locked methods
+    # (Cash App Pay, ACH) expose no country in their preview blocks, but Stripe only lets a US Cash
+    # App account or US bank account fund them — the region lock IS the funding country, so verify
+    # them as US (U13's region-locked bucket). We deliberately do NOT fall back to buyer-supplied
+    # billing_details: that is checkout-form input, so trusting it would let a buyer spoof the
+    # discounted country. When Stripe exposes no funding country the value stays nil and a
     # PPP-discounted purchase fails closed. Uses [] access because a Stripe::StripeObject raises on a
     # missing attribute reader but returns nil for an absent key.
     def previewed_country(preview)
@@ -124,7 +128,13 @@ class Order::PreparePaymentIntentService
       return card_country if card_country.present?
 
       method_type = preview[:type]
-      method_type.present? ? preview[method_type.to_sym]&.[](:country) : nil
+      return nil if method_type.blank?
+
+      method_country = preview[method_type.to_sym]&.[](:country)
+      return method_country if method_country.present?
+      return Checkout::PaymentMethodResolver::US_ALPHA2 if Checkout::PaymentMethodResolver::US_LOCKED_PAYMENT_METHOD_TYPES.include?(method_type)
+
+      nil
     end
 
     def block_purchasing_power_parity_mismatches
@@ -231,8 +241,23 @@ class Order::PreparePaymentIntentService
         sellers: [seller],
         recurring: purchases_to_charge.any? { _1.link.is_recurring_billing? },
         commission: purchases_to_charge.any? { _1.link.native_type == Link::NATIVE_TYPE_COMMISSION },
-        buyer_country: buyer_country_alpha2
+        buyer_country: buyer_country_alpha2,
+        ppp_discounted: ppp_verification_applies?
       ).resolve
+    end
+
+    # U13: mirrors the presenter's PPP input so the deferred intent's method set equals the Payment
+    # Element's on a PPP checkout (the step-1 invariant). Keyed on discount AVAILABILITY for the
+    # buyer's server-owned GeoIP country — the same basis the presenter uses — NOT on whether the
+    # buyer took the discount: the Element is configured before that choice, so keying prepare on
+    # is_purchasing_power_parity_discounted would widen the intent past the Element whenever an
+    # offered discount goes unused. Skipped when the seller disables PPP payment verification
+    # (validate_purchasing_power_parity is a no-op then, so no method needs gating).
+    def ppp_verification_applies?
+      return false if seller.purchasing_power_parity_payment_verification_disabled?
+      return false if purchases_to_charge.none? { _1.link.purchasing_power_parity_enabled? }
+
+      PurchasingPowerParityService.new.get_factor(buyer_country_alpha2, seller) < 1
     end
 
     # The buyer's country as an alpha2, derived from server-owned GeoIP data (ip_country, a country

--- a/spec/presenters/checkout/stripe_payment_presenter_spec.rb
+++ b/spec/presenters/checkout/stripe_payment_presenter_spec.rb
@@ -3,7 +3,7 @@
 describe Checkout::StripePaymentPresenter do
   def checkout_product_for(product, price: product.price_cents, recurrence: nil, pay_in_installments: false,
                            is_preorder: product.is_in_preorder_state, free_trial: product.free_trial_enabled,
-                           native_type: product.native_type, buyer_currency_display: nil)
+                           native_type: product.native_type, buyer_currency_display: nil, ppp_details: nil)
     {
       product: {
         creator: { id: product.user.external_id },
@@ -11,6 +11,7 @@ describe Checkout::StripePaymentPresenter do
         free_trial: free_trial ? { duration: { unit: "day", amount: 1 } } : nil,
         native_type:,
         buyer_currency_display:,
+        ppp_details:,
       },
       price:,
       recurrence:,
@@ -371,6 +372,48 @@ describe Checkout::StripePaymentPresenter do
 
       expect(stripe_payment_props(add_products: [confirm_flagged_seller_product], ip: "0.0.0.0"))
         .to eq(payment_element_client_confirm_props(payment_method_types: ["card"]))
+    end
+
+    describe "PPP method matrix (U13)" do
+      let(:ppp_details) { { country: "Brazil", factor: 0.5, minimum_price: 99 } }
+
+      it "keeps card and the US-locked methods on a PPP checkout for a US buyer" do
+        stub_geoip_country("104.28.0.1", "United States")
+
+        expect(stripe_payment_props(add_products: [confirm_flagged_seller_product(ppp_details:)], ip: "104.28.0.1"))
+          .to eq(payment_element_client_confirm_props(payment_method_types: %w[card cashapp us_bank_account]))
+      end
+
+      it "gates Link out on a PPP checkout — its funding country is not verifiable pre-charge" do
+        stub_geoip_country("104.28.0.1", "United States")
+        item = confirm_flagged_seller_product(ppp_details:)
+        seller = User.find_by(external_id: item[:product][:creator][:id])
+        Feature.activate_user(Checkout::PaymentMethodResolver::STRIPE_PAYMENT_ELEMENT_LINK_FEATURE_NAME, seller)
+
+        props = stripe_payment_props(add_products: [item], ip: "104.28.0.1")
+
+        expect(props[:elements_options][:payment_method_types]).to eq(%w[card cashapp us_bank_account])
+        expect(props[:elements_options][:stripe_link_enabled]).to eq(false)
+      end
+
+      it "does not gate methods when the seller disabled PPP payment verification" do
+        stub_geoip_country("104.28.0.1", "United States")
+        item = confirm_flagged_seller_product(ppp_details:)
+        seller = User.find_by(external_id: item[:product][:creator][:id])
+        seller.update!(purchasing_power_parity_payment_verification_disabled: true)
+        Feature.activate_user(Checkout::PaymentMethodResolver::STRIPE_PAYMENT_ELEMENT_LINK_FEATURE_NAME, seller)
+
+        props = stripe_payment_props(add_products: [item], ip: "104.28.0.1")
+
+        expect(props[:elements_options][:payment_method_types]).to eq(%w[card link cashapp us_bank_account])
+      end
+
+      it "leaves a non-PPP checkout's method set untouched" do
+        stub_geoip_country("104.28.0.1", "United States")
+
+        expect(stripe_payment_props(add_products: [confirm_flagged_seller_product], ip: "104.28.0.1"))
+          .to eq(payment_element_client_confirm_props(payment_method_types: %w[card cashapp us_bank_account]))
+      end
     end
 
     it "keeps server-confirm Payment Element when only the base flag is enabled" do

--- a/spec/services/checkout/payment_method_resolver_spec.rb
+++ b/spec/services/checkout/payment_method_resolver_spec.rb
@@ -65,6 +65,32 @@ describe Checkout::PaymentMethodResolver do
       it "returns an explicit list of method-type strings, never Stripe's automatic_payment_methods shape" do
         expect(resolve.payment_method_types).to be_an(Array).and(all(be_a(String)))
       end
+
+      context "with a PPP-discounted checkout (U13 method matrix)" do
+        it "keeps card and the US-locked methods for a US buyer — verifiable + region-matched" do
+          expect(resolve(ppp_discounted: true).payment_method_types).to eq(%w[card cashapp us_bank_account])
+        end
+
+        it "resolves card-only for a non-US PPP buyer (region-locked methods already dropped)" do
+          expect(resolve(buyer_country: "BR", ppp_discounted: true).payment_method_types).to eq(["card"])
+        end
+
+        it "gates Link out — no Stripe-owned funding country to verify pre-charge" do
+          Feature.activate_user(described_class::STRIPE_PAYMENT_ELEMENT_LINK_FEATURE_NAME, seller)
+
+          expect(resolve(ppp_discounted: true).payment_method_types).to eq(%w[card cashapp us_bank_account])
+          expect(resolve(ppp_discounted: false).payment_method_types).to eq(%w[card link cashapp us_bank_account])
+        end
+
+        it "logs the PPP gate input" do
+          resolver = described_class.new(sellers: [seller], buyer_country: "US", ppp_discounted: true)
+          allow(Rails.logger).to receive(:info)
+
+          resolver.resolve
+
+          expect(Rails.logger).to have_received(:info).with(a_string_matching(/ppp_discounted=true/))
+        end
+      end
     end
 
     context "with a recurring (subscription) lifecycle" do

--- a/spec/services/order/prepare_payment_intent_service_spec.rb
+++ b/spec/services/order/prepare_payment_intent_service_spec.rb
@@ -134,6 +134,77 @@ describe Order::PreparePaymentIntentService, :vcr do
         preview = preview_from(type: "link", link: {})
         expect(service.send(:previewed_country, preview)).to be_nil
       end
+
+      # U13 region-locked bucket: Stripe exposes no country on cashapp/us_bank_account previews, but
+      # only a US Cash App account / US bank account can fund them — the lock IS the funding country.
+      it "verifies a Cash App Pay preview as US via the region lock" do
+        preview = preview_from(type: "cashapp", cashapp: {}, card: nil)
+        expect(service.send(:previewed_country, preview)).to eq("US")
+      end
+
+      it "verifies an ACH (us_bank_account) preview as US via the region lock" do
+        preview = preview_from(type: "us_bank_account", us_bank_account: { last4: "6789" }, card: nil)
+        expect(service.send(:previewed_country, preview)).to eq("US")
+      end
+
+      it "prefers an explicit method-block country over the region lock if Stripe ever exposes one" do
+        preview = preview_from(type: "us_bank_account", us_bank_account: { country: "US" }, card: nil)
+        expect(service.send(:previewed_country, preview)).to eq("US")
+      end
+    end
+
+    # U13: the deferred intent's method set must equal the Payment Element's on a PPP checkout, so
+    # prepare recomputes the same ppp_discounted input from server-owned data (product PPP config +
+    # the buyer's GeoIP-derived ip_country factor).
+    context "with a PPP-eligible checkout (U13 method matrix)" do
+      before do
+        create(:merchant_account, user: seller, charge_processor_merchant_id: "acct_test")
+        product.update!(purchasing_power_parity_disabled: false)
+        seller.update!(purchasing_power_parity_enabled: true)
+        PurchasingPowerParityService.new.set_factor("US", 0.5)
+      end
+
+      after { PurchasingPowerParityService.new.set_factor("US", 1) }
+
+      def create_args_for(order, params)
+        preview = Stripe::StripeObject.construct_from(card: { country: "US" })
+        allow(Stripe::ConfirmationToken).to receive(:retrieve)
+          .and_return(Stripe::StripeObject.construct_from(payment_method_preview: preview))
+
+        charge_intent = instance_double(StripeChargeIntent, id: "pi_test", client_secret: "pi_test_secret")
+        create_args = nil
+        allow(StripeDeferredPaymentIntent).to receive(:create) do |**kwargs|
+          create_args = kwargs
+          charge_intent
+        end
+
+        described_class.new(order:, params:, confirmation_token: "ctoken_ppp").perform
+        create_args
+      end
+
+      it "keeps card and the US-locked methods for a US PPP buyer, matching the Payment Element" do
+        order, params = build_order
+        order.purchases.each { _1.update!(ip_country: "United States") }
+
+        expect(create_args_for(order, params)[:payment_method_types]).to eq(%w[card cashapp us_bank_account])
+      end
+
+      it "gates Link out of the intent on a PPP checkout even when the seller has the Link flag" do
+        Feature.activate_user(Checkout::PaymentMethodResolver::STRIPE_PAYMENT_ELEMENT_LINK_FEATURE_NAME, seller)
+        order, params = build_order
+        order.purchases.each { _1.update!(ip_country: "United States") }
+
+        expect(create_args_for(order, params)[:payment_method_types]).to eq(%w[card cashapp us_bank_account])
+      end
+
+      it "does not gate the intent when the seller disabled PPP payment verification" do
+        Feature.activate_user(Checkout::PaymentMethodResolver::STRIPE_PAYMENT_ELEMENT_LINK_FEATURE_NAME, seller)
+        seller.update!(purchasing_power_parity_payment_verification_disabled: true)
+        order, params = build_order
+        order.purchases.each { _1.update!(ip_country: "United States") }
+
+        expect(create_args_for(order, params)[:payment_method_types]).to eq(%w[card link cashapp us_bank_account])
+      end
     end
 
     context "when no confirmation token is supplied" do


### PR DESCRIPTION
## What

Applies the **PPP method matrix** to the client-confirmed Intent path (Lane B) — #5640 step 8 (plan unit U13), the final implementation step. On a PPP-discounted checkout, the resolver now offers only methods that can actually complete the discounted purchase, sorted into #5640's three buckets:

- **Verifiable pre-charge** (`PPP_VERIFIABLE_PAYMENT_METHOD_TYPES = card, sepa_debit`): the funding country is read from the ConfirmationToken preview and checked against the buyer's IP country before any client secret is issued. `sepa_debit` is wired but dormant until SEPA launches post-FX — `previewed_country`'s generic method-typed-block read picks up `sepa_debit.country` with no further change.
- **Region-locked** (`cashapp`, `us_bank_account`): allowed only when the lock matches the discount country. The resolver's existing US region gate (#5686) already drops these for non-US buyers, so on a PPP checkout the surviving entries match by construction. `Order::PreparePaymentIntentService#previewed_country` now verifies these previews as `US` via the region lock — Stripe exposes no country on `cashapp`/`us_bank_account` preview blocks, but only a US Cash App account or US bank account can fund them, so the lock IS the funding country. Without this, every PPP ACH/Cash App purchase would fail closed at prepare despite being correctly offered.
- **Not verifiable** (Link today; Klarna/Afterpay/Affirm/PayPal when they launch): gated out of the launched set on PPP checkouts. Their previews yield no Stripe-owned funding country, so a PPP purchase would always fail closed at prepare — never render a method that cannot complete.

Both sides compute the same `ppp_discounted` input from server-owned data, preserving the step-1 Element↔intent invariant:

- `Checkout::StripePaymentPresenter`: true when any item offers a PPP discount for the buyer's GeoIP country (`ppp_details`) and the seller enforces PPP payment verification.
- `Order::PreparePaymentIntentService`: recomputed from the purchase's `ip_country` PPP factor and the product's PPP config — keyed on discount **availability** (the presenter's basis), not on whether the buyer took the discount, so an unused offered discount can't widen the intent past the Element. Sellers with `purchasing_power_parity_payment_verification_disabled` skip the gate entirely (the validation it protects is a no-op for them).

The gate decision (`ppp_discounted`) is logged with every resolution. No frontend change: `payment_method_types` is already a server-resolved `string[]` (#5686), and `stripe_link_enabled` already derives from the resolved set, so Link's toggle turns off automatically on PPP checkouts.

## Why

#5640's step 8 closes the gap between PPP verification and method offering. Steps 1–7 enforce PPP **at prepare** (fail closed on a nil/mismatched funding country) but offer methods without regard to PPP — so a PPP-discounted buyer could select Link (no funding country → guaranteed prepare failure after filling out the form) or, worse, ACH/Cash App would *always* fail on PPP checkouts because their previews carry no country at all. This PR makes the offered set and the verifiable set agree: what renders can complete, and what cannot complete never renders.

Everything stays behind `:stripe_payment_element_checkout` AND `:stripe_payment_element_client_confirm` (seller-scoped, off by default). Non-PPP checkouts are byte-for-byte unchanged.

## Test plan

- `spec/services/checkout/payment_method_resolver_spec.rb` (19 examples): PPP + US buyer keeps `card, cashapp, us_bank_account`; PPP + non-US buyer resolves card-only; Link gated out on PPP even when flagged (and kept when not PPP); `ppp_discounted` logged.
- `spec/presenters/checkout/stripe_payment_presenter_spec.rb` (43 examples): PPP checkout gates Link out of the Element config (`stripe_link_enabled: false` follows); verification-disabled seller keeps the full set; non-PPP checkout untouched; all pre-existing contexts unchanged.
- `spec/services/order/prepare_payment_intent_service_spec.rb` (18 examples): `previewed_country` verifies `cashapp`/`us_bank_account` previews as US via the region lock (explicit method-block country still preferred if Stripe ever exposes one); the deferred intent's method set matches the Element's on PPP checkouts (with/without the Link flag, with verification disabled).
- `spec/presenters/checkout_presenter_spec.rb` (45 examples) green — the `ppp_details`-consuming integration surface.
- 94 examples, 0 failures across the three directly-touched spec files; `rubocop` clean on all six touched files.
- Codex autoreview (gpt-5.5): "patch is correct (0.82)", no actionable findings.

No UI change with the flags off. With flags on, the only UI difference is Stripe's Payment Element rendering fewer method tabs on PPP-discounted checkouts, driven entirely by the server-resolved `payment_method_types`.

Part of #5640 (step 8 / U13). Stacked on #5686 (step 7) — the diff includes U11 until that merges; review the `af45752` commit for U13 alone.


## After


https://github.com/user-attachments/assets/9f478374-84e3-471d-b7b6-94b48a771d67


https://github.com/user-attachments/assets/482d03b9-840e-4dd4-b0a1-a642e67f9365


https://github.com/user-attachments/assets/8b9d2bcc-0b1c-42fd-b44a-137e4ed90a2d


https://github.com/user-attachments/assets/e68b67aa-c029-4c58-9bd5-0b84c27f9e3d

