### PR TITLE
Stop unsaved-changes confirm dialog firing repeatedly in the profile editor

### DIFF
--- a/app/javascript/pages/Settings/Profile/Show.tsx
+++ b/app/javascript/pages/Settings/Profile/Show.tsx
@@ -130,8 +130,9 @@ export default function SettingsPage() {
   // navigation attempts (for example a caller that retries after being blocked, or several visits
   // queued while the dialog was open) reuses that answer instead of opening one dialog per attempt.
   // Without this, sellers saw the same confirm dialog dozens of times in a row. We record which
-  // URL the answer was for: "stay" safely blocks any attempt in the window, but "leave" is only
-  // reused for the same destination, so an unrelated navigation can't ride on a stale grant.
+  // URL the answer was for and only reuse the answer for that same destination: a "leave" grant
+  // must not let an unrelated navigation ride on it, and a "stay" refusal must not silently
+  // swallow a deliberate click somewhere else — a new destination always prompts again.
   const lastLeaveAnswer = React.useRef<{ time: number; allowed: boolean; href: string } | null>(null);
   React.useEffect(() => {
     const beforeUnload = (e: BeforeUnloadEvent) => {
@@ -148,15 +149,15 @@ export default function SettingsPage() {
       //   the preview refresh), which keep this component mounted and its state intact
       if (visit.prefetch || visit.async || visit.url.pathname === window.location.pathname) return;
       const previousAnswer = lastLeaveAnswer.current;
-      if (previousAnswer && Date.now() - previousAnswer.time < 2000) {
-        // A "stay" answer safely blocks every retry in the window. A "leave" answer is only
-        // reused when the retry targets the same destination as the prompt the user answered —
-        // a different destination is a genuinely new navigation and must ask again.
+      if (previousAnswer && Date.now() - previousAnswer.time < 2000 && previousAnswer.href === visit.url.href) {
+        // Reuse the answer only for the same destination the user was asked about. A retry of
+        // that navigation repeats their choice — "stay" blocks it again silently, "leave" lets it
+        // through — while a click to a different destination is a genuinely new navigation and
+        // falls through to a fresh prompt.
         if (!previousAnswer.allowed) {
           event.preventDefault();
-          return;
         }
-        if (previousAnswer.href === visit.url.href) return;
+        return;
       }
       // eslint-disable-next-line no-alert
       const allowed = window.confirm(

--- a/app/javascript/pages/Settings/Profile/Show.tsx
+++ b/app/javascript/pages/Settings/Profile/Show.tsx
@@ -37,6 +37,11 @@ import { useReactNativeMessage } from "$app/components/useReactNativeMessage";
 
 type ProfileSettingsTab = "about" | "pages" | "share";
 
+// How long the user's most recent answer to the unsaved-changes prompt stays reusable for a
+// retry of the same navigation. Long enough to absorb a burst of repeated attempts (the bug
+// this guards against), short enough that a deliberate second click a few seconds later asks again.
+const LEAVE_ANSWER_REUSE_WINDOW_MS = 2000;
+
 type ProfileSettingsForm = {
   name: string | null;
   bio: string | null;
@@ -144,12 +149,19 @@ export default function SettingsPage() {
       if (!isDirtyRef.current || visit.method !== "get") return;
       // Background requests never discard the editor's local state, so they must not prompt:
       // - prefetch: Inertia warming a link on hover
-      // - async: polling-style requests that update props in place
-      // - same-path visits: reloads of this page (including our own post-save router.reload and
-      //   the preview refresh), which keep this component mounted and its state intact
-      if (visit.prefetch || visit.async || visit.url.pathname === window.location.pathname) return;
+      // - async: polling-style requests that update props in place (router.reload sets this,
+      //   which covers our own post-save reload and the preview refresh)
+      // - preserveState visits: the component stays mounted with its state intact
+      // Note we intentionally do NOT exempt plain same-path visits: a regular GET to the current
+      // path defaults to preserveState: false, so Inertia's React adapter remounts the page with
+      // a new key and the pending edits are lost — exactly the loss this prompt protects against.
+      if (visit.prefetch || visit.async || visit.preserveState === true) return;
       const previousAnswer = lastLeaveAnswer.current;
-      if (previousAnswer && Date.now() - previousAnswer.time < 2000 && previousAnswer.href === visit.url.href) {
+      if (
+        previousAnswer &&
+        Date.now() - previousAnswer.time < LEAVE_ANSWER_REUSE_WINDOW_MS &&
+        previousAnswer.href === visit.url.href
+      ) {
         // Reuse the answer only for the same destination the user was asked about. A retry of
         // that navigation repeats their choice — "stay" blocks it again silently, "leave" lets it
         // through — while a click to a different destination is a genuinely new navigation and

--- a/app/javascript/pages/Settings/Profile/Show.tsx
+++ b/app/javascript/pages/Settings/Profile/Show.tsx
@@ -126,16 +126,36 @@ export default function SettingsPage() {
 
   const isDirtyRef = React.useRef(isDirty);
   isDirtyRef.current = isDirty;
+  // Remembers the user's most recent answer to the unsaved-changes prompt so that a burst of
+  // navigation attempts (for example a caller that retries after being blocked, or several visits
+  // queued while the dialog was open) reuses that answer instead of opening one dialog per attempt.
+  // Without this, sellers saw the same confirm dialog dozens of times in a row.
+  const lastLeaveAnswer = React.useRef<{ time: number; allowed: boolean } | null>(null);
   React.useEffect(() => {
     const beforeUnload = (e: BeforeUnloadEvent) => {
       if (isDirtyRef.current) e.preventDefault();
     };
     window.addEventListener("beforeunload", beforeUnload);
     const removeInertiaListener = router.on("before", (event) => {
-      if (!isDirtyRef.current || event.detail.visit.method !== "get") return;
+      const visit = event.detail.visit;
+      if (!isDirtyRef.current || visit.method !== "get") return;
+      // Background requests never discard the editor's local state, so they must not prompt:
+      // - prefetch: Inertia warming a link on hover
+      // - async: polling-style requests that update props in place
+      // - same-path visits: reloads of this page (including our own post-save router.reload and
+      //   the preview refresh), which keep this component mounted and its state intact
+      if (visit.prefetch || visit.async || visit.url.pathname === window.location.pathname) return;
+      const previousAnswer = lastLeaveAnswer.current;
+      if (previousAnswer && Date.now() - previousAnswer.time < 2000) {
+        if (!previousAnswer.allowed) event.preventDefault();
+        return;
+      }
       // eslint-disable-next-line no-alert
-      if (!window.confirm("You have unsaved changes that will be lost if you leave this page. Leave anyway?"))
-        event.preventDefault();
+      const allowed = window.confirm(
+        "You have unsaved changes that will be lost if you leave this page. Leave anyway?",
+      );
+      lastLeaveAnswer.current = { time: Date.now(), allowed };
+      if (!allowed) event.preventDefault();
     });
     return () => {
       window.removeEventListener("beforeunload", beforeUnload);

--- a/app/javascript/pages/Settings/Profile/Show.tsx
+++ b/app/javascript/pages/Settings/Profile/Show.tsx
@@ -129,8 +129,10 @@ export default function SettingsPage() {
   // Remembers the user's most recent answer to the unsaved-changes prompt so that a burst of
   // navigation attempts (for example a caller that retries after being blocked, or several visits
   // queued while the dialog was open) reuses that answer instead of opening one dialog per attempt.
-  // Without this, sellers saw the same confirm dialog dozens of times in a row.
-  const lastLeaveAnswer = React.useRef<{ time: number; allowed: boolean } | null>(null);
+  // Without this, sellers saw the same confirm dialog dozens of times in a row. We record which
+  // URL the answer was for: "stay" safely blocks any attempt in the window, but "leave" is only
+  // reused for the same destination, so an unrelated navigation can't ride on a stale grant.
+  const lastLeaveAnswer = React.useRef<{ time: number; allowed: boolean; href: string } | null>(null);
   React.useEffect(() => {
     const beforeUnload = (e: BeforeUnloadEvent) => {
       if (isDirtyRef.current) e.preventDefault();
@@ -147,14 +149,20 @@ export default function SettingsPage() {
       if (visit.prefetch || visit.async || visit.url.pathname === window.location.pathname) return;
       const previousAnswer = lastLeaveAnswer.current;
       if (previousAnswer && Date.now() - previousAnswer.time < 2000) {
-        if (!previousAnswer.allowed) event.preventDefault();
-        return;
+        // A "stay" answer safely blocks every retry in the window. A "leave" answer is only
+        // reused when the retry targets the same destination as the prompt the user answered —
+        // a different destination is a genuinely new navigation and must ask again.
+        if (!previousAnswer.allowed) {
+          event.preventDefault();
+          return;
+        }
+        if (previousAnswer.href === visit.url.href) return;
       }
       // eslint-disable-next-line no-alert
       const allowed = window.confirm(
         "You have unsaved changes that will be lost if you leave this page. Leave anyway?",
       );
-      lastLeaveAnswer.current = { time: Date.now(), allowed };
+      lastLeaveAnswer.current = { time: Date.now(), allowed, href: visit.url.href };
       if (!allowed) event.preventDefault();
     });
     return () => {


### PR DESCRIPTION
## What

Stops the "You have unsaved changes that will be lost if you leave this page. Leave anyway?" confirm dialog from firing repeatedly in the profile editor.

The `router.on("before")` navigation guard in `Settings/Profile/Show.tsx` opened one native confirm per Inertia GET event while the dirty flag was set. Two changes:

1. **Skip background requests that never discard editor state** — prefetch visits, `async` visits, and `preserveState: true` visits. `router.reload()` sets both `async` and `preserveState`, so the component's own post-save reload and preview refresh stay exempt. Plain same-path GET visits are deliberately *not* exempt: they default to `preserveState: false`, which remounts the page and discards pending edits, so they must prompt.
2. **Reuse the user's answer for a short window** (`LEAVE_ANSWER_REUSE_WINDOW_MS`, 2s) — a burst of navigation attempts to the same destination (e.g. a caller retrying after being blocked, or visits queued while the dialog was open) reuses the most recent answer instead of opening one dialog per attempt. A different destination always prompts fresh.

## Why

A creator reported the dialog firing ~50 times in a row while updating her profile, making the editor unusable. The mechanism: any repeated Inertia GET activity while the dirty flag is true fired one confirm per event, and answering "Cancel" blocks the visit so a retrying caller re-fires it in a loop.

Fixes antiwork/gumroad-private#995

## Test evidence

- `npx prettier --write` — unchanged (already formatted)
- `npx eslint app/javascript/pages/Settings/Profile/Show.tsx` — 15 errors before and after the change, all pre-existing `Routes`/asset-global typing issues unrelated to this diff; no new findings introduced
- The change is scoped to the navigation-guard effect; the `beforeUnload` browser guard and the save flow are untouched
- The guard behavior itself has no automated test. It hinges on `window.confirm` plus Inertia visit internals (`prefetch`/`async`/`preserveState` on the `before` event), and the repo has no JS component-test harness for Inertia pages — a system spec would need to drive a dirty editor through repeated same-URL navigation attempts and script the native confirm, which the current suite doesn't support cleanly. Verified by reasoning against the Inertia source (`router.reload()` sets `preserveState: true` + `async: true`) and manual code-path tracing; flagging rather than shipping a flaky spec.

## Before/After

Not a visual change — the dialog is the browser's native confirm (screenshots of the repeated dialog are in the linked issue). The fix changes when it opens, not how it looks: background/self reloads no longer prompt, and rapid repeated navigation attempts prompt once instead of once per attempt.
