### PR TITLE
Bridge same-store product links out of the sandboxed custom profile iframe

### DIFF
--- a/app/controllers/concerns/renders_custom_html_pages.rb
+++ b/app/controllers/concerns/renders_custom_html_pages.rb
@@ -108,6 +108,93 @@ module RendersCustomHtmlPages
   end
 
   private
+    # --- Same-store navigation bridge ---------------------------------------
+    #
+    # The seller's HTML lives in an opaque-origin sandboxed iframe. A plain
+    # product link (<a href="/l/xyz">) therefore navigates the IFRAME itself,
+    # loading the full product page + checkout on an origin where cookies and
+    # storage are unavailable — checkout hangs, and Safari won't render the
+    # page at all. The seller can't use target="_top" either: the sanitizer
+    # strips it and the sandbox omits allow-top-navigation on purpose (seller
+    # HTML must never be able to redirect the visitor's tab to an arbitrary
+    # site).
+    #
+    # So, mirroring the product wrapper's gumroad:checkout pattern, clicks on
+    # links that point at the seller's OWN store are turned into a postMessage
+    # to the trusted parent wrapper, which re-validates the destination host
+    # and performs the top-level navigation itself. Links to any other host
+    # keep the browser's default in-frame behavior, and the parent ignores any
+    # message whose URL isn't on the seller's own hosts — the sandbox
+    # guarantee is unchanged for everything except the seller's own store
+    # pages.
+
+    # Runs inside the sandboxed (untrusted) document. It only decides which
+    # clicks to FORWARD; the parent independently re-validates the URL, so a
+    # compromised copy of this script gains nothing.
+    def custom_html_navigation_bridge_child_script(allowed_hosts:)
+      hosts_js = ERB::Util.json_escape(allowed_hosts.to_json)
+      <<~HTML
+        <script data-cfasync="false" data-gumroad-nav-bridge>
+          (function () {
+            var ALLOWED_HOSTS = #{hosts_js};
+            document.addEventListener("click", function (e) {
+              if (e.defaultPrevented) return;
+              // Respect modified clicks (open in new tab/window) and non-left buttons.
+              if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+              var anchor = e.target && e.target.closest ? e.target.closest("a[href]") : null;
+              if (!anchor) return;
+              // A seller who set an explicit target (e.g. _blank) keeps it.
+              var target = (anchor.getAttribute("target") || "").trim();
+              if (target !== "" && target.toLowerCase() !== "_self") return;
+              var url;
+              try { url = new URL(anchor.getAttribute("href"), window.location.href); } catch (_e) { return; }
+              if (url.protocol !== "https:" && url.protocol !== "http:") return;
+              if (ALLOWED_HOSTS.indexOf(url.hostname.toLowerCase()) === -1) return;
+              e.preventDefault();
+              parent.postMessage({ type: "gumroad:navigate", url: url.href }, "*");
+            }, true);
+          })();
+        </script>
+      HTML
+    end
+
+    # Runs in the trusted parent wrapper (real origin, nonce'd under the
+    # global CSP). Validates that the message came from our iframe and that
+    # the destination is one of the seller's own hosts before navigating
+    # top-level.
+    def custom_html_navigation_bridge_parent_script(allowed_hosts:, nonce:)
+      hosts_js = ERB::Util.json_escape(allowed_hosts.to_json)
+      <<~HTML
+        <script nonce="#{ERB::Util.h(nonce)}" data-cfasync="false">
+          (function () {
+            var frame = document.getElementById("gumroad-landing-frame");
+            var ALLOWED_HOSTS = #{hosts_js};
+            window.addEventListener("message", function (e) {
+              // Opaque-origin iframes report origin "null"; also require the
+              // message to come from our own frame, not a nested one.
+              if (!frame || e.source !== frame.contentWindow || e.origin !== "null") return;
+              var d = e.data;
+              if (!d || typeof d !== "object" || d.type !== "gumroad:navigate") return;
+              var url;
+              try { url = new URL(String(d.url), window.location.origin); } catch (_e) { return; }
+              if (url.protocol !== "https:" && url.protocol !== "http:") return;
+              if (ALLOWED_HOSTS.indexOf(url.hostname.toLowerCase()) === -1) return;
+              window.location.href = url.href;
+            });
+          })();
+        </script>
+      HTML
+    end
+
+    # The hosts the bridge may navigate to: the host currently being browsed
+    # (subdomain or verified custom domain), plus the seller's subdomain and
+    # custom domain, so product URLs generated for either surface work on
+    # both.
+    def custom_html_navigation_allowed_hosts(user)
+      hosts = [request.host, user.subdomain, user.custom_domain&.domain]
+      hosts.compact.map { _1.to_s.downcase.strip }.reject(&:empty?).uniq
+    end
+
     def render_landing_version(visible:, page:)
       render json: { present: visible, version: visible ? page&.updated_at&.to_i : nil }
     end

--- a/app/controllers/concerns/renders_custom_html_pages.rb
+++ b/app/controllers/concerns/renders_custom_html_pages.rb
@@ -200,16 +200,20 @@ module RendersCustomHtmlPages
 
     # The hosts the bridge may navigate to: the host currently being browsed
     # (subdomain or verified custom domain), plus the seller's subdomain and
-    # VERIFIED custom domain, so product URLs generated for either surface
-    # work on both. An unverified custom-domain record must never qualify: a
-    # seller could save an arbitrary external domain and use the bridge to
+    # currently ACTIVE custom domain, so product URLs generated for either
+    # surface work on both. `active?` (verified + valid certificate) is the
+    # same eligibility check the rest of the app uses before emitting
+    # custom-domain URLs (UrlService, ContentExtractor). An unverified or
+    # stale record must never qualify: a saved-but-unverified domain can be
+    # any arbitrary external site, and a previously-verified domain may have
+    # since been pointed off-platform — either would let the bridge
     # top-navigate the visitor's tab there, which is exactly what the missing
     # allow-top-navigation sandbox token is meant to prevent. request.host is
     # safe as-is — it is only ever a host Gumroad actually served this page on.
     def custom_html_navigation_allowed_hosts(user)
       custom_domain = user.custom_domain
-      verified_custom_domain = custom_domain&.verified? ? custom_domain.domain : nil
-      hosts = [request.host, user.subdomain, verified_custom_domain]
+      active_custom_domain = custom_domain&.active? ? custom_domain.domain : nil
+      hosts = [request.host, user.subdomain, active_custom_domain]
       hosts.compact.map { _1.to_s.downcase.strip }.reject(&:empty?).uniq
     end
 

--- a/app/controllers/concerns/renders_custom_html_pages.rb
+++ b/app/controllers/concerns/renders_custom_html_pages.rb
@@ -146,10 +146,22 @@ module RendersCustomHtmlPages
               // A seller who set an explicit target (e.g. _blank) keeps it.
               var target = (anchor.getAttribute("target") || "").trim();
               if (target !== "" && target.toLowerCase() !== "_self") return;
+              var rawHref = (anchor.getAttribute("href") || "").trim();
+              // Hash-only and empty hrefs are same-document navigations (section
+              // jumps, "#"-placeholder buttons wired up by the seller's own JS).
+              // They resolve against the iframe's /landing/embed URL, so without
+              // this guard they would pass the host allowlist and top-navigate
+              // the visitor to the raw embed endpoint. Leave them to the browser
+              // / the seller's scripts.
+              if (rawHref === "" || rawHref.charAt(0) === "#") return;
               var url;
-              try { url = new URL(anchor.getAttribute("href"), window.location.href); } catch (_e) { return; }
+              try { url = new URL(rawHref, window.location.href); } catch (_e) { return; }
               if (url.protocol !== "https:" && url.protocol !== "http:") return;
               if (ALLOWED_HOSTS.indexOf(url.hostname.toLowerCase()) === -1) return;
+              // Same-document by resolution too (e.g. href="?x#y" or the page's
+              // own URL): anything that lands back on this embed document should
+              // stay in-frame, never become a top-level navigation.
+              if (url.pathname === window.location.pathname && url.hostname === window.location.hostname) return;
               e.preventDefault();
               parent.postMessage({ type: "gumroad:navigate", url: url.href }, "*");
             }, true);

--- a/app/controllers/concerns/renders_custom_html_pages.rb
+++ b/app/controllers/concerns/renders_custom_html_pages.rb
@@ -188,10 +188,16 @@ module RendersCustomHtmlPages
 
     # The hosts the bridge may navigate to: the host currently being browsed
     # (subdomain or verified custom domain), plus the seller's subdomain and
-    # custom domain, so product URLs generated for either surface work on
-    # both.
+    # VERIFIED custom domain, so product URLs generated for either surface
+    # work on both. An unverified custom-domain record must never qualify: a
+    # seller could save an arbitrary external domain and use the bridge to
+    # top-navigate the visitor's tab there, which is exactly what the missing
+    # allow-top-navigation sandbox token is meant to prevent. request.host is
+    # safe as-is — it is only ever a host Gumroad actually served this page on.
     def custom_html_navigation_allowed_hosts(user)
-      hosts = [request.host, user.subdomain, user.custom_domain&.domain]
+      custom_domain = user.custom_domain
+      verified_custom_domain = custom_domain&.verified? ? custom_domain.domain : nil
+      hosts = [request.host, user.subdomain, verified_custom_domain]
       hosts.compact.map { _1.to_s.downcase.strip }.reject(&:empty?).uniq
     end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -180,9 +180,11 @@ class UsersController < ApplicationController
 
   private
     # The profile is authored entirely through the seller's agent + CLI, so the
-    # custom HTML never carries a buy affordance — there's no checkout bridge or
-    # ?wanted=true fall-through like the product landing page has. The wrapper is
-    # a display-only sandboxed iframe.
+    # custom HTML never carries a native buy affordance — there's no checkout
+    # bridge or ?wanted=true fall-through like the product landing page has.
+    # Product links in the seller's HTML top-navigate through the
+    # gumroad:navigate bridge (RendersCustomHtmlPages) so checkout happens on a
+    # real origin, never inside the sandboxed iframe.
     def render_custom_html_if_present
       return unless custom_html_visible?
       # The public profile also answers JSON (GET /:username.json) with the
@@ -224,6 +226,7 @@ class UsersController < ApplicationController
           <body>
             <script id="gumroad-data" type="application/json">#{data_json}</script>
             #{custom_html}
+            #{custom_html_navigation_bridge_child_script(allowed_hosts: custom_html_navigation_allowed_hosts(@user))}
             #{live_fields ? PROFILE_FIELDS_PREVIEW_SCRIPT : ""}
           </body>
         </html>
@@ -233,17 +236,20 @@ class UsersController < ApplicationController
     # Omitting `allow-same-origin` keeps the seller's HTML on an opaque origin —
     # no access to gumroad.com cookies or the parent DOM. We also omit
     # `allow-top-navigation` so the seller's HTML can never navigate the
-    # visitor's tab away from gumroad.com. Unlike the product wrapper there is no
-    # checkout postMessage bridge: a profile has no native buy button.
+    # visitor's tab away from gumroad.com. Product links in the seller's HTML
+    # escape the sandbox via the gumroad:navigate postMessage bridge (see
+    # RendersCustomHtmlPages), which only follows destinations on the seller's
+    # own store hosts.
     def profile_custom_html_wrapper_document(user)
       iframe_src = ERB::Util.h(profile_landing_src(user, "embed"))
       title = ERB::Util.h(user.name_or_username.to_s)
       canonical = ERB::Util.h(user.profile_url(custom_domain_url: seller_custom_domain_url).to_s)
+      nonce = SecureHeaders.content_security_policy_script_nonce(request)
       # avatar_url always returns a value (it falls back to the default avatar),
       # so only advertise og:image when the seller uploaded a real one.
       og_image_tag = user.avatar.attached? ? %(<meta property="og:image" content="#{ERB::Util.h(user.avatar_url)}">) : ""
       live_reload = if current_seller_owns_profile?
-        custom_html_live_reload_script(version_src: profile_landing_src(user, "version"), nonce: SecureHeaders.content_security_policy_script_nonce(request))
+        custom_html_live_reload_script(version_src: profile_landing_src(user, "version"), nonce:)
       else
         ""
       end
@@ -269,6 +275,7 @@ class UsersController < ApplicationController
               title="#{title}"
               sandbox="allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox"
             ></iframe>
+            #{custom_html_navigation_bridge_parent_script(allowed_hosts: custom_html_navigation_allowed_hosts(user), nonce:)}
             #{live_reload}
           </body>
         </html>

--- a/spec/controllers/users_controller_custom_html_spec.rb
+++ b/spec/controllers/users_controller_custom_html_spec.rb
@@ -34,7 +34,11 @@ describe UsersController, :vcr, type: :controller do
       get :show
       expect(response.body).not_to include("gumroad:checkout")
       expect(response.body).not_to include("wanted=true")
-      expect(response.body).not_to include("postMessage")
+    end
+
+    it "embeds the navigation bridge listener so same-store links can escape the sandbox" do
+      get :show
+      expect(response.body).to include("gumroad:navigate")
     end
 
     it "falls back to the default profile page when custom_html is blank" do
@@ -114,8 +118,14 @@ describe UsersController, :vcr, type: :controller do
       get :landing_iframe_content
 
       expect(response.body).not_to include("gumroad:checkout")
-      expect(response.body).not_to include("postMessage")
       expect(response.body).not_to include("wanted=true")
+    end
+
+    it "embeds the same-store navigation forwarder in the iframe document" do
+      get :landing_iframe_content
+
+      expect(response.body).to include("data-gumroad-nav-bridge")
+      expect(response.body).to include("gumroad:navigate")
     end
 
     it "resolves the seller by username on the root domain" do

--- a/spec/requests/profile_custom_html_spec.rb
+++ b/spec/requests/profile_custom_html_spec.rb
@@ -67,6 +67,14 @@ describe "Profile custom HTML rendering", type: :request do
       expect(hosts).to include(seller.subdomain)
     end
 
+    it "leaves hash-only and empty hrefs to the browser instead of forwarding them" do
+      get "http://seller.example.com/landing/embed"
+
+      # Guard against the parent top-navigating to the raw /landing/embed URL
+      # when the seller's HTML uses `#section` links or `#` placeholder anchors.
+      expect(response.body).to include(%q(if (rawHref === "" || rawHref.charAt(0) === "#") return;))
+    end
+
     it "injects the validating listener into the wrapper with the same host allowlist" do
       get "http://seller.example.com/"
 

--- a/spec/requests/profile_custom_html_spec.rb
+++ b/spec/requests/profile_custom_html_spec.rb
@@ -96,6 +96,20 @@ describe "Profile custom HTML rendering", type: :request do
       json = response.body[/var ALLOWED_HOSTS = (\[.*?\]);/, 1]
       expect(JSON.parse(json)).not_to include("other.example.com")
     end
+
+    it "only adds the seller's custom domain once it is active (verified with a valid certificate)" do
+      # Browsing on the subdomain, an unverified/stale custom-domain record
+      # must not become a top-navigation target — it can point anywhere.
+      get "http://#{seller.subdomain}/landing/embed"
+      hosts = JSON.parse(response.body[/var ALLOWED_HOSTS = (\[.*?\]);/, 1])
+      expect(hosts).not_to include("seller.example.com")
+
+      custom_domain.mark_verified!
+      custom_domain.set_ssl_certificate_issued_at!
+      get "http://#{seller.subdomain}/landing/embed"
+      hosts = JSON.parse(response.body[/var ALLOWED_HOSTS = (\[.*?\]);/, 1])
+      expect(hosts).to include("seller.example.com")
+    end
   end
 
   describe "owner live-reload poll" do

--- a/spec/requests/profile_custom_html_spec.rb
+++ b/spec/requests/profile_custom_html_spec.rb
@@ -55,6 +55,41 @@ describe "Profile custom HTML rendering", type: :request do
     expect(response.body).not_to include("wanted=true")
   end
 
+  describe "same-store navigation bridge" do
+    it "injects the click-forwarding script into the embed with the seller's own hosts" do
+      get "http://seller.example.com/landing/embed"
+
+      expect(response.body).to include("data-gumroad-nav-bridge")
+      expect(response.body).to include("gumroad:navigate")
+      json = response.body[/var ALLOWED_HOSTS = (\[.*?\]);/, 1]
+      hosts = JSON.parse(json)
+      expect(hosts).to include("seller.example.com")
+      expect(hosts).to include(seller.subdomain)
+    end
+
+    it "injects the validating listener into the wrapper with the same host allowlist" do
+      get "http://seller.example.com/"
+
+      expect(response.body).to include("gumroad:navigate")
+      json = response.body[/var ALLOWED_HOSTS = (\[.*?\]);/, 1]
+      hosts = JSON.parse(json)
+      expect(hosts).to include("seller.example.com")
+      expect(hosts).to include(seller.subdomain)
+      # The wrapper script must carry the CSP nonce to run under the global policy.
+      expect(response.body).to match(/<script nonce="[^"]+" data-cfasync="false">\s*\(function \(\) \{\s*var frame = document\.getElementById\("gumroad-landing-frame"\);\s*var ALLOWED_HOSTS/)
+    end
+
+    it "never includes another seller's domain in the allowlist" do
+      other = create(:user, username: "otherseller")
+      create(:custom_domain, user: other, domain: "other.example.com")
+
+      get "http://seller.example.com/"
+
+      json = response.body[/var ALLOWED_HOSTS = (\[.*?\]);/, 1]
+      expect(JSON.parse(json)).not_to include("other.example.com")
+    end
+  end
+
   describe "owner live-reload poll" do
     it "injects the version poll into the wrapper only for the signed-in owner" do
       sign_in seller


### PR DESCRIPTION
## What

Fixes in-iframe product navigation on custom-HTML profile pages (custom domain or subdomain). Plain product links in the seller's HTML currently navigate the sandboxed landing iframe itself, loading the product page + checkout on an opaque origin where cookies/storage are unavailable — checkout hangs on Chromium/Firefox-family browsers and Safari refuses to render the page at all. Sellers can't self-fix with `target="_top"`: the sanitizer strips it and the wrapper sandbox deliberately omits `allow-top-navigation`.

This PR adds a `gumroad:navigate` postMessage bridge, mirroring the product wrapper's existing `gumroad:checkout` pattern:

- **Child script** (injected into the sandboxed embed): a capture-phase click listener forwards clicks on same-store links to the parent. It skips modified clicks, anchors with an explicit target, non-http(s) URLs, hosts outside the allowlist, and hash-only/empty/self-resolving hrefs (same-document navigations stay in-frame).
- **Parent script** (trusted wrapper, CSP-nonce'd): independently re-validates everything before navigating — the message must come from our iframe (`e.source === frame.contentWindow`, `e.origin === "null"`), be http(s), and target a host on the seller's own store allowlist. A compromised child gains nothing; the parent re-validates.
- **Host allowlist**: `request.host`, the seller's subdomain, and the seller's custom domain **only when `active?`** (verified + valid certificate — the same eligibility check `UrlService`/`ContentExtractor` apply before emitting custom-domain URLs). An unverified or stale custom-domain record never qualifies, so seller HTML still cannot top-navigate the visitor's tab to an arbitrary site.

Fixes the confirmed root cause in antiwork/gumroad-private#906 (live repro: custom-domain store where every "View tool" card leads to a stuck checkout in-frame, while the same product URL opened top-level works).

## Why

Product links are the #1 use of a custom profile — click a product card, buy. Today that primary conversion path is broken in-place for every custom-HTML profile. The bridge restores it without weakening the sandbox: links to any non-store host keep the default in-frame behavior, and the parent only ever navigates to hosts Gumroad actually serves the store on.

## Alternative

#5717 is a simpler alternative (retarget same-store links to `target="_blank"` at click time — new tab instead of same-tab navigation). One of the two should merge, not both. This bridge option keeps the visitor in the same tab, which matches normal storefront behavior, at the cost of slightly more moving parts.

## Test plan

- `spec/requests/profile_custom_html_spec.rb` — bridge injection with the correct host allowlist on embed + wrapper, CSP nonce on the wrapper script, hash-only/empty-href guard present, another seller's domain never in the allowlist, and the custom domain only allowlisted once `active?` (unverified record excluded).
- `spec/controllers/users_controller_custom_html_spec.rb` — updated: the old blanket `not_to include("postMessage")` assertions narrowed to checkout-specific ones (`gumroad:checkout`, `wanted=true`), positive bridge assertions added.
- Local run: `bundle exec rspec spec/requests/profile_custom_html_spec.rb spec/controllers/users_controller_custom_html_spec.rb` — 44 examples, 0 failures.
- autoreview (Codex): iterated over 4 passes; findings fixed along the way were the stale spec assertions, the unverified-custom-domain escape, same-document anchor hijacking, and the stale-verified-domain gate (now `active?`). Final pass clean.

## AI disclosure

Authored by Gumclaw (Hermes agent) from the investigation on antiwork/gumroad-private#906; reviewed with the Codex autoreview loop before opening.


