### PR TITLE
Fix store agent failures on long description edits (max_tokens truncation)

### DIFF
--- a/app/services/ai/anthropic_client.rb
+++ b/app/services/ai/anthropic_client.rb
@@ -91,7 +91,7 @@ class Ai::AnthropicClient
       end
     end
 
-    Result.new(text:, tool_uses: assemble_tool_uses(blocks), stop_reason:)
+    Result.new(text:, tool_uses: assemble_tool_uses(blocks, stop_reason:), stop_reason:)
   rescue HTTP::Error => e
     raise Error, "Anthropic network error: #{e.message}"
   end
@@ -165,13 +165,24 @@ class Ai::AnthropicClient
 
     # Turn the accumulated streamed blocks into the same tool_use shape #parse_message returns. A
     # tool_use block with no input fragments is a no-arg call; malformed non-empty input must fail the
-    # turn instead of dispatching a lossy {} tool call.
-    def assemble_tool_uses(blocks)
+    # turn instead of dispatching a lossy {} tool call — EXCEPT when the model was cut off by
+    # max_tokens. A turn truncated mid-tool-call always ends with half-written (unparseable) JSON;
+    # that isn't the model misbehaving, it's the token cap. Dropping the cut-off block and letting
+    # the caller see stop_reason == "max_tokens" lets it respond honestly instead of erroring out.
+    def assemble_tool_uses(blocks, stop_reason: nil)
+      truncated = stop_reason == "max_tokens"
       blocks.keys.sort.filter_map do |index|
         block = blocks[index]
         next unless block[:type] == "tool_use"
 
-        { id: block[:id], name: block[:name], input: parse_tool_use_input(block) }
+        input = begin
+          parse_tool_use_input(block)
+        rescue Error
+          # Only swallow the parse failure for a truncated turn; otherwise it is a real error.
+          raise unless truncated
+          next
+        end
+        { id: block[:id], name: block[:name], input: }
       end
     end
 

--- a/app/services/ai/store_agent_service.rb
+++ b/app/services/ai/store_agent_service.rb
@@ -27,8 +27,19 @@ class Ai::StoreAgentService
   REQUEST_TIMEOUT_IN_SECONDS = 60
   MAX_TOOL_ITERATIONS = 5
   MAX_MESSAGE_LENGTH = 2_000
-  # Anthropic requires max_tokens; size it for a brief chat reply plus a tool call's JSON args.
-  MAX_REPLY_TOKENS = 1_500
+  # Anthropic requires max_tokens on every request. This cap has to fit more than a brief chat
+  # reply: when the agent edits a product, the model must emit the ENTIRE new value (for example a
+  # long description's full HTML) inside the tool call's JSON arguments. A cap sized only for text
+  # replies (this was previously 1,500) cut those tool calls off mid-JSON, which surfaced to the
+  # seller as a generic "Something went wrong" error. 8,192 comfortably fits real product
+  # descriptions while still bounding the cost of a runaway turn.
+  MAX_REPLY_TOKENS = 8_192
+  # What the seller sees when a model turn still hits MAX_REPLY_TOKENS (stop_reason "max_tokens").
+  # A truncated turn is unusable — a cut-off tool call has unparseable arguments, and a cut-off
+  # text reply would silently present half an answer as if it were complete — so we replace it
+  # with an honest ask to scope the request down instead of streaming garbage or raising.
+  TRUNCATED_REPLY = "That's too much for me to handle in one go — try asking me to change or " \
+                    "summarize a smaller section, and I'll take it from there."
   # How many prior turns of context we forward to the model. Keeps token usage bounded and avoids
   # echoing an unbounded client-supplied history back to the model.
   MAX_HISTORY_MESSAGES = 20
@@ -129,6 +140,13 @@ class Ai::StoreAgentService
         max_tokens: MAX_REPLY_TOKENS,
       )
 
+      # The model hit MAX_REPLY_TOKENS mid-turn. Whatever came back is incomplete — a cut-off tool
+      # call has unusable arguments, and a cut-off text answer would read as a complete reply when
+      # it isn't — so stop here with an honest message instead of acting on a truncated turn.
+      if result.stop_reason == "max_tokens"
+        return { reply: TRUNCATED_REPLY, proposed_action: proposed_action&.as_json, objects: deduped_objects }
+      end
+
       if result.tool_uses.blank?
         return { reply: result.text.to_s.strip, proposed_action: proposed_action&.as_json, objects: deduped_objects }
       end
@@ -168,6 +186,15 @@ class Ai::StoreAgentService
       ) do |text|
         streamed_any = true
         emit.call(:token, { text: })
+      end
+
+      # Same truncation handling as #respond. Anything this turn streamed is incomplete, so tell
+      # the UI to discard it and stream the honest fallback instead of leaving half an answer (or
+      # half a tool call's preamble) on screen as if it were the finished reply.
+      if result.stop_reason == "max_tokens"
+        emit.call(:reset, {}) if streamed_any
+        emit.call(:token, { text: TRUNCATED_REPLY })
+        return finish_stream(reply: TRUNCATED_REPLY, proposed_action:, last_user_message:, emit:)
       end
 
       if result.tool_uses.blank?

--- a/spec/services/ai/anthropic_client_spec.rb
+++ b/spec/services/ai/anthropic_client_spec.rb
@@ -148,6 +148,24 @@ describe Ai::AnthropicClient do
         .to raise_error(described_class::Error, /unreadable tool call/i)
     end
 
+    it "drops a tool call whose JSON was cut off by max_tokens instead of raising" do
+      # When the stream stops with stop_reason "max_tokens", a half-written tool call's JSON is
+      # expected (the token cap cut it off mid-arguments), not a model bug. Returning a Result with
+      # the broken block dropped and stop_reason intact lets the caller handle the truncation
+      # honestly instead of blowing up with "unreadable tool call".
+      stream = sse(
+        ["content_block_start", { index: 0, content_block: { type: "tool_use", id: "toolu_x", name: "api_write" } }],
+        ["content_block_delta", { index: 0, delta: { type: "input_json_delta", partial_json: '{"endpoint":"update_product","params":{"description":"<p>very long' } }],
+        ["message_delta", { delta: { stop_reason: "max_tokens" } }],
+      )
+      stub_request(:post, url).to_return(status: 200, body: stream, headers: { "Content-Type" => "text/event-stream" })
+
+      result = client.stream_messages(system: "s", messages: [{ role: "user", content: "update my description" }])
+
+      expect(result.tool_uses).to eq([])
+      expect(result.stop_reason).to eq("max_tokens")
+    end
+
     it "raises Error on a stream-level error event" do
       stream = sse(["error", { error: { message: "overloaded" } }])
       stub_request(:post, url).to_return(status: 200, body: stream, headers: { "Content-Type" => "text/event-stream" })

--- a/spec/services/ai/store_agent_service_spec.rb
+++ b/spec/services/ai/store_agent_service_spec.rb
@@ -387,6 +387,36 @@ describe Ai::StoreAgentService do
       end
     end
 
+    context "when a model turn is truncated by the max_tokens cap" do
+      # A truncated turn (stop_reason "max_tokens") is incomplete no matter what it contains: a
+      # cut-off text answer reads as a finished reply but isn't, and a cut-off tool call has
+      # unusable arguments. The service must return the honest fallback rather than the fragment.
+      def truncated_text_result(text)
+        Ai::AnthropicClient::Result.new(text:, tool_uses: [], stop_reason: "max_tokens")
+      end
+
+      it "does not return a truncated text turn as if it were a complete reply" do
+        allow(client).to receive(:messages).and_return(truncated_text_result("Sorry about that — let me"))
+
+        result = service.respond(messages: [{ role: "user", content: "rewrite my whole description" }])
+
+        expect(result[:reply]).to eq(described_class::TRUNCATED_REPLY)
+        expect(result[:reply]).not_to include("Sorry about that")
+        expect(result[:proposed_action]).to be_nil
+      end
+
+      it "handles a truncated tool-call turn gracefully instead of raising" do
+        # The client drops a tool call whose JSON was cut off mid-stream, so the truncated turn
+        # arrives here with no usable tool_uses and stop_reason "max_tokens".
+        allow(client).to receive(:messages).and_return(truncated_text_result(""))
+
+        expect do
+          result = service.respond(messages: [{ role: "user", content: "update the description" }])
+          expect(result[:reply]).to eq(described_class::TRUNCATED_REPLY)
+        end.not_to raise_error
+      end
+    end
+
     context "when the model emits a non-hash tool input" do
       # Anthropic normally delivers tool input as a JSON object, but our client coerces a malformed
       # input to {}; the tool then falls through to its normal "endpoint is required" handling rather
@@ -499,6 +529,23 @@ describe Ai::StoreAgentService do
       expect(event_names).to include(:reset)
       expect(event_names.index(:reset)).to be < event_names.rindex(:token)
       expect(result[:reply]).to eq("You have 3 products.")
+    end
+
+    it "resets any streamed fragment and streams the honest fallback when a turn hits max_tokens" do
+      # The model streams part of a reply (or a tool call's preamble) and is then cut off by the
+      # token cap. What streamed is incomplete, so the UI must be told to discard it and the seller
+      # must get the honest fallback rather than half an answer presented as complete.
+      truncated = Ai::AnthropicClient::Result.new(text: "Here's the new descri", tool_uses: [], stop_reason: "max_tokens")
+      stub_stream_turns(stream: ["Here's the new descri"], result: truncated)
+      allow(client).to receive(:messages).and_return(text_result("[]"))
+
+      events, result = collect_events([{ role: "user", content: "rewrite my whole description" }])
+
+      event_names = events.map(&:first)
+      expect(event_names).to include(:reset)
+      final_tokens = events.filter_map { |event, payload| payload[:text] if event == :token }
+      expect(final_tokens.last).to eq(described_class::TRUNCATED_REPLY)
+      expect(result[:reply]).to eq(described_class::TRUNCATED_REPLY)
     end
   end
 end

--- a/spec/services/ai/store_agent_service_spec.rb
+++ b/spec/services/ai/store_agent_service_spec.rb
@@ -543,6 +543,11 @@ describe Ai::StoreAgentService do
 
       event_names = events.map(&:first)
       expect(event_names).to include(:reset)
+      # The reset must come BEFORE the fallback token. If the order were flipped, the UI would
+      # render the fallback and then immediately wipe it, leaving the seller with nothing.
+      fallback_index = events.index { |event, payload| event == :token && payload[:text] == described_class::TRUNCATED_REPLY }
+      expect(fallback_index).not_to be_nil
+      expect(event_names.index(:reset)).to be < fallback_index
       final_tokens = events.filter_map { |event, payload| payload[:text] if event == :token }
       expect(final_tokens.last).to eq(described_class::TRUNCATED_REPLY)
       expect(result[:reply]).to eq(described_class::TRUNCATED_REPLY)


### PR DESCRIPTION
## What

Fixes the store AI agent failing with "Something went wrong" whenever a seller asks it to edit a long product description.

- Raises `Ai::StoreAgentService::MAX_REPLY_TOKENS` from 1,500 to 8,192 so a description edit's full HTML fits inside the tool call's JSON arguments.
- Checks `result.stop_reason == "max_tokens"` in both `#respond` and `#respond_streaming`: a truncated turn now returns an honest fallback ("That's too much for me to handle in one go — try asking me to change or summarize a smaller section…") instead of raising or presenting a fragment as a complete answer. In the streaming path, any partially streamed text is discarded via the existing `:reset` event before the fallback is streamed.
- In `Ai::AnthropicClient#stream_messages`, a tool call whose JSON was cut off by the token cap (`stop_reason: "max_tokens"`) is dropped from the assembled result instead of raising "Anthropic produced an unreadable tool call". Genuinely malformed input on a completed turn still raises as before.

## Why

Root cause (tracked in antiwork/gumroad-private#951, hit in production by a seller with ~$565K lifetime sales): every model turn was capped at `MAX_REPLY_TOKENS = 1_500`, sized only for a brief text reply. Editing a description requires the model to emit the ENTIRE new description HTML inside `api_write`'s JSON args, so long descriptions blew the cap. The stream stopped with `stop_reason: "max_tokens"` mid `input_json_delta`, the half-written JSON failed `JSON.parse` in `parse_tool_use_input`, the service raised, and the frontend (`AgentChat.tsx`) showed the generic "Something went wrong". Separately, a truncated TEXT turn ("Sorry about that — let me") was returned as if complete because `stop_reason` was captured on the Result struct but never checked.

**Before:** long description edit → hard error to the seller; truncated text replies silently shown as complete.
**After:** description edits up to 8,192 output tokens succeed normally; anything still larger gets a clear, honest message asking to scope the edit down; truncated text is never presented as a finished reply.

## Test plan

- `bundle exec rspec spec/services/ai/store_agent_service_spec.rb spec/services/ai/anthropic_client_spec.rb` — 41 examples, 0 failures.
- New specs (all verified to fail with the fix reverted):
  - truncated tool-call stream → client returns a Result with the cut-off block dropped and `stop_reason: "max_tokens"` (no raise)
  - truncated text turn → service returns `TRUNCATED_REPLY`, never the fragment
  - streaming truncation → `:reset` emitted, fallback streamed as the final token
  - all existing normal-turn specs unchanged and passing
- `bundle exec rubocop` on the 4 touched files — no offenses.
- autoreview: clean.

No UI files touched; the frontend already renders whatever reply text the service returns.

---

AI disclosure: authored with Claude (Hermes Agent). Prompt: fix gumroad-private#951 (store agent tool-call JSON truncated at MAX_REPLY_TOKENS=1500 breaking description edits; handle stop_reason "max_tokens" honestly) with specs.
