### PR TITLE
Size Indian e-mandate cap to the undiscounted total for limited-duration discounts

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -3078,16 +3078,26 @@ class Purchase < ApplicationRecord
   # legitimately make: the undiscounted equivalent of today's total when the discount is
   # temporary, today's total otherwise.
   def mandate_maximum_amount_cents
-    base_cents = is_upgrade_purchase? ? subscription.original_purchase.total_transaction_cents : total_transaction_cents
-    discount = purchase_offer_code_discount
+    # An upgrade purchase only charges the prorated difference today, and any active
+    # discount record lives on the subscription's original purchase rather than on the
+    # upgrade purchase itself. Future renewals bill that original purchase (which
+    # `Subscription#update_current_plan!` rebuilds to reflect the new plan), so for
+    # upgrades derive every input below — charged total, discount record, discounted
+    # price, quantity — from the original purchase. Mixing sources would pair the
+    # original purchase's total with the upgrade's small prorated price (wildly
+    # inflating the cap) or miss a temporary discount that only exists on the original
+    # purchase (undersizing the cap so renewals fail).
+    reference_purchase = is_upgrade_purchase? ? subscription.original_purchase : self
+    base_cents = reference_purchase.total_transaction_cents
+    discount = reference_purchase.purchase_offer_code_discount
     return base_cents if discount.blank? || discount.duration_in_billing_cycles.blank?
-    return base_cents unless displayed_price_cents.to_i.positive?
+    return base_cents unless reference_purchase.displayed_price_cents.to_i.positive?
 
     # Scale the charged total (which already includes tax) by the pre-discount/discounted
     # price ratio instead of re-deriving price + tax + FX from scratch — the mandate is an
     # upper bound, so a proportional estimate is sufficient and much simpler.
-    pre_discount_cents = discount.pre_discount_minimum_price_cents * quantity
-    [(Rational(base_cents * pre_discount_cents, displayed_price_cents)).ceil, base_cents].max
+    pre_discount_cents = discount.pre_discount_minimum_price_cents * reference_purchase.quantity
+    [(Rational(base_cents * pre_discount_cents, reference_purchase.displayed_price_cents)).ceil, base_cents].max
   end
 
   def name_or_email

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -3055,7 +3055,7 @@ class Purchase < ApplicationRecord
           mandate_options: {
             reference: StripeChargeProcessor::MANDATE_PREFIX + (Rails.env.production? ? external_id : SecureRandom.hex),
             amount_type: "maximum",
-            amount: is_upgrade_purchase? ? subscription.original_purchase.total_transaction_cents : total_transaction_cents,
+            amount: mandate_maximum_amount_cents,
             start_date: Time.current.to_i,
             interval:,
             interval_count:,
@@ -3066,6 +3066,28 @@ class Purchase < ApplicationRecord
     }
     mandate_options[:payment_method_options][:card][:mandate_options][:currency] = "usd" if with_currency
     mandate_options
+  end
+
+  # The e-mandate registered with the first charge caps every future off-session charge on
+  # this card (RBI rules for Indian cards; see mandate_options_for_stripe). Sizing that cap
+  # to the first charge's total breaks subscriptions bought with a limited-duration discount
+  # code: once the discount's billing cycles run out, the renewal charges the full
+  # undiscounted price, which is guaranteed to exceed a cap sized to the discounted first
+  # charge — the renewal then fails at the card network and the buyer has to come back and
+  # re-authenticate manually. Size the cap to the largest charge this subscription can
+  # legitimately make: the undiscounted equivalent of today's total when the discount is
+  # temporary, today's total otherwise.
+  def mandate_maximum_amount_cents
+    base_cents = is_upgrade_purchase? ? subscription.original_purchase.total_transaction_cents : total_transaction_cents
+    discount = purchase_offer_code_discount
+    return base_cents if discount.blank? || discount.duration_in_billing_cycles.blank?
+    return base_cents unless displayed_price_cents.to_i.positive?
+
+    # Scale the charged total (which already includes tax) by the pre-discount/discounted
+    # price ratio instead of re-deriving price + tax + FX from scratch — the mandate is an
+    # upper bound, so a proportional estimate is sufficient and much simpler.
+    pre_discount_cents = discount.pre_discount_minimum_price_cents * quantity
+    [(Rational(base_cents * pre_discount_cents, displayed_price_cents)).ceil, base_cents].max
   end
 
   def name_or_email

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -6002,6 +6002,42 @@ describe Purchase, :vcr do
       expect(mandate_options).to be_present
       expect(mandate_options[:payment_method_options][:card][:mandate_options][:amount_type]).to eq("maximum")
     end
+
+    it "caps the mandate at the undiscounted total when a limited-duration discount code was applied" do
+      product = create(:membership_product_with_preset_tiered_pricing)
+      subscription = create(:subscription, link: product)
+      offer_code = create(:offer_code, products: [product], amount_percentage: 10, duration_in_billing_cycles: 1)
+      purchase = create(:purchase, charge_processor_id: StripeChargeProcessor.charge_processor_id, link: product, purchase_state: "in_progress",
+                                   card_country: "IN", subscription:, is_original_subscription_purchase: true,
+                                   offer_code:, price_cents: 100, total_transaction_cents: 105, displayed_price_cents: 100)
+      purchase.create_purchase_offer_code_discount!(offer_code:, offer_code_amount: 80, offer_code_is_percent: true,
+                                                    pre_discount_minimum_price_cents: 500, duration_in_billing_cycles: 1)
+      allow(purchase).to receive(:chargeable).and_return(instance_double(StripeChargeablePaymentMethod, requires_mandate?: true))
+
+      mandate_options = purchase.mandate_options_for_stripe
+
+      # Once the single discounted cycle is over, renewals charge the full 500¢ price, so the
+      # cap must cover the undiscounted total (105 * 500 / 100 = 525), not the first charge.
+      expect(mandate_options[:payment_method_options][:card][:mandate_options][:amount]).to eq(525)
+    end
+
+    it "caps the mandate at the charged total when the discount applies to all billing cycles" do
+      product = create(:membership_product_with_preset_tiered_pricing)
+      subscription = create(:subscription, link: product)
+      offer_code = create(:offer_code, products: [product], amount_percentage: 10)
+      purchase = create(:purchase, charge_processor_id: StripeChargeProcessor.charge_processor_id, link: product, purchase_state: "in_progress",
+                                   card_country: "IN", subscription:, is_original_subscription_purchase: true,
+                                   offer_code:, price_cents: 100, total_transaction_cents: 105, displayed_price_cents: 100)
+      purchase.create_purchase_offer_code_discount!(offer_code:, offer_code_amount: 80, offer_code_is_percent: true,
+                                                    pre_discount_minimum_price_cents: 500)
+      allow(purchase).to receive(:chargeable).and_return(instance_double(StripeChargeablePaymentMethod, requires_mandate?: true))
+
+      mandate_options = purchase.mandate_options_for_stripe
+
+      # A discount without a billing-cycle limit applies to every renewal, so the first
+      # charge's total is the correct maximum — no headroom needed.
+      expect(mandate_options[:payment_method_options][:card][:mandate_options][:amount]).to eq(105)
+    end
   end
 
   describe "#is_an_off_session_charge_on_indian_card?" do

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -6038,6 +6038,48 @@ describe Purchase, :vcr do
       # charge's total is the correct maximum — no headroom needed.
       expect(mandate_options[:payment_method_options][:card][:mandate_options][:amount]).to eq(105)
     end
+
+    it "sizes the mandate from the subscription's original purchase (not the prorated charge) for upgrade purchases" do
+      product = create(:membership_product_with_preset_tiered_pricing)
+      subscription = create(:subscription, link: product)
+      offer_code = create(:offer_code, products: [product], amount_percentage: 10, duration_in_billing_cycles: 1)
+      original_purchase = create(:purchase, charge_processor_id: StripeChargeProcessor.charge_processor_id, link: product, purchase_state: "successful",
+                                            card_country: "IN", subscription:, is_original_subscription_purchase: true,
+                                            offer_code:, price_cents: 100, total_transaction_cents: 105, displayed_price_cents: 100)
+      original_purchase.create_purchase_offer_code_discount!(offer_code:, offer_code_amount: 80, offer_code_is_percent: true,
+                                                             pre_discount_minimum_price_cents: 500, duration_in_billing_cycles: 1)
+      # The upgrade purchase itself only charges a small prorated amount and carries no
+      # discount record — none of its numbers should influence the mandate cap.
+      upgrade_purchase = create(:purchase, charge_processor_id: StripeChargeProcessor.charge_processor_id, link: product, purchase_state: "in_progress",
+                                           card_country: "IN", subscription:, is_upgrade_purchase: true,
+                                           price_cents: 37, total_transaction_cents: 37, displayed_price_cents: 37)
+      allow(upgrade_purchase).to receive(:chargeable).and_return(instance_double(StripeChargeablePaymentMethod, requires_mandate?: true))
+
+      mandate_options = upgrade_purchase.mandate_options_for_stripe
+
+      # Renewals bill the original purchase, whose limited-duration discount expires after
+      # one cycle — so the cap scales the original total to its undiscounted equivalent
+      # (105 * 500 / 100 = 525), ignoring the 37¢ prorated upgrade charge entirely.
+      expect(mandate_options[:payment_method_options][:card][:mandate_options][:amount]).to eq(525)
+    end
+
+    it "caps an upgrade purchase's mandate at the original purchase total when there is no limited-duration discount" do
+      product = create(:membership_product_with_preset_tiered_pricing)
+      subscription = create(:subscription, link: product)
+      create(:purchase, charge_processor_id: StripeChargeProcessor.charge_processor_id, link: product, purchase_state: "successful",
+                        card_country: "IN", subscription:, is_original_subscription_purchase: true,
+                        price_cents: 500, total_transaction_cents: 525, displayed_price_cents: 500)
+      upgrade_purchase = create(:purchase, charge_processor_id: StripeChargeProcessor.charge_processor_id, link: product, purchase_state: "in_progress",
+                                           card_country: "IN", subscription:, is_upgrade_purchase: true,
+                                           price_cents: 37, total_transaction_cents: 37, displayed_price_cents: 37)
+      allow(upgrade_purchase).to receive(:chargeable).and_return(instance_double(StripeChargeablePaymentMethod, requires_mandate?: true))
+
+      mandate_options = upgrade_purchase.mandate_options_for_stripe
+
+      # No discount on the original purchase means renewals charge its full total, which is
+      # the correct cap — unchanged from the pre-existing upgrade behavior.
+      expect(mandate_options[:payment_method_options][:card][:mandate_options][:amount]).to eq(525)
+    end
   end
 
   describe "#is_an_off_session_charge_on_indian_card?" do


### PR DESCRIPTION
## Context

Support ticket: buyers of vivekjoshi's yearly INR membership using promo code `flat80off` reported a "₹0 OTP" at checkout with an expected charge of ~$105.

**Investigation findings** (audited prod console + Stripe API, request IDs `20260705T230715Z-7179ce6d` through `20260705T233446Z-d5d3a1a5`):

- The discount and charge amounts are **correct** — the Jul 5 successful purchase charged exactly $105.33 (verified on the Stripe PaymentIntent). The ₹0 OTP is the RBI e-mandate registration step for recurring payments on Indian cards, not a mispriced charge.
- The **real defect**: the e-mandate is registered with `amount_type: maximum` sized to the *discounted first charge* ($105.33). For limited-duration discount codes, renewals after the discount expires charge the full undiscounted price — guaranteed to exceed the cap, so the off-session renewal fails and the buyer has to manually restart. Both affected buyers in the ticket were exactly this: year-2 renewal failures (purchases 335763855, 344883460) forcing manual restarts.

## Changes

- `Purchase#mandate_options_for_stripe` now sizes the mandate cap via a new `mandate_maximum_amount_cents`: when the purchase used a **limited-duration** discount code, the cap is scaled up by the pre-discount/discounted price ratio (covering the future full-price renewal); otherwise the charged total is kept as-is.
- The ratio-scaling approach reuses the charged total (which already includes tax) rather than re-deriving price + tax + FX — the mandate is an upper bound, so a proportional estimate is sufficient.

## Notes for review

- `flat80off` itself has `duration_in_billing_cycles: nil` (applies to every cycle), so **this specific seller's renewals keep the old cap** — their year-2 failures suggest the discount didn't apply to the renewal price at charge time despite the unlimited duration. Worth confirming during review whether renewal pricing honors the discount here; if it does, those failures were plain 3DS authentication failures and this fix simply hardens the general case.
- `Stripe::SetupIntentsController#mandate_options_for_stripe` (multi-buy cart path) has the same discounted-price-based cap and could use the same treatment in a follow-up; kept out of scope to keep this reviewable.

## Verification

- New spec (limited-duration case) **fails on main** (cap = 105, expects 525) and passes with the fix — failing-first proven by stash/restore.
- New spec (all-cycles discount) passes on both, guarding no-change behavior.
- Full `#mandate_options_for_stripe` describe block: 7 examples, 0 failures; adjacent `is_an_off_session_charge_on_indian_card?` + `create_setup_intent` specs: 12 examples, 0 failures; rubocop clean.

**Per request: no auto-merge — assigned for review.**