### PR TITLE
Give buyers actionable guidance when checkout CAPTCHA fails or is blocked

### DIFF
--- a/app/controllers/concerns/validate_recaptcha.rb
+++ b/app/controllers/concerns/validate_recaptcha.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 
 module ValidateRecaptcha
+  # Buyer/user-facing message for a failed CAPTCHA verification. Names the most common
+  # self-fixable causes (ad blockers / privacy extensions blocking the reCAPTCHA script)
+  # so people aren't stranded with "try again" that never works — the only way they used
+  # to discover the cause was emailing support (gumroad-private#927). Kept in sync with
+  # RECAPTCHA_UNAVAILABLE_MESSAGE in app/javascript/components/useRecaptcha.tsx.
+  CAPTCHA_FAILURE_MESSAGE = "Sorry, we could not verify the CAPTCHA. This can be caused by ad blockers, " \
+    "privacy extensions, or VPNs — try disabling them for this page or using a " \
+    "private/incognito window, then try again."
+
   ENTERPRISE_VERIFICATION_URL =
     "https://recaptchaenterprise.googleapis.com/v1/projects/#{GOOGLE_CLOUD_PROJECT_ID}/" \
     "assessments?key=#{GlobalConfig.get("ENTERPRISE_RECAPTCHA_API_KEY")}"

--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -32,7 +32,7 @@ class LoginsController < Devise::SessionsController
     unless Feature.active?(:disable_login_recaptcha)
       site_key = GlobalConfig.get("RECAPTCHA_LOGIN_SITE_KEY")
       if !(Rails.env.development? && site_key.blank?) && !valid_recaptcha_response?(site_key: site_key, surface: :login)
-        return redirect_with_login_error("Sorry, we could not verify the CAPTCHA. Please try again.")
+        return redirect_with_login_error(ValidateRecaptcha::CAPTCHA_FAILURE_MESSAGE)
       end
     end
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -114,7 +114,7 @@ class OrdersController < ApplicationController
 
       # Verify reCAPTCHA response
       if !skip_recaptcha? && !valid_recaptcha_response_and_hostname?(site_key: CheckoutRecaptcha.site_key(logged_in_user), surface: CheckoutRecaptcha.surface(logged_in_user))
-        render_error("Sorry, we could not verify the CAPTCHA. Please try again.")
+        render_error(ValidateRecaptcha::CAPTCHA_FAILURE_MESSAGE)
       end
     end
 

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -362,7 +362,7 @@ class PurchasesController < ApplicationController
 
       # Verify reCAPTCHA response
       unless skip_recaptcha?
-        render_error("Sorry, we could not verify the CAPTCHA. Please try again.") unless valid_recaptcha_response_and_hostname?(site_key: GlobalConfig.get("RECAPTCHA_MONEY_SITE_KEY"))
+        render_error(ValidateRecaptcha::CAPTCHA_FAILURE_MESSAGE) unless valid_recaptcha_response_and_hostname?(site_key: GlobalConfig.get("RECAPTCHA_MONEY_SITE_KEY"))
       end
     end
 

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -132,8 +132,8 @@ class SignupController < Devise::RegistrationsController
         site_key = GlobalConfig.get("RECAPTCHA_SIGNUP_SITE_KEY")
         if !(Rails.env.development? && site_key.blank?) && !valid_recaptcha_response?(site_key: site_key, surface: :signup)
           respond_to do |format|
-            format.html { redirect_with_signup_error("Sorry, we could not verify the CAPTCHA. Please try again.") }
-            format.json { render json: { success: false, error_message: "Sorry, we could not verify the CAPTCHA. Please try again." } }
+            format.html { redirect_with_signup_error(ValidateRecaptcha::CAPTCHA_FAILURE_MESSAGE) }
+            format.json { render json: { success: false, error_message: ValidateRecaptcha::CAPTCHA_FAILURE_MESSAGE } }
           end
           return
         end

--- a/app/javascript/components/Checkout/PaymentForm.tsx
+++ b/app/javascript/components/Checkout/PaymentForm.tsx
@@ -71,7 +71,12 @@ import { Radio } from "$app/components/ui/Radio";
 import { Select } from "$app/components/ui/Select";
 import { useIsDarkTheme } from "$app/components/useIsDarkTheme";
 import { useOnChangeSync } from "$app/components/useOnChange";
-import { RecaptchaCancelledError, useRecaptcha } from "$app/components/useRecaptcha";
+import {
+  RECAPTCHA_UNAVAILABLE_MESSAGE,
+  RecaptchaCancelledError,
+  RecaptchaUnavailableError,
+  useRecaptcha,
+} from "$app/components/useRecaptcha";
 import { useRefToLatest } from "$app/components/useRefToLatest";
 import { useRunOnce } from "$app/components/useRunOnce";
 
@@ -1380,7 +1385,14 @@ export const PaymentForm = ({
           .execute()
           .then((recaptchaResponse) => dispatch({ type: "set-recaptcha-response", recaptchaResponse }))
           .catch((e: unknown) => {
-            assert(e instanceof RecaptchaCancelledError);
+            // The security check being unloadable (ad blocker / privacy extension / restricted
+            // network) is fixable by the buyer, but only if we say so — a silent reset here
+            // strands them with no way to complete checkout (see gumroad-private#927).
+            if (e instanceof RecaptchaUnavailableError) {
+              showAlert(RECAPTCHA_UNAVAILABLE_MESSAGE, "error");
+            } else {
+              assert(e instanceof RecaptchaCancelledError);
+            }
             dispatch({ type: "cancel" });
           });
       }

--- a/app/javascript/components/useRecaptcha.tsx
+++ b/app/javascript/components/useRecaptcha.tsx
@@ -92,6 +92,10 @@ export function useRecaptcha({
   const containerRef = React.useRef<HTMLDivElement | null>(null);
   const recaptchaId = React.useRef<number | null>(null);
   const resolveRef = React.useRef<((response: string) => void) | null>(null);
+  // Tracks the script-load + widget-render sequence so execute() can wait for it. Without
+  // this, a submit that happens before initialization finishes would see a missing widget
+  // and wrongly report the CAPTCHA as unavailable (blocked), when it was simply still loading.
+  const initPromiseRef = React.useRef<Promise<void> | null>(null);
 
   React.useEffect(() => {
     if (!siteKey) return;
@@ -104,23 +108,28 @@ export function useRecaptcha({
       return;
     }
 
-    const initRecaptcha = () => {
-      grecaptcha.enterprise.ready(() => {
-        if (!containerRef.current || containerRef.current.childElementCount) return;
-        recaptchaId.current = grecaptcha.enterprise.render(containerRef.current, {
-          sitekey: siteKey,
-          callback: (response) => {
-            resolveRef.current?.(response);
-            resolveRef.current = null;
-          },
-          size: "invisible",
+    const initRecaptcha = () =>
+      new Promise<void>((resolve) => {
+        grecaptcha.enterprise.ready(() => {
+          if (containerRef.current && !containerRef.current.childElementCount) {
+            recaptchaId.current = grecaptcha.enterprise.render(containerRef.current, {
+              sitekey: siteKey,
+              callback: (response) => {
+                resolveRef.current?.(response);
+                resolveRef.current = null;
+              },
+              size: "invisible",
+            });
+          }
+          resolve();
         });
       });
-    };
 
-    loadRecaptchaScript(CHALLENGE_SCRIPT_URL)
-      .then(initRecaptcha)
-      .catch(() => {});
+    const initPromise = loadRecaptchaScript(CHALLENGE_SCRIPT_URL).then(initRecaptcha);
+    initPromiseRef.current = initPromise;
+    // Swallow the rejection here so a blocked script doesn't surface as an unhandled promise
+    // rejection — execute() re-checks the stored promise and reports the failure to the user.
+    initPromise.catch(() => {});
   }, [siteKey, scoreBased]);
 
   const execute = () => {
@@ -147,22 +156,34 @@ export function useRecaptcha({
         );
     }
 
-    const widgetId = recaptchaId.current;
-    // A null widget means the reCAPTCHA script never loaded (typically blocked by an ad
-    // blocker / privacy extension), so the challenge can never run — distinct from the user
-    // dismissing a rendered challenge.
-    if (widgetId === null) return Promise.reject(new RecaptchaUnavailableError());
-    grecaptcha.enterprise.reset(widgetId);
-    void grecaptcha.enterprise.execute(widgetId);
-    // This promise should always complete if recaptcha works correctly, but it's not guaranteed to (e.g.
-    // if recaptcha's DOM structure ever changes, or if there's an error during their processing).
-    return new Promise<string>((resolve, reject) => {
-      listenForRecaptchaCancel(widgetId, () => {
-        reject(new RecaptchaCancelledError());
-        resolveRef.current = null;
+    // Wait for initialization to finish before checking the widget: a submit that lands
+    // before the script has loaded and rendered the widget is a normal timing race, not a
+    // blocked CAPTCHA, so we must not report it as unavailable prematurely.
+    const initPromise = initPromiseRef.current ?? Promise.reject(new Error("reCAPTCHA was never initialized"));
+    return initPromise
+      .catch(() => {
+        // The script failing to load is environmental (blocked by an extension or the
+        // network), not a user dismissal — surface it as such so the UI can show guidance.
+        throw new RecaptchaUnavailableError();
+      })
+      .then(() => {
+        const widgetId = recaptchaId.current;
+        // Initialization finished but no widget exists — the reCAPTCHA script loaded without
+        // producing a usable challenge (or its container never mounted), so the challenge can
+        // never run. Distinct from the user dismissing a rendered challenge.
+        if (widgetId === null) throw new RecaptchaUnavailableError();
+        grecaptcha.enterprise.reset(widgetId);
+        void grecaptcha.enterprise.execute(widgetId);
+        // This promise should always complete if recaptcha works correctly, but it's not guaranteed to (e.g.
+        // if recaptcha's DOM structure ever changes, or if there's an error during their processing).
+        return new Promise<string>((resolve, reject) => {
+          listenForRecaptchaCancel(widgetId, () => {
+            reject(new RecaptchaCancelledError());
+            resolveRef.current = null;
+          });
+          resolveRef.current = resolve;
+        });
       });
-      resolveRef.current = resolve;
-    });
   };
 
   return {

--- a/app/javascript/components/useRecaptcha.tsx
+++ b/app/javascript/components/useRecaptcha.tsx
@@ -2,6 +2,20 @@ import * as React from "react";
 
 export class RecaptchaCancelledError extends Error {}
 
+// Thrown when reCAPTCHA itself never produced a token for a reason that was NOT the user
+// dismissing a challenge — most commonly the Google script being blocked by an ad blocker /
+// privacy extension, or failing to load on a restricted network. Callers should surface
+// actionable guidance for this case instead of failing silently: the buyer can fix it
+// themselves (disable the extension for this page, use a private window, or switch networks),
+// but only if we tell them.
+export class RecaptchaUnavailableError extends Error {}
+
+// The buyer-facing guidance for RecaptchaUnavailableError. Shared so every checkout surface
+// shows the same message. Kept in sync with the server-side CAPTCHA failure message in
+// OrdersController / PurchasesController.
+export const RECAPTCHA_UNAVAILABLE_MESSAGE =
+  "We couldn't load the security check. This is often caused by an ad blocker or privacy extension — try disabling it for this page, using a private/incognito window, or switching networks, then try again.";
+
 const SCRIPT_BASE_URL = "https://www.google.com/recaptcha/enterprise.js";
 const CHALLENGE_SCRIPT_URL = `${SCRIPT_BASE_URL}?render=explicit`;
 const scoreScriptUrl = (siteKey: string) => `${SCRIPT_BASE_URL}?render=${encodeURIComponent(siteKey)}`;
@@ -113,27 +127,31 @@ export function useRecaptcha({
     if (!siteKey) return Promise.reject(new RecaptchaCancelledError());
 
     if (scoreBased) {
-      return (
-        loadRecaptchaScript(scoreScriptUrl(siteKey))
-          .then(
-            () =>
-              new Promise<string>((resolve, reject) => {
-                grecaptcha.enterprise.ready(() => {
-                  grecaptcha.enterprise.execute(siteKey, { action }).then(resolve, () => {
-                    reject(new RecaptchaCancelledError());
-                  });
+      return loadRecaptchaScript(scoreScriptUrl(siteKey))
+        .catch(() => {
+          // The script failing to load is environmental (blocked by an extension or the
+          // network), not a user dismissal — surface it as such so the UI can show guidance.
+          throw new RecaptchaUnavailableError();
+        })
+        .then(
+          () =>
+            new Promise<string>((resolve, reject) => {
+              grecaptcha.enterprise.ready(() => {
+                grecaptcha.enterprise.execute(siteKey, { action }).then(resolve, () => {
+                  // Score keys never show a challenge, so there is nothing for the user to
+                  // dismiss — a token failure here is also environmental.
+                  reject(new RecaptchaUnavailableError());
                 });
-              }),
-          )
-          // Normalize any pre-token failure (e.g. the script being blocked or
-          // failing to load) to RecaptchaCancelledError so callers can treat it
-          // like a dismissed challenge and reset, rather than hanging.
-          .catch(() => Promise.reject(new RecaptchaCancelledError()))
-      );
+              });
+            }),
+        );
     }
 
     const widgetId = recaptchaId.current;
-    if (widgetId === null) return Promise.reject(new RecaptchaCancelledError());
+    // A null widget means the reCAPTCHA script never loaded (typically blocked by an ad
+    // blocker / privacy extension), so the challenge can never run — distinct from the user
+    // dismissing a rendered challenge.
+    if (widgetId === null) return Promise.reject(new RecaptchaUnavailableError());
     grecaptcha.enterprise.reset(widgetId);
     void grecaptcha.enterprise.execute(widgetId);
     // This promise should always complete if recaptcha works correctly, but it's not guaranteed to (e.g.

--- a/app/javascript/pages/Logins/New.tsx
+++ b/app/javascript/pages/Logins/New.tsx
@@ -17,12 +17,18 @@ import { SocialAuth } from "$app/components/Authentication/SocialAuth";
 import { Button } from "$app/components/Button";
 import { PasswordInput } from "$app/components/PasswordInput";
 import { Separator } from "$app/components/Separator";
+import { showAlert } from "$app/components/server-components/Alert";
 import { Alert } from "$app/components/ui/Alert";
 import { Fieldset, FieldsetTitle } from "$app/components/ui/Fieldset";
 import { Input } from "$app/components/ui/Input";
 import { Label } from "$app/components/ui/Label";
 import { useOriginalLocation } from "$app/components/useOriginalLocation";
-import { RecaptchaCancelledError, useRecaptcha } from "$app/components/useRecaptcha";
+import {
+  RECAPTCHA_UNAVAILABLE_MESSAGE,
+  RecaptchaCancelledError,
+  RecaptchaUnavailableError,
+  useRecaptcha,
+} from "$app/components/useRecaptcha";
 
 const PASSKEY_ERROR = "We couldn't sign you in with that passkey. Please try again or use your password.";
 
@@ -90,6 +96,12 @@ function LoginPage() {
       form.post(Routes.login_path());
     } catch (e) {
       if (e instanceof RecaptchaCancelledError) return;
+      // The reCAPTCHA script being blocked (ad blocker / privacy extension) is fixable by the
+      // user — tell them how instead of failing silently (see gumroad-private#927).
+      if (e instanceof RecaptchaUnavailableError) {
+        showAlert(RECAPTCHA_UNAVAILABLE_MESSAGE, "error");
+        return;
+      }
       throw e;
     }
   };

--- a/app/javascript/pages/Signup/New.tsx
+++ b/app/javascript/pages/Signup/New.tsx
@@ -9,11 +9,17 @@ import { SocialAuth } from "$app/components/Authentication/SocialAuth";
 import { Button } from "$app/components/Button";
 import { PasswordInput } from "$app/components/PasswordInput";
 import { Separator } from "$app/components/Separator";
+import { showAlert } from "$app/components/server-components/Alert";
 import { Fieldset, FieldsetTitle } from "$app/components/ui/Fieldset";
 import { Input } from "$app/components/ui/Input";
 import { Label } from "$app/components/ui/Label";
 import { useOriginalLocation } from "$app/components/useOriginalLocation";
-import { RecaptchaCancelledError, useRecaptcha } from "$app/components/useRecaptcha";
+import {
+  RECAPTCHA_UNAVAILABLE_MESSAGE,
+  RecaptchaCancelledError,
+  RecaptchaUnavailableError,
+  useRecaptcha,
+} from "$app/components/useRecaptcha";
 
 type PageProps = {
   email: string | null;
@@ -69,6 +75,12 @@ function SignupPage() {
       form.post(Routes.signup_path());
     } catch (e) {
       if (e instanceof RecaptchaCancelledError) return;
+      // The reCAPTCHA script being blocked (ad blocker / privacy extension) is fixable by the
+      // user — tell them how instead of failing silently (see gumroad-private#927).
+      if (e instanceof RecaptchaUnavailableError) {
+        showAlert(RECAPTCHA_UNAVAILABLE_MESSAGE, "error");
+        return;
+      }
       throw e;
     }
   };

--- a/spec/controllers/logins_controller_spec.rb
+++ b/spec/controllers/logins_controller_spec.rb
@@ -275,7 +275,7 @@ describe LoginsController, type: :controller, inertia: true do
       post :create, params: { user: { login_identifier: @user.email, password: "password" } }
 
       expect(response).to redirect_to(login_path)
-      expect(flash[:warning]).to eq "Sorry, we could not verify the CAPTCHA. Please try again."
+      expect(flash[:warning]).to eq ValidateRecaptcha::CAPTCHA_FAILURE_MESSAGE
       expect(controller.user_signed_in?).to be(false)
     end
 

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -1088,7 +1088,7 @@ describe OrdersController, :vcr do
 
         expect(response).to be_successful
         expect(response.parsed_body["success"]).to eq false
-        expect(response.parsed_body["error_message"]).to eq "Sorry, we could not verify the CAPTCHA. Please try again."
+        expect(response.parsed_body["error_message"]).to eq ValidateRecaptcha::CAPTCHA_FAILURE_MESSAGE
         expect(response.parsed_body["can_buyer_sign_up"]).to be_nil
       end
 

--- a/spec/controllers/purchases_controller_spec.rb
+++ b/spec/controllers/purchases_controller_spec.rb
@@ -1382,7 +1382,7 @@ describe PurchasesController, :vcr do
 
           expect(response).to be_successful
           expect(response.parsed_body["success"]).to eq false
-          expect(response.parsed_body["error_message"]).to eq "Sorry, we could not verify the CAPTCHA. Please try again."
+          expect(response.parsed_body["error_message"]).to eq ValidateRecaptcha::CAPTCHA_FAILURE_MESSAGE
         end
       end
     end


### PR DESCRIPTION
## What

Buyers whose ad blocker / privacy extension blocks reCAPTCHA were stranded at checkout with no way forward (internal ref: gumroad-private#927). Two dead ends, both fixed:

1. **Client — blocked script = silent form reset.** `useRecaptcha` normalized *every* pre-token failure (script blocked / failed to load, score-key token failure, widget never initialized) into `RecaptchaCancelledError`, the same error as a user dismissing the challenge — so `PaymentForm`/login/signup silently reset with no message at all. For a buyer with uBlock/Ghostery/etc., the pay button just… did nothing, forever.
2. **Server — "Please try again" that never works.** When token verification failed server-side, all four surfaces said `Sorry, we could not verify the CAPTCHA. Please try again.` — retrying can't fix an extension blocking the script.

## How

**Client** (`useRecaptcha.tsx`): new `RecaptchaUnavailableError` for environmental failures, kept distinct from `RecaptchaCancelledError` (genuine challenge dismissals still reset silently — correct UX). Shared `RECAPTCHA_UNAVAILABLE_MESSAGE` shown via `showAlert` in all three callers (checkout `PaymentForm`, `Logins/New`, `Signup/New`):

> We couldn't load the security check. This is often caused by an ad blocker or privacy extension — try disabling it for this page, using a private/incognito window, or switching networks, then try again.

**Server** (`ValidateRecaptcha::CAPTCHA_FAILURE_MESSAGE`, used by orders/purchases/logins/signup controllers):

> Sorry, we could not verify the CAPTCHA. This can be caused by ad blockers, privacy extensions, or VPNs — try disabling them for this page or using a private/incognito window, then try again.

## Not in scope (issue's suggestion 2)

Making the CAPTCHA less sensitive to privacy extensions is already structurally underway via the `recaptcha_score_checkout` cohort (score-based keys never render an interactive challenge; trusted buyers get a 0.3 threshold). Widening that cohort is a rollout decision, not a code change — noted on the internal issue.

## Verification

- `tsc --noEmit`: no errors in touched files
- `eslint`: error set on touched files identical to main (pre-existing `Routes`-typing noise only); import order fixed
- `rubocop` on 5 touched Ruby files: 0 offenses
- Controller specs asserting the message (now via the shared constant):
  - `logins_controller_spec -e CAPTCHA`: 6 examples, 0 failures
  - `orders_controller_spec -e CAPTCHA -e recaptcha`: 9 examples, 0 failures
  - `purchases_controller_spec -e CAPTCHA -e recaptcha`: 4 examples, 0 failures
