### PR TITLE
docs: document the terminal state for Stripe-rejected accounts

### DIFF
--- a/app/views/help_center/articles/contents/_13-getting-paid.html.erb
+++ b/app/views/help_center/articles/contents/_13-getting-paid.html.erb
@@ -405,6 +405,7 @@
   <p>PayPal payouts have a 2% processing fee.</p>
   <h3 id="Stripe-verification-process-ZFq5c">Verification process</h3>
   <p>Our payment processor, Stripe, requires additional information to verify the identity of the account holder after a certain amount of time has passed and sales accrued. This is a standard practice in the financial industry and is part of their <a href="https://support.stripe.com/questions/know-your-customer-obligations">Know Your Customer (KYC) obligations</a>.</p>
+  <p><i>Note:</i> In rare cases, Stripe makes a final decision to reject an account. If that happens, we email you once to let you know, verification requests stop, and any remaining balance of $1 or more is paid out automatically even if it is below the usual $100 minimum. Your <a href="https://gumroad.com/settings/payments">payments settings page</a> shows your account status. See <a href="160-suspension">this article</a> for details.</p>
   <h3>ID verification</h3>
   <p>You can learn the correct documents needed for ID verification for your specific location <a href="https://docs.stripe.com/connect/handling-api-verification?country=CA&amp;document-type=identity#acceptable-verification-documents">here</a>. </p>
   <h4>Before you upload your ID</h4>

--- a/app/views/help_center/articles/contents/_160-suspension.html.erb
+++ b/app/views/help_center/articles/contents/_160-suspension.html.erb
@@ -78,7 +78,13 @@
     <li>Your bank account has been connected to fraud in the past that Stripe has had to deal with</li>
   </ul>
   <h4><b>What now? </b></h4>
-  <p>If this is the case, we will forward your case to the support staff of either PayPal or Stripe. We may also put you in an email thread with them to answer any questions that they have. If they do not allow us to pay you, then unfortunately we have no way to send you money. The easiest solution in this example would be to refund your sales and contact your customers to pay you via an alternate route. </p>
+  <p>If Stripe makes a final decision to reject your account, we will email you once to let you know. The decision is made by Stripe, not Gumroad, and it cannot be appealed or reversed. Buyers can no longer purchase your products, and you will not receive any further verification requests from us. Your <a href="https://gumroad.com/settings/payments">payments settings page</a> shows your account status and what will happen to your remaining balance:</p>
+  <ul>
+    <li>If your balance is $1 or more, we pay it out to your bank account automatically on your next scheduled payout, even if it is below the usual $100 minimum.</li>
+    <li>If Stripe has also disabled payouts on the account, Stripe holds the balance. If Stripe releases it, we pay it out to you automatically.</li>
+    <li>If your balance is under $1, it is below the minimum our payout system can send, so we are unable to pay it out.</li>
+  </ul>
+  <p>For PayPal, we will forward your case to their support staff. We may also put you in an email thread with them to answer any questions that they have. If they do not allow us to pay you, then unfortunately we have no way to send you money. The easiest solution in this example would be to refund your sales and contact your customers to pay you via an alternate route. </p>
   <h3 id="Frequently-Asked-Questions-VUUqd">Frequently Asked Questions</h3>
   <p><b>Q1. Why doesn't Gumroad inform users that their account is suspended? </b></p>
   <p>A1: A vast majority of the accounts we suspend (around 50,000/month) are created by actual scammers or spammers. To inform them via email that their attempts to defraud us were unsuccessful would effectively amount to us offering them a <a href="https://en.wikipedia.org/wiki/Mulligan_(games)">Mulligan</a>. </p>


### PR DESCRIPTION
## What

Updates two help-center articles to document the terminal state for Stripe-rejected accounts shipped in #5765:

- **`_160-suspension.html.erb`** ("Reason 4: Your account was rejected by our partners"): the "What now?" section now describes the actual Stripe-rejection flow — one-time email, decision is Stripe's and final, sales stop, no more verification requests — and lists the three balance outcomes (automatic payout of $1+ below the usual $100 minimum, Stripe hold when Stripe also disabled payouts, under-$1 balances that can't be sent). The old PayPal/Stripe escalation copy is kept for PayPal.
- **`_13-getting-paid.html.erb`** ("Verification process" section): adds a one-sentence note that a final Stripe rejection stops verification requests and releases balances of $1 or more below the $100 minimum, linking to the suspension article.

## Why

#5765 changed user-facing behavior: rejected sellers now get a rejection email, remediation reminders stop, and sub-$100 balances are paid out. The suspension article previously said we'd "forward your case to Stripe" and that we "have no way to send you money" — both now wrong for Stripe rejections.

## Payout/policy wording flag

⚠️ This touches payout wording: the $1 floor (`Payouts::REJECTED_ACCOUNT_MIN_AMOUNT_CENTS = 1_00`) and the $100-minimum bypass for rejected accounts, mirroring the rejection email and Payments-page banner copy in #5765. Please verify the exact numbers/wording.

## Test evidence

- Both partials render via `ApplicationController.render` in test env: `160-suspension: render OK (14487 bytes)`, `13-getting-paid: render OK (17608 bytes)`, new copy asserted present.
- `articles.yml` untouched (body-only edits, no title/description change).
- Anchor IDs preserved.

Autoreview skipped (docs copy only, no logic).
