### PR TITLE
Record client-confirm purchases in payment-flow analytics

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -48,7 +48,10 @@ class OrdersController < ApplicationController
 
   # Starts client-confirm Payment Element checkout by returning an unconfirmed PaymentIntent.
   def prepare
-    order_params = build_order_params
+    # The ConfirmationToken is deliberately absent from permitted_order_params: only this endpoint
+    # accepts it, so #create requests can never carry one. It is merged here so purchase creation
+    # can record the client-confirm lane in the purchase's payment-flow analytics row.
+    order_params = build_order_params.merge(confirmation_token: params[:confirmation_token].presence)
 
     order, purchase_responses, offer_codes = Order::CreateService.new(
       buyer: logged_in_user,

--- a/app/models/purchase_payment_flow.rb
+++ b/app/models/purchase_payment_flow.rb
@@ -9,6 +9,7 @@ class PurchasePaymentFlow < ApplicationRecord
   SAVED_PAYMENT_METHOD = "saved_payment_method"
 
   PAYMENT_METHOD = "payment_method"
+  CONFIRMATION_TOKEN = "confirmation_token"
 
   CARD = "card"
 
@@ -22,18 +23,25 @@ class PurchasePaymentFlow < ApplicationRecord
     saved_payment_method: SAVED_PAYMENT_METHOD,
   }, prefix: true, validate: true
 
-  enum :payment_details_transport, { payment_method: PAYMENT_METHOD }, prefix: true, validate: true
+  # The transport distinguishes the two checkout lanes, which is what rollout monitoring compares:
+  # the existing server-confirmed lane submits a PaymentMethod id (`payment_method`), while the
+  # client-confirmed Intent lane submits a ConfirmationToken (`confirmation_token`). The source
+  # alone cannot tell them apart — both lanes report `payment_element` when the buyer uses the
+  # Payment Element.
+  enum :payment_details_transport, { payment_method: PAYMENT_METHOD, confirmation_token: CONFIRMATION_TOKEN }, prefix: true, validate: true
 
   validates :stripe_payment_method_type, presence: true
 
   def self.attributes_for_checkout_params(params)
     source = payment_details_source_for(params)
     return if source.nil?
-    return unless stripe_payment_submission?(source, params)
+
+    transport = payment_details_transport_for(source, params)
+    return if transport.nil?
 
     {
       payment_details_source: source,
-      payment_details_transport: PAYMENT_METHOD,
+      payment_details_transport: transport,
       stripe_payment_method_type: CARD,
     }
   end
@@ -46,11 +54,18 @@ class PurchasePaymentFlow < ApplicationRecord
   end
   private_class_method :payment_details_source_for
 
-  def self.stripe_payment_submission?(source, params)
-    return false if NON_STRIPE_PAYMENT_PARAM_KEYS.any? { params[_1].present? }
-    return params[:stripe_payment_method_id].blank? if source == SAVED_PAYMENT_METHOD
+  # Derived from which payment params the server actually received, never from a client-supplied
+  # label. The `confirmation_token` param only exists on the client-confirm prepare endpoint
+  # (OrdersController#prepare threads it through; the server-confirm create endpoint never permits
+  # it), so its presence is a reliable lane signal.
+  def self.payment_details_transport_for(source, params)
+    return if NON_STRIPE_PAYMENT_PARAM_KEYS.any? { params[_1].present? }
+    return CONFIRMATION_TOKEN if params[:confirmation_token].present?
+    # A saved card sends no new payment details, so a submitted PaymentMethod id contradicts the
+    # claimed source and nothing is recorded.
+    return params[:stripe_payment_method_id].blank? ? PAYMENT_METHOD : nil if source == SAVED_PAYMENT_METHOD
 
-    STRIPE_PAYMENT_PARAM_KEYS.any? { params[_1].present? }
+    PAYMENT_METHOD if STRIPE_PAYMENT_PARAM_KEYS.any? { params[_1].present? }
   end
-  private_class_method :stripe_payment_submission?
+  private_class_method :payment_details_transport_for
 end

--- a/app/models/purchase_payment_flow.rb
+++ b/app/models/purchase_payment_flow.rb
@@ -60,10 +60,12 @@ class PurchasePaymentFlow < ApplicationRecord
   # it), so its presence is a reliable lane signal.
   def self.payment_details_transport_for(source, params)
     return if NON_STRIPE_PAYMENT_PARAM_KEYS.any? { params[_1].present? }
+    # A saved card sends no new payment details, so any submitted new-payment param (a PaymentMethod
+    # id or a ConfirmationToken) contradicts the claimed source and nothing is recorded. This guard
+    # must run before the confirmation_token branch below, or a saved-card request carrying a token
+    # would be misclassified as a client-confirm purchase.
+    return params[:stripe_payment_method_id].blank? && params[:confirmation_token].blank? ? PAYMENT_METHOD : nil if source == SAVED_PAYMENT_METHOD
     return CONFIRMATION_TOKEN if params[:confirmation_token].present?
-    # A saved card sends no new payment details, so a submitted PaymentMethod id contradicts the
-    # claimed source and nothing is recorded.
-    return params[:stripe_payment_method_id].blank? ? PAYMENT_METHOD : nil if source == SAVED_PAYMENT_METHOD
 
     PAYMENT_METHOD if STRIPE_PAYMENT_PARAM_KEYS.any? { params[_1].present? }
   end

--- a/app/services/order/create_service.rb
+++ b/app/services/order/create_service.rb
@@ -174,8 +174,11 @@ class Order::CreateService
 
       force_new_subscription = purchase_params.delete(:force_new_subscription)
       gift_params = purchase_params.extract!(:giftee_email, :giftee_id, :gift_note)
+      # confirmation_token is extracted alongside the other payment-surface hints so it reaches
+      # Purchase::CreateService as a service-level param (used to record the client-confirm lane in
+      # payment-flow analytics) instead of being treated as a Purchase attribute.
       additional_params = purchase_params.extract!(
-        :is_gift, :price_id, :wallet_type, :payment_details_source, :perceived_free_trial_duration, :accepted_offer,
+        :is_gift, :price_id, :wallet_type, :payment_details_source, :confirmation_token, :perceived_free_trial_duration, :accepted_offer,
         :cart_items, :variants, :bundle_products, :custom_fields, :tip_cents, :call_start_time,
         :pay_in_installments
       )

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -2483,6 +2483,17 @@ describe OrdersController, :vcr do
       expect(Event.purchase.where(purchase_id: Purchase.last.id)).to be_empty
     end
 
+    it "records the client-confirm lane in the purchase's payment-flow analytics row" do
+      post :prepare, params: { line_items:, confirmation_token: confirmation_token_id, payment_details_source: "payment_element" }.merge(common_params)
+
+      expect(response.parsed_body["success"]).to be(true)
+      flow = Purchase.last.purchase_payment_flow
+      expect(flow).to be_present
+      expect(flow.payment_details_source).to eq("payment_element")
+      expect(flow.payment_details_transport).to eq("confirmation_token")
+      expect(flow.stripe_payment_method_type).to eq("card")
+    end
+
     it "enforces reCAPTCHA before building the order or issuing a client_secret" do
       allow(CheckoutRecaptcha).to receive(:site_key).and_return("test-site-key")
       allow_any_instance_of(described_class).to receive(:valid_recaptcha_response_and_hostname?).and_return(false)

--- a/spec/models/purchase_payment_flow_spec.rb
+++ b/spec/models/purchase_payment_flow_spec.rb
@@ -90,5 +90,40 @@ describe PurchasePaymentFlow do
     it "does not record a saved-card flow when a new Stripe PaymentMethod is also submitted" do
       expect(described_class.attributes_for_checkout_params(payment_details_source: "saved_payment_method", stripe_payment_method_id: "pm_123")).to be_nil
     end
+
+    it "records the confirmation_token transport for a client-confirm submission" do
+      attributes = described_class.attributes_for_checkout_params(payment_details_source: "payment_element", confirmation_token: "ctoken_123")
+
+      expect(attributes).to eq(
+        payment_details_source: "payment_element",
+        payment_details_transport: "confirmation_token",
+        stripe_payment_method_type: "card"
+      )
+    end
+
+    it "records a client-confirm wallet payment as a payment request over the confirmation_token transport" do
+      attributes = described_class.attributes_for_checkout_params(
+        wallet_type: "apple_pay",
+        payment_details_source: "payment_element",
+        confirmation_token: "ctoken_123"
+      )
+
+      expect(attributes[:payment_details_source]).to eq("payment_request")
+      expect(attributes[:payment_details_transport]).to eq("confirmation_token")
+    end
+
+    it "prefers the confirmation_token transport when a PaymentMethod id is also present" do
+      attributes = described_class.attributes_for_checkout_params(
+        payment_details_source: "payment_element",
+        confirmation_token: "ctoken_123",
+        stripe_payment_method_id: "pm_123"
+      )
+
+      expect(attributes[:payment_details_transport]).to eq("confirmation_token")
+    end
+
+    it "does not record a Stripe flow for a PayPal submission carrying a forged confirmation_token" do
+      expect(described_class.attributes_for_checkout_params(payment_details_source: "payment_element", confirmation_token: "ctoken_123", paypal_order_id: "PAY-123")).to be_nil
+    end
   end
 end

--- a/spec/models/purchase_payment_flow_spec.rb
+++ b/spec/models/purchase_payment_flow_spec.rb
@@ -91,6 +91,10 @@ describe PurchasePaymentFlow do
       expect(described_class.attributes_for_checkout_params(payment_details_source: "saved_payment_method", stripe_payment_method_id: "pm_123")).to be_nil
     end
 
+    it "does not record a saved-card flow when a confirmation_token is also submitted, rather than misclassifying it as client-confirm" do
+      expect(described_class.attributes_for_checkout_params(payment_details_source: "saved_payment_method", confirmation_token: "ctoken_123")).to be_nil
+    end
+
     it "records the confirmation_token transport for a client-confirm submission" do
       attributes = described_class.attributes_for_checkout_params(payment_details_source: "payment_element", confirmation_token: "ctoken_123")
 

--- a/spec/services/order/create_service_spec.rb
+++ b/spec/services/order/create_service_spec.rb
@@ -149,6 +149,20 @@ describe Order::CreateService, :vcr do
         expect(order.reload.purchases.map { _1.purchase_payment_flow.payment_details_source }.uniq).to eq(["card_element"])
       end
 
+      it "records the confirmation_token transport for a client-confirm submission" do
+        params[:payment_details_source] = "payment_element"
+        params[:confirmation_token] = "ctoken_123"
+
+        order, _ = Order::CreateService.new(params:).perform
+
+        flows = order.reload.purchases.map(&:purchase_payment_flow)
+        expect(flows.size).to eq(5)
+        expect(flows).to all(be_present)
+        expect(flows.map(&:payment_details_source).uniq).to eq(["payment_element"])
+        expect(flows.map(&:payment_details_transport).uniq).to eq(["confirmation_token"])
+        expect(flows.map(&:stripe_payment_method_type).uniq).to eq(["card"])
+      end
+
       it "records a wallet payment as a payment request" do
         params[:wallet_type] = "apple_pay"
         params[:payment_details_source] = "payment_element"

--- a/spec/support/fixtures/vcr_cassettes/OrdersController/POST_prepare/records_the_client-confirm_lane_in_the_purchase_s_payment-flow_analytics_row.yml
+++ b/spec/support/fixtures/vcr_cassettes/OrdersController/POST_prepare/records_the_client-confirm_lane_in_the_purchase_s_payment-flow_analytics_row.yml
@@ -1,0 +1,464 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/test_helpers/confirmation_tokens
+    body:
+      encoding: UTF-8
+      string: payment_method=pm_card_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Idempotency-Key:
+      - 158c5a3d-2eac-4947-9bfa-17570050f080
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        KMBP.local 24.6.0 Darwin Kernel Version 24.6.0: Mon Jan 19 21:56:28 PST 2026;
+        root:xnu-11417.140.69.708.3~1/RELEASE_ARM64_T6020 arm64","hostname":"KMBP.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 30 Jun 2026 22:16:17 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1430'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=GxkqqZzGQBiVq0HqgSgwy8mV3SLXiiD1RFgOiB2HEgsHQeXgObLuqQCB8b02UnDhcwiitgYARZ1Q1lRZ;
+        report-to csp
+      Idempotency-Key:
+      - 158c5a3d-2eac-4947-9bfa-17570050f080
+      Original-Request:
+      - req_bHA3rXnjRVHp3x
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=GxkqqZzGQBiVq0HqgSgwy8mV3SLXiiD1RFgOiB2HEgsHQeXgObLuqQCB8b02UnDhcwiitgYARZ1Q1lRZ&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=GxkqqZzGQBiVq0HqgSgwy8mV3SLXiiD1RFgOiB2HEgsHQeXgObLuqQCB8b02UnDhcwiitgYARZ1Q1lRZ&t=1"
+      Request-Id:
+      - req_bHA3rXnjRVHp3x
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ctoken_1To9wzIBOqvOFDrfmMhiRDWm",
+          "object": "confirmation_token",
+          "created": 1782857777,
+          "expires_at": 1782900977,
+          "livemode": false,
+          "mandate_data": null,
+          "payment_intent": null,
+          "payment_method_options": null,
+          "payment_method_preview": {
+            "allow_redisplay": "unspecified",
+            "billing_details": {
+              "address": {
+                "city": null,
+                "country": null,
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "email": null,
+              "name": null,
+              "phone": null,
+              "tax_id": null
+            },
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "unchecked"
+              },
+              "country": "US",
+              "display_brand": "visa",
+              "exp_month": 6,
+              "exp_year": 2027,
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "generated_from": null,
+              "last4": "4242",
+              "networks": {
+                "available": [
+                  "visa"
+                ],
+                "preferred": null
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure_usage": {
+                "supported": true
+              },
+              "wallet": null
+            },
+            "customer": null,
+            "customer_account": null,
+            "type": "card"
+          },
+          "return_url": null,
+          "setup_future_usage": null,
+          "setup_intent": null,
+          "shipping": null,
+          "use_stripe_sdk": true
+        }
+  recorded_at: Tue, 30 Jun 2026 22:16:17 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/confirmation_tokens/ctoken_1To9wzIBOqvOFDrfmMhiRDWm
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_bHA3rXnjRVHp3x","request_duration_ms":314,"usage":["raw_request"]}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        KMBP.local 24.6.0 Darwin Kernel Version 24.6.0: Mon Jan 19 21:56:28 PST 2026;
+        root:xnu-11417.140.69.708.3~1/RELEASE_ARM64_T6020 arm64","hostname":"KMBP.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 30 Jun 2026 22:16:17 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1430'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=pFDRLjLzVEfGWjvHAahSbXHrcIQK1-IUMWXZtCScSI4gB-VkHXXhmGQJKNmLhi7ueanS2Zbs6y9oTnCW;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=pFDRLjLzVEfGWjvHAahSbXHrcIQK1-IUMWXZtCScSI4gB-VkHXXhmGQJKNmLhi7ueanS2Zbs6y9oTnCW&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=pFDRLjLzVEfGWjvHAahSbXHrcIQK1-IUMWXZtCScSI4gB-VkHXXhmGQJKNmLhi7ueanS2Zbs6y9oTnCW&t=1"
+      Request-Id:
+      - req_J5gdZyaNQKQCaD
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ctoken_1To9wzIBOqvOFDrfmMhiRDWm",
+          "object": "confirmation_token",
+          "created": 1782857777,
+          "expires_at": 1782900977,
+          "livemode": false,
+          "mandate_data": null,
+          "payment_intent": null,
+          "payment_method_options": null,
+          "payment_method_preview": {
+            "allow_redisplay": "unspecified",
+            "billing_details": {
+              "address": {
+                "city": null,
+                "country": null,
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "email": null,
+              "name": null,
+              "phone": null,
+              "tax_id": null
+            },
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "unchecked"
+              },
+              "country": "US",
+              "display_brand": "visa",
+              "exp_month": 6,
+              "exp_year": 2027,
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "generated_from": null,
+              "last4": "4242",
+              "networks": {
+                "available": [
+                  "visa"
+                ],
+                "preferred": null
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure_usage": {
+                "supported": true
+              },
+              "wallet": null
+            },
+            "customer": null,
+            "customer_account": null,
+            "type": "card"
+          },
+          "return_url": null,
+          "setup_future_usage": null,
+          "setup_intent": null,
+          "shipping": null,
+          "use_stripe_sdk": true
+        }
+  recorded_at: Tue, 30 Jun 2026 22:16:17 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=1000&currency=usd&description=Gumroad+Charge+Dpy_wNcsAa0jANXMy2eF3w%3D%3D&metadata[purchase]=CH-Dpy_wNcsAa0jANXMy2eF3w%3D%3D&automatic_payment_methods[enabled]=true&automatic_payment_methods[allow_redirects]=never&transfer_group=CH-3&statement_descriptor_suffix=edgarf81030861
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_J5gdZyaNQKQCaD","request_duration_ms":198}}'
+      Idempotency-Key:
+      - deferred_intent_Dpy_wNcsAa0jANXMy2eF3w==
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        KMBP.local 24.6.0 Darwin Kernel Version 24.6.0: Mon Jan 19 21:56:28 PST 2026;
+        root:xnu-11417.140.69.708.3~1/RELEASE_ARM64_T6020 arm64","hostname":"KMBP.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 30 Jun 2026 22:16:18 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1762'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=pFDRLjLzVEfGWjvHAahSbXHrcIQK1-IUMWXZtCScSI4gB-VkHXXhmGQJKNmLhi7ueanS2Zbs6y9oTnCW;
+        report-to csp
+      Idempotency-Key:
+      - deferred_intent_Dpy_wNcsAa0jANXMy2eF3w==
+      Original-Request:
+      - req_AErRHxkb0yWKPh
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=pFDRLjLzVEfGWjvHAahSbXHrcIQK1-IUMWXZtCScSI4gB-VkHXXhmGQJKNmLhi7ueanS2Zbs6y9oTnCW&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=pFDRLjLzVEfGWjvHAahSbXHrcIQK1-IUMWXZtCScSI4gB-VkHXXhmGQJKNmLhi7ueanS2Zbs6y9oTnCW&t=1"
+      Request-Id:
+      - req_AErRHxkb0yWKPh
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3To9x0IBOqvOFDrf1XxFMdYJ",
+          "object": "payment_intent",
+          "amount": 1000,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 0,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": {
+            "allow_redirects": "never",
+            "enabled": true
+          },
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3To9x0IBOqvOFDrf1XxFMdYJ_secret_A5P4VKzWZyoBXPXrtwXDBHVni",
+          "confirmation_method": "automatic",
+          "created": 1782857778,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "Gumroad Charge Dpy_wNcsAa0jANXMy2eF3w==",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": null,
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "CH-Dpy_wNcsAa0jANXMy2eF3w=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": null,
+          "payment_method_configuration_details": {
+            "id": "pmc_1SNEhPIBOqvOFDrf4FaJwgdM",
+            "parent": null
+          },
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            },
+            "link": {
+              "persistent_token": null
+            }
+          },
+          "payment_method_types": [
+            "card",
+            "link"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgarf81030861",
+          "status": "requires_payment_method",
+          "transfer_data": null,
+          "transfer_group": "CH-3"
+        }
+  recorded_at: Tue, 30 Jun 2026 22:16:18 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## What

Records `purchase_payment_flows` analytics rows for purchases made through the client-confirmed Intent path (#5640). Client-confirm submissions carry a `confirmation_token` instead of the PaymentMethod params the recording guard looked for, so Lane B purchases were silently skipped.

Changes:

- `payment_details_transport` gains the `confirmation_token` value that #5618 reserved. Transport is now derived server-side from which payment param actually arrived: `stripe_payment_method_id` (and friends) → `payment_method`; `confirmation_token` → `confirmation_token`. Still never trusted from the client — `confirmation_token` is only accepted by the `#prepare` endpoint (it is deliberately absent from `permitted_order_params`, so `#create` requests can never carry one).
- `OrdersController#prepare` merges the token into the order params, and `Order::CreateService` extracts it as a service-level param (alongside `payment_details_source` / `wallet_type`) so it reaches `Purchase::CreateService` without being treated as a Purchase attribute.
- Non-Stripe submissions (PayPal/Braintree) still record nothing, even with a forged token param.

## Why

`purchase_payment_flows` (#5618) exists to compare checkout surfaces during the Stripe Payment Element rollout, and `payment_details_source` alone cannot distinguish the server-confirmed Payment Element lane from the client-confirmed one — both report `payment_element`. The transport is that discriminator, but without this change every client-confirm purchase records no row at all, leaving the rollout's monitoring blind on exactly the cohort it needs to measure. With this fix:

| Lane | `payment_details_source` | `payment_details_transport` |
|---|---|---|
| Server-confirm, CardElement | `card_element` | `payment_method` |
| Server-confirm, Payment Element | `payment_element` | `payment_method` |
| Client-confirm (#5640) | `payment_element` | `confirmation_token` |

Joining the flow row against `purchases.purchase_state` then gives per-lane conversion/failure rates, and (because the row is written at `#prepare`) post-prepare abandonment for the client-confirm lane. Managed-by-Gumroad vs. connected-Stripe-account comparisons need no new column — `purchases.merchant_account_id` already records that on both lanes.

No schema change: the enum values are strings in the existing `payment_details_transport` column.

Refs #5640.

autoreview: clean (Codex/gpt-5.5, branch mode vs origin/main — no accepted/actionable findings)

## Test plan

- `spec/models/purchase_payment_flow_spec.rb` — confirmation_token transport attributes, wallet + token combination, token preferred over a simultaneous PaymentMethod id, forged token on a PayPal submission records nothing.
- `spec/services/order/create_service_spec.rb` — client-confirm submission records the flow row with `confirmation_token` transport on every purchase in the order.
- `spec/controllers/orders_controller_spec.rb` (`POST prepare`) — end-to-end: a prepare request with a real ConfirmationToken records the client-confirm lane on the created purchase.
- All existing Lane A recording specs unchanged and green (45 examples model+service, `POST prepare` suite green, RuboCop clean on touched files).

No UI changes — server-side analytics recording only; checkout behavior and responses are unchanged.
