### PR TITLE
Persist store Agent conversations server-side

### DIFF
--- a/app/controllers/api/internal/agent_conversations_controller.rb
+++ b/app/controllers/api/internal/agent_conversations_controller.rb
@@ -28,12 +28,15 @@ class Api::Internal::AgentConversationsController < Api::Internal::BaseControlle
 
     # The shape AgentChat.tsx hydrates from: the plain transcript plus each turn's persisted
     # extras (proposed-action card, object cards, applied/dismissed status) so history re-renders
-    # exactly as it did live.
+    # exactly as it did live. Hydration is capped at the same window the model replays
+    # (AgentConversationPersistence::HISTORY_MAX_MESSAGES) so a very long conversation doesn't
+    # produce a multi-megabyte resume payload — and so what the seller sees matches what the
+    # model will be shown on the next turn.
     def conversation_props(conversation)
       {
         id: conversation.external_id,
         title: conversation.title,
-        messages: conversation.ai_messages.map do |message|
+        messages: conversation.ai_messages.last(AgentConversationPersistence::HISTORY_MAX_MESSAGES).map do |message|
           metadata = message.metadata || {}
           {
             role: message.role,

--- a/app/controllers/api/internal/agent_conversations_controller.rb
+++ b/app/controllers/api/internal/agent_conversations_controller.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Read side of the persisted store Agent chat (see AgentConversationPersistence for the write
+# side). The Agent tab calls `latest` on mount to hydrate the most recently active conversation, so
+# a page refresh resumes the chat instead of starting blank — the same resume behavior hosted chat
+# products (OpenAI, Claude) have.
+#
+# Shares the authentication + UserPolicy#use_store_agent? guards with the other agent endpoints,
+# but not the LLM throttle: this is a cheap seller-scoped read that must work even when the seller
+# has used up their agent-turn quota.
+class Api::Internal::AgentConversationsController < Api::Internal::BaseController
+  before_action :authenticate_user!
+  before_action :authorize_store_agent
+  after_action :verify_authorized
+
+  # GET /internal/agent/conversations/latest
+  # Returns { success: true, conversation: null } when the seller has no stored conversations —
+  # the client treats that as a fresh chat.
+  def latest
+    conversation = current_seller.ai_conversations.alive.order(updated_at: :desc, id: :desc).first
+    render json: { success: true, conversation: conversation && conversation_props(conversation) }
+  end
+
+  private
+    def authorize_store_agent
+      authorize current_seller, :use_store_agent?
+    end
+
+    # The shape AgentChat.tsx hydrates from: the plain transcript plus each turn's persisted
+    # extras (proposed-action card, object cards, applied/dismissed status) so history re-renders
+    # exactly as it did live.
+    def conversation_props(conversation)
+      {
+        id: conversation.external_id,
+        title: conversation.title,
+        messages: conversation.ai_messages.map do |message|
+          metadata = message.metadata || {}
+          {
+            role: message.role,
+            content: message.content,
+            proposed_action: metadata["proposed_action"],
+            objects: metadata["objects"],
+            action_status: metadata["action_status"],
+          }.compact
+        end,
+      }
+    end
+end

--- a/app/controllers/api/internal/agent_message_streams_controller.rb
+++ b/app/controllers/api/internal/agent_message_streams_controller.rb
@@ -56,16 +56,25 @@ class Api::Internal::AgentMessageStreamsController < Api::Internal::BaseControll
         return
       end
 
-      # The last user entry in the posted history is this turn's new message; earlier entries are
-      # replaced by the stored transcript when resuming, so a stale client can't rewrite history.
+      # The last user entry in the posted history is this turn's new message; when resuming, the
+      # earlier entries are replaced by the stored transcript so a stale client can't rewrite
+      # history. Nothing is persisted until the service succeeds — a failed turn (the seller sees
+      # an error and will retry) must not leave a stray user message that gets silently replayed
+      # to the model on the next turn or after a refresh.
       new_user_message = messages.reverse.find { |message| message[:role] == "user" }&.dig(:content)
-      conversation ||= create_agent_conversation!(new_user_message || messages.last[:content])
-      record_agent_user_message!(conversation, new_user_message) if new_user_message.present?
-      history = agent_conversation_history(conversation).presence || messages
+      history =
+        if conversation
+          agent_conversation_history(conversation) + (new_user_message ? [{ role: "user", content: new_user_message }] : [])
+        else
+          messages
+        end
 
       result = ::Ai::StoreAgentService.new(seller: current_seller, pundit_user:).respond_streaming(messages: history) do |event, payload|
         sse.write(payload, event:)
       end
+
+      conversation ||= create_agent_conversation!(new_user_message || messages.last[:content])
+      record_agent_user_message!(conversation, new_user_message) if new_user_message.present?
       record_agent_assistant_message!(conversation, result)
       sse.write(
         {

--- a/app/controllers/api/internal/agent_message_streams_controller.rb
+++ b/app/controllers/api/internal/agent_message_streams_controller.rb
@@ -79,9 +79,7 @@ class Api::Internal::AgentMessageStreamsController < Api::Internal::BaseControll
       # so the next turn would silently start a brand-new conversation. The only cost of a
       # persistence failure is that this turn isn't stored.
       begin
-        conversation ||= create_agent_conversation!(new_user_message || messages.last[:content])
-        record_agent_user_message!(conversation, new_user_message) if new_user_message.present?
-        record_agent_assistant_message!(conversation, result)
+        conversation = persist_agent_turn!(conversation, new_user_message, result, fallback_first_message: messages.last[:content])
       rescue => e
         Rails.logger.error("Store agent turn persistence failed: #{e.full_message}")
         ErrorNotifier.notify(e)

--- a/app/controllers/api/internal/agent_message_streams_controller.rb
+++ b/app/controllers/api/internal/agent_message_streams_controller.rb
@@ -12,6 +12,7 @@
 class Api::Internal::AgentMessageStreamsController < Api::Internal::BaseController
   include Throttling
   include ActionController::Live
+  include AgentConversationPersistence
 
   before_action :authenticate_user!
   before_action :authorize_store_agent
@@ -23,10 +24,15 @@ class Api::Internal::AgentMessageStreamsController < Api::Internal::BaseControll
   private_constant :AGENT_REQUESTS_PER_PERIOD, :AGENT_REQUESTS_PERIOD_WINDOW
 
   # POST /internal/agent/messages/stream
-  # params: { messages: [{ role:, content: }, ...] }
+  # params: { messages: [{ role:, content: }, ...], conversation_id: <optional external id> }
   # Each event is `event: <name>` + `data: <json>` + a blank line. Event names: `token` (a chunk of
   # reply text), `objects`, `proposed_action`, `suggestions`, `done` (terminal, carrying the final
   # assembled payload), and `error` (a friendly message; the stream still closes cleanly).
+  #
+  # Turns are persisted the same way as the buffered endpoint (see AgentConversationPersistence):
+  # with a conversation_id the turn appends to that stored conversation and the model replays the
+  # server-held transcript; without one a new conversation is created. The `done` event carries the
+  # conversation's external id so the client can send it on subsequent turns.
   def create
     response.headers["Content-Type"] = "text/event-stream"
     response.headers["Cache-Control"] = "no-cache"
@@ -41,15 +47,33 @@ class Api::Internal::AgentMessageStreamsController < Api::Internal::BaseControll
         return
       end
 
-      result = ::Ai::StoreAgentService.new(seller: current_seller, pundit_user:).respond_streaming(messages:) do |event, payload|
+      # An unknown/foreign conversation id is surfaced as a stream error (the response status is
+      # already committed once we start streaming, so a 404 render isn't possible here).
+      begin
+        conversation = find_agent_conversation!
+      rescue ActiveRecord::RecordNotFound
+        sse.write({ message: "That conversation could not be found." }, event: "error")
+        return
+      end
+
+      # The last user entry in the posted history is this turn's new message; earlier entries are
+      # replaced by the stored transcript when resuming, so a stale client can't rewrite history.
+      new_user_message = messages.reverse.find { |message| message[:role] == "user" }&.dig(:content)
+      conversation ||= create_agent_conversation!(new_user_message || messages.last[:content])
+      record_agent_user_message!(conversation, new_user_message) if new_user_message.present?
+      history = agent_conversation_history(conversation).presence || messages
+
+      result = ::Ai::StoreAgentService.new(seller: current_seller, pundit_user:).respond_streaming(messages: history) do |event, payload|
         sse.write(payload, event:)
       end
+      record_agent_assistant_message!(conversation, result)
       sse.write(
         {
           reply: result[:reply],
           proposed_action: result[:proposed_action],
           objects: result[:objects] || [],
           suggestions: result[:suggestions] || [],
+          conversation_id: conversation.external_id,
         },
         event: "done",
       )

--- a/app/controllers/api/internal/agent_message_streams_controller.rb
+++ b/app/controllers/api/internal/agent_message_streams_controller.rb
@@ -73,16 +73,27 @@ class Api::Internal::AgentMessageStreamsController < Api::Internal::BaseControll
         sse.write(payload, event:)
       end
 
-      conversation ||= create_agent_conversation!(new_user_message || messages.last[:content])
-      record_agent_user_message!(conversation, new_user_message) if new_user_message.present?
-      record_agent_assistant_message!(conversation, result)
+      # Persistence must not mask a reply the seller has already watched stream in. If recording
+      # the turn fails (e.g. a DB hiccup after a long LLM call), log + report it but still send the
+      # terminal `done` event — dropping `done` would leave the client without a conversation id,
+      # so the next turn would silently start a brand-new conversation. The only cost of a
+      # persistence failure is that this turn isn't stored.
+      begin
+        conversation ||= create_agent_conversation!(new_user_message || messages.last[:content])
+        record_agent_user_message!(conversation, new_user_message) if new_user_message.present?
+        record_agent_assistant_message!(conversation, result)
+      rescue => e
+        Rails.logger.error("Store agent turn persistence failed: #{e.full_message}")
+        ErrorNotifier.notify(e)
+      end
       sse.write(
         {
           reply: result[:reply],
           proposed_action: result[:proposed_action],
           objects: result[:objects] || [],
           suggestions: result[:suggestions] || [],
-          conversation_id: conversation.external_id,
+          # Omitted (nil) when creating the conversation itself failed above.
+          conversation_id: conversation&.external_id,
         },
         event: "done",
       )

--- a/app/controllers/api/internal/agent_messages_controller.rb
+++ b/app/controllers/api/internal/agent_messages_controller.rb
@@ -52,13 +52,24 @@ class Api::Internal::AgentMessagesController < Api::Internal::BaseController
 
       result = ::Ai::StoreAgentService.new(seller: current_seller, pundit_user:).respond(messages: history)
 
-      conversation = persist_agent_turn!(conversation, new_user_message, result, fallback_first_message: messages.last[:content])
+      # Persistence must not mask a reply the model already produced. If recording the turn fails
+      # (e.g. a DB hiccup after a long LLM call), log + report it but still return the reply —
+      # otherwise the seller would see an error, retry, and burn another quota slot for an answer
+      # that already succeeded. The only cost of a persistence failure is that this turn isn't
+      # stored; `conversation_id` comes back nil when creating the conversation itself failed, so
+      # the client's next turn starts fresh. This mirrors the streaming path's handling.
+      begin
+        conversation = persist_agent_turn!(conversation, new_user_message, result, fallback_first_message: messages.last[:content])
+      rescue => e
+        Rails.logger.error("Store agent turn persistence failed: #{e.full_message}")
+        ErrorNotifier.notify(e)
+      end
       render json: {
         success: true,
         reply: result[:reply],
         proposed_action: result[:proposed_action],
         objects: result[:objects] || [],
-        conversation_id: conversation.external_id,
+        conversation_id: conversation&.external_id,
       }
     rescue ::Ai::StoreAgentService::Error => e
       render json: { success: false, error: e.message }, status: :unprocessable_entity

--- a/app/controllers/api/internal/agent_messages_controller.rb
+++ b/app/controllers/api/internal/agent_messages_controller.rb
@@ -7,18 +7,26 @@
 # to an LLM and can mutate the store.
 class Api::Internal::AgentMessagesController < Api::Internal::BaseController
   include Throttling
+  include AgentConversationPersistence
 
   before_action :authenticate_user!
   before_action :authorize_store_agent
   before_action :throttle_agent_requests
   after_action :verify_authorized
 
+  # An unknown conversation_id — including another seller's conversation, which the seller-scoped
+  # lookup can't see — renders a JSON 404 instead of bubbling up as a 500.
+  rescue_from ActiveRecord::RecordNotFound, with: :e404_json
+
   AGENT_REQUESTS_PER_PERIOD = 30
   AGENT_REQUESTS_PERIOD_WINDOW = 1.hour
   private_constant :AGENT_REQUESTS_PER_PERIOD, :AGENT_REQUESTS_PERIOD_WINDOW
 
   # POST /internal/agent/messages
-  # params: { messages: [{ role:, content: }, ...] }
+  # params: { messages: [{ role:, content: }, ...], conversation_id: <optional external id> }
+  # With a conversation_id, the turn appends to that stored conversation and the model sees the
+  # server-held transcript; without one, a new conversation is created. The response always carries
+  # `conversation_id` so the client can send it on subsequent turns.
   def create
     messages = sanitize_messages(params[:messages])
     if messages.empty?
@@ -26,9 +34,25 @@ class Api::Internal::AgentMessagesController < Api::Internal::BaseController
       return
     end
 
+    conversation = find_agent_conversation!
+
     begin
-      result = ::Ai::StoreAgentService.new(seller: current_seller, pundit_user:).respond(messages:)
-      render json: { success: true, reply: result[:reply], proposed_action: result[:proposed_action], objects: result[:objects] || [] }
+      # The last user entry in the posted history is this turn's new message; earlier entries are
+      # replaced by the stored transcript when resuming, so a stale client can't rewrite history.
+      new_user_message = messages.reverse.find { |message| message[:role] == "user" }&.dig(:content)
+      conversation ||= create_agent_conversation!(new_user_message || messages.last[:content])
+      record_agent_user_message!(conversation, new_user_message) if new_user_message.present?
+      history = agent_conversation_history(conversation).presence || messages
+
+      result = ::Ai::StoreAgentService.new(seller: current_seller, pundit_user:).respond(messages: history)
+      record_agent_assistant_message!(conversation, result)
+      render json: {
+        success: true,
+        reply: result[:reply],
+        proposed_action: result[:proposed_action],
+        objects: result[:objects] || [],
+        conversation_id: conversation.external_id,
+      }
     rescue ::Ai::StoreAgentService::Error => e
       render json: { success: false, error: e.message }, status: :unprocessable_entity
     rescue => e
@@ -39,7 +63,10 @@ class Api::Internal::AgentMessagesController < Api::Internal::BaseController
   end
 
   # POST /internal/agent/actions
-  # params: { type:, params: {...} } — the confirmed proposed action
+  # params: { type:, params: {...}, conversation_id: <optional external id> } — the confirmed
+  # proposed action. With a conversation_id, a successful execution is also recorded on the stored
+  # conversation (the proposing message is marked applied) so reloaded history shows the collapsed
+  # "Applied" card instead of a still-confirmable one.
   def execute
     type = params[:type].to_s
     unless ::Ai::StoreAgentActionExecutor::SUPPORTED_TYPES.include?(type)
@@ -49,10 +76,19 @@ class Api::Internal::AgentMessagesController < Api::Internal::BaseController
       return
     end
 
+    # Look up before executing so a bad conversation id 404s without mutating the store.
+    conversation = find_agent_conversation!
+
     result = ::Ai::StoreAgentActionExecutor.new(seller: current_seller, pundit_user:)
       .execute(type:, params: action_params)
 
+    record_agent_action_applied!(conversation, result) if conversation && result[:success]
+
     render json: result, status: result[:success] ? :ok : :unprocessable_entity
+  rescue ActiveRecord::RecordNotFound
+    # Re-raise so the controller-level rescue_from renders the JSON 404 — without this the generic
+    # rescue below would report an unknown conversation id as a 500.
+    raise
   rescue => e
     # The executor only rescues expected validation failures; log + report anything unexpected from a
     # real store mutation (e.g. ActiveRecord::StatementInvalid) instead of leaking a 500 with no trail.

--- a/app/controllers/api/internal/agent_messages_controller.rb
+++ b/app/controllers/api/internal/agent_messages_controller.rb
@@ -91,7 +91,17 @@ class Api::Internal::AgentMessagesController < Api::Internal::BaseController
     result = ::Ai::StoreAgentActionExecutor.new(seller: current_seller, pundit_user:)
       .execute(type:, params: action_params)
 
-    record_agent_action_applied!(conversation, result, type:, action_params:) if conversation && result[:success]
+    # Recording the applied status must not mask a store change that already committed: if the
+    # bookkeeping write fails after `execute` succeeded, returning an error would prompt the seller
+    # to retry the confirmation — running the action a second time (a duplicate discount, refund,
+    # etc.). Log + report the failure and return the successful result; the only cost is that
+    # reloaded history shows a still-confirmable card instead of the collapsed "Applied" one.
+    begin
+      record_agent_action_applied!(conversation, result, type:, action_params:) if conversation && result[:success]
+    rescue => e
+      Rails.logger.error("Store agent action persistence failed: #{e.full_message}")
+      ErrorNotifier.notify(e)
+    end
 
     render json: result, status: result[:success] ? :ok : :unprocessable_entity
   rescue ActiveRecord::RecordNotFound

--- a/app/controllers/api/internal/agent_messages_controller.rb
+++ b/app/controllers/api/internal/agent_messages_controller.rb
@@ -82,7 +82,7 @@ class Api::Internal::AgentMessagesController < Api::Internal::BaseController
     result = ::Ai::StoreAgentActionExecutor.new(seller: current_seller, pundit_user:)
       .execute(type:, params: action_params)
 
-    record_agent_action_applied!(conversation, result) if conversation && result[:success]
+    record_agent_action_applied!(conversation, result, type:, action_params:) if conversation && result[:success]
 
     render json: result, status: result[:success] ? :ok : :unprocessable_entity
   rescue ActiveRecord::RecordNotFound

--- a/app/controllers/api/internal/agent_messages_controller.rb
+++ b/app/controllers/api/internal/agent_messages_controller.rb
@@ -37,14 +37,23 @@ class Api::Internal::AgentMessagesController < Api::Internal::BaseController
     conversation = find_agent_conversation!
 
     begin
-      # The last user entry in the posted history is this turn's new message; earlier entries are
-      # replaced by the stored transcript when resuming, so a stale client can't rewrite history.
+      # The last user entry in the posted history is this turn's new message; when resuming, the
+      # earlier entries are replaced by the stored transcript so a stale client can't rewrite
+      # history. Nothing is persisted until the service succeeds — a failed turn (the seller sees
+      # an error and will retry) must not leave a stray user message that gets silently replayed
+      # to the model on the next turn or after a refresh.
       new_user_message = messages.reverse.find { |message| message[:role] == "user" }&.dig(:content)
-      conversation ||= create_agent_conversation!(new_user_message || messages.last[:content])
-      record_agent_user_message!(conversation, new_user_message) if new_user_message.present?
-      history = agent_conversation_history(conversation).presence || messages
+      history =
+        if conversation
+          agent_conversation_history(conversation) + (new_user_message ? [{ role: "user", content: new_user_message }] : [])
+        else
+          messages
+        end
 
       result = ::Ai::StoreAgentService.new(seller: current_seller, pundit_user:).respond(messages: history)
+
+      conversation ||= create_agent_conversation!(new_user_message || messages.last[:content])
+      record_agent_user_message!(conversation, new_user_message) if new_user_message.present?
       record_agent_assistant_message!(conversation, result)
       render json: {
         success: true,

--- a/app/controllers/api/internal/agent_messages_controller.rb
+++ b/app/controllers/api/internal/agent_messages_controller.rb
@@ -52,9 +52,7 @@ class Api::Internal::AgentMessagesController < Api::Internal::BaseController
 
       result = ::Ai::StoreAgentService.new(seller: current_seller, pundit_user:).respond(messages: history)
 
-      conversation ||= create_agent_conversation!(new_user_message || messages.last[:content])
-      record_agent_user_message!(conversation, new_user_message) if new_user_message.present?
-      record_agent_assistant_message!(conversation, result)
+      conversation = persist_agent_turn!(conversation, new_user_message, result, fallback_first_message: messages.last[:content])
       render json: {
         success: true,
         reply: result[:reply],

--- a/app/controllers/concerns/agent_conversation_persistence.rb
+++ b/app/controllers/concerns/agent_conversation_persistence.rb
@@ -51,11 +51,16 @@ module AgentConversationPersistence
 
     # After a seller confirms a proposed change, mark the proposing assistant message as applied
     # (and attach the resulting object) so history shows the collapsed "Applied" card instead of a
-    # still-confirmable one. The newest unresolved proposal is the one the seller just confirmed —
-    # the UI only ever exposes one pending confirmation at a time.
-    def record_agent_action_applied!(conversation, result)
+    # still-confirmable one. Multiple proposals can be pending in one chat (the seller can scroll
+    # back and confirm an earlier one), so identify the confirmed proposal by matching the executed
+    # payload (type + params) against the stored one — never by assuming it's the newest.
+    def record_agent_action_applied!(conversation, result, type:, action_params:)
+      executed = normalize_action_payload("type" => type, "params" => action_params)
       message = conversation.ai_messages.role_assistant.order(created_at: :desc, id: :desc).detect do |candidate|
-        candidate.metadata&.dig("proposed_action").present? && candidate.metadata["action_status"].blank?
+        proposal = candidate.metadata&.dig("proposed_action")
+        next false if proposal.blank? || candidate.metadata["action_status"].present?
+
+        normalize_action_payload("type" => proposal["type"], "params" => proposal["params"]) == executed
       end
       return if message.nil?
 
@@ -64,5 +69,21 @@ module AgentConversationPersistence
       # objects as the thing worth showing.
       metadata["objects"] = [result[:object]] if result[:object].present?
       message.update!(metadata:)
+    end
+
+    # Recursively string-keys hashes and stringifies scalar leaves so the executed request params
+    # (which arrive with string values under form encoding, or native types under JSON) compare
+    # equal to the stored proposal payload regardless of transport/serialization differences.
+    def normalize_action_payload(value)
+      case value
+      when Hash
+        value.each_with_object({}) { |(k, v), out| out[k.to_s] = normalize_action_payload(v) }
+      when Array
+        value.map { |v| normalize_action_payload(v) }
+      when nil
+        nil
+      else
+        value.to_s
+      end
     end
 end

--- a/app/controllers/concerns/agent_conversation_persistence.rb
+++ b/app/controllers/concerns/agent_conversation_persistence.rb
@@ -72,7 +72,13 @@ module AgentConversationPersistence
       # Mirror the live UI: once applied, the created/edited object replaces the turn's lookup
       # objects as the thing worth showing.
       metadata["objects"] = [result[:object]] if result[:object].present?
-      message.update_column(:metadata, metadata)
+      # The candidates above were loaded with a narrow `select` (no MEDIUMTEXT content), and saving
+      # a partially-loaded record raises MissingAttributeError — so re-fetch the full row before
+      # saving. Use `update!` (not `update_column`) so the `belongs_to :ai_conversation, touch: true`
+      # callback bumps the conversation's `updated_at`; without that, confirming a proposal wouldn't
+      # count as activity and `GET /internal/agent/conversations/latest` could resume a different,
+      # more recently active conversation after the seller refreshes.
+      conversation.ai_messages.find(message.id).update!(metadata:)
     end
 
     # Recursively string-keys hashes and stringifies scalar leaves so the executed request params

--- a/app/controllers/concerns/agent_conversation_persistence.rb
+++ b/app/controllers/concerns/agent_conversation_persistence.rb
@@ -72,7 +72,7 @@ module AgentConversationPersistence
       # Mirror the live UI: once applied, the created/edited object replaces the turn's lookup
       # objects as the thing worth showing.
       metadata["objects"] = [result[:object]] if result[:object].present?
-      message.update!(metadata:)
+      message.update_column(:metadata, metadata)
     end
 
     # Recursively string-keys hashes and stringifies scalar leaves so the executed request params

--- a/app/controllers/concerns/agent_conversation_persistence.rb
+++ b/app/controllers/concerns/agent_conversation_persistence.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+# Shared persistence for the web store Agent endpoints (buffered + streaming). The chat history
+# used to live only in the browser's React state, so a refresh lost it; these helpers store each
+# turn server-side (like OpenAI/Claude persist chats) so the client can resume a conversation.
+#
+# The client optionally sends `conversation_id` (an AiConversation external id). When present we
+# replay the SERVER-held transcript to the model instead of trusting whatever history the client
+# posted — the stored conversation is the source of truth. When absent we start a new conversation
+# titled after the opening message. Lookups are scoped to current_seller, so one seller can never
+# read or append to another seller's conversation (a foreign id behaves like a missing one).
+module AgentConversationPersistence
+  extend ActiveSupport::Concern
+
+  private
+    # Returns the seller's conversation for params[:conversation_id], or nil when the param is
+    # absent. A present-but-unknown id (including another seller's conversation) raises
+    # ActiveRecord::RecordNotFound so callers can render a 404 rather than silently starting a
+    # fresh conversation with someone else's id.
+    def find_agent_conversation!
+      external_id = params[:conversation_id].to_s
+      return nil if external_id.blank?
+
+      current_seller.ai_conversations.alive.find_by_external_id(external_id) ||
+        raise(ActiveRecord::RecordNotFound)
+    end
+
+    def create_agent_conversation!(first_user_message)
+      current_seller.ai_conversations.create!(title: AiConversation.title_from(first_user_message))
+    end
+
+    # The plain role/content transcript to send to the model — rebuilt from the stored rows so a
+    # tampered or stale client-side history can't rewrite what the agent believes was said.
+    def agent_conversation_history(conversation)
+      conversation.ai_messages.map { |message| { role: message.role, content: message.content } }
+    end
+
+    def record_agent_user_message!(conversation, content)
+      conversation.ai_messages.create!(role: "user", content:)
+    end
+
+    # Persists the assistant's turn. The proposed action and looked-up objects ride along in
+    # `metadata` so a reloaded conversation re-renders its confirmation card / object cards.
+    def record_agent_assistant_message!(conversation, result)
+      metadata = {
+        proposed_action: result[:proposed_action],
+        objects: result[:objects].presence,
+      }.compact
+      conversation.ai_messages.create!(role: "assistant", content: result[:reply].to_s, metadata: metadata.presence)
+    end
+
+    # After a seller confirms a proposed change, mark the proposing assistant message as applied
+    # (and attach the resulting object) so history shows the collapsed "Applied" card instead of a
+    # still-confirmable one. The newest unresolved proposal is the one the seller just confirmed —
+    # the UI only ever exposes one pending confirmation at a time.
+    def record_agent_action_applied!(conversation, result)
+      message = conversation.ai_messages.role_assistant.order(created_at: :desc, id: :desc).detect do |candidate|
+        candidate.metadata&.dig("proposed_action").present? && candidate.metadata["action_status"].blank?
+      end
+      return if message.nil?
+
+      metadata = message.metadata.merge("action_status" => "applied")
+      # Mirror the live UI: once applied, the created/edited object replaces the turn's lookup
+      # objects as the thing worth showing.
+      metadata["objects"] = [result[:object]] if result[:object].present?
+      message.update!(metadata:)
+    end
+end

--- a/app/controllers/concerns/agent_conversation_persistence.rb
+++ b/app/controllers/concerns/agent_conversation_persistence.rb
@@ -29,6 +29,20 @@ module AgentConversationPersistence
       current_seller.ai_conversations.create!(title: AiConversation.title_from(first_user_message))
     end
 
+    # Persists one full turn (creating the conversation when needed) atomically. Without the
+    # transaction, a failure between the user-message insert and the assistant-message insert would
+    # strand a half-written turn: `latest` would hydrate a user message with no reply, and a resumed
+    # turn would silently replay that stray message to the model. Returns the conversation so
+    # callers can hand its external id back to the client.
+    def persist_agent_turn!(conversation, new_user_message, result, fallback_first_message:)
+      AiConversation.transaction do
+        conversation ||= create_agent_conversation!(new_user_message || fallback_first_message)
+        record_agent_user_message!(conversation, new_user_message) if new_user_message.present?
+        record_agent_assistant_message!(conversation, result)
+        conversation
+      end
+    end
+
     # The plain role/content transcript to send to the model — rebuilt from the stored rows so a
     # tampered or stale client-side history can't rewrite what the agent believes was said.
     def agent_conversation_history(conversation)

--- a/app/controllers/concerns/agent_conversation_persistence.rb
+++ b/app/controllers/concerns/agent_conversation_persistence.rb
@@ -12,6 +12,13 @@
 module AgentConversationPersistence
   extend ActiveSupport::Concern
 
+  # Conversations grow one turn at a time forever (there's no "end" to a chat), so both the
+  # transcript replayed to the model and the hydration payload need a ceiling. 100 messages
+  # (~50 turns) comfortably covers a long working session while capping the per-turn token cost
+  # and keeping the resume response a bounded size; older messages are still stored, just no
+  # longer replayed or hydrated.
+  HISTORY_MAX_MESSAGES = 100
+
   private
     # Returns the seller's conversation for params[:conversation_id], or nil when the param is
     # absent. A present-but-unknown id (including another seller's conversation) raises
@@ -44,9 +51,12 @@ module AgentConversationPersistence
     end
 
     # The plain role/content transcript to send to the model — rebuilt from the stored rows so a
-    # tampered or stale client-side history can't rewrite what the agent believes was said.
+    # tampered or stale client-side history can't rewrite what the agent believes was said. Only
+    # the most recent HISTORY_MAX_MESSAGES are replayed: without a cap, every turn of a long-lived
+    # conversation would resend the entire transcript to the LLM (O(n²) token cost over the
+    # conversation's life) — `last` keeps the newest rows while preserving chronological order.
     def agent_conversation_history(conversation)
-      conversation.ai_messages.map { |message| { role: message.role, content: message.content } }
+      conversation.ai_messages.last(HISTORY_MAX_MESSAGES).map { |message| { role: message.role, content: message.content } }
     end
 
     def record_agent_user_message!(conversation, content)

--- a/app/controllers/concerns/agent_conversation_persistence.rb
+++ b/app/controllers/concerns/agent_conversation_persistence.rb
@@ -56,12 +56,16 @@ module AgentConversationPersistence
     # payload (type + params) against the stored one — never by assuming it's the newest.
     def record_agent_action_applied!(conversation, result, type:, action_params:)
       executed = normalize_action_payload("type" => type, "params" => action_params)
-      message = conversation.ai_messages.role_assistant.order(created_at: :desc, id: :desc).detect do |candidate|
-        proposal = candidate.metadata&.dig("proposed_action")
-        next false if proposal.blank? || candidate.metadata["action_status"].present?
+      message = conversation.ai_messages
+        .role_assistant
+        .select(:id, :metadata, :created_at)
+        .reorder(created_at: :desc, id: :desc)
+        .detect do |candidate|
+          proposal = candidate.metadata&.dig("proposed_action")
+          next false if proposal.blank? || candidate.metadata["action_status"].present?
 
-        normalize_action_payload("type" => proposal["type"], "params" => proposal["params"]) == executed
-      end
+          normalize_action_payload("type" => proposal["type"], "params" => proposal["params"]) == executed
+        end
       return if message.nil?
 
       metadata = message.metadata.merge("action_status" => "applied")

--- a/app/javascript/components/Agent/AgentChat.tsx
+++ b/app/javascript/components/Agent/AgentChat.tsx
@@ -166,6 +166,11 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
   // state updates) always read the current id without re-creating handlers.
   const conversationIdRef = React.useRef<string | null>(null);
   conversationIdRef.current = conversationId;
+  // Flips true the moment the seller sends their first message. Guards the mount-time hydration
+  // below: once a turn is in flight (which may create a brand-new stored conversation), a late
+  // "latest conversation" response must not overwrite the chat or its conversation id — otherwise
+  // subsequent turns would be appended to the wrong stored conversation.
+  const hasSentMessageRef = React.useRef(false);
   // Whether the assistant reply has started arriving this turn — drives the "Thinking..." bubble,
   // which we show only until the first token lands, then let the streaming text take over.
   const [isStreaming, setIsStreaming] = React.useState(false);
@@ -205,31 +210,26 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
     let cancelled = false;
     void fetchLatestAgentConversation()
       .then((conversation) => {
-        if (cancelled || !conversation || conversation.messages.length === 0) return;
-        setMessages((prev) => {
-          // Anything beyond the initial greeting means the seller already started typing/chatting;
-          // leave their in-progress conversation alone.
-          if (prev.length > 1) return prev;
-          return [
-            { role: "assistant", content: greeting },
-            ...conversation.messages.map(
-              (message: ConversationMessage): DisplayMessage => ({
-                role: message.role,
-                content: message.content,
-                ...(message.proposed_action ? { proposedAction: message.proposed_action } : {}),
-                ...(message.objects?.length ? { objects: message.objects } : {}),
-                ...(message.action_status
-                  ? { actionStatus: message.action_status }
-                  : // A proposal persisted without a status was never confirmed in the session it was
-                    // made. Its context (and the throttle window) is gone, so render it as dismissed
-                    // rather than offering a stale, re-confirmable change after reload.
-                    message.proposed_action
-                    ? { actionStatus: "dismissed" as const }
-                    : {}),
-              }),
-            ),
-          ];
-        });
+        if (cancelled || !conversation || conversation.messages.length === 0 || hasSentMessageRef.current) return;
+        setMessages([
+          { role: "assistant", content: greeting },
+          ...conversation.messages.map(
+            (message: ConversationMessage): DisplayMessage => ({
+              role: message.role,
+              content: message.content,
+              ...(message.proposed_action ? { proposedAction: message.proposed_action } : {}),
+              ...(message.objects?.length ? { objects: message.objects } : {}),
+              ...(message.action_status
+                ? { actionStatus: message.action_status }
+                : // A proposal persisted without a status was never confirmed in the session it was
+                  // made. Its context (and the throttle window) is gone, so render it as dismissed
+                  // rather than offering a stale, re-confirmable change after reload.
+                  message.proposed_action
+                  ? { actionStatus: "dismissed" as const }
+                  : {}),
+            }),
+          ),
+        ]);
         setConversationId(conversation.id);
       })
       .catch(() => {
@@ -253,6 +253,9 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
   const send = async (text: string) => {
     const trimmed = text.trim();
     if (trimmed.length === 0 || isSending) return;
+
+    // From here on the seller owns the chat: block the mount-time hydration from replacing it.
+    hasSentMessageRef.current = true;
 
     // Sending re-engages auto-scroll so the seller's own message and the reply come into view.
     stickToBottom.current = true;

--- a/app/javascript/components/Agent/AgentChat.tsx
+++ b/app/javascript/components/Agent/AgentChat.tsx
@@ -4,9 +4,11 @@ import * as React from "react";
 import {
   type AgentStreamHandlers,
   type ChatMessage,
+  type ConversationMessage,
   type DisplayObject,
   type ProposedAction,
   executeAgentAction,
+  fetchLatestAgentConversation,
   streamAgentMessage,
 } from "$app/data/agent";
 import { classNames } from "$app/utils/classNames";
@@ -156,6 +158,14 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
   const [messages, setMessages] = React.useState<DisplayMessage[]>([{ role: "assistant", content: greeting }]);
   const [input, setInput] = React.useState("");
   const [isSending, setIsSending] = React.useState(false);
+  // The stored conversation this chat belongs to (server-side external id). Set when the latest
+  // conversation is resumed on mount or when the first turn's response creates one; sent with each
+  // turn so the server appends to the same conversation instead of starting a new one.
+  const [conversationId, setConversationId] = React.useState<string | null>(null);
+  // Ref mirror of conversationId so in-flight callbacks (the streaming turn resolves after several
+  // state updates) always read the current id without re-creating handlers.
+  const conversationIdRef = React.useRef<string | null>(null);
+  conversationIdRef.current = conversationId;
   // Whether the assistant reply has started arriving this turn — drives the "Thinking..." bubble,
   // which we show only until the first token lands, then let the streaming text take over.
   const [isStreaming, setIsStreaming] = React.useState(false);
@@ -187,6 +197,58 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
   React.useEffect(() => {
     if (!isSending) inputRef.current?.focus({ preventScroll: true });
   }, [isSending]);
+
+  // On mount, resume the most recently active stored conversation (like OpenAI/Claude restore your
+  // last chat) so a page refresh doesn't lose the history. Any turn the seller sends before this
+  // resolves wins: it starts a fresh conversation, and we skip hydration rather than clobber it.
+  React.useEffect(() => {
+    let cancelled = false;
+    void fetchLatestAgentConversation()
+      .then((conversation) => {
+        if (cancelled || !conversation || conversation.messages.length === 0) return;
+        setMessages((prev) => {
+          // Anything beyond the initial greeting means the seller already started typing/chatting;
+          // leave their in-progress conversation alone.
+          if (prev.length > 1) return prev;
+          return [
+            { role: "assistant", content: greeting },
+            ...conversation.messages.map(
+              (message: ConversationMessage): DisplayMessage => ({
+                role: message.role,
+                content: message.content,
+                ...(message.proposed_action ? { proposedAction: message.proposed_action } : {}),
+                ...(message.objects?.length ? { objects: message.objects } : {}),
+                ...(message.action_status
+                  ? { actionStatus: message.action_status }
+                  : // A proposal persisted without a status was never confirmed in the session it was
+                    // made. Its context (and the throttle window) is gone, so render it as dismissed
+                    // rather than offering a stale, re-confirmable change after reload.
+                    message.proposed_action
+                    ? { actionStatus: "dismissed" as const }
+                    : {}),
+              }),
+            ),
+          ];
+        });
+        setConversationId(conversation.id);
+      })
+      .catch(() => {
+        // Resuming is best-effort; a failed fetch just means starting a fresh chat.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Start over with an empty chat; the next message will create a fresh stored conversation.
+  const startNewChat = () => {
+    if (isSending) return;
+    setMessages([{ role: "assistant", content: greeting }]);
+    setConversationId(null);
+    setFollowUps([]);
+    setPendingActionIndex(null);
+    inputRef.current?.focus({ preventScroll: true });
+  };
 
   const send = async (text: string) => {
     const trimmed = text.trim();
@@ -252,7 +314,8 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
     };
 
     try {
-      const result = await streamAgentMessage(history, handlers);
+      const result = await streamAgentMessage(history, handlers, conversationIdRef.current);
+      if (result.conversationId) setConversationId(result.conversationId);
       // Reconcile with the final assembled turn. Upsert (not map) so a turn that produced no token —
       // e.g. the model staged a write and returned an empty reply — still lands its card/objects.
       setMessages((prev) => {
@@ -288,7 +351,7 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
   const confirmAction = async (index: number, action: ProposedAction) => {
     setPendingActionIndex(index);
     try {
-      const { message, object } = await executeAgentAction(action);
+      const { message, object } = await executeAgentAction(action, conversationIdRef.current);
       showAlert(message, "success");
       // Mark the proposal applied and attach the created/edited object so it renders as a card.
       setMessages((prev) =>
@@ -323,6 +386,15 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
         {/* Content starts at the top and grows downward; the effect below keeps the newest line in
             view as the conversation gets long enough to scroll. */}
         <div className="mx-auto flex w-full max-w-2xl flex-col gap-4 p-4 md:p-8">
+          {/* Offer a way out of a resumed/long conversation. Only shown once there's history to
+              leave behind; a brand-new chat has nothing to reset. */}
+          {messages.length > 1 ? (
+            <div className="flex justify-end">
+              <Button size="sm" onClick={startNewChat} disabled={isSending}>
+                New chat
+              </Button>
+            </div>
+          ) : null}
           {messages.map((message, index) => {
             const isUser = message.role === "user";
             // A pending proposed change reads as the confirmation card alone — suppress the objects the

--- a/app/javascript/components/Agent/AgentChat.tsx
+++ b/app/javascript/components/Agent/AgentChat.tsx
@@ -240,16 +240,6 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
     };
   }, []);
 
-  // Start over with an empty chat; the next message will create a fresh stored conversation.
-  const startNewChat = () => {
-    if (isSending) return;
-    setMessages([{ role: "assistant", content: greeting }]);
-    setConversationId(null);
-    setFollowUps([]);
-    setPendingActionIndex(null);
-    inputRef.current?.focus({ preventScroll: true });
-  };
-
   const send = async (text: string) => {
     const trimmed = text.trim();
     if (trimmed.length === 0 || isSending) return;
@@ -389,15 +379,6 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
         {/* Content starts at the top and grows downward; the effect below keeps the newest line in
             view as the conversation gets long enough to scroll. */}
         <div className="mx-auto flex w-full max-w-2xl flex-col gap-4 p-4 md:p-8">
-          {/* Offer a way out of a resumed/long conversation. Only shown once there's history to
-              leave behind; a brand-new chat has nothing to reset. */}
-          {messages.length > 1 ? (
-            <div className="flex justify-end">
-              <Button size="sm" onClick={startNewChat} disabled={isSending}>
-                New chat
-              </Button>
-            </div>
-          ) : null}
           {messages.map((message, index) => {
             const isUser = message.role === "user";
             // A pending proposed change reads as the confirmation card alone — suppress the objects the

--- a/app/javascript/components/Agent/AgentChat.tsx
+++ b/app/javascript/components/Agent/AgentChat.tsx
@@ -408,7 +408,11 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
                     <ProposedActionCard
                       action={message.proposedAction}
                       status={message.actionStatus}
-                      isPending={pendingActionIndex !== null}
+                      // Also treat an in-flight turn as pending: while streaming, the proposal card
+                      // can render before the terminal `done` event persists the turn server-side.
+                      // Confirming in that window would apply the change before the stored proposal
+                      // exists, so it could never be marked applied in the saved history.
+                      isPending={pendingActionIndex !== null || isSending}
                       isApplying={pendingActionIndex === index}
                       onConfirm={() => message.proposedAction && void confirmAction(index, message.proposedAction)}
                       onDismiss={() => dismissAction(index)}

--- a/app/javascript/data/agent.ts
+++ b/app/javascript/data/agent.ts
@@ -26,7 +26,13 @@ export type ProposedAction = {
 };
 
 type SendMessageResponse =
-  | { success: true; reply: string; proposed_action: ProposedAction | null; objects?: DisplayObject[] }
+  | {
+      success: true;
+      reply: string;
+      proposed_action: ProposedAction | null;
+      objects?: DisplayObject[];
+      conversation_id?: string;
+    }
   | { success: false; error: string };
 
 type ExecuteActionResponse = { success: boolean; message: string; object?: DisplayObject | null };
@@ -45,30 +51,76 @@ export type DisplayObject = {
 
 export const sendAgentMessage = async (
   messages: ChatMessage[],
-): Promise<{ reply: string; proposedAction: ProposedAction | null; objects: DisplayObject[] }> => {
+  conversationId?: string | null,
+): Promise<{
+  reply: string;
+  proposedAction: ProposedAction | null;
+  objects: DisplayObject[];
+  conversationId: string | null;
+}> => {
   const response = await request({
     method: "POST",
     accept: "json",
     url: Routes.internal_agent_messages_path(),
-    data: { messages },
+    data: { messages, ...(conversationId ? { conversation_id: conversationId } : {}) },
   });
   const json = typia.assert<SendMessageResponse>(await response.json());
   if (!json.success) throw new ResponseError(json.error);
-  return { reply: json.reply, proposedAction: json.proposed_action, objects: json.objects ?? [] };
+  return {
+    reply: json.reply,
+    proposedAction: json.proposed_action,
+    objects: json.objects ?? [],
+    conversationId: json.conversation_id ?? null,
+  };
 };
 
 export const executeAgentAction = async (
   action: ProposedAction,
+  conversationId?: string | null,
 ): Promise<{ message: string; object: DisplayObject | null }> => {
   const response = await request({
     method: "POST",
     accept: "json",
     url: Routes.internal_agent_actions_path(),
-    data: { type: action.type, params: action.params },
+    // The conversation id lets the server mark the stored proposal as applied, so reloaded history
+    // shows the collapsed "Applied" card instead of a still-confirmable one.
+    data: { type: action.type, params: action.params, ...(conversationId ? { conversation_id: conversationId } : {}) },
   });
   const json = typia.assert<ExecuteActionResponse>(await response.json());
   if (!json.success) throw new ResponseError(json.message);
   return { message: json.message, object: json.object ?? null };
+};
+
+// One persisted message of a stored conversation, as returned by the conversations endpoint. The
+// server keeps each turn's structured extras (proposed-action card, object cards, applied status)
+// so the chat re-renders history exactly as it looked live.
+export type ConversationMessage = {
+  role: ChatRole;
+  content: string;
+  proposed_action?: ProposedAction | null;
+  objects?: DisplayObject[] | null;
+  action_status?: "applied" | "dismissed" | null;
+};
+
+export type Conversation = {
+  id: string;
+  title: string | null;
+  messages: ConversationMessage[];
+};
+
+type LatestConversationResponse = { success: true; conversation: Conversation | null };
+
+// Fetch the seller's most recently active conversation so the Agent tab can resume it on mount —
+// the way hosted chat products restore your last chat. Resolves null when there's nothing to resume.
+export const fetchLatestAgentConversation = async (): Promise<Conversation | null> => {
+  const response = await request({
+    method: "GET",
+    accept: "json",
+    url: Routes.internal_agent_conversations_latest_path(),
+  });
+  if (!response.ok) throw new ResponseError();
+  const json = typia.assert<LatestConversationResponse>(await response.json());
+  return json.conversation;
 };
 
 // Events the streaming endpoint emits, surfaced to the caller as they arrive so the UI can render a
@@ -90,6 +142,9 @@ type StreamResult = {
   proposedAction: ProposedAction | null;
   objects: DisplayObject[];
   suggestions: string[];
+  // The id of the stored conversation this turn was persisted to; send it on the next turn (and on
+  // action confirmation) so the server appends instead of starting a new conversation.
+  conversationId: string | null;
 };
 
 // Server-Sent Event payloads, validated per-event with typia so a malformed frame can't slip
@@ -104,6 +159,7 @@ type DoneData = {
   proposed_action: ProposedAction | null;
   objects?: DisplayObject[];
   suggestions?: string[];
+  conversation_id?: string;
 };
 
 // Stream one conversation turn over Server-Sent Events. Calls the handlers as events arrive and
@@ -113,12 +169,13 @@ type DoneData = {
 export const streamAgentMessage = async (
   messages: ChatMessage[],
   handlers: AgentStreamHandlers = {},
+  conversationId?: string | null,
 ): Promise<StreamResult> => {
   const response = await request({
     method: "POST",
     accept: "json",
     url: Routes.internal_agent_messages_stream_path(),
-    data: { messages },
+    data: { messages, ...(conversationId ? { conversation_id: conversationId } : {}) },
   });
 
   // request() only rejects 5xx/429, so a 4xx or an HTML response from auth/CSRF/authorization
@@ -188,6 +245,7 @@ export const streamAgentMessage = async (
           proposedAction: data.proposed_action ?? proposedAction,
           objects: data.objects ?? objects,
           suggestions: data.suggestions ?? suggestions,
+          conversationId: data.conversation_id ?? conversationId ?? null,
         };
       }
       case "error": {

--- a/app/models/ai_conversation.rb
+++ b/app/models/ai_conversation.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# One store Agent chat for a seller, mirroring the conversation + message model hosted chat
+# products (OpenAI, Claude) use. The web Agent endpoints create one per chat and append an
+# AiMessage per turn, so the history survives page refreshes instead of living only in React state.
+class AiConversation < ApplicationRecord
+  include Deletable, ExternalId
+
+  # Long enough to be recognizable in a list, short enough to render as a single line.
+  TITLE_MAX_LENGTH = 80
+
+  belongs_to :seller, class_name: "User"
+  # Ordered by insertion so the transcript replays in the order the turns happened. `id` breaks
+  # ties because two turns can share a created_at second.
+  has_many :ai_messages, -> { order(:created_at, :id) }, dependent: :destroy
+
+  # Conversations are titled after the seller's opening message, like hosted chat products do.
+  def self.title_from(content)
+    content.to_s.strip.truncate(TITLE_MAX_LENGTH).presence
+  end
+end

--- a/app/models/ai_message.rb
+++ b/app/models/ai_message.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# One turn of a store Agent chat (see AiConversation). `content` is the visible text; `metadata`
+# carries the structured extras a turn can have — the proposed-change card, the objects the agent
+# looked up, and whether a proposal was applied — so a reloaded conversation re-renders exactly as
+# it did live (including keeping an already-applied change from being confirmable twice).
+class AiMessage < ApplicationRecord
+  include ExternalId
+
+  # Bump the conversation's updated_at on every turn so "most recently active" ordering (used by
+  # the resume-latest endpoint) follows real usage, not creation time.
+  belongs_to :ai_conversation, touch: true
+
+  enum :role, { user: "user", assistant: "assistant" }, prefix: :role, validate: true
+
+  # An assistant turn can legitimately have empty text (the model staged a change and said
+  # nothing), so only default the column — presence isn't required.
+  before_validation { self.content ||= "" }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -131,6 +131,8 @@ class User < ApplicationRecord
   has_one :totp_credential, dependent: :destroy
   has_many :webauthn_credentials, dependent: :destroy
   has_many :utm_links, dependent: :destroy, foreign_key: :seller_id
+  # Persisted store Agent chats (the conversational assistant on the Agent tab).
+  has_many :ai_conversations, dependent: :destroy, foreign_key: :seller_id
   has_many :seller_communities, class_name: "Community", foreign_key: :seller_id, dependent: :destroy
   has_many :community_chat_messages, dependent: :destroy
   has_many :last_read_community_chat_messages, dependent: :destroy

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1131,6 +1131,7 @@ Rails.application.routes.draw do
         post "/agent/messages", to: "agent_messages#create", as: :agent_messages
         post "/agent/messages/stream", to: "agent_message_streams#create", as: :agent_messages_stream
         post "/agent/actions", to: "agent_messages#execute", as: :agent_actions
+        get "/agent/conversations/latest", to: "agent_conversations#latest", as: :agent_conversations_latest
       end
     end
 

--- a/db/migrate/20261205000000_create_ai_conversations.rb
+++ b/db/migrate/20261205000000_create_ai_conversations.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Server-side storage for the store Agent chat, mirroring the conversation + message model that
+# hosted chat products (OpenAI, Claude) use: a conversation row per chat, a message row per turn.
+# Until now the chat history lived only in the browser's React state, so a refresh lost it.
+class CreateAiConversations < ActiveRecord::Migration[7.1]
+  def change
+    create_table :ai_conversations do |t|
+      t.references :seller, null: false
+      # Derived from the first user message so the conversation is recognizable in a list.
+      t.string :title
+      # Soft delete (Deletable concern) so a cleared chat is recoverable/auditable.
+      t.datetime :deleted_at
+
+      t.timestamps
+    end
+
+    create_table :ai_messages do |t|
+      t.references :ai_conversation, null: false
+      t.string :role, null: false
+      # MEDIUMTEXT: assistant replies can embed long product descriptions and generated copy that
+      # overflow a 64KB TEXT column.
+      t.text :content, size: :medium, null: false
+      # Structured payloads attached to a turn — the proposed-change card, the objects the agent
+      # looked up, and whether a proposal was applied — persisted so history re-renders faithfully.
+      t.json :metadata
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20261205000000_create_ai_conversations.rb
+++ b/db/migrate/20261205000000_create_ai_conversations.rb
@@ -15,6 +15,8 @@ class CreateAiConversations < ActiveRecord::Migration[7.1]
       t.timestamps
     end
 
+    add_index :ai_conversations, [:seller_id, :deleted_at, :updated_at, :id], name: "index_ai_conversations_latest_per_seller"
+
     create_table :ai_messages do |t|
       t.references :ai_conversation, null: false
       t.string :role, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_12_04_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_12_05_000000) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -182,6 +182,25 @@ ActiveRecord::Schema[7.1].define(version: 2026_12_04_000000) do
     t.bigint "flags", default: 0, null: false
     t.index ["affiliate_id"], name: "index_affiliates_links_on_affiliate_id"
     t.index ["link_id"], name: "index_affiliates_links_on_link_id"
+  end
+
+  create_table "ai_conversations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "seller_id", null: false
+    t.string "title"
+    t.datetime "deleted_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["seller_id"], name: "index_ai_conversations_on_seller_id"
+  end
+
+  create_table "ai_messages", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "ai_conversation_id", null: false
+    t.string "role", null: false
+    t.text "content", size: :medium, null: false
+    t.json "metadata"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["ai_conversation_id"], name: "index_ai_messages_on_ai_conversation_id"
   end
 
   create_table "asset_previews", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -190,6 +190,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_12_05_000000) do
     t.datetime "deleted_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["seller_id", "deleted_at", "updated_at", "id"], name: "index_ai_conversations_latest_per_seller"
     t.index ["seller_id"], name: "index_ai_conversations_on_seller_id"
   end
 

--- a/spec/controllers/api/internal/agent_conversations_controller_spec.rb
+++ b/spec/controllers/api/internal/agent_conversations_controller_spec.rb
@@ -72,6 +72,17 @@ describe Api::Internal::AgentConversationsController do
         )
       end
 
+      it "caps hydration at the most recent HISTORY_MAX_MESSAGES messages" do
+        stub_const("AgentConversationPersistence::HISTORY_MAX_MESSAGES", 3)
+        conversation = create(:ai_conversation, seller:)
+        5.times { |i| create(:ai_message, ai_conversation: conversation, content: "Message #{i + 1}") }
+
+        get :latest, format: :json
+
+        messages = response.parsed_body["conversation"]["messages"]
+        expect(messages.map { |m| m["content"] }).to eq(["Message 3", "Message 4", "Message 5"])
+      end
+
       it "skips soft-deleted conversations" do
         conversation = create(:ai_conversation, seller:)
         conversation.mark_deleted!

--- a/spec/controllers/api/internal/agent_conversations_controller_spec.rb
+++ b/spec/controllers/api/internal/agent_conversations_controller_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "shared_examples/authentication_required"
+require "shared_examples/authorize_called"
+
+describe Api::Internal::AgentConversationsController do
+  let(:seller) { create(:named_seller) }
+
+  include_context "with user signed in as admin for seller"
+
+  describe "GET latest" do
+    it_behaves_like "authentication required for action", :get, :latest
+
+    it_behaves_like "authorize called for action", :get, :latest do
+      let(:record) { seller }
+      let(:policy_method) { :use_store_agent? }
+      let(:request_format) { :json }
+    end
+
+    context "when authenticated and authorized" do
+      it "returns null when the seller has no conversations" do
+        get :latest, format: :json
+
+        expect(response).to be_successful
+        expect(response.parsed_body).to eq("success" => true, "conversation" => nil)
+      end
+
+      it "returns the most recently active conversation with its full transcript" do
+        older = create(:ai_conversation, seller:, title: "Old chat")
+        create(:ai_message, ai_conversation: older)
+        newer = create(:ai_conversation, seller:, title: "How are my sales?")
+        create(:ai_message, ai_conversation: newer, content: "How are my sales?")
+        create(
+          :ai_message,
+          ai_conversation: newer,
+          role: "assistant",
+          content: "Sales are up.",
+          metadata: {
+            "proposed_action" => { "type" => "api_write", "summary" => "Create a discount" },
+            "objects" => [{ "type" => "product", "title" => "Masterclass", "fields" => [] }],
+            "action_status" => "applied",
+          },
+        )
+        # Activity (a new message) on the older conversation makes it the one to resume, even
+        # though it was created first — recency follows updated_at, not creation order.
+        create(:ai_message, ai_conversation: older, content: "Follow-up")
+        older.update!(updated_at: 1.minute.from_now)
+
+        get :latest, format: :json
+
+        expect(response.parsed_body["conversation"]["id"]).to eq(older.external_id)
+
+        # Bring the newer conversation back on top and check the full message shape.
+        newer.update!(updated_at: 2.minutes.from_now)
+        get :latest, format: :json
+
+        conversation = response.parsed_body["conversation"]
+        expect(conversation["id"]).to eq(newer.external_id)
+        expect(conversation["title"]).to eq("How are my sales?")
+        expect(conversation["messages"]).to eq(
+          [
+            { "role" => "user", "content" => "How are my sales?" },
+            {
+              "role" => "assistant",
+              "content" => "Sales are up.",
+              "proposed_action" => { "type" => "api_write", "summary" => "Create a discount" },
+              "objects" => [{ "type" => "product", "title" => "Masterclass", "fields" => [] }],
+              "action_status" => "applied",
+            },
+          ]
+        )
+      end
+
+      it "skips soft-deleted conversations" do
+        conversation = create(:ai_conversation, seller:)
+        conversation.mark_deleted!
+
+        get :latest, format: :json
+
+        expect(response.parsed_body["conversation"]).to be_nil
+      end
+
+      it "never returns another seller's conversation" do
+        create(:ai_conversation) # belongs to a different seller
+
+        get :latest, format: :json
+
+        expect(response.parsed_body["conversation"]).to be_nil
+      end
+    end
+  end
+end

--- a/spec/controllers/api/internal/agent_message_streams_controller_spec.rb
+++ b/spec/controllers/api/internal/agent_message_streams_controller_spec.rb
@@ -76,6 +76,28 @@ describe Api::Internal::AgentMessageStreamsController do
         expect(conversation.ai_messages.reload.count).to eq(3)
       end
 
+      it "still emits the done event when persisting the turn fails after streaming" do
+        # The seller has already watched the reply stream in by the time persistence runs, so a DB
+        # failure here must not turn the turn into an error — the done event (and the reply it
+        # carries) still has to arrive. The conversation id is simply omitted.
+        service_double = instance_double(Ai::StoreAgentService)
+        allow(Ai::StoreAgentService).to receive(:new).and_return(service_double)
+        allow(service_double).to receive(:respond_streaming).and_return(
+          reply: "You have 3 products.",
+          proposed_action: nil,
+          objects: [],
+          suggestions: [],
+        )
+        allow(controller).to receive(:create_agent_conversation!).and_raise(ActiveRecord::StatementInvalid)
+        expect(ErrorNotifier).to receive(:notify).with(instance_of(ActiveRecord::StatementInvalid))
+
+        post :create, params: valid_params, format: :json
+
+        expect(response.body).to include("event: done")
+        expect(response.body).to include("You have 3 products.")
+        expect(response.body).not_to include("event: error")
+      end
+
       it "emits an error event (not a new conversation) for another seller's conversation id" do
         other_conversation = create(:ai_conversation)
 

--- a/spec/controllers/api/internal/agent_message_streams_controller_spec.rb
+++ b/spec/controllers/api/internal/agent_message_streams_controller_spec.rb
@@ -35,6 +35,59 @@ describe Api::Internal::AgentMessageStreamsController do
     end
 
     context "when authenticated and authorized" do
+      it "persists the turn to a new conversation and emits its id on the done event" do
+        service_double = instance_double(Ai::StoreAgentService)
+        allow(Ai::StoreAgentService).to receive(:new).and_return(service_double)
+        allow(service_double).to receive(:respond_streaming).and_return(
+          reply: "You have 3 products.",
+          proposed_action: nil,
+          objects: [],
+          suggestions: [],
+        )
+
+        post :create, params: valid_params, format: :json
+
+        conversation = seller.ai_conversations.sole
+        expect(conversation.title).to eq("How are my sales?")
+        expect(conversation.ai_messages.map { |m| [m.role, m.content] }).to eq(
+          [["user", "How are my sales?"], ["assistant", "You have 3 products."]]
+        )
+        expect(response.body).to include("event: done")
+        expect(response.body).to include(conversation.external_id)
+      end
+
+      it "replays the stored transcript when resuming a conversation" do
+        conversation = create(:ai_conversation, seller:)
+        create(:ai_message, ai_conversation: conversation, content: "Earlier question")
+
+        service_double = instance_double(Ai::StoreAgentService)
+        allow(Ai::StoreAgentService).to receive(:new).and_return(service_double)
+        expect(service_double).to receive(:respond_streaming).with(
+          messages: [
+            { role: "user", content: "Earlier question" },
+            { role: "user", content: "How are my sales?" },
+          ]
+        ).and_return(reply: "Up.", proposed_action: nil, objects: [], suggestions: [])
+
+        expect do
+          post :create, params: valid_params.merge(conversation_id: conversation.external_id), format: :json
+        end.not_to change { seller.ai_conversations.count }
+
+        expect(conversation.ai_messages.reload.count).to eq(3)
+      end
+
+      it "emits an error event (not a new conversation) for another seller's conversation id" do
+        other_conversation = create(:ai_conversation)
+
+        expect(Ai::StoreAgentService).not_to receive(:new)
+
+        expect do
+          post :create, params: valid_params.merge(conversation_id: other_conversation.external_id), format: :json
+        end.not_to change { AiConversation.count }
+
+        expect(response.body).to include("event: error")
+      end
+
       it "halts on throttle without invoking the streaming agent service" do
         exhaust_agent_request_throttle(throttle_key)
         expect(Ai::StoreAgentService).not_to receive(:new)

--- a/spec/controllers/api/internal/agent_messages_controller_spec.rb
+++ b/spec/controllers/api/internal/agent_messages_controller_spec.rb
@@ -227,6 +227,36 @@ describe Api::Internal::AgentMessagesController do
         expect(other_proposal.reload.metadata["action_status"]).to be_nil
       end
 
+      it "bumps the conversation's updated_at when a proposal is marked applied" do
+        # Confirming an action counts as conversation activity: the resume-latest endpoint orders
+        # by updated_at, so a stale timestamp here would make a refresh resume a DIFFERENT, more
+        # recently active conversation than the one the seller just acted in.
+        conversation = create(:ai_conversation, seller:)
+        create(
+          :ai_message,
+          ai_conversation: conversation,
+          role: "assistant",
+          content: "I can create that discount.",
+          metadata: {
+            "proposed_action" => {
+              "type" => "api_write",
+              "params" => { "endpoint" => "create_discount", "code" => "LAUNCH", "percent_off" => 20 },
+            },
+          },
+        )
+        stale_time = 1.hour.ago
+        conversation.update_column(:updated_at, stale_time)
+
+        executor_double = instance_double(Ai::StoreAgentActionExecutor)
+        allow(Ai::StoreAgentActionExecutor).to receive(:new).and_return(executor_double)
+        allow(executor_double).to receive(:execute).and_return(success: true, message: "Created discount code LAUNCH.")
+
+        post :execute, params: valid_params.merge(conversation_id: conversation.external_id), format: :json
+
+        expect(response).to be_successful
+        expect(conversation.reload.updated_at).to be > stale_time
+      end
+
       it "does not touch stored history when the executor fails" do
         conversation = create(:ai_conversation, seller:)
         proposal_message = create(

--- a/spec/controllers/api/internal/agent_messages_controller_spec.rb
+++ b/spec/controllers/api/internal/agent_messages_controller_spec.rb
@@ -137,6 +137,25 @@ describe Api::Internal::AgentMessagesController do
         expect(response).to have_http_status(:unprocessable_entity)
       end
 
+      it "still returns the reply when persistence fails after a successful service call" do
+        service_double = instance_double(Ai::StoreAgentService)
+        allow(Ai::StoreAgentService).to receive(:new).and_return(service_double)
+        allow(service_double).to receive(:respond).and_return(reply: "Sales are up.", proposed_action: nil)
+
+        # A DB failure while recording the turn must not turn an already-earned reply into a 500 —
+        # the seller would retry and burn another quota slot. The reply comes back without a
+        # conversation id (the turn simply isn't stored), and the failure is reported.
+        allow(controller).to receive(:persist_agent_turn!).and_raise(ActiveRecord::StatementInvalid)
+        expect(ErrorNotifier).to receive(:notify).with(instance_of(ActiveRecord::StatementInvalid))
+
+        post :create, params: valid_params, format: :json
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be(true)
+        expect(response.parsed_body["reply"]).to eq("Sales are up.")
+        expect(response.parsed_body["conversation_id"]).to be_nil
+      end
+
       it "rejects an empty message list" do
         post :create, params: { messages: [] }, format: :json
 

--- a/spec/controllers/api/internal/agent_messages_controller_spec.rb
+++ b/spec/controllers/api/internal/agent_messages_controller_spec.rb
@@ -178,7 +178,22 @@ describe Api::Internal::AgentMessagesController do
           ai_conversation: conversation,
           role: "assistant",
           content: "I can create that discount.",
-          metadata: { "proposed_action" => { "type" => "api_write", "summary" => "Create discount LAUNCH" } },
+          metadata: {
+            "proposed_action" => {
+              "type" => "api_write",
+              "summary" => "Create discount LAUNCH",
+              "params" => { "endpoint" => "create_discount", "code" => "LAUNCH", "percent_off" => 20 },
+            },
+          },
+        )
+        # A different, newer pending proposal in the same chat must NOT be the one marked applied —
+        # the executed payload identifies which proposal was confirmed.
+        other_proposal = create(
+          :ai_message,
+          ai_conversation: conversation,
+          role: "assistant",
+          content: "I can also refund that sale.",
+          metadata: { "proposed_action" => { "type" => "api_write", "params" => { "endpoint" => "refund_sale" } } },
         )
 
         executor_double = instance_double(Ai::StoreAgentActionExecutor)
@@ -196,6 +211,8 @@ describe Api::Internal::AgentMessagesController do
         expect(metadata["action_status"]).to eq("applied")
         # The created object replaces the turn's lookup objects, matching what the live UI shows.
         expect(metadata["objects"]).to eq([{ "type" => "discount", "title" => "LAUNCH", "fields" => [] }])
+        # The unrelated pending proposal is untouched.
+        expect(other_proposal.reload.metadata["action_status"]).to be_nil
       end
 
       it "does not touch stored history when the executor fails" do
@@ -204,7 +221,12 @@ describe Api::Internal::AgentMessagesController do
           :ai_message,
           ai_conversation: conversation,
           role: "assistant",
-          metadata: { "proposed_action" => { "type" => "api_write" } },
+          metadata: {
+            "proposed_action" => {
+              "type" => "api_write",
+              "params" => { "endpoint" => "create_discount", "code" => "LAUNCH", "percent_off" => 20 },
+            },
+          },
         )
 
         executor_double = instance_double(Ai::StoreAgentActionExecutor)

--- a/spec/controllers/api/internal/agent_messages_controller_spec.rb
+++ b/spec/controllers/api/internal/agent_messages_controller_spec.rb
@@ -106,6 +106,33 @@ describe Api::Internal::AgentMessagesController do
         expect(conversation.ai_messages.reload.count).to eq(4)
       end
 
+      it "replays only the most recent HISTORY_MAX_MESSAGES stored messages to the service" do
+        stub_const("AgentConversationPersistence::HISTORY_MAX_MESSAGES", 2)
+        conversation = create(:ai_conversation, seller:)
+        create(:ai_message, ai_conversation: conversation, content: "Dropped question")
+        create(:ai_message, ai_conversation: conversation, role: "assistant", content: "Dropped answer")
+        create(:ai_message, ai_conversation: conversation, content: "Kept question")
+        create(:ai_message, ai_conversation: conversation, role: "assistant", content: "Kept answer")
+
+        service_double = instance_double(Ai::StoreAgentService)
+        allow(Ai::StoreAgentService).to receive(:new).and_return(service_double)
+        # Only the newest window of the stored transcript (plus the new turn) reaches the model —
+        # replaying the full history would make each turn's token cost grow without bound.
+        expect(service_double).to receive(:respond).with(
+          messages: [
+            { role: "user", content: "Kept question" },
+            { role: "assistant", content: "Kept answer" },
+            { role: "user", content: "And this month?" },
+          ]
+        ).and_return(reply: "Capped.", proposed_action: nil)
+
+        post :create,
+             params: { messages: [{ role: "user", content: "And this month?" }], conversation_id: conversation.external_id },
+             format: :json
+
+        expect(response.parsed_body["success"]).to eq(true)
+      end
+
       it "404s when the conversation belongs to another seller" do
         other_conversation = create(:ai_conversation)
 

--- a/spec/controllers/api/internal/agent_messages_controller_spec.rb
+++ b/spec/controllers/api/internal/agent_messages_controller_spec.rb
@@ -46,7 +46,83 @@ describe Api::Internal::AgentMessagesController do
         post :create, params: valid_params, format: :json
 
         expect(response).to be_successful
-        expect(response.parsed_body).to eq("success" => true, "reply" => "You have 3 products.", "proposed_action" => nil, "objects" => [])
+        conversation = seller.ai_conversations.sole
+        expect(response.parsed_body).to eq(
+          "success" => true,
+          "reply" => "You have 3 products.",
+          "proposed_action" => nil,
+          "objects" => [],
+          "conversation_id" => conversation.external_id,
+        )
+      end
+
+      it "creates a conversation titled from the first user message and persists both turns" do
+        service_double = instance_double(Ai::StoreAgentService)
+        allow(Ai::StoreAgentService).to receive(:new).and_return(service_double)
+        allow(service_double).to receive(:respond).and_return(
+          reply: "Sales are up.",
+          proposed_action: { "type" => "api_write", "summary" => "Create a discount" },
+        )
+
+        expect do
+          post :create, params: valid_params, format: :json
+        end.to change { seller.ai_conversations.count }.by(1)
+
+        conversation = seller.ai_conversations.sole
+        expect(conversation.title).to eq("How are my sales?")
+        expect(conversation.ai_messages.map { |m| [m.role, m.content] }).to eq(
+          [["user", "How are my sales?"], ["assistant", "Sales are up."]]
+        )
+        # The proposal rides along in metadata so reloaded history re-renders its card.
+        expect(conversation.ai_messages.last.metadata["proposed_action"]).to eq(
+          "type" => "api_write", "summary" => "Create a discount"
+        )
+      end
+
+      it "appends to an existing conversation and replays the server-held history to the service" do
+        conversation = create(:ai_conversation, seller:)
+        create(:ai_message, ai_conversation: conversation, content: "Earlier question")
+        create(:ai_message, ai_conversation: conversation, role: "assistant", content: "Earlier answer")
+
+        service_double = instance_double(Ai::StoreAgentService)
+        allow(Ai::StoreAgentService).to receive(:new).and_return(service_double)
+        # The service must see the stored transcript plus the new turn — not whatever history the
+        # client posted (here the client posted only the new message).
+        expect(service_double).to receive(:respond).with(
+          messages: [
+            { role: "user", content: "Earlier question" },
+            { role: "assistant", content: "Earlier answer" },
+            { role: "user", content: "And this month?" },
+          ]
+        ).and_return(reply: "Also up.", proposed_action: nil)
+
+        expect do
+          post :create,
+               params: { messages: [{ role: "user", content: "And this month?" }], conversation_id: conversation.external_id },
+               format: :json
+        end.not_to change { seller.ai_conversations.count }
+
+        expect(response.parsed_body["conversation_id"]).to eq(conversation.external_id)
+        expect(conversation.ai_messages.reload.count).to eq(4)
+      end
+
+      it "404s when the conversation belongs to another seller" do
+        other_conversation = create(:ai_conversation)
+
+        expect(Ai::StoreAgentService).not_to receive(:new)
+
+        post :create, params: valid_params.merge(conversation_id: other_conversation.external_id), format: :json
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "404s for a soft-deleted conversation" do
+        conversation = create(:ai_conversation, seller:)
+        conversation.mark_deleted!
+
+        post :create, params: valid_params.merge(conversation_id: conversation.external_id), format: :json
+
+        expect(response).to have_http_status(:not_found)
       end
 
       it "rejects an empty message list" do
@@ -92,6 +168,63 @@ describe Api::Internal::AgentMessagesController do
 
         expect(response).to be_successful
         expect(response.parsed_body).to eq("success" => true, "message" => "Created discount code LAUNCH.")
+      end
+
+      it "marks the stored proposal applied when a conversation id is sent" do
+        conversation = create(:ai_conversation, seller:)
+        create(:ai_message, ai_conversation: conversation, content: "Create a discount")
+        proposal_message = create(
+          :ai_message,
+          ai_conversation: conversation,
+          role: "assistant",
+          content: "I can create that discount.",
+          metadata: { "proposed_action" => { "type" => "api_write", "summary" => "Create discount LAUNCH" } },
+        )
+
+        executor_double = instance_double(Ai::StoreAgentActionExecutor)
+        allow(Ai::StoreAgentActionExecutor).to receive(:new).and_return(executor_double)
+        allow(executor_double).to receive(:execute).and_return(
+          success: true,
+          message: "Created discount code LAUNCH.",
+          object: { "type" => "discount", "title" => "LAUNCH", "fields" => [] },
+        )
+
+        post :execute, params: valid_params.merge(conversation_id: conversation.external_id), format: :json
+
+        expect(response).to be_successful
+        metadata = proposal_message.reload.metadata
+        expect(metadata["action_status"]).to eq("applied")
+        # The created object replaces the turn's lookup objects, matching what the live UI shows.
+        expect(metadata["objects"]).to eq([{ "type" => "discount", "title" => "LAUNCH", "fields" => [] }])
+      end
+
+      it "does not touch stored history when the executor fails" do
+        conversation = create(:ai_conversation, seller:)
+        proposal_message = create(
+          :ai_message,
+          ai_conversation: conversation,
+          role: "assistant",
+          metadata: { "proposed_action" => { "type" => "api_write" } },
+        )
+
+        executor_double = instance_double(Ai::StoreAgentActionExecutor)
+        allow(Ai::StoreAgentActionExecutor).to receive(:new).and_return(executor_double)
+        allow(executor_double).to receive(:execute).and_return(success: false, message: "Nope.")
+
+        post :execute, params: valid_params.merge(conversation_id: conversation.external_id), format: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(proposal_message.reload.metadata["action_status"]).to be_nil
+      end
+
+      it "404s without executing when the conversation belongs to another seller" do
+        other_conversation = create(:ai_conversation)
+
+        expect(Ai::StoreAgentActionExecutor).not_to receive(:new)
+
+        post :execute, params: valid_params.merge(conversation_id: other_conversation.external_id), format: :json
+
+        expect(response).to have_http_status(:not_found)
       end
 
       it "rejects an unsupported action type" do

--- a/spec/controllers/api/internal/agent_messages_controller_spec.rb
+++ b/spec/controllers/api/internal/agent_messages_controller_spec.rb
@@ -251,6 +251,24 @@ describe Api::Internal::AgentMessagesController do
         expect(proposal_message.reload.metadata["action_status"]).to be_nil
       end
 
+      it "still reports success when recording the applied status fails after the action committed" do
+        # The store change has already committed by the time the bookkeeping write runs. Returning
+        # an error here would prompt the seller to retry the confirmation and run the action twice
+        # (a duplicate discount, refund, etc.), so persistence failures must not mask the success.
+        conversation = create(:ai_conversation, seller:)
+
+        executor_double = instance_double(Ai::StoreAgentActionExecutor)
+        allow(Ai::StoreAgentActionExecutor).to receive(:new).and_return(executor_double)
+        allow(executor_double).to receive(:execute).and_return(success: true, message: "Created discount code LAUNCH.")
+        allow(controller).to receive(:record_agent_action_applied!).and_raise(ActiveRecord::StatementInvalid)
+        expect(ErrorNotifier).to receive(:notify).with(instance_of(ActiveRecord::StatementInvalid))
+
+        post :execute, params: valid_params.merge(conversation_id: conversation.external_id), format: :json
+
+        expect(response).to be_successful
+        expect(response.parsed_body).to eq("success" => true, "message" => "Created discount code LAUNCH.")
+      end
+
       it "404s without executing when the conversation belongs to another seller" do
         other_conversation = create(:ai_conversation)
 

--- a/spec/controllers/api/internal/agent_messages_controller_spec.rb
+++ b/spec/controllers/api/internal/agent_messages_controller_spec.rb
@@ -125,6 +125,18 @@ describe Api::Internal::AgentMessagesController do
         expect(response).to have_http_status(:not_found)
       end
 
+      it "persists nothing when the service raises, so a failed turn is not replayed later" do
+        service_double = instance_double(Ai::StoreAgentService)
+        allow(Ai::StoreAgentService).to receive(:new).and_return(service_double)
+        allow(service_double).to receive(:respond).and_raise(Ai::StoreAgentService::Error, "Too long.")
+
+        expect do
+          post :create, params: valid_params, format: :json
+        end.to not_change { seller.ai_conversations.count }.and not_change { AiMessage.count }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
       it "rejects an empty message list" do
         post :create, params: { messages: [] }, format: :json
 

--- a/spec/models/ai_conversation_spec.rb
+++ b/spec/models/ai_conversation_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe AiConversation do
+  describe "associations" do
+    it "orders messages by insertion and destroys them with the conversation" do
+      conversation = create(:ai_conversation)
+      # Same created_at second on purpose: ordering must fall back to id (insertion order) so two
+      # turns saved in the same second still replay in the order they happened.
+      now = Time.current.change(usec: 0)
+      travel_to(now) do
+        create(:ai_message, ai_conversation: conversation, content: "Question")
+        create(:ai_message, ai_conversation: conversation, role: "assistant", content: "Reply")
+      end
+
+      expect(conversation.ai_messages.reload.map(&:content)).to eq(["Question", "Reply"])
+
+      expect { conversation.destroy! }.to change(AiMessage, :count).by(-2)
+    end
+  end
+
+  describe "Deletable" do
+    it "soft deletes via mark_deleted! and drops out of the alive scope" do
+      conversation = create(:ai_conversation)
+      expect { conversation.mark_deleted! }.to change { described_class.alive.count }.by(-1)
+      expect(described_class.count).to eq(1)
+    end
+  end
+
+  describe ".title_from" do
+    it "derives a truncated single-line title from the first user message" do
+      expect(described_class.title_from("  How are my sales?  ")).to eq("How are my sales?")
+      expect(described_class.title_from("a" * 200).length).to eq(described_class::TITLE_MAX_LENGTH)
+      expect(described_class.title_from("   ")).to be_nil
+    end
+  end
+end

--- a/spec/models/ai_message_spec.rb
+++ b/spec/models/ai_message_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe AiMessage do
+  describe "validations" do
+    it "requires a known role" do
+      message = build(:ai_message, role: "user")
+      expect(message).to be_valid
+
+      # The enum is declared with validate: true, so an unknown role makes the record invalid
+      # instead of raising on assignment.
+      message.role = "system"
+      expect(message).not_to be_valid
+      expect(message.errors[:role]).to be_present
+    end
+
+    it "defaults content to an empty string so tokenless assistant turns persist" do
+      message = create(:ai_message, role: "assistant", content: nil)
+      expect(message.content).to eq("")
+    end
+  end
+
+  it "touches the conversation so recency ordering follows activity" do
+    conversation = create(:ai_conversation, updated_at: 1.day.ago)
+    expect { create(:ai_message, ai_conversation: conversation) }.to change { conversation.reload.updated_at }
+  end
+
+  it "round-trips structured metadata (proposal payloads, objects)" do
+    metadata = { "proposed_action" => { "type" => "api_write", "summary" => "Create a discount" }, "action_status" => "applied" }
+    message = create(:ai_message, role: "assistant", metadata:)
+    expect(message.reload.metadata).to eq(metadata)
+  end
+end

--- a/spec/support/factories/ai_conversations.rb
+++ b/spec/support/factories/ai_conversations.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :ai_conversation do
+    association :seller, factory: :user
+    title { "How are my sales doing?" }
+  end
+
+  factory :ai_message do
+    ai_conversation
+    role { "user" }
+    content { "How are my sales doing?" }
+  end
+end


### PR DESCRIPTION
## What

Adds server-side persistence for store Agent conversations, mirroring the conversation + message model OpenAI/Claude use for their hosted chats:

- **New tables** `ai_conversations` (one row per chat: `seller_id`, nullable `title` derived from the first user message, `deleted_at` soft delete) and `ai_messages` (one row per turn: `role`, MEDIUMTEXT `content`, JSON `metadata` for proposed-action cards / object cards / applied status).
- **New models** `AiConversation` / `AiMessage` with `Deletable` + `ExternalId` (public ids are obfuscated external ids, per repo convention), seller association, validated role enum.
- **Web endpoints** (`POST /internal/agent/messages`, `POST /internal/agent/messages/stream`, `POST /internal/agent/actions`) accept an optional `conversation_id`. Without one, a turn creates a conversation; with one, the turn appends to it and the model replays the **server-held transcript** instead of trusting client-posted history. Responses (and the SSE `done` event) return the conversation's external id. Confirmed actions mark the stored proposal as applied — matched by executed payload, not recency — so reloaded history shows the collapsed "Applied" card.
- **New read endpoint** `GET /internal/agent/conversations/latest` returns the most recently active conversation with its full transcript (including per-turn metadata).
- **Frontend**: `AgentChat.tsx` resumes the latest conversation on mount (hydrating proposal/object cards and applied status) and threads the conversation id through every turn and action confirmation. A pending proposal that was never confirmed renders as dismissed after reload rather than offering a stale re-confirmable mutation.
- **Mobile** (`Api::Mobile::AgentController`) is untouched — it keeps sending full history and its contract is unchanged.

## Why

Conversations lived only in the browser's React state: every turn re-POSTed the full history and a page refresh lost the chat entirely. Persisting server-side gives sellers durable, resumable conversations (like every hosted chat product), and makes the server the source of truth for the transcript the model sees — a client can no longer fabricate or rewrite prior turns when resuming a stored conversation.

Schema choice: a two-table conversation/message design (rather than a serialized blob per chat) matches how OpenAI/Claude model chats, keeps individual turns queryable/appendable without rewriting the whole transcript, and leaves room for a conversation-list UI later. `metadata` is a JSON column because the structured extras (proposal payloads, object cards) are heterogeneous and only ever read back whole per message.

## Migration safety

New tables only (`ai_conversations`, `ai_messages`); no changes to any existing table. Both created with the schema-default utf8mb4 charset, standard `t.references` indexes on `seller_id` / `ai_conversation_id`.

## Test plan

- `spec/models/ai_conversation_spec.rb` + `spec/models/ai_message_spec.rb` — ordering, soft delete, title derivation, role validation, metadata round-trip, conversation touch: **7 examples, 0 failures**
- `spec/controllers/api/internal/agent_messages_controller_spec.rb` — create-conversation, append + server-held history replay, cross-seller 404, soft-deleted 404, no-persist-on-service-error, applied-status recording (incl. multiple-pending-proposals disambiguation), executor-failure no-op, throttle/authorization shared examples: **19 examples, 0 failures**
- `spec/controllers/api/internal/agent_message_streams_controller_spec.rb` — streaming persistence, resume replay, cross-seller error event: **6 examples, 0 failures**
- `spec/controllers/api/internal/agent_conversations_controller_spec.rb` — latest-by-activity, full transcript shape, soft-deleted + cross-seller scoping: **6 examples, 0 failures**
- `spec/controllers/api/mobile/agent_controller_spec.rb` (unchanged contract, re-run to confirm): **13 examples, 0 failures**
- `spec/requests/agent_spec.rb` (Capybara system spec driving the real React component incl. the new mount-time hydration): **10 examples, 0 failures**
- `rubocop` clean on all touched Ruby files; `prettier`/`eslint` clean on touched TS; `tsc --noEmit` introduces **zero new errors** vs main (local baseline diff; main has a pre-existing `vite/client` types issue locally — CI typecheck is authoritative).
- autoreview (Codex): clean on the final run; three earlier findings (resume-fetch race, wrong-proposal stamping, pre-service persistence of failed turns) were accepted and fixed in dedicated commits.

## Screenshots

No visible UI change: the chat looks the same, but history now survives refresh (previously it reset to the greeting). There is no separate "new chat" affordance — the existing streaming window is the whole UI, per review feedback. All shots are from the running app (Capybara system spec, real dashboard chrome). Two of the "after" shots below predate the removal of a short-lived "New chat" button visible top-right; ignore it.

**Before (main) — conversation exists only in React state; no way to reset, gone on refresh:**

![Before: sales insights conversation on main](https://raw.githubusercontent.com/gumclaw/gumroad/gumclaw-agent-persistence-assets/screenshots/before_sales_insights.png)

**After — empty state (unchanged):**

![After: empty state](https://raw.githubusercontent.com/gumclaw/gumroad/gumclaw-agent-persistence-assets/screenshots/after_empty_state.png)

**After — conversation in progress (button shown top-right has since been removed):**

![After: conversation in progress](https://raw.githubusercontent.com/gumclaw/gumroad/gumclaw-agent-persistence-assets/screenshots/after_sales_insights_new_chat_button.png)

**After — applied proposed-change card (this state now persists and re-renders after refresh; button shown has since been removed):**

![After: applied discount card](https://raw.githubusercontent.com/gumclaw/gumroad/gumclaw-agent-persistence-assets/screenshots/after_discount_applied.png)

