### PR TITLE
docs: add AI services to prohibited products list

### DIFF
--- a/app/views/help_center/articles/contents/_155-things-you-cant-sell-on-gumroad.html.erb
+++ b/app/views/help_center/articles/contents/_155-things-you-cant-sell-on-gumroad.html.erb
@@ -17,7 +17,7 @@
     <li>Reselling proprietary products - i.e. you are reselling ebooks, courses, prompts, notion planners, templates, video clips, fonts, and presets</li>
     <li>Reselling ebooks that you have reseller rights to (<strong>PLR or MRR products</strong>) </li>
     <li>Reselling software that you've purchased in the past, like Windows 10 license keys, etc. </li>
-    <li>AI services — selling access to AI tools, chatbots, or subscriptions to AI services fulfilled outside of Gumroad</li>
+    <li>AI services — selling access to AI tools, chatbots, image or content generation services, or subscriptions to AI services fulfilled outside of Gumroad</li>
     <li>Web hosting or servers</li>
     <li>Tickets to events or using Gumroad to process money for events you are hosting</li>
     <li>Physical products</li>

--- a/app/views/help_center/articles/contents/_155-things-you-cant-sell-on-gumroad.html.erb
+++ b/app/views/help_center/articles/contents/_155-things-you-cant-sell-on-gumroad.html.erb
@@ -17,6 +17,7 @@
     <li>Reselling proprietary products - i.e. you are reselling ebooks, courses, prompts, notion planners, templates, video clips, fonts, and presets</li>
     <li>Reselling ebooks that you have reseller rights to (<strong>PLR or MRR products</strong>) </li>
     <li>Reselling software that you've purchased in the past, like Windows 10 license keys, etc. </li>
+    <li>AI services — selling access to AI tools, chatbots, or subscriptions to AI services fulfilled outside of Gumroad</li>
     <li>Web hosting or servers</li>
     <li>Tickets to events or using Gumroad to process money for events you are hosting</li>
     <li>Physical products</li>

--- a/app/views/home/prohibited.html.erb
+++ b/app/views/home/prohibited.html.erb
@@ -1,12 +1,13 @@
 <%= render "home/shared/header",
   bg_color: "pink",
   title: "Prohibited Products and Activities",
-  description: "Last revised: April 17, 2019" %>
+  description: "Last revised: July 6, 2026" %>
 
 <div class="max-w-6xl px-8 lg:px-[4vw] py-12 md:py-20 mx-auto space-y-8 text-lg">
   <p>The following products and activities are not allowed on Gumroad. This is almost always because they violate U.S. federal law, they are prohibited by card network rules, or they are restricted by our payment processing partners. If you are unsure whether your content is prohibited on Gumroad, please contact us at support@gumroad.com with a description or example of the content.</p>
   <ol class="list-decimal my-10 mx-6 [&>li]:mb-1 [&>li]:leading-8">
     <li>age or legally restricted products or services</li>
+    <li>AI services which includes selling access to AI tools, chatbots, image or content generation services, or subscriptions to AI services that are fulfilled outside of Gumroad</li>
     <li>alcohol which includes alcohol or alcoholic beverages such as beer, liquor, wine, or champagne</li>
     <li>airlines</li>
     <li>bail bonds</li>


### PR DESCRIPTION
## What

Adds "AI services" to the prohibited products list in two places:

- `app/views/home/prohibited.html.erb` — the public [Prohibited Products and Activities](https://gumroad.com/prohibited) page (also bumps the last-revised date)
- `app/views/help_center/articles/contents/_155-things-you-cant-sell-on-gumroad.html.erb` — the "Things you can't sell on Gumroad" help center article

The new entry covers selling access to AI tools, chatbots, content generation services, or subscriptions to AI services fulfilled outside of Gumroad.

## Why

Selling externally fulfilled AI service subscriptions isn't allowed — these are zero-file products where the entire deliverable lives off-platform, which makes non-delivery invisible to Gumroad and drives buyer complaints and chargebacks. The policy pages didn't name AI services explicitly; this makes the prohibition unambiguous for suspension enforcement. Directed via gumroad-private#925.

## Before/After

Not a UI change — copy-only additions to two static policy lists. The diff is the full change.

## Test Results

Copy-only; no specs assert this page content. `grep` confirmed no specs reference the edited copy.

## AI Disclosure

Authored by Gumclaw (Claude) — wrote the copy additions and opened the PR. Autoreview skipped: no-logic copy change (exempt category).
