### PR TITLE
fix: clear buyer-hidden flag when reassigning purchases to a new email

### DIFF
--- a/app/services/purchase/reassign_by_email_service.rb
+++ b/app/services/purchase/reassign_by_email_service.rb
@@ -64,9 +64,14 @@ class Purchase::ReassignByEmailService
 
     purchases.each do |purchase|
       purchase.email = @to_email
+      # A purchase hidden from the old account's library (is_deleted_by_buyer)
+      # stays hidden after the move, so the buyer's new library looks empty.
+      # Transferring the library means the buyer wants these purchases visible
+      # again, so clear the flag as part of the reassignment.
+      purchase.is_deleted_by_buyer = false
 
       if purchase.subscription.present? && !purchase.is_original_subscription_purchase? && !purchase_id_set.include?(purchase.original_purchase.id)
-        if purchase.original_purchase.update(email: @to_email, purchaser_id: target_user&.id)
+        if purchase.original_purchase.update(email: @to_email, purchaser_id: target_user&.id, is_deleted_by_buyer: false)
           reassigned_purchase_ids << purchase.original_purchase.id if purchase.original_purchase.saved_changes?
           purchase.subscription.update(user: target_user)
         end

--- a/spec/services/purchase/reassign_by_email_service_spec.rb
+++ b/spec/services/purchase/reassign_by_email_service_spec.rb
@@ -169,6 +169,27 @@ describe Purchase::ReassignByEmailService do
         expect(original_purchase.reload.email).to eq("old_original@example.com")
       end
 
+      it "clears is_deleted_by_buyer so transferred purchases show in the new library" do
+        hidden_purchase = create(:purchase, email: from_email, purchaser: buyer, merchant_account:, is_deleted_by_buyer: true)
+
+        result = described_class.new(from_email:, to_email:).perform
+
+        expect(result.success?).to be(true)
+        expect(hidden_purchase.reload.is_deleted_by_buyer).to be(false)
+        expect(hidden_purchase.email).to eq(to_email)
+      end
+
+      it "clears is_deleted_by_buyer on an unmatched original subscription purchase" do
+        subscription = create(:subscription, user: buyer)
+        original_purchase = create(:purchase, email: "old_original@example.com", purchaser: buyer, is_original_subscription_purchase: true, subscription:, merchant_account:, is_deleted_by_buyer: true)
+        create(:purchase, email: from_email, purchaser: buyer, subscription:, merchant_account:)
+
+        described_class.new(from_email:, to_email:).perform
+
+        expect(original_purchase.reload.is_deleted_by_buyer).to be(false)
+        expect(original_purchase.email).to eq(to_email)
+      end
+
       it "enqueues a grouped receipt for all reassigned purchases" do
         expect(CustomerMailer).to receive(:grouped_receipt).with(match_array([purchase1.id, purchase2.id])).and_call_original
 


### PR DESCRIPTION
## What

`Purchase::ReassignByEmailService` now clears `is_deleted_by_buyer` on every purchase it moves, including original subscription purchases pulled into the batch alongside recurring charges.

## Why

A buyer who transfers their library to a new email expects to see those purchases in the new account's library. But the reassignment only moved `email`/`purchaser_id` — if a purchase had been hidden from the old account's library (`is_deleted_by_buyer`), it stayed hidden after the move, so the destination library looked empty even though the records transferred correctly. This surfaced in a real support-driven reassignment where 79 of 86 moved purchases carried the hidden flag and had to be cleared manually afterwards. Requesting a library transfer is a clear signal the buyer wants those purchases visible again.

## Test evidence

```
bundle exec rspec spec/services/purchase/reassign_by_email_service_spec.rb
28 examples, 0 failures
```

Two new specs: one covering matched purchases with the flag set, one covering an unmatched original subscription purchase reassigned alongside a recurring charge.

Autoreview (Codex, branch mode vs origin/main): clean, no actionable findings.

## Before/After

Not a UI change — backend service behavior only.

## AI disclosure

Authored by an AI agent (Claude, Hermes Agent): wrote the service change, specs, and this PR.
