### PR TITLE
docs: update slogan to "See what sticks."

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-  <strong>Sell your stuff. See what sticks.</strong>
+  <strong>See what sticks.</strong>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Updates the README tagline from "Sell your stuff. See what sticks." to just "See what sticks." per Sahil — the shortened slogan is now canonical (the GitHub repo description already uses it).

Checked the rest of the codebase and org for other occurrences of the old slogan: the only remaining one is in antiwork/gumroad-private's README, which I'm updating directly. Marketing copy that uses "see what sticks" mid-sentence (about page hero, home meta description, product-creation blurb) reads naturally and wasn't the two-part slogan, so it's untouched.