### PR TITLE
Finance report mailers: remove Harbaksh and Steve, send to finance@

### DIFF
--- a/app/mailers/accounting_mailer.rb
+++ b/app/mailers/accounting_mailer.rb
@@ -16,7 +16,7 @@ class AccountingMailer < ApplicationMailer
     report_csv = AdminFundsCsvReportService.new(@report).generate
     attachments["funds-received-report-#{month}-#{year}.csv"] = { data: report_csv }
     mail subject: "#{SUBJECT_PREFIX}Funds Received Report – #{month}/#{year}",
-         to: PAYMENTS_EMAIL,
+         to: FINANCE_EMAIL,
          cc: %w[gumclaw@gumroad.com]
   end
 
@@ -26,7 +26,7 @@ class AccountingMailer < ApplicationMailer
     report_csv = AdminFundsCsvReportService.new(@report).generate
     attachments["deferred-refunds-report-#{month}-#{year}.csv"] = { data: report_csv }
     mail subject: "#{SUBJECT_PREFIX}Deferred Refunds Report – #{month}/#{year}",
-         to: PAYMENTS_EMAIL,
+         to: FINANCE_EMAIL,
          cc: %w[gumclaw@gumroad.com]
   end
 
@@ -36,7 +36,7 @@ class AccountingMailer < ApplicationMailer
     year = last_month.year
 
     attachments["stripe_currency_balances_#{month}_#{year}.csv"] = { data: ::Base64.encode64(balances_csv), encoding: "base64" }
-    mail to: PAYMENTS_EMAIL,
+    mail to: FINANCE_EMAIL,
          cc: %w[gumclaw@gumroad.com],
          subject: "Stripe currency balances report for #{month}/#{year}"
   end
@@ -46,7 +46,7 @@ class AccountingMailer < ApplicationMailer
     @s3_url = s3_read_url
 
     mail subject: @subject_and_title,
-         to: PAYMENTS_EMAIL,
+         to: FINANCE_EMAIL,
          cc: %w[gumclaw@gumroad.com]
   end
 
@@ -56,7 +56,7 @@ class AccountingMailer < ApplicationMailer
     @s3_url = s3_read_url
 
     mail subject: @subject_and_title,
-         to: PAYMENTS_EMAIL,
+         to: FINANCE_EMAIL,
          cc: %w[gumclaw@gumroad.com]
   end
 
@@ -65,7 +65,7 @@ class AccountingMailer < ApplicationMailer
     @csv_url = csv_url
 
     mail subject: @subject_and_title,
-         to: PAYMENTS_EMAIL,
+         to: FINANCE_EMAIL,
          cc: %w[gumclaw@gumroad.com]
   end
 
@@ -95,7 +95,7 @@ class AccountingMailer < ApplicationMailer
     end
 
     attachments["outstanding_balances.csv"] = { data: ::Base64.encode64(balances_csv), encoding: "base64" }
-    mail to: PAYMENTS_EMAIL,
+    mail to: FINANCE_EMAIL,
          cc: %w[gumclaw@gumroad.com],
          subject: "Outstanding balances"
   end

--- a/app/mailers/accounting_mailer.rb
+++ b/app/mailers/accounting_mailer.rb
@@ -17,7 +17,7 @@ class AccountingMailer < ApplicationMailer
     attachments["funds-received-report-#{month}-#{year}.csv"] = { data: report_csv }
     mail subject: "#{SUBJECT_PREFIX}Funds Received Report – #{month}/#{year}",
          to: PAYMENTS_EMAIL,
-         cc: %w[steven.olson@gumroad.com chhabra.harbaksh@gmail.com gumclaw@gumroad.com]
+         cc: %w[gumclaw@gumroad.com]
   end
 
   def deferred_refunds_report(month, year)
@@ -27,7 +27,7 @@ class AccountingMailer < ApplicationMailer
     attachments["deferred-refunds-report-#{month}-#{year}.csv"] = { data: report_csv }
     mail subject: "#{SUBJECT_PREFIX}Deferred Refunds Report – #{month}/#{year}",
          to: PAYMENTS_EMAIL,
-         cc: %w[steven.olson@gumroad.com chhabra.harbaksh@gmail.com gumclaw@gumroad.com]
+         cc: %w[gumclaw@gumroad.com]
   end
 
   def stripe_currency_balances_report(balances_csv)
@@ -37,7 +37,7 @@ class AccountingMailer < ApplicationMailer
 
     attachments["stripe_currency_balances_#{month}_#{year}.csv"] = { data: ::Base64.encode64(balances_csv), encoding: "base64" }
     mail to: PAYMENTS_EMAIL,
-         cc: %w[steven.olson@gumroad.com chhabra.harbaksh@gmail.com gumclaw@gumroad.com],
+         cc: %w[gumclaw@gumroad.com],
          subject: "Stripe currency balances report for #{month}/#{year}"
   end
 
@@ -47,7 +47,7 @@ class AccountingMailer < ApplicationMailer
 
     mail subject: @subject_and_title,
          to: PAYMENTS_EMAIL,
-         cc: %w[steven.olson@gumroad.com chhabra.harbaksh@gmail.com gumclaw@gumroad.com]
+         cc: %w[gumclaw@gumroad.com]
   end
 
   def gst_report(country_code, quarter, year, s3_read_url)
@@ -57,7 +57,7 @@ class AccountingMailer < ApplicationMailer
 
     mail subject: @subject_and_title,
          to: PAYMENTS_EMAIL,
-         cc: %w[steven.olson@gumroad.com chhabra.harbaksh@gmail.com gumclaw@gumroad.com]
+         cc: %w[gumclaw@gumroad.com]
   end
 
   def payable_report(csv_url, year)
@@ -66,7 +66,7 @@ class AccountingMailer < ApplicationMailer
 
     mail subject: @subject_and_title,
          to: PAYMENTS_EMAIL,
-         cc: %w[steven.olson@gumroad.com chhabra.harbaksh@gmail.com gumclaw@gumroad.com]
+         cc: %w[gumclaw@gumroad.com]
   end
 
   def email_outstanding_balances_csv
@@ -96,7 +96,7 @@ class AccountingMailer < ApplicationMailer
 
     attachments["outstanding_balances.csv"] = { data: ::Base64.encode64(balances_csv), encoding: "base64" }
     mail to: PAYMENTS_EMAIL,
-         cc: %w[steven.olson@gumroad.com gumclaw@gumroad.com],
+         cc: %w[gumclaw@gumroad.com],
          subject: "Outstanding balances"
   end
 
@@ -163,8 +163,7 @@ class AccountingMailer < ApplicationMailer
     @s3_url = s3_read_url
 
     mail subject: @subject_and_title,
-         to: "salestax@gumroad.com",
-         cc: %w[steven.olson@gumroad.com]
+         to: "salestax@gumroad.com"
   end
 
   def global_sales_tax_summary_report_failed(month, year, error_class, error_message)

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -10,6 +10,7 @@ class ApplicationMailer < ActionMailer::Base
   {
     ADMIN_EMAIL: "hi@#{DEFAULT_EMAIL_DOMAIN}",
     DEVELOPERS_EMAIL: "developers@#{DEFAULT_EMAIL_DOMAIN}",
+    FINANCE_EMAIL: "finance@#{DEFAULT_EMAIL_DOMAIN}",
     NOREPLY_EMAIL: "noreply@#{DEFAULT_EMAIL_DOMAIN}",
     PAYMENTS_EMAIL: "payments@#{DEFAULT_EMAIL_DOMAIN}",
     RISK_EMAIL: "risk@#{DEFAULT_EMAIL_DOMAIN}",

--- a/spec/mailers/accounting_mailer_spec.rb
+++ b/spec/mailers/accounting_mailer_spec.rb
@@ -104,7 +104,7 @@ describe AccountingMailer, :vcr do
 
     it "goes to payments and accounting" do
       expect(@mail.to).to eq [ApplicationMailer::PAYMENTS_EMAIL]
-      expect(@mail.cc).to eq %w{steven.olson@gumroad.com gumclaw@gumroad.com}
+      expect(@mail.cc).to eq %w{gumclaw@gumroad.com}
     end
 
     it "includes the outstanding balance totals" do

--- a/spec/mailers/accounting_mailer_spec.rb
+++ b/spec/mailers/accounting_mailer_spec.rb
@@ -19,7 +19,7 @@ describe AccountingMailer, :vcr do
     end
 
     it "is to team" do
-      expect(@mail.to).to eq([ApplicationMailer::PAYMENTS_EMAIL])
+      expect(@mail.to).to eq([ApplicationMailer::FINANCE_EMAIL])
     end
   end
 
@@ -39,7 +39,7 @@ describe AccountingMailer, :vcr do
     end
 
     it "sends to team" do
-      expect(@mail.to).to eq([ApplicationMailer::PAYMENTS_EMAIL])
+      expect(@mail.to).to eq([ApplicationMailer::FINANCE_EMAIL])
     end
   end
 
@@ -103,7 +103,7 @@ describe AccountingMailer, :vcr do
     end
 
     it "goes to payments and accounting" do
-      expect(@mail.to).to eq [ApplicationMailer::PAYMENTS_EMAIL]
+      expect(@mail.to).to eq [ApplicationMailer::FINANCE_EMAIL]
       expect(@mail.cc).to eq %w{gumclaw@gumroad.com}
     end
 

--- a/spec/sidekiq/create_global_sales_tax_summary_report_job_spec.rb
+++ b/spec/sidekiq/create_global_sales_tax_summary_report_job_spec.rb
@@ -111,7 +111,7 @@ describe CreateGlobalSalesTaxSummaryReportJob do
 
         expect(ActionMailer::Base.deliveries.last.subject).to eq("Global Sales Tax Summary Report for 1/2024")
         expect(ActionMailer::Base.deliveries.last.to).to eq(["salestax@gumroad.com"])
-        expect(ActionMailer::Base.deliveries.last.cc).to eq(["steven.olson@gumroad.com"])
+        expect(ActionMailer::Base.deliveries.last.cc).to be_blank
       end
     end
 


### PR DESCRIPTION
Follow-up to #5721, per founder direction.

## Changes
- Removed `chhabra.harbaksh@gmail.com` and `steven.olson@gumroad.com` from all `AccountingMailer` recipient lists (funds received, deferred refunds, Stripe balances, VAT, GST, payable report, outstanding balances, global sales tax summary).
- All finance reports now go **to `finance@gumroad.com`** (new `FINANCE_EMAIL` constant) instead of `payments@`. The global sales tax summary keeps `salestax@gumroad.com`.
- `gumclaw@gumroad.com` stays CC'd for automated delivery verification.
- Specs updated to match.

## Verification
- `rspec` accounting mailer + application mailer + global sales tax job specs — 58 examples, 0 failures
- `git grep` confirms no remaining references to the removed addresses in app/lib/config/spec
- rubocop clean