### PR TITLE
Block cross-seller access revocation

### DIFF
--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -32,7 +32,7 @@ class PurchasesController < ApplicationController
     update resend_receipt change_can_contact cancel_preorder_by_seller receipt
     revoke_access undo_revoke_access confirm_receipt_email
   ]
-  before_action :verify_current_seller_is_seller_for_purchase, only: %i[update change_can_contact cancel_preorder_by_seller]
+  before_action :verify_current_seller_is_seller_for_purchase, only: %i[update change_can_contact cancel_preorder_by_seller revoke_access undo_revoke_access]
   before_action :hide_layouts, only: %i[subscribe unsubscribe receipt confirm_receipt_email]
   before_action :set_noindex_header, only: [:receipt, :confirm_receipt_email]
 

--- a/spec/controllers/purchases_controller_spec.rb
+++ b/spec/controllers/purchases_controller_spec.rb
@@ -949,6 +949,16 @@ describe PurchasesController, :vcr do
         expect(purchase.reload.is_access_revoked).to eq(true)
         expect(response).to be_successful
       end
+
+      it "does not revoke access for another seller's purchase" do
+        other_seller = create(:user)
+        other_purchase = create(:purchase, link: create(:product, user: other_seller), seller: other_seller)
+
+        put :revoke_access, params: { id: other_purchase.external_id }, as: :json
+
+        expect(other_purchase.reload.is_access_revoked).to eq(false)
+        expect(response).to have_http_status(:not_found)
+      end
     end
 
     describe "PUT undo_revoke_access" do
@@ -966,6 +976,16 @@ describe PurchasesController, :vcr do
         put :undo_revoke_access, params: { id: purchase.external_id }, as: :json
         expect(purchase.reload.is_access_revoked).to eq(false)
         expect(response).to be_successful
+      end
+
+      it "does not restore access for another seller's purchase" do
+        other_seller = create(:user)
+        other_purchase = create(:purchase, link: create(:product, user: other_seller), seller: other_seller, is_access_revoked: true)
+
+        put :undo_revoke_access, params: { id: other_purchase.external_id }, as: :json
+
+        expect(other_purchase.reload.is_access_revoked).to eq(true)
+        expect(response).to have_http_status(:not_found)
       end
     end
   end


### PR DESCRIPTION
Fixes #5725

## Root cause

Confirmed. `PurchasesController#revoke_access` and `#undo_revoke_access` loaded `@purchase` from the external id and authorized with `Audience::PurchasePolicy`, but they were missing from the existing `verify_current_seller_is_seller_for_purchase` before_action. Other seller-side write actions already use that guard.

That meant a seller could send `PUT /purchases/:external_id/revoke_access` or `PUT /purchases/:external_id/undo_revoke_access` for another seller's purchase and get a successful mutation if they knew the external id.

## Fix

Add `revoke_access` and `undo_revoke_access` to the existing seller-ownership guard in `PurchasesController`.

## Verification

- Failing-first: added cross-seller specs before the controller change; both failed on current main because the other seller's purchase was mutated.
- After fix: focused controller + adjacent mobile API coverage passes:
  - `rspec spec/controllers/purchases_controller_spec.rb:935 spec/controllers/purchases_controller_spec.rb:964 spec/controllers/api/mobile/sales_controller_spec.rb:180` — 12 examples, 0 failures
- `rubocop app/controllers/purchases_controller.rb spec/controllers/purchases_controller_spec.rb --force-exclusion` — clean

Note: full `spec/controllers/purchases_controller_spec.rb` currently has 18 local failures in unrelated receipt-rendering examples; the seller-area revoke/restore block and adjacent mobile access-revoke specs are green.