### PR TITLE
Report EasyPost auth/config errors to Sentry in shipping-address verification

### DIFF
--- a/app/controllers/shipments_controller.rb
+++ b/app/controllers/shipments_controller.rb
@@ -37,7 +37,15 @@ class ShipmentsController < ApplicationController
     else
       render_error("We are unable to verify your shipping address. Is your address correct?")
     end
-  rescue EasyPost::Errors::EasyPostError
+  rescue EasyPost::Errors::EasyPostError => e
+    # Auth/config-class failures (dead or unauthorized API key, billing lockout on the
+    # EasyPost account) mean address verification is broken for every buyer, not that
+    # this buyer's address is wrong. Report those to Sentry so a dead vendor key alerts
+    # us instead of silently blocking all physical-product checkouts behind a generic
+    # "is your address correct?" message (see gumroad-private#916, where a deactivated
+    # key blocked physical checkout platform-wide with zero error-tracker visibility).
+    # Buyers still get the same generic message either way.
+    ErrorNotifier.notify(e) if easypost_config_error?(e)
     render_error("We are unable to verify your shipping address. Is your address correct?")
   end
 
@@ -65,6 +73,15 @@ class ShipmentsController < ApplicationController
   private
     def render_error(error_message)
       render json: { success: false, error_message: }
+    end
+
+    # True for EasyPost failures caused by OUR configuration/account rather than the
+    # buyer's input: 401 Unauthorized, 403 Forbidden (deactivated key), and 402 Payment
+    # Required (EasyPost billing lockout). These affect every request platform-wide.
+    def easypost_config_error?(error)
+      error.is_a?(EasyPost::Errors::UnauthorizedError) ||
+        error.is_a?(EasyPost::Errors::ForbiddenError) ||
+        error.is_a?(EasyPost::Errors::PaymentError)
     end
 
     def render_address_response(address)

--- a/spec/controllers/shipments_controller_spec.rb
+++ b/spec/controllers/shipments_controller_spec.rb
@@ -84,6 +84,60 @@ describe ShipmentsController, :vcr  do
       end
     end
 
+    describe "EasyPost errors" do
+      before do
+        @params = {
+          street_address: "1640 17th St",
+          city: "San Francisco",
+          state: "CA",
+          zip_code: "94107",
+          country: "United States"
+        }
+      end
+
+      def stub_easypost_error(error)
+        allow_any_instance_of(EasyPost::Services::Address).to receive(:create).and_raise(error)
+      end
+
+      it "reports deactivated-key (forbidden) errors to Sentry and renders the generic error" do
+        stub_easypost_error(EasyPost::Errors::ForbiddenError.new("This api key is no longer active.", 403))
+
+        expect(ErrorNotifier).to receive(:notify).with(instance_of(EasyPost::Errors::ForbiddenError))
+        post :verify_shipping_address, params: @params
+
+        expect(response.parsed_body["success"]).to be(false)
+        expect(response.parsed_body["error_message"]).to eq "We are unable to verify your shipping address. Is your address correct?"
+      end
+
+      it "reports unauthorized-key errors to Sentry" do
+        stub_easypost_error(EasyPost::Errors::UnauthorizedError.new("Unauthorized", 401))
+
+        expect(ErrorNotifier).to receive(:notify).with(instance_of(EasyPost::Errors::UnauthorizedError))
+        post :verify_shipping_address, params: @params
+
+        expect(response.parsed_body["success"]).to be(false)
+      end
+
+      it "reports billing-lockout errors to Sentry" do
+        stub_easypost_error(EasyPost::Errors::PaymentError.new("Payment required", 402))
+
+        expect(ErrorNotifier).to receive(:notify).with(instance_of(EasyPost::Errors::PaymentError))
+        post :verify_shipping_address, params: @params
+
+        expect(response.parsed_body["success"]).to be(false)
+      end
+
+      it "does not report buyer-input-class errors to Sentry" do
+        stub_easypost_error(EasyPost::Errors::InvalidRequestError.new("Invalid address", 422))
+
+        expect(ErrorNotifier).not_to receive(:notify)
+        post :verify_shipping_address, params: @params
+
+        expect(response.parsed_body["success"]).to be(false)
+        expect(response.parsed_body["error_message"]).to eq "We are unable to verify your shipping address. Is your address correct?"
+      end
+    end
+
     describe "international address" do
       before do
         @params = {


### PR DESCRIPTION
## What

`ShipmentsController#verify_shipping_address` now reports auth/config-class EasyPost errors (401 `UnauthorizedError`, 403 `ForbiddenError`, 402 `PaymentError`) to Sentry via `ErrorNotifier`, instead of silently swallowing them behind the generic "We are unable to verify your shipping address. Is your address correct?" message. Buyer-input-class errors (e.g. 422 `InvalidRequestError`) keep the old behavior: generic message, no Sentry noise. The buyer-facing response is unchanged in every case.

## Why

The production EasyPost API key was deactivated, which made every shipping-address verification fail platform-wide — all physical-product checkouts were blocked. Because the controller rescued `EasyPost::Errors::EasyPostError` and returned the generic validation message, there were zero Sentry events and no failed-purchase rows: the outage was invisible to monitoring and only surfaced when a buyer wrote in after retrying 5+ valid addresses. See antiwork/gumroad-private#916 (which also covers the key rotation itself — this PR is only the observability hardening so a dead vendor key pages us next time).

## Test plan

Added a controller spec block covering all four cases; RED on main (first three fail — no reporting existed), GREEN on this branch:

```
bundle exec rspec spec/controllers/shipments_controller_spec.rb -e "EasyPost errors"
4 examples, 0 failures
```

- reports `ForbiddenError` (deactivated key) to Sentry, renders the generic error
- reports `UnauthorizedError` to Sentry
- reports `PaymentError` (billing lockout) to Sentry
- does NOT report `InvalidRequestError` (buyer-input class)

autoreview (Codex): clean, no actionable findings.

## Before/After

Not a UI change — buyers see the identical message; the difference is a Sentry event for platform-level EasyPost failures.

---

Draft for review. Note: this does not fix the live outage — the EasyPost key itself still needs to be reactivated/rotated per antiwork/gumroad-private#916.
