### PR TITLE
Show a default products section on profiles with no saved sections

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -210,7 +210,17 @@ class LinksController < ApplicationController
     if in_section
       user = User.find_by_external_id(search_params[:user_id])
       section = user && user.seller_profile_products_sections.find_by_external_id(search_params[:section_id])
-      return render json: { total: 0, filetypes_data: [], tags_data: [], products: [] } if user.nil? || (section.nil? && search_params[:ids].blank?)
+      # The profile page can show a virtual "default products section" (all of the creator's
+      # live products) when the creator has products but hasn't saved any profile sections yet.
+      # That section has no database row, so when the frontend fetches more results for it,
+      # accept its well-known id and search across all the creator's profile products (leaving
+      # `section` nil below does exactly that). Guarded on the creator still having no saved
+      # sections so this id can't be used to bypass a customized profile layout.
+      searching_default_products_section =
+        user.present? &&
+        search_params[:section_id] == ProfileSectionsPresenter::DEFAULT_PRODUCTS_SECTION_ID &&
+        user.seller_profile_sections.on_profile.none?
+      return render json: { total: 0, filetypes_data: [], tags_data: [], products: [] } if user.nil? || (section.nil? && !searching_default_products_section && search_params[:ids].blank?)
       search_params[:section] = section if section
       search_params[:is_alive_on_profile] = true
       search_params[:user_id] = user.id

--- a/app/presenters/profile_presenter.rb
+++ b/app/presenters/profile_presenter.rb
@@ -27,7 +27,11 @@ class ProfilePresenter
     # to /profile, so the public component no longer renders the owner/editing shape. The real viewer
     # is still passed through, so "you own this", "already following this wishlist", and currency
     # reflect them (including the seller viewing their own page).
-    shared_profile_props(seller_custom_domain_url:, request:, editing: false).merge(creator_profile:, seller_analytics:)
+    # include_default_products_section only applies to the public page: creators with products
+    # but no saved sections get a virtual products section instead of a bare email signup box.
+    # The profile editor (profile_settings_props below) never asks for it, so the editing
+    # experience is unchanged.
+    shared_profile_props(seller_custom_domain_url:, request:, editing: false, include_default_products_section: true).merge(creator_profile:, seller_analytics:)
   end
 
   def profile_settings_props(request:)
@@ -61,12 +65,22 @@ class ProfilePresenter
   end
 
   private
-    def shared_profile_props(seller_custom_domain_url:, request:, pundit_user: @pundit_user, editing: pundit_user.seller == seller)
+    def shared_profile_props(seller_custom_domain_url:, request:, pundit_user: @pundit_user, editing: pundit_user.seller == seller, include_default_products_section: false)
+      sections_props = profile_sections_presenter.props(request:, pundit_user:, seller_custom_domain_url:, editing:, include_default_products_section:)
+      tabs = (seller.seller_profile.json_data["tabs"] || [])
+               .map { |tab| { name: tab["name"], sections: tab["sections"].map { ObfuscateIds.encrypt(_1) } } }
+      # The frontend only renders sections that a tab points at, so when the presenter injected
+      # the virtual default products section (only possible when the creator has no saved
+      # sections), replace the tabs with a single tab that points at it. Any leftover saved tabs
+      # can't reference real sections here - there are none.
+      if include_default_products_section &&
+         sections_props[:sections].any? { _1[:id] == ProfileSectionsPresenter::DEFAULT_PRODUCTS_SECTION_ID }
+        tabs = [{ name: "Products", sections: [ProfileSectionsPresenter::DEFAULT_PRODUCTS_SECTION_ID] }]
+      end
       {
-        **profile_sections_presenter.props(request:, pundit_user:, seller_custom_domain_url:, editing:),
+        **sections_props,
         bio: seller.bio,
-        tabs: (seller.seller_profile.json_data["tabs"] || [])
-                .map { |tab| { name: tab["name"], sections: tab["sections"].map { ObfuscateIds.encrypt(_1) } } },
+        tabs:,
       }
     end
 

--- a/app/presenters/profile_sections_presenter.rb
+++ b/app/presenters/profile_sections_presenter.rb
@@ -5,6 +5,13 @@ class ProfileSectionsPresenter
 
   CACHE_KEY_PREFIX = "profile-sections"
 
+  # Identifier for the "default products section": a virtual (never saved to the database)
+  # products section that the public profile shows when a creator has published products but
+  # hasn't set up any profile sections yet. Without it, new creators' profiles showed only an
+  # email signup box even though they had products for sale. The frontend passes this id back
+  # as section_id when it fetches more results, so LinksController#search recognizes it too.
+  DEFAULT_PRODUCTS_SECTION_ID = "default-products"
+
   # seller is the owner of the section
   # pundit_user.seller is the selected seller for the logged-in user (pundit_user.user) - which may be different from seller
   def initialize(seller:, query:)
@@ -12,7 +19,7 @@ class ProfileSectionsPresenter
     @query = query
   end
 
-  def props(request:, pundit_user:, seller_custom_domain_url:, editing: pundit_user.seller == seller)
+  def props(request:, pundit_user:, seller_custom_domain_url:, editing: pundit_user.seller == seller, include_default_products_section: false)
     sections = query.to_a
 
     props = {
@@ -23,6 +30,17 @@ class ProfileSectionsPresenter
         section_props(sections.find { _1.external_id == props[:id] }, cached_props: props, request:, pundit_user:, seller_custom_domain_url:, editing:)
       end
     }
+    # New creators who haven't customized their profile yet get a virtual products section so
+    # visitors see what's for sale instead of just an email signup box. It only appears on the
+    # public page (never in the profile editor, so `editing` must be false), only when the
+    # creator has no saved sections, and only when they have products to show. The moment they
+    # save a real section in the editor, their own layout takes over.
+    if include_default_products_section && !editing && sections.empty?
+      default_section = cached_default_products_section
+      if default_section
+        props[:sections] = [section_props(nil, cached_props: default_section, request:, pundit_user:, seller_custom_domain_url:, editing: false)]
+      end
+    end
     if editing
       props[:products] = seller.products.alive.not_archived.select(:id, :name).map { { id: ObfuscateIds.encrypt(_1.id), name: _1.name } }
       props[:posts] = visible_posts
@@ -68,6 +86,32 @@ class ProfileSectionsPresenter
 
   private
     attr_reader :seller, :query
+
+    # Builds the cacheable data for the virtual default products section (see
+    # DEFAULT_PRODUCTS_SECTION_ID above). Returns nil when the creator has no products that
+    # could appear on their profile, so the caller can keep the existing email-signup fallback.
+    # Cached with the same 10-minute window as saved sections; the cache key includes the
+    # products' cache version so publishing, archiving, or deleting a product refreshes it.
+    def cached_default_products_section
+      # `alive.not_archived` mirrors the `is_alive_on_profile` flag the product search index
+      # uses, so this guard agrees with what the search below would actually return.
+      return nil unless seller.products.alive.not_archived.exists?
+
+      products_cache_key = seller.products.cache_key_with_version
+      cache_key = "#{CACHE_KEY_PREFIX}_default_#{REVISION}-#{products_cache_key}"
+      Rails.cache.fetch(cache_key, expires_in: 10.minutes) do
+        {
+          id: DEFAULT_PRODUCTS_SECTION_ID,
+          header: nil,
+          type: "SellerProfileProductsSection",
+          # Match what a freshly added products section would use: no filter sidebar, and the
+          # page-layout sort (which, with no saved ordering, falls back to newest first).
+          show_filters: false,
+          default_product_sort: ProductSortKey::PAGE_LAYOUT,
+          search_results: section_search_results(nil),
+        }
+      end
+    end
 
     def section_props(section, cached_props:, request:, pundit_user:, seller_custom_domain_url:, editing:)
       params = request.query_parameters
@@ -137,7 +181,9 @@ class ProfileSectionsPresenter
       search_results = search_products(
         params.merge(
           {
-            sort: params[:sort] || section.default_product_sort,
+            # `section` is nil for the virtual default products section, which has no saved
+            # sort preference - fall back to page-layout (effectively newest first).
+            sort: params[:sort] || section&.default_product_sort || ProductSortKey::PAGE_LAYOUT,
             section:,
             is_alive_on_profile: true,
             user_id: seller.id,

--- a/app/presenters/profile_sections_presenter.rb
+++ b/app/presenters/profile_sections_presenter.rb
@@ -50,7 +50,6 @@ class ProfileSectionsPresenter
   end
 
   def cached_sections
-    products_cache_key = seller.products.cache_key_with_version
     sections_cache_key = query.cache_key_with_version
     cache_key = "#{CACHE_KEY_PREFIX}_#{REVISION}-#{products_cache_key}-#{sections_cache_key}"
     Rails.cache.fetch(cache_key, expires_in: 10.minutes) do
@@ -87,6 +86,13 @@ class ProfileSectionsPresenter
   private
     attr_reader :seller, :query
 
+    # Computing this cache key runs a SQL query (count + max updated_at over the seller's
+    # products), and both `cached_sections` and `cached_default_products_section` need it on the
+    # same request - memoize so we only hit the database once per presenter instance.
+    def products_cache_key
+      @products_cache_key ||= seller.products.cache_key_with_version
+    end
+
     # Builds the cacheable data for the virtual default products section (see
     # DEFAULT_PRODUCTS_SECTION_ID above). Returns nil when the creator has no products that
     # could appear on their profile, so the caller can keep the existing email-signup fallback.
@@ -97,7 +103,6 @@ class ProfileSectionsPresenter
       # uses, so this guard agrees with what the search below would actually return.
       return nil unless seller.products.alive.not_archived.exists?
 
-      products_cache_key = seller.products.cache_key_with_version
       cache_key = "#{CACHE_KEY_PREFIX}_default_#{REVISION}-#{products_cache_key}"
       Rails.cache.fetch(cache_key, expires_in: 10.minutes) do
         {

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -4784,6 +4784,30 @@ describe LinksController, :vcr, inertia: true do
           expect(response.parsed_body).to eq({ "total" => 0, "tags_data" => [], "filetypes_data" => [], "products" => [] })
         end
 
+        it "returns all the creator's live profile products for the virtual default products section" do
+          @recommended_by = nil
+          @on_profile = true
+          # The default products section only exists for creators with no saved sections, so
+          # remove the one this describe block sets up.
+          @section.destroy!
+          another_product = create(:product, name: "Another product", user: @creator)
+          Link.import(force: true, refresh: true)
+
+          get :search, params: { user_id: @creator.external_id, section_id: ProfileSectionsPresenter::DEFAULT_PRODUCTS_SECTION_ID }
+
+          expect(response).to be_successful
+          expect(response.parsed_body["total"]).to eq(2)
+          expect(response.parsed_body["products"]).to match_array([product_json(@product, "profile"), product_json(another_product, "profile")])
+        end
+
+        it "returns an empty response for the default products section id when the creator has saved sections" do
+          # A creator with real sections controls exactly which products show on their profile;
+          # the virtual section id must not offer a way around that.
+          get :search, params: { user_id: @creator.external_id, section_id: ProfileSectionsPresenter::DEFAULT_PRODUCTS_SECTION_ID }
+
+          expect(response.parsed_body).to eq({ "total" => 0, "tags_data" => [], "filetypes_data" => [], "products" => [] })
+        end
+
 
         it "searches only for recommendable products" do
           bad_text = "Previously-owned weasel"

--- a/spec/presenters/profile_presenter_spec.rb
+++ b/spec/presenters/profile_presenter_spec.rb
@@ -127,6 +127,44 @@ describe ProfilePresenter do
       expect(props).not_to have_key(:products)
       expect(props[:sections].first).not_to have_key(:shown_products)
     end
+
+    context "when the seller has products but no profile sections" do
+      let(:new_seller) { create(:user, name: "New Seller") }
+      let!(:new_seller_product) { create(:product, user: new_seller) }
+      let(:visitor_pundit_user) { SellerContext.new(user: logged_in_user, seller: logged_in_user) }
+
+      before { Link.import(force: true, refresh: true) }
+
+      it "serves the virtual default products section with a matching tab" do
+        props = described_class.new(pundit_user: visitor_pundit_user, seller: new_seller).profile_props(seller_custom_domain_url: nil, request:)
+
+        expect(props[:sections].size).to eq(1)
+        expect(props[:sections].first[:id]).to eq(ProfileSectionsPresenter::DEFAULT_PRODUCTS_SECTION_ID)
+        expect(props[:sections].first[:type]).to eq("SellerProfileProductsSection")
+        # The frontend only renders sections referenced by a tab, so the virtual section needs
+        # one pointing at it.
+        expect(props[:tabs]).to eq([{ name: "Products", sections: [ProfileSectionsPresenter::DEFAULT_PRODUCTS_SECTION_ID] }])
+      end
+
+      it "does not serve the virtual section in the profile editor payload" do
+        pundit_user = SellerContext.new(user: new_seller, seller: new_seller)
+        props = described_class.new(pundit_user:, seller: new_seller).profile_settings_props(request:)
+
+        expect(props[:editable_profile][:sections]).to eq([])
+      end
+    end
+
+    context "when the seller has no products and no profile sections" do
+      it "keeps the empty-sections shape so the email signup fallback still renders" do
+        new_seller = create(:user, name: "New Seller")
+        visitor_pundit_user = SellerContext.new(user: logged_in_user, seller: logged_in_user)
+
+        props = described_class.new(pundit_user: visitor_pundit_user, seller: new_seller).profile_props(seller_custom_domain_url: nil, request:)
+
+        expect(props[:sections]).to eq([])
+        expect(props[:tabs]).to eq([])
+      end
+    end
   end
 
   describe "#profile_settings_props" do

--- a/spec/presenters/profile_sections_presenter_spec.rb
+++ b/spec/presenters/profile_sections_presenter_spec.rb
@@ -275,4 +275,83 @@ describe ProfileSectionsPresenter do
       subject.props(request:, pundit_user:, seller_custom_domain_url: nil)
     end
   end
+
+  describe "default products section" do
+    let(:new_seller) { create(:user, name: "New Seller") }
+    let(:presenter) { described_class.new(seller: new_seller, query: new_seller.seller_profile_sections.on_profile) }
+    let(:visitor_pundit_user) { SellerContext.new(user: logged_in_user, seller: logged_in_user) }
+
+    context "when the seller has products but no profile sections" do
+      let!(:new_seller_products) { create_list(:product, 2, user: new_seller) }
+
+      before { Link.import(force: true, refresh: true) }
+
+      it "injects a virtual products section when asked to" do
+        props = presenter.props(request:, pundit_user: visitor_pundit_user, seller_custom_domain_url: nil, editing: false, include_default_products_section: true)
+
+        expect(props[:sections].size).to eq(1)
+        expect(props[:sections].first).to match(
+          {
+            id: described_class::DEFAULT_PRODUCTS_SECTION_ID,
+            header: nil,
+            type: "SellerProfileProductsSection",
+            show_filters: false,
+            default_product_sort: ProductSortKey::PAGE_LAYOUT,
+            search_results: {
+              total: 2,
+              filetypes_data: [],
+              tags_data: [],
+              products: a_collection_containing_exactly(
+                *new_seller_products.map do |product|
+                  ProductPresenter.card_for_web(product:, request:, target: Product::Layout::PROFILE, show_seller: false, compute_description: false)
+                end
+              )
+            },
+          }
+        )
+      end
+
+      it "does not inject the virtual section by default" do
+        props = presenter.props(request:, pundit_user: visitor_pundit_user, seller_custom_domain_url: nil, editing: false)
+
+        expect(props[:sections]).to eq([])
+      end
+
+      it "does not inject the virtual section into the editing payload" do
+        props = presenter.props(request:, pundit_user: SellerContext.new(user: new_seller, seller: new_seller), seller_custom_domain_url: nil, include_default_products_section: true)
+
+        expect(props[:sections]).to eq([])
+        # The editing shape (with the section-builder helper lists) must be untouched.
+        expect(props).to have_key(:products)
+        expect(props).to have_key(:posts)
+        expect(props).to have_key(:wishlist_options)
+      end
+    end
+
+    context "when the seller has no products and no profile sections" do
+      it "returns no sections, preserving the email signup fallback" do
+        props = presenter.props(request:, pundit_user: visitor_pundit_user, seller_custom_domain_url: nil, editing: false, include_default_products_section: true)
+
+        expect(props[:sections]).to eq([])
+      end
+
+      it "returns no sections when the seller's only products are archived or unpublished" do
+        create(:product, user: new_seller, archived: true)
+        create(:product, user: new_seller, purchase_disabled_at: Time.current)
+        Link.import(force: true, refresh: true)
+
+        props = presenter.props(request:, pundit_user: visitor_pundit_user, seller_custom_domain_url: nil, editing: false, include_default_products_section: true)
+
+        expect(props[:sections]).to eq([])
+      end
+    end
+
+    context "when the seller has saved profile sections" do
+      it "renders only the saved sections, never the virtual one" do
+        props = subject.props(request:, pundit_user: visitor_pundit_user, seller_custom_domain_url: nil, editing: false, include_default_products_section: true)
+
+        expect(props[:sections].map { _1[:id] }).to match_array(sections.map(&:external_id))
+      end
+    end
+  end
 end

--- a/spec/requests/user/profile_spec.rb
+++ b/spec/requests/user/profile_spec.rb
@@ -166,7 +166,20 @@ describe "User profile page", type: :system, js: true do
         end
       end
 
-      it "shows the subscribe block when there are no sections" do
+      it "shows a default products section when there are no sections but there are products" do
+        # The server renders the section's initial results from Elasticsearch, so make sure the
+        # products created above are searchable before the page loads.
+        Link.import(force: true, refresh: true)
+        visit seller.subdomain_with_protocol
+        expect(page).to_not have_selector "main > header"
+        # No saved sections + published products = the virtual default products section, so
+        # visitors see the catalog instead of only an email signup box.
+        expect(page).to_not have_text "Subscribe to receive email updates from #{seller.name}"
+        expect_product_cards_in_order([@product4, @product3, @product2, @product1])
+      end
+
+      it "shows the subscribe block when there are no sections and no products" do
+        seller.links.each { _1.update!(deleted_at: Time.current) }
         visit seller.subdomain_with_protocol
         expect(page).to_not have_selector "main > header"
         expect(page).to have_text "Subscribe to receive email updates from #{seller.name}"


### PR DESCRIPTION
## What

Adds a virtual "default products section" to public creator profiles. When a seller has zero saved profile sections (`seller_profile_sections.on_profile` is empty) but has at least one live, non-archived product, the public profile now renders a Products section listing all of their profile products (newest first, no filter sidebar) — the same UI a freshly added `SellerProfileProductsSection` with `add_new_products` would produce. Nothing is written to the database: the section is injected by `ProfileSectionsPresenter` at render time under the stable id `default-products`, and `ProfilePresenter` points a single synthetic "Products" tab at it so the frontend renders it with the existing `Section` component, unchanged.

- Sellers with no sections and no live products keep the current fallback: the email signup form.
- As soon as the creator saves any real section in the profile editor, their own layout takes over — the virtual section disappears.
- The profile editor (`/profile` settings) is unchanged: the virtual section is never included in the editing payload.
- `LinksController#search` accepts the `default-products` section id (guarded on the creator still having no saved sections) so pagination and client-side filtering on the default section keep working.

## Why

New creators who published products but never customized their profile got a public page showing only an email signup box — their products were invisible. A real seller (Keith of PixelPop Studio, 4 published products) hit exactly this confusion in support: products live, storefront apparently "empty". Auto-showing the products is the better default, and the email-signup fallback remains for creators who have nothing to sell yet.

autoreview: clean (Codex, `overall: patch is correct (0.86)`, no actionable findings).

## Screenshots

**After — seller with published products and no saved sections (previously showed only the email signup box):**

![Default products section](https://raw.githubusercontent.com/gumclaw/gumroad/gumclaw-default-products-assets/screenshots/after-default-products-section.png)

**Unchanged fallback — seller with no live products still gets the email signup form:**

![Email signup fallback](https://raw.githubusercontent.com/gumclaw/gumroad/gumclaw-default-products-assets/screenshots/fallback-email-signup.png)

## Test plan

- `spec/presenters/profile_sections_presenter_spec.rb` — new "default products section" block: virtual section injected with the correct `SellerProfileProductsSection` prop shape (search results, `show_filters: false`, `default_product_sort: page_layout`); not injected by default; not injected in the editing payload; empty when the seller has no products or only archived/unpublished products; real sections always win. **30 examples, 0 failures** (with `profile_presenter_spec.rb`).
- `spec/presenters/profile_presenter_spec.rb` — public props carry the virtual section plus a matching synthetic tab; editor payload (`profile_settings_props`) unchanged; no-products profile keeps the empty sections/tabs shape.
- `spec/controllers/links_controller_spec.rb` — search with `section_id=default-products` returns all the creator's live profile products; returns empty when the creator has saved sections (no layout bypass). **10 examples, 0 failures** ("Setting and ordering" block).
- `spec/requests/user/profile_spec.rb` — system spec: profile with products and no sections renders the product grid; subscribe block still shows when there are no products. **2 examples, 0 failures.**
- `rubocop` on all 7 touched files: 0 offenses.
