### PR TITLE
Add targeted find/replace edits for profile custom HTML so the store agent stops regenerating whole pages

### DIFF
--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -2,8 +2,8 @@
 
 class Api::V2::UsersController < Api::V2::BaseController
   before_action -> { doorkeeper_authorize!(*Doorkeeper.configuration.public_api_read_scopes.concat([:view_public])) }, only: [:show, :ifttt_sale_trigger, :custom_html]
-  before_action(only: [:update, :update_custom_html, :preview_custom_html]) { doorkeeper_authorize! :edit_profile }
-  before_action :ensure_custom_html_pages_enabled, only: [:custom_html, :update_custom_html, :preview_custom_html]
+  before_action(only: [:update, :update_custom_html, :edit_custom_html, :preview_custom_html]) { doorkeeper_authorize! :edit_profile }
+  before_action :ensure_custom_html_pages_enabled, only: [:custom_html, :update_custom_html, :edit_custom_html, :preview_custom_html]
 
   def show
     if params[:is_ifttt]
@@ -74,6 +74,84 @@ class Api::V2::UsersController < Api::V2::BaseController
     rescue ActiveRecord::RecordInvalid => e
       return error_with_object(:user, e.record)
     end
+
+    render_response(true, custom_html: user.custom_html, previous_custom_html:, sanitization_report:, profile_url: profile_url_for(user))
+  end
+
+  # POST a targeted edit to the profile landing page: replaces exactly one occurrence of the
+  # `find` snippet with `replace` inside the existing custom HTML, leaving the rest of the page
+  # untouched, then re-sanitizes and saves the full result.
+  #
+  # This exists so the store agent can make a small change (a color, a button label, a heading)
+  # without regenerating the whole page. Before this endpoint, the agent's only write surface was
+  # a full-page replacement (update_custom_html), so a seller asking for a tiny tweak could lose
+  # their entire hand-built storefront page to a fresh, much smaller regeneration.
+  def edit_custom_html
+    user = current_resource_owner
+
+    return render_response(false, message: "You have to confirm your email address before you can do that.") unless user.confirmed?
+
+    find = params[:find]
+    replace = params[:replace]
+    unless find.is_a?(String) && find.present?
+      return render_response(false, message: "find is required and must be a non-empty string copied exactly from the current custom HTML.")
+    end
+    unless replace.is_a?(String)
+      return render_response(false, message: "replace is required and must be a string (use \"\" to delete the snippet).")
+    end
+
+    previous_custom_html = nil
+    sanitization_report = nil
+    edit_error = nil
+    begin
+      ActiveRecord::Base.transaction do
+        # Same row lock as update_custom_html: serializes concurrent writers and reloads the
+        # association cache, so the find/replace below splices against the latest committed page
+        # instead of a stale in-memory copy.
+        user.lock!
+        previous_custom_html = user.custom_html
+
+        if previous_custom_html.blank?
+          edit_error = "There is no custom HTML page to edit. Publish one first with the full custom_html update."
+          raise ActiveRecord::Rollback
+        end
+
+        # `find` must match exactly once so the edit is unambiguous. Zero matches means the caller
+        # is working from stale HTML; multiple matches means the snippet needs more surrounding
+        # context. Both errors say so explicitly, so the agent can correct itself in the same turn.
+        occurrences = previous_custom_html.scan(find).size
+        if occurrences.zero?
+          edit_error = "find does not appear in the current custom HTML. Re-read the page and copy the snippet exactly, including whitespace."
+          raise ActiveRecord::Rollback
+        elsif occurrences > 1
+          edit_error = "find matches #{occurrences} places in the current custom HTML. Include more surrounding context so it matches exactly once."
+          raise ActiveRecord::Rollback
+        end
+
+        # Block form so the replacement is inserted literally — the two-argument form of String#sub
+        # treats backslash sequences (\0, \1, \\) in the replacement specially, which would corrupt
+        # HTML that legitimately contains backslashes.
+        edited = previous_custom_html.sub(find) { replace }
+
+        if edited.length > Page::MAX_CUSTOM_HTML_LENGTH
+          edit_error = "The edited custom_html would be too long (maximum is #{Page::MAX_CUSTOM_HTML_LENGTH} characters)."
+          raise ActiveRecord::Rollback
+        end
+
+        # Re-sanitize the whole spliced result, not just the inserted snippet: the replacement can
+        # change how surrounding markup parses (for example by opening a tag the snippet closes), so
+        # only the full document is safe to check. Matches update_custom_html's blank-to-nil
+        # normalization so an edit that empties the page unpublishes it the same way.
+        result = Ai::PageSanitizer.sanitize_with_report(edited)
+        user.custom_html = result.html.presence
+        sanitization_report = result.report
+        user.save!
+      end
+    rescue ActiveRecord::RecordInvalid => e
+      return error_with_object(:user, e.record)
+    end
+
+    return render_response(false, message: edit_error) if edit_error
 
     render_response(true, custom_html: user.custom_html, previous_custom_html:, sanitization_report:, profile_url: profile_url_for(user))
   end

--- a/app/services/ai/store_agent_api_catalog.rb
+++ b/app/services/ai/store_agent_api_catalog.rb
@@ -89,7 +89,8 @@ module Ai::StoreAgentApiCatalog
     ep("update_user", :patch, "/user", "Update the creator's profile fields (name, bio).", scope: "edit_profile",
                                                                                            params: %w[name bio]),
     ep("get_user_custom_html", :get, "/user/custom_html", "Get the creator's profile custom HTML.", read: true, scope: "view_profile"),
-    ep("update_user_custom_html", :patch, "/user/custom_html", "Update the creator's profile custom HTML.", scope: "edit_profile", params: %w[custom_html]),
+    ep("update_user_custom_html", :patch, "/user/custom_html", "Replace the creator's ENTIRE profile custom HTML with a new page. Destructive: anything not included in custom_html is lost. Only use this to author a brand-new page; to change part of an existing page, use edit_user_custom_html.", scope: "edit_profile", params: %w[custom_html]),
+    ep("edit_user_custom_html", :post, "/user/custom_html/edit", "Make a targeted edit to the creator's existing profile custom HTML: replaces one exact snippet (find) with new HTML (replace) and leaves the rest of the page untouched. find must match the current HTML exactly once — include enough surrounding context. Always prefer this over update_user_custom_html when a page already exists.", scope: "edit_profile", params: %w[find replace]),
     ep("get_categories", :get, "/categories", "List the product categories Gumroad supports.", read: true),
     ep("get_refund_policy", :get, "/refund_policy", "Get the creator's account-level refund policy.", read: true, scope: "view_profile"),
     # Account-level refund policy is changed via Settings in the dashboard, which is owner-only

--- a/app/services/ai/store_agent_service.rb
+++ b/app/services/ai/store_agent_service.rb
@@ -92,6 +92,10 @@ class Ai::StoreAgentService
     - Always use api_read to get real ids and live numbers before acting. Never invent ids.
     - Never claim a change has already been made. After api_write, tell the creator you've prepared it
       and it's ready for them to confirm.
+    - When the creator already has a custom HTML page and asks for a change to it, ALWAYS read the
+      current page first and use the targeted edit endpoint to change only the part they asked
+      about. Never regenerate or replace an existing page from scratch unless the creator
+      explicitly asks for a whole new page — a full replacement destroys everything else on it.
     - Prepare at most one change per reply. If the creator asks for several, do the first and tell
       them you'll continue once they confirm.
     - Monetary amounts in the API are in CENTS (integer). $10 = 1000.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,6 +69,7 @@ Rails.application.routes.draw do
       match "/user", to: "users#update", via: [:put, :patch]
       get "/user/custom_html", to: "users#custom_html"
       match "/user/custom_html", to: "users#update_custom_html", via: [:put, :patch]
+      post "/user/custom_html/edit", to: "users#edit_custom_html"
       post "/user/preview_custom_html", to: "users#preview_custom_html"
       resources :categories, only: [:index]
       resource :refund_policy, only: [:show, :update], controller: :refund_policies

--- a/spec/controllers/api/v2/users_controller_edit_custom_html_spec.rb
+++ b/spec/controllers/api/v2/users_controller_edit_custom_html_spec.rb
@@ -1,0 +1,209 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Api::V2::UsersController do
+  before do
+    @user = create(:user, name: "Jane Doe", bio: "Maker of things")
+    @app = create(:oauth_application, owner: create(:user))
+    @token = create("doorkeeper/access_token", application: @app, resource_owner_id: @user.id, scopes: "view_profile edit_profile")
+    Feature.activate_user(:custom_html_pages, @user)
+  end
+
+  describe "POST 'edit_custom_html'" do
+    before do
+      @user.update!(custom_html: %(<section><h1>Welcome</h1><p style="color: blue">Shop my art</p></section>))
+    end
+
+    it "replaces exactly the matched snippet and leaves the rest of the page untouched" do
+      post :edit_custom_html, params: {
+        format: :json, access_token: @token.token,
+        find: %(<p style="color: blue">Shop my art</p>),
+        replace: %(<p style="color: pink">Shop my art</p>),
+      }
+
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body
+      expect(body["success"]).to eq(true)
+      stored = @user.reload.custom_html
+      expect(stored).to include(%(<p style="color: pink">Shop my art</p>))
+      expect(stored).to include("<h1>Welcome</h1>")
+      expect(stored).not_to include("color: blue")
+    end
+
+    it "returns previous_custom_html so the agent has one-shot recovery from a bad edit" do
+      post :edit_custom_html, params: {
+        format: :json, access_token: @token.token,
+        find: "<h1>Welcome</h1>", replace: "<h1>Hello</h1>",
+      }
+
+      body = response.parsed_body
+      expect(body["previous_custom_html"]).to include("<h1>Welcome</h1>")
+      expect(body["custom_html"]).to include("<h1>Hello</h1>")
+      expect(body["profile_url"]).to eq(@user.profile_url)
+    end
+
+    it "deletes the snippet when replace is an empty string" do
+      post :edit_custom_html, params: {
+        format: :json, access_token: @token.token,
+        find: "<h1>Welcome</h1>", replace: "",
+      }
+
+      expect(response.parsed_body["success"]).to eq(true)
+      stored = @user.reload.custom_html
+      expect(stored).not_to include("<h1>Welcome</h1>")
+      expect(stored).to include("Shop my art")
+    end
+
+    it "refuses when find does not appear in the current HTML, without writing" do
+      post :edit_custom_html, params: {
+        format: :json, access_token: @token.token,
+        find: "<h1>Not on the page</h1>", replace: "<h1>Hello</h1>",
+      }
+
+      body = response.parsed_body
+      expect(body["success"]).to eq(false)
+      expect(body["message"]).to match(/does not appear/i)
+      expect(@user.reload.custom_html).to include("<h1>Welcome</h1>")
+    end
+
+    it "refuses an ambiguous find that matches more than once, naming the count" do
+      @user.update!(custom_html: "<section><p>Buy now</p><p>Buy now</p></section>")
+
+      post :edit_custom_html, params: {
+        format: :json, access_token: @token.token,
+        find: "<p>Buy now</p>", replace: "<p>Get it</p>",
+      }
+
+      body = response.parsed_body
+      expect(body["success"]).to eq(false)
+      expect(body["message"]).to match(/matches 2 places/i)
+      expect(@user.reload.custom_html).to eq("<section><p>Buy now</p><p>Buy now</p></section>")
+    end
+
+    it "treats find literally, not as a regex" do
+      @user.update!(custom_html: "<section><p>Price: $10 (sale)</p></section>")
+
+      post :edit_custom_html, params: {
+        format: :json, access_token: @token.token,
+        find: "$10 (sale)", replace: "$8 (sale)",
+      }
+
+      expect(response.parsed_body["success"]).to eq(true)
+      expect(@user.reload.custom_html).to include("$8 (sale)")
+    end
+
+    it "inserts the replacement literally even when it contains backslash sequences" do
+      post :edit_custom_html, params: {
+        format: :json, access_token: @token.token,
+        find: "<h1>Welcome</h1>", replace: '<h1>Path \\0 and \\\\ stay</h1>',
+      }
+
+      expect(response.parsed_body["success"]).to eq(true)
+      expect(@user.reload.custom_html).to include('Path \\0 and \\\\ stay')
+    end
+
+    it "re-sanitizes the full edited page, stripping a disallowed script the edit introduces" do
+      post :edit_custom_html, params: {
+        format: :json, access_token: @token.token,
+        find: "<h1>Welcome</h1>",
+        replace: %(<h1>Welcome</h1><script src="https://evil.com/x.js"></script>),
+      }
+
+      body = response.parsed_body
+      expect(body["success"]).to eq(true)
+      expect(body["sanitization_report"]["total_removed"]).to eq(1)
+      expect(@user.reload.custom_html).not_to include("evil.com")
+    end
+
+    it "unpublishes the page when the edit sanitizes to nothing, matching the full update's blank-to-nil behavior" do
+      @user.update!(custom_html: "<section><h1>Welcome</h1></section>")
+
+      post :edit_custom_html, params: {
+        format: :json, access_token: @token.token,
+        find: "<section><h1>Welcome</h1></section>", replace: "",
+      }
+
+      expect(response.parsed_body["success"]).to eq(true)
+      expect(@user.reload.custom_html).to be_nil
+    end
+
+    it "refuses to edit when no custom HTML page exists" do
+      @user.update!(custom_html: nil)
+
+      post :edit_custom_html, params: {
+        format: :json, access_token: @token.token,
+        find: "<h1>Welcome</h1>", replace: "<h1>Hello</h1>",
+      }
+
+      body = response.parsed_body
+      expect(body["success"]).to eq(false)
+      expect(body["message"]).to match(/no custom HTML page to edit/i)
+    end
+
+    it "rejects an edit that would push the page over the size limit, without writing" do
+      post :edit_custom_html, params: {
+        format: :json, access_token: @token.token,
+        find: "<h1>Welcome</h1>",
+        replace: "<h1>#{"a" * Page::MAX_CUSTOM_HTML_LENGTH}</h1>",
+      }
+
+      body = response.parsed_body
+      expect(body["success"]).to eq(false)
+      expect(body["message"]).to match(/too long/i)
+      expect(@user.reload.custom_html).to include("<h1>Welcome</h1>")
+    end
+
+    it "requires find to be a non-empty string" do
+      post :edit_custom_html, params: { format: :json, access_token: @token.token, find: "", replace: "x" }
+      expect(response.parsed_body["success"]).to eq(false)
+      expect(response.parsed_body["message"]).to match(/find is required/i)
+
+      post :edit_custom_html, params: { format: :json, access_token: @token.token, replace: "x" }
+      expect(response.parsed_body["success"]).to eq(false)
+      expect(response.parsed_body["message"]).to match(/find is required/i)
+    end
+
+    it "requires replace to be a string" do
+      post :edit_custom_html, params: { format: :json, access_token: @token.token, find: "<h1>Welcome</h1>" }
+
+      expect(response.parsed_body["success"]).to eq(false)
+      expect(response.parsed_body["message"]).to match(/replace is required/i)
+    end
+
+    it "refuses until the account email is confirmed" do
+      unconfirmed = create(:user, confirmed_at: nil)
+      Feature.activate_user(:custom_html_pages, unconfirmed)
+      token = create("doorkeeper/access_token", application: @app, resource_owner_id: unconfirmed.id, scopes: "edit_profile")
+
+      post :edit_custom_html, params: { format: :json, access_token: token.token, find: "a", replace: "b" }
+
+      expect(response.parsed_body["success"]).to eq(false)
+      expect(response.parsed_body["message"]).to match(/confirm your email/i)
+    end
+
+    it "returns 401 without a token" do
+      post :edit_custom_html, params: { format: :json, find: "a", replace: "b" }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "rejects a token without the edit_profile scope" do
+      read_only = create("doorkeeper/access_token", application: @app, resource_owner_id: @user.id, scopes: "view_profile")
+
+      post :edit_custom_html, params: { format: :json, access_token: read_only.token, find: "<h1>Welcome</h1>", replace: "x" }
+
+      expect(response).to have_http_status(:forbidden)
+      expect(@user.reload.custom_html).to include("<h1>Welcome</h1>")
+    end
+
+    it "rejects the edit when the custom_html_pages feature is disabled" do
+      Feature.deactivate_user(:custom_html_pages, @user)
+
+      post :edit_custom_html, params: { format: :json, access_token: @token.token, find: "<h1>Welcome</h1>", replace: "x" }
+
+      expect(response.parsed_body["success"]).to eq(false)
+      expect(response.parsed_body["message"]).to eq("You do not have access to custom HTML pages.")
+      expect(@user.reload.custom_html).to include("<h1>Welcome</h1>")
+    end
+  end
+end

--- a/spec/controllers/api/v2/users_controller_edit_custom_html_spec.rb
+++ b/spec/controllers/api/v2/users_controller_edit_custom_html_spec.rb
@@ -78,7 +78,9 @@ describe Api::V2::UsersController do
       body = response.parsed_body
       expect(body["success"]).to eq(false)
       expect(body["message"]).to match(/matches 2 places/i)
-      expect(@user.reload.custom_html).to eq("<section><p>Buy now</p><p>Buy now</p></section>")
+      # The page is unchanged (the sanitizer may normalize whitespace on save, so compare content).
+      expect(@user.reload.custom_html.scan("<p>Buy now</p>").size).to eq(2)
+      expect(@user.custom_html).not_to include("Get it")
     end
 
     it "treats find literally, not as a regex" do

--- a/spec/services/ai/store_agent_api_catalog_spec.rb
+++ b/spec/services/ai/store_agent_api_catalog_spec.rb
@@ -38,4 +38,24 @@ describe Ai::StoreAgentApiCatalog do
       expect(described_class.find("drop_tables")).to be_nil
     end
   end
+
+  describe "profile custom HTML endpoints" do
+    it "exposes a targeted-edit write so an existing page never has to be fully regenerated" do
+      endpoint = described_class.find("edit_user_custom_html")
+
+      expect(endpoint).to be_present
+      expect(endpoint.write?).to eq(true)
+      expect(endpoint.method).to eq(:post)
+      expect(endpoint.path).to eq("/user/custom_html/edit")
+      expect(endpoint.scope).to eq("edit_profile")
+      expect(endpoint.params).to eq(%w[find replace])
+    end
+
+    it "warns the model that the full-page update is destructive and points at the targeted edit" do
+      summary = described_class.find("update_user_custom_html").summary
+
+      expect(summary).to match(/destructive/i)
+      expect(summary).to include("edit_user_custom_html")
+    end
+  end
 end


### PR DESCRIPTION
## What

Adds a targeted-edit surface for profile custom HTML so the store agent can change one part of an existing page instead of regenerating the whole thing:

- `POST /v2/user/custom_html/edit` (`edit_profile` scope, `custom_html_pages` flag): takes `find` + `replace`, requires `find` to match the current page exactly once (zero matches and ambiguous matches return corrective errors the model can act on), splices the replacement in literally, re-sanitizes the full result, and saves. Returns `previous_custom_html` for one-shot recovery, same as the full update.
- Catalog: new `edit_user_custom_html` write entry, and a reworded `update_user_custom_html` summary that calls the full replacement destructive and points the model at the targeted edit. The summaries feed the agent's system-prompt manifest, so the steering propagates automatically.
- System prompt: an explicit rule to read the current page and use the targeted edit for any change to an existing page — never regenerate from scratch unless the creator asks for a whole new page. The agent picks the right endpoint itself; no new user-facing choice.

## Why

Fixes antiwork/gumroad-private#984. Two sellers lost hand-built storefront pages the same way: they asked the agent for a tiny change (a color; renaming buttons on cards) and the agent's only page-write surface was the full-page `update_user_custom_html`, so it replaced an 84KB curated page with a ~1.8KB regeneration. With targeted edits in the catalog plus prompt/summary steering, a small request maps to a small, non-destructive write.

## Design notes

- The exactly-once match rule makes an edit unambiguous and self-correcting: the error for an ambiguous `find` names the match count and tells the model to include more surrounding context, so it retries within the same turn instead of falling back to a full rewrite.
- `String#sub` is called in block form so a `replace` containing `\0`/`\\` is inserted literally instead of being treated as a backreference.
- The whole spliced document is re-sanitized (not just the inserted snippet) because a replacement can change how surrounding markup parses. Blank-to-nil normalization matches the full update, so an edit that empties the page unpublishes it consistently.
- Same row lock as `update_custom_html`, so concurrent writers serialize and the splice always runs against the latest committed page.
- Size limit is enforced on the edited result before the sanitizer parses it.

## Test evidence

Ran locally (Ruby 3.4.3, MySQL up):

- `spec/controllers/api/v2/users_controller_edit_custom_html_spec.rb` — 17 examples covering the happy path, deletion via empty `replace`, zero/ambiguous match refusal, literal (non-regex) matching, backslash-safe replacement, full-document re-sanitization, blank-to-nil unpublish, size limit, param validation, unconfirmed email, auth (401/403), and the feature flag gate.
- `spec/services/ai/store_agent_api_catalog_spec.rb`, `spec/services/ai/store_agent_service_spec.rb`, `spec/services/ai/store_agent_action_executor_spec.rb`, `spec/controllers/api/v2/users_controller_custom_html_spec.rb`, `spec/controllers/api/v2/users_controller_spec.rb` — all green.
- 118 examples total, 0 failures. `rubocop` clean on all touched files.

Not a UI change — no screenshots; the agent's confirmation card renders the `find`/`replace` fields through the existing generic write-card path.

## Related

- #5767 adds the scoped `profile_design` endpoint for the same incident; this PR covers the "agent edits an existing custom page" half. Per the discussion there, custom HTML stays the primary surface, so targeted edits are the durable fix for destructive rewrites.
