### PR TITLE
Complete the 3DS challenge for the Mexico Stripe test card in tax specs

### DIFF
--- a/spec/requests/purchases/product/taxes_spec.rb
+++ b/spec/requests/purchases/product/taxes_spec.rb
@@ -3885,7 +3885,9 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
 
       expect(page).to have_select("Country", selected: "Austria")
 
-      check_out(@product, country: "Mexico", zip_code: nil, credit_card: { number: "4000004840008001" })
+      # Stripe's Mexico test card now triggers a 3D Secure challenge, so tell the checkout
+      # helper to complete it or the purchase never finishes.
+      check_out(@product, country: "Mexico", zip_code: nil, credit_card: { number: "4000004840008001" }, sca: true)
 
       purchase = Purchase.last
       expect(purchase.country).to eq("Mexico")
@@ -3915,7 +3917,9 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
 
       select("Mexico", from: "Country")
 
-      check_out(@product, zip_code: nil, credit_card: { number: "4000004840008001" })
+      # Stripe's Mexico test card now triggers a 3D Secure challenge, so tell the checkout
+      # helper to complete it or the purchase never finishes.
+      check_out(@product, zip_code: nil, credit_card: { number: "4000004840008001" }, sca: true)
 
       purchase = Purchase.last
       expect(purchase.country).to eq("Mexico")
@@ -4051,7 +4055,9 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
 
       expect(page).to have_select("Country", selected: "Mexico")
 
-      check_out(@product, country: "Austria", zip_code: nil, credit_card: { number: "4000004840008001" })
+      # Stripe's Mexico test card now triggers a 3D Secure challenge, so tell the checkout
+      # helper to complete it or the purchase never finishes.
+      check_out(@product, country: "Austria", zip_code: nil, credit_card: { number: "4000004840008001" }, sca: true)
 
       purchase = Purchase.last
       expect(purchase.country).to eq("Austria")


### PR DESCRIPTION
## What

Passes `sca: true` to `check_out` in the three "country change scenarios" tax specs that pay with Stripe's Mexico test card (`4000004840008001`), so the checkout helper clicks through the 3D Secure challenge. Adds a short comment at each call site explaining why.

## Why

Since ~15:30 UTC on 2026-07-07 these three specs fail on **every** branch (confirmed across `feat/default-products-section`, `fix/store-agent-max-tokens-truncation-951`, `fix/store-agent-param-validation-953`, `fix/client-confirm-async-failure-error-code`, and `apple-pay-merchant-tokens` — the same three specs each time). The last green main run was 05:28 UTC.

The failure screenshot from CI shows the checkout stuck on Stripe's "3D Secure 2 Test Page" modal — Stripe now returns `requires_action` for this test card (verified directly against the test-mode API: a confirmed PaymentIntent with a Mexico card comes back `status: requires_action`). The specs never complete the challenge, so the purchase never succeeds and they time out waiting for the success alert. `check_out` already supports completing the challenge via `sca: true` (same pattern as the existing SCA specs).

autoreview: clean (Codex, `overall: patch is correct (0.89)`, no actionable findings).

## Test plan

- `rubocop spec/requests/purchases/product/taxes_spec.rb`: no offenses.
- Could not fully verify the system specs locally — in this checkout the charge fails server-side before the 3DS modal renders (local env is missing the Gumroad merchant account, a known limitation of running these system specs locally). CI on this PR will verify; the three specs are deterministic, not flaky (failed all 3 rspec-retry attempts on 5+ branches).
