### PR TITLE
Give payout batch jobs a 2-hour statement timeout

### DIFF
--- a/app/sidekiq/perform_daily_instant_payouts_worker.rb
+++ b/app/sidekiq/perform_daily_instant_payouts_worker.rb
@@ -9,7 +9,12 @@ class PerformDailyInstantPayoutsWorker
 
     Rails.logger.info("AUTOMATED DAILY INSTANT PAYOUTS: #{payout_period_end_date} (Started)")
 
-    Payouts.create_instant_payouts_for_balances_up_to_date(payout_period_end_date)
+    # Same 2-hour budget as the weekly batch worker: the payout eligibility queries scan
+    # `balances` at a scale that can outrun the connection's default 5-minute statement cap
+    # (the StatementTimeout incident class tracked in gumroad-private#955).
+    WithMaxExecutionTime.timeout_queries(seconds: 2.hours) do
+      Payouts.create_instant_payouts_for_balances_up_to_date(payout_period_end_date)
+    end
 
     Rails.logger.info("AUTOMATED DAILY INSTANT PAYOUTS: #{payout_period_end_date} (Finished)")
   end

--- a/app/sidekiq/perform_payouts_up_to_delay_days_ago_worker.rb
+++ b/app/sidekiq/perform_payouts_up_to_delay_days_ago_worker.rb
@@ -31,10 +31,20 @@ class PerformPayoutsUpToDelayDaysAgoWorker
 
     Rails.logger.info("AUTOMATED PAYOUTS: #{payout_period_end_date}, #{payout_processor_type}, #{bank_account_types} (Started)")
 
-    if bank_account_types
-      Payouts.create_payments_for_balances_up_to_date_for_bank_account_types(payout_period_end_date, payout_processor_type, bank_account_types)
-    else
-      Payouts.create_payments_for_balances_up_to_date(payout_period_end_date, payout_processor_type)
+    # The database connection defaults to a 5-minute statement cap (config/database.yml).
+    # The `holding_balance` eligibility query for a large bank-account-type cohort (US ACH,
+    # India, UK) regularly exceeds that cap during the 10:00 UTC batch window, and because
+    # all Sidekiq retries land in the same contention window, retries exhaust and every
+    # seller in the bucket goes unpaid for the week (4 incidents: #434, #870, #955, and the
+    # 2026-07-08 UK batch). Payouts are a weekly batch job, not a user-facing request — a
+    # long-running query here is expected, so give it a 2-hour budget instead of letting
+    # the default cap kill the batch.
+    WithMaxExecutionTime.timeout_queries(seconds: 2.hours) do
+      if bank_account_types
+        Payouts.create_payments_for_balances_up_to_date_for_bank_account_types(payout_period_end_date, payout_processor_type, bank_account_types)
+      else
+        Payouts.create_payments_for_balances_up_to_date(payout_period_end_date, payout_processor_type)
+      end
     end
 
     Rails.logger.info("AUTOMATED PAYOUTS: #{payout_period_end_date}, #{payout_processor_type} #{bank_account_types} (Finished)")


### PR DESCRIPTION
## What

Wraps the payout batch workers' eligibility queries in `WithMaxExecutionTime.timeout_queries(seconds: 2.hours)` — the same helper the long-running report jobs (`GenerateCanadaSalesReportJob`, `GenerateFeesByCreatorLocationReportJob`, etc.) already use:

- `PerformPayoutsUpToDelayDaysAgoWorker` (weekly batches, all processors/bank types)
- `PerformDailyInstantPayoutsWorker` (daily instant payouts — same query family, same exposure)

## Why

The connection's default **5-minute statement cap** (`config/database.yml`) keeps killing the payout eligibility query for large bank-account-type cohorts in the 10:00 UTC batch window — this is now a **weekly-recurring incident**:

| Date | Cohort | Outcome |
|---|---|---|
| 2026-05-27 | non-US Stripe | #434 class, ~80% drop |
| 2026-07-02 | US ACH/Card | ~1,124 sellers unpaid (gumroad-private#870) |
| 2026-07-07 | IndianBankAccount | ~240 sellers unpaid (gumroad-private#955) |
| 2026-07-08 | UkBankAccount | retries exhausted, re-run enqueued |

The #5698 fan-out + `retry: 3` fix works as designed but can't save a slice whose query *structurally* exceeds the cap — all retries land in the same contention window and exhaust. Payouts are batch jobs, not user-facing requests: a long-running query here is expected and should be allowed to finish.

Per Sahil (2026-07-08): "make the timeout 2 hours for all these jobs."

Complements #5755 (chunking the eligibility query), which remains the structural fix — this stops sellers going unpaid on every batch day in between.

## Notes

- `timeout_queries` sets `max_execution_time` on the session and restores the previous value in an `ensure` — no connection-pool leakage.
- `PayoutUsersWorker` (per-user fan-out) is untouched: per-user queries are small and have never hit the cap.

## Test plan

- `spec/sidekiq/perform_payouts_up_to_delay_days_ago_worker_spec.rb` — 5 examples, 0 failures
- `spec/sidekiq/perform_daily_instant_payouts_worker_spec.rb` + `spec/lib/utilities/with_max_execution_time_spec.rb` — 5 examples, 0 failures
- rubocop: 2 files, no offenses