### PR TITLE
Remove the :stripe_payment_element_link flag — Link auto-enables with the Payment Element

### DIFF
--- a/app/javascript/components/Checkout/payment.ts
+++ b/app/javascript/components/Checkout/payment.ts
@@ -44,8 +44,9 @@ export type PaymentElementConfig = {
 // Client-confirm checkout mints a ConfirmationToken from the Payment Element, so it omits
 // payment_method_creation and stays in one-time payment mode. The method list is
 // server-resolved (Checkout::PaymentMethodResolver) and must match the deferred intent's;
-// the browser never widens it — card everywhere, "link" iff stripe_link_enabled, plus the
-// US-locked methods (cashapp, us_bank_account) for US buyers.
+// the browser never widens it — card and Link everywhere (stripe_link_enabled reflects the
+// resolved set; Link auto-enables with the Payment Element, dropped only by the PPP gate), plus
+// the US-locked methods (cashapp, us_bank_account) for US buyers.
 export type PaymentElementClientConfirmConfig = {
   stripe_elements_mode: typeof STRIPE_ELEMENTS_MODE_FOR_PAYMENT_INTENT;
   currency: "usd";

--- a/app/presenters/checkout/stripe_payment_presenter.rb
+++ b/app/presenters/checkout/stripe_payment_presenter.rb
@@ -5,7 +5,6 @@ class Checkout::StripePaymentPresenter
   include CurrencyHelper
 
   STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME = :stripe_payment_element_checkout
-  STRIPE_PAYMENT_ELEMENT_LINK_FEATURE_NAME = :stripe_payment_element_link
   STRIPE_PAYMENT_ELEMENT_CLIENT_CONFIRM_FEATURE_NAME = :stripe_payment_element_client_confirm
   STRIPE_CARD_ELEMENT_INTEGRATION = "card_element"
   STRIPE_PAYMENT_ELEMENT_INTEGRATION = "payment_element"
@@ -84,7 +83,13 @@ class Checkout::StripePaymentPresenter
           currency: "usd",
           payment_method_types: ["card"],
           payment_method_creation: "manual",
-          stripe_link_enabled: sellers.all? { Feature.active?(STRIPE_PAYMENT_ELEMENT_LINK_FEATURE_NAME, _1) },
+          # Link auto-enables with the Payment Element: it's inline (PaymentMethod-mode here, no
+          # return-page/webhook dependency), and Stripe's dashboard payment-method settings remain
+          # the emergency kill switch — a per-seller Flipper flag added no useful lever. The one
+          # exception mirrors the client-confirm PPP method matrix: Link's funding country can't be
+          # verified pre-charge, so on a PPP-verified checkout it would only fail the card-country
+          # check at purchase (Purchase#validate_purchasing_power_parity). Gate it out up front.
+          stripe_link_enabled: !ppp_verification_applies?,
         },
       }
     end
@@ -109,14 +114,17 @@ class Checkout::StripePaymentPresenter
     end
 
     # U13 PPP method matrix input. True when any item offers a PPP discount for this buyer's GeoIP
-    # country AND the seller enforces PPP payment verification — the case where prepare will run the
-    # funding-country check and a non-verifiable method would fail closed. Keyed on discount
+    # country AND that item's own seller enforces PPP payment verification — the case where prepare
+    # will run the funding-country check and a non-verifiable method would fail closed. Item-scoped
+    # (not cart-scoped): on a multi-seller Lane A cart, one seller disabling verification must not
+    # re-enable Link for another seller's still-verified PPP purchase. Keyed on discount
     # AVAILABILITY (ppp_details for this ip), the same server-owned basis
     # Order::PreparePaymentIntentService recomputes from the purchase's ip_country, so the Payment
     # Element and the deferred intent gate identically (the step-1 method-set invariant).
     def ppp_verification_applies?
-      items.any? { _1[:ppp_discounted] } &&
-        sellers.none? { _1&.purchasing_power_parity_payment_verification_disabled? }
+      items.any? do |item|
+        item[:ppp_discounted] && !item[:seller]&.purchasing_power_parity_payment_verification_disabled?
+      end
     end
 
     # GeoIP-detected country (never the user's profile country) so the resolver's US-locked-method

--- a/app/services/checkout/payment_method_resolver.rb
+++ b/app/services/checkout/payment_method_resolver.rb
@@ -8,10 +8,10 @@
 # Two method sets are distinguished:
 #   - eligible_payment_method_types: the policy set the cart *could* use (the eligibility-by-product-type
 #     policy). This is the logged decision and what later units intersect with per-method launch/PPP gates.
-#   - payment_method_types: what Stripe actually receives on the client-confirmed path today. Card is
-#     always launched; Link joins it per-seller behind the same :stripe_payment_element_link flag
-#     that ramps Link on Lane A, so one flag governs Link everywhere; and the US-locked first-launch
-#     methods (Cash App Pay, ACH Direct Debit) join for US buyers via the GeoIP gate below.
+#   - payment_method_types: what Stripe actually receives on the client-confirmed path today. Card and
+#     Link are always launched (Link is inline and auto-enables with the Payment Element itself); the
+#     US-locked first-launch methods (Cash App Pay, ACH Direct Debit) join for US buyers via the GeoIP
+#     gate below.
 #
 # Handshake note: the deferred PaymentIntent's payment_method_types must equal the Payment Element's or
 # Stripe rejects the ConfirmationToken (which is payment_method_types-scoped, so it also can't be
@@ -29,17 +29,15 @@ class Checkout::PaymentMethodResolver
   ONE_TIME_PAYMENT_METHOD_TYPES = %w[card link klarna afterpay_clearpay affirm ideal bancontact cashapp us_bank_account].freeze
   # Afterpay/Clearpay and Affirm are one-time, buyer-present only, so a recurring lifecycle drops them.
   RECURRING_INELIGIBLE_PAYMENT_METHOD_TYPES = %w[afterpay_clearpay affirm].freeze
-  # Launched on the client-confirmed path: card everywhere, plus the US-locked first-launch methods
+  # Launched on the client-confirmed path: card everywhere; Link everywhere (inline — it rides
+  # card's two-step confirm machinery with no return-page/webhook dependency, launched under the
+  # element flags themselves since Stripe's dashboard payment-method settings are the emergency
+  # kill switch, per-seller Flipper adds no useful lever); plus the US-locked first-launch methods
   # (region-gated below) — Cash App Pay (redirect; confirms via the #5664 return page) and ACH Direct
   # Debit (delayed-notification; settles via the PaymentIntent webhook lifecycle). The EUR methods
   # (iDEAL/Bancontact/SEPA) stay gated until buyer-currency FX lands.
-  LAUNCHED_PAYMENT_METHOD_TYPES = %w[card cashapp us_bank_account].freeze
-  # Link is inline (non-redirect), so it needs none of the return-page/webhook machinery the other
-  # gated methods wait on. It launches per-seller behind Lane A's existing Link flag (#5614) so the
-  # rollout ramps once for both integrations. This resolver is the ONLY place that widens the
-  # client-confirm method list — the presenter derives the Element's Link config from this output.
+  LAUNCHED_PAYMENT_METHOD_TYPES = %w[card link cashapp us_bank_account].freeze
   LINK_PAYMENT_METHOD_TYPE = "link"
-  STRIPE_PAYMENT_ELEMENT_LINK_FEATURE_NAME = :stripe_payment_element_link
   # Methods that only work for US buyers on USD PaymentIntents. ACH Direct Debit debits a US bank
   # account; Cash App Pay is US-locked. These are dropped from the launched set unless GeoIP ∈ {US}.
   US_LOCKED_PAYMENT_METHOD_TYPES = %w[us_bank_account cashapp].freeze
@@ -122,21 +120,13 @@ class Checkout::PaymentMethodResolver
       methods
     end
 
-    # Order follows ONE_TIME_PAYMENT_METHOD_TYPES (the resolve intersection preserves the receiver's
-    # order), so card always renders as the first Payment Element tab.
-    def launched_payment_method_types
-      launched = LAUNCHED_PAYMENT_METHOD_TYPES
-      launched += [LINK_PAYMENT_METHOD_TYPE] if sellers.all? { Feature.active?(STRIPE_PAYMENT_ELEMENT_LINK_FEATURE_NAME, _1) }
-      launched
-    end
-
     # What Stripe actually receives: the eligible policy set intersected with the launched set, then
     # region-gated, then PPP-gated. A US-locked method (ACH, Cash App Pay) is only offered when the
     # buyer's GeoIP country is US, so a non-US buyer never sees a method they can't complete. When the
     # buyer country is unknown (nil), US-locked methods are dropped to fail safe. Card always survives,
     # and Link (inline, not US-locked) is unaffected by the region gate.
     def launched_method_set(eligible)
-      launched = eligible & launched_payment_method_types
+      launched = eligible & LAUNCHED_PAYMENT_METHOD_TYPES
       launched -= US_LOCKED_PAYMENT_METHOD_TYPES unless buyer_country == US_ALPHA2
       launched = ppp_method_matrix(launched) if ppp_discounted
       launched

--- a/spec/presenters/checkout/stripe_payment_presenter_spec.rb
+++ b/spec/presenters/checkout/stripe_payment_presenter_spec.rb
@@ -39,9 +39,9 @@ describe Checkout::StripePaymentPresenter do
   end
 
   # The Element's Link toggle and the intent's method list derive from the same resolver output, so
-  # they move together; the US-locked methods (cashapp/us_bank_account) are passed explicitly by the
-  # region-gate specs.
-  def payment_element_client_confirm_props(stripe_link_enabled: false, payment_method_types: (stripe_link_enabled ? %w[card link] : ["card"]), stripe_connect_account_id: nil)
+  # they move together; Link is always launched, and the US-locked methods (cashapp/us_bank_account)
+  # are passed explicitly by the region-gate specs.
+  def payment_element_client_confirm_props(stripe_link_enabled: true, payment_method_types: %w[card link], stripe_connect_account_id: nil)
     {
       integration: described_class::STRIPE_PAYMENT_ELEMENT_CLIENT_CONFIRM_INTEGRATION,
       fallback_reason: nil,
@@ -56,7 +56,7 @@ describe Checkout::StripePaymentPresenter do
     }
   end
 
-  def payment_element_props(stripe_elements_mode: described_class::STRIPE_ELEMENTS_MODE_FOR_PAYMENT_INTENT, stripe_link_enabled: false)
+  def payment_element_props(stripe_elements_mode: described_class::STRIPE_ELEMENTS_MODE_FOR_PAYMENT_INTENT, stripe_link_enabled: true)
     {
       integration: described_class::STRIPE_PAYMENT_ELEMENT_INTEGRATION,
       fallback_reason: nil,
@@ -325,26 +325,59 @@ describe Checkout::StripePaymentPresenter do
     expect(stripe_payment_props(cart:, add_products: [flagged_seller_product], clear_cart: true)).to eq(payment_element_props)
   end
 
-  it "keeps Link disabled in the Payment Element when only the Payment Element flag is enabled" do
-    expect(stripe_payment_props(add_products: [flagged_seller_product])).to eq(payment_element_props(stripe_link_enabled: false))
-  end
-
-  it "enables Link in the Payment Element when the seller has the Link flag enabled" do
+  it "always enables Link in the Payment Element (no per-seller flag)" do
     seller = create(:user)
     product = create(:product, user: seller, price_cents: 1234)
     Feature.activate_user(described_class::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, seller)
-    Feature.activate_user(described_class::STRIPE_PAYMENT_ELEMENT_LINK_FEATURE_NAME, seller)
 
     expect(stripe_payment_props(add_products: [checkout_product_for(product)])).to eq(payment_element_props(stripe_link_enabled: true))
   end
 
-  it "does not render the Payment Element when the Link flag is enabled but the Payment Element flag is not" do
-    seller = create(:user)
-    product = create(:product, user: seller, price_cents: 1234)
-    Feature.activate_user(described_class::STRIPE_PAYMENT_ELEMENT_LINK_FEATURE_NAME, seller)
+  it "disables Link on a PPP-verified Payment Element checkout — its funding country is not verifiable pre-charge" do
+    stub_geoip_country("104.28.0.1", "United States")
+    ppp_details = { country: "Brazil", factor: 0.5, minimum_price: 99 }
 
-    expect(stripe_payment_props(add_products: [checkout_product_for(product)]))
-      .to eq(card_element_fallback("stripe_payment_element_flag_disabled"))
+    props = stripe_payment_props(add_products: [flagged_seller_product(ppp_details:)], ip: "104.28.0.1")
+
+    expect(props).to eq(payment_element_props(stripe_link_enabled: false))
+  end
+
+  it "keeps Link on a PPP Payment Element checkout when the seller disabled PPP payment verification" do
+    stub_geoip_country("104.28.0.1", "United States")
+    ppp_details = { country: "Brazil", factor: 0.5, minimum_price: 99 }
+    item = flagged_seller_product(ppp_details:)
+    seller = User.find_by(external_id: item[:product][:creator][:id])
+    seller.update!(purchasing_power_parity_payment_verification_disabled: true)
+
+    props = stripe_payment_props(add_products: [item], ip: "104.28.0.1")
+
+    expect(props).to eq(payment_element_props(stripe_link_enabled: true))
+  end
+
+  it "gates Link item-scoped: another seller disabling PPP verification does not re-enable Link for a still-verified PPP item" do
+    stub_geoip_country("104.28.0.1", "United States")
+    ppp_details = { country: "Brazil", factor: 0.5, minimum_price: 99 }
+    verified_ppp_item = flagged_seller_product(ppp_details:)
+    unverified_seller_item = flagged_seller_product
+    unverified_seller = User.find_by(external_id: unverified_seller_item[:product][:creator][:id])
+    unverified_seller.update!(purchasing_power_parity_payment_verification_disabled: true)
+
+    props = stripe_payment_props(add_products: [verified_ppp_item, unverified_seller_item], ip: "104.28.0.1")
+
+    expect(props).to eq(payment_element_props(stripe_link_enabled: false))
+  end
+
+  it "keeps Link on a multi-seller cart when the only PPP item's own seller disabled verification" do
+    stub_geoip_country("104.28.0.1", "United States")
+    ppp_details = { country: "Brazil", factor: 0.5, minimum_price: 99 }
+    ppp_item = flagged_seller_product(ppp_details:)
+    ppp_seller = User.find_by(external_id: ppp_item[:product][:creator][:id])
+    ppp_seller.update!(purchasing_power_parity_payment_verification_disabled: true)
+    other_item = flagged_seller_product
+
+    props = stripe_payment_props(add_products: [ppp_item, other_item], ip: "104.28.0.1")
+
+    expect(props).to eq(payment_element_props(stripe_link_enabled: true))
   end
 
   describe "Payment Element confirm integration" do
@@ -357,21 +390,21 @@ describe Checkout::StripePaymentPresenter do
       stub_geoip_country("104.28.0.1", "United States")
 
       expect(stripe_payment_props(add_products: [confirm_flagged_seller_product], ip: "104.28.0.1"))
-        .to eq(payment_element_client_confirm_props(payment_method_types: %w[card cashapp us_bank_account]))
+        .to eq(payment_element_client_confirm_props(payment_method_types: %w[card link cashapp us_bank_account]))
     end
 
-    it "offers card only for a non-US buyer (Cash App/ACH are US-locked)" do
+    it "offers card and Link only for a non-US buyer (Cash App/ACH are US-locked)" do
       stub_geoip_country("2.2.2.2", "United Kingdom")
 
       expect(stripe_payment_props(add_products: [confirm_flagged_seller_product], ip: "2.2.2.2"))
-        .to eq(payment_element_client_confirm_props(payment_method_types: ["card"]))
+        .to eq(payment_element_client_confirm_props(payment_method_types: %w[card link]))
     end
 
-    it "offers card only when the buyer's country cannot be resolved" do
+    it "offers card and Link only when the buyer's country cannot be resolved" do
       allow(GeoIp).to receive(:lookup).and_return(nil)
 
       expect(stripe_payment_props(add_products: [confirm_flagged_seller_product], ip: "0.0.0.0"))
-        .to eq(payment_element_client_confirm_props(payment_method_types: ["card"]))
+        .to eq(payment_element_client_confirm_props(payment_method_types: %w[card link]))
     end
 
     describe "PPP method matrix (U13)" do
@@ -381,16 +414,13 @@ describe Checkout::StripePaymentPresenter do
         stub_geoip_country("104.28.0.1", "United States")
 
         expect(stripe_payment_props(add_products: [confirm_flagged_seller_product(ppp_details:)], ip: "104.28.0.1"))
-          .to eq(payment_element_client_confirm_props(payment_method_types: %w[card cashapp us_bank_account]))
+          .to eq(payment_element_client_confirm_props(payment_method_types: %w[card cashapp us_bank_account], stripe_link_enabled: false))
       end
 
       it "gates Link out on a PPP checkout — its funding country is not verifiable pre-charge" do
         stub_geoip_country("104.28.0.1", "United States")
-        item = confirm_flagged_seller_product(ppp_details:)
-        seller = User.find_by(external_id: item[:product][:creator][:id])
-        Feature.activate_user(Checkout::PaymentMethodResolver::STRIPE_PAYMENT_ELEMENT_LINK_FEATURE_NAME, seller)
 
-        props = stripe_payment_props(add_products: [item], ip: "104.28.0.1")
+        props = stripe_payment_props(add_products: [confirm_flagged_seller_product(ppp_details:)], ip: "104.28.0.1")
 
         expect(props[:elements_options][:payment_method_types]).to eq(%w[card cashapp us_bank_account])
         expect(props[:elements_options][:stripe_link_enabled]).to eq(false)
@@ -401,7 +431,6 @@ describe Checkout::StripePaymentPresenter do
         item = confirm_flagged_seller_product(ppp_details:)
         seller = User.find_by(external_id: item[:product][:creator][:id])
         seller.update!(purchasing_power_parity_payment_verification_disabled: true)
-        Feature.activate_user(Checkout::PaymentMethodResolver::STRIPE_PAYMENT_ELEMENT_LINK_FEATURE_NAME, seller)
 
         props = stripe_payment_props(add_products: [item], ip: "104.28.0.1")
 
@@ -412,7 +441,7 @@ describe Checkout::StripePaymentPresenter do
         stub_geoip_country("104.28.0.1", "United States")
 
         expect(stripe_payment_props(add_products: [confirm_flagged_seller_product], ip: "104.28.0.1"))
-          .to eq(payment_element_client_confirm_props(payment_method_types: %w[card cashapp us_bank_account]))
+          .to eq(payment_element_client_confirm_props(payment_method_types: %w[card link cashapp us_bank_account]))
       end
     end
 
@@ -467,12 +496,11 @@ describe Checkout::StripePaymentPresenter do
         .to eq(payment_element_client_confirm_props(stripe_connect_account_id: connect_account.charge_processor_merchant_id))
     end
 
-    it "enables Link in client-confirm mode when the seller has the Link flag" do
+    it "always enables Link in client-confirm mode (no per-seller flag)" do
       seller = create(:user)
       product = create(:product, user: seller, price_cents: 1234)
       Feature.activate_user(described_class::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, seller)
       Feature.activate_user(described_class::STRIPE_PAYMENT_ELEMENT_CLIENT_CONFIRM_FEATURE_NAME, seller)
-      Feature.activate_user(described_class::STRIPE_PAYMENT_ELEMENT_LINK_FEATURE_NAME, seller)
 
       expect(stripe_payment_props(add_products: [checkout_product_for(product)]))
         .to eq(payment_element_client_confirm_props(stripe_link_enabled: true))

--- a/spec/requests/purchases/product/stripejs_purchase_spec.rb
+++ b/spec/requests/purchases/product/stripejs_purchase_spec.rb
@@ -324,7 +324,6 @@ describe("PurchaseScenario using StripeJs", type: :system, js: true) do
       create(:merchant_account, user: nil, charge_processor_merchant_id: "acct_#{SecureRandom.hex(8)}")
     product = create(:product_with_pdf_file, user: seller)
     Feature.activate_user(Checkout::StripePaymentPresenter::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, product.user)
-    Feature.activate_user(Checkout::StripePaymentPresenter::STRIPE_PAYMENT_ELEMENT_LINK_FEATURE_NAME, product.user)
 
     visit("/checkout?product=#{product.unique_permalink}")
 

--- a/spec/services/checkout/payment_method_resolver_spec.rb
+++ b/spec/services/checkout/payment_method_resolver_spec.rb
@@ -30,36 +30,25 @@ describe Checkout::PaymentMethodResolver do
       it "enables the launched methods on Stripe for a US buyer, gating the rest behind later units" do
         resolution = resolve(buyer_country: "US")
 
-        expect(resolution.payment_method_types).to eq(%w[card cashapp us_bank_account])
+        expect(resolution.payment_method_types).to eq(%w[card link cashapp us_bank_account])
         # The launched set is always a subset of the eligible policy set.
         expect(resolution.eligible_payment_method_types).to include(*resolution.payment_method_types)
       end
 
-      it "drops US-locked methods (Cash App/ACH) for a non-US buyer, leaving card only" do
-        expect(resolve(buyer_country: "GB").payment_method_types).to eq(["card"])
+      it "drops US-locked methods (Cash App/ACH) for a non-US buyer, keeping card and Link" do
+        expect(resolve(buyer_country: "GB").payment_method_types).to eq(%w[card link])
       end
 
-      it "drops US-locked methods when the buyer country is unknown, failing safe to card only" do
-        expect(resolve(buyer_country: nil).payment_method_types).to eq(["card"])
+      it "drops US-locked methods when the buyer country is unknown, failing safe to card and Link" do
+        expect(resolve(buyer_country: nil).payment_method_types).to eq(%w[card link])
       end
 
-      context "when the seller has the Stripe Link flag enabled" do
-        before { Feature.activate_user(described_class::STRIPE_PAYMENT_ELEMENT_LINK_FEATURE_NAME, seller) }
+      it "launches Link with no per-seller flag — it auto-enables with the Payment Element" do
+        expect(resolve.payment_method_types).to include("link")
+      end
 
-        it "launches Link alongside the US set, keeping card as the first Payment Element tab" do
-          resolution = resolve
-
-          expect(resolution.payment_method_types).to eq(%w[card link cashapp us_bank_account])
-          expect(resolution.eligible_payment_method_types).to include(*resolution.payment_method_types)
-        end
-
-        it "keeps Link for a non-US buyer — the region gate only drops the US-locked methods" do
-          expect(resolve(buyer_country: "GB").payment_method_types).to eq(%w[card link])
-        end
-
-        it "still gates the remaining redirect methods behind later units" do
-          expect(resolve.payment_method_types).not_to include("klarna", "afterpay_clearpay", "affirm", "ideal", "bancontact")
-        end
+      it "still gates the remaining redirect methods behind later units" do
+        expect(resolve.payment_method_types).not_to include("klarna", "afterpay_clearpay", "affirm", "ideal", "bancontact")
       end
 
       it "returns an explicit list of method-type strings, never Stripe's automatic_payment_methods shape" do
@@ -76,8 +65,6 @@ describe Checkout::PaymentMethodResolver do
         end
 
         it "gates Link out — no Stripe-owned funding country to verify pre-charge" do
-          Feature.activate_user(described_class::STRIPE_PAYMENT_ELEMENT_LINK_FEATURE_NAME, seller)
-
           expect(resolve(ppp_discounted: true).payment_method_types).to eq(%w[card cashapp us_bank_account])
           expect(resolve(ppp_discounted: false).payment_method_types).to eq(%w[card link cashapp us_bank_account])
         end
@@ -134,14 +121,14 @@ describe Checkout::PaymentMethodResolver do
         expect(resolution.client_confirm_eligible?).to be(true)
         expect(resolution.fallback_reason).to be_nil
         expect(resolution.stripe_connect_account_id).to eq(connect_account.charge_processor_merchant_id)
-        expect(resolution.payment_method_types).to eq(%w[card cashapp us_bank_account])
+        expect(resolution.payment_method_types).to eq(%w[card link cashapp us_bank_account])
       end
 
       it "drops US-locked methods for a non-US buyer while keeping the connected-account scope" do
         resolution = resolve(buyer_country: "GB")
 
         expect(resolution.stripe_connect_account_id).to eq(connect_account.charge_processor_merchant_id)
-        expect(resolution.payment_method_types).to eq(["card"])
+        expect(resolution.payment_method_types).to eq(%w[card link])
       end
 
       it "falls back to Lane A when the connected account has no Charge Processor Merchant ID" do
@@ -165,7 +152,7 @@ describe Checkout::PaymentMethodResolver do
 
         expect(resolution.client_confirm_eligible?).to be(true)
         expect(resolution.stripe_connect_account_id).to be_nil
-        expect(resolution.payment_method_types).to eq(%w[card cashapp us_bank_account])
+        expect(resolution.payment_method_types).to eq(%w[card link cashapp us_bank_account])
       end
     end
 
@@ -194,7 +181,7 @@ describe Checkout::PaymentMethodResolver do
       resolver.resolve
 
       expect(Rails.logger).to have_received(:info).with(
-        a_string_matching(/client_confirm_eligible=true.*enabled=\["card"\].*launch_gated_out=.*stripe_connect_account_id=nil/)
+        a_string_matching(/client_confirm_eligible=true.*enabled=\["card", "link"\].*launch_gated_out=.*stripe_connect_account_id=nil/)
       )
     end
 
@@ -205,7 +192,7 @@ describe Checkout::PaymentMethodResolver do
       resolver.resolve
 
       expect(Rails.logger).to have_received(:info).with(
-        a_string_matching(/buyer_country="US".*enabled=\["card", "cashapp", "us_bank_account"\]/)
+        a_string_matching(/buyer_country="US".*enabled=\["card", "link", "cashapp", "us_bank_account"\]/)
       )
     end
 

--- a/spec/services/order/prepare_payment_intent_service_spec.rb
+++ b/spec/services/order/prepare_payment_intent_service_spec.rb
@@ -189,8 +189,7 @@ describe Order::PreparePaymentIntentService, :vcr do
         expect(create_args_for(order, params)[:payment_method_types]).to eq(%w[card cashapp us_bank_account])
       end
 
-      it "gates Link out of the intent on a PPP checkout even when the seller has the Link flag" do
-        Feature.activate_user(Checkout::PaymentMethodResolver::STRIPE_PAYMENT_ELEMENT_LINK_FEATURE_NAME, seller)
+      it "gates Link out of the intent on a PPP checkout" do
         order, params = build_order
         order.purchases.each { _1.update!(ip_country: "United States") }
 
@@ -198,7 +197,6 @@ describe Order::PreparePaymentIntentService, :vcr do
       end
 
       it "does not gate the intent when the seller disabled PPP payment verification" do
-        Feature.activate_user(Checkout::PaymentMethodResolver::STRIPE_PAYMENT_ELEMENT_LINK_FEATURE_NAME, seller)
         seller.update!(purchasing_power_parity_payment_verification_disabled: true)
         order, params = build_order
         order.purchases.each { _1.update!(ip_country: "United States") }
@@ -348,7 +346,7 @@ describe Order::PreparePaymentIntentService, :vcr do
     context "the deferred intent method/currency contract" do
       before { create(:merchant_account, user: seller, charge_processor_merchant_id: "acct_test") }
 
-      it "creates the intent with only card for a buyer whose country cannot be resolved (US-locked methods dropped)" do
+      it "creates the intent with card and Link for a buyer whose country cannot be resolved (US-locked methods dropped)" do
         order, params = build_order
 
         preview = Stripe::StripeObject.construct_from(card: { country: "US" })
@@ -364,7 +362,7 @@ describe Order::PreparePaymentIntentService, :vcr do
 
         described_class.new(order:, params:, confirmation_token: "ctoken_test").perform
 
-        expect(create_args[:payment_method_types]).to eq(["card"])
+        expect(create_args[:payment_method_types]).to eq(%w[card link])
         expect(create_args[:currency]).to eq(Checkout::StripePaymentPresenter::CLIENT_CONFIRM_CURRENCY)
       end
 
@@ -387,14 +385,13 @@ describe Order::PreparePaymentIntentService, :vcr do
 
         described_class.new(order:, params:, confirmation_token: "ctoken_us").perform
 
-        expect(create_args[:payment_method_types]).to eq(%w[card cashapp us_bank_account])
+        expect(create_args[:payment_method_types]).to eq(%w[card link cashapp us_bank_account])
       end
 
-      # The presenter derives the Element's Link config from the same resolver output, so a
-      # Link-flagged seller's Payment Element and deferred intent both carry "link". Without a
+      # The presenter derives the Element's Link config from the same resolver output, so the
+      # Payment Element and deferred intent both carry "link" with no per-seller flag. Without a
       # resolvable ip_country the US-locked methods stay dropped — Link is not region-gated.
-      it "includes Link in the intent's payment_method_types when the seller has the Link flag" do
-        Feature.activate_user(Checkout::PaymentMethodResolver::STRIPE_PAYMENT_ELEMENT_LINK_FEATURE_NAME, seller)
+      it "always includes Link in the intent's payment_method_types" do
         order, params = build_order
 
         preview = Stripe::StripeObject.construct_from(card: { country: "US" })

--- a/spec/support/checkout_helpers.rb
+++ b/spec/support/checkout_helpers.rb
@@ -218,7 +218,18 @@ def fill_in_payment_element(number: "4242424242424242", expiry: StripePaymentMet
     fill_in_stripe_field ["Card number"], with: number
     fill_in_stripe_field ["Expiration date", "Expiration", "MM / YY"], with: expiry
     fill_in_stripe_field ["Security code", "CVC", "CVV"], with: cvc
+    uncheck_link_save_in_payment_element
   end
+end
+
+# With Link always enabled, the Payment Element may render Link's pre-checked
+# "Save my information for faster checkout" pane, whose required mobile-number
+# field would block confirm. Specs pay as a plain card guest, so uncheck it.
+def uncheck_link_save_in_payment_element
+  save_checkbox = first(:checkbox, "Save my information for faster checkout", visible: false, wait: 0)
+  save_checkbox.click if save_checkbox&.checked?
+rescue Capybara::ElementNotFound, Selenium::WebDriver::Error::ElementNotInteractableError
+  # Older Element layouts (no Link pane) simply don't render the checkbox.
 end
 
 def within_payment_element_frame(&block)

--- a/spec/support/checkout_helpers.rb
+++ b/spec/support/checkout_helpers.rb
@@ -225,8 +225,13 @@ end
 # With Link always enabled, the Payment Element may render Link's pre-checked
 # "Save my information for faster checkout" pane, whose required mobile-number
 # field would block confirm. Specs pay as a plain card guest, so uncheck it.
+#
+# Stripe renders the Link pane asynchronously after the card fields are filled,
+# so we wait a few seconds for the checkbox to appear. We deliberately don't use
+# Capybara's default wait (25s here) because layouts without the Link pane never
+# render the checkbox at all, and every spec would stall for the full timeout.
 def uncheck_link_save_in_payment_element
-  save_checkbox = first(:checkbox, "Save my information for faster checkout", visible: false, wait: 0)
+  save_checkbox = first(:checkbox, "Save my information for faster checkout", visible: false, wait: 5)
   save_checkbox.click if save_checkbox&.checked?
 rescue Capybara::ElementNotFound, Selenium::WebDriver::Error::ElementNotInteractableError
   # Older Element layouts (no Link pane) simply don't render the checkbox.


### PR DESCRIPTION
## Summary

Removes the per-seller `:stripe_payment_element_link` Flipper flag. Link now auto-enables wherever the Stripe Payment Element is enabled.

**Why:** Link is inline — it rides the Payment Element's existing confirm machinery (PaymentMethod mode on Lane A, the two-step ConfirmationToken flow on the client-confirm path) with no return-page or webhook dependency. Gating it behind a second per-seller flag added a rollout surface with no useful lever: the element flags themselves gate the integration, and Stripe's dashboard payment-method settings remain the emergency kill switch.

Part of #5640. Stacked on #5701 (base: `u13-ppp-method-matrix`); retarget to `main` once that merges.

## Changes

- **Resolver** (`payment_method_resolver.rb`): `link` joins `LAUNCHED_PAYMENT_METHOD_TYPES` unconditionally; flag constant and per-seller intersection logic deleted.
- **Lane A presenter** (`stripe_payment_presenter.rb`): `stripe_link_enabled` is now `!ppp_verification_applies?` instead of a flag check. The PPP exception mirrors the client-confirm method matrix: Link's funding country can't be verified pre-charge, so on a PPP-verified checkout it would only fail `Purchase#validate_purchasing_power_parity` at purchase — gate it out up front.
- **PPP gate is item-scoped** (autoreview finding): on a multi-seller Lane A cart, one seller disabling PPP verification must not re-enable Link for another seller's still-verified PPP purchase. `ppp_verification_applies?` now checks each PPP-discounted item's own seller.
- **`payment.ts`**: contract comment updated — `stripe_link_enabled` reflects the resolved set, not a flag.
- **Spec helper** (`checkout_helpers.rb`): with Link always on, the Payment Element can render Link's pre-checked "Save my information" pane whose required mobile-number field blocks confirm; `fill_in_payment_element` now unchecks it.

## Testing

- `stripe_payment_presenter_spec` + `payment_method_resolver_spec` + `prepare_payment_intent_service_spec`: **95 examples, 0 failures** (on the rebased tip)
- Full verification set incl. `client_confirm_webhook_lifecycle_spec`: 134/134
- `stripejs_purchase_spec.rb` browser specs: the Link save-pane helper fix took 4 previously-failing Payment Element cases back to green. The multi-seller case (`:357`) fails identically on the base commit (pre-existing env flake: `track_user_action` savepoint error under load), not introduced here.
- Vitest Checkout suites 60/60; eslint/rubocop clean
- Codex autoreview (gpt-5.5): two P2 findings surfaced and fixed (Lane A PPP gate, then item-scoping); final run **clean — "patch is correct (0.82)"**

## New specs

- Lane A always enables Link (no flag)
- Lane A disables Link on a PPP-verified checkout
- Lane A keeps Link when the PPP item's own seller disabled verification
- Item-scoping both ways on multi-seller carts

🤖 Generated with [Hermes Agent](https://hermes.nousresearch.com)
