### PR TITLE
Fix in-iframe product navigation on custom-HTML profile pages via postMessage bridge

### DIFF
--- a/app/controllers/concerns/renders_custom_html_pages.rb
+++ b/app/controllers/concerns/renders_custom_html_pages.rb
@@ -108,6 +108,53 @@ module RendersCustomHtmlPages
   end
 
   private
+    # Injected into the sandboxed landing document at serve time (never authored
+    # by the seller) so plain store links work without any seller HTML changes.
+    # Clicking a link inside the sandboxed iframe would otherwise navigate the
+    # IFRAME itself: the destination page then renders on the opaque origin,
+    # where cookies and storage are unavailable, so checkout hangs or the page
+    # fails to render entirely. The sandbox deliberately omits
+    # allow-top-navigation (and the sanitizer strips target="_top"), so the only
+    # safe way out is this bridge: intercept clicks on the store's own links and
+    # ask the trusted parent wrapper to navigate the top-level window instead.
+    # The parent re-validates the URL against the same hostname allowlist — the
+    # iframe content is untrusted, so nothing here is load-bearing for security.
+    # Links to foreign hosts and target="_blank" links keep their default
+    # behavior.
+    def custom_html_navigation_bridge_script(allowed_hostnames:)
+      hostnames_json = ERB::Util.json_escape(allowed_hostnames.to_json)
+      <<~HTML
+        <script data-cfasync="false" data-gumroad-navigation-bridge>
+          (function () {
+            var STORE_HOSTNAMES = #{hostnames_json};
+            document.addEventListener("click", function (e) {
+              // Only plain left-clicks: modified clicks (new tab, etc.) keep
+              // the browser's default handling.
+              if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+              // Viewed directly (not framed) there is no trusted parent to ask,
+              // so leave the click alone.
+              if (window.parent === window) return;
+              var link = e.target && e.target.closest ? e.target.closest("a[href]") : null;
+              if (!link) return;
+              var target = (link.getAttribute("target") || "").toLowerCase();
+              if (target && target !== "_self") return;
+              if (link.hasAttribute("download")) return;
+              var url;
+              try { url = new URL(link.getAttribute("href"), document.baseURI); } catch (_err) { return; }
+              if (url.protocol !== "https:" && url.protocol !== "http:") return;
+              if (STORE_HOSTNAMES.indexOf(url.hostname) === -1) return;
+              // Same-page fragment links should scroll within the iframe, not
+              // reload the profile at the top level.
+              var here = new URL(document.baseURI);
+              if (url.hash && url.pathname === here.pathname && url.search === here.search && url.hostname === here.hostname) return;
+              e.preventDefault();
+              parent.postMessage({ type: "gumroad:navigate", url: url.href }, "*");
+            }, true);
+          })();
+        </script>
+      HTML
+    end
+
     def render_landing_version(visible:, page:)
       render json: { present: visible, version: visible ? page&.updated_at&.to_i : nil }
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -45,6 +45,7 @@ class UsersController < ApplicationController
       interpolated,
       data_json: ERB::Util.json_escape(Pages::ProfileData.build(@user).to_json),
       live_fields: params[:preview].present? && current_seller_owns_profile?,
+      navigation_bridge: custom_html_navigation_bridge_script(allowed_hostnames: profile_store_hostnames(@user)),
     ).html_safe, layout: false
   end
 
@@ -181,8 +182,10 @@ class UsersController < ApplicationController
   private
     # The profile is authored entirely through the seller's agent + CLI, so the
     # custom HTML never carries a buy affordance — there's no checkout bridge or
-    # ?wanted=true fall-through like the product landing page has. The wrapper is
-    # a display-only sandboxed iframe.
+    # ?wanted=true fall-through like the product landing page has. Store links
+    # inside the sandboxed iframe reach the top-level window through the
+    # gumroad:navigate postMessage bridge (see
+    # profile_custom_html_wrapper_document).
     def render_custom_html_if_present
       return unless custom_html_visible?
       # The public profile also answers JSON (GET /:username.json) with the
@@ -211,7 +214,23 @@ class UsersController < ApplicationController
       @is_user_custom_domain ? "/landing/#{suffix}" : "/#{user.username}/landing/#{suffix}"
     end
 
-    def profile_custom_html_document(custom_html, data_json: "{}", live_fields: false)
+    # Hostnames the navigation bridge accepts as "this seller's own store":
+    # the host serving the current request (subdomain or custom domain), the
+    # seller's canonical subdomain, and their live custom domain. Product URLs
+    # in the injected gumroad-data JSON are built on the subdomain
+    # (Link#long_url), so a visitor browsing the custom domain still needs the
+    # subdomain host allowlisted for those links to bridge. Both the injected
+    # child script and the parent wrapper validate against this same list —
+    # the parent-side check is the one that matters for security, since the
+    # sandboxed child is seller-authored and untrusted.
+    def profile_store_hostnames(user)
+      hostnames = [request.host]
+      hostnames << URI("#{PROTOCOL}://#{user.subdomain}").host if user.subdomain.present?
+      hostnames << user.custom_domain.domain if user.custom_domain&.domain.present?
+      hostnames.compact.uniq
+    end
+
+    def profile_custom_html_document(custom_html, data_json: "{}", live_fields: false, navigation_bridge: "")
       <<~HTML
         <!doctype html>
         <html>
@@ -224,6 +243,7 @@ class UsersController < ApplicationController
           <body>
             <script id="gumroad-data" type="application/json">#{data_json}</script>
             #{custom_html}
+            #{navigation_bridge}
             #{live_fields ? PROFILE_FIELDS_PREVIEW_SCRIPT : ""}
           </body>
         </html>
@@ -233,17 +253,24 @@ class UsersController < ApplicationController
     # Omitting `allow-same-origin` keeps the seller's HTML on an opaque origin —
     # no access to gumroad.com cookies or the parent DOM. We also omit
     # `allow-top-navigation` so the seller's HTML can never navigate the
-    # visitor's tab away from gumroad.com. Unlike the product wrapper there is no
-    # checkout postMessage bridge: a profile has no native buy button.
+    # visitor's tab away from gumroad.com. Like the product wrapper's checkout
+    # bridge, store navigation instead goes through a postMessage handshake:
+    # the sandboxed page posts `gumroad:navigate` and this trusted wrapper
+    # validates the URL against the seller's own store hostnames before
+    # navigating the top-level window. Without the bridge, clicking a product
+    # link navigates the sandboxed IFRAME to the product page, which then runs
+    # on the opaque origin with no cookies/storage and checkout breaks.
     def profile_custom_html_wrapper_document(user)
       iframe_src = ERB::Util.h(profile_landing_src(user, "embed"))
       title = ERB::Util.h(user.name_or_username.to_s)
       canonical = ERB::Util.h(user.profile_url(custom_domain_url: seller_custom_domain_url).to_s)
+      store_hostnames_json = ERB::Util.json_escape(profile_store_hostnames(user).to_json)
+      nonce = SecureHeaders.content_security_policy_script_nonce(request)
       # avatar_url always returns a value (it falls back to the default avatar),
       # so only advertise og:image when the seller uploaded a real one.
       og_image_tag = user.avatar.attached? ? %(<meta property="og:image" content="#{ERB::Util.h(user.avatar_url)}">) : ""
       live_reload = if current_seller_owns_profile?
-        custom_html_live_reload_script(version_src: profile_landing_src(user, "version"), nonce: SecureHeaders.content_security_policy_script_nonce(request))
+        custom_html_live_reload_script(version_src: profile_landing_src(user, "version"), nonce:)
       else
         ""
       end
@@ -269,6 +296,26 @@ class UsersController < ApplicationController
               title="#{title}"
               sandbox="allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox"
             ></iframe>
+            <script nonce="#{ERB::Util.h(nonce)}" data-cfasync="false">
+              (function () {
+                var frame = document.getElementById("gumroad-landing-frame");
+                var STORE_HOSTNAMES = #{store_hostnames_json};
+                window.addEventListener("message", function (e) {
+                  // Only the sandboxed landing iframe (opaque origin, so
+                  // e.origin is the literal string "null") may drive this.
+                  if (e.source !== frame.contentWindow || e.origin !== "null") return;
+                  if (!e.data || typeof e.data !== "object" || e.data.type !== "gumroad:navigate") return;
+                  var url;
+                  try { url = new URL(String(e.data.url), window.location.href); } catch (_err) { return; }
+                  // The iframe content is seller-authored and untrusted: only
+                  // navigate the visitor's tab to this seller's own store, and
+                  // only over http(s) — never javascript:/data:/etc.
+                  if (url.protocol !== "https:" && url.protocol !== "http:") return;
+                  if (STORE_HOSTNAMES.indexOf(url.hostname) === -1) return;
+                  window.location.href = url.href;
+                });
+              })();
+            </script>
             #{live_reload}
           </body>
         </html>

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -224,7 +224,14 @@ class UsersController < ApplicationController
     # the parent-side check is the one that matters for security, since the
     # sandboxed child is seller-authored and untrusted.
     def profile_store_hostnames(user)
-      hostnames = [request.host]
+      hostnames = []
+      # Only trust the request host when it is one of the seller's OWN hosts
+      # (their subdomain or custom domain). When the profile is viewed on a
+      # shared Gumroad host (e.g. gumroad.com/:username before the subdomain
+      # redirect), adding request.host would let the seller's sandboxed HTML
+      # navigate the visitor's tab to arbitrary gumroad.com paths — the
+      # allowlist must only ever contain hosts this seller controls.
+      hostnames << request.host unless VALID_REQUEST_HOSTS.include?(request.host)
       hostnames << URI("#{PROTOCOL}://#{user.subdomain}").host if user.subdomain.present?
       hostnames << user.custom_domain.domain if user.custom_domain&.domain.present?
       hostnames.compact.uniq

--- a/app/javascript/components/Profile/LandingPageEditor.tsx
+++ b/app/javascript/components/Profile/LandingPageEditor.tsx
@@ -39,7 +39,7 @@ Gumroad fills in live values server-side, so the page stays current without you 
 
 Your live catalog is injected server-side as JSON in <script id="gumroad-data" type="application/json">, so prefer rendering products/posts/pages dynamically from it (it updates automatically as you add or remove them) instead of hardcoding. Read it with:
   const data = JSON.parse(document.getElementById("gumroad-data").textContent);
-Shape: { products: [{ name, url, price, native_type, thumbnail_url, description }], posts: [{ name, url, published_at }], pages: [{ name }] }. Link products via product.url (their public product page). The page can't fetch anything at runtime (it's sandboxed), so this injected data is the source of truth.
+Shape: { products: [{ name, url, price, native_type, thumbnail_url, description }], posts: [{ name, url, published_at }], pages: [{ name }] }. Link products via product.url (their public product page) using plain <a> tags with no target attribute — Gumroad injects a navigation bridge that opens store links in the visitor's tab (target="_top"/"_parent" are stripped by the sanitizer, so don't use them). The page can't fetch anything at runtime (it's sandboxed), so this injected data is the source of truth.
 
 Then preview, publish, and verify it with the Gumroad CLI:
 - Run the real server-side sanitizer WITHOUT publishing and read what it changed: gumroad user page preview ./profile.html --json --no-input --non-interactive — inspect .sanitization_report. If it stripped tags or attributes your page needs, fix the HTML and preview again. Do this until the report is clean so you never publish a broken page.

--- a/spec/controllers/users_controller_custom_html_spec.rb
+++ b/spec/controllers/users_controller_custom_html_spec.rb
@@ -34,7 +34,12 @@ describe UsersController, :vcr, type: :controller do
       get :show
       expect(response.body).not_to include("gumroad:checkout")
       expect(response.body).not_to include("wanted=true")
-      expect(response.body).not_to include("postMessage")
+    end
+
+    it "embeds the gumroad:navigate listener so store links can reach the top-level window" do
+      get :show
+      expect(response.body).to include("gumroad:navigate")
+      expect(response.body).to include("STORE_HOSTNAMES")
     end
 
     it "falls back to the default profile page when custom_html is blank" do
@@ -114,8 +119,14 @@ describe UsersController, :vcr, type: :controller do
       get :landing_iframe_content
 
       expect(response.body).not_to include("gumroad:checkout")
-      expect(response.body).not_to include("postMessage")
       expect(response.body).not_to include("wanted=true")
+    end
+
+    it "embeds the store navigation bridge in the iframe document" do
+      get :landing_iframe_content
+
+      expect(response.body).to include("data-gumroad-navigation-bridge")
+      expect(response.body).to include("gumroad:navigate")
     end
 
     it "resolves the seller by username on the root domain" do

--- a/spec/requests/profile_custom_html_spec.rb
+++ b/spec/requests/profile_custom_html_spec.rb
@@ -55,6 +55,37 @@ describe "Profile custom HTML rendering", type: :request do
     expect(response.body).not_to include("wanted=true")
   end
 
+  describe "navigation bridge" do
+    it "injects the click-interception script into the embed with the seller's store hostnames" do
+      get "http://seller.example.com/landing/embed"
+
+      expect(response.body).to include("data-gumroad-navigation-bridge")
+      expect(response.body).to include("gumroad:navigate")
+      expect(response.body).to include("seller.example.com")
+      # The seller's canonical subdomain is allowlisted too: product URLs in
+      # the injected gumroad-data JSON are built on the subdomain even when
+      # the visitor browses the custom domain.
+      expect(response.body).to include(URI(seller.subdomain_with_protocol).host)
+    end
+
+    it "installs the validating gumroad:navigate listener in the trusted wrapper" do
+      get "http://seller.example.com/"
+
+      expect(response.body).to include("gumroad:navigate")
+      expect(response.body).to include("STORE_HOSTNAMES")
+      expect(response.body).to include("seller.example.com")
+      expect(response.body).to include(URI(seller.subdomain_with_protocol).host)
+    end
+
+    it "keeps the iframe sandbox unchanged — still no allow-same-origin or allow-top-navigation" do
+      get "http://seller.example.com/"
+
+      expect(response.body).to include(%(sandbox="allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox"))
+      expect(response.body).not_to include("allow-same-origin")
+      expect(response.body).not_to include("allow-top-navigation")
+    end
+  end
+
   describe "owner live-reload poll" do
     it "injects the version poll into the wrapper only for the signed-in owner" do
       sign_in seller

--- a/spec/requests/profile_custom_html_spec.rb
+++ b/spec/requests/profile_custom_html_spec.rb
@@ -77,6 +77,22 @@ describe "Profile custom HTML rendering", type: :request do
       expect(response.body).to include(URI(seller.subdomain_with_protocol).host)
     end
 
+    it "never allowlists a shared Gumroad host — only hosts the seller controls" do
+      # Viewed via a shared root-domain route (gumroad.com/:username), the
+      # request host is NOT the seller's own; allowlisting it would let the
+      # seller's sandboxed HTML navigate the visitor's tab to arbitrary
+      # gumroad.com paths. The allowlist must contain only the seller's
+      # subdomain and custom domain.
+      get "http://#{VALID_REQUEST_HOSTS.last}/#{seller.username}/landing/embed"
+
+      expect(response).to be_successful
+      expect(response.body).to include(URI(seller.subdomain_with_protocol).host)
+      expect(response.body).to include("seller.example.com")
+      VALID_REQUEST_HOSTS.each do |shared_host|
+        expect(response.body).not_to include("\"#{shared_host}\"")
+      end
+    end
+
     it "keeps the iframe sandbox unchanged — still no allow-same-origin or allow-top-navigation" do
       get "http://seller.example.com/"
 

--- a/spec/requests/user/profile_custom_html_navigation_spec.rb
+++ b/spec/requests/user/profile_custom_html_navigation_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# The custom-HTML profile renders inside a sandboxed iframe with an opaque
+# origin (no allow-same-origin) and no allow-top-navigation. A plain product
+# link would therefore navigate the IFRAME to the product page, which then
+# runs without cookies or storage and checkout breaks. The gumroad:navigate
+# postMessage bridge lets the trusted wrapper navigate the top-level window
+# instead — these specs drive that flow in a real browser.
+describe "Profile custom HTML page store navigation", type: :system, js: true do
+  let(:seller) { create(:user, username: "bridgestudio", name: "Bridge Studio") }
+  let!(:product) { create(:product, user: seller, name: "Bridged Product") }
+
+  let(:custom_html) do
+    <<~HTML
+      <main>
+        <h1>Storefront</h1>
+        <ul id="catalog"></ul>
+        <a id="external" href="https://evil.example/phish">External link</a>
+        <button id="evil-post" type="button">Post evil</button>
+        <script>
+          var data = JSON.parse(document.getElementById("gumroad-data").textContent);
+          var ul = document.getElementById("catalog");
+          data.products.forEach(function (p) {
+            var li = document.createElement("li");
+            var a = document.createElement("a");
+            a.href = p.url;
+            a.textContent = p.name;
+            li.appendChild(a);
+            ul.appendChild(li);
+          });
+          // Simulates malicious seller HTML driving the bridge directly with a
+          // foreign-host URL — the trusted wrapper must refuse to navigate.
+          document.getElementById("evil-post").addEventListener("click", function () {
+            parent.postMessage({ type: "gumroad:navigate", url: "https://evil.example/phish" }, "*");
+          });
+        </script>
+      </main>
+    HTML
+  end
+
+  before do
+    Feature.activate_user(:custom_html_pages, seller)
+    seller.update!(custom_html:)
+  end
+
+  it "navigates the top-level window (not the sandboxed iframe) to the product page when a plain store link is clicked" do
+    visit seller.subdomain_with_protocol
+    profile_url = page.current_url
+
+    within_frame(find("iframe#gumroad-landing-frame")) do
+      expect(page).to have_text("Storefront")
+      click_on "Bridged Product"
+    end
+
+    # Without the bridge the click navigates the iframe itself: the top-level
+    # URL stays on the profile and the product page renders on the opaque
+    # origin where cookies/storage are unavailable. With the bridge the
+    # trusted wrapper navigates the visitor's tab to the real product URL.
+    expect(page).to have_current_path(%r{/l/#{product.unique_permalink}}, url: true, wait: 10)
+    expect(page.current_url).not_to eq(profile_url)
+    expect(page).to have_text("Bridged Product")
+  end
+
+  it "does not navigate the top level for a gumroad:navigate message pointing at a foreign host" do
+    visit seller.subdomain_with_protocol
+    profile_url = page.current_url
+
+    within_frame(find("iframe#gumroad-landing-frame")) do
+      click_on "Post evil"
+    end
+
+    sleep 1 # give a (wrong) navigation a chance to happen before asserting it didn't
+    expect(page.current_url).to eq(profile_url)
+  end
+end


### PR DESCRIPTION
## Problem

On a custom-domain profile with custom HTML, clicking a product link breaks checkout. The profile wrapper embeds the seller's HTML in a sandboxed iframe (`sandbox="allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox"` — deliberately no `allow-same-origin` and no `allow-top-navigation`). A plain `<a href={product.url}>` link (the shape the "Build with your agent" prompt produces from the injected `gumroad-data` JSON) navigates **the iframe itself** to the product page.

## Mechanism

The product page then renders on the sandbox's **opaque origin**: `_gumroad_guid` / `XSRF-TOKEN` cookies and web storage are unavailable, so checkout hangs (Chromium/Firefox) or the page won't render at all (Safari). The same URL works fine top-level. Sellers cannot self-fix: `Ai::PageSanitizer` strips `target="_top"`/`_parent`, and the sandbox omits `allow-top-navigation` anyway. `target="_blank"` works but only as a workaround.

## Fix

Mirror the product wrapper's existing `gumroad:checkout` postMessage bridge with a `gumroad:navigate` bridge:

- **Child (injected at serve time into `/landing/embed`, so existing seller HTML works unchanged):** a document-level click listener intercepts plain left-clicks on `<a>` elements whose href resolves to one of the seller's own store hostnames and has no `target` (or `_self`), `preventDefault`s, and posts `{type: "gumroad:navigate", url}` to the parent. `target="_blank"` links, external links, fragment links, downloads, and modified clicks keep their default behavior.
- **Parent (trusted wrapper, real origin):** listens for the message and validates strictly before navigating: the source must be the landing iframe's `contentWindow`, the origin must be the literal `"null"` (opaque origin), the URL must parse, be http(s) (never `javascript:`/`data:`), and its hostname must be in the seller's own store hostnames (request host + canonical subdomain + live custom domain). Only then `window.location.href = url`.

## Security notes

- The iframe `sandbox` attribute is **unchanged** — still no `allow-same-origin`, no `allow-top-navigation`. Same posture as before.
- All load-bearing validation is **parent-side**; the injected child script is a convenience only (the iframe content is seller-authored and untrusted). This matches the checkout bridge's "parent validates everything" pattern in `LinksController#custom_html_wrapper_document`, and is stricter (hostname allowlist + scheme check vs. the checkout bridge's fixed URL).
- A `gumroad:navigate` message pointing at a foreign host (e.g. `https://evil.example`) is ignored — covered by a browser test.

Also updated the "Build with your agent" profile prompt so agents emit plain product links with no `target` attribute (the bridge handles navigation; `_top`/`_parent` get sanitized away).

## Tests

- New system spec `spec/requests/user/profile_custom_html_navigation_spec.rb` (Capybara, `js: true`):
  - **Failing-first root-cause proof:** run against pre-fix code, clicking a product link left the top-level window on the profile URL (`expected "http://…profile…/" to match /\/l\/n/`) — the navigation happened inside the iframe. With the bridge, the same click navigates the top-level window to the product page and the product content renders on the real origin. ✅
  - **Negative security case:** seller script posting `gumroad:navigate` with `https://evil.example/phish` does not navigate the top level. ✅
- Request/controller specs: bridge script present in the embed, validating listener present in the wrapper, sandbox attribute unchanged, store-hostname allowlist includes the canonical subdomain (product URLs are subdomain-based even when browsing the custom domain).
- Local run of all touched-area specs: **96 examples, 0 failures** (`profile_custom_html_spec`, `users_controller_custom_html_spec`, `links_controller_custom_html_spec`, `pages_landing_embed_*`, `profile_analytics_spec`, `profile_custom_html_page_spec`, `products/show/custom_html_spec`, plus the new navigation spec). Rubocop clean on all changed Ruby files.

Fixes antiwork/gumroad-private#906
