### PR TITLE
Show the below-minimum balance notice for first-payout sellers and fold stale under-review notes

### DIFF
--- a/app/helpers/payouts_helper.rb
+++ b/app/helpers/payouts_helper.rb
@@ -89,15 +89,19 @@ module PayoutsHelper
         nil
       end
 
-    skipped_note_match = payout_note&.match(BELOW_MINIMUM_PAYOUT_NOTE_REGEX)
-    # A "not_payable" status here always means the balance is below the payout
-    # minimum, so for a not-reviewed seller a stale "under review" note is
-    # really a below-minimum skip and gets folded the same way.
-    skipped_note_match ||= payout_note&.match(UNDER_REVIEW_PAYOUT_NOTE_REGEX) if user.not_reviewed?
-    if payout_period_data[:status] == "not_payable" && skipped_note_match
+    below_minimum_note_match = payout_note&.match(BELOW_MINIMUM_PAYOUT_NOTE_REGEX)
+    if payout_period_data[:status] == "not_payable" && below_minimum_note_match
       # The below-minimum skip is folded into the not-payable notice (with the
       # current balance) instead of rendering the stored note verbatim.
-      payout_period_data[:skipped_payout_date] = skipped_note_match[:date]
+      payout_period_data[:skipped_payout_date] = below_minimum_note_match[:date]
+      payout_note = nil
+    elsif payout_period_data[:status] == "not_payable" && user.not_reviewed? && payout_note&.match?(UNDER_REVIEW_PAYOUT_NOTE_REGEX)
+      # A stale "under review" note on a not-reviewed account blames a review
+      # that doesn't exist, so we hide it and let the below-minimum notice
+      # explain the current state. We deliberately don't claim the old skip was
+      # caused by the balance: the note doesn't record the balance at the time,
+      # and it may have been written while the balance was above the minimum
+      # (the account was skipped back then for not being reviewed yet).
       payout_note = nil
     end
     payout_period_data[:payout_note] = payout_note

--- a/app/helpers/payouts_helper.rb
+++ b/app/helpers/payouts_helper.rb
@@ -10,6 +10,13 @@ module PayoutsHelper
   # rendering the stored note verbatim.
   BELOW_MINIMUM_PAYOUT_NOTE_REGEX = /\A(?:Your payout|Payout) on (?<date>\w+ \d{1,2}, \d{4}) was skipped because (?:your balance of .+ was below|the account balance .+ was less than the minimum payout amount)/
 
+  # Notes written before the below-minimum fix attributed a skipped payout to a
+  # review that doesn't exist ("not_reviewed" is the default state, not an
+  # active review). For a not-reviewed seller whose balance is below the
+  # minimum, the real cause of the skip is the balance, so these stale notes
+  # are folded into the same below-minimum notice instead of being shown.
+  UNDER_REVIEW_PAYOUT_NOTE_REGEX = /\APayout on (?<date>\w+ \d{1,2}, \d{4}) was skipped because the account was under review\.\z/
+
   def formatted_payout_date(payout_date)
     return "" if payout_date.nil?
     payout_date.strftime("%B #{payout_date.day.ordinalize}, %Y")
@@ -82,11 +89,15 @@ module PayoutsHelper
         nil
       end
 
-    below_minimum_note_match = payout_note&.match(BELOW_MINIMUM_PAYOUT_NOTE_REGEX)
-    if payout_period_data[:status] == "not_payable" && below_minimum_note_match
+    skipped_note_match = payout_note&.match(BELOW_MINIMUM_PAYOUT_NOTE_REGEX)
+    # A "not_payable" status here always means the balance is below the payout
+    # minimum, so for a not-reviewed seller a stale "under review" note is
+    # really a below-minimum skip and gets folded the same way.
+    skipped_note_match ||= payout_note&.match(UNDER_REVIEW_PAYOUT_NOTE_REGEX) if user.not_reviewed?
+    if payout_period_data[:status] == "not_payable" && skipped_note_match
       # The below-minimum skip is folded into the not-payable notice (with the
       # current balance) instead of rendering the stored note verbatim.
-      payout_period_data[:skipped_payout_date] = below_minimum_note_match[:date]
+      payout_period_data[:skipped_payout_date] = skipped_note_match[:date]
       payout_note = nil
     end
     payout_period_data[:payout_note] = payout_note

--- a/app/javascript/pages/Payouts/Index.tsx
+++ b/app/javascript/pages/Payouts/Index.tsx
@@ -746,52 +746,44 @@ export default function PayoutsIndex() {
                 </Alert>
               ) : null}
               {next_payout_period_data.status === "not_payable" ? (
-                past_payout_period_data.length > 0 ? (
+                // Sellers with a positive balance below the payout minimum get the
+                // balance notice even before their first payout — otherwise a
+                // first-time seller whose payout was skipped would only see the
+                // generic empty state and have no way to see their balance or the
+                // reason the payout didn't go out.
+                next_payout_period_data.balance_cents != null &&
+                next_payout_period_data.balance_cents > 0 &&
+                next_payout_period_data.balance_cents < next_payout_period_data.minimum_payout_amount_cents ? (
                   <Alert variant="info" role="status">
                     <p>
-                      {next_payout_period_data.balance_cents != null &&
-                      next_payout_period_data.balance_cents < next_payout_period_data.minimum_payout_amount_cents ? (
-                        <>
-                          Your balance is{" "}
-                          {formatPriceCentsWithCurrencySymbol("usd", next_payout_period_data.balance_cents, {
-                            symbolFormat: "short",
-                            noCentsIfWhole: false,
-                          })}
-                          , below the{" "}
-                          {formatPriceCentsWithCurrencySymbol(
-                            "usd",
-                            next_payout_period_data.minimum_payout_amount_cents,
-                            {
-                              symbolFormat: "short",
-                            },
-                          )}{" "}
-                          minimum
-                          {next_payout_period_data.skipped_payout_date != null
-                            ? ` — so your ${next_payout_period_data.skipped_payout_date} payout was skipped`
-                            : ""}
-                          . You'll be paid out automatically once your balance reaches{" "}
-                          {formatPriceCentsWithCurrencySymbol(
-                            "usd",
-                            next_payout_period_data.minimum_payout_amount_cents,
-                            {
-                              symbolFormat: "short",
-                            },
-                          )}
-                          .
-                        </>
-                      ) : (
-                        <>
-                          Reach a balance of at least{" "}
-                          {formatPriceCentsWithCurrencySymbol(
-                            "usd",
-                            next_payout_period_data.minimum_payout_amount_cents,
-                            {
-                              symbolFormat: "short",
-                            },
-                          )}{" "}
-                          to be paid out for your sales.
-                        </>
-                      )}
+                      Your balance is{" "}
+                      {formatPriceCentsWithCurrencySymbol("usd", next_payout_period_data.balance_cents, {
+                        symbolFormat: "short",
+                        noCentsIfWhole: false,
+                      })}
+                      , below the{" "}
+                      {formatPriceCentsWithCurrencySymbol("usd", next_payout_period_data.minimum_payout_amount_cents, {
+                        symbolFormat: "short",
+                      })}{" "}
+                      minimum
+                      {next_payout_period_data.skipped_payout_date != null
+                        ? ` — so your ${next_payout_period_data.skipped_payout_date} payout was skipped`
+                        : ""}
+                      . You'll be paid out automatically once your balance reaches{" "}
+                      {formatPriceCentsWithCurrencySymbol("usd", next_payout_period_data.minimum_payout_amount_cents, {
+                        symbolFormat: "short",
+                      })}
+                      .
+                    </p>
+                  </Alert>
+                ) : past_payout_period_data.length > 0 ? (
+                  <Alert variant="info" role="status">
+                    <p>
+                      Reach a balance of at least{" "}
+                      {formatPriceCentsWithCurrencySymbol("usd", next_payout_period_data.minimum_payout_amount_cents, {
+                        symbolFormat: "short",
+                      })}{" "}
+                      to be paid out for your sales.
                     </p>
                   </Alert>
                 ) : (

--- a/spec/helpers/payouts_helper_spec.rb
+++ b/spec/helpers/payouts_helper_spec.rb
@@ -261,11 +261,28 @@ describe PayoutsHelper do
         expect(data[:skipped_payout_date]).to eq("June 12, 2026")
       end
 
-      it "keeps other payout notes verbatim" do
+      it "folds a stale under-review note into skipped_payout_date when the user is not reviewed" do
+        user.add_payout_note(content: "Payout on June 12, 2026 was skipped because the account was under review.")
+
+        data = self.payout_period_data(user)
+        expect(data[:payout_note]).to be_nil
+        expect(data[:skipped_payout_date]).to eq("June 12, 2026")
+      end
+
+      it "keeps the under-review note verbatim when the account is under an actual review" do
+        user.update!(user_risk_state: "flagged_for_fraud")
         user.add_payout_note(content: "Payout on June 12, 2026 was skipped because the account was under review.")
 
         data = self.payout_period_data(user)
         expect(data[:payout_note]).to eq("Payout on June 12, 2026 was skipped because the account was under review.")
+        expect(data[:skipped_payout_date]).to be_nil
+      end
+
+      it "keeps other payout notes verbatim" do
+        user.add_payout_note(content: "Payout on June 12, 2026 was skipped because a bank account wasn't added at the time.")
+
+        data = self.payout_period_data(user)
+        expect(data[:payout_note]).to eq("Payout on June 12, 2026 was skipped because a bank account wasn't added at the time.")
         expect(data[:skipped_payout_date]).to be_nil
       end
     end

--- a/spec/helpers/payouts_helper_spec.rb
+++ b/spec/helpers/payouts_helper_spec.rb
@@ -261,12 +261,14 @@ describe PayoutsHelper do
         expect(data[:skipped_payout_date]).to eq("June 12, 2026")
       end
 
-      it "folds a stale under-review note into skipped_payout_date when the user is not reviewed" do
+      it "hides a stale under-review note when the user is not reviewed, without claiming a balance skip" do
         user.add_payout_note(content: "Payout on June 12, 2026 was skipped because the account was under review.")
 
         data = self.payout_period_data(user)
         expect(data[:payout_note]).to be_nil
-        expect(data[:skipped_payout_date]).to eq("June 12, 2026")
+        # The stale note doesn't record the balance at the time of the skip, so
+        # we don't attribute the old skip to the current below-minimum balance.
+        expect(data[:skipped_payout_date]).to be_nil
       end
 
       it "keeps the under-review note verbatim when the account is under an actual review" do

--- a/spec/requests/balance_pages_spec.rb
+++ b/spec/requests/balance_pages_spec.rb
@@ -504,11 +504,15 @@ describe "Balance Pages Scenario", js: true, type: :system do
                 seller.add_payout_note(content: "Payout on June 12, 2026 was skipped because the account was under review.")
               end
 
-              it "folds the stale note into the below-minimum notice instead of showing it" do
+              it "hides the stale note and shows the plain below-minimum notice" do
                 visit balance_path
 
-                expect(page).to have_text("Your balance is $59.72, below the $100 minimum — so your June 12, 2026 payout was skipped. You'll be paid out automatically once your balance reaches $100.")
+                # The old note doesn't record what the balance was at the time,
+                # so the page doesn't claim that payout was skipped for the
+                # current balance — it just shows the current below-minimum state.
+                expect(page).to have_text("Your balance is $59.72, below the $100 minimum. You'll be paid out automatically once your balance reaches $100.")
                 expect(page).not_to have_text("was skipped because the account was under review")
+                expect(page).not_to have_text("so your June 12, 2026 payout was skipped")
               end
             end
           end

--- a/spec/requests/balance_pages_spec.rb
+++ b/spec/requests/balance_pages_spec.rb
@@ -494,6 +494,36 @@ describe "Balance Pages Scenario", js: true, type: :system do
                 expect(page).not_to have_text("was skipped because your balance of")
               end
             end
+
+            context "when a stale under-review payout note was recorded for a not-reviewed account" do
+              before do
+                seller.payments.last.update!(created_at: 1.hour.ago)
+                seller.update!(user_risk_state: "not_reviewed")
+                # Pre-fix payout notes blamed a review that doesn't exist; the page
+                # folds them into the below-minimum notice for not-reviewed sellers.
+                seller.add_payout_note(content: "Payout on June 12, 2026 was skipped because the account was under review.")
+              end
+
+              it "folds the stale note into the below-minimum notice instead of showing it" do
+                visit balance_path
+
+                expect(page).to have_text("Your balance is $59.72, below the $100 minimum — so your June 12, 2026 payout was skipped. You'll be paid out automatically once your balance reaches $100.")
+                expect(page).not_to have_text("was skipped because the account was under review")
+              end
+            end
+          end
+
+          context "when a below-minimum seller has never been paid out" do
+            before do
+              allow_any_instance_of(User).to receive(:unpaid_balance_cents).and_return(59_72)
+            end
+
+            it "shows the balance notice instead of the empty state" do
+              visit balance_path
+
+              expect(page).to have_text("Your balance is $59.72, below the $100 minimum. You'll be paid out automatically once your balance reaches $100.")
+              expect(page).not_to have_content("Let's get you paid.")
+            end
           end
 
           context "when the payout was skipped because the account was under review" do


### PR DESCRIPTION
## What

- The Payouts page now shows the below-minimum balance notice ("Your balance is $59.72, below the $100 minimum…") for sellers who have **never had a payout**, instead of only the generic "Let's get you paid." empty state. Previously the balance notice from #5700 only rendered when the seller had at least one past payout.
- Stale "Payout on … was skipped because the account was under review." notes — written before #5700 for `not_reviewed` sellers — are now folded into the same below-minimum notice instead of being rendered verbatim. #5700 fixed the note text for *future* skips, but existing sellers still carry the old misleading note as their latest payout note, so their page looked unchanged after the fix shipped.

## Why

A seller (Helper ticket [7593a7e3](https://help.gumroad.com/all?id=7593a7e3ce816c8bb25ab66ed121acb5), the same seller whose report prompted #5700) confirmed after that fix deployed that their Payouts page still shows only the "under review" warning with no balance, in both Chrome and Firefox with caches cleared. Two gaps in #5700 explain it:

1. The seller has **zero past payouts** (`payments_count=0` verified in production), so the page renders `PeriodEmpty` and never reaches the new balance notice — exactly the seller most likely to be confused about why they haven't been paid.
2. Their latest payout note (July 3, written before the fix deployed) is the **old "under review" wording**, which doesn't match `BELOW_MINIMUM_PAYOUT_NOTE_REGEX`, so it renders verbatim as the misleading warning. Since payouts for below-minimum sellers keep skipping without writing new notes until the balance crosses $100, the stale note would stick around indefinitely.

The fold of stale under-review notes is gated on `user.not_reviewed?` so accounts under an actual review (flagged, etc.) keep the accurate note.

## Verification

- `spec/helpers/payouts_helper_spec.rb`: 21 examples, 0 failures locally (includes new examples for the stale-note fold, the flagged-account guard, and other notes staying verbatim).
- New system-spec coverage in `spec/requests/balance_pages_spec.rb` for the never-paid-out balance notice and the stale-note fold (js specs can't run on this macOS box — CI will confirm).
- `rubocop` clean on changed Ruby files; `prettier --check` clean on the TSX; `tsc` diff vs baseline is zero.
