### PR TITLE
docs: document the automatic products section on new profiles

### DIFF
--- a/app/views/help_center/articles/contents/_124-your-gumroad-profile-page.html.erb
+++ b/app/views/help_center/articles/contents/_124-your-gumroad-profile-page.html.erb
@@ -36,6 +36,7 @@
   <p>Click on the three-dot menu and select New page to get started. On a given page, click the + icon at the bottom to create a new section to be displayed on your profile.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/660a470bd00a8f46829b75dc/file-LcDS8NDJzg.gif" %></figure>
   <p>You can also rename and reorder your pages and sections from the three-dot menu.</p>
+  <p><i>Note:</i> If you have published products but haven't added any sections yet, your profile automatically shows a section with all of your products, newest first. As soon as you save a section of your own, your layout replaces the automatic one. If you have no products for sale and no sections, your profile shows an email signup form instead.</p>
   <h3 id="Product-sections-WxaV_">Product sections</h3>
   <p>On a given product section, click the three-dot menu on the left to assign a name and select the products you want it to contain. You can choose whether to display the section's name or not, and automatically add any new products to a section (enabled by default on new sections).</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/6597f226df35c837879e8922/file-d1pwX1X2F6.gif" %></figure>


### PR DESCRIPTION
## What

Adds a short note to the "Your Gumroad profile page" help article (`_124-your-gumroad-profile-page.html.erb`, under "Create pages and sections") explaining that a profile with published products but no saved sections automatically shows a section with all of the creator's products, newest first; that saving any section replaces the automatic one; and that the email signup form remains the fallback when there are no products.

## Why

PR #5747 (merged) changed the public profile behavior: creators with live products and no saved sections now get an automatic products section instead of only the email signup box. The help article described sections as purely manual, so it was silent about the new default. One added sentence, no removals, no policy/pricing/tax/payout wording.

Body-only copy edit — `articles.yml` untouched, anchor IDs preserved. ERB syntax verified. Autoreview skipped (docs copy only, no logic).
