### PR TITLE
docs: carve out final Stripe rejections from the FAQ suspension-protest answer

### DIFF
--- a/app/views/help_center/articles/contents/_160-suspension.html.erb
+++ b/app/views/help_center/articles/contents/_160-suspension.html.erb
@@ -104,7 +104,9 @@
   <p>If your account has been suspended and your customers are asking about refunds, they can email us directly at <a href="mailto:support@gumroad.com">support@gumroad.com</a> for assistance. </p>
   <br>
   <p><b>Q3: Can I protest my suspension? </b></p>
-  <p>A3: Absolutely. To be clear, we don't enjoy suspending accounts, and sometimes our review process can be flawed. Contact us at <a href="mailto:support@gumroad.com">support@gumroad.com</a> and we will inform you as to why your account was suspended. We will then ask for pertinent information that may help us get your account back and running. </p>
+  <p>A3: In most cases, yes. To be clear, we don't enjoy suspending accounts, and sometimes our review process can be flawed. Contact us at <a href="mailto:support@gumroad.com">support@gumroad.com</a> and we will inform you as to why your account was suspended. We will then ask for pertinent information that may help us get your account back and running. </p>
+  <br>
+  <p>The one exception is a final rejection by Stripe (see <a href="#Reason-4-Your-account-was-rejected-by-our-partners-ZZ2z5">Reason 4</a> above). That decision is made by Stripe, not Gumroad, and neither we nor our support team can appeal or reverse it. </p>
   <br>
   <p><b>Q4: Why doesn't Gumroad provide me with specific reasons why my account was suspended? </b></p>
   <p>A4: The Internet is a pretty awful place when it comes to fraud and risk management, and unfortunately the more specific information we give out about our risk and fraud detection, the more information there is that's able to leak to fraudsters trying to make money off of us. </p>


### PR DESCRIPTION
## What

Fixes the contradiction Greptile flagged on #5771: FAQ Q3 in the suspension article ("Can I protest my suspension?") answered "Absolutely" and promised that emailing support could get any suspended account reinstated. That directly contradicted the new Reason 4 copy on the same page, which documents final Stripe rejections as unappealable.

Q3 now answers "In most cases, yes" and adds one sentence carving out the exception: a final Stripe rejection (linked to the Reason 4 anchor on the same page) is Stripe's decision and cannot be appealed or reversed by Gumroad or support.

## Why

A Stripe-rejected seller reading the article top to bottom would hit the terminal-state copy in Reason 4, then FAQ Q3's blanket reinstatement promise, take the hopeful one, and email support for help we already know we cannot provide. The protest path stays fully intact for every other suspension reason.

## Payout/policy wording flag

⚠️ Suspension-appeal wording. The carve-out mirrors the Reason 4 copy shipped in #5771 ("The decision is made by Stripe, not Gumroad, and it cannot be appealed or reversed") — no new facts introduced.

## Test evidence

- Partial renders via `ApplicationController.render` in test env: `160-suspension: render OK (14763 bytes)`, new copy asserted present, old "Absolutely" copy asserted gone, Reason 4 anchor ID asserted intact.
- `articles.yml` untouched (body-only edit, no title/description change).
- Diff scope: one file, +3/−1.

Autoreview skipped (docs copy only, no logic).
