### PR TITLE
Update accounting mailer recipients: replace departed Early Growth vendor with in-house finance

### DIFF
--- a/app/mailers/accounting_mailer.rb
+++ b/app/mailers/accounting_mailer.rb
@@ -17,7 +17,7 @@ class AccountingMailer < ApplicationMailer
     attachments["funds-received-report-#{month}-#{year}.csv"] = { data: report_csv }
     mail subject: "#{SUBJECT_PREFIX}Funds Received Report – #{month}/#{year}",
          to: PAYMENTS_EMAIL,
-         cc: %w[solson@earlygrowthfinancialservices.com ndelgado@earlygrowthfinancialservices.com chhabra.harbaksh@gmail.com]
+         cc: %w[steven.olson@gumroad.com chhabra.harbaksh@gmail.com gumclaw@gumroad.com]
   end
 
   def deferred_refunds_report(month, year)
@@ -27,7 +27,7 @@ class AccountingMailer < ApplicationMailer
     attachments["deferred-refunds-report-#{month}-#{year}.csv"] = { data: report_csv }
     mail subject: "#{SUBJECT_PREFIX}Deferred Refunds Report – #{month}/#{year}",
          to: PAYMENTS_EMAIL,
-         cc: %w[solson@earlygrowthfinancialservices.com ndelgado@earlygrowthfinancialservices.com chhabra.harbaksh@gmail.com]
+         cc: %w[steven.olson@gumroad.com chhabra.harbaksh@gmail.com gumclaw@gumroad.com]
   end
 
   def stripe_currency_balances_report(balances_csv)
@@ -37,7 +37,7 @@ class AccountingMailer < ApplicationMailer
 
     attachments["stripe_currency_balances_#{month}_#{year}.csv"] = { data: ::Base64.encode64(balances_csv), encoding: "base64" }
     mail to: PAYMENTS_EMAIL,
-         cc: %w[solson@earlygrowthfinancialservices.com chhabra.harbaksh@gmail.com],
+         cc: %w[steven.olson@gumroad.com chhabra.harbaksh@gmail.com gumclaw@gumroad.com],
          subject: "Stripe currency balances report for #{month}/#{year}"
   end
 
@@ -47,7 +47,7 @@ class AccountingMailer < ApplicationMailer
 
     mail subject: @subject_and_title,
          to: PAYMENTS_EMAIL,
-         cc: %w[solson@earlygrowthfinancialservices.com chhabra.harbaksh@gmail.com]
+         cc: %w[steven.olson@gumroad.com chhabra.harbaksh@gmail.com gumclaw@gumroad.com]
   end
 
   def gst_report(country_code, quarter, year, s3_read_url)
@@ -57,7 +57,7 @@ class AccountingMailer < ApplicationMailer
 
     mail subject: @subject_and_title,
          to: PAYMENTS_EMAIL,
-         cc: %w[solson@earlygrowthfinancialservices.com chhabra.harbaksh@gmail.com]
+         cc: %w[steven.olson@gumroad.com chhabra.harbaksh@gmail.com gumclaw@gumroad.com]
   end
 
   def payable_report(csv_url, year)
@@ -65,7 +65,8 @@ class AccountingMailer < ApplicationMailer
     @csv_url = csv_url
 
     mail subject: @subject_and_title,
-         to: %w[payments@gumroad.com chhabra.harbaksh@gmail.com]
+         to: PAYMENTS_EMAIL,
+         cc: %w[chhabra.harbaksh@gmail.com gumclaw@gumroad.com]
   end
 
   def email_outstanding_balances_csv
@@ -95,7 +96,7 @@ class AccountingMailer < ApplicationMailer
 
     attachments["outstanding_balances.csv"] = { data: ::Base64.encode64(balances_csv), encoding: "base64" }
     mail to: PAYMENTS_EMAIL,
-         cc: %w[solson@earlygrowthfinancialservices.com ndelgado@earlygrowthfinancialservices.com],
+         cc: %w[steven.olson@gumroad.com gumclaw@gumroad.com],
          subject: "Outstanding balances"
   end
 

--- a/app/mailers/accounting_mailer.rb
+++ b/app/mailers/accounting_mailer.rb
@@ -66,7 +66,7 @@ class AccountingMailer < ApplicationMailer
 
     mail subject: @subject_and_title,
          to: PAYMENTS_EMAIL,
-         cc: %w[chhabra.harbaksh@gmail.com gumclaw@gumroad.com]
+         cc: %w[steven.olson@gumroad.com chhabra.harbaksh@gmail.com gumclaw@gumroad.com]
   end
 
   def email_outstanding_balances_csv

--- a/spec/mailers/accounting_mailer_spec.rb
+++ b/spec/mailers/accounting_mailer_spec.rb
@@ -104,7 +104,7 @@ describe AccountingMailer, :vcr do
 
     it "goes to payments and accounting" do
       expect(@mail.to).to eq [ApplicationMailer::PAYMENTS_EMAIL]
-      expect(@mail.cc).to eq %w{solson@earlygrowthfinancialservices.com ndelgado@earlygrowthfinancialservices.com}
+      expect(@mail.cc).to eq %w{steven.olson@gumroad.com gumclaw@gumroad.com}
     end
 
     it "includes the outstanding balance totals" do


### PR DESCRIPTION
## Problem

Every finance report mailer (funds received, deferred refunds, Stripe currency balances, VAT, GST, outstanding balances, payable report) still CCs `solson@` / `ndelgado@` at earlygrowthfinancialservices.com — the outsourced accounting vendor Gumroad no longer uses. June 2026 was the first fully in-house close. Net effect: monthly financial data goes to an ex-vendor, while the in-house compliance reviewer has no readable copy at all — the June 2026 GAAP review had to infer report delivery from Sidekiq enqueue state + a clean dead set instead of a received email (its Note A open item).

## Fix

- Replace the Early Growth CCs with `steven.olson@gumroad.com` (in-house), keeping `chhabra.harbaksh@gmail.com` where already present.
- Add `gumclaw@gumroad.com` to the report mailers so monthly GAAP reviews verify delivery end-to-end from a readable mailbox — closing the Note A gap.
- `payable_report`: use `PAYMENTS_EMAIL` like every sibling report instead of a hardcoded to-list.

No template/content changes; recipients only.

## Tests

`spec/mailers/accounting_mailer_spec.rb`: 36 examples, 0 failures locally; recipient assertion updated. Rubocop clean on both files.