### PR TITLE
Batch user lookups in per-bank-type payouts so a large cohort cannot trigger a full-table scan

### DIFF
--- a/app/business/payments/payouts/payouts.rb
+++ b/app/business/payments/payouts/payouts.rb
@@ -8,6 +8,10 @@ class Payouts
   PAYOUT_TYPE_INSTANT = "instant"
   BANK_ACCOUNT_LOOKUP_BATCH_SIZE = 10_000
   HOLDING_BALANCE_ID_BATCH_SIZE = 25_000
+  # Max user ids per `User.where(id: ...)` lookup. See the comment in
+  # create_payments_for_balances_up_to_date_for_bank_account_types for why a large
+  # IN() list has to be split before it reaches MySQL.
+  USER_LOOKUP_BATCH_SIZE = 1_000
 
   def self.is_user_payable(user, date, processor_type: nil, add_comment: false, from_admin: false, bypass_minimum_payout: false, payout_type: Payouts::PAYOUT_TYPE_STANDARD)
     payout_date = Time.current.to_fs(:formatted_date_full_month)
@@ -100,8 +104,21 @@ class Payouts
       user_ids = holding_balance_user_ids.each_slice(BANK_ACCOUNT_LOOKUP_BATCH_SIZE).flat_map do |user_ids_batch|
         BankAccount.alive.where(user_id: user_ids_batch, type: bank_account_type).distinct.pluck(:user_id)
       end
-      users = User.where(id: user_ids)
-      self.create_payments_for_balances_up_to_date_for_users(date, processor_type, users, perform_async: true, bank_account_type:)
+
+      # Load the matched users in id-bounded slices rather than one
+      # `User.where(id: user_ids)`. For a large bank-account cohort that id list runs
+      # to tens of thousands of ids, and MySQL abandons the primary-key range plan
+      # once the IN() list outgrows the range optimizer's memory budget
+      # (range_optimizer_max_mem_size), falling back to a full scan of the very large
+      # users table. That scan can't finish inside the statement timeout, so the whole
+      # per-bank-type payout job dies (gumroad-private#955). Slicing keeps every lookup
+      # on the fast primary-key range plan. This path is Stripe-only and enqueues one
+      # job per user, so processing the cohort a slice at a time is equivalent to
+      # processing it all at once.
+      user_ids.each_slice(USER_LOOKUP_BATCH_SIZE) do |user_ids_batch|
+        users = User.where(id: user_ids_batch)
+        self.create_payments_for_balances_up_to_date_for_users(date, processor_type, users, perform_async: true, bank_account_type:)
+      end
     end
   end
 

--- a/spec/business/payments/payouts/payouts_spec.rb
+++ b/spec/business/payments/payouts/payouts_spec.rb
@@ -457,6 +457,24 @@ describe Payouts do
 
       described_class.create_payments_for_balances_up_to_date_for_bank_account_types(payout_date, payout_processor_type, [AustralianBankAccount.name])
     end
+
+    it "loads the matched users in id-bounded batches so a large cohort cannot force a full-table scan" do
+      stub_const("Payouts::USER_LOOKUP_BATCH_SIZE", 1)
+      allow(Payouts).to receive(:is_user_payable).and_return(true)
+
+      loaded_batches = []
+      allow(described_class).to receive(:create_payments_for_balances_up_to_date_for_users) do |_date, _processor, users, **_options|
+        loaded_batches << users.to_a
+      end
+
+      described_class.create_payments_for_balances_up_to_date_for_bank_account_types(payout_date, payout_processor_type, [AustralianBankAccount.name])
+
+      # One batch per user at a batch size of 1: no single lookup ever exceeds the cap,
+      # and the union across batches is still the full Australian cohort.
+      expect(loaded_batches.size).to eq(2)
+      expect(loaded_batches.map(&:size)).to all(be <= 1)
+      expect(loaded_batches.flatten).to match_array([u1_2, u2_2])
+    end
   end
 
   describe ".holding_balance_user_ids" do


### PR DESCRIPTION
Stacked on #5755 (base branch: `fix/chunk-holding-balance-user-id-materialization`). Merge #5755 first, or merge this into #5755.

## What

Loads the matched users in id-bounded slices inside `Payouts.create_payments_for_balances_up_to_date_for_bank_account_types` instead of building one `User.where(id: user_ids)` over the entire cohort.

## Why

#5755 fixes the holding-balance aggregation, but it isn't the statement that's actually timing out. Decoding the dead payout jobs' backtraces points at the line right after the id materialization: `create_payments_for_balances_up_to_date_for_users` iterating `User.where(id: user_ids)`.

For a large bank-account cohort, `user_ids` is tens of thousands of ids. Past a threshold, MySQL's range optimizer can't hold an IN() list that large within `range_optimizer_max_mem_size`, abandons the primary-key range plan, and full-scans the (very large) users table. That scan can't complete inside the statement timeout, so the per-bank-type job dies with `ActiveRecord::StatementTimeout`. The plan is deterministic, not load-dependent — which is why retries and off-peak re-runs died identically rather than draining clean like earlier recoveries.

Verified against the read replica with `EXPLAIN` on `SELECT users.* WHERE id IN (...)`: a ~1k id list uses `type: range` on `PRIMARY`; a ~10k+ id list flips to `type: ALL` (full scan). Slicing to `USER_LOOKUP_BATCH_SIZE` (1,000) keeps every lookup on the range plan.

This path is Stripe cross-border only and `enqueue_payments` enqueues one `PayoutUsersWorker` per user, so splitting the cohort into slices enqueues exactly the same set of per-user jobs — no behavior change, just bounded queries. `find_each`/`in_batches` do **not** help here: they keep the full IN() list in every batched statement, so the cliff still triggers.

### Why not the other proposed mitigations

- Raising the statement timeout lets the job "succeed," but only by letting each large cohort complete a full users-table scan every batch — expensive and worsens as the table grows.
- This keeps the query cheap, which is the actual fix.

## Before / After

Non-user-facing backend change (Sidekiq payout batch query path); no UI surface to capture. Behavior is covered by the specs below.

## Test Results

`bundle exec rspec spec/business/payments/payouts/payouts_spec.rb` — `.create_payments_for_balances_up_to_date_for_bank_account_types` and `.holding_balance_user_ids` groups: **7 examples, 0 failures**.

New test `loads the matched users in id-bounded batches so a large cohort cannot force a full-table scan` stubs `USER_LOOKUP_BATCH_SIZE` to 1 and asserts the cohort is loaded across multiple bounded lookups whose union is the full cohort. Confirmed it **fails when the fix is reverted** (single lookup → `Expected 1 to eq 2`), so it can't pass without the code change. #5755's existing tests still pass unchanged (a small cohort fits in one batch at the default size).

---

AI disclosure: drafted with Claude Opus 4.8.
