### PR TITLE
Split payout bank-account-type user query to stay under the statement timeout

### DIFF
--- a/app/business/payments/payouts/payouts.rb
+++ b/app/business/payments/payouts/payouts.rb
@@ -6,6 +6,7 @@ class Payouts
   MIN_AMOUNT_CENTS = 100_00
   PAYOUT_TYPE_STANDARD = "standard"
   PAYOUT_TYPE_INSTANT = "instant"
+  BANK_ACCOUNT_LOOKUP_BATCH_SIZE = 10_000
 
   def self.is_user_payable(user, date, processor_type: nil, add_comment: false, from_admin: false, bypass_minimum_payout: false, payout_type: Payouts::PAYOUT_TYPE_STANDARD)
     payout_date = Time.current.to_fs(:formatted_date_full_month)
@@ -73,11 +74,20 @@ class Payouts
   end
 
   def self.create_payments_for_balances_up_to_date_for_bank_account_types(date, processor_type, bank_account_types)
+    # Materialize the holding-balance user ids first, then look up bank accounts in
+    # chunks by user_id (indexed). The previous single statement joined
+    # users × balances × bank_accounts, and MySQL drove it from a full scan of
+    # bank_accounts (no index on `type`), repeatedly blowing the 5-minute statement
+    # cap at the scheduled slot and aborting entire payout batches. Splitting the
+    # query leaves no join for the optimizer to get wrong, and each piece stays far
+    # under the statement cap.
+    holding_balance_user_ids = User.holding_balance.ids
+
     bank_account_types.each do |bank_account_type|
-      users = User.holding_balance
-                  .joins("inner join bank_accounts on bank_accounts.user_id = users.id")
-                  .where("bank_accounts.type = ?", bank_account_type)
-                  .where("bank_accounts.deleted_at is null")
+      user_ids = holding_balance_user_ids.each_slice(BANK_ACCOUNT_LOOKUP_BATCH_SIZE).flat_map do |user_ids_batch|
+        BankAccount.alive.where(user_id: user_ids_batch, type: bank_account_type).distinct.pluck(:user_id)
+      end
+      users = User.where(id: user_ids)
       self.create_payments_for_balances_up_to_date_for_users(date, processor_type, users, perform_async: true, bank_account_type:)
     end
   end

--- a/spec/business/payments/payouts/payouts_spec.rb
+++ b/spec/business/payments/payouts/payouts_spec.rb
@@ -437,6 +437,17 @@ describe Payouts do
 
       described_class.create_payments_for_balances_up_to_date_for_bank_account_types(payout_date, payout_processor_type, [AustralianBankAccount.name, CanadianBankAccount.name])
     end
+
+    it "looks up bank accounts in chunks of holding-balance user ids" do
+      stub_const("Payouts::BANK_ACCOUNT_LOOKUP_BATCH_SIZE", 1)
+
+      allow(Payouts).to receive(:is_user_payable).and_return(true)
+      expect(described_class).to receive(:create_payments_for_balances_up_to_date_for_users).with(payout_date, payout_processor_type, [u1_2, u2_2], perform_async: true, bank_account_type: "AustralianBankAccount").and_call_original
+
+      expect(BankAccount).to receive(:alive).at_least(:twice).and_call_original
+
+      described_class.create_payments_for_balances_up_to_date_for_bank_account_types(payout_date, payout_processor_type, [AustralianBankAccount.name])
+    end
   end
 
   describe "create_payments_for_balances_up_to_date_for_users" do


### PR DESCRIPTION
## What

Splits the query in `Payouts.create_payments_for_balances_up_to_date_for_bank_account_types` into two pieces:

1. Materialize the holding-balance user ids once per batch (`User.holding_balance.ids` — ~3s in production on the existing `(state, merchant_account_id, date, user_id)` balances index).
2. Per bank account type, look up alive bank accounts in chunks of 10,000 user ids (`bank_accounts.user_id` is indexed), then feed the matched users into the existing per-user payability loop.

There is no join left for the optimizer to get wrong, and each individual statement stays far under the 5-minute statement cap. This composes with the per-bank-type fan-out in #5698 — each fanned-out child job runs its own (now cheap) id materialization + chunked lookup.

## Why

Third recurrence of the same failure class (antiwork/gumroad-private#870, most recently 2026-07-02: the Thursday US Stripe batch died 300s in with `ActiveRecord::StatementTimeout` and ~1,124 sellers went unpaid for the week).

Production profiling on the read replica showed the `holding_balance` GROUP BY itself is fine (~3s for 725k unpaid balance rows across 235k sellers). The killer is the combined statement: MySQL drives the users × balances × bank_accounts join from a full table scan of `bank_accounts` (1.36M rows, no index on `type`, ~1% filtered), then probes users and balances per row — which blows the `max_execution_time` cap at the contended scheduled slot.

Behavior is unchanged: same set of users selected (holding a positive unpaid balance AND owning an alive bank account of the given type), same downstream `create_payments_for_balances_up_to_date_for_users` call per type.

## Test evidence

- `bundle exec rspec spec/business/payments/payouts/payouts_spec.rb -e "create_payments_for_balances_up_to_date_for_bank_account_types"` → **2 examples, 0 failures** (existing multi-type behavior spec + new spec covering the chunked lookup with a stubbed batch size of 1)
- `bundle exec rubocop` on both touched files → no offenses
- autoreview (Codex, branch mode vs origin/main) → clean, no actionable findings

Not a UI change — backend query restructuring only; no visual evidence applicable.

Part of antiwork/gumroad-private#870 (left open for production verification of the next scheduled runs).
