### PR TITLE
Remove stale TODO in TwoFactorAuthenticationMailer

### DIFF
--- a/app/mailers/two_factor_authentication_mailer.rb
+++ b/app/mailers/two_factor_authentication_mailer.rb
@@ -6,7 +6,6 @@ class TwoFactorAuthenticationMailer < ApplicationMailer
 
   layout "layouts/email"
 
-  # TODO(ershad): Remove this once the issue with Resend is resolved
   default delivery_method_options: -> { MailerInfo.default_delivery_method_options(domain: :gumroad) }
 
   def authentication_token(user_id, email_provider: nil)


### PR DESCRIPTION
### What

Removes a stale TODO comment in `TwoFactorAuthenticationMailer`. The `default delivery_method_options` override it referred to is staying, so the comment no longer applies.

Comment-only change — no behavior affected.

---

AI disclosure: PR prepared with Claude Fable 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)