### PR TITLE
Make dispute-formalized webhook replay-safe: resume unfinished chargeback side effects

### DIFF
--- a/app/models/concerns/charge/disputable.rb
+++ b/app/models/concerns/charge/disputable.rb
@@ -99,15 +99,25 @@ module Charge::Disputable
 
     dispute = find_or_build_dispute(event)
 
+    if dispute.formalized? && dispute.formalized_side_effects_finished_at.nil?
+      # The first webhook attempt marked the dispute formalized but crashed partway through
+      # the side effects (balance decrement, payout pause, notifications). The processor
+      # re-delivers the webhook; resume the remaining work instead of skipping it.
+      # Every step inside is guarded so already-completed work is not applied twice.
+      perform_dispute_formalized_side_effects!(event, dispute)
+      return
+    end
+
     unless dispute.initiated? || dispute.created?
-      # The dispute is already past its initial state, which means this event is a replay —
-      # the payment processor re-delivers the webhook when an earlier attempt failed partway
-      # through. Refund-policy enforcement is enqueued late in the first attempt (after the
-      # dispute is marked formalized), so a failure at that point — say, a Redis outage during
-      # the Sidekiq enqueue — would otherwise leave the seller's enforcement check unscheduled
-      # forever, because the replay returns here without reaching that code. Re-enqueueing on
-      # every replay is safe: the job no-ops once the seller is already enforced (or doesn't
-      # cross the dispute-rate thresholds), so duplicates do nothing.
+      # The dispute is already past its initial state AND its side effects finished (or it has
+      # since been won/lost), which means this event is a replay — the payment processor
+      # re-delivers the webhook when an earlier attempt failed partway through. Refund-policy
+      # enforcement is enqueued late in the first attempt (after the dispute is marked
+      # formalized), so a failure at that point — say, a Redis outage during the Sidekiq
+      # enqueue — would otherwise leave the seller's enforcement check unscheduled forever,
+      # because the replay returns here without reaching that code. Re-enqueueing on every
+      # replay is safe: the job no-ops once the seller is already enforced (or doesn't cross
+      # the dispute-rate thresholds), so duplicates do nothing.
       disputed_purchases.each { |purchase| EnforceRefundPolicyForSellerJob.perform_async(purchase.id) }
       return
     end
@@ -115,6 +125,11 @@ module Charge::Disputable
     mark_as_disputed!(disputed_at: event.created_at)
 
     disputed_purchases.each do |purchase|
+      # A replay that crashed after creating this event but before mark_formalized! re-enters
+      # this normal path (the dispute is still in its initial state), so skip purchases that
+      # already have their chargeback event to avoid duplicate analytics rows.
+      next if Event.where(purchase_id: purchase.id, event_name: "chargeback").exists?
+
       purchase_event = Event.where(purchase_id: purchase.id, event_name: "purchase").last
       if purchase_event.present?
         Event.create(
@@ -128,49 +143,7 @@ module Charge::Disputable
 
     dispute.mark_formalized!
 
-    disputed_purchases.each do |purchase|
-      flow_of_funds = build_flow_of_funds(event.flow_of_funds, purchase)
-      purchase.decrement_balance_for_refund_or_chargeback!(flow_of_funds, dispute:)
-
-      if purchase.link.is_recurring_billing
-        subscription = Subscription.find_by(id: purchase.subscription_id)
-        subscription.cancel_effective_immediately!(by_buyer: true)
-        subscription.original_purchase.update!(should_exclude_product_review: true) if subscription.should_exclude_product_review_on_charge_reversal?
-      end
-
-      purchase.enqueue_update_sales_related_products_infos_job(false)
-      purchase.mark_giftee_purchase_as_chargeback if purchase.is_gift_sender_purchase
-
-      purchase.chargeback_date = event.created_at
-      purchase.chargeback_reason = event.extras.try(:[], :reason)
-      purchase.save!
-
-      purchase.mark_product_purchases_as_chargedback!
-
-      purchase.pause_payouts_for_seller_based_on_chargeback_rate!
-      # Enforcement runs as a background job rather than inline: the dispute was already
-      # marked formalized above, so an inline failure here would be skipped forever on
-      # webhook retry (the handler returns early for formalized disputes). The job gets
-      # its own Sidekiq retries and the enforcement method is idempotent.
-      EnforceRefundPolicyForSellerJob.perform_async(purchase.id)
-      purchase.block_buyer_based_on_chargeback_count!
-    end
-
-    dispute_evidence = create_dispute_evidence_if_needed!
-    dispute_evidence&.update_as_seller_contacted!
-
-    ContactingCreatorMailer.chargeback_notice(dispute.id).deliver_later
-    AdminMailer.chargeback_notify(dispute.id).deliver_later
-    CustomerLowPriorityMailer.chargeback_notice_to_customer(dispute.id).deliver_later(wait: 5.seconds)
-
-    disputed_purchases.each do |purchase|
-      # Check for low balance and put the creator on probation
-      LowBalanceFraudCheckWorker.perform_in(5.seconds, purchase.id)
-
-      PostToPingEndpointsWorker.perform_in(5.seconds, purchase.id, purchase.url_parameters, ResourceSubscription::DISPUTE_RESOURCE_NAME)
-    end
-
-    FightDisputeJob.perform_async(dispute_evidence.dispute.id) if dispute_evidence.present?
+    perform_dispute_formalized_side_effects!(event, dispute)
   end
 
   def resolve_pending_dispute_evidence_if_any!(error_message)
@@ -286,4 +259,78 @@ module Charge::Disputable
 
     ChargeProcessor.fight_chargeback(charge_processor, charge_processor_transaction_id, dispute_evidence)
   end
+
+  private
+    # Everything that must happen after a dispute is formalized: seller balance decrement,
+    # subscription cancellation, chargeback flags, payout pause, buyer block, notifications.
+    # Runs on the first delivery and again on webhook replay if a previous attempt crashed
+    # before writing formalized_side_effects_finished_at, so each step is either guarded here
+    # or idempotent on its own.
+    def perform_dispute_formalized_side_effects!(event, dispute)
+      disputed_purchases.each do |purchase|
+        flow_of_funds = build_flow_of_funds(event.flow_of_funds, purchase)
+        # Replay-safe without a guard here: decrement_balance_for_refund_or_chargeback! checks
+        # seller_balance_update_eligible? internally and returns early once the purchase already
+        # has a purchase_chargeback_balance, so a replay never debits the seller twice.
+        purchase.decrement_balance_for_refund_or_chargeback!(flow_of_funds, dispute:)
+
+        if purchase.link.is_recurring_billing
+          subscription = Subscription.find_by(id: purchase.subscription_id)
+          # Only cancel a live subscription: re-cancelling one that a previous attempt already
+          # deactivated would re-fire the cancellation webhooks and customer emails on replay.
+          # The review exclusion stays inside this guard because it is tied to the cancellation.
+          if subscription.present? && subscription.deactivated_at.nil?
+            subscription.cancel_effective_immediately!(by_buyer: true)
+            subscription.original_purchase.update!(should_exclude_product_review: true) if subscription.should_exclude_product_review_on_charge_reversal?
+          end
+        end
+
+        purchase.enqueue_update_sales_related_products_infos_job(false)
+        purchase.mark_giftee_purchase_as_chargeback if purchase.is_gift_sender_purchase
+
+        # No replay guard needed for these writes: the same event always carries the same
+        # date and reason, so rewriting them is a no-op.
+        purchase.chargeback_date = event.created_at
+        purchase.chargeback_reason = event.extras.try(:[], :reason)
+        purchase.save!
+
+        purchase.mark_product_purchases_as_chargedback!
+
+        # pause_payouts_for_seller_based_on_chargeback_rate! and block_buyer_based_on_chargeback_count!
+        # are both idempotent (they recompute from current data and re-apply the same state),
+        # so replays can safely call them again.
+        purchase.pause_payouts_for_seller_based_on_chargeback_rate!
+        # Enforcement runs as a background job rather than inline: the dispute was already
+        # marked formalized above, so an inline failure here would otherwise be skipped on
+        # webhook retry. The job gets its own Sidekiq retries and the enforcement method is
+        # idempotent.
+        EnforceRefundPolicyForSellerJob.perform_async(purchase.id)
+        purchase.block_buyer_based_on_chargeback_count!
+      end
+
+      dispute_evidence = create_dispute_evidence_if_needed!
+      # Don't re-stamp seller_contacted_at on replay: it anchors the 72-hour evidence-submission
+      # window, and moving it forward would silently extend the seller's deadline.
+      dispute_evidence.update_as_seller_contacted! if dispute_evidence.present? && !dispute_evidence.seller_contacted?
+
+      # No per-step guards from here down: the completion marker written at the end prevents
+      # any re-delivery from reaching this code, except for a crash inside the tiny window
+      # between these enqueues and the marker write — that degrades to at-least-once
+      # email/webhook delivery, which is normal for crash-retry semantics.
+      ContactingCreatorMailer.chargeback_notice(dispute.id).deliver_later
+      AdminMailer.chargeback_notify(dispute.id).deliver_later
+      CustomerLowPriorityMailer.chargeback_notice_to_customer(dispute.id).deliver_later(wait: 5.seconds)
+
+      disputed_purchases.each do |purchase|
+        # Check for low balance and put the creator on probation
+        LowBalanceFraudCheckWorker.perform_in(5.seconds, purchase.id)
+
+        PostToPingEndpointsWorker.perform_in(5.seconds, purchase.id, purchase.url_parameters, ResourceSubscription::DISPUTE_RESOURCE_NAME)
+      end
+
+      FightDisputeJob.perform_async(dispute_evidence.dispute.id) if dispute_evidence.present?
+
+      # Completion marker: a replayed webhook only re-runs these side effects while this is nil.
+      dispute.update!(formalized_side_effects_finished_at: Time.current)
+    end
 end

--- a/app/models/concerns/charge/disputable.rb
+++ b/app/models/concerns/charge/disputable.rb
@@ -328,7 +328,7 @@ module Charge::Disputable
         PostToPingEndpointsWorker.perform_in(5.seconds, purchase.id, purchase.url_parameters, ResourceSubscription::DISPUTE_RESOURCE_NAME)
       end
 
-      FightDisputeJob.perform_async(dispute_evidence.dispute.id) if dispute_evidence.present?
+      FightDisputeJob.perform_async(dispute.id) if dispute_evidence.present?
 
       # Completion marker: a replayed webhook only re-runs these side effects while this is nil.
       dispute.update!(formalized_side_effects_finished_at: Time.current)

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -1880,6 +1880,9 @@ class Purchase < ApplicationRecord
   def mark_giftee_purchase_as_chargeback
     giftee_purchase = gift_given.present? ? gift_given.giftee_purchase : nil
     return if giftee_purchase.nil?
+    # Already marked (e.g. a replayed dispute webhook re-running its side effects) —
+    # rewriting the date would move the recorded chargeback time for no reason.
+    return if giftee_purchase.chargeback_date.present?
 
     giftee_purchase.chargeback_date = DateTime.current
     giftee_purchase.save!
@@ -1896,6 +1899,10 @@ class Purchase < ApplicationRecord
   def mark_product_purchases_as_chargedback!
     return unless is_bundle_purchase?
     product_purchases.each do |product_purchase|
+      # Skip children that are already charged back (e.g. a replayed dispute webhook
+      # re-running its side effects) so their original chargeback timestamp is preserved.
+      next if product_purchase.chargeback_date.present?
+
       product_purchase.update!(chargeback_date: DateTime.current)
     end
   end

--- a/db/migrate/20261204000000_add_formalized_side_effects_finished_at_to_disputes.rb
+++ b/db/migrate/20261204000000_add_formalized_side_effects_finished_at_to_disputes.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddFormalizedSideEffectsFinishedAtToDisputes < ActiveRecord::Migration[7.1]
+  def up
+    add_column :disputes, :formalized_side_effects_finished_at, :datetime
+
+    # Backfill every dispute that was already formalized (including ones that later
+    # transitioned to won/lost) so pre-existing disputes keep today's replay behavior:
+    # a re-delivered "dispute formalized" webhook skips the side effects and only
+    # re-enqueues the refund-policy enforcement job. The new resume-on-replay path
+    # (Charge::Disputable#handle_event_dispute_formalized!) should only ever fire for
+    # disputes formalized after this deploy whose side effects genuinely crashed partway.
+    Dispute.where.not(formalized_at: nil).update_all("formalized_side_effects_finished_at = formalized_at")
+  end
+
+  def down
+    remove_column :disputes, :formalized_side_effects_finished_at
+  end
+end

--- a/db/migrate/20261204000000_add_formalized_side_effects_finished_at_to_disputes.rb
+++ b/db/migrate/20261204000000_add_formalized_side_effects_finished_at_to_disputes.rb
@@ -10,7 +10,11 @@ class AddFormalizedSideEffectsFinishedAtToDisputes < ActiveRecord::Migration[7.1
     # re-enqueues the refund-policy enforcement job. The new resume-on-replay path
     # (Charge::Disputable#handle_event_dispute_formalized!) should only ever fire for
     # disputes formalized after this deploy whose side effects genuinely crashed partway.
-    Dispute.where.not(formalized_at: nil).update_all("formalized_side_effects_finished_at = formalized_at")
+    # Batched so the backfill never holds row locks on the whole table at once: a single
+    # unbounded UPDATE could block live dispute webhook processing for its full duration.
+    Dispute.where.not(formalized_at: nil).in_batches do |batch|
+      batch.update_all("formalized_side_effects_finished_at = formalized_at")
+    end
   end
 
   def down

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_12_03_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_12_04_000000) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -874,6 +874,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_12_03_000000) do
     t.bigint "seller_id"
     t.datetime "event_created_at"
     t.bigint "charge_id"
+    t.datetime "formalized_side_effects_finished_at"
     t.index ["charge_id"], name: "index_disputes_on_charge_id"
     t.index ["purchase_id"], name: "index_disputes_on_purchase_id"
     t.index ["seller_id", "event_created_at"], name: "index_disputes_on_seller_id_and_event_created_at"

--- a/spec/models/concerns/charge/disputable_spec.rb
+++ b/spec/models/concerns/charge/disputable_spec.rb
@@ -578,6 +578,165 @@ describe Charge::Disputable, :vcr do
           expect(seller.reload.unpaid_balance_cents).to eq initial_balance - purchase.reload.payment_cents
         end
       end
+
+      describe "webhook replay safety" do
+        let!(:purchase_event) { create(:event, event_name: "purchase", purchase_id: purchase.id, link_id: product.id) }
+
+        context "when the first delivery crashes partway through the side effects" do
+          before do
+            # Simulate a crash on a late step: the creator notification raises on the first
+            # delivery only, leaving the dispute formalized with unfinished side effects.
+            call_count = 0
+            allow(ContactingCreatorMailer).to receive(:chargeback_notice).and_wrap_original do |original, *args|
+              call_count += 1
+              raise "simulated crash" if call_count == 1
+              original.call(*args)
+            end
+          end
+
+          it "resumes and completes the side effects on replay without applying them twice" do
+            expect { Purchase.handle_charge_event(event) }.to raise_error("simulated crash")
+
+            dispute = purchase.reload.dispute
+            expect(dispute.state).to eq("formalized")
+            expect(dispute.formalized_side_effects_finished_at).to be_nil
+            seller_contacted_at_after_crash = dispute.dispute_evidence.seller_contacted_at
+            expect(seller_contacted_at_after_crash).to be_present
+
+            expect { Purchase.handle_charge_event(event) }.not_to raise_error
+
+            dispute.reload
+            purchase.reload
+            seller.reload
+            expect(dispute.formalized_side_effects_finished_at).to be_present
+            # Balance decremented exactly once across both deliveries.
+            expect(seller.unpaid_balance_cents).to eq initial_balance - purchase.payment_cents
+            expect(purchase.purchase_chargeback_balance).to be_present
+            expect(Event.where(purchase_id: purchase.id, event_name: "chargeback").count).to eq(1)
+            # The replay must not move the evidence-submission window.
+            expect(dispute.dispute_evidence.reload.seller_contacted_at).to eq(seller_contacted_at_after_crash)
+            expect(FightDisputeJob).to have_enqueued_sidekiq_job(dispute.id)
+          end
+
+          context "when the product is a subscription" do
+            let(:product) { create(:subscription_product, user: seller) }
+            let!(:purchase) do
+              subscription = create(:subscription, link: product, cancelled_at: nil)
+              purchase = create(:purchase, link: product, is_original_subscription_purchase: true, subscription:, stripe_transaction_id: "ch_zitkxbhds3zqlt")
+              purchase.update(is_original_subscription_purchase: true, subscription:)
+              purchase
+            end
+
+            it "does not cancel the already-deactivated subscription again on replay" do
+              expect { Purchase.handle_charge_event(event) }.to raise_error("simulated crash")
+
+              subscription = purchase.reload.subscription
+              deactivated_at_after_crash = subscription.deactivated_at
+              expect(deactivated_at_after_crash).to be_present
+
+              expect_any_instance_of(Subscription).not_to receive(:cancel_effective_immediately!)
+              expect { Purchase.handle_charge_event(event) }.not_to raise_error
+
+              expect(subscription.reload.deactivated_at).to eq(deactivated_at_after_crash)
+              expect(purchase.reload.dispute.formalized_side_effects_finished_at).to be_present
+            end
+          end
+        end
+
+        context "when the first delivery fully succeeded" do
+          before do
+            Purchase.handle_charge_event(event)
+          end
+
+          it "does not re-run the side effects but still enqueues the enforcement job" do
+            purchase.reload
+            seller.reload
+            dispute = purchase.dispute
+            expect(dispute.formalized_side_effects_finished_at).to be_present
+            balance_after_first_delivery = seller.unpaid_balance_cents
+            seller_contacted_at_after_first_delivery = dispute.dispute_evidence.seller_contacted_at
+            marker_after_first_delivery = dispute.formalized_side_effects_finished_at
+
+            expect(ContactingCreatorMailer).not_to receive(:chargeback_notice)
+            expect(AdminMailer).not_to receive(:chargeback_notify)
+            expect_any_instance_of(Purchase).not_to receive(:decrement_balance_for_refund_or_chargeback!)
+
+            EnforceRefundPolicyForSellerJob.jobs.clear
+            Purchase.handle_charge_event(event)
+
+            expect(seller.reload.unpaid_balance_cents).to eq(balance_after_first_delivery)
+            expect(Event.where(purchase_id: purchase.id, event_name: "chargeback").count).to eq(1)
+            dispute.reload
+            expect(dispute.dispute_evidence.seller_contacted_at).to eq(seller_contacted_at_after_first_delivery)
+            expect(dispute.formalized_side_effects_finished_at).to eq(marker_after_first_delivery)
+            expect(EnforceRefundPolicyForSellerJob).to have_enqueued_sidekiq_job(purchase.id)
+          end
+
+          it "keeps the enqueue-only replay behavior once the dispute has been won" do
+            purchase.reload.dispute.update!(state: "won")
+
+            expect_any_instance_of(Purchase).not_to receive(:decrement_balance_for_refund_or_chargeback!)
+
+            EnforceRefundPolicyForSellerJob.jobs.clear
+            Purchase.handle_charge_event(event)
+
+            expect(EnforceRefundPolicyForSellerJob).to have_enqueued_sidekiq_job(purchase.id)
+          end
+        end
+
+        context "for a charge" do
+          let(:transaction_id) { "ch_charge_884" }
+          let!(:charge_purchase) do
+            create(:purchase, link: product, seller:, stripe_transaction_id: transaction_id, price_cents: 100,
+                              total_transaction_cents: 100, fee_cents: 30)
+          end
+          let!(:charge) { create(:charge, seller:, processor_transaction_id: transaction_id, amount_cents: 100, purchases: [charge_purchase]) }
+          let!(:charge_purchase_event) { create(:event, event_name: "purchase", purchase_id: charge_purchase.id, link_id: product.id) }
+          let(:charge_event) { build(:charge_event_dispute_formalized, charge_id: transaction_id) }
+
+          before do
+            sample_image = File.read(Rails.root.join("spec", "support", "fixtures", "test-small.jpg"))
+            allow(DisputeEvidence::GenerateReceiptImageService).to receive(:perform).and_return(sample_image)
+          end
+
+          it "resumes unfinished side effects on replay without double-applying them" do
+            call_count = 0
+            allow(ContactingCreatorMailer).to receive(:chargeback_notice).and_wrap_original do |original, *args|
+              call_count += 1
+              raise "simulated crash" if call_count == 1
+              original.call(*args)
+            end
+
+            expect { charge.handle_event(charge_event) }.to raise_error("simulated crash")
+
+            dispute = charge.reload.dispute
+            expect(dispute.state).to eq("formalized")
+            expect(dispute.formalized_side_effects_finished_at).to be_nil
+
+            expect { charge.handle_event(charge_event) }.not_to raise_error
+
+            expect(dispute.reload.formalized_side_effects_finished_at).to be_present
+            expect(charge_purchase.reload.purchase_chargeback_balance).to be_present
+            expect(seller.reload.unpaid_balance_cents).to eq initial_balance - charge_purchase.payment_cents
+            expect(Event.where(purchase_id: charge_purchase.id, event_name: "chargeback").count).to eq(1)
+          end
+
+          it "does not re-run the side effects when replayed after a fully successful delivery" do
+            charge.handle_event(charge_event)
+            balance_after_first_delivery = seller.reload.unpaid_balance_cents
+            expect(charge.reload.dispute.formalized_side_effects_finished_at).to be_present
+
+            expect_any_instance_of(Purchase).not_to receive(:decrement_balance_for_refund_or_chargeback!)
+
+            EnforceRefundPolicyForSellerJob.jobs.clear
+            charge.handle_event(charge_event)
+
+            expect(seller.reload.unpaid_balance_cents).to eq(balance_after_first_delivery)
+            expect(Event.where(purchase_id: charge_purchase.id, event_name: "chargeback").count).to eq(1)
+            expect(EnforceRefundPolicyForSellerJob).to have_enqueued_sidekiq_job(charge_purchase.id)
+          end
+        end
+      end
     end
 
     describe "dispute closed" do

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -3149,6 +3149,16 @@ describe Purchase, :vcr do
       expect(purchase.product_purchases.first.chargeback_date).to_not be_nil
       expect(purchase.product_purchases.second.chargeback_date).to_not be_nil
     end
+
+    it "keeps the original chargeback_date of an already-chargedback bundle purchase" do
+      original_chargeback_date = 3.days.ago
+      purchase.product_purchases.first.update!(chargeback_date: original_chargeback_date)
+
+      purchase.mark_product_purchases_as_chargedback!
+
+      expect(purchase.product_purchases.first.reload.chargeback_date).to be_within(1.second).of(original_chargeback_date)
+      expect(purchase.product_purchases.second.reload.chargeback_date).to_not be_nil
+    end
   end
 
   describe "#mark_product_purchases_as_chargeback_reversed!" do


### PR DESCRIPTION
## What

Makes `Charge::Disputable#handle_event_dispute_formalized!` safe to replay after a partial failure. Adds a `formalized_side_effects_finished_at` completion marker to `disputes`, extracts the post-formalization work into `perform_dispute_formalized_side_effects!`, and adds a resume branch plus per-step idempotency guards.

Fixes gumroad-private#884. Follows up on the Greptile discussion on #5712.

## Why

Today, if the handler crashes after `dispute.mark_formalized!` but before the side effects finish (balance decrement, subscription cancellation, payout pause, buyer block, dispute evidence, notifications), the processor's webhook replay hits the "already formalized" early return and skips the unfinished work **forever**. That leaves a dispute formalized with no seller balance decrement, no payout pause, no buyer block, and no evidence — money silently not recovered and no fraud controls applied.

## Design

- **Completion marker:** `perform_dispute_formalized_side_effects!` stamps `dispute.formalized_side_effects_finished_at` as its last step. A replay that finds the dispute `formalized?` with a nil marker resumes the side effects; once set (or the dispute has been won/lost), replays keep the existing behavior of only re-enqueueing `EnforceRefundPolicyForSellerJob` (preserves the #5712 recovery).
- **Backfill:** the migration sets the marker to `formalized_at` for every pre-existing formalized/won/lost dispute, so the resume path only ever fires for post-deploy partial failures.
- **Per-step idempotency:**
  - Balance decrement: unchanged — replay safety rides on the existing `seller_balance_update_eligible?` guard inside `decrement_balance_for_refund_or_chargeback!` (returns early once `purchase_chargeback_balance` is set). Stated in a comment at the call site.
  - Subscription cancellation only fires when `deactivated_at` is nil (avoids re-firing cancellation webhooks/mailers).
  - Chargeback `Event` rows: skipped when one already exists (covers a crash between `Event.create` and `mark_formalized!`, which re-enters the normal path).
  - `mark_giftee_purchase_as_chargeback` / `mark_product_purchases_as_chargedback!`: now skip already-chargedback rows (idempotent for all callers).
  - `update_as_seller_contacted!`: skipped when already stamped so a replay can't silently extend the 72h evidence-submission window.
  - `pause_payouts…` / `block_buyer…` / `EnforceRefundPolicyForSellerJob` / `create_dispute_evidence_if_needed!`: already idempotent, unchanged.
  - Mailers + `LowBalanceFraudCheckWorker` + `PostToPingEndpointsWorker` + `FightDisputeJob`: no per-step guards — the marker prevents re-delivery except for a crash in the tiny window between the enqueues and the marker write, which degrades to at-least-once delivery (normal crash-retry semantics).
- The `flow_of_funds` normalization for non-Stripe events stays before the resume branch so a replayed non-Stripe event gets its flow of funds rebuilt.

## Known adjacent gap (out of scope, for the reviewer)

`handle_event_dispute_won!` credits the seller without checking that the formalization decrement actually happened. This is now largely mitigated: a `dispute.formalized` replay completes the side effects (including the decrement) before any won event that goes through the normal replay ordering. But a direct created→won transition (the state machine allows `created => won`) skips formalization entirely and would credit without a prior decrement. Left out of scope here; flagging for a follow-up.

## Verification

- `bin/rails db:migrate` → schema.rb updated (disputes table only)
- `bundle exec rubocop` on all 6 touched files → 0 offenses
- `bundle exec rspec spec/models/concerns/charge/disputable_spec.rb` → **124 examples, 0 failures** (includes new replay-safety specs: crash-then-resume for Purchase and Charge, replay-after-success no-double-apply, won-dispute replay unchanged, subscription no-double-cancel)
- `bundle exec rspec spec/models/purchase_spec.rb -e "mark_product_purchases_as_chargedback"` → 2 examples, 0 failures (includes new idempotency example)
- `bundle exec rspec spec/models/concerns/purchase/charge_events_handler_spec.rb` → 29 examples, 0 failures