### PR TITLE
Chunk the payout eligibility query so large bank-type cohorts cannot hit the statement timeout

### DIFF
--- a/app/business/payments/payouts/payouts.rb
+++ b/app/business/payments/payouts/payouts.rb
@@ -7,6 +7,7 @@ class Payouts
   PAYOUT_TYPE_STANDARD = "standard"
   PAYOUT_TYPE_INSTANT = "instant"
   BANK_ACCOUNT_LOOKUP_BATCH_SIZE = 10_000
+  HOLDING_BALANCE_ID_BATCH_SIZE = 25_000
 
   def self.is_user_payable(user, date, processor_type: nil, add_comment: false, from_admin: false, bypass_minimum_payout: false, payout_type: Payouts::PAYOUT_TYPE_STANDARD)
     payout_date = Time.current.to_fs(:formatted_date_full_month)
@@ -93,7 +94,7 @@ class Payouts
     # cap at the scheduled slot and aborting entire payout batches. Splitting the
     # query leaves no join for the optimizer to get wrong, and each piece stays far
     # under the statement cap.
-    holding_balance_user_ids = User.holding_balance.ids
+    holding_balance_user_ids = self.holding_balance_user_ids
 
     bank_account_types.each do |bank_account_type|
       user_ids = holding_balance_user_ids.each_slice(BANK_ACCOUNT_LOOKUP_BATCH_SIZE).flat_map do |user_ids_batch|
@@ -102,6 +103,62 @@ class Payouts
       users = User.where(id: user_ids)
       self.create_payments_for_balances_up_to_date_for_users(date, processor_type, users, perform_async: true, bank_account_type:)
     end
+  end
+
+  # Returns the ids of every user holding a positive unpaid balance — the same set
+  # as User.holding_balance — but computed in bounded batches so that no single SQL
+  # statement has to aggregate the entire balances table in one go.
+  #
+  # The single-statement version (users JOIN balances GROUP BY user, or even
+  # User.holding_balance.ids on its own) aggregates every unpaid balance row on the
+  # platform in one query. That query's runtime grows with the size of the platform,
+  # and during the contended 10:00 UTC scheduled-jobs window it has repeatedly
+  # exceeded MySQL's 5-minute statement cap, killing whole payout batches
+  # (StatementTimeout incidents on 2026-05-26, 07-02, and 07-07). Retries don't help
+  # because they land in the same contention window.
+  #
+  # Instead we walk balances.user_id in ascending order with a keyset cursor
+  # (`user_id > last seen id`), aggregating at most HOLDING_BALANCE_ID_BATCH_SIZE
+  # users' balances per statement and applying the "sum is positive" filter in Ruby.
+  # The positivity check deliberately lives here and not in a SQL HAVING clause:
+  # HAVING filters groups after aggregation but before LIMIT, so a long run of
+  # users with zero or negative net balances would force one statement to keep
+  # aggregating until it found enough positive ones — reintroducing unbounded work.
+  # Grouping without HAVING lets MySQL stream exactly LIMIT groups off the
+  # `(state, user_id, amount_cents)` covering index and stop, so each statement's
+  # work is bounded by the batch size — not by how many sellers Gumroad has. A
+  # user's balance rows all share one user_id, so partitioning by user_id ranges
+  # never splits a user's SUM across batches, and the union of batches is exactly
+  # the users with SUM > 0.
+  #
+  # One deliberate difference from the JOIN version: this reads only the balances
+  # table, so a balance row pointing at a deleted/nonexistent user id would be
+  # included here where the JOIN would have dropped it. That cannot change who gets
+  # paid — every caller resolves these ids through `User.where(id: ...)`, which
+  # drops ids without a users row.
+  #
+  # Balances don't move out of the `unpaid` state while this worker is only reading,
+  # so re-running after a partial failure re-selects the same users; actual payout
+  # creation stays idempotent downstream (per-user jobs are deduplicated and
+  # Payouts.create_payment no-ops once a user's balances leave `unpaid`).
+  def self.holding_balance_user_ids
+    user_ids = []
+    last_user_id = 0
+
+    loop do
+      batch = Balance.unpaid
+                     .where("user_id > ?", last_user_id)
+                     .group(:user_id)
+                     .order(:user_id)
+                     .limit(HOLDING_BALANCE_ID_BATCH_SIZE)
+                     .pluck(:user_id, Arel.sql("SUM(amount_cents)"))
+      break if batch.empty?
+
+      user_ids.concat(batch.filter_map { |user_id, amount_cents| user_id if amount_cents > 0 })
+      last_user_id = batch.last.first
+    end
+
+    user_ids
   end
 
   def self.create_instant_payouts_for_balances_up_to_date(date)

--- a/app/business/payments/payouts/payouts.rb
+++ b/app/business/payments/payouts/payouts.rb
@@ -8,6 +8,10 @@ class Payouts
   PAYOUT_TYPE_INSTANT = "instant"
   BANK_ACCOUNT_LOOKUP_BATCH_SIZE = 10_000
   HOLDING_BALANCE_ID_BATCH_SIZE = 25_000
+  # Max user ids per `User.where(id: ...)` lookup. See the comment in
+  # create_payments_for_balances_up_to_date_for_bank_account_types for why a large
+  # IN() list has to be split before it reaches MySQL.
+  USER_LOOKUP_BATCH_SIZE = 1_000
 
   def self.is_user_payable(user, date, processor_type: nil, add_comment: false, from_admin: false, bypass_minimum_payout: false, payout_type: Payouts::PAYOUT_TYPE_STANDARD)
     payout_date = Time.current.to_fs(:formatted_date_full_month)
@@ -100,8 +104,21 @@ class Payouts
       user_ids = holding_balance_user_ids.each_slice(BANK_ACCOUNT_LOOKUP_BATCH_SIZE).flat_map do |user_ids_batch|
         BankAccount.alive.where(user_id: user_ids_batch, type: bank_account_type).distinct.pluck(:user_id)
       end
-      users = User.where(id: user_ids)
-      self.create_payments_for_balances_up_to_date_for_users(date, processor_type, users, perform_async: true, bank_account_type:)
+
+      # Load the matched users in id-bounded slices rather than one
+      # `User.where(id: user_ids)`. For a large bank-account cohort that id list runs
+      # to tens of thousands of ids, and MySQL abandons the primary-key range plan
+      # once the IN() list outgrows the range optimizer's memory budget
+      # (range_optimizer_max_mem_size), falling back to a full scan of the very large
+      # users table. That scan can't finish inside the statement timeout, so the whole
+      # per-bank-type payout job dies (gumroad-private#955). Slicing keeps every lookup
+      # on the fast primary-key range plan. This path is Stripe-only and enqueues one
+      # job per user, so processing the cohort a slice at a time is equivalent to
+      # processing it all at once.
+      user_ids.each_slice(USER_LOOKUP_BATCH_SIZE) do |user_ids_batch|
+        users = User.where(id: user_ids_batch)
+        self.create_payments_for_balances_up_to_date_for_users(date, processor_type, users, perform_async: true, bank_account_type:)
+      end
     end
   end
 

--- a/app/business/payments/payouts/payouts.rb
+++ b/app/business/payments/payouts/payouts.rb
@@ -8,9 +8,7 @@ class Payouts
   PAYOUT_TYPE_INSTANT = "instant"
   BANK_ACCOUNT_LOOKUP_BATCH_SIZE = 10_000
   HOLDING_BALANCE_ID_BATCH_SIZE = 25_000
-  # Max user ids per `User.where(id: ...)` lookup. See the comment in
-  # create_payments_for_balances_up_to_date_for_bank_account_types for why a large
-  # IN() list has to be split before it reaches MySQL.
+  # Max ids per `User.where(id: ...)` lookup, so the IN() list stays on MySQL's PK range plan.
   USER_LOOKUP_BATCH_SIZE = 1_000
 
   def self.is_user_payable(user, date, processor_type: nil, add_comment: false, from_admin: false, bypass_minimum_payout: false, payout_type: Payouts::PAYOUT_TYPE_STANDARD)
@@ -91,13 +89,9 @@ class Payouts
   end
 
   def self.create_payments_for_balances_up_to_date_for_bank_account_types(date, processor_type, bank_account_types)
-    # Materialize the holding-balance user ids first, then look up bank accounts in
-    # chunks by user_id (indexed). The previous single statement joined
-    # users × balances × bank_accounts, and MySQL drove it from a full scan of
-    # bank_accounts (no index on `type`), repeatedly blowing the 5-minute statement
-    # cap at the scheduled slot and aborting entire payout batches. Splitting the
-    # query leaves no join for the optimizer to get wrong, and each piece stays far
-    # under the statement cap.
+    # Materialize holding-balance user ids, then look up bank accounts in user_id chunks.
+    # The old single join (users × balances × bank_accounts) full-scanned bank_accounts
+    # and blew the statement timeout; splitting it keeps each piece cheap.
     holding_balance_user_ids = self.holding_balance_user_ids
 
     bank_account_types.each do |bank_account_type|
@@ -105,16 +99,10 @@ class Payouts
         BankAccount.alive.where(user_id: user_ids_batch, type: bank_account_type).distinct.pluck(:user_id)
       end
 
-      # Load the matched users in id-bounded slices rather than one
-      # `User.where(id: user_ids)`. For a large bank-account cohort that id list runs
-      # to tens of thousands of ids, and MySQL abandons the primary-key range plan
-      # once the IN() list outgrows the range optimizer's memory budget
-      # (range_optimizer_max_mem_size), falling back to a full scan of the very large
-      # users table. That scan can't finish inside the statement timeout, so the whole
-      # per-bank-type payout job dies (gumroad-private#955). Slicing keeps every lookup
-      # on the fast primary-key range plan. This path is Stripe-only and enqueues one
-      # job per user, so processing the cohort a slice at a time is equivalent to
-      # processing it all at once.
+      # Load users in id-bounded slices. One `User.where(id: user_ids)` over a large
+      # cohort exceeds MySQL's range_optimizer_max_mem_size and full-scans the users
+      # table, blowing the statement timeout (gumroad-private#955); slicing keeps each
+      # lookup on the PK range plan. Enqueue is per-user, so slicing changes nothing.
       user_ids.each_slice(USER_LOOKUP_BATCH_SIZE) do |user_ids_batch|
         users = User.where(id: user_ids_batch)
         self.create_payments_for_balances_up_to_date_for_users(date, processor_type, users, perform_async: true, bank_account_type:)
@@ -122,42 +110,17 @@ class Payouts
     end
   end
 
-  # Returns the ids of every user holding a positive unpaid balance — the same set
-  # as User.holding_balance — but computed in bounded batches so that no single SQL
-  # statement has to aggregate the entire balances table in one go.
+  # Ids of every user holding a positive unpaid balance (same set as User.holding_balance),
+  # computed in bounded batches. The single-statement GROUP BY aggregates the whole balances
+  # table and kept blowing MySQL's 5-minute statement cap in the contended batch window.
   #
-  # The single-statement version (users JOIN balances GROUP BY user, or even
-  # User.holding_balance.ids on its own) aggregates every unpaid balance row on the
-  # platform in one query. That query's runtime grows with the size of the platform,
-  # and during the contended 10:00 UTC scheduled-jobs window it has repeatedly
-  # exceeded MySQL's 5-minute statement cap, killing whole payout batches
-  # (StatementTimeout incidents on 2026-05-26, 07-02, and 07-07). Retries don't help
-  # because they land in the same contention window.
-  #
-  # Instead we walk balances.user_id in ascending order with a keyset cursor
-  # (`user_id > last seen id`), aggregating at most HOLDING_BALANCE_ID_BATCH_SIZE
-  # users' balances per statement and applying the "sum is positive" filter in Ruby.
-  # The positivity check deliberately lives here and not in a SQL HAVING clause:
-  # HAVING filters groups after aggregation but before LIMIT, so a long run of
-  # users with zero or negative net balances would force one statement to keep
-  # aggregating until it found enough positive ones — reintroducing unbounded work.
-  # Grouping without HAVING lets MySQL stream exactly LIMIT groups off the
-  # `(state, user_id, amount_cents)` covering index and stop, so each statement's
-  # work is bounded by the batch size — not by how many sellers Gumroad has. A
-  # user's balance rows all share one user_id, so partitioning by user_id ranges
-  # never splits a user's SUM across batches, and the union of batches is exactly
-  # the users with SUM > 0.
-  #
-  # One deliberate difference from the JOIN version: this reads only the balances
-  # table, so a balance row pointing at a deleted/nonexistent user id would be
-  # included here where the JOIN would have dropped it. That cannot change who gets
-  # paid — every caller resolves these ids through `User.where(id: ...)`, which
-  # drops ids without a users row.
-  #
-  # Balances don't move out of the `unpaid` state while this worker is only reading,
-  # so re-running after a partial failure re-selects the same users; actual payout
-  # creation stays idempotent downstream (per-user jobs are deduplicated and
-  # Payouts.create_payment no-ops once a user's balances leave `unpaid`).
+  # We walk balances.user_id with a keyset cursor, aggregating HOLDING_BALANCE_ID_BATCH_SIZE
+  # users per statement, and apply the positivity filter in Ruby rather than SQL HAVING:
+  # HAVING runs before LIMIT, so a run of non-positive users would keep one statement
+  # scanning, whereas plain GROUP BY streams exactly LIMIT groups off the
+  # (state, user_id, amount_cents) covering index and stops. Grouping by user_id never
+  # splits a user's SUM, so the union is exactly SUM > 0. Reads only balances, so ids for
+  # deleted users may appear; callers resolve them via User.where(id:), which drops them.
   def self.holding_balance_user_ids
     user_ids = []
     last_user_id = 0

--- a/db/migrate/20261205000001_add_covering_index_for_holding_balance_to_balances.rb
+++ b/db/migrate/20261205000001_add_covering_index_for_holding_balance_to_balances.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class AddCoveringIndexForHoldingBalanceToBalances < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    # The weekly payout batch first has to answer "which users hold a positive
+    # unpaid balance?" — a GROUP BY over the balances table filtered on
+    # state = 'unpaid', grouped by user_id, summing amount_cents
+    # (Payouts.holding_balance_user_ids / User.holding_balance).
+    #
+    # This index covers that query exactly: MySQL can read `state = 'unpaid'`
+    # entries already ordered by user_id and sum amount_cents straight out of the
+    # index, with no table lookups and no temporary table. Production profiling on
+    # gumroad-private#870 measured the aggregation at ~3s on the existing
+    # (state, merchant_account_id, date, user_id) index; this takes it to
+    # sub-second and keeps it fast as the table grows.
+    add_index :balances,
+              [:state, :user_id, :amount_cents],
+              name: "index_balances_on_state_user_id_amount_cents"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_12_04_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_12_05_000001) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -295,6 +295,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_12_04_000000) do
     t.string "holding_currency", default: "usd"
     t.integer "holding_amount_cents", default: 0
     t.index ["state", "merchant_account_id", "date", "user_id"], name: "index_balances_on_state_merchant_account_date_for_payouts"
+    t.index ["state", "user_id", "amount_cents"], name: "index_balances_on_state_user_id_amount_cents"
     t.index ["user_id", "merchant_account_id", "date"], name: "index_on_user_merchant_account_date"
   end
 

--- a/spec/business/payments/payouts/payouts_spec.rb
+++ b/spec/business/payments/payouts/payouts_spec.rb
@@ -457,6 +457,24 @@ describe Payouts do
 
       described_class.create_payments_for_balances_up_to_date_for_bank_account_types(payout_date, payout_processor_type, [AustralianBankAccount.name])
     end
+
+    it "loads the matched users in id-bounded batches so a large cohort cannot force a full-table scan" do
+      stub_const("Payouts::USER_LOOKUP_BATCH_SIZE", 1)
+      allow(Payouts).to receive(:is_user_payable).and_return(true)
+
+      loaded_batches = []
+      allow(described_class).to receive(:create_payments_for_balances_up_to_date_for_users) do |_date, _processor, users, **_options|
+        loaded_batches << users.to_a
+      end
+
+      described_class.create_payments_for_balances_up_to_date_for_bank_account_types(payout_date, payout_processor_type, [AustralianBankAccount.name])
+
+      # One batch per user at a batch size of 1: no single lookup ever exceeds the cap,
+      # and the union across batches is still the full Australian cohort.
+      expect(loaded_batches.size).to eq(2)
+      expect(loaded_batches.map(&:size)).to all(be <= 1)
+      expect(loaded_batches.flatten).to match_array([u1_2, u2_2])
+    end
   end
 
   describe ".holding_balance_user_ids" do

--- a/spec/business/payments/payouts/payouts_spec.rb
+++ b/spec/business/payments/payouts/payouts_spec.rb
@@ -448,6 +448,67 @@ describe Payouts do
 
       described_class.create_payments_for_balances_up_to_date_for_bank_account_types(payout_date, payout_processor_type, [AustralianBankAccount.name])
     end
+
+    it "selects the same users when the holding-balance ids are materialized in multiple batches" do
+      stub_const("Payouts::HOLDING_BALANCE_ID_BATCH_SIZE", 1)
+
+      allow(Payouts).to receive(:is_user_payable).and_return(true)
+      expect(described_class).to receive(:create_payments_for_balances_up_to_date_for_users).with(payout_date, payout_processor_type, [u1_2, u2_2], perform_async: true, bank_account_type: "AustralianBankAccount").and_call_original
+
+      described_class.create_payments_for_balances_up_to_date_for_bank_account_types(payout_date, payout_processor_type, [AustralianBankAccount.name])
+    end
+  end
+
+  describe ".holding_balance_user_ids" do
+    let!(:zero_balance_user) { create(:user, unpaid_balance_cents: 0) }
+    let!(:below_minimum_user) { create(:user, unpaid_balance_cents: 10_00) }
+    let!(:above_minimum_user) { create(:user, unpaid_balance_cents: 100_00) }
+    let!(:multiple_balances_user) do
+      user = create(:user)
+      create(:balance, user:, amount_cents: 60_00, date: Date.today - 3)
+      create(:balance, user:, amount_cents: -20_00, date: Date.today - 2)
+      user
+    end
+    let!(:negative_net_balance_user) do
+      user = create(:user)
+      create(:balance, user:, amount_cents: 10_00, date: Date.today - 3)
+      create(:balance, user:, amount_cents: -30_00, date: Date.today - 2)
+      user
+    end
+    let!(:paid_balance_user) do
+      user = create(:user)
+      create(:balance, user:, amount_cents: 500_00, date: Date.today - 3, state: "paid")
+      user
+    end
+    let!(:mixed_bank_type_user) do
+      user = create(:user, unpaid_balance_cents: 200_00)
+      create(:ach_account, user:)
+      create(:australian_bank_account, user:)
+      user
+    end
+
+    it "returns exactly the same user set as the single-statement User.holding_balance query" do
+      expect(described_class.holding_balance_user_ids.sort).to eq(User.holding_balance.ids.sort)
+      expect(described_class.holding_balance_user_ids).to match_array(
+        [below_minimum_user.id, above_minimum_user.id, multiple_balances_user.id, mixed_bank_type_user.id]
+      )
+    end
+
+    it "returns the same user set when materialized across multiple batches" do
+      stub_const("Payouts::HOLDING_BALANCE_ID_BATCH_SIZE", 1)
+
+      expect(described_class.holding_balance_user_ids.sort).to eq(User.holding_balance.ids.sort)
+    end
+
+    it "never splits a user's balance aggregation across batches" do
+      stub_const("Payouts::HOLDING_BALANCE_ID_BATCH_SIZE", 1)
+
+      # negative_net_balance_user has a positive row and a larger negative row; a
+      # per-row (rather than per-user) batching bug would surface them as holding
+      # a balance.
+      expect(described_class.holding_balance_user_ids).not_to include(negative_net_balance_user.id)
+      expect(described_class.holding_balance_user_ids).to include(multiple_balances_user.id)
+    end
   end
 
   describe "create_payments_for_balances_up_to_date_for_users" do


### PR DESCRIPTION
## What

Rewrites the payout batch's "which users hold a positive unpaid balance?" step (`Payouts.holding_balance_user_ids`, new) so that no single SQL statement's runtime scales with the size of the full cohort. Previously `create_payments_for_balances_up_to_date_for_bank_account_types` ran `User.holding_balance.ids` — one `GROUP BY` over every unpaid balance row on the platform (~725k rows / 235k sellers per the gumroad-private#870 profiling). That statement is now a keyset-paginated walk over `balances.user_id`: each statement aggregates at most `HOLDING_BALANCE_ID_BATCH_SIZE` (25k) user groups off an index in `user_id` order and stops, with the `SUM(amount_cents) > 0` filter applied in Ruby so a `HAVING` clause can't force one statement to keep aggregating through long runs of zero/negative-balance users.

Also adds a covering index on `balances (state, user_id, amount_cents)` (separate migration) so each batch statement streams straight out of the index — no table lookups, no temporary table, no filesort.

## Why

This is the 4th `StatementTimeout` incident in the payout-batch class (gumroad-private#434 → #870 → #955). Most recently, the 2026-07-07 cross-border batch's `IndianBankAccount` slice died with `ActiveRecord::StatementTimeout` at the 10:00 UTC contention window, exhausted all 3 retries (added in #5698), and landed in the dead set — leaving ~240 India sellers unpaid until an off-peak manual re-run.

Root cause chain:
- #5698 added per-bank-type fan-out + `retry: 3`, which correctly isolated failures per type — but all retries land in the same 10:00 UTC contention window, so a slice whose query structurally exceeds MySQL's 5-minute `max_execution_time` can never succeed on schedule.
- #5702 split the users × balances × bank_accounts join (the `bank_accounts` full-scan driver), but kept `User.holding_balance.ids` as one monolithic aggregation. That statement's runtime grows with the platform and has now outgrown the cap under contention (~3s off-peak per the #870 read-replica profiling, but 300s+ at the contended slot).

**Why chunking rather than indexes alone:** an index only shrinks the constant factor of a query that still scales with the whole cohort — the timeout class survives and recurs as the table grows (which is exactly the #434 → #870 → #955 progression). Bounding each statement's work by a fixed batch size eliminates the class: a statement can only ever aggregate 25k user groups, no matter how large the platform gets. The covering index is added as well because it makes each bounded statement near-instant and keeps the total wall-clock for all batches low, but it is the chunking that removes the failure mode.

**Selection semantics are unchanged.** The union of batches is exactly the users with `SUM(amount_cents) > 0` over `unpaid` balances — the same set as `User.holding_balance`:
- Partitioning by `user_id` ranges never splits one user's SUM across batches (all of a user's balance rows share one `user_id`, and the cursor advances past whole groups).
- The positive-sum filter is evaluated per complete user group, identically to the old `HAVING`.
- Ids are resolved through `User.where(id: ...)` exactly as before, so a balance row with a dangling `user_id` still cannot select anyone the old JOIN wouldn't have.
- Re-run safety is unchanged: this path only reads; payout creation stays idempotent downstream (per-user jobs are deduplicated by their `until_executed` lock, and `Payouts.create_payment` no-ops once a user's balances leave `unpaid`).

Specs prove the equivalence directly: `Payouts.holding_balance_user_ids` is asserted equal to `User.holding_balance.ids` on a fixture covering zero balances, below-minimum users, multi-balance users (including negative rows), negative-net users, `paid`-state balances, and mixed bank-account types — both at the default batch size and with `HOLDING_BALANCE_ID_BATCH_SIZE` stubbed to 1 so every user crosses a batch boundary. A third spec pins the "never split a user's aggregation across batches" invariant.

**Migration safety:** `disable_ddl_transaction!` + a plain `add_index`, matching the repo's existing pattern for index-on-big-table migrations (e.g. `20261130000006_add_payout_estimate_index_to_balances.rb`, which added a 4-column index to this same table); the deploy tooling runs these as online DDL. The index is on `(state, user_id, amount_cents)` — `state` is the only filter the payout path uses, so this is a strict improvement for it, per the #870 profiling discussion.

Refs: [gumroad-private#955](https://github.com/antiwork/gumroad-private/issues/955), [gumroad-private#870](https://github.com/antiwork/gumroad-private/issues/870) (item 4), #5698, #5702.

autoreview: clean (Codex; an earlier finding that `HAVING`-before-`LIMIT` left the aggregation unbounded was accepted and fixed by moving the positivity filter to Ruby).

## Test plan

- `bundle exec rspec spec/business/payments/payouts/payouts_spec.rb spec/sidekiq/perform_payouts_up_to_delay_days_ago_worker_spec.rb` — **67 examples, 0 failures** locally (includes the 3 new equivalence specs and the batch-boundary variants of the bank-account-type specs).
- `bundle exec rubocop` on the three touched Ruby files — **3 files inspected, no offenses detected**.
- Migration applied locally against the test DB; verified `index_balances_on_state_user_id_amount_cents` exists with the expected column order.
- After deploy: watch the Tue/Wed/Thu 10:00 UTC batches (`payouts_us_stripe`, `payouts_non_us_stripe`, `payouts_cross_border_stripe`) on gumroad-private#955 — dead set stays clean for `PerformPayouts*`, per-type payment counts match baseline, and the `IndianBankAccount` slice completes inside the window.

⚠️ Payments surface — **no auto-merge**; requires human review.
