### PR TITLE
Open same-store product links from custom profile pages in a new tab

### DIFF
--- a/app/controllers/concerns/renders_custom_html_pages.rb
+++ b/app/controllers/concerns/renders_custom_html_pages.rb
@@ -139,10 +139,20 @@ module RendersCustomHtmlPages
               // A seller who set an explicit target (e.g. their own _blank) keeps it.
               var target = (anchor.getAttribute("target") || "").trim();
               if (target !== "" && target.toLowerCase() !== "_self") return;
+              var rawHref = (anchor.getAttribute("href") || "").trim();
+              // Hash-only and empty hrefs are same-document navigations (section
+              // jumps, "#"-placeholder buttons wired up by the seller's own JS).
+              // They resolve against the iframe's own /landing/embed URL, so
+              // without this guard they would pass the host check and open the
+              // raw embed endpoint in a new tab instead of scrolling in place.
+              if (rawHref === "" || rawHref.charAt(0) === "#") return;
               var url;
-              try { url = new URL(anchor.getAttribute("href"), window.location.href); } catch (_e) { return; }
+              try { url = new URL(rawHref, window.location.href); } catch (_e) { return; }
               if (url.protocol !== "https:" && url.protocol !== "http:") return;
               if (ALLOWED_HOSTS.indexOf(url.hostname.toLowerCase()) === -1) return;
+              // Same-document by resolution too (e.g. href="?x#y" or the page's
+              // own URL): leave those to the browser, never a new tab.
+              if (url.pathname === window.location.pathname && url.hostname === window.location.hostname) return;
               anchor.target = "_blank";
               anchor.rel = "noopener";
             }, true);
@@ -153,10 +163,18 @@ module RendersCustomHtmlPages
 
     # The hosts whose links get the new-tab treatment: the host currently
     # being browsed (subdomain or verified custom domain), plus the seller's
-    # subdomain and custom domain, so product URLs generated for either
-    # surface work on both.
+    # subdomain and currently ACTIVE custom domain, so product URLs generated
+    # for either surface work on both. `active?` (verified + valid
+    # certificate) is the same eligibility check the rest of the app uses
+    # before emitting custom-domain URLs (UrlService, ContentExtractor). An
+    # unverified or stale record never qualifies: it can be any arbitrary
+    # domain the seller typed in (or one that has since been pointed
+    # off-platform), and only hosts Gumroad actually serves this store on
+    # belong in the allowlist.
     def custom_html_same_store_hosts(user)
-      hosts = [request.host, user.subdomain, user.custom_domain&.domain]
+      custom_domain = user.custom_domain
+      active_custom_domain = custom_domain&.active? ? custom_domain.domain : nil
+      hosts = [request.host, user.subdomain, active_custom_domain]
       hosts.compact.map { _1.to_s.downcase.strip }.reject(&:empty?).uniq
     end
 

--- a/app/controllers/concerns/renders_custom_html_pages.rb
+++ b/app/controllers/concerns/renders_custom_html_pages.rb
@@ -108,6 +108,58 @@ module RendersCustomHtmlPages
   end
 
   private
+    # --- Same-store links open in a new tab ---------------------------------
+    #
+    # The seller's HTML lives in an opaque-origin sandboxed iframe. A plain
+    # product link (<a href="/l/xyz">) therefore navigates the IFRAME itself,
+    # loading the full product page + checkout on an origin where cookies and
+    # storage are unavailable — checkout hangs, and Safari won't render the
+    # page at all. The seller can't fix it with target="_top" either: the
+    # sanitizer strips it and the sandbox omits allow-top-navigation on
+    # purpose (seller HTML must never be able to redirect the visitor's tab
+    # to an arbitrary site).
+    #
+    # The sandbox already grants allow-popups + allow-popups-to-escape-sandbox,
+    # so a target="_blank" link opens the product page in a NEW tab with a
+    # real origin where checkout works. This script retargets clicks on links
+    # that point at the seller's own store hosts (whether the anchor was in
+    # the served HTML or built later by the seller's scripts) to _blank at
+    # click time. Links to other hosts keep their default in-frame behavior,
+    # so nothing about the sandbox guarantee changes.
+    def custom_html_same_store_links_new_tab_script(allowed_hosts:)
+      hosts_js = ERB::Util.json_escape(allowed_hosts.to_json)
+      <<~HTML
+        <script data-cfasync="false" data-gumroad-store-links>
+          (function () {
+            var ALLOWED_HOSTS = #{hosts_js};
+            document.addEventListener("click", function (e) {
+              if (e.defaultPrevented) return;
+              var anchor = e.target && e.target.closest ? e.target.closest("a[href]") : null;
+              if (!anchor) return;
+              // A seller who set an explicit target (e.g. their own _blank) keeps it.
+              var target = (anchor.getAttribute("target") || "").trim();
+              if (target !== "" && target.toLowerCase() !== "_self") return;
+              var url;
+              try { url = new URL(anchor.getAttribute("href"), window.location.href); } catch (_e) { return; }
+              if (url.protocol !== "https:" && url.protocol !== "http:") return;
+              if (ALLOWED_HOSTS.indexOf(url.hostname.toLowerCase()) === -1) return;
+              anchor.target = "_blank";
+              anchor.rel = "noopener";
+            }, true);
+          })();
+        </script>
+      HTML
+    end
+
+    # The hosts whose links get the new-tab treatment: the host currently
+    # being browsed (subdomain or verified custom domain), plus the seller's
+    # subdomain and custom domain, so product URLs generated for either
+    # surface work on both.
+    def custom_html_same_store_hosts(user)
+      hosts = [request.host, user.subdomain, user.custom_domain&.domain]
+      hosts.compact.map { _1.to_s.downcase.strip }.reject(&:empty?).uniq
+    end
+
     def render_landing_version(visible:, page:)
       render json: { present: visible, version: visible ? page&.updated_at&.to_i : nil }
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -180,9 +180,11 @@ class UsersController < ApplicationController
 
   private
     # The profile is authored entirely through the seller's agent + CLI, so the
-    # custom HTML never carries a buy affordance — there's no checkout bridge or
-    # ?wanted=true fall-through like the product landing page has. The wrapper is
-    # a display-only sandboxed iframe.
+    # custom HTML never carries a native buy affordance — there's no checkout
+    # bridge or ?wanted=true fall-through like the product landing page has.
+    # Product links in the seller's HTML open in a new tab (see
+    # RendersCustomHtmlPages#custom_html_same_store_links_new_tab_script) so
+    # checkout happens on a real origin, never inside the sandboxed iframe.
     def render_custom_html_if_present
       return unless custom_html_visible?
       # The public profile also answers JSON (GET /:username.json) with the
@@ -224,6 +226,7 @@ class UsersController < ApplicationController
           <body>
             <script id="gumroad-data" type="application/json">#{data_json}</script>
             #{custom_html}
+            #{custom_html_same_store_links_new_tab_script(allowed_hosts: custom_html_same_store_hosts(@user))}
             #{live_fields ? PROFILE_FIELDS_PREVIEW_SCRIPT : ""}
           </body>
         </html>

--- a/spec/requests/profile_custom_html_spec.rb
+++ b/spec/requests/profile_custom_html_spec.rb
@@ -75,6 +75,28 @@ describe "Profile custom HTML rendering", type: :request do
       json = response.body[/var ALLOWED_HOSTS = (\[.*?\]);/, 1]
       expect(JSON.parse(json)).not_to include("other.example.com")
     end
+
+    it "only adds the seller's custom domain once it is active (verified with a valid certificate)" do
+      # Browsing on the subdomain, an unverified/stale custom-domain record
+      # must not get the new-tab treatment — it can point anywhere.
+      get "http://#{seller.subdomain}/landing/embed"
+      hosts = JSON.parse(response.body[/var ALLOWED_HOSTS = (\[.*?\]);/, 1])
+      expect(hosts).not_to include("seller.example.com")
+
+      custom_domain.mark_verified!
+      custom_domain.set_ssl_certificate_issued_at!
+      get "http://#{seller.subdomain}/landing/embed"
+      hosts = JSON.parse(response.body[/var ALLOWED_HOSTS = (\[.*?\]);/, 1])
+      expect(hosts).to include("seller.example.com")
+    end
+
+    it "leaves hash-only and empty hrefs to the browser instead of retargeting them" do
+      get "http://seller.example.com/landing/embed"
+
+      # Guard against opening the raw /landing/embed URL in a new tab when the
+      # seller's HTML uses `#section` links or `#` placeholder anchors.
+      expect(response.body).to include(%q(if (rawHref === "" || rawHref.charAt(0) === "#") return;))
+    end
   end
 
   describe "owner live-reload poll" do

--- a/spec/requests/profile_custom_html_spec.rb
+++ b/spec/requests/profile_custom_html_spec.rb
@@ -55,6 +55,28 @@ describe "Profile custom HTML rendering", type: :request do
     expect(response.body).not_to include("wanted=true")
   end
 
+  describe "same-store links open in a new tab" do
+    it "injects the retargeting script into the embed with the seller's own hosts" do
+      get "http://seller.example.com/landing/embed"
+
+      expect(response.body).to include("data-gumroad-store-links")
+      json = response.body[/var ALLOWED_HOSTS = (\[.*?\]);/, 1]
+      hosts = JSON.parse(json)
+      expect(hosts).to include("seller.example.com")
+      expect(hosts).to include(seller.subdomain)
+    end
+
+    it "never includes another seller's domain in the host allowlist" do
+      other = create(:user, username: "otherseller")
+      create(:custom_domain, user: other, domain: "other.example.com")
+
+      get "http://seller.example.com/landing/embed"
+
+      json = response.body[/var ALLOWED_HOSTS = (\[.*?\]);/, 1]
+      expect(JSON.parse(json)).not_to include("other.example.com")
+    end
+  end
+
   describe "owner live-reload poll" do
     it "injects the version poll into the wrapper only for the signed-in owner" do
       sign_in seller


### PR DESCRIPTION
## What

Fixes in-iframe product navigation on custom-HTML profile pages (custom domain or subdomain). Plain product links in the seller's HTML currently navigate the sandboxed landing iframe itself, loading the product page + checkout on an opaque origin where cookies/storage are unavailable — checkout hangs on Chromium/Firefox-family browsers and Safari refuses to render the page at all. Sellers can't self-fix with `target="_top"`: the sanitizer strips it and the wrapper sandbox deliberately omits `allow-top-navigation`.

This PR takes the simpler of the two viable approaches: a small script injected into the sandboxed embed retargets clicks on same-store links to `target="_blank" rel="noopener"` at click time. The sandbox already grants `allow-popups allow-popups-to-escape-sandbox`, so the product page opens in a new tab with a real origin where cookies and checkout work.

Details:

- Click-time retargeting (not serve-time HTML rewriting) because the real-world breakage builds product cards **after** load from the injected `gumroad-data` JSON (`a.href = p.url`) — serve-time rewriting would miss every JS-built link.
- Skips anchors with an explicit target, non-http(s) URLs, hosts outside the store allowlist, and hash-only/empty/self-resolving hrefs (same-document navigations stay in place).
- **Host allowlist**: `request.host`, the seller's subdomain, and the seller's custom domain **only when `active?`** (verified + valid certificate — the same eligibility check `UrlService`/`ContentExtractor` apply before emitting custom-domain URLs). A saved-but-unverified or stale custom-domain record never qualifies.
- No change to the sandbox tokens; links to non-store hosts keep the default in-frame behavior.

Fixes the confirmed root cause in antiwork/gumroad-private#906 (live repro: custom-domain store where every "View tool" card leads to a stuck checkout in-frame, while the same product URL opened top-level works).

## Why

Product links are the #1 use of a custom profile — click a product card, buy. Today that primary conversion path is broken in-place for every custom-HTML profile.

## Alternative

#5716 is the fuller alternative (a `gumroad:navigate` postMessage bridge that top-navigates the same tab, mirroring the product wrapper's `gumroad:checkout` pattern). One of the two should merge, not both. This option is smaller and touches no parent-window code, at the cost of opening products in a new tab instead of the same tab.

## Test plan

- `spec/requests/profile_custom_html_spec.rb` — retargeting script injected with the correct host allowlist, another seller's domain never in the allowlist, custom domain only allowlisted once `active?` (unverified record excluded), hash-only/empty-href guard present.
- Local run: `bundle exec rspec spec/requests/profile_custom_html_spec.rb` — 20 examples, 0 failures.
- autoreview (Codex): the unverified/stale-custom-domain allowlist gap and same-document anchor retargeting were found and fixed during review.

## AI disclosure

Authored by Gumclaw (Hermes agent) from the investigation on antiwork/gumroad-private#906; reviewed with the Codex autoreview loop before opening.


