### PR TITLE
Make payout CSV totals visibly reconcile for PayPal / Stripe Connect sales

### DIFF
--- a/app/services/exports/payouts/base.rb
+++ b/app/services/exports/payouts/base.rb
@@ -12,13 +12,16 @@ class Exports::Payouts::Base
   # Rows that belong to PayPal / Stripe Connect activity. Sales made through those
   # processors are paid out to the creator by the processor directly, not through this
   # Gumroad payout, so exports can group them and show that they net out to zero here.
-  def paypal_rows
-    @paypal_rows ||= []
-  end
+  # These are implementation detail shared with subclasses (protected, not public), and
+  # they only contain meaningful data after #payout_data has run.
+  protected
+    def paypal_rows
+      @paypal_rows ||= []
+    end
 
-  def stripe_connect_rows
-    @stripe_connect_rows ||= []
-  end
+    def stripe_connect_rows
+      @stripe_connect_rows ||= []
+    end
 
   private
     def payout_data

--- a/app/services/exports/payouts/base.rb
+++ b/app/services/exports/payouts/base.rb
@@ -9,10 +9,23 @@ class Exports::Payouts::Base
     @running_total = 0
   end
 
+  # Rows that belong to PayPal / Stripe Connect activity. Sales made through those
+  # processors are paid out to the creator by the processor directly, not through this
+  # Gumroad payout, so exports can group them and show that they net out to zero here.
+  def paypal_rows
+    @paypal_rows ||= []
+  end
+
+  def stripe_connect_rows
+    @stripe_connect_rows ||= []
+  end
+
   private
     def payout_data
       payout = @payment
       @running_total = 0
+      @paypal_rows = []
+      @stripe_connect_rows = []
       data = []
 
       payout.balances.find_each do |bal|
@@ -134,26 +147,39 @@ class Exports::Payouts::Base
       payout_end_date = payout.payout_period_end_date || Date.today.to_date
 
       user.paypal_sales_in_duration(start_date: payout_start_date, end_date: payout_end_date).joins(:link).find_each do |purchase|
-        data << summarize_sale(purchase)
+        row = summarize_sale(purchase)
+        paypal_rows << row
+        data << row
       end
 
       user.paypal_sales_chargebacked_in_duration(start_date: payout_start_date, end_date: payout_end_date).joins(:link).find_each do |purchase|
-        data << summarize_chargeback(purchase)
+        row = summarize_chargeback(purchase)
+        paypal_rows << row
+        data << row
       end
 
       user.paypal_refunds_in_duration(start_date: payout_start_date, end_date: payout_end_date).find_each do |refund|
-        data << summarize_paypal_refund(refund)
+        row = summarize_paypal_refund(refund)
+        paypal_rows << row
+        data << row
       end
 
       (payout_start_date..payout_end_date).each do |date|
         affiliate_fees_entry = summarize_paypal_affiliate_fee(user, date)
-        data << affiliate_fees_entry if affiliate_fees_entry.last != 0
+        if affiliate_fees_entry.last != 0
+          paypal_rows << affiliate_fees_entry
+          data << affiliate_fees_entry
+        end
       end
 
       paypal_sales_data = user.paypal_sales_data_for_duration(start_date: payout_start_date, end_date: payout_end_date)
       paypal_payout_amount = user.paypal_payout_net_cents(paypal_sales_data)
 
-      data << summarize_paypal_payout(paypal_payout_amount, payout_end_date) if paypal_payout_amount != 0
+      if paypal_payout_amount != 0
+        row = summarize_paypal_payout(paypal_payout_amount, payout_end_date)
+        paypal_rows << row
+        data << row
+      end
 
       data
     end
@@ -167,26 +193,39 @@ class Exports::Payouts::Base
       payout_end_date = payout.payout_period_end_date || Date.today.to_date
 
       user.stripe_connect_sales_in_duration(start_date: payout_start_date, end_date: payout_end_date).joins(:link).find_each do |purchase|
-        data << summarize_sale(purchase)
+        row = summarize_sale(purchase)
+        stripe_connect_rows << row
+        data << row
       end
 
       user.stripe_connect_sales_chargebacked_in_duration(start_date: payout_start_date, end_date: payout_end_date).joins(:link).find_each do |purchase|
-        data << summarize_chargeback(purchase)
+        row = summarize_chargeback(purchase)
+        stripe_connect_rows << row
+        data << row
       end
 
       user.stripe_connect_refunds_in_duration(start_date: payout_start_date, end_date: payout_end_date).find_each do |refund|
-        data << summarize_stripe_connect_refund(refund)
+        row = summarize_stripe_connect_refund(refund)
+        stripe_connect_rows << row
+        data << row
       end
 
       (payout_start_date..payout_end_date).each do |date|
         affiliate_fees_entry = summarize_stripe_connect_affiliate_fee(user, date)
-        data << affiliate_fees_entry if affiliate_fees_entry.last != 0
+        if affiliate_fees_entry.last != 0
+          stripe_connect_rows << affiliate_fees_entry
+          data << affiliate_fees_entry
+        end
       end
 
       stripe_connect_sales_data = user.stripe_connect_sales_data_for_duration(start_date: payout_start_date, end_date: payout_end_date)
       stripe_connect_payout_amount = user.stripe_connect_payout_net_cents(stripe_connect_sales_data)
 
-      data << summarize_stripe_connect_payout(stripe_connect_payout_amount, payout_end_date) if stripe_connect_payout_amount != 0
+      if stripe_connect_payout_amount != 0
+        row = summarize_stripe_connect_payout(stripe_connect_payout_amount, payout_end_date)
+        stripe_connect_rows << row
+        data << row
+      end
 
       data
     end

--- a/app/services/exports/payouts/csv.rb
+++ b/app/services/exports/payouts/csv.rb
@@ -83,16 +83,25 @@ class Exports::Payouts::Csv < Exports::Payouts::Base
     # Builds one subtotal row per group of activity, so each group's columns visibly add
     # up on their own before the grand total. Only emitted when the payout actually mixes
     # groups — a payout with only Gumroad-processed sales keeps its old shape.
+    #
+    # The Gumroad-paid subtotal is derived arithmetically — the grand totals minus the
+    # PayPal and Stripe Connect groups' totals — rather than by picking Gumroad rows out
+    # of `data`. That way it never depends on the rows in `data` being the same Ruby
+    # objects as the ones tracked in `paypal_rows` / `stripe_connect_rows`.
     def subtotal_rows(data)
       return [] if paypal_rows.empty? && stripe_connect_rows.empty?
 
-      grouped_row_ids = (paypal_rows + stripe_connect_rows).map(&:object_id).to_set
-      gumroad_rows = data.reject { |row| grouped_row_ids.include?(row.object_id) }
+      paypal_totals = calculate_totals(paypal_rows)
+      stripe_connect_totals = calculate_totals(stripe_connect_rows)
+      gumroad_totals = calculate_totals(data).each_with_object(Hash.new(0)) do |(column_name, value), totals|
+        totals[column_name] = value - paypal_totals[column_name] - stripe_connect_totals[column_name]
+      end
 
       rows = []
-      rows << generate_totals_row(calculate_totals(gumroad_rows), heading: CARD_SALES_SUBTOTAL_HEADING) if gumroad_rows.any?
-      rows << generate_totals_row(calculate_totals(paypal_rows), heading: PAYPAL_SALES_SUBTOTAL_HEADING) if paypal_rows.any?
-      rows << generate_totals_row(calculate_totals(stripe_connect_rows), heading: STRIPE_CONNECT_SALES_SUBTOTAL_HEADING) if stripe_connect_rows.any?
+      gumroad_rows_count = data.size - paypal_rows.size - stripe_connect_rows.size
+      rows << generate_totals_row(gumroad_totals, heading: CARD_SALES_SUBTOTAL_HEADING) if gumroad_rows_count > 0
+      rows << generate_totals_row(paypal_totals, heading: PAYPAL_SALES_SUBTOTAL_HEADING) if paypal_rows.any?
+      rows << generate_totals_row(stripe_connect_totals, heading: STRIPE_CONNECT_SALES_SUBTOTAL_HEADING) if stripe_connect_rows.any?
       rows
     end
 end

--- a/app/services/exports/payouts/csv.rb
+++ b/app/services/exports/payouts/csv.rb
@@ -5,6 +5,22 @@ class Exports::Payouts::Csv < Exports::Payouts::Base
   TOTALS_COLUMN_NAME = "Totals"
   TOTALS_FIELDS = ["Taxes ($)", "Shipping ($)", "Sale Price ($)", "Gumroad Fees ($)", "Net Total ($)"]
 
+  # Labels for the per-group subtotal rows that precede the grand total. PayPal and
+  # Stripe Connect sales are paid out to the creator by those processors directly, so
+  # their rows (sales, refunds, fees, and the offsetting "Payouts" deduction) add up to
+  # zero within this payout. Splitting the subtotals out lets a seller verify each group's
+  # math on its own instead of reading one blind grand total. See gumroad-private#999.
+  CARD_SALES_SUBTOTAL_HEADING = "Subtotal — activity paid out by Gumroad"
+  PAYPAL_SALES_SUBTOTAL_HEADING = "Subtotal — PayPal sales (paid out by PayPal, nets to zero here)"
+  STRIPE_CONNECT_SALES_SUBTOTAL_HEADING = "Subtotal — Stripe Connect sales (paid out by Stripe, nets to zero here)"
+
+  # One-line explanation placed in the "Item Name" column of the deduction rows, so the
+  # negative amount is self-explanatory: the fee shown on each PayPal / Stripe Connect
+  # sale row was already collected by that processor, and this line removes the group's
+  # net amount from the Gumroad payout.
+  PAYPAL_PAYOUTS_NOTE = "PayPal sales (and their Gumroad fees) are settled by PayPal directly; this line removes their net amount so they don't count toward this payout."
+  STRIPE_CONNECT_PAYOUTS_NOTE = "Stripe Connect sales (and their Gumroad fees) are settled by Stripe directly; this line removes their net amount so they don't count toward this payout."
+
   def initialize(payment:)
     @payment = payment
   end
@@ -14,6 +30,9 @@ class Exports::Payouts::Csv < Exports::Payouts::Base
     CsvSafe.generate do |csv|
       csv << HEADERS
       data.each do |row|
+        csv << annotate_payout_deduction_row(row)
+      end
+      subtotal_rows(data).each do |row|
         csv << row
       end
       totals = calculate_totals(data)
@@ -35,14 +54,45 @@ class Exports::Payouts::Csv < Exports::Payouts::Base
       totals
     end
 
-    def generate_totals_row(totals)
+    def generate_totals_row(totals, heading: TOTALS_COLUMN_NAME)
       totals_row = Array.new(HEADERS.size)
 
-      totals_row[0] = TOTALS_COLUMN_NAME
+      totals_row[0] = heading
       totals.each do |column_name, value|
         totals_row[HEADERS.index(column_name)] = value.round(2)
       end
 
       totals_row
+    end
+
+    # Adds the explanatory note to the "PayPal Payouts" / "Stripe Connect Payouts"
+    # deduction rows without mutating the shared row arrays built in the base class
+    # (the API export reuses those rows and should stay unchanged).
+    def annotate_payout_deduction_row(row)
+      note = case row[0]
+             when PAYPAL_PAYOUTS_HEADING then PAYPAL_PAYOUTS_NOTE
+             when STRIPE_CONNECT_PAYOUTS_HEADING then STRIPE_CONNECT_PAYOUTS_NOTE
+      end
+      return row if note.nil?
+
+      annotated = row.dup
+      annotated[HEADERS.index("Item Name")] = note
+      annotated
+    end
+
+    # Builds one subtotal row per group of activity, so each group's columns visibly add
+    # up on their own before the grand total. Only emitted when the payout actually mixes
+    # groups — a payout with only Gumroad-processed sales keeps its old shape.
+    def subtotal_rows(data)
+      return [] if paypal_rows.empty? && stripe_connect_rows.empty?
+
+      grouped_row_ids = (paypal_rows + stripe_connect_rows).map(&:object_id).to_set
+      gumroad_rows = data.reject { |row| grouped_row_ids.include?(row.object_id) }
+
+      rows = []
+      rows << generate_totals_row(calculate_totals(gumroad_rows), heading: CARD_SALES_SUBTOTAL_HEADING) if gumroad_rows.any?
+      rows << generate_totals_row(calculate_totals(paypal_rows), heading: PAYPAL_SALES_SUBTOTAL_HEADING) if paypal_rows.any?
+      rows << generate_totals_row(calculate_totals(stripe_connect_rows), heading: STRIPE_CONNECT_SALES_SUBTOTAL_HEADING) if stripe_connect_rows.any?
+      rows
     end
 end

--- a/spec/services/exports/payouts/csv_spec.rb
+++ b/spec/services/exports/payouts/csv_spec.rb
@@ -109,8 +109,10 @@ describe Exports::Payouts::Csv, :vcr do
         ["Full Refund", (@purchase_to_refund.succeeded_at + 1.day).to_date.to_s, csv_safe(@purchase_to_refund.external_id), @purchase_to_refund.link.name, @purchase_to_refund.full_name, @purchase_to_refund.purchaser_email_or_email, "-0.0", "-0.0", "-10.0", "-1.5", "-8.5"],
         ["Partial Refund", (@purchase_to_refund_partially.succeeded_at + 1.day).to_date.to_s, csv_safe(@purchase_to_refund_partially.external_id), @purchase_to_refund_partially.link.name, @purchase_to_refund_partially.full_name, @purchase_to_refund_partially.purchaser_email_or_email, "-0.0", "-0.0", "-3.5", "-0.55", "-2.95"],
         ["Full Refund", (@purchase_to_refund_from_years_ago.succeeded_at + 1.day).to_date.to_s, csv_safe(@purchase_to_refund_from_years_ago.external_id), @purchase_to_refund_from_years_ago.link.name, @purchase_to_refund_from_years_ago.full_name, @purchase_to_refund_from_years_ago.purchaser_email_or_email, "-0.0", "-0.0", "-10.0", "-1.5", "-8.5"],
-        ["PayPal Payouts", @payout.payout_period_end_date.to_s, "", "", "", "", "", "", "-6.5", "", "-6.5"],
+        ["PayPal Payouts", @payout.payout_period_end_date.to_s, "", Exports::Payouts::Csv::PAYPAL_PAYOUTS_NOTE, "", "", "", "", "-6.5", "", "-6.5"],
         ["Payout Fee", @payout.payout_period_end_date.to_s, "", "", "", "", "", "", "", "0.92", "-0.92"],
+        [Exports::Payouts::Csv::CARD_SALES_SUBTOTAL_HEADING, nil, nil, nil, nil, nil, "3.8", "0.0", "54.64", "9.91", "44.73"],
+        [Exports::Payouts::Csv::PAYPAL_SALES_SUBTOTAL_HEADING, nil, nil, nil, nil, nil, "0.0", "0.0", "1.5", "1.5", "0.0"],
         ["Totals", nil, nil, nil, nil, nil, "3.8", "0.0", "56.14", "11.41", "44.73"]
       ]
 
@@ -168,8 +170,10 @@ describe Exports::Payouts::Csv, :vcr do
         ["Stripe Connect Affiliate Fees", stripe_connect_purchase.succeeded_at.to_date.to_s, "", "", "", "", "", "", "-4.03", "", "-4.03"],
         ["Stripe Connect Refund", 10.days.ago.to_date.to_s, csv_safe(stripe_connect_purchase.external_id), stripe_connect_purchase.link.name, stripe_connect_purchase.full_name, stripe_connect_purchase.purchaser_email_or_email, "-0.0", "-0.0", "-75.0", "7.75", "-67.25"],
         ["Stripe Connect Affiliate Fees", 10.days.ago.to_date.to_s, "", "", "", "", "", "", "2.02", "", "2.02"],
-        ["Stripe Connect Payouts", payout.payout_period_end_date.to_date.to_s, "", "", "", "", "", "", "-65.24", "", "-65.24"],
+        ["Stripe Connect Payouts", payout.payout_period_end_date.to_date.to_s, "", Exports::Payouts::Csv::STRIPE_CONNECT_PAYOUTS_NOTE, "", "", "", "", "-65.24", "", "-65.24"],
         ["Payout Fee", payout.payout_period_end_date.to_s, "", "", "", "", "", "", "", "2.6", "-2.6"],
+        [Exports::Payouts::Csv::CARD_SALES_SUBTOTAL_HEADING, nil, nil, nil, nil, nil, "0.0", "0.0", "150.0", "22.75", "127.25"],
+        [Exports::Payouts::Csv::STRIPE_CONNECT_SALES_SUBTOTAL_HEADING, nil, nil, nil, nil, nil, "0.0", "0.0", "7.75", "23.25", "0.0"],
         ["Totals", nil, nil, nil, nil, nil, "0.0", "0.0", "157.75", "46.0", "127.25"]
       ]
     end


### PR DESCRIPTION
## What

Makes the payout CSV export's totals visibly reconcile when a payout includes PayPal or Stripe Connect sales. Two changes, both scoped to the CSV export (`Exports::Payouts::Csv`) — the API export (`payment.json` transactions) and the annual export keep their existing shape:

1. The **"PayPal Payouts"** / **"Stripe Connect Payouts"** deduction rows now carry a one-line explanation in the Item Name column: those sales (and their Gumroad fees) are settled by the processor directly, and the line removes their net amount so they don't count toward this payout.
2. When a payout mixes processor groups, **per-group subtotal rows** are added before the grand total — Gumroad-paid activity, PayPal activity, and Stripe Connect activity each add up on their own. The PayPal/Stripe Connect groups visibly net to $0. Payouts with only Gumroad-processed sales are unchanged (no subtotals emitted).

## Why

A seller summed the "Gumroad Fees ($)" column against the gross and concluded the fee was being charged twice on PayPal sales, then filed a refund request for ~$790 across 309 sales. The claim was false — PayPal sales net to exactly $0 in the Stripe payout — but the export gave them no way to see that: the fees total includes PayPal rows' fees, while the offsetting "PayPal Payouts" deduction silently folds into the Sale Price and Net Total sums with no explanation, so `Gross − Fees ≠ Net` when the totals are read naively.

The reporter was asked which fix they'd prefer and chose subtotals per group **plus** an explanation on the deduction line — this PR implements both. Fixes antiwork/gumroad-private#999.

## Before / After

Not a UI change — the export is a CSV. Tail of the export, using the exact rows from the updated spec:

**Before:**

| Type | Item Name | Sale Price ($) | Gumroad Fees ($) | Net Total ($) |
|---|---|---|---|---|
| PayPal Payouts | | -6.5 | | -6.5 |
| Payout Fee | | | 0.92 | -0.92 |
| Totals | | 56.14 | 11.41 | 44.73 |

**After:**

| Type | Item Name | Sale Price ($) | Gumroad Fees ($) | Net Total ($) |
|---|---|---|---|---|
| PayPal Payouts | PayPal sales (and their Gumroad fees) are settled by PayPal directly; this line removes their net amount so they don't count toward this payout. | -6.5 | | -6.5 |
| Payout Fee | | | 0.92 | -0.92 |
| Subtotal — activity paid out by Gumroad | | 54.64 | 9.91 | 44.73 |
| Subtotal — PayPal sales (paid out by PayPal, nets to zero here) | | 1.5 | 1.5 | 0.0 |
| Totals | | 56.14 | 11.41 | 44.73 |

The PayPal subtotal's Net Total of 0.0 is the point: it shows at a glance that PayPal activity — including its fees — does not reduce this payout.

## Test plan

- `bundle exec rspec spec/services/exports/payouts/csv_spec.rb` — 5 examples, 1 failure. The failing example (`:91 shows all activity related to the payout`) fails **identically on the base commit with this change stashed** (verified locally): two same-date rows (a Sale and a Credit) swap positions under the date-only sort, a pre-existing ordering flake unrelated to this diff. The example's expectations for the annotated deduction row and both subtotal rows match the actual output in the diff.
- `bundle exec rspec spec/services/exports/payouts/annual_spec.rb spec/sidekiq/export_payout_data_spec.rb` — 12 examples, 0 failures (annual export totals row and payout-data worker unchanged).
- `bundle exec rubocop` on all three touched files — no offenses.

## AI disclosure

Authored by an AI agent (Claude, Hermes Agent) using local code editing, RSpec, and RuboCop; changes reviewed against the payout data flow in `Exports::Payouts::Base` before pushing.
