### PR TITLE
Guard PayPal refund webhook against multi-item cart misattribution

### DIFF
--- a/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
@@ -124,15 +124,54 @@ class PaypalChargeProcessor
     usd_amount_cents = get_usd_cents(refund_currency.downcase, (refunded_amount.to_f * unit_scaling_factor(refund_currency)).to_i)
 
     refund_purchase(capture_id:, usd_amount_cents:,
-                    processor_refund: OpenStruct.new({ id: refund_id, status: event_info["resource"]["status"] }))
+                    processor_refund: OpenStruct.new({ id: refund_id, status: event_info["resource"]["status"] }),
+                    skip_if_capture_shared: true)
   end
   private_class_method :handle_payment_capture_refunded_event
 
-  def self.refund_purchase(capture_id:, usd_amount_cents: nil, processor_refund: nil)
+  def self.refund_purchase(capture_id:, usd_amount_cents: nil, processor_refund: nil, skip_if_capture_shared: false)
     raise ArgumentError, "No paypal transaction id found in refund webhook" if capture_id.blank?
 
     purchase = Purchase.find_by(stripe_transaction_id: capture_id)
     return unless purchase&.successful?
+
+    # A single PayPal capture can back multiple Purchase rows (a multi-item cart from one seller
+    # is charged as one capture). Looking a purchase up by the capture id alone finds only ONE of
+    # those rows, so blindly recording the capture's refund against it can mark the wrong item
+    # refunded. Real incident: a partial refund issued for two FAILED (undelivered, never-credited)
+    # items in a 3-item cart was recorded against the cart's one successful purchase, flipped it to
+    # fully refunded, and revoked the buyer's Library access to the item they paid for and kept.
+    # When sibling purchases share this capture (same capture id, or same PayPal order with no
+    # capture of their own — e.g. failed rows), we can't tell which item the refund belongs to,
+    # so skip the automatic refund and alert a human to attribute it manually instead. Siblings
+    # from the same PayPal order that carry a DIFFERENT capture id (multi-seller carts get one
+    # capture per seller) are unambiguous and do not block the refund, and neither do free
+    # ($0) siblings since a refund can never belong to them.
+    # This ambiguity only exists for item-level refund webhooks (PAYMENT.CAPTURE.REFUNDED), so
+    # callers opt in via skip_if_capture_shared. Whole-capture events like
+    # PAYMENT.CAPTURE.DENIED mean the entire capture failed and must keep unwinding.
+    if skip_if_capture_shared
+      sibling_scope = Purchase.where.not(id: purchase.id).where(stripe_transaction_id: capture_id)
+      if purchase.paypal_order_id.present?
+        sibling_scope = sibling_scope.or(
+          Purchase.where.not(id: purchase.id)
+                  .where(paypal_order_id: purchase.paypal_order_id)
+                  .where(stripe_transaction_id: [nil, "", capture_id])
+        )
+      end
+      sibling_scope = sibling_scope.where("price_cents > 0")
+      if sibling_scope.exists?
+        ErrorNotifier.notify(
+          "PayPal refund webhook: capture is shared by multiple purchases; skipping automatic refund attribution",
+          capture_id:,
+          resolved_purchase_id: purchase.id,
+          sibling_purchase_ids: sibling_scope.pluck(:id),
+          usd_amount_cents:,
+          processor_refund_id: processor_refund&.id
+        )
+        return
+      end
+    end
 
     usd_cents_to_refund = usd_amount_cents.present? ?
                             [usd_amount_cents, purchase.gross_amount_refundable_cents].min :

--- a/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
@@ -147,9 +147,11 @@ class PaypalChargeProcessor
     # from the same PayPal order that carry a DIFFERENT capture id (multi-seller carts get one
     # capture per seller) are unambiguous and do not block the refund, and neither do free
     # ($0) siblings since a refund can never belong to them.
-    # This ambiguity only exists for item-level refund webhooks (PAYMENT.CAPTURE.REFUNDED), so
-    # callers opt in via skip_if_capture_shared. Whole-capture events like
-    # PAYMENT.CAPTURE.DENIED mean the entire capture failed and must keep unwinding.
+    # This ambiguity only exists for item-level money-back webhooks — PAYMENT.CAPTURE.REFUNDED
+    # and PAYMENT.CAPTURE.REVERSED both route here and both opt in via skip_if_capture_shared
+    # (a reversal on a shared capture is just as ambiguous as a refund, so it also deserves
+    # human review). Whole-capture events like PAYMENT.CAPTURE.DENIED mean the entire capture
+    # failed and must keep unwinding unconditionally.
     if skip_if_capture_shared
       sibling_scope = Purchase.where.not(id: purchase.id).where(stripe_transaction_id: capture_id)
       if purchase.paypal_order_id.present?
@@ -166,12 +168,15 @@ class PaypalChargeProcessor
       # auto-apply in exactly the rows we can't attribute. Unknown price stays ambiguous
       # and fails toward manual review.
       sibling_scope = sibling_scope.where("price_cents IS NULL OR price_cents > 0")
-      if sibling_scope.exists?
+      # A single pluck drives both the "any siblings?" check and the notification payload, so
+      # the ids a human needs to attribute the refund always match the rows that blocked it.
+      sibling_purchase_ids = sibling_scope.pluck(:id)
+      if sibling_purchase_ids.any?
         ErrorNotifier.notify(
           "PayPal refund webhook: capture is shared by multiple purchases; skipping automatic refund attribution",
           capture_id:,
           resolved_purchase_id: purchase.id,
-          sibling_purchase_ids: sibling_scope.pluck(:id),
+          sibling_purchase_ids:,
           usd_amount_cents:,
           processor_refund_id: processor_refund&.id
         )

--- a/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
@@ -159,7 +159,13 @@ class PaypalChargeProcessor
                   .where(stripe_transaction_id: [nil, "", capture_id])
         )
       end
-      sibling_scope = sibling_scope.where("price_cents > 0")
+      # Free ($0) siblings can never be what the refund belongs to, so they don't make the
+      # capture ambiguous. Keep siblings whose price is NULL, though: price_cents is a
+      # nullable column, and an unknown price tells us nothing about whether money moved
+      # for that row — excluding NULLs (a bare price_cents > 0) would let the refund
+      # auto-apply in exactly the rows we can't attribute. Unknown price stays ambiguous
+      # and fails toward manual review.
+      sibling_scope = sibling_scope.where("price_cents IS NULL OR price_cents > 0")
       if sibling_scope.exists?
         ErrorNotifier.notify(
           "PayPal refund webhook: capture is shared by multiple purchases; skipping automatic refund attribution",

--- a/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
@@ -554,6 +554,26 @@ describe PaypalChargeProcessor, :vcr do
           expect(@purchase.reload.refunds.count).to eq(0)
         end
 
+        it "does not refund and notifies when a same-order sibling has a NULL price" do
+          # price_cents is a nullable column. A NULL price tells us nothing about whether
+          # money moved for that sibling, so the guard must treat the capture as ambiguous
+          # and fail toward manual review instead of auto-applying the refund.
+          @purchase.update!(stripe_transaction_id: "0JF852973C016714D", paypal_order_id: "5O190127TN364715T")
+          sibling = create(:failed_purchase, link: @purchase.link, paypal_order_id: "5O190127TN364715T",
+                                             stripe_transaction_id: nil,
+                                             charge_processor_id: PaypalChargeProcessor.charge_processor_id)
+          sibling.update_column(:price_cents, nil)
+
+          expect(ErrorNotifier).to receive(:notify).with(
+            "PayPal refund webhook: capture is shared by multiple purchases; skipping automatic refund attribution",
+            hash_including(capture_id: "0JF852973C016714D", resolved_purchase_id: @purchase.id)
+          )
+
+          described_class.handle_order_events(refund_event_info)
+
+          expect(@purchase.reload.refunds.count).to eq(0)
+        end
+
         it "still refunds when same-order siblings carry their own different capture ids (multi-seller cart)" do
           @purchase.update!(stripe_transaction_id: "0JF852973C016714D", paypal_order_id: "5O190127TN364715T")
           create(:purchase, link: @purchase.link, paypal_order_id: "5O190127TN364715T",

--- a/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
@@ -599,6 +599,27 @@ describe PaypalChargeProcessor, :vcr do
           expect(@purchase.reload.refunds.count).to eq(1)
         end
 
+        it "also blocks PAYMENT.CAPTURE.REVERSED and notifies when the capture is shared" do
+          # Reversals (chargebacks) route through the same handler as refunds, so a reversal
+          # on a shared capture is just as ambiguous and must also defer to human review.
+          @purchase.update!(stripe_transaction_id: "0JF852973C016714D", paypal_order_id: "5O190127TN364715T")
+          create(:failed_purchase, link: @purchase.link, paypal_order_id: "5O190127TN364715T",
+                                   stripe_transaction_id: nil,
+                                   charge_processor_id: PaypalChargeProcessor.charge_processor_id)
+
+          reversed_event_info = refund_event_info.merge("event_type" => "PAYMENT.CAPTURE.REVERSED")
+
+          expect(ErrorNotifier).to receive(:notify).with(
+            "PayPal refund webhook: capture is shared by multiple purchases; skipping automatic refund attribution",
+            hash_including(capture_id: "0JF852973C016714D", resolved_purchase_id: @purchase.id)
+          )
+
+          described_class.handle_order_events(reversed_event_info)
+
+          expect(@purchase.reload.refunds.count).to eq(0)
+          expect(@purchase.stripe_refunded?).to be(false)
+        end
+
         it "still unwinds PAYMENT.CAPTURE.DENIED even when the capture is shared" do
           # A denied capture means the WHOLE capture failed, so the shared-capture ambiguity
           # guard must not block it — only item-level refund webhooks opt into the skip.

--- a/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
@@ -515,6 +515,87 @@ describe PaypalChargeProcessor, :vcr do
         expect(@purchase.refunds.count).to eq(1)
         expect(@purchase.refunds.last.amount_cents).to eq(253)
       end
+
+      context "when the capture is shared by multiple purchases (multi-item cart)" do
+        let(:refund_event_info) do
+          { "id" => "WH-1GE84257G0350133W-6RW800890C634293G", "create_time" => "2018-08-15T19:14:04.543Z", "resource_type" => "refund", "event_type" => "PAYMENT.CAPTURE.REFUNDED", "summary" => "A $ 0.99 USD capture payment was refunded", "resource" => { "seller_payable_breakdown" => { "gross_amount" => { "currency_code" => "USD", "value" => "0.99" }, "paypal_fee" => { "currency_code" => "USD", "value" => "0.02" }, "net_amount" => { "currency_code" => "USD", "value" => "0.97" }, "total_refunded_amount" => { "currency_code" => "USD", "value" => "10.00" } }, "amount" => { "currency_code" => "USD", "value" => "0.99" }, "update_time" => "2018-08-15T12:13:29-07:00", "create_time" => "2018-08-15T12:13:29-07:00", "links" => [{ "href" => "https://api.paypal.com/v2/payments/refunds/1Y107995YT783435V", "rel" => "self", "method" => "GET" }, { "href" => "https://api.paypal.com/v2/payments/captures/0JF852973C016714D", "rel" => "up", "method" => "GET" }], "id" => "1Y107995YT783435V", "status" => "COMPLETED" }, "links" => [], "event_version" => "1.0", "resource_version" => "2.0" }
+        end
+
+        it "does not refund and notifies when a failed sibling purchase shares the same PayPal order" do
+          # Regression test for a real incident: a partial refund issued for two failed
+          # (undelivered) items in a 3-item cart was recorded against the cart's one
+          # successful purchase, marking it fully refunded and revoking Library access.
+          @purchase.update!(stripe_transaction_id: "0JF852973C016714D", paypal_order_id: "5O190127TN364715T")
+          create(:failed_purchase, link: @purchase.link, paypal_order_id: "5O190127TN364715T",
+                                   stripe_transaction_id: nil,
+                                   charge_processor_id: PaypalChargeProcessor.charge_processor_id)
+
+          expect(ErrorNotifier).to receive(:notify).with(
+            "PayPal refund webhook: capture is shared by multiple purchases; skipping automatic refund attribution",
+            hash_including(capture_id: "0JF852973C016714D", resolved_purchase_id: @purchase.id)
+          )
+
+          described_class.handle_order_events(refund_event_info)
+
+          expect(@purchase.reload.refunds.count).to eq(0)
+          expect(@purchase.stripe_refunded?).to be(false)
+        end
+
+        it "does not refund and notifies when another purchase carries the same capture id" do
+          @purchase.update!(stripe_transaction_id: "0JF852973C016714D")
+          sibling = create(:purchase, link: @purchase.link,
+                                      charge_processor_id: PaypalChargeProcessor.charge_processor_id)
+          sibling.update_column(:stripe_transaction_id, "0JF852973C016714D")
+
+          expect(ErrorNotifier).to receive(:notify)
+
+          described_class.handle_order_events(refund_event_info)
+
+          expect(@purchase.reload.refunds.count).to eq(0)
+        end
+
+        it "still refunds when same-order siblings carry their own different capture ids (multi-seller cart)" do
+          @purchase.update!(stripe_transaction_id: "0JF852973C016714D", paypal_order_id: "5O190127TN364715T")
+          create(:purchase, link: @purchase.link, paypal_order_id: "5O190127TN364715T",
+                            stripe_transaction_id: "9XA12345BB678901C",
+                            charge_processor_id: PaypalChargeProcessor.charge_processor_id)
+
+          expect(ErrorNotifier).not_to receive(:notify)
+
+          described_class.handle_order_events(refund_event_info)
+
+          expect(@purchase.reload.refunds.count).to eq(1)
+        end
+
+        it "still refunds when the only same-order sibling is a free purchase" do
+          @purchase.update!(stripe_transaction_id: "0JF852973C016714D", paypal_order_id: "5O190127TN364715T")
+          free_product = create(:product, price_cents: 0)
+          create(:free_purchase, link: free_product, paypal_order_id: "5O190127TN364715T")
+
+          expect(ErrorNotifier).not_to receive(:notify)
+
+          described_class.handle_order_events(refund_event_info)
+
+          expect(@purchase.reload.refunds.count).to eq(1)
+        end
+
+        it "still unwinds PAYMENT.CAPTURE.DENIED even when the capture is shared" do
+          # A denied capture means the WHOLE capture failed, so the shared-capture ambiguity
+          # guard must not block it — only item-level refund webhooks opt into the skip.
+          @purchase.update!(stripe_transaction_id: "0JF852973C016714D", paypal_order_id: "5O190127TN364715T")
+          create(:failed_purchase, link: @purchase.link, paypal_order_id: "5O190127TN364715T",
+                                   stripe_transaction_id: nil,
+                                   charge_processor_id: PaypalChargeProcessor.charge_processor_id)
+
+          denied_event_info = { "id" => "WH-4SW78779LY2325805-07E03580SX1414828", "create_time" => "2019-02-14T22:20:08.370Z", "resource_type" => "capture", "event_type" => "PAYMENT.CAPTURE.DENIED", "summary" => "A capture payment was denied", "resource" => { "amount" => { "currency_code" => "USD", "value" => "0.99" }, "final_capture" => true, "links" => [{ "href" => "https://api.paypal.com/v2/payments/captures/0JF852973C016714D", "rel" => "self", "method" => "GET" }], "id" => "0JF852973C016714D", "status" => "DECLINED" }, "links" => [], "event_version" => "1.0", "resource_version" => "2.0" }
+
+          expect(ErrorNotifier).not_to receive(:notify)
+
+          described_class.handle_order_events(denied_event_info)
+
+          verify_purchase_refunded
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## What

Guards the PayPal `PAYMENT.CAPTURE.REFUNDED` webhook handler against misattributing refunds on multi-item carts: when the capture backing the refund is shared by multiple purchases, the handler now skips the automatic refund and notifies via `ErrorNotifier` so a human attributes it, instead of pinning the whole refunded amount on whichever successful purchase happens to carry the `stripe_transaction_id`.

Fixes antiwork/gumroad-private#923.

## Why

A single PayPal capture can back multiple `Purchase` rows (a multi-item cart from one seller is charged as one capture), but `refund_purchase(capture_id:)` assumed 1:1 capture→purchase.

Real incident (July 2026): in a 3-item PayPal cart, only one purchase succeeded; the other two were `failed` (never credited). A partial refund was later issued against the capture for the two undelivered items. The webhook resolved the capture to the one successful purchase, capped the refund at that purchase's refundable amount, flipped it to `stripe_refunded: true`, and revoked the buyer's Library access to the item they legitimately paid for and kept. (The data was manually repaired via an audited console write; this PR prevents recurrence.)

## Fix

- In `refund_purchase`, when the resolved purchase has sibling purchases sharing the capture — same `stripe_transaction_id`, or same `paypal_order_id` with no capture of their own (e.g. failed rows) — skip the automatic refund and `ErrorNotifier.notify` with the capture id, resolved purchase, and sibling ids so a human attributes the refund correctly.
- The guard is scoped precisely:
  - Same-order siblings with a DIFFERENT capture id (multi-seller carts get one capture per seller) do NOT block the refund.
  - Free ($0) siblings do NOT block it (a refund can never belong to them).
  - Only the item-level `PAYMENT.CAPTURE.REFUNDED` webhook opts into the guard (`skip_if_capture_shared: true`). `PAYMENT.CAPTURE.DENIED` means the whole capture failed and keeps unwinding unconditionally.

## Test plan

Ran locally (`bundle exec rspec spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb -e "payment capture failure"`): **16 examples, 0 failures** — 11 pre-existing + 5 new:

- does not refund and notifies when a failed sibling shares the same PayPal order (the incident shape)
- does not refund and notifies when another purchase carries the same capture id
- still refunds when same-order siblings carry their own different capture ids (multi-seller cart)
- still refunds when the only same-order sibling is a free purchase
- still unwinds `PAYMENT.CAPTURE.DENIED` even when the capture is shared

Autoreview (Codex) run to clean: first pass caught that the guard would have blocked shared-capture DENIED events from unwinding — fixed by making the guard opt-in for the refund webhook only, with a regression spec; second pass clean.

Not applicable — backend webhook handler, no UI change.

## AI disclosure

Authored by Gumclaw (Hermes agent) from the confirmed investigation on the private issue; reviewed with the Codex autoreview gate.


---
_Re-opened from #5729 (fork PR): fork PRs run `pull_request_target` and CI Gate waits forever on the `ci-protected` environment approval. Same branch, same commit (61c9a311), pushed to the main repo so CI runs normally._
