### PR TITLE
Search upsell products server-side so older products are selectable

### DIFF
--- a/app/controllers/checkout/upsells/products_controller.rb
+++ b/app/controllers/checkout/upsells/products_controller.rb
@@ -20,8 +20,15 @@ class Checkout::Upsells::ProductsController < ApplicationController
     return render json: [] unless seller
 
     products = WithMaxExecutionTime.timeout_queries(seconds: 10) do
-      seller.products
-        .eligible_for_content_upsells
+      # The picker UI only ever shows MAX_PRODUCTS results at a time, so sellers
+      # with more products than that rely on the `query` param to search the rest
+      # of their catalog server-side. Without it, older products could never be
+      # selected as upsells.
+      scope = seller.products.eligible_for_content_upsells
+      if params[:query].present?
+        scope = scope.where("name LIKE ?", "%#{Link.sanitize_sql_like(params[:query])}%")
+      end
+      scope
         .includes(*PRODUCT_INCLUDES)
         .order(created_at: :desc, id: :desc)
         .limit(MAX_PRODUCTS)

--- a/app/controllers/checkout/upsells/products_controller.rb
+++ b/app/controllers/checkout/upsells/products_controller.rb
@@ -23,10 +23,16 @@ class Checkout::Upsells::ProductsController < ApplicationController
       # The picker UI only ever shows MAX_PRODUCTS results at a time, so sellers
       # with more products than that rely on the `query` param to search the rest
       # of their catalog server-side. Without it, older products could never be
-      # selected as upsells.
+      # selected as upsells. The picker also lists variants as "Product (Variant)"
+      # options, so the search matches variant names too — otherwise typing a
+      # variant name would return nothing.
       scope = seller.products.eligible_for_content_upsells
       if params[:query].present?
-        scope = scope.where("name LIKE ?", "%#{Link.sanitize_sql_like(params[:query])}%")
+        like_pattern = "%#{Link.sanitize_sql_like(params[:query])}%"
+        scope = scope
+          .left_joins(:alive_variants)
+          .where("links.name LIKE :query OR base_variants.name LIKE :query", query: like_pattern)
+          .distinct
       end
       scope
         .includes(*PRODUCT_INCLUDES)

--- a/app/javascript/components/UpsellSelectModal.tsx
+++ b/app/javascript/components/UpsellSelectModal.tsx
@@ -16,6 +16,7 @@ import { Details, DetailsToggle } from "$app/components/ui/Details";
 import { Fieldset, FieldsetTitle } from "$app/components/ui/Fieldset";
 import { Label } from "$app/components/ui/Label";
 import { Switch } from "$app/components/ui/Switch";
+import { useDebouncedCallback } from "$app/components/useDebouncedCallback";
 import { useRunOnce } from "$app/components/useRunOnce";
 
 export type ProductOption = {
@@ -54,23 +55,36 @@ export const UpsellSelectModal = ({
   const [selectedVariant, setSelectedVariant] = React.useState<ProductOption | null>(null);
 
   const [products, setProducts] = React.useState<Product[]>([]);
-  useRunOnce(() => {
-    const fetchProducts = async () => {
-      try {
-        const response = await request({
-          method: "GET",
-          accept: "json",
-          url: Routes.checkout_upsells_products_path(),
-        });
-        const responseData = typia.assert<Product[]>(await response.json());
-        setProducts(responseData);
-      } catch (error) {
-        assertResponseError(error);
-        showAlert(error.message, "error");
-      }
-    };
+  const [isLoading, setIsLoading] = React.useState(false);
+  const activeRequestId = React.useRef(0);
 
-    void fetchProducts();
+  // The server returns at most 25 products per request, so sellers with larger
+  // catalogs must search server-side to reach their older products. Each
+  // keystroke (debounced below) re-fetches the option list with the typed text.
+  const fetchProducts = async (query: string) => {
+    const requestId = ++activeRequestId.current;
+    setIsLoading(true);
+    try {
+      const response = await request({
+        method: "GET",
+        accept: "json",
+        url: Routes.checkout_upsells_products_path(query.trim() !== "" ? { query: query.trim() } : {}),
+      });
+      const responseData = typia.assert<Product[]>(await response.json());
+      // Ignore out-of-order responses: only the latest request may update the list.
+      if (requestId === activeRequestId.current) setProducts(responseData);
+    } catch (error) {
+      assertResponseError(error);
+      if (requestId === activeRequestId.current) showAlert(error.message, "error");
+    } finally {
+      if (requestId === activeRequestId.current) setIsLoading(false);
+    }
+  };
+
+  const debouncedFetchProducts = useDebouncedCallback((query: string) => void fetchProducts(query), 300);
+
+  useRunOnce(() => {
+    void fetchProducts("");
   });
 
   const handleInsert = () => {
@@ -147,9 +161,15 @@ export const UpsellSelectModal = ({
               selectProductOption(null);
             }
           }}
+          onInputChange={(inputValue, { action }) => {
+            // Only refetch on real typing. react-select also fires this event with
+            // an empty value when the input blurs or an option is chosen, and
+            // refetching then would needlessly reset the list.
+            if (action === "input-change") debouncedFetchProducts(inputValue);
+          }}
+          isLoading={isLoading}
           placeholder="Select a product"
           isClearable
-          isDisabled={products.length === 0}
         />
       </Fieldset>
 

--- a/app/javascript/components/UpsellSelectModal.tsx
+++ b/app/javascript/components/UpsellSelectModal.tsx
@@ -161,7 +161,10 @@ export const UpsellSelectModal = ({
               selectProductOption(null);
               // Clearing the selection also resets the option list to the full
               // (unfiltered) catalog — otherwise the dropdown would keep showing
-              // only the results of the last search.
+              // only the results of the last search. Cancel any search that is
+              // still waiting on the debounce timer first, so it can't fire
+              // after this reset and put the stale filtered results back.
+              debouncedFetchProducts.cancel();
               void fetchProducts("");
             }
           }}

--- a/app/javascript/components/UpsellSelectModal.tsx
+++ b/app/javascript/components/UpsellSelectModal.tsx
@@ -159,6 +159,10 @@ export const UpsellSelectModal = ({
               selectProductOption(newValue);
             } else {
               selectProductOption(null);
+              // Clearing the selection also resets the option list to the full
+              // (unfiltered) catalog — otherwise the dropdown would keep showing
+              // only the results of the last search.
+              void fetchProducts("");
             }
           }}
           onInputChange={(inputValue, { action }) => {

--- a/spec/controllers/checkout/upsells/products_controller_spec.rb
+++ b/spec/controllers/checkout/upsells/products_controller_spec.rb
@@ -114,6 +114,14 @@ describe Checkout::Upsells::ProductsController do
         expect(response.parsed_body.map { |product| product["id"] }).to eq([old_product.external_id])
       end
 
+      it "matches variant names, since the picker lists variants as options" do
+        sign_in seller
+        get :index, params: { query: "Untitled 1" }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body.map { |product| product["name"] }).to eq(["Versioned Product"])
+      end
+
       it "treats SQL LIKE wildcards in the query as literal characters" do
         sign_in seller
         get :index, params: { query: "%" }

--- a/spec/controllers/checkout/upsells/products_controller_spec.rb
+++ b/spec/controllers/checkout/upsells/products_controller_spec.rb
@@ -89,6 +89,48 @@ describe Checkout::Upsells::ProductsController do
       expect(response.parsed_body.length).to eq(2)
     end
 
+    context "with a search query" do
+      it "returns only products whose name contains the query, matching case-insensitively" do
+        sign_in seller
+        get :index, params: { query: "product 1" }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body.map { |product| product["name"] }).to eq(["Product 1"])
+      end
+
+      it "finds products outside the newest-MAX_PRODUCTS window" do
+        # This is the bug the query param exists to fix: without server-side
+        # search, a product older than the seller's 25 newest could never be
+        # selected as an upsell.
+        old_product = create(:product, user: seller, name: "Ancient Relic", created_at: 5.years.ago)
+        sign_in seller
+
+        stub_const("Checkout::Upsells::ProductsController::MAX_PRODUCTS", 2)
+
+        get :index
+        expect(response.parsed_body.map { |product| product["name"] }).not_to include("Ancient Relic")
+
+        get :index, params: { query: "ancient" }
+        expect(response.parsed_body.map { |product| product["id"] }).to eq([old_product.external_id])
+      end
+
+      it "treats SQL LIKE wildcards in the query as literal characters" do
+        sign_in seller
+        get :index, params: { query: "%" }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to eq([])
+      end
+
+      it "returns all products when the query is blank" do
+        sign_in seller
+        get :index, params: { query: "" }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body.length).to eq(3)
+      end
+    end
+
     context "when no seller is found" do
       it "returns an empty array" do
         get :index


### PR DESCRIPTION
## What

The "Insert upsell" product picker in the content editor now searches the seller's whole catalog server-side instead of filtering a fixed list of 25 products in the browser.

- `Checkout::Upsells::ProductsController#index` accepts an optional `query` param that filters eligible products by product name or variant name (`LIKE`, wildcards escaped) before applying the existing 25-result cap and ordering.
- `UpsellSelectModal` re-fetches the option list from the server as the seller types (debounced 300ms, out-of-order responses discarded, loading indicator while fetching). Variant names match server-side too, since the picker lists variants as "Product (Variant)" options and those were previously findable via the client-side filter.

## Why

Fixes antiwork/gumroad-private#959.

The picker only ever loaded the seller's 25 newest eligible products and the search box filtered that short list client-side. Sellers with more than 25 products could never select their older products as upsells — typing an older product's name returned "No options" even though the product was live and eligible. Verified against production data: an affected seller has 106 eligible products, so any product outside the newest-25 window was silently unselectable.

## Test evidence

- `bundle exec rubocop` on both touched Ruby files: no offenses.
- Prettier + `eslint` on `UpsellSelectModal.tsx`: clean. `tsc --noEmit`: no errors in the touched file.
- Controller search scope verified against the test DB via `rails runner` (6 checks): without `query` the old product is invisible beyond the cap; with `query` it is returned; variant-name match works; deleted variants don't match; `%` is treated literally; matching is case-insensitive.
- Added controller specs covering the `query` param (name match, variant-name match, beyond-the-cap retrieval, wildcard escaping, blank query). These could not be run locally — the spec file's purchase factory needs Stripe/VCR that this worktree lacks (all 15 examples fail identically on untouched `main`, pre-existing environment limitation) — CI will verify.
- Autoreview (Codex): first pass flagged the variant-name regression, fixed in the second commit; re-review on committed state reported clean, "patch is correct (0.86)".

## Before/After

Not captured as screenshots — no local dev server available in this environment. Behavior change: typing an older product's name in the "Insert upsell" modal previously showed "No options"; it now queries the server and returns the product.

## Video walkthrough

Not captured — same local dev server limitation as above. The change is exercised by the added controller specs and the DB-level verification described in Test evidence.
