### PR TITLE
Help center: clarify custom domains don't break existing Gumroad URLs

### DIFF
--- a/app/views/help_center/articles/contents/_153-setting-up-a-custom-domain.html.erb
+++ b/app/views/help_center/articles/contents/_153-setting-up-a-custom-domain.html.erb
@@ -162,6 +162,7 @@
   <p>Annnd we're done! If you're lucky, your custom domain will be functional within a few hours. However, on some unfortunate days, it might take up to 24 hours for it to kick in finally.</p>
   <h3 id="What-does-your-audience-see-HOJPZ">What does your audience see?</h3>
   <p>Once the custom domain setup is complete and everything is up and running, yourcustomdomain.com will point to your Gumroad profile or product page based on your settings. </p>
+  <p><strong>Your original Gumroad links keep working.</strong> Adding a custom domain is additive — it does not replace, break, or redirect your existing username.gumroad.com URLs. Both addresses stay live and show the same content, so links you have already shared, embedded, or printed (for example, QR codes on physical packaging or flyers) will continue to work exactly as before.</p>
   <p>We also provide your custom domain with a free SSL certificate; please give it up to 24 hours to activate.</p>
   <p>In case you do not have any products published yet, your audience will be taken to yourcustomdomain.com/subscribe, which is your Gumroad subscribe page, identical to https://username.gumroad.com/subscribe.</p>
   <p>Also, this feature does not allow customers to access their content through your own URL. They still have access their content through a Gumroad download link.</p>


### PR DESCRIPTION
## What

Adds one paragraph to the **Setting up a custom domain** help article ('What does your audience see?' section) stating explicitly that adding a custom domain is additive: existing `username.gumroad.com` links keep working, nothing redirects, and already-printed QR codes / shared links are unaffected.

## Why

This question comes up in support regularly — most recently a seller asking whether connecting a custom domain would break the Gumroad URL their already-printed QR codes point to. The article walks through setup but never says the original URL survives, so cautious sellers write in before enabling the feature.

Verified behavior: custom domains serve the same content alongside the gumroad.com URL with no redirect (confirmed in the support thread before replying).

Doc-only change — one `.html.erb` paragraph, no code paths touched.