### PR TITLE
docs: document "all products, except selected" discount exclusions

### DIFF
--- a/app/views/help_center/articles/contents/_128-discount-codes.html.erb
+++ b/app/views/help_center/articles/contents/_128-discount-codes.html.erb
@@ -18,6 +18,7 @@
   <p><span>Note:</span> The code can contain only numbers and letters.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/65c309278106ae1c4ab6f392/file-GAk6eFEPyf.png" %></figure>
   <p>Choose the product(s) you want this discount code to apply to, or check “All products” if you want it to apply to all your products.</p>
+  <p>When “All products” is checked, you can also pick products under “Excluded products”. The discount then applies to all your current and future products except the ones you exclude. The code can't be used on an excluded product, and excluded products don't count toward a minimum qualifying amount.</p>
   <p>Enter the discount code and the amount or percentage off of your full price.</p>
   <h3 id="Allow-customers-to-enter-discount-codes-IN4wU">Allow customers to enter discount codes</h3>
   <p>To show the discount code input box on the checkout page, toggle  "Only if a discount is available" in the <a href="https://gumroad.com/checkout/form">Checkout form</a> tab, otherwise, it will only be possible to apply a discount code by using a <a href="270-url-parameters">URL parameter</a>.</p>


### PR DESCRIPTION
## What

Adds a paragraph to the "Discount codes" help article (`128-discount-codes`) documenting the new "Excluded products" option: when "All products" is checked, sellers can exclude selected products, the discount covers all current and future products except those, the code can't be used on an excluded product, and excluded products don't count toward a minimum qualifying amount.

## Why

#5703 shipped "all products, except selected" exclusion scoping for discount codes. The help article only described the previous two options (pick products, or all products), so it was out of date for the new capability.

## Test plan

- ERB syntax check on the article partial passes (`ERB.new(...).src`).
- Copy matches the shipped UI wording ("Excluded products", "The discount applies to all current and future products except the ones you exclude here") and the server-side behavior in #5703 (excluded items rejected at resolution and skipped for `minimum_amount_cents`).
- No `articles.yml` change needed — title/description/slug unchanged.

Autoreview: skipped — copy-only docs change, no code logic.
