### PR TITLE
Fix Library infinite scroll: listen on window when the page is the scroller

### DIFF
--- a/app/javascript/components/useOnScrollToBottom.tsx
+++ b/app/javascript/components/useOnScrollToBottom.tsx
@@ -2,6 +2,15 @@ import * as React from "react";
 
 import { useRefToLatest } from "$app/components/useRefToLatest";
 
+// True when the element is a scroll container (can scroll vertically).
+// Check overflowY rather than the `overflow` shorthand: a style like
+// `overflow: hidden auto` computes to overflowY "auto" but the shorthand
+// reads "hidden auto", which a naive `overflow === "auto"` check misses.
+const isScrollContainer = (element: HTMLElement) => {
+  const { overflowY } = getComputedStyle(element);
+  return overflowY === "auto" || overflowY === "scroll";
+};
+
 export const useOnScrollToBottom = (
   ref: React.MutableRefObject<HTMLElement | null>,
   cb: () => void,
@@ -11,17 +20,28 @@ export const useOnScrollToBottom = (
   React.useEffect(() => {
     if (!ref.current) return;
     let el: HTMLElement | null = ref.current;
-    while (el && getComputedStyle(el).overflow !== "auto") el = el.parentElement;
-    const scrollContainer = el ?? document.body;
+    while (el && !isScrollContainer(el)) el = el.parentElement;
+    // When no scrollable ancestor exists, the page itself is the scroller.
+    // Scroll events for normal page scrolling fire on window/document, NOT on
+    // document.body, so we must listen on window and measure the viewport via
+    // document.scrollingElement (listening on document.body never fires and
+    // its scrollTop stays 0, which silently breaks infinite scroll).
+    const scrollContainer = el;
+    const eventTarget: EventTarget = scrollContainer ?? window;
     const scrollListener = () => {
-      if (scrollContainer.scrollTop + scrollContainer.offsetHeight > scrollContainer.scrollHeight - (threshold ?? 0))
-        cbRef.current();
+      if (scrollContainer) {
+        if (scrollContainer.scrollTop + scrollContainer.offsetHeight > scrollContainer.scrollHeight - (threshold ?? 0))
+          cbRef.current();
+      } else {
+        const scroller = document.scrollingElement ?? document.documentElement;
+        if (scroller.scrollTop + scroller.clientHeight > scroller.scrollHeight - (threshold ?? 0)) cbRef.current();
+      }
     };
     scrollListener();
-    scrollContainer.addEventListener("scroll", scrollListener);
+    eventTarget.addEventListener("scroll", scrollListener);
     window.addEventListener("resize", scrollListener);
     return () => {
-      scrollContainer.removeEventListener("scroll", scrollListener);
+      eventTarget.removeEventListener("scroll", scrollListener);
       window.removeEventListener("resize", scrollListener);
     };
   }, [ref]);


### PR DESCRIPTION
## What

Fixes infinite scroll silently never firing on pages that scroll with the page itself (no `overflow` scroll container) — most visibly the Library, where buyers with more than 15 purchases see "Showing 1-15 of N products" and can never load the rest.

`useOnScrollToBottom` walked up from the ref looking for an ancestor with computed `overflow === "auto"` and, finding none, attached its scroll listener to `document.body`. Page scrolling fires scroll events on window/document, not on `document.body`, so the listener never fired and `body.scrollTop` stayed 0. The Library's `resultsLimit` therefore never advanced past 15 (`app/javascript/pages/Library/Index.tsx` re-resets it to 15 on every `filteredResults` change, so even the one initial listener invocation at mount didn't help).

Changes to `app/javascript/components/useOnScrollToBottom.tsx`:
- When no scrollable ancestor exists, listen on `window` and measure `document.scrollingElement` instead of `document.body`.
- Detect scroll containers via `overflowY` (`auto`/`scroll`) rather than strict equality on the `overflow` shorthand, which can compute to values like `"hidden auto"`.

Behavior inside a real scroll container (e.g. `Bundles/Content/Edit.tsx`) is unchanged: same element, same measurement.

## Why

Fixes antiwork/gumroad-private#915 — buyer reported (reproduced across Firefox, Zen, Chrome, Vivaldi) that the Library caps at 15 of 31 purchases with no way to see the rest. Affects every buyer with more than 15 library purchases.

## Verification

- Local jsdom harness exercising the real hook (uncommitted, since jsdom/@testing-library aren't project deps): simulates a page taller than the viewport scrolled to the bottom and dispatches scroll on window/document.
  - On `origin/main`'s hook: **fails** — callback never fires (listener on `document.body`).
  - With this change: **passes** — callback fires.
- `tsc --noEmit`: no new errors (only the pre-existing `vite/client` type-lib error, identical on main).
- autoreview (Codex): clean, no actionable findings.

## Before/After

Not a visual change — the Library grid simply continues loading batches of 15 as you scroll, instead of stopping at 15.

---

Draft for review; fixes antiwork/gumroad-private#915 (kept open until verified in production).
