### PR TITLE
Fail open on EasyPost service errors so physical checkout isn't blocked

### DIFF
--- a/app/controllers/shipments_controller.rb
+++ b/app/controllers/shipments_controller.rb
@@ -37,12 +37,17 @@ class ShipmentsController < ApplicationController
     else
       render_error("We are unable to verify your shipping address. Is your address correct?")
     end
+  rescue EasyPost::Errors::BadRequestError, EasyPost::Errors::InvalidRequestError,
+         EasyPost::Errors::InvalidParameterError, EasyPost::Errors::MissingParameterError
+    # EasyPost rejected the request itself (malformed or missing address fields), which means
+    # the buyer's input is the problem — keep asking them to correct it.
+    render_error("We are unable to verify your shipping address. Is your address correct?")
   rescue EasyPost::Errors::EasyPostError => e
-    # If EasyPost itself fails (deactivated API key, outage, timeout), the problem is on our
-    # side, not the buyer's. Returning an error here blocks every physical-product checkout
-    # platform-wide, so we accept the address exactly as the buyer entered it and let the
-    # purchase proceed. We still report the failure so a broken EasyPost integration pages us
-    # instead of silently degrading address verification.
+    # Any other EasyPost failure (deactivated API key, outage, timeout, rate limit) is a
+    # problem on our side, not the buyer's. Returning an error here blocks every
+    # physical-product checkout platform-wide, so we accept the address exactly as the buyer
+    # entered it and let the purchase proceed. We still report the failure so a broken
+    # EasyPost integration pages us instead of silently degrading address verification.
     ErrorNotifier.notify(e, context: { action: "verify_shipping_address" })
     render json: { success: true,
                    street_address: params[:street_address],

--- a/app/controllers/shipments_controller.rb
+++ b/app/controllers/shipments_controller.rb
@@ -37,8 +37,18 @@ class ShipmentsController < ApplicationController
     else
       render_error("We are unable to verify your shipping address. Is your address correct?")
     end
-  rescue EasyPost::Errors::EasyPostError
-    render_error("We are unable to verify your shipping address. Is your address correct?")
+  rescue EasyPost::Errors::EasyPostError => e
+    # If EasyPost itself fails (deactivated API key, outage, timeout), the problem is on our
+    # side, not the buyer's. Returning an error here blocks every physical-product checkout
+    # platform-wide, so we accept the address exactly as the buyer entered it and let the
+    # purchase proceed. We still report the failure so a broken EasyPost integration pages us
+    # instead of silently degrading address verification.
+    ErrorNotifier.notify(e, context: { action: "verify_shipping_address" })
+    render json: { success: true,
+                   street_address: params[:street_address],
+                   city: params[:city],
+                   state: params[:state],
+                   zip_code: params[:zip_code] }
   end
 
   def mark_as_shipped

--- a/spec/controllers/shipments_controller_spec.rb
+++ b/spec/controllers/shipments_controller_spec.rb
@@ -128,6 +128,35 @@ describe ShipmentsController, :vcr  do
         end
       end
     end
+
+    describe "EasyPost API failure" do
+      before do
+        @params = {
+          street_address: "1640 17th St",
+          city: "San Francisco",
+          state: "CA",
+          zip_code: "94107",
+          country: "United States"
+        }
+      end
+
+      it "accepts the buyer's address as entered so checkout is not blocked, and reports the error" do
+        expect_any_instance_of(EasyPost::Services::Address).to receive(:create)
+          .and_raise(EasyPost::Errors::EasyPostError.new("This api key is no longer active. Please use a different api key or reactivate this key."))
+        expect(ErrorNotifier).to receive(:notify).with(
+          an_instance_of(EasyPost::Errors::EasyPostError),
+          context: { action: "verify_shipping_address" }
+        )
+
+        post :verify_shipping_address, params: @params
+
+        expect(response.parsed_body["success"]).to be(true)
+        expect(response.parsed_body["street_address"]).to eq "1640 17th St"
+        expect(response.parsed_body["city"]).to eq "San Francisco"
+        expect(response.parsed_body["state"]).to eq "CA"
+        expect(response.parsed_body["zip_code"]).to eq "94107"
+      end
+    end
   end
 
   describe "POST mark_as_shipped" do

--- a/spec/controllers/shipments_controller_spec.rb
+++ b/spec/controllers/shipments_controller_spec.rb
@@ -142,9 +142,9 @@ describe ShipmentsController, :vcr  do
 
       it "accepts the buyer's address as entered so checkout is not blocked, and reports the error" do
         expect_any_instance_of(EasyPost::Services::Address).to receive(:create)
-          .and_raise(EasyPost::Errors::EasyPostError.new("This api key is no longer active. Please use a different api key or reactivate this key."))
+          .and_raise(EasyPost::Errors::ForbiddenError.new("This api key is no longer active. Please use a different api key or reactivate this key.", 403))
         expect(ErrorNotifier).to receive(:notify).with(
-          an_instance_of(EasyPost::Errors::EasyPostError),
+          an_instance_of(EasyPost::Errors::ForbiddenError),
           context: { action: "verify_shipping_address" }
         )
 
@@ -155,6 +155,17 @@ describe ShipmentsController, :vcr  do
         expect(response.parsed_body["city"]).to eq "San Francisco"
         expect(response.parsed_body["state"]).to eq "CA"
         expect(response.parsed_body["zip_code"]).to eq "94107"
+      end
+
+      it "still asks the buyer to correct their address when EasyPost rejects the request as invalid" do
+        expect_any_instance_of(EasyPost::Services::Address).to receive(:create)
+          .and_raise(EasyPost::Errors::BadRequestError.new("Unable to parse address", 400))
+        expect(ErrorNotifier).not_to receive(:notify)
+
+        post :verify_shipping_address, params: @params
+
+        expect(response.parsed_body["success"]).to be(false)
+        expect(response.parsed_body["error_message"]).to eq "We are unable to verify your shipping address. Is your address correct?"
       end
     end
   end

--- a/spec/requests/purchases/product/shipping/shipping_address_verification_spec.rb
+++ b/spec/requests/purchases/product/shipping/shipping_address_verification_spec.rb
@@ -10,8 +10,9 @@ describe("Product Page - Shipping Scenarios Address verification", type: :system
     end
 
     it "shows that the address is not valid but will let the purchase through if user says yes" do
-      # have to mock EasyPost calls because the timeout throws before EasyPost responds in testing
-      exception = EasyPost::Errors::EasyPostError.new
+      # Mock EasyPost rejecting the address as unparseable — an input-class error, which keeps
+      # the "Is your address correct?" prompt (service-side EasyPost failures fail open instead).
+      exception = EasyPost::Errors::InvalidRequestError.new("Unable to verify address", 422)
       expect_any_instance_of(EasyPost::Services::Address).to receive(:create).and_raise(exception)
 
       visit "/l/#{@product.unique_permalink}"
@@ -191,14 +192,45 @@ describe("Product Page - Shipping Scenarios Address verification", type: :system
       @product.shipping_destinations << ShippingDestination.new(country_code: "CA", one_item_rate_cents: 2000, multiple_items_rate_cents: 1000)
       @product.save!
 
-      # have to mock EasyPost calls because the timeout throws before EasyPost responds in testing
-      exception = EasyPost::Errors::EasyPostError.new
+      # Mock EasyPost rejecting the address as unparseable — an input-class error, which keeps
+      # the "Is your address correct?" prompt (service-side EasyPost failures fail open instead
+      # and are covered by the spec below).
+      exception = EasyPost::Errors::InvalidRequestError.new("Unable to verify address", 422)
       expect_any_instance_of(EasyPost::Services::Address).to receive(:create).and_raise(exception)
 
       visit "/l/#{@product.unique_permalink}"
 
       add_to_cart(@product)
       check_out(@product, address: { city: "Burnaby", state: "BC", zip_code: "V3N 4H4" }, country: "Canada", should_verify_address: true)
+
+      expect(page).to have_alert("Your purchase was successful!")
+
+      purchase = Purchase.last
+      expect(purchase.street_address).to eq("1640 17th St")
+      expect(purchase.city).to eq("Burnaby")
+      expect(purchase.state).to eq("BC")
+      expect(purchase.zip_code).to eq("V3N 4H4")
+      expect(purchase.country).to eq("Canada")
+    end
+
+    it "lets the purchase through without a confirmation prompt when EasyPost itself is unavailable" do
+      @user = create(:user)
+
+      @product = create(:physical_product, user: @user, require_shipping: true, price_cents: 100_00)
+      @product.shipping_destinations << ShippingDestination.new(country_code: "CA", one_item_rate_cents: 2000, multiple_items_rate_cents: 1000)
+      @product.save!
+
+      # A service-side EasyPost failure (outage, bad API key) fails open: the address is accepted
+      # as entered so checkout isn't blocked, and no confirmation dialog is shown.
+      exception = EasyPost::Errors::ForbiddenError.new("This api key is no longer active.", 403)
+      expect_any_instance_of(EasyPost::Services::Address).to receive(:create).and_raise(exception)
+
+      visit "/l/#{@product.unique_permalink}"
+
+      add_to_cart(@product)
+      check_out(@product, address: { city: "Burnaby", state: "BC", zip_code: "V3N 4H4" }, country: "Canada")
+
+      expect(page).not_to have_text("We are unable to verify your shipping address. Is your address correct?")
 
       expect(page).to have_alert("Your purchase was successful!")
 

--- a/spec/requests/purchases/product/taxes_spec.rb
+++ b/spec/requests/purchases/product/taxes_spec.rb
@@ -156,11 +156,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(page).to have_text("Total US$658.85", normalize_ws: true)
 
         click_on "Pay"
-        if page.has_text?("We are unable to verify your shipping address. Is your address correct?", wait: 5)
-          click_on "Yes, it is"
-        elsif page.has_text?("You entered this address:", wait: 5) && page.has_text?("We recommend using this format:", wait: 5)
-          click_on "No, continue"
-        end
+        confirm_shipping_address_if_prompted
         expect(page).to have_alert(text: "Your purchase was successful!")
 
         purchase = Purchase.last

--- a/spec/requests/subscription/non_tiered_membership_spec.rb
+++ b/spec/requests/subscription/non_tiered_membership_spec.rb
@@ -422,7 +422,8 @@ describe "Non Tiered Membership Subscriptions", type: :system, js: true do
 
       fill_in_credit_card(number: CardParamsSpecHelper.card_number(:success))
       click_on "Update membership"
-      click_on "Yes, it is" # verify shipping address
+      # verify shipping address (skipped automatically if verification failed open)
+      confirm_shipping_address_if_prompted(success_text: "Your membership has been updated.")
       wait_for_ajax
 
       expect(page).to have_alert(text: "Your membership has been updated.")

--- a/spec/requests/subscription/tiered_membership_fixed_length_spec.rb
+++ b/spec/requests/subscription/tiered_membership_fixed_length_spec.rb
@@ -49,7 +49,8 @@ describe "Tiered Memberships Fixed Length Spec", type: :system, js: true do
     select "United States", from: "Country"
 
     click_on "Update membership"
-    click_on "Yes, it is"
+    # verify shipping address (skipped automatically if verification failed open)
+    confirm_shipping_address_if_prompted(success_text: "Your membership has been updated.")
     wait_for_ajax
 
     expect(page).to have_alert(text: "Your membership has been updated.")

--- a/spec/support/checkout_helpers.rb
+++ b/spec/support/checkout_helpers.rb
@@ -156,15 +156,7 @@ module CheckoutHelpers
       click_on is_free ? "Get" : "Pay", exact: true
 
       if should_verify_address
-        begin
-          if page.has_text?("We are unable to verify your shipping address. Is your address correct?", wait: 5)
-            click_on "Yes, it is"
-          elsif page.has_text?("You entered this address:", wait: 5) && page.has_text?("We recommend using this format:", wait: 5)
-            click_on "No, continue"
-          end
-        rescue Capybara::ElementNotFound, Selenium::WebDriver::Error::StaleElementReferenceError
-          # Page may still be loading after payment processing or Chrome may be unstable; continue to success assertion
-        end
+        confirm_shipping_address_if_prompted
       end
 
       within_sca_frame { click_on sca ? "Complete" : "Fail" } unless sca.nil?
@@ -194,6 +186,31 @@ module CheckoutHelpers
     end.to change { product.preorder_link.present? ? product.sales.preorder_authorization_successful.count : product.sales.successful.count }.by(error.blank? && logged_in_user&.id != product.user.id && (product.not_free_trial_enabled || gift.present?) ? cart_item_count : 0)
       .and change { product.preorder_link.present? ? product.sales.preorder_authorization_failed.count : product.sales.failed.count }.by(error.present? && error != true ? 1 : 0)
       .and change { product&.subscriptions&.count }.by(error.blank? && product.is_recurring_billing ? 1 : 0)
+  end
+
+  # Clicks through the shipping address confirmation dialog if one appears after submitting a
+  # form that verifies the address. Address verification fails open when EasyPost itself is
+  # unavailable (see ShipmentsController#verify_shipping_address), so a confirmation dialog may
+  # never appear and the flow proceeds straight to success. We wait once for whichever outcome
+  # shows up first instead of waiting out each dialog text in turn — otherwise we burn the full
+  # wait on absent dialogs and the transient success alert can auto-dismiss before the caller's
+  # own assertions run.
+  def confirm_shipping_address_if_prompted(success_text: "Your purchase was successful!", wait: 10)
+    page.has_text?(
+      Regexp.union(
+        "We are unable to verify your shipping address. Is your address correct?",
+        "You entered this address:",
+        success_text
+      ),
+      wait:
+    )
+    if page.has_text?("We are unable to verify your shipping address. Is your address correct?", wait: 0)
+      click_on "Yes, it is"
+    elsif page.has_text?("You entered this address:", wait: 0) && page.has_text?("We recommend using this format:", wait: 0)
+      click_on "No, continue"
+    end
+  rescue Capybara::ElementNotFound, Selenium::WebDriver::Error::StaleElementReferenceError
+    # Page may still be loading after payment processing or Chrome may be unstable; continue to success assertion
   end
 end
 


### PR DESCRIPTION
## What

`ShipmentsController#verify_shipping_address` now fails open when EasyPost itself is broken. Service-side EasyPost errors (deactivated API key, outage, timeout, rate limit) accept the address exactly as the buyer entered it (`success: true`) so checkout can proceed, and report the exception to Sentry via `ErrorNotifier`. Request/input-class errors (`BadRequestError`, `InvalidRequestError`, `InvalidParameterError`, `MissingParameterError`) still return the "Is your address correct?" prompt, since those mean the buyer's input is the problem.

## Why

The production EasyPost API key was deactivated, and the previous `rescue EasyPost::Errors::EasyPostError` swallowed the resulting `ForbiddenError` into the generic buyer-facing validation error. Every physical-product checkout was blocked platform-wide, buyers blamed their own addresses, and nothing reached Sentry — the failure was invisible in monitoring. A vendor outage should degrade address verification, not bring down physical purchases; and it should page us via Sentry instead of failing silently.

Fixes antiwork/gumroad-private#916

## Test evidence

Backend-only change, no UI difference (the frontend `verifyShippingAddress` in `app/javascript/data/shipping.ts` already handles the `success: true` payload shape returned here — same fields as a normal verified address).

- `bundle exec rspec spec/controllers/shipments_controller_spec.rb` — 18 examples, 0 failures (includes 2 new specs: fail-open on `ForbiddenError` with Sentry report, and buyer-facing error retained on `BadRequestError`)
- `bundle exec rubocop app/controllers/shipments_controller.rb spec/controllers/shipments_controller_spec.rb` — no offenses
- autoreview (Codex, branch mode vs origin/main): clean, no actionable findings

Note: this makes checkout resilient, but the deactivated EasyPost key still needs to be reactivated/rotated so verification actually works again (tracked in the linked issue).
