### PR TITLE
Daily payouts: price via the instant payout fee constant (single source of truth)

### DIFF
--- a/app/javascript/components/Payouts/index.tsx
+++ b/app/javascript/components/Payouts/index.tsx
@@ -234,6 +234,7 @@ export type PayoutsProps = {
   payouts_paused_by: "stripe" | "admin" | "system" | "user" | null;
   past_payout_period_data: PayoutPeriodData[];
   instant_payout: {
+    instant_payout_fee_percent: number;
     payable_amount_cents: number;
     payable_balances: {
       id: string;

--- a/app/javascript/pages/Payouts/Index.tsx
+++ b/app/javascript/pages/Payouts/Index.tsx
@@ -37,7 +37,6 @@ import { WithTooltip } from "$app/components/WithTooltip";
 
 import placeholder from "$assets/images/placeholders/payouts.png";
 
-const INSTANT_PAYOUT_FEE_PERCENTAGE = 0.03;
 const MINIMUM_INSTANT_PAYOUT_AMOUNT_CENTS = 10000;
 const MAXIMUM_INSTANT_PAYOUT_AMOUNT_CENTS = 999900;
 
@@ -465,8 +464,11 @@ export default function PayoutsIndex() {
       return selectedBalance && balance.date <= selectedBalance.date ? sum + balance.amount_cents : sum;
     }, 0) ?? 0;
 
+  // The fee rate comes from the backend (StripePayoutProcessor::INSTANT_PAYOUT_FEE_PERCENT)
+  // so the amount previewed here always matches what the payout processor deducts.
+  const instantPayoutFeeFraction = instant_payout ? instant_payout.instant_payout_fee_percent / 100 : 0;
   const instantPayoutFee = instant_payout
-    ? instantPayoutAmountCents - Math.floor(instantPayoutAmountCents / (1 + INSTANT_PAYOUT_FEE_PERCENTAGE))
+    ? instantPayoutAmountCents - Math.floor(instantPayoutAmountCents / (1 + instantPayoutFeeFraction))
     : 0;
 
   const onRequestInstantPayout = () => {
@@ -686,7 +688,7 @@ export default function PayoutsIndex() {
                       price={`$${formatPriceCentsWithoutCurrencySymbol("usd", instantPayoutAmountCents)}`}
                     />
                     <PayoutLineItem
-                      title={`Instant payout fee (${INSTANT_PAYOUT_FEE_PERCENTAGE * 100}%)`}
+                      title={`Instant payout fee (${instant_payout.instant_payout_fee_percent}%)`}
                       price={`-$${formatPriceCentsWithoutCurrencySymbol("usd", instantPayoutFee)}`}
                     />
                   </div>

--- a/app/javascript/pages/Settings/Payments/Show.tsx
+++ b/app/javascript/pages/Settings/Payments/Show.tsx
@@ -99,6 +99,7 @@ type PaymentsPageProps = {
   payout_country_name: string | null;
   payout_frequency: PayoutFrequency;
   payout_frequency_daily_supported: boolean;
+  instant_payout_fee_percent: number;
   buyer_local_currency_enabled: boolean;
   disable_buyer_local_currency: boolean;
   can_manage_beneficial_owners: boolean;
@@ -1024,7 +1025,7 @@ export default function PaymentsPage() {
               <Alert variant="info" role="status">
                 <div>
                   Every day, your balance from the previous day will be sent to you via instant payouts, subject to a{" "}
-                  <b>3% fee</b>.
+                  <b>{props.instant_payout_fee_percent}% fee</b> — the same fee as a one-off instant payout.
                 </div>
               </Alert>
             ) : null}

--- a/app/presenters/payouts_presenter.rb
+++ b/app/presenters/payouts_presenter.rb
@@ -34,6 +34,10 @@ class PayoutsPresenter
     return nil unless seller.instant_payouts_supported?
 
     {
+      # The fee rate charged on instant (and daily-scheduled) payouts. Sent to the
+      # frontend so the fee shown to the creator is always the rate the Stripe
+      # payout processor deducts, rather than a separately maintained constant.
+      instant_payout_fee_percent: StripePayoutProcessor::INSTANT_PAYOUT_FEE_PERCENT,
       payable_amount_cents: seller.instantly_payable_unpaid_balance_cents,
       payable_balances: seller.instantly_payable_unpaid_balances.sort_by(&:date).reverse.map do |balance|
         {

--- a/app/presenters/settings_presenter.rb
+++ b/app/presenters/settings_presenter.rb
@@ -264,6 +264,10 @@ class SettingsPresenter
       payout_country_name: Compliance::Countries.for_select.to_h[seller.alive_user_compliance_info&.legal_entity_country_code],
       payout_frequency: seller.payout_frequency,
       payout_frequency_daily_supported: seller.instant_payouts_supported?,
+      # Daily payouts are executed as Stripe instant payouts, so they carry the same
+      # fee. Expose the canonical rate here so the settings UI can never drift from
+      # what the payout processor actually charges.
+      instant_payout_fee_percent: StripePayoutProcessor::INSTANT_PAYOUT_FEE_PERCENT,
       buyer_local_currency_enabled: Feature.active?(:buyer_local_currency, seller),
       disable_buyer_local_currency: seller.disable_buyer_local_currency?,
       can_manage_beneficial_owners: payments_policy.update? && StripeBeneficialOwnersManager.eligible?(seller),

--- a/spec/business/payments/payouts/payouts_spec.rb
+++ b/spec/business/payments/payouts/payouts_spec.rb
@@ -371,6 +371,23 @@ describe Payouts do
         end.to_not change { Payment.count }
       end
     end
+
+    context "when the seller is payable" do
+      # Daily-scheduled payouts must always be enqueued as instant payouts. That is what
+      # makes the daily fee identical to the manual instant payout fee: both paths go
+      # through StripePayoutProcessor#prepare_payment_and_set_amount, which deducts
+      # StripePayoutProcessor::INSTANT_PAYOUT_FEE_PERCENT for PAYOUT_TYPE_INSTANT payments.
+      it "enqueues the payout as an instant payout so the instant payout fee applies" do
+        creator = create(:user_with_compliance_info)
+        allow(described_class).to receive(:is_user_payable).and_return(true)
+
+        expect(StripePayoutProcessor).to receive(:enqueue_payments).with(
+          [creator.id], payout_date.to_s, payout_type: Payouts::PAYOUT_TYPE_INSTANT
+        )
+
+        described_class.create_instant_payouts_for_balances_up_to_date_for_users(payout_date, [creator], perform_async: true)
+      end
+    end
   end
 
   describe ".create_payments_for_balances_up_to_date_for_bank_account_types" do

--- a/spec/presenters/payouts_presenter_spec.rb
+++ b/spec/presenters/payouts_presenter_spec.rb
@@ -87,6 +87,7 @@ describe PayoutsPresenter do
 
       expect(instance.instant_payout_data).to eq(
         {
+          instant_payout_fee_percent: StripePayoutProcessor::INSTANT_PAYOUT_FEE_PERCENT,
           payable_amount_cents: 1000,
           payable_balances: [],
           bank_account_type: "checking",

--- a/spec/presenters/settings_presenter_spec.rb
+++ b/spec/presenters/settings_presenter_spec.rb
@@ -632,6 +632,7 @@ describe SettingsPresenter do
         payout_country_name: nil,
         payout_frequency: User::PayoutSchedule::WEEKLY,
         payout_frequency_daily_supported: false,
+        instant_payout_fee_percent: StripePayoutProcessor::INSTANT_PAYOUT_FEE_PERCENT,
         can_manage_beneficial_owners: false,
       }
     end


### PR DESCRIPTION
## What

Creators can already opt into **daily payouts** via Settings → Payments → Schedule (frequency enum `daily|weekly|monthly|quarterly` on `User::PayoutSchedule`, executed by the `PerformDailyInstantPayoutsWorker` cron at 08:00 UTC → `Payouts.create_instant_payouts_for_balances_up_to_date` → Stripe **instant payouts**). This PR makes the pricing of that daily schedule share a **single source of truth** with the manual Instant Payout fee, per Sahil's directive: *daily payout fee == instant payout fee*.

- `SettingsPresenter#payments_props` and `PayoutsPresenter#instant_payout_data` now expose `instant_payout_fee_percent: StripePayoutProcessor::INSTANT_PAYOUT_FEE_PERCENT` (the constant the payout processor actually deducts in `prepare_payment_and_set_amount`).
- The frontend no longer hardcodes the rate:
  - `pages/Settings/Payments/Show.tsx`: the daily-schedule disclosure previously said a literal “**3% fee**”; it now renders the backend-provided percent and clarifies it's “the same fee as a one-off instant payout”.
  - `pages/Payouts/Index.tsx`: removed the local `INSTANT_PAYOUT_FEE_PERCENTAGE = 0.03` constant; the instant-payout fee preview and the “Instant payout fee (N%)” line item now use `instant_payout.instant_payout_fee_percent` from the presenter.
- Added a spec pinning that daily-scheduled payouts are enqueued with `payout_type: Payouts::PAYOUT_TYPE_INSTANT` — that payout type is exactly what triggers the `INSTANT_PAYOUT_FEE_PERCENT` deduction in `StripePayoutProcessor`, so daily and instant fees stay in lockstep by construction.

## Why

Sahil (2026-07-08): “Is daily not an option? It should = instant payout fees but we should support it.” Daily *is* already supported and already routes through instant payouts (so the fee is mechanically identical today) — but the fee shown to creators was maintained in two independent hardcoded places (a `3%` string in settings, a `0.03` const in the payouts page). If `INSTANT_PAYOUT_FEE_PERCENT` ever changes, the UI would silently lie about what creators are charged. This change makes drift impossible: one Ruby constant feeds the deduction, the settings disclosure, and the payouts fee preview.

## ⚠️ Money flow — requires Sahil's review

This PR touches payout fee disclosure surfaces and the presenters feeding them. It does **not** change the fee amount (still 3%) or the payout execution path, but because it is payments-adjacent it should be reviewed by @slavingia before merge. **Do not auto-merge.**

## UI before/after

Settings → Payments → Payout schedule (no local render; text description):

- **Before:** selecting Daily showed: “Every day, your balance from the previous day will be sent to you via instant payouts, subject to a **3% fee**.” (hardcoded)
- **After:** same alert, but the percent is rendered from `instant_payout_fee_percent` (backend constant) and reads: “…subject to a **3% fee** — the same fee as a one-off instant payout.”

Payouts page instant-payout modal: fee line item and net-amount preview unchanged visually (still 3%), now computed from the backend-provided rate.

## Test plan

- `bin/rspec spec/presenters/payouts_presenter_spec.rb spec/presenters/settings_presenter_spec.rb` → **71 examples, 0 failures**
- `bin/rspec spec/business/payments/payouts/payouts_spec.rb -e "create_instant_payouts_for_balances_up_to_date"` → **3 examples, 0 failures** (includes the new fee-parity/instant-enqueue spec)
- `bundle exec rubocop` on all touched Ruby files → **no offenses**
- Note: two pre-existing local failures (missing merchant-account seed in local test DB) were confirmed environmental via baseline run on pristine `origin/main`, then fixed by seeding; CI seeds these already.
