### PR TITLE
Record Gumroad views from custom HTML product pages

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1081,6 +1081,12 @@ class LinksController < ApplicationController
     def custom_html_analytics_head(product)
       tracking_enabled = analytics_enabled?(seller: product.user)
       analytics = product.analytics_data
+      # When third-party tracking is off, blank the pixel ids before they reach
+      # the props JSON. The frontend never uses them in that case (every pixel
+      # call is gated on tracking_enabled), but without this a seller who
+      # disabled third-party analytics would still see their Google/Facebook/
+      # TikTok ids embedded in the page source for anyone to inspect.
+      analytics = analytics.merge(google_analytics_id: nil, facebook_pixel_id: nil, tiktok_pixel_id: nil) unless tracking_enabled
       has_product_third_party_analytics = tracking_enabled && product.has_third_party_analytics?("product")
       has_configured_pixel = tracking_enabled && analytics.values_at(:google_analytics_id, :facebook_pixel_id, :tiktok_pixel_id).any?(&:present?)
 
@@ -1094,10 +1100,11 @@ class LinksController < ApplicationController
         name: product.name,
       }
 
-      # All three enabled flags are "true" (not per-pixel): this block only renders
-      # when analytics_enabled?, and the frontend gates each pixel on its own
-      # configured id — mirroring PageMeta::Analytics#set_analytics_meta_tags, which
-      # the wrapper's layout-less document can't accumulate. The props JSON goes in a
+      # The pixel meta tags render only when tracking is enabled and the seller has
+      # at least one pixel id configured. All three enabled flags are "true" rather
+      # than per-pixel because the frontend gates each pixel on its own configured
+      # id — mirroring PageMeta::Analytics#set_analytics_meta_tags, which the
+      # wrapper's layout-less document can't accumulate. The props JSON goes in a
       # double-quoted attribute, so ERB::Util.h (which escapes ") is the right escape
       # here — json_escape would leave quotes intact and break out of the attribute.
       pixel_meta_tags = if has_configured_pixel

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1009,6 +1009,7 @@ class LinksController < ApplicationController
             <meta property="og:type" content="product">
             <meta property="og:url" content="#{canonical}">
             #{og_image_tag}
+            <meta name="csrf-token" content="#{ERB::Util.h(form_authenticity_token)}">
             #{custom_html_analytics_head(product)}
             <style>html,body{margin:0;padding:0;height:100%;overflow:hidden}iframe{display:block;width:100%;height:100%;border:0}</style>
           </head>
@@ -1068,16 +1069,15 @@ class LinksController < ApplicationController
     # the standard checkout and receipt pages the buy button navigates to, which
     # already fire them — firing them here too would double-count.
     def custom_html_analytics_head(product)
-      return "" unless analytics_enabled?(seller: product.user)
-
+      tracking_enabled = analytics_enabled?(seller: product.user)
       analytics = product.analytics_data
-      has_product_third_party_analytics = product.has_third_party_analytics?("product")
-      has_configured_pixel = analytics.values_at(:google_analytics_id, :facebook_pixel_id, :tiktok_pixel_id).any?(&:present?)
-      return "" unless has_configured_pixel || has_product_third_party_analytics
+      has_product_third_party_analytics = tracking_enabled && product.has_third_party_analytics?("product")
+      has_configured_pixel = tracking_enabled && analytics.values_at(:google_analytics_id, :facebook_pixel_id, :tiktok_pixel_id).any?(&:present?)
 
       props = {
         seller_id: product.user.external_id,
         analytics:,
+        tracking_enabled:,
         has_product_third_party_analytics:,
         third_party_analytics_domain: THIRD_PARTY_ANALYTICS_DOMAIN,
         permalink: product.unique_permalink,
@@ -1090,10 +1090,18 @@ class LinksController < ApplicationController
       # the wrapper's layout-less document can't accumulate. The props JSON goes in a
       # double-quoted attribute, so ERB::Util.h (which escapes ") is the right escape
       # here — json_escape would leave quotes intact and break out of the attribute.
+      pixel_meta_tags = if has_configured_pixel
+        <<~HTML
+          <meta property="gr:google_analytics:enabled" content="true">
+          <meta property="gr:fb_pixel:enabled" content="true">
+          <meta property="gr:tiktok_pixel:enabled" content="true">
+        HTML
+      else
+        ""
+      end
+
       <<~HTML.strip
-        <meta property="gr:google_analytics:enabled" content="true">
-        <meta property="gr:fb_pixel:enabled" content="true">
-        <meta property="gr:tiktok_pixel:enabled" content="true">
+        #{pixel_meta_tags}
         <meta name="gr:custom-html-analytics" content="#{ERB::Util.h(props.to_json)}">
         #{helpers.vite_typescript_tag("custom_html_analytics")}
       HTML

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -353,6 +353,7 @@ class UsersController < ApplicationController
       props = {
         seller_id: user.external_id,
         analytics:,
+        tracking_enabled: true,
         has_universal_third_party_analytics:,
         third_party_analytics_domain: THIRD_PARTY_ANALYTICS_DOMAIN,
         username: user.username,

--- a/app/javascript/entrypoints/custom_html_analytics.ts
+++ b/app/javascript/entrypoints/custom_html_analytics.ts
@@ -1,6 +1,8 @@
 import typia from "typia";
 
+import { incrementProductViews } from "$app/data/view_event";
 import { AnalyticsData } from "$app/parsers/product";
+import { defaults as requestDefaults } from "$app/utils/request";
 import { startTrackingForSeller, trackProductEvent, trackProfilePageView } from "$app/utils/user_analytics";
 
 import { addProfileThirdPartyAnalytics, addThirdPartyAnalytics } from "$app/components/useAddThirdPartyAnalytics";
@@ -8,6 +10,7 @@ import { addProfileThirdPartyAnalytics, addThirdPartyAnalytics } from "$app/comp
 type SharedProps = {
   seller_id: string;
   analytics: AnalyticsData;
+  tracking_enabled: boolean;
   third_party_analytics_domain: string;
 };
 
@@ -50,11 +53,19 @@ type ProfileProps = SharedProps & {
 const configElement = document.querySelector('meta[name="gr:custom-html-analytics"]');
 if (configElement) {
   const props = typia.assert<ProductProps | ProfileProps>(JSON.parse(configElement.getAttribute("content") ?? ""));
+  const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute("content");
+  if (csrfToken) requestDefaults.headers = { ...requestDefaults.headers, "X-CSRF-Token": csrfToken };
 
-  startTrackingForSeller(props.seller_id, props.analytics);
+  if (props.tracking_enabled) startTrackingForSeller(props.seller_id, props.analytics);
 
   if ("permalink" in props) {
-    trackProductEvent(props.seller_id, { permalink: props.permalink, action: "viewed", product_name: props.name });
+    void incrementProductViews({
+      permalink: props.permalink,
+      recommendedBy: new URLSearchParams(window.location.search).get("recommended_by"),
+    });
+
+    if (props.tracking_enabled)
+      trackProductEvent(props.seller_id, { permalink: props.permalink, action: "viewed", product_name: props.name });
     if (props.has_product_third_party_analytics)
       addThirdPartyAnalytics({
         domain: props.third_party_analytics_domain,
@@ -75,10 +86,11 @@ if (configElement) {
       const isCheckout =
         data === "gumroad:checkout" || (typia.is<{ type: string }>(data) && data.type === "gumroad:checkout");
       if (!isCheckout) return;
+      if (!props.tracking_enabled) return;
       trackProductEvent(props.seller_id, { permalink: props.permalink, action: "iwantthis", product_name: props.name });
     });
   } else {
-    trackProfilePageView(props.seller_id);
+    if (props.tracking_enabled) trackProfilePageView(props.seller_id);
     if (props.has_universal_third_party_analytics && props.username != null)
       addProfileThirdPartyAnalytics({ domain: props.third_party_analytics_domain, username: props.username });
   }

--- a/spec/requests/products/show/custom_html_analytics_spec.rb
+++ b/spec/requests/products/show/custom_html_analytics_spec.rb
@@ -4,9 +4,8 @@ require "spec_helper"
 
 # A custom HTML landing page renders as a bare wrapper document that embeds the
 # seller's HTML in a sandboxed, opaque-origin iframe. That bypasses the React
-# product page which normally fires the seller's analytics, so the wrapper has to
-# re-inject the tracking itself. These specs verify it does — and only in the
-# trusted wrapper, only when the seller has analytics configured and enabled.
+# product page which normally records Gumroad's internal view count and fires the
+# seller's analytics, so the trusted wrapper has to own both jobs.
 describe "Custom HTML landing page analytics", type: :request do
   let(:seller) { create(:user, username: "analyticsseller", google_analytics_id: "G-ABC123") }
   let(:product) { create(:product, user: seller, custom_html: "<main><h1>Custom landing</h1></main>") }
@@ -40,6 +39,7 @@ describe "Custom HTML landing page analytics", type: :request do
     expect(response.body).to include('<meta property="gr:google_analytics:enabled" content="true">')
     expect(response.body).to include('<meta property="gr:fb_pixel:enabled" content="true">')
     expect(response.body).to include('<meta property="gr:tiktok_pixel:enabled" content="true">')
+    expect(response.body).to include('<meta name="csrf-token"')
     expect(response.body).to include('src="/custom_html_analytics.js"')
 
     props = analytics_props(response.body)
@@ -48,6 +48,7 @@ describe "Custom HTML landing page analytics", type: :request do
       "permalink" => product.unique_permalink,
       "name" => product.name,
       "third_party_analytics_domain" => THIRD_PARTY_ANALYTICS_DOMAIN,
+      "tracking_enabled" => true,
       "has_product_third_party_analytics" => false,
     )
     expect(props["analytics"]).to include("google_analytics_id" => "G-ABC123")
@@ -61,23 +62,40 @@ describe "Custom HTML landing page analytics", type: :request do
   end
 
   context "when the seller has no analytics configured" do
-    let(:seller) { create(:user, username: "noanalytics") }
+    let(:seller) { create(:user, username: "noanalyticsseller") }
 
-    it "omits the analytics block so the wrapper stays minimal" do
+    it "still loads the entry point so Gumroad's internal view counter fires" do
       get_wrapper
 
-      expect(response.body).not_to include("gr:custom-html-analytics")
+      expect(response.body).to include("gr:custom-html-analytics")
+      expect(response.body).to include('src="/custom_html_analytics.js"')
       expect(response.body).not_to include("gr:google_analytics:enabled")
+
+      props = analytics_props(response.body)
+      expect(props).to include(
+        "tracking_enabled" => true,
+        "has_product_third_party_analytics" => false,
+        "permalink" => product.unique_permalink,
+      )
     end
   end
 
   context "when the seller disabled third-party analytics" do
     before { seller.update!(disable_third_party_analytics: true) }
 
-    it "omits the analytics block" do
+    it "still loads the entry point with third-party tracking disabled" do
       get_wrapper
 
-      expect(response.body).not_to include("gr:custom-html-analytics")
+      expect(response.body).to include("gr:custom-html-analytics")
+      expect(response.body).to include('src="/custom_html_analytics.js"')
+      expect(response.body).not_to include("gr:google_analytics:enabled")
+
+      props = analytics_props(response.body)
+      expect(props).to include(
+        "tracking_enabled" => false,
+        "has_product_third_party_analytics" => false,
+        "permalink" => product.unique_permalink,
+      )
     end
   end
 

--- a/spec/requests/products/show/custom_html_analytics_spec.rb
+++ b/spec/requests/products/show/custom_html_analytics_spec.rb
@@ -83,18 +83,26 @@ describe "Custom HTML landing page analytics", type: :request do
   context "when the seller disabled third-party analytics" do
     before { seller.update!(disable_third_party_analytics: true) }
 
-    it "still loads the entry point with third-party tracking disabled" do
+    it "still loads the entry point with third-party tracking disabled and no pixel ids in the source" do
       get_wrapper
 
       expect(response.body).to include("gr:custom-html-analytics")
       expect(response.body).to include('src="/custom_html_analytics.js"')
       expect(response.body).not_to include("gr:google_analytics:enabled")
+      # The seller has a configured Google Analytics id, but with tracking
+      # disabled it must not be visible anywhere in the page source.
+      expect(response.body).not_to include("G-ABC123")
 
       props = analytics_props(response.body)
       expect(props).to include(
         "tracking_enabled" => false,
         "has_product_third_party_analytics" => false,
         "permalink" => product.unique_permalink,
+      )
+      expect(props["analytics"]).to include(
+        "google_analytics_id" => nil,
+        "facebook_pixel_id" => nil,
+        "tiktok_pixel_id" => nil,
       )
     end
   end

--- a/spec/requests/profile_analytics_spec.rb
+++ b/spec/requests/profile_analytics_spec.rb
@@ -100,6 +100,7 @@ describe "Profile page analytics", type: :request do
         "seller_id" => seller.external_id,
         "username" => "analyticsseller",
         "third_party_analytics_domain" => THIRD_PARTY_ANALYTICS_DOMAIN,
+        "tracking_enabled" => true,
         "has_universal_third_party_analytics" => false,
       )
       expect(props["analytics"]).to include("google_analytics_id" => "G-ABC123")


### PR DESCRIPTION
## What

Custom HTML product wrappers now load the existing internal product view counter entrypoint even when the seller has no third-party analytics configured or has disabled third-party analytics.

The wrapper also renders a CSRF token and initializes the request helper with it so the `/increment_views` POST succeeds from the layout-less wrapper document.

## Why

Root cause: confirmed. Custom HTML product pages bypass the React product page, so `incrementProductViews` never ran and Gumroad dashboard views flatlined for sellers who switched their products to custom HTML.

This keeps seller pixels/snippets gated by `tracking_enabled`, but records Gumroad's own product page view regardless of seller analytics configuration, matching the standard product page behavior.

## Test plan

- `rbenv exec bundle exec rspec spec/requests/products/show/custom_html_analytics_spec.rb spec/requests/profile_analytics_spec.rb --format progress`
- `npm run lint-fast -- app/javascript/entrypoints/custom_html_analytics.ts`
- `npm run typecheck` was attempted, but the local checkout is missing the `vite/client` type definition in `node_modules`, so the full typecheck fails before checking this patch.
- `python3 ~/.hermes/skills/software-development/autoreview/scripts/autoreview --mode branch --base origin/main` returned clean after the CSRF fix.

## Visual evidence

Not applicable. This is an analytics instrumentation fix for custom HTML wrappers, with request specs covering the rendered wrapper head and config payload.

## AI disclosure

Gumclaw drafted and tested this change, including an autoreview pass before opening the PR.

Fixes antiwork/gumroad-private#954.
