### PR TITLE
Add a daily self-verifying backstop for scheduled finance report runs

### DIFF
--- a/app/mailers/accounting_mailer.rb
+++ b/app/mailers/accounting_mailer.rb
@@ -124,6 +124,19 @@ class AccountingMailer < ApplicationMailer
          to: PAYMENTS_NOTIFICATION_EMAIL
   end
 
+  # Backstop alert: a scheduled finance report run never completed and was re-enqueued
+  # (see VerifyFinanceReportsDeliveryJob).
+  def finance_report_delivery_backstop_triggered(job_name, args, fire_time, last_completed_at)
+    @job_name = job_name
+    @args = Array(args)
+    @fire_time = fire_time
+    @last_completed_at = last_completed_at
+    @rerun_command = "#{job_name}.perform_async(#{@args.map(&:inspect).join(', ')})"
+
+    mail subject: "#{SUBJECT_PREFIX}#{job_name} scheduled run never completed - re-enqueued by backstop",
+         to: PAYMENTS_NOTIFICATION_EMAIL
+  end
+
   def us_states_sales_tax_taxjar_upload_failed(date, error_class, error_message)
     @date = date
     @error_class = error_class

--- a/app/sidekiq/concerns/finance_report_completion_tracking.rb
+++ b/app/sidekiq/concerns/finance_report_completion_tracking.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Records a "last completed at" timestamp in Redis whenever a finance report job finishes
+# successfully. VerifyFinanceReportsDeliveryJob (the daily backstop) compares these
+# timestamps against each job's schedule to catch runs that silently never happened —
+# e.g. a Sidekiq process killed mid-deploy losing the job entirely, so retries (and the
+# retry-exhaustion alert) never fire.
+#
+# Completion is recorded only when #perform returns without raising.
+module FinanceReportCompletionTracking
+  REDIS_KEY_TTL = 120.days # covers a full quarterly cadence with room to spare
+
+  def self.redis_key(class_name)
+    "finance_report_last_completed_at:#{class_name}"
+  end
+
+  def self.last_completed_at(class_name)
+    timestamp = $redis.get(redis_key(class_name))
+    timestamp && Time.zone.at(timestamp.to_i)
+  end
+
+  module PerformWrapper
+    def perform(*args)
+      super.tap do
+        $redis.set(
+          FinanceReportCompletionTracking.redis_key(self.class.name),
+          Time.current.to_i,
+          ex: FinanceReportCompletionTracking::REDIS_KEY_TTL.to_i
+        )
+      end
+    end
+  end
+
+  def self.included(base)
+    base.prepend(PerformWrapper)
+  end
+end

--- a/app/sidekiq/concerns/finance_report_completion_tracking.rb
+++ b/app/sidekiq/concerns/finance_report_completion_tracking.rb
@@ -6,27 +6,36 @@
 # e.g. a Sidekiq process killed mid-deploy losing the job entirely, so retries (and the
 # retry-exhaustion alert) never fire.
 #
+# Completions are keyed by class AND the run's resolved period args (explicit perform
+# args, or the job's `.default_alert_args` for a no-arg scheduled run). This way a manual
+# re-run for a DIFFERENT period (e.g. a TaxJar month re-push) can't mask a missed
+# scheduled run — the scheduled period's own key stays stale and the backstop still
+# catches it.
+#
 # Completion is recorded only when #perform returns without raising.
 module FinanceReportCompletionTracking
   REDIS_KEY_TTL = 120.days # covers a full quarterly cadence with room to spare
 
-  def self.redis_key(class_name)
-    "finance_report_last_completed_at:#{class_name}"
+  def self.redis_key(class_name, period_args)
+    "finance_report_last_completed_at:#{class_name}:#{Array(period_args).join(',')}"
   end
 
-  def self.last_completed_at(class_name)
-    timestamp = $redis.get(redis_key(class_name))
+  def self.last_completed_at(class_name, period_args)
+    timestamp = $redis.get(redis_key(class_name, period_args))
     timestamp && Time.zone.at(timestamp.to_i)
+  end
+
+  def self.record_completion(class_name, period_args, at: Time.current)
+    $redis.set(redis_key(class_name, period_args), at.to_i, ex: REDIS_KEY_TTL.to_i)
   end
 
   module PerformWrapper
     def perform(*args)
       super.tap do
-        $redis.set(
-          FinanceReportCompletionTracking.redis_key(self.class.name),
-          Time.current.to_i,
-          ex: FinanceReportCompletionTracking::REDIS_KEY_TTL.to_i
-        )
+        klass = self.class
+        period_args = args.presence ||
+          (klass.respond_to?(:default_alert_args) ? klass.default_alert_args : [])
+        FinanceReportCompletionTracking.record_completion(klass.name, period_args)
       end
     end
   end

--- a/app/sidekiq/concerns/finance_report_failure_alert.rb
+++ b/app/sidekiq/concerns/finance_report_failure_alert.rb
@@ -20,6 +20,8 @@
 # period the failed run was actually for.
 module FinanceReportFailureAlert
   def self.included(base)
+    base.include(FinanceReportCompletionTracking)
+
     base.sidekiq_retries_exhausted do |job, exception|
       args = job["args"]
       if args.blank? && base.respond_to?(:default_alert_args)

--- a/app/sidekiq/upload_us_states_sales_tax_to_taxjar_job.rb
+++ b/app/sidekiq/upload_us_states_sales_tax_to_taxjar_job.rb
@@ -13,6 +13,7 @@
 # or an overlap with a manual month re-push is safe.
 class UploadUsStatesSalesTaxToTaxjarJob
   include Sidekiq::Job
+  include FinanceReportCompletionTracking
   sidekiq_options retry: 5, queue: :default, lock: :until_executed
 
   sidekiq_retries_exhausted do |job, exception|

--- a/app/sidekiq/upload_us_states_sales_tax_to_taxjar_job.rb
+++ b/app/sidekiq/upload_us_states_sales_tax_to_taxjar_job.rb
@@ -16,6 +16,13 @@ class UploadUsStatesSalesTaxToTaxjarJob
   include FinanceReportCompletionTracking
   sidekiq_options retry: 5, queue: :default, lock: :until_executed
 
+  # Resolved default for a no-arg scheduled run (mirrors #perform's default). Used to key
+  # completion tracking so the backstop can distinguish the scheduled day's upload from a
+  # manual re-push of another day/month.
+  def self.default_alert_args(reference_time = Time.current)
+    [(reference_time.to_date - 1).iso8601]
+  end
+
   sidekiq_retries_exhausted do |job, exception|
     # The scheduler fires with no args (see config/sidekiq_schedule.yml), so job["args"].first is
     # nil for a scheduled run. Mirror #perform's default so the alert email's re-run command is

--- a/app/sidekiq/verify_finance_reports_delivery_job.rb
+++ b/app/sidekiq/verify_finance_reports_delivery_job.rb
@@ -26,6 +26,11 @@ class VerifyFinanceReportsDeliveryJob
   # while still checking every fire at least once — this job runs daily, so a miss is
   # seen within ~30 hours of the fire.
   LOOKBACK = 48.hours
+  # Set on the backstop's first ever run (which only records the baseline and checks
+  # nothing). Fires from before this moment predate completion tracking — the runs may
+  # well have completed without leaving a Redis key — so they are skipped instead of
+  # being replayed as false positives right after the first deploy.
+  ACTIVE_SINCE_REDIS_KEY = "finance_report_backstop_active_since"
 
   # Scheduler-fired jobs to verify, mapped to a builder for the re-run args pinned to the
   # period the missed fire was for. Fanned-out report jobs (Canada, VAT, fees, ...) are
@@ -47,6 +52,13 @@ class VerifyFinanceReportsDeliveryJob
 
     now = Time.current
 
+    active_since_raw = $redis.get(ACTIVE_SINCE_REDIS_KEY)
+    if active_since_raw.nil?
+      $redis.set(ACTIVE_SINCE_REDIS_KEY, now.to_i)
+      return
+    end
+    active_since = Time.zone.at(active_since_raw.to_i)
+
     schedule = YAML.load_file(Rails.root.join("config", "sidekiq_schedule.yml"))
     schedule.each_value do |entry|
       class_name = entry["class"]
@@ -57,11 +69,12 @@ class VerifyFinanceReportsDeliveryJob
       # pin the parse to UTC explicitly so this doesn't drift with server TZ.
       fire_time = Fugit::Cron.parse("#{entry['cron'].sub(/#.*/, '').strip} UTC").previous_time(now - GRACE_PERIOD).to_t.utc
       next if fire_time < now - LOOKBACK
-
-      last_completed_at = FinanceReportCompletionTracking.last_completed_at(class_name)
-      next if last_completed_at && last_completed_at >= fire_time
+      next if fire_time < active_since
 
       args = args_builder.call(fire_time)
+      last_completed_at = FinanceReportCompletionTracking.last_completed_at(class_name, args)
+      next if last_completed_at && last_completed_at >= fire_time
+
       class_name.constantize.perform_async(*args)
       AccountingMailer.finance_report_delivery_backstop_triggered(
         class_name, args, fire_time, last_completed_at

--- a/app/sidekiq/verify_finance_reports_delivery_job.rb
+++ b/app/sidekiq/verify_finance_reports_delivery_job.rb
@@ -21,11 +21,6 @@ class VerifyFinanceReportsDeliveryJob
   # Only fires older than this are checked, so a run that is merely slow (or scheduled
   # shortly before this backstop) isn't flagged as missing.
   GRACE_PERIOD = 6.hours
-  # Only fires within this window are checked. Keeps the first deploy (and any job whose
-  # last scheduled fire predates completion tracking) from alerting on missing history,
-  # while still checking every fire at least once — this job runs daily, so a miss is
-  # seen within ~30 hours of the fire.
-  LOOKBACK = 48.hours
   # Set on the backstop's first ever run (which only records the baseline and checks
   # nothing). Fires from before this moment predate completion tracking — the runs may
   # well have completed without leaving a Redis key — so they are skipped instead of
@@ -67,15 +62,31 @@ class VerifyFinanceReportsDeliveryJob
 
       # The schedule's cron expressions are documented (and fired in production) in UTC —
       # pin the parse to UTC explicitly so this doesn't drift with server TZ.
+      # The most recent fire is checked no matter how long ago it was (there is no
+      # lookback cutoff): a missed monthly or quarterly fire stays flagged on every
+      # verifier run until its completion is recorded, even if the verifier itself was
+      # down for days when the fire happened. Completion keys live 120 days
+      # (FinanceReportCompletionTracking::REDIS_KEY_TTL), longer than the longest cadence
+      # here (quarterly), so a completed run's key is always still present when its fire
+      # is checked. Fires from before activation are the one exception — they predate
+      # completion tracking entirely and are skipped as unknowable, not missing.
       fire_time = Fugit::Cron.parse("#{entry['cron'].sub(/#.*/, '').strip} UTC").previous_time(now - GRACE_PERIOD).to_t.utc
-      next if fire_time < now - LOOKBACK
       next if fire_time < active_since
 
       args = args_builder.call(fire_time)
       last_completed_at = FinanceReportCompletionTracking.last_completed_at(class_name, args)
       next if last_completed_at && last_completed_at >= fire_time
 
-      class_name.constantize.perform_async(*args)
+      # A duplicate enqueue can raise for unique jobs with on_conflict: :raise (e.g.
+      # yesterday's backstop re-run is still queued or running). The gap still gets
+      # alerted below, and one job's conflict must not stop the remaining jobs from
+      # being verified — so notify and carry on rather than let it bubble.
+      begin
+        class_name.constantize.perform_async(*args)
+      rescue => e
+        ErrorNotifier.notify(e, class_name:, fire_time: fire_time.iso8601)
+      end
+
       AccountingMailer.finance_report_delivery_backstop_triggered(
         class_name, args, fire_time, last_completed_at
       ).deliver_later

--- a/app/sidekiq/verify_finance_reports_delivery_job.rb
+++ b/app/sidekiq/verify_finance_reports_delivery_job.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# Daily backstop for the scheduler-fired finance report jobs (phase 2 of the robustness
+# pass — see FinanceReportFailureAlert).
+#
+# Retry-exhaustion alerts only fire when Sidekiq gets to run the retries. A run can also
+# vanish entirely — a Sidekiq process killed mid-deploy loses the in-flight job, or the
+# scheduler tick itself is missed — and then nothing raises, nothing retries, and no alert
+# goes out. This job closes that gap: every day it checks, for each scheduler-fired
+# finance report job, that a completion was recorded (FinanceReportCompletionTracking)
+# after the job's most recent scheduled fire time. If not, it re-enqueues the job with
+# arguments pinned to the period the missed run was for, and emails the payments
+# notification address so the gap is visible.
+#
+# Re-enqueueing is safe: every verified job is a read-only aggregation (or, for the
+# TaxJar upload, idempotent — already-imported orders are skipped).
+class VerifyFinanceReportsDeliveryJob
+  include Sidekiq::Job
+  sidekiq_options retry: 5, queue: :default, lock: :until_executed, on_conflict: :replace
+
+  # Only fires older than this are checked, so a run that is merely slow (or scheduled
+  # shortly before this backstop) isn't flagged as missing.
+  GRACE_PERIOD = 6.hours
+  # Only fires within this window are checked. Keeps the first deploy (and any job whose
+  # last scheduled fire predates completion tracking) from alerting on missing history,
+  # while still checking every fire at least once — this job runs daily, so a miss is
+  # seen within ~30 hours of the fire.
+  LOOKBACK = 48.hours
+
+  # Scheduler-fired jobs to verify, mapped to a builder for the re-run args pinned to the
+  # period the missed fire was for. Fanned-out report jobs (Canada, VAT, fees, ...) are
+  # covered transitively: if an orchestrator run vanishes, re-enqueueing the orchestrator
+  # re-enqueues them all.
+  VERIFIED_JOBS = {
+    "SendFinancesReportWorker" => ->(fire_time) { SendFinancesReportWorker.default_alert_args(fire_time) },
+    "SendDeferredRefundsReportWorker" => ->(fire_time) { SendDeferredRefundsReportWorker.default_alert_args(fire_time) },
+    "SendStripeCurrencyBalancesReportJob" => ->(_fire_time) { [] },
+    "EmailOutstandingBalancesCsvWorker" => ->(_fire_time) { [] },
+    "CreateIndiaSalesReportJob" => ->(fire_time) { CreateIndiaSalesReportJob.default_alert_args(fire_time) },
+    "GenerateFinancialReportsForPreviousMonthJob" => ->(fire_time) { GenerateFinancialReportsForPreviousMonthJob.default_alert_args(fire_time) },
+    "GenerateFinancialReportsForPreviousQuarterJob" => ->(fire_time) { GenerateFinancialReportsForPreviousQuarterJob.default_alert_args(fire_time) },
+    "UploadUsStatesSalesTaxToTaxjarJob" => ->(fire_time) { [(fire_time.to_date - 1).iso8601] },
+  }.freeze
+
+  def perform
+    return unless Rails.env.production?
+
+    now = Time.current
+
+    schedule = YAML.load_file(Rails.root.join("config", "sidekiq_schedule.yml"))
+    schedule.each_value do |entry|
+      class_name = entry["class"]
+      args_builder = VERIFIED_JOBS[class_name]
+      next if args_builder.nil?
+
+      # The schedule's cron expressions are documented (and fired in production) in UTC —
+      # pin the parse to UTC explicitly so this doesn't drift with server TZ.
+      fire_time = Fugit::Cron.parse("#{entry['cron'].sub(/#.*/, '').strip} UTC").previous_time(now - GRACE_PERIOD).to_t.utc
+      next if fire_time < now - LOOKBACK
+
+      last_completed_at = FinanceReportCompletionTracking.last_completed_at(class_name)
+      next if last_completed_at && last_completed_at >= fire_time
+
+      args = args_builder.call(fire_time)
+      class_name.constantize.perform_async(*args)
+      AccountingMailer.finance_report_delivery_backstop_triggered(
+        class_name, args, fire_time, last_completed_at
+      ).deliver_later
+    end
+  end
+end

--- a/app/views/accounting_mailer/finance_report_delivery_backstop_triggered.html.erb
+++ b/app/views/accounting_mailer/finance_report_delivery_backstop_triggered.html.erb
@@ -1,0 +1,10 @@
+<%= header_section("#{@job_name} scheduled run never completed") %>
+<div>
+  <p>The daily backstop (<code>VerifyFinanceReportsDeliveryJob</code>) found no recorded completion for <code><%= @job_name %></code> after its scheduled fire time. This usually means the run was lost entirely (e.g. a Sidekiq process died mid-deploy), so no retries — and no retry-exhaustion alert — ever fired.</p>
+  <ul>
+    <li>Scheduled fire time: <%= @fire_time %></li>
+    <li>Last recorded completion: <%= @last_completed_at || "never" %></li>
+  </ul>
+  <p><strong>The job has been re-enqueued automatically</strong> with the period pinned to the missed run: <code><%= @rerun_command %></code> (safe — these reports are read-only aggregations / idempotent uploads).</p>
+  <p>No action needed unless this alert repeats for the same job tomorrow — that means the re-enqueued run also failed to complete and needs investigation.</p>
+</div>

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -385,6 +385,10 @@ upload_us_states_sales_tax_to_taxjar:
   cron: "0 3 * * *" # UTC 03:00 every day (uploads the previous day's orders)
   class: UploadUsStatesSalesTaxToTaxjarJob
   description: Upload the previous day's taxable US-state order transactions to TaxJar
+verify_finance_reports_delivery:
+  cron: "0 18 * * *" # UTC 18:00 every day (after the monthly 11:00 fires + 6h grace period)
+  class: VerifyFinanceReportsDeliveryJob
+  description: Re-enqueue and alert on scheduled finance report runs that never completed
 delete_old_sent_email_info_records:
   cron: "0 1 1 * *" # UTC 01:00 on 1st of every month
   class: DeleteOldSentEmailInfoRecordsJob

--- a/spec/mailers/accounting_mailer_spec.rb
+++ b/spec/mailers/accounting_mailer_spec.rb
@@ -189,6 +189,36 @@ describe AccountingMailer, :vcr do
     end
   end
 
+  describe "#finance_report_delivery_backstop_triggered" do
+    let(:mail) do
+      AccountingMailer.finance_report_delivery_backstop_triggered(
+        "SendFinancesReportWorker", [6, 2026], Time.utc(2026, 7, 1, 11), nil
+      )
+    end
+
+    it "sends to the payments notification email" do
+      expect(mail.to).to eq([PAYMENTS_NOTIFICATION_EMAIL])
+    end
+
+    it "names the job in the subject" do
+      expect(mail.subject).to include("SendFinancesReportWorker scheduled run never completed")
+    end
+
+    it "includes the fire time, missing completion, and re-run command in the body" do
+      body = mail.body.encoded
+      expect(body).to include("2026-07-01 11:00:00")
+      expect(body).to include("never")
+      expect(body).to include("SendFinancesReportWorker.perform_async(6, 2026)")
+    end
+
+    it "shows the stale completion time when one exists" do
+      stale_mail = AccountingMailer.finance_report_delivery_backstop_triggered(
+        "SendDeferredRefundsReportWorker", [6, 2026], Time.utc(2026, 7, 1, 11), Time.utc(2026, 6, 1, 11, 5)
+      )
+      expect(stale_mail.body.encoded).to include("2026-06-01 11:05:00")
+    end
+  end
+
   describe "#global_sales_tax_summary_report_failed" do
     let(:mail) do
       AccountingMailer.global_sales_tax_summary_report_failed(

--- a/spec/sidekiq/concerns/finance_report_completion_tracking_spec.rb
+++ b/spec/sidekiq/concerns/finance_report_completion_tracking_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+describe FinanceReportCompletionTracking do
+  before do
+    allow(Rails.env).to receive(:production?).and_return(true)
+    $redis.del(FinanceReportCompletionTracking.redis_key("SendStripeCurrencyBalancesReportJob"))
+  end
+
+  it "records a completion timestamp when perform succeeds" do
+    allow(StripeCurrencyBalancesReport).to receive(:stripe_currency_balances_report).and_return("csv")
+    mailer = double("mailer", deliver_now: true)
+    allow(AccountingMailer).to receive(:stripe_currency_balances_report).and_return(mailer)
+
+    travel_to(Time.utc(2026, 7, 1, 11)) do
+      SendStripeCurrencyBalancesReportJob.new.perform
+
+      expect(FinanceReportCompletionTracking.last_completed_at("SendStripeCurrencyBalancesReportJob"))
+        .to eq(Time.utc(2026, 7, 1, 11))
+    end
+  end
+
+  it "does not record a completion timestamp when perform raises" do
+    allow(StripeCurrencyBalancesReport).to receive(:stripe_currency_balances_report)
+      .and_raise(ActiveRecord::StatementTimeout)
+
+    expect do
+      SendStripeCurrencyBalancesReportJob.new.perform
+    end.to raise_error(ActiveRecord::StatementTimeout)
+
+    expect(FinanceReportCompletionTracking.last_completed_at("SendStripeCurrencyBalancesReportJob")).to be_nil
+  end
+
+  it "returns nil when no completion has been recorded" do
+    expect(FinanceReportCompletionTracking.last_completed_at("SendStripeCurrencyBalancesReportJob")).to be_nil
+  end
+end

--- a/spec/sidekiq/concerns/finance_report_completion_tracking_spec.rb
+++ b/spec/sidekiq/concerns/finance_report_completion_tracking_spec.rb
@@ -3,34 +3,68 @@
 describe FinanceReportCompletionTracking do
   before do
     allow(Rails.env).to receive(:production?).and_return(true)
-    $redis.del(FinanceReportCompletionTracking.redis_key("SendStripeCurrencyBalancesReportJob"))
   end
 
-  it "records a completion timestamp when perform succeeds" do
-    allow(StripeCurrencyBalancesReport).to receive(:stripe_currency_balances_report).and_return("csv")
-    mailer = double("mailer", deliver_now: true)
-    allow(AccountingMailer).to receive(:stripe_currency_balances_report).and_return(mailer)
+  describe "no-arg job without period defaults (SendStripeCurrencyBalancesReportJob)" do
+    before do
+      $redis.del(FinanceReportCompletionTracking.redis_key("SendStripeCurrencyBalancesReportJob", []))
+    end
 
-    travel_to(Time.utc(2026, 7, 1, 11)) do
-      SendStripeCurrencyBalancesReportJob.new.perform
+    it "records a completion timestamp when perform succeeds" do
+      allow(StripeCurrencyBalancesReport).to receive(:stripe_currency_balances_report).and_return("csv")
+      mailer = double("mailer", deliver_now: true)
+      allow(AccountingMailer).to receive(:stripe_currency_balances_report).and_return(mailer)
 
-      expect(FinanceReportCompletionTracking.last_completed_at("SendStripeCurrencyBalancesReportJob"))
-        .to eq(Time.utc(2026, 7, 1, 11))
+      travel_to(Time.utc(2026, 7, 1, 11)) do
+        SendStripeCurrencyBalancesReportJob.new.perform
+
+        expect(FinanceReportCompletionTracking.last_completed_at("SendStripeCurrencyBalancesReportJob", []))
+          .to eq(Time.utc(2026, 7, 1, 11))
+      end
+    end
+
+    it "does not record a completion timestamp when perform raises" do
+      allow(StripeCurrencyBalancesReport).to receive(:stripe_currency_balances_report)
+        .and_raise(ActiveRecord::StatementTimeout)
+
+      expect do
+        SendStripeCurrencyBalancesReportJob.new.perform
+      end.to raise_error(ActiveRecord::StatementTimeout)
+
+      expect(FinanceReportCompletionTracking.last_completed_at("SendStripeCurrencyBalancesReportJob", [])).to be_nil
+    end
+
+    it "returns nil when no completion has been recorded" do
+      expect(FinanceReportCompletionTracking.last_completed_at("SendStripeCurrencyBalancesReportJob", [])).to be_nil
     end
   end
 
-  it "does not record a completion timestamp when perform raises" do
-    allow(StripeCurrencyBalancesReport).to receive(:stripe_currency_balances_report)
-      .and_raise(ActiveRecord::StatementTimeout)
+  describe "period keying (SendFinancesReportWorker)" do
+    let(:mailer) { double("mailer", deliver_now: true) }
 
-    expect do
-      SendStripeCurrencyBalancesReportJob.new.perform
-    end.to raise_error(ActiveRecord::StatementTimeout)
+    before do
+      allow(AccountingMailer).to receive(:funds_received_report).and_return(mailer)
+      $redis.del(FinanceReportCompletionTracking.redis_key("SendFinancesReportWorker", [6, 2026]))
+      $redis.del(FinanceReportCompletionTracking.redis_key("SendFinancesReportWorker", [3, 2026]))
+    end
 
-    expect(FinanceReportCompletionTracking.last_completed_at("SendStripeCurrencyBalancesReportJob")).to be_nil
-  end
+    it "keys a no-arg scheduled run by the resolved default period" do
+      travel_to(Time.utc(2026, 7, 1, 11)) do
+        SendFinancesReportWorker.new.perform
 
-  it "returns nil when no completion has been recorded" do
-    expect(FinanceReportCompletionTracking.last_completed_at("SendStripeCurrencyBalancesReportJob")).to be_nil
+        expect(FinanceReportCompletionTracking.last_completed_at("SendFinancesReportWorker", [6, 2026]))
+          .to eq(Time.utc(2026, 7, 1, 11))
+      end
+    end
+
+    it "keys an explicit-args run by those args, leaving other periods untouched" do
+      travel_to(Time.utc(2026, 7, 1, 12)) do
+        SendFinancesReportWorker.new.perform(3, 2026)
+
+        expect(FinanceReportCompletionTracking.last_completed_at("SendFinancesReportWorker", [3, 2026]))
+          .to eq(Time.utc(2026, 7, 1, 12))
+        expect(FinanceReportCompletionTracking.last_completed_at("SendFinancesReportWorker", [6, 2026])).to be_nil
+      end
+    end
   end
 end

--- a/spec/sidekiq/verify_finance_reports_delivery_job_spec.rb
+++ b/spec/sidekiq/verify_finance_reports_delivery_job_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+describe VerifyFinanceReportsDeliveryJob do
+  before do
+    allow(Rails.env).to receive(:production?).and_return(true)
+    allow(AccountingMailer).to receive(:finance_report_delivery_backstop_triggered).and_return(double("mailer", deliver_later: true))
+    described_class::VERIFIED_JOBS.each_key do |class_name|
+      $redis.del(FinanceReportCompletionTracking.redis_key(class_name))
+    end
+  end
+
+  def record_completion(class_name, at:)
+    $redis.set(FinanceReportCompletionTracking.redis_key(class_name), at.to_i)
+  end
+
+  # 2026-07-01 was a monthly fire day (11:00 UTC); backstop runs at 18:00 UTC.
+  let(:backstop_run_time) { Time.utc(2026, 7, 1, 18) }
+
+  it "re-enqueues a monthly job whose scheduled run never completed, with the period pinned to the missed run" do
+    travel_to(backstop_run_time) do
+      described_class::VERIFIED_JOBS.each_key { |name| record_completion(name, at: Time.current) }
+      $redis.del(FinanceReportCompletionTracking.redis_key("SendFinancesReportWorker"))
+
+      described_class.new.perform
+
+      expect(SendFinancesReportWorker).to have_enqueued_sidekiq_job(6, 2026)
+      expect(AccountingMailer).to have_received(:finance_report_delivery_backstop_triggered)
+        .with("SendFinancesReportWorker", [6, 2026], Time.utc(2026, 7, 1, 11), nil)
+    end
+  end
+
+  it "re-enqueues the daily TaxJar upload with the day the missed run was for" do
+    travel_to(backstop_run_time) do
+      described_class::VERIFIED_JOBS.each_key { |name| record_completion(name, at: Time.current) }
+      $redis.del(FinanceReportCompletionTracking.redis_key("UploadUsStatesSalesTaxToTaxjarJob"))
+
+      described_class.new.perform
+
+      # Fire was 03:00 UTC on 2026-07-01, which uploads the previous day's orders.
+      expect(UploadUsStatesSalesTaxToTaxjarJob).to have_enqueued_sidekiq_job("2026-06-30")
+    end
+  end
+
+  it "does nothing when every job completed after its scheduled fire time" do
+    travel_to(backstop_run_time) do
+      described_class::VERIFIED_JOBS.each_key { |name| record_completion(name, at: Time.current) }
+
+      described_class.new.perform
+
+      expect(SendFinancesReportWorker.jobs).to be_empty
+      expect(UploadUsStatesSalesTaxToTaxjarJob.jobs).to be_empty
+      expect(AccountingMailer).not_to have_received(:finance_report_delivery_backstop_triggered)
+    end
+  end
+
+  it "flags a stale completion from before the scheduled fire time" do
+    travel_to(backstop_run_time) do
+      described_class::VERIFIED_JOBS.each_key { |name| record_completion(name, at: Time.current) }
+      record_completion("SendDeferredRefundsReportWorker", at: Time.utc(2026, 6, 1, 11, 5))
+
+      described_class.new.perform
+
+      expect(SendDeferredRefundsReportWorker).to have_enqueued_sidekiq_job(6, 2026)
+      expect(AccountingMailer).to have_received(:finance_report_delivery_backstop_triggered)
+        .with("SendDeferredRefundsReportWorker", [6, 2026], Time.utc(2026, 7, 1, 11), Time.utc(2026, 6, 1, 11, 5))
+    end
+  end
+
+  it "skips fires older than the lookback window instead of alerting on missing history" do
+    # Mid-month: the last monthly fire (June 1) is far outside the 48h lookback; only the
+    # daily TaxJar fire is within it.
+    travel_to(Time.utc(2026, 7, 15, 18)) do
+      record_completion("UploadUsStatesSalesTaxToTaxjarJob", at: Time.current)
+
+      described_class.new.perform
+
+      expect(SendFinancesReportWorker.jobs).to be_empty
+      expect(GenerateFinancialReportsForPreviousMonthJob.jobs).to be_empty
+      expect(AccountingMailer).not_to have_received(:finance_report_delivery_backstop_triggered)
+    end
+  end
+
+  it "leaves a recent fire inside the grace period unchecked" do
+    # At 08:00 UTC the 03:00 TaxJar fire is only 5h old (< 6h grace): the checked fire is
+    # yesterday's, which completed — so a still-running today's job isn't flagged.
+    travel_to(Time.utc(2026, 7, 15, 8)) do
+      record_completion("UploadUsStatesSalesTaxToTaxjarJob", at: Time.utc(2026, 7, 14, 3, 30))
+
+      described_class.new.perform
+
+      expect(UploadUsStatesSalesTaxToTaxjarJob.jobs).to be_empty
+      expect(AccountingMailer).not_to have_received(:finance_report_delivery_backstop_triggered)
+    end
+  end
+
+  it "re-enqueues the quarterly orchestrator with the quarter the missed run was for" do
+    # Quarterly fire: 10:00 UTC on July 2nd.
+    travel_to(Time.utc(2026, 7, 2, 18)) do
+      described_class::VERIFIED_JOBS.each_key { |name| record_completion(name, at: Time.current) }
+      $redis.del(FinanceReportCompletionTracking.redis_key("GenerateFinancialReportsForPreviousQuarterJob"))
+
+      described_class.new.perform
+
+      expect(GenerateFinancialReportsForPreviousQuarterJob).to have_enqueued_sidekiq_job(2, 2026)
+    end
+  end
+
+  it "verifies every scheduler-fired job in VERIFIED_JOBS exists in the schedule" do
+    schedule_classes = YAML.load_file(Rails.root.join("config", "sidekiq_schedule.yml")).values.map { _1["class"] }
+    described_class::VERIFIED_JOBS.each_key do |class_name|
+      expect(schedule_classes).to include(class_name), "#{class_name} is verified but not in sidekiq_schedule.yml"
+      expect(class_name.constantize.ancestors).to include(FinanceReportCompletionTracking),
+                                                  "#{class_name} is verified but does not record completions"
+    end
+  end
+end

--- a/spec/sidekiq/verify_finance_reports_delivery_job_spec.rb
+++ b/spec/sidekiq/verify_finance_reports_delivery_job_spec.rb
@@ -127,12 +127,27 @@ describe VerifyFinanceReportsDeliveryJob do
     end
   end
 
-  it "skips fires older than the lookback window instead of alerting on missing history" do
-    # Mid-month: the last monthly fire (June 1) is far outside the 48h lookback; only the
-    # daily TaxJar fire is within it.
+  it "still flags a missed fire when the verifier itself is delayed for days (no age-out)" do
+    # The monthly fire on July 1 was missed and the verifier didn't run until July 3 —
+    # the miss must still be caught, not aged out of a lookback window.
+    travel_to(Time.utc(2026, 7, 3, 18)) do
+      activate_backstop(at: Time.utc(2026, 6, 25))
+      record_all_completions(Time.utc(2026, 7, 3, 18))
+      clear_completion_for_fire("SendFinancesReportWorker", monthly_fire)
+
+      described_class.new.perform
+
+      expect(SendFinancesReportWorker).to have_enqueued_sidekiq_job(6, 2026)
+      expect(AccountingMailer).to have_received(:finance_report_delivery_backstop_triggered)
+        .with("SendFinancesReportWorker", [6, 2026], monthly_fire, nil)
+    end
+  end
+
+  it "does not re-flag old completed fires mid-month" do
+    # Mid-month, every job's most recent fire has a completion recorded — nothing alerts.
     travel_to(Time.utc(2026, 7, 15, 18)) do
       activate_backstop(at: Time.utc(2026, 6, 25))
-      record_completion_for_fire("UploadUsStatesSalesTaxToTaxjarJob", Time.utc(2026, 7, 15, 3), at: Time.current)
+      record_all_completions(Time.utc(2026, 7, 15, 18))
 
       described_class.new.perform
 
@@ -142,12 +157,34 @@ describe VerifyFinanceReportsDeliveryJob do
     end
   end
 
+  it "alerts and keeps verifying the remaining jobs when a re-enqueue raises (e.g. a pending-rerun lock conflict)" do
+    travel_to(backstop_run_time) do
+      activate_backstop(at: Time.utc(2026, 6, 25))
+      record_all_completions(backstop_run_time)
+      clear_completion_for_fire("SendFinancesReportWorker", monthly_fire)
+      clear_completion_for_fire("UploadUsStatesSalesTaxToTaxjarJob", taxjar_fire)
+      # SendFinancesReportWorker's rerun conflicts with one still pending from yesterday.
+      allow(SendFinancesReportWorker).to receive(:perform_async).and_raise(RuntimeError, "lock conflict")
+
+      described_class.new.perform
+
+      # The gap is still alerted even though the re-enqueue was refused...
+      expect(AccountingMailer).to have_received(:finance_report_delivery_backstop_triggered)
+        .with("SendFinancesReportWorker", [6, 2026], monthly_fire, nil)
+      # ...and the loop went on to check (and fix) the remaining jobs.
+      expect(UploadUsStatesSalesTaxToTaxjarJob).to have_enqueued_sidekiq_job("2026-06-30")
+    end
+  end
+
   it "leaves a recent fire inside the grace period unchecked" do
     # At 08:00 UTC the 03:00 TaxJar fire is only 5h old (< 6h grace): the checked fire is
     # yesterday's, which completed — so a still-running today's job isn't flagged.
     travel_to(Time.utc(2026, 7, 15, 8)) do
       activate_backstop(at: Time.utc(2026, 6, 25))
-      record_completion_for_fire("UploadUsStatesSalesTaxToTaxjarJob", Time.utc(2026, 7, 14, 3), at: Time.utc(2026, 7, 14, 3, 30))
+      # Every job's CHECKED fire (the last one older than the grace period) completed —
+      # for TaxJar that's yesterday's 03:00 fire; today's 03:00 fire has no completion
+      # but is inside the grace period, so it isn't checked.
+      record_all_completions(Time.utc(2026, 7, 15, 8))
 
       described_class.new.perform
 

--- a/spec/sidekiq/verify_finance_reports_delivery_job_spec.rb
+++ b/spec/sidekiq/verify_finance_reports_delivery_job_spec.rb
@@ -4,35 +4,78 @@ describe VerifyFinanceReportsDeliveryJob do
   before do
     allow(Rails.env).to receive(:production?).and_return(true)
     allow(AccountingMailer).to receive(:finance_report_delivery_backstop_triggered).and_return(double("mailer", deliver_later: true))
-    described_class::VERIFIED_JOBS.each_key do |class_name|
-      $redis.del(FinanceReportCompletionTracking.redis_key(class_name))
-    end
+    $redis.del(described_class::ACTIVE_SINCE_REDIS_KEY)
   end
 
-  def record_completion(class_name, at:)
-    $redis.set(FinanceReportCompletionTracking.redis_key(class_name), at.to_i)
+  def activate_backstop(at:)
+    $redis.set(described_class::ACTIVE_SINCE_REDIS_KEY, at.to_i)
+  end
+
+  def record_completion_for_fire(class_name, fire_time, at:)
+    args = described_class::VERIFIED_JOBS[class_name].call(fire_time)
+    FinanceReportCompletionTracking.record_completion(class_name, args, at:)
+  end
+
+  def clear_completion_for_fire(class_name, fire_time)
+    args = described_class::VERIFIED_JOBS[class_name].call(fire_time)
+    $redis.del(FinanceReportCompletionTracking.redis_key(class_name, args))
   end
 
   # 2026-07-01 was a monthly fire day (11:00 UTC); backstop runs at 18:00 UTC.
   let(:backstop_run_time) { Time.utc(2026, 7, 1, 18) }
+  let(:monthly_fire) { Time.utc(2026, 7, 1, 11) }
+  let(:taxjar_fire) { Time.utc(2026, 7, 1, 3) }
+
+  def record_all_completions(now)
+    described_class::VERIFIED_JOBS.each_key do |class_name|
+      entry = YAML.load_file(Rails.root.join("config", "sidekiq_schedule.yml")).values.find { _1["class"] == class_name }
+      fire_time = Fugit::Cron.parse("#{entry['cron'].sub(/#.*/, '').strip} UTC").previous_time(now - described_class::GRACE_PERIOD).to_t.utc
+      record_completion_for_fire(class_name, fire_time, at: now)
+    end
+  end
+
+  it "records a baseline and checks nothing on its first ever run" do
+    travel_to(backstop_run_time) do
+      described_class.new.perform
+
+      expect($redis.get(described_class::ACTIVE_SINCE_REDIS_KEY)).to eq(backstop_run_time.to_i.to_s)
+      expect(SendFinancesReportWorker.jobs).to be_empty
+      expect(UploadUsStatesSalesTaxToTaxjarJob.jobs).to be_empty
+      expect(AccountingMailer).not_to have_received(:finance_report_delivery_backstop_triggered)
+    end
+  end
+
+  it "skips fires that predate activation instead of replaying already-completed history" do
+    travel_to(backstop_run_time) do
+      # Activated after today's fires: nothing recorded completions, but nothing alerts.
+      activate_backstop(at: Time.utc(2026, 7, 1, 17))
+
+      described_class.new.perform
+
+      expect(SendFinancesReportWorker.jobs).to be_empty
+      expect(AccountingMailer).not_to have_received(:finance_report_delivery_backstop_triggered)
+    end
+  end
 
   it "re-enqueues a monthly job whose scheduled run never completed, with the period pinned to the missed run" do
     travel_to(backstop_run_time) do
-      described_class::VERIFIED_JOBS.each_key { |name| record_completion(name, at: Time.current) }
-      $redis.del(FinanceReportCompletionTracking.redis_key("SendFinancesReportWorker"))
+      activate_backstop(at: Time.utc(2026, 6, 25))
+      record_all_completions(backstop_run_time)
+      clear_completion_for_fire("SendFinancesReportWorker", monthly_fire)
 
       described_class.new.perform
 
       expect(SendFinancesReportWorker).to have_enqueued_sidekiq_job(6, 2026)
       expect(AccountingMailer).to have_received(:finance_report_delivery_backstop_triggered)
-        .with("SendFinancesReportWorker", [6, 2026], Time.utc(2026, 7, 1, 11), nil)
+        .with("SendFinancesReportWorker", [6, 2026], monthly_fire, nil)
     end
   end
 
   it "re-enqueues the daily TaxJar upload with the day the missed run was for" do
     travel_to(backstop_run_time) do
-      described_class::VERIFIED_JOBS.each_key { |name| record_completion(name, at: Time.current) }
-      $redis.del(FinanceReportCompletionTracking.redis_key("UploadUsStatesSalesTaxToTaxjarJob"))
+      activate_backstop(at: Time.utc(2026, 6, 25))
+      record_all_completions(backstop_run_time)
+      clear_completion_for_fire("UploadUsStatesSalesTaxToTaxjarJob", taxjar_fire)
 
       described_class.new.perform
 
@@ -41,9 +84,26 @@ describe VerifyFinanceReportsDeliveryJob do
     end
   end
 
+  it "is not fooled by a manual re-run for a different period completing after the fire" do
+    travel_to(backstop_run_time) do
+      activate_backstop(at: Time.utc(2026, 6, 25))
+      record_all_completions(backstop_run_time)
+      clear_completion_for_fire("UploadUsStatesSalesTaxToTaxjarJob", taxjar_fire)
+      # A manual re-push of an OLD day completed after today's fire — different period key.
+      FinanceReportCompletionTracking.record_completion(
+        "UploadUsStatesSalesTaxToTaxjarJob", ["2026-06-15"], at: Time.utc(2026, 7, 1, 12)
+      )
+
+      described_class.new.perform
+
+      expect(UploadUsStatesSalesTaxToTaxjarJob).to have_enqueued_sidekiq_job("2026-06-30")
+    end
+  end
+
   it "does nothing when every job completed after its scheduled fire time" do
     travel_to(backstop_run_time) do
-      described_class::VERIFIED_JOBS.each_key { |name| record_completion(name, at: Time.current) }
+      activate_backstop(at: Time.utc(2026, 6, 25))
+      record_all_completions(backstop_run_time)
 
       described_class.new.perform
 
@@ -55,14 +115,15 @@ describe VerifyFinanceReportsDeliveryJob do
 
   it "flags a stale completion from before the scheduled fire time" do
     travel_to(backstop_run_time) do
-      described_class::VERIFIED_JOBS.each_key { |name| record_completion(name, at: Time.current) }
-      record_completion("SendDeferredRefundsReportWorker", at: Time.utc(2026, 6, 1, 11, 5))
+      activate_backstop(at: Time.utc(2026, 6, 25))
+      record_all_completions(backstop_run_time)
+      record_completion_for_fire("SendDeferredRefundsReportWorker", monthly_fire, at: Time.utc(2026, 7, 1, 10))
 
       described_class.new.perform
 
       expect(SendDeferredRefundsReportWorker).to have_enqueued_sidekiq_job(6, 2026)
       expect(AccountingMailer).to have_received(:finance_report_delivery_backstop_triggered)
-        .with("SendDeferredRefundsReportWorker", [6, 2026], Time.utc(2026, 7, 1, 11), Time.utc(2026, 6, 1, 11, 5))
+        .with("SendDeferredRefundsReportWorker", [6, 2026], monthly_fire, Time.utc(2026, 7, 1, 10))
     end
   end
 
@@ -70,7 +131,8 @@ describe VerifyFinanceReportsDeliveryJob do
     # Mid-month: the last monthly fire (June 1) is far outside the 48h lookback; only the
     # daily TaxJar fire is within it.
     travel_to(Time.utc(2026, 7, 15, 18)) do
-      record_completion("UploadUsStatesSalesTaxToTaxjarJob", at: Time.current)
+      activate_backstop(at: Time.utc(2026, 6, 25))
+      record_completion_for_fire("UploadUsStatesSalesTaxToTaxjarJob", Time.utc(2026, 7, 15, 3), at: Time.current)
 
       described_class.new.perform
 
@@ -84,7 +146,8 @@ describe VerifyFinanceReportsDeliveryJob do
     # At 08:00 UTC the 03:00 TaxJar fire is only 5h old (< 6h grace): the checked fire is
     # yesterday's, which completed — so a still-running today's job isn't flagged.
     travel_to(Time.utc(2026, 7, 15, 8)) do
-      record_completion("UploadUsStatesSalesTaxToTaxjarJob", at: Time.utc(2026, 7, 14, 3, 30))
+      activate_backstop(at: Time.utc(2026, 6, 25))
+      record_completion_for_fire("UploadUsStatesSalesTaxToTaxjarJob", Time.utc(2026, 7, 14, 3), at: Time.utc(2026, 7, 14, 3, 30))
 
       described_class.new.perform
 
@@ -96,8 +159,9 @@ describe VerifyFinanceReportsDeliveryJob do
   it "re-enqueues the quarterly orchestrator with the quarter the missed run was for" do
     # Quarterly fire: 10:00 UTC on July 2nd.
     travel_to(Time.utc(2026, 7, 2, 18)) do
-      described_class::VERIFIED_JOBS.each_key { |name| record_completion(name, at: Time.current) }
-      $redis.del(FinanceReportCompletionTracking.redis_key("GenerateFinancialReportsForPreviousQuarterJob"))
+      activate_backstop(at: Time.utc(2026, 6, 25))
+      record_all_completions(Time.utc(2026, 7, 2, 18))
+      clear_completion_for_fire("GenerateFinancialReportsForPreviousQuarterJob", Time.utc(2026, 7, 2, 10))
 
       described_class.new.perform
 
@@ -105,12 +169,30 @@ describe VerifyFinanceReportsDeliveryJob do
     end
   end
 
-  it "verifies every scheduler-fired job in VERIFIED_JOBS exists in the schedule" do
+  it "verifies every scheduler-fired job in VERIFIED_JOBS exists in the schedule and records completions" do
     schedule_classes = YAML.load_file(Rails.root.join("config", "sidekiq_schedule.yml")).values.map { _1["class"] }
     described_class::VERIFIED_JOBS.each_key do |class_name|
       expect(schedule_classes).to include(class_name), "#{class_name} is verified but not in sidekiq_schedule.yml"
       expect(class_name.constantize.ancestors).to include(FinanceReportCompletionTracking),
                                                   "#{class_name} is verified but does not record completions"
+    end
+  end
+
+  it "resolves the same period key at completion time as the verifier does for the fire" do
+    # A scheduled no-arg run completes shortly after its fire; the tracking key it writes
+    # must be the one the verifier reads for that fire, for every verified job.
+    described_class::VERIFIED_JOBS.each do |class_name, args_builder|
+      klass = class_name.constantize
+      fire_args = args_builder.call(monthly_fire)
+      completion_args =
+        if klass.respond_to?(:default_alert_args)
+          travel_to(monthly_fire + 5.minutes) { klass.default_alert_args }
+        else
+          []
+        end
+
+      expect(completion_args).to eq(fire_args),
+                                 "#{class_name}: completion key #{completion_args.inspect} != verifier key #{fire_args.inspect}"
     end
   end
 end


### PR DESCRIPTION
Phase 2 of #5697 — a self-verifying backstop for the scheduled finance report runs. Follows #5699 (retry-exhaustion alerts).

## What

- **`FinanceReportCompletionTracking`**: records a last-completed-at timestamp in Redis when a finance report job's `perform` returns without raising. Included automatically by `FinanceReportFailureAlert` (all 12 report jobs + both orchestrators) and added to `UploadUsStatesSalesTaxToTaxjarJob`. Completions are keyed by **class + resolved period args**, so a manual re-run for a different period (e.g. a TaxJar month re-push) can't mask a missed scheduled run.
- **`VerifyFinanceReportsDeliveryJob`** (new, daily at 18:00 UTC): for each scheduler-fired finance report job, checks that a completion was recorded after the job's most recent scheduled fire (6h grace period, 48h lookback). If not, it **re-enqueues the job with args pinned to the period the missed run was for** and emails the payments notification address. Fanned-out report jobs (Canada, VAT, fees, …) are covered transitively — if an orchestrator run vanishes, re-enqueueing it re-enqueues them all.
- **First-run baseline**: the backstop's first ever run only records an activation timestamp and checks nothing; fires predating activation are skipped. Prevents duplicate reports right after deploy, when no completion keys exist yet.

## Why

Retry-exhaustion alerts (#5699) only fire when Sidekiq gets to run the retries. A run can also vanish entirely — a Sidekiq process killed mid-deploy loses the in-flight job, or the scheduler tick itself is missed — and then nothing raises, nothing retries, and no alert goes out. This is the exact silent-zero shape of the Feb 2026 TaxJar incident. The backstop closes that gap: any scheduled finance report run that never completes is now noticed and healed within ~a day.

Re-enqueueing is safe: every verified job is a read-only aggregation, and the TaxJar upload is idempotent (already-imported orders are skipped).

## Test plan

- `spec/sidekiq/verify_finance_reports_delivery_job_spec.rb` (11 examples): first-run baseline; pre-activation fires skipped; missed monthly/daily/quarterly runs re-enqueued with the correct pinned period; stale (pre-fire) completions flagged; manual re-run for a different period doesn't mask a miss; grace period and lookback windows; consistency checks that every verified job is in the schedule, records completions, and writes the same period key the verifier reads.
- `spec/sidekiq/concerns/finance_report_completion_tracking_spec.rb`: completion recorded on success, not on raise; period keying for no-arg scheduled runs vs explicit-args runs.
- `spec/mailers/accounting_mailer_spec.rb` — `#finance_report_delivery_backstop_triggered` recipient/subject/body (fire time, stale completion, re-run command).
- Existing specs for all touched jobs pass: 54 examples, 0 failures locally. Rubocop clean.
