### PR TITLE
Verify every scheduled finance report fire since activation, not just the latest

### DIFF
--- a/app/sidekiq/verify_finance_reports_delivery_job.rb
+++ b/app/sidekiq/verify_finance_reports_delivery_job.rb
@@ -8,9 +8,9 @@
 # scheduler tick itself is missed — and then nothing raises, nothing retries, and no alert
 # goes out. This job closes that gap: every day it checks, for each scheduler-fired
 # finance report job, that a completion was recorded (FinanceReportCompletionTracking)
-# after the job's most recent scheduled fire time. If not, it re-enqueues the job with
-# arguments pinned to the period the missed run was for, and emails the payments
-# notification address so the gap is visible.
+# for every scheduled fire time since the backstop was activated. If a fire has no
+# completion, it re-enqueues the job with arguments pinned to the period the missed run
+# was for, and emails the payments notification address so the gap is visible.
 #
 # Re-enqueueing is safe: every verified job is a read-only aggregation (or, for the
 # TaxJar upload, idempotent — already-imported orders are skipped).
@@ -62,25 +62,48 @@ class VerifyFinanceReportsDeliveryJob
 
       # The schedule's cron expressions are documented (and fired in production) in UTC —
       # pin the parse to UTC explicitly so this doesn't drift with server TZ.
-      # The most recent fire is checked no matter how long ago it was (there is no
-      # lookback cutoff): a missed monthly or quarterly fire stays flagged on every
-      # verifier run until its completion is recorded, even if the verifier itself was
-      # down for days when the fire happened. Completion keys live 120 days
-      # (FinanceReportCompletionTracking::REDIS_KEY_TTL), longer than the longest cadence
-      # here (quarterly), so a completed run's key is always still present when its fire
-      # is checked. Fires from before activation are the one exception — they predate
-      # completion tracking entirely and are skipped as unknowable, not missing.
-      fire_time = Fugit::Cron.parse("#{entry['cron'].sub(/#.*/, '').strip} UTC").previous_time(now - GRACE_PERIOD).to_t.utc
-      next if fire_time < active_since
+      cron = Fugit::Cron.parse("#{entry['cron'].sub(/#.*/, '').strip} UTC")
 
-      args = args_builder.call(fire_time)
+      # EVERY fire since activation is checked, not just the most recent one. Checking
+      # only the latest fire loses older gaps: if the verifier is down while a monthly
+      # fire is missed and the NEXT month's fire then completes, a latest-only check sees
+      # that newer completion and the older missed month is never re-enqueued or alerted.
+      # Each period has its own completion key, so walking back through the fires reads
+      # each one independently and a newer completion can't mask an older gap.
+      #
+      # The walk is bounded (besides by activation) by the completion keys' own lifetime:
+      # keys expire after 120 days (FinanceReportCompletionTracking::REDIS_KEY_TTL), so a
+      # fire older than that may have completed and had its key expire — unknowable, not
+      # missing, same as pre-activation fires. The most recent fire alone is still
+      # checked with no age cutoff, so even after a very long outage the newest gap is
+      # always caught. Fires from before activation predate completion tracking entirely
+      # and are skipped as unknowable, not missing.
+      oldest_verifiable_fire = now - FinanceReportCompletionTracking::REDIS_KEY_TTL
+      fire_time = cron.previous_time(now - GRACE_PERIOD).to_t.utc
+      # Jobs without period args (their builder ignores the fire time) resolve every
+      # fire to the same completion key — checking that key once covers the whole walk,
+      # and skipping the repeats avoids re-enqueueing the identical job several times.
+      seen_period_keys = Set.new
+      while fire_time >= active_since
+        args = args_builder.call(fire_time)
+        if seen_period_keys.add?(FinanceReportCompletionTracking.redis_key(class_name, args))
+          verify_fire(class_name, args, fire_time)
+        end
+        fire_time = cron.previous_time(fire_time).to_t.utc
+        break if fire_time < oldest_verifiable_fire
+      end
+    end
+  end
+
+  private
+    def verify_fire(class_name, args, fire_time)
       last_completed_at = FinanceReportCompletionTracking.last_completed_at(class_name, args)
-      next if last_completed_at && last_completed_at >= fire_time
+      return if last_completed_at && last_completed_at >= fire_time
 
       # A duplicate enqueue can raise for unique jobs with on_conflict: :raise (e.g.
       # yesterday's backstop re-run is still queued or running). The gap still gets
-      # alerted below, and one job's conflict must not stop the remaining jobs from
-      # being verified — so notify and carry on rather than let it bubble.
+      # alerted below, and one fire's conflict must not stop the remaining fires and
+      # jobs from being verified — so notify and carry on rather than let it bubble.
       begin
         class_name.constantize.perform_async(*args)
       rescue => e
@@ -91,5 +114,4 @@ class VerifyFinanceReportsDeliveryJob
         class_name, args, fire_time, last_completed_at
       ).deliver_later
     end
-  end
 end

--- a/spec/sidekiq/verify_finance_reports_delivery_job_spec.rb
+++ b/spec/sidekiq/verify_finance_reports_delivery_job_spec.rb
@@ -26,11 +26,18 @@ describe VerifyFinanceReportsDeliveryJob do
   let(:monthly_fire) { Time.utc(2026, 7, 1, 11) }
   let(:taxjar_fire) { Time.utc(2026, 7, 1, 3) }
 
+  # Records a completion for every fire the verifier will check: each job's fires from
+  # the most recent one (outside the grace period) back to the activation baseline.
   def record_all_completions(now)
+    active_since = Time.zone.at($redis.get(described_class::ACTIVE_SINCE_REDIS_KEY).to_i)
     described_class::VERIFIED_JOBS.each_key do |class_name|
       entry = YAML.load_file(Rails.root.join("config", "sidekiq_schedule.yml")).values.find { _1["class"] == class_name }
-      fire_time = Fugit::Cron.parse("#{entry['cron'].sub(/#.*/, '').strip} UTC").previous_time(now - described_class::GRACE_PERIOD).to_t.utc
-      record_completion_for_fire(class_name, fire_time, at: now)
+      cron = Fugit::Cron.parse("#{entry['cron'].sub(/#.*/, '').strip} UTC")
+      fire_time = cron.previous_time(now - described_class::GRACE_PERIOD).to_t.utc
+      while fire_time >= active_since
+        record_completion_for_fire(class_name, fire_time, at: now)
+        fire_time = cron.previous_time(fire_time).to_t.utc
+      end
     end
   end
 
@@ -140,6 +147,28 @@ describe VerifyFinanceReportsDeliveryJob do
       expect(SendFinancesReportWorker).to have_enqueued_sidekiq_job(6, 2026)
       expect(AccountingMailer).to have_received(:finance_report_delivery_backstop_triggered)
         .with("SendFinancesReportWorker", [6, 2026], monthly_fire, nil)
+    end
+  end
+
+  it "catches an older missed fire even after a newer fire of the same job completed" do
+    # The verifier was down across two monthly fires: June 1 was missed, July 1
+    # completed. When the verifier finally runs on July 15 it must not stop at the
+    # completed July fire — the June gap has its own period key and must still be
+    # re-enqueued and alerted.
+    june_fire = Time.utc(2026, 6, 1, 11)
+    travel_to(Time.utc(2026, 7, 15, 18)) do
+      activate_backstop(at: Time.utc(2026, 5, 20))
+      record_all_completions(Time.utc(2026, 7, 15, 18))
+      clear_completion_for_fire("SendFinancesReportWorker", june_fire)
+
+      described_class.new.perform
+
+      expect(SendFinancesReportWorker).to have_enqueued_sidekiq_job(5, 2026)
+      expect(AccountingMailer).to have_received(:finance_report_delivery_backstop_triggered)
+        .with("SendFinancesReportWorker", [5, 2026], june_fire, nil)
+      # The completed July fire itself was not flagged.
+      expect(AccountingMailer).not_to have_received(:finance_report_delivery_backstop_triggered)
+        .with("SendFinancesReportWorker", [6, 2026], anything, anything)
     end
   end
 


### PR DESCRIPTION
## What

Follow-up to #5704 (merged before the last Greptile review landed). The daily finance report backstop now verifies **every** scheduled fire since its activation baseline, not just each job's most recent one. The per-fire check moved into a `verify_fire` helper and the loop walks backwards through the cron's prior fire times, reading each period's own completion key.

## Why

Greptile flagged on #5704 that checking only the latest fire before the grace period can silently lose an older gap: if the verifier is down while `SendFinancesReportWorker` misses June 1 and the July 1 run then completes, a latest-only check resolves to the July fire, sees that completion, and never reads the June period key — the June report is never re-enqueued or alerted.

Since each period has its own completion key (that was the design of `FinanceReportCompletionTracking`), walking back through the fires reads each one independently, so a newer completion can't mask an older miss. The walk is bounded by:

- the activation baseline (fires before it predate tracking and are unknowable, unchanged), and
- the completion keys' 120-day TTL (a fire older than that may have completed and had its key expire — unknowable, not missing). The most recent fire alone is still checked with no age cutoff, matching #5704's behavior.

Jobs whose args builders ignore the fire time (`SendStripeCurrencyBalancesReportJob`, `EmailOutstandingBalancesCsvWorker`) resolve every fire to the same completion key, so they are checked once per run — a dedupe on the resolved key avoids re-enqueueing the identical job several times in one pass.

## Test plan

- New spec: verifier down across two monthly fires (June missed, July completed, verifier runs July 15) re-enqueues and alerts the June period only.
- `record_all_completions` test helper updated to record every fire the walk now checks.
- Ran locally: `bundle exec rspec spec/sidekiq/verify_finance_reports_delivery_job_spec.rb` — 15 examples, 0 failures.
- `bundle exec rubocop` on both touched files — no offenses.
- Autoreview (Codex, branch vs origin/main): clean, no actionable findings.
