### PR TITLE
Gate bank-account saves on countries where new Stripe accounts are blocked

### DIFF
--- a/app/controllers/settings/payments_controller.rb
+++ b/app/controllers/settings/payments_controller.rb
@@ -247,6 +247,8 @@ class Settings::PaymentsController < Settings::BaseController
                         "Email address cannot contain non-ASCII characters"
                       when :paypal_payouts_not_supported
                         "PayPal payouts are not supported in your country."
+                      when :bank_payouts_not_supported
+                        "Bank payouts are not supported in your country yet. Please use PayPal instead."
                       when :concurrent_payout_method_change
                         "Another change was submitted at the same time. Please try again."
       end

--- a/app/services/update_payout_method.rb
+++ b/app/services/update_payout_method.rb
@@ -196,6 +196,8 @@ class UpdatePayoutMethod
     ACCOUNT_NUMBER_SEPARATOR_CHARACTERS = /[[:space:]\p{Cf}-]/
 
     def process_full_bank_account_replacement
+      return { error: :bank_payouts_not_supported } unless bank_payouts_supported?
+
       account_number = normalize_account_number(params[:bank_account][:account_number])
       account_number_confirmation = normalize_account_number(params[:bank_account][:account_number_confirmation])
       return { error: :account_number_does_not_match } if account_number != account_number_confirmation
@@ -292,6 +294,30 @@ class UpdatePayoutMethod
 
     def paypal_payouts_supported?
       user.can_setup_paypal_payouts? || switching_to_uae_individual_account?
+    end
+
+    # Guards the bank-account branch the same way process_payment_address_params guards the
+    # PayPal branch. A bank account is only useful if it can link to a Stripe merchant
+    # account, and StripeMerchantAccountManager refuses to create one for countries in
+    # NEW_ACCOUNT_CREATION_BLOCKED_COUNTRIES (currently India). Without this gate, a seller
+    # from a blocked country can save bank details that persist but never link
+    # (stripe_bank_account_id stays NULL, no merchant_accounts row is ever created), so
+    # every weekly payout silently skips with "the payout bank account was not correctly
+    # set up" while the dashboard keeps showing a next-payout date.
+    #
+    # Sellers who already have a working Stripe merchant account (e.g. India accounts
+    # grandfathered in before the block) are allowed through so they can keep updating
+    # their bank details. When the country isn't known yet we allow the save and let the
+    # downstream merchant-account creation surface the error, matching prior behavior.
+    def bank_payouts_supported?
+      return true if user.stripe_account.present?
+
+      country_code = user.alive_user_compliance_info&.legal_entity_country_code
+      return true if country_code.blank?
+      return true if country_code == Compliance::Countries::ARE.alpha2
+
+      user.native_payouts_supported?(country_code:) &&
+        StripeMerchantAccountManager::NEW_ACCOUNT_CREATION_BLOCKED_COUNTRIES.exclude?(country_code)
     end
 
     def switching_to_uae_individual_account?

--- a/spec/services/update_payout_method_spec.rb
+++ b/spec/services/update_payout_method_spec.rb
@@ -119,6 +119,63 @@ describe UpdatePayoutMethod do
       end
     end
 
+    describe "gating bank payouts by country" do
+      context "when the seller signed up from a country where new Stripe accounts are blocked" do
+        let(:user) { create(:named_user) }
+        let!(:compliance_info) { create(:user_compliance_info, user:, country: "India") }
+
+        let(:params) do
+          ActionController::Parameters.new(
+            bank_account: {
+              type: IndianBankAccount.name,
+              account_holder_full_name: "Indian Creator",
+              account_number: "000123456789",
+              account_number_confirmation: "000123456789",
+              ifsc: "HDFC0004051",
+            }
+          )
+        end
+
+        it "returns bank_payouts_not_supported and does not persist a bank account" do
+          result = described_class.new(user_params: params, seller: user).process
+
+          expect(result).to eq(error: :bank_payouts_not_supported)
+          expect(user.bank_accounts.alive.count).to eq(0)
+        end
+
+        it "still allows the save when the seller already has a live Stripe merchant account" do
+          create(:merchant_account, user:)
+
+          result = described_class.new(user_params: params, seller: user).process
+
+          expect(result).to eq(success: true)
+          expect(user.active_bank_account).to be_a(IndianBankAccount)
+        end
+      end
+
+      context "when the seller signed up from a country where bank payouts are supported" do
+        let(:user) { create(:named_user) }
+        let!(:compliance_info) { create(:user_compliance_info, user:, country: "United States") }
+
+        it "persists the bank account" do
+          params = ActionController::Parameters.new(
+            bank_account: {
+              type: AchAccount.name,
+              account_holder_full_name: "Named User",
+              account_number: "123456789",
+              account_number_confirmation: "123456789",
+              routing_number: "110000000",
+            }
+          )
+
+          result = described_class.new(user_params: params, seller: user).process
+
+          expect(result).to eq(success: true)
+          expect(user.bank_accounts.alive.count).to eq(1)
+        end
+      end
+    end
+
     describe "replacing the active bank account" do
       let(:user) { create(:named_user) }
       let!(:existing_bank_account) { create(:ach_account, user:) }


### PR DESCRIPTION
## What

Gates the bank-account branch of `UpdatePayoutMethod` on whether the seller's country can actually create a Stripe merchant account, mirroring the guard the PayPal branch already has (`paypal_payouts_supported?`). Sellers from blocked countries (currently India, per `StripeMerchantAccountManager::NEW_ACCOUNT_CREATION_BLOCKED_COUNTRIES`) now get a clear inline error — "Bank payouts are not supported in your country yet. Please use PayPal instead." — instead of a persisted-but-dead bank account row.

## Why

India was intentionally blocked for new Stripe Connect accounts in #4803, but the bank-details save path was never gated (this exact persistence gap was flagged in the #4803 review; only the 500-error was fixed). The result for a new India seller:

1. The `bank_accounts` row saves fine and the UI says "Thanks! You're all set."
2. `StripeMerchantAccountManager.create_account` raises `MerchantRegistrationUserNotReadyError` (blocked country), and `StripeCreateMerchantAccountsWorker` skips the user — so no `merchant_accounts` row is ever created and `stripe_bank_account_id` stays NULL forever.
3. `StripePayoutProcessor.is_user_payable` fails every week → the misleading "the payout bank account was not correctly set up" payout note, while the dashboard keeps showing a concrete next-payout date and amount.
4. The seller re-enters bank details repeatedly (each save "succeeds") and files repeated support tickets.

Investigated in antiwork/gumroad-private#886 (worked example there: 7 dead bank rows, 5 consecutive weekly skips, a three-figure balance stranded ~6 weeks).

## How

- `UpdatePayoutMethod#process_full_bank_account_replacement` now returns `{ error: :bank_payouts_not_supported }` before validating/persisting when the country can't link a bank account.
- Grandfathered sellers (an alive Stripe merchant account already exists — e.g. India accounts created before the #4803 block) are allowed through so they can keep updating their bank details.
- UAE stays allowed (business-account path), and an unknown/blank country falls through to the existing downstream error, matching prior behavior.
- Controller maps the new error symbol to the same message the merchant-account-creation rescue already uses for this case.

## Test plan

- `bundle exec rspec spec/services/update_payout_method_spec.rb` — 17 examples, 0 failures locally (3 new: India seller blocked with no row persisted; India seller with a live merchant account still allowed; US seller unaffected).
- `bundle exec rubocop` on the three changed files — no offenses.
- autoreview (Codex, branch mode vs origin/main) — clean, no actionable findings.

Not covered here (follow-ups noted on the tracking issue): hiding the next-payout date when the payout method can never process, and a one-time sweep of existing India accounts with dead bank rows + stranded balances.
