### PR TITLE
prod_query.sh: probe instances and fail over instead of hard-picking the oldest

### DIFF
--- a/.agents/skills/gumroad-prod-console/scripts/prod_query.sh
+++ b/.agents/skills/gumroad-prod-console/scripts/prod_query.sh
@@ -68,6 +68,30 @@ else
     exit 1
   fi
 
+  # Bound each probe so a hung docker exec can't stall the whole run. GNU
+  # coreutils `timeout` does this on Linux, but macOS — where many of us run
+  # this from a laptop — ships no `timeout` (and often no `gtimeout` either).
+  # A missing binary would exit 127 and be misread as "instance unhealthy",
+  # failing every candidate and killing the console entirely. So resolve a real
+  # timeout binary if present, else fall back to a small pure-bash timer.
+  if command -v timeout >/dev/null 2>&1; then
+    probe_timeout() { timeout "$@"; }
+  elif command -v gtimeout >/dev/null 2>&1; then
+    probe_timeout() { gtimeout "$@"; }
+  else
+    probe_timeout() {
+      local dur=$1; shift
+      "$@" & local pid=$!
+      ( sleep "$dur"; kill -TERM "$pid" 2>/dev/null ) & local watcher=$!
+      # Drop the watcher from the job table so killing it below doesn't print a
+      # "Terminated" notice on every successful probe.
+      disown "$watcher" 2>/dev/null
+      wait "$pid" 2>/dev/null; local rc=$?
+      kill -TERM "$watcher" 2>/dev/null
+      return $rc
+    }
+  fi
+
   # Probe each candidate with a cheap 20s check and take the first one that
   # responds. The probe runs a no-op docker exec inside the puma container —
   # the same operation the real query uses — because the hangs that motivated
@@ -76,7 +100,7 @@ else
   # outer timeout; now it costs <=20s and we fail over to the next-oldest.
   instance_ip=""
   for ip in $candidate_ips; do
-    if LC_PAPER="$ip" timeout 20 ssh -o SendEnv=LC_PAPER -o StrictHostKeyChecking=accept-new \
+    if LC_PAPER="$ip" probe_timeout 20 ssh -o SendEnv=LC_PAPER -o StrictHostKeyChecking=accept-new \
         -o ConnectTimeout=10 "admin@$PROD_BASTION" \
         'sudo docker exec $(sudo docker ps -qf "name='"$PROD_CONTAINER_FILTER"'" -f "status=running" | head -n1) true' \
         >/dev/null 2>&1; then

--- a/.agents/skills/gumroad-prod-console/scripts/prod_query.sh
+++ b/.agents/skills/gumroad-prod-console/scripts/prod_query.sh
@@ -47,15 +47,44 @@ if ! aws sts get-caller-identity >/dev/null 2>&1; then
   exit 1
 fi
 
-# Pick oldest running instance in the production security group.
-instance_ip=$(aws ec2 describe-instances \
-  --filter "Name=instance.group-name,Values=$PROD_SECURITY_GROUP" \
-  --query "Reservations[].Instances[].[LaunchTime,PrivateIpAddress] | sort_by(@, &[0])" \
-  --output text | awk '{print $2}' | head -n1)
+# Pick a healthy instance in the production security group.
+# Honor an explicit override first (set PROD_INSTANCE_IP to pin a host, e.g.
+# when you already know a specific instance is healthy or sick).
+if [ -n "${PROD_INSTANCE_IP:-}" ]; then
+  instance_ip="$PROD_INSTANCE_IP"
+  >&2 echo "Using PROD_INSTANCE_IP override: $instance_ip"
+else
+  # List all running instances, oldest first (oldest is warmest, but any works).
+  candidate_ips=$(aws ec2 describe-instances \
+    --filter "Name=instance.group-name,Values=$PROD_SECURITY_GROUP" \
+    --query "Reservations[].Instances[].[LaunchTime,PrivateIpAddress] | sort_by(@, &[0])" \
+    --output text | awk '{print $2}')
 
-if [ -z "$instance_ip" ]; then
-  echo "Error: No running instance found in security group $PROD_SECURITY_GROUP" >&2
-  exit 1
+  if [ -z "$candidate_ips" ]; then
+    echo "Error: No running instance found in security group $PROD_SECURITY_GROUP" >&2
+    exit 1
+  fi
+
+  # Probe each candidate with a cheap 20s docker-level check and take the first
+  # one that responds. A hung/recycling instance (SSH accepts but exec never
+  # returns) previously burned the full outer timeout; now it costs <=20s and
+  # we fail over to the next-oldest instance.
+  instance_ip=""
+  for ip in $candidate_ips; do
+    if LC_PAPER="$ip" timeout 20 ssh -o SendEnv=LC_PAPER -o StrictHostKeyChecking=accept-new \
+        -o ConnectTimeout=10 "admin@$PROD_BASTION" \
+        'sudo docker ps -qf "name='"$PROD_CONTAINER_FILTER"'" -f "status=running" | head -n1 | grep -q .' \
+        >/dev/null 2>&1; then
+      instance_ip="$ip"
+      break
+    fi
+    >&2 echo "Instance $ip failed health probe, trying next..."
+  done
+
+  if [ -z "$instance_ip" ]; then
+    echo "Error: No instance in $PROD_SECURITY_GROUP passed the health probe. Set PROD_INSTANCE_IP to force one." >&2
+    exit 1
+  fi
 fi
 
 >&2 echo "Connecting to $instance_ip via $PROD_BASTION..."

--- a/.agents/skills/gumroad-prod-console/scripts/prod_query.sh
+++ b/.agents/skills/gumroad-prod-console/scripts/prod_query.sh
@@ -58,8 +58,8 @@ else
   # Only running instances: stopped or terminating ones have no private IP
   # (the CLI prints "None"), and probing those would waste 20 seconds each.
   candidate_ips=$(aws ec2 describe-instances \
-    --filter "Name=instance.group-name,Values=$PROD_SECURITY_GROUP" \
-    --filter "Name=instance-state-name,Values=running" \
+    --filters "Name=instance.group-name,Values=$PROD_SECURITY_GROUP" \
+              "Name=instance-state-name,Values=running" \
     --query "Reservations[].Instances[].[LaunchTime,PrivateIpAddress] | sort_by(@, &[0])" \
     --output text | awk '{print $2}')
 

--- a/.agents/skills/gumroad-prod-console/scripts/prod_query.sh
+++ b/.agents/skills/gumroad-prod-console/scripts/prod_query.sh
@@ -55,8 +55,11 @@ if [ -n "${PROD_INSTANCE_IP:-}" ]; then
   >&2 echo "Using PROD_INSTANCE_IP override: $instance_ip"
 else
   # List all running instances, oldest first (oldest is warmest, but any works).
+  # Only running instances: stopped or terminating ones have no private IP
+  # (the CLI prints "None"), and probing those would waste 20 seconds each.
   candidate_ips=$(aws ec2 describe-instances \
     --filter "Name=instance.group-name,Values=$PROD_SECURITY_GROUP" \
+    --filter "Name=instance-state-name,Values=running" \
     --query "Reservations[].Instances[].[LaunchTime,PrivateIpAddress] | sort_by(@, &[0])" \
     --output text | awk '{print $2}')
 

--- a/.agents/skills/gumroad-prod-console/scripts/prod_query.sh
+++ b/.agents/skills/gumroad-prod-console/scripts/prod_query.sh
@@ -68,15 +68,17 @@ else
     exit 1
   fi
 
-  # Probe each candidate with a cheap 20s docker-level check and take the first
-  # one that responds. A hung/recycling instance (SSH accepts but exec never
-  # returns) previously burned the full outer timeout; now it costs <=20s and
-  # we fail over to the next-oldest instance.
+  # Probe each candidate with a cheap 20s check and take the first one that
+  # responds. The probe runs a no-op docker exec inside the puma container —
+  # the same operation the real query uses — because the hangs that motivated
+  # this failover happened at the docker exec step (SSH connected fine, but
+  # exec never returned). A hung/recycling instance previously burned the full
+  # outer timeout; now it costs <=20s and we fail over to the next-oldest.
   instance_ip=""
   for ip in $candidate_ips; do
     if LC_PAPER="$ip" timeout 20 ssh -o SendEnv=LC_PAPER -o StrictHostKeyChecking=accept-new \
         -o ConnectTimeout=10 "admin@$PROD_BASTION" \
-        'sudo docker ps -qf "name='"$PROD_CONTAINER_FILTER"'" -f "status=running" | head -n1 | grep -q .' \
+        'sudo docker exec $(sudo docker ps -qf "name='"$PROD_CONTAINER_FILTER"'" -f "status=running" | head -n1) true' \
         >/dev/null 2>&1; then
       instance_ip="$ip"
       break


### PR DESCRIPTION
## What

The prod-console helper (`.agents/skills/gumroad-prod-console/scripts/prod_query.sh`) previously hard-picked the single **oldest** instance in `production-web_cluster_green` and connected to it, with no recovery path. When that instance was hung or mid-recycle (SSH accepts the connection but the docker exec never returns), every query burned the caller's full timeout, and retrying re-picked the same sick host.

Now the script:
- walks the instance list oldest-first and runs a cheap **20s docker-level health probe** through the bastion, using the first instance that responds; a sick instance now costs ≤20s before failover instead of the full outer timeout
- supports a **`PROD_INSTANCE_IP` env override** to pin a specific host — matching how on-call already worked around sick instances by hand

## Why

Hit twice in two days on real support/on-call work: 2026-07-08 (10.1.33.22 hung, 5 consecutive 120s timeouts) and 2026-07-09 (10.1.33.215 hung on 4 attempts including a bare `puts` ping; instance was later recycled by the ASG, confirming it was genuinely unhealthy). Both times the fix was manually targeting a sibling instance, which worked first try in ~12-35s.

## Test plan

- `bash -n` clean
- Ran end-to-end against production via the audited wrapper: probe selected the current oldest healthy instance (10.1.34.4) and the query returned in 12s (`status: ok`)
- Verified the failover path logic: a probe failure prints `Instance <ip> failed health probe, trying next...` and advances; if all fail, exits 1 with a message pointing at `PROD_INSTANCE_IP`
- `PROD_INSTANCE_IP` override short-circuits discovery (message: `Using PROD_INSTANCE_IP override: <ip>`)