### PR TITLE
Fix wrong holding currency in self-affiliate proceeds backfill

### DIFF
--- a/app/services/onetime/backfill_self_affiliate_dropped_proceeds.rb
+++ b/app/services/onetime/backfill_self_affiliate_dropped_proceeds.rb
@@ -102,6 +102,7 @@ class Onetime::BackfillSelfAffiliateDroppedProceeds
       # Recover the real settlement amounts from the charge processor BEFORE opening the
       # database transaction — this is a network call and must not run while we hold row
       # locks. Eligibility is re-checked under lock below in case anything changed.
+      prefetched_net_cents = purchase.payment_cents.to_i - purchase.affiliate_credit_cents.to_i
       holding_amount = seller_holding_amount(purchase)
 
       ApplicationRecord.transaction do
@@ -114,7 +115,7 @@ class Onetime::BackfillSelfAffiliateDroppedProceeds
           next
         end
 
-        new_bt = insert_seller_bt!(purchase, holding_amount)
+        new_bt = insert_seller_bt!(purchase, holding_amount, prefetched_net_cents)
       end
 
       return unless new_bt
@@ -192,9 +193,19 @@ class Onetime::BackfillSelfAffiliateDroppedProceeds
       :eligible
     end
 
-    def insert_seller_bt!(p, holding_amount)
+    def insert_seller_bt!(p, holding_amount, prefetched_net_cents)
       existing_bt = p.balance_transactions.first
       missing_net_cents = p.payment_cents.to_i - p.affiliate_credit_cents.to_i
+
+      # The holding amount was built from a read of the purchase taken before this row
+      # lock. If the purchase's fee or affiliate-credit figures changed in that window,
+      # the issued and holding nets would silently disagree — refuse to book rather than
+      # write a mismatched pair. (The holding amount's own net may legitimately be in the
+      # settlement currency, so we compare the USD net it was derived from instead.)
+      if prefetched_net_cents != missing_net_cents
+        raise "Missing net changed between prefetch and lock for purchase #{p.id} " \
+              "(holding built for #{prefetched_net_cents}, locked purchase implies #{missing_net_cents})"
+      end
 
       issued = BalanceTransaction::Amount.new(
         currency: existing_bt.issued_amount_currency,
@@ -245,6 +256,11 @@ class Onetime::BackfillSelfAffiliateDroppedProceeds
     # the normal purchase flow builds and no processor call is needed.
     def flow_of_funds_for(purchase)
       if purchase.merchant_account.holder_of_funds == HolderOfFunds::GUMROAD
+        # For charges presented in the buyer's currency, the gross booked here is the
+        # canonical USD transaction amount rather than a replay of Stripe's exact
+        # post-conversion settled cents, so it can differ from the original booking by
+        # FX rounding. The net cents — the figure balances and payouts actually use —
+        # is computed the same way either way, so payability is unaffected.
         return FlowOfFunds.build_simple_flow_of_funds(Currency::USD, purchase.total_transaction_cents)
       end
 

--- a/app/services/onetime/backfill_self_affiliate_dropped_proceeds.rb
+++ b/app/services/onetime/backfill_self_affiliate_dropped_proceeds.rb
@@ -90,7 +90,19 @@ class Onetime::BackfillSelfAffiliateDroppedProceeds
       end
 
       new_bt = nil
-      purchase = nil
+      purchase = Purchase.find(purchase_id)
+      reason = check_eligibility(purchase)
+
+      if reason != :eligible
+        @stats[reason] += 1
+        @skipped[reason] << purchase_id if @verbose
+        return
+      end
+
+      # Recover the real settlement amounts from the charge processor BEFORE opening the
+      # database transaction — this is a network call and must not run while we hold row
+      # locks. Eligibility is re-checked under lock below in case anything changed.
+      holding_amount = seller_holding_amount(purchase)
 
       ApplicationRecord.transaction do
         purchase = Purchase.lock.find(purchase_id)
@@ -102,7 +114,7 @@ class Onetime::BackfillSelfAffiliateDroppedProceeds
           next
         end
 
-        new_bt = insert_seller_bt!(purchase)
+        new_bt = insert_seller_bt!(purchase, holding_amount)
       end
 
       return unless new_bt
@@ -180,17 +192,12 @@ class Onetime::BackfillSelfAffiliateDroppedProceeds
       :eligible
     end
 
-    def insert_seller_bt!(p)
+    def insert_seller_bt!(p, holding_amount)
       existing_bt = p.balance_transactions.first
       missing_net_cents = p.payment_cents.to_i - p.affiliate_credit_cents.to_i
 
       issued = BalanceTransaction::Amount.new(
         currency: existing_bt.issued_amount_currency,
-        gross_cents: p.total_transaction_cents,
-        net_cents: missing_net_cents,
-      )
-      holding = BalanceTransaction::Amount.new(
-        currency: existing_bt.holding_amount_currency,
         gross_cents: p.total_transaction_cents,
         net_cents: missing_net_cents,
       )
@@ -200,9 +207,58 @@ class Onetime::BackfillSelfAffiliateDroppedProceeds
         merchant_account: p.merchant_account,
         purchase: p,
         issued_amount: issued,
-        holding_amount: holding,
+        holding_amount:,
         update_user_balance: false,
       )
+    end
+
+    # Builds the seller-leg holding amount from the charge processor's settlement data,
+    # the same way the normal purchase flow does.
+    #
+    # We can NOT copy the holding currency from the purchase's existing balance
+    # transaction: for a self-affiliate sale the only existing transaction is the
+    # affiliate leg, and affiliate holding amounts are always denominated in Gumroad's
+    # own currency (USD). A seller-leg holding amount must instead be in the currency of
+    # the merchant account the funds actually settled into (GBP, CAD, ...). Copying the
+    # affiliate leg's currency wrote "usd" holding amounts onto non-USD merchant
+    # accounts, and payout runs exclude balances whose holding currency does not match
+    # the account — leaving that money permanently stranded as "unpaid".
+    def seller_holding_amount(purchase)
+      missing_net_cents = purchase.payment_cents.to_i - purchase.affiliate_credit_cents.to_i
+
+      BalanceTransaction::Amount.create_holding_amount_for_seller(
+        flow_of_funds: flow_of_funds_for(purchase),
+        issued_net_cents: missing_net_cents,
+        # For buyer-currency (presentment) charges the processor-issued amount is in the
+        # buyer's currency; this substitutes the canonical USD amount, exactly like the
+        # normal purchase flow does. The method is private on Purchase because only
+        # balance-booking code should use it — which is what this is.
+        canonical_issued_amount: purchase.send(:presentment_canonical_issued_amount),
+      )
+    end
+
+    # Rebuilds the flow of funds for an already-settled charge. The purchase's original
+    # in-memory flow_of_funds is not persisted, so when the funds live in the seller's
+    # own Stripe account we re-fetch the charge (and its balance transactions) from
+    # Stripe to recover the real settlement currency and amounts. When Gumroad itself
+    # holds the funds, settlement is always in USD, so a simple USD flow matches what
+    # the normal purchase flow builds and no processor call is needed.
+    def flow_of_funds_for(purchase)
+      if purchase.merchant_account.holder_of_funds == HolderOfFunds::GUMROAD
+        return FlowOfFunds.build_simple_flow_of_funds(Currency::USD, purchase.total_transaction_cents)
+      end
+
+      processor_charge = ChargeProcessor.get_charge(
+        purchase.charge_processor_id,
+        purchase.stripe_transaction_id,
+        merchant_account: purchase.merchant_account,
+      )
+      flow_of_funds = processor_charge.flow_of_funds
+      raise "Could not rebuild flow of funds for purchase #{purchase.id} (charge #{purchase.stripe_transaction_id})" if flow_of_funds.nil?
+
+      # A purchase paid as part of a multi-product charge only owns a slice of the
+      # charge's money; split the combined flow the same way charge processing does.
+      purchase.is_part_of_combined_charge? ? purchase.build_flow_of_funds_from_combined_charge(flow_of_funds) : flow_of_funds
     end
 
     def credit_summary(p)

--- a/app/services/onetime/backfill_self_affiliate_dropped_proceeds.rb
+++ b/app/services/onetime/backfill_self_affiliate_dropped_proceeds.rb
@@ -253,6 +253,8 @@ class Onetime::BackfillSelfAffiliateDroppedProceeds
         purchase.stripe_transaction_id,
         merchant_account: purchase.merchant_account,
       )
+      raise "Could not fetch processor charge for purchase #{purchase.id} (charge #{purchase.stripe_transaction_id})" if processor_charge.nil?
+
       flow_of_funds = processor_charge.flow_of_funds
       raise "Could not rebuild flow of funds for purchase #{purchase.id} (charge #{purchase.stripe_transaction_id})" if flow_of_funds.nil?
 

--- a/spec/services/onetime/backfill_self_affiliate_dropped_proceeds_spec.rb
+++ b/spec/services/onetime/backfill_self_affiliate_dropped_proceeds_spec.rb
@@ -408,6 +408,17 @@ describe Onetime::BackfillSelfAffiliateDroppedProceeds do
       expect(purchase.balance_transactions.count).to eq(1)
     end
 
+    it "raises (and records an error, creating no BT) when the processor charge cannot be fetched" do
+      purchase = build_gbp_purchase
+
+      allow(ChargeProcessor).to receive(:get_charge).and_return(nil)
+
+      result = described_class.new(dry_run: false, purchase_ids: [purchase.id], verbose: true).process
+      expect(result[:stats][:error]).to eq(1)
+      expect(result[:skipped][:error].first[:error]).to include("Could not fetch processor charge")
+      expect(purchase.balance_transactions.count).to eq(1)
+    end
+
     it "does not call the charge processor when Gumroad holds the funds" do
       build_affected_purchase
       expect(ChargeProcessor).not_to receive(:get_charge)

--- a/spec/services/onetime/backfill_self_affiliate_dropped_proceeds_spec.rb
+++ b/spec/services/onetime/backfill_self_affiliate_dropped_proceeds_spec.rb
@@ -345,6 +345,78 @@ describe Onetime::BackfillSelfAffiliateDroppedProceeds do
     end
   end
 
+  describe "holding currency for sellers paid through their own Stripe account" do
+    # Sellers outside the US settle into a Stripe account denominated in their local
+    # currency (GBP, CAD, ...). The seller-leg holding amount must be in that currency
+    # or payout runs will exclude the resulting balance forever. The affiliate-leg BT
+    # is always USD, so the service must NOT copy its holding currency — it has to
+    # rebuild the settlement amounts from the charge processor.
+    let(:seller_stripe_account) do
+      create(:merchant_account, user: seller, currency: "gbp",
+                                charge_processor_id: StripeChargeProcessor.charge_processor_id)
+    end
+
+    def gbp_flow_of_funds(purchase)
+      FlowOfFunds.new(
+        issued_amount: FlowOfFunds::Amount.new(currency: Currency::USD, cents: purchase.total_transaction_cents),
+        settled_amount: FlowOfFunds::Amount.new(currency: Currency::USD, cents: purchase.total_transaction_cents),
+        gumroad_amount: FlowOfFunds::Amount.new(currency: Currency::USD, cents: purchase.fee_cents),
+        merchant_account_gross_amount: FlowOfFunds::Amount.new(currency: Currency::GBP, cents: 790),
+        merchant_account_net_amount: FlowOfFunds::Amount.new(currency: Currency::GBP, cents: 560),
+      )
+    end
+
+    def build_gbp_purchase
+      purchase = build_affected_purchase
+      purchase.update_columns(merchant_account_id: seller_stripe_account.id)
+      # A seller-owned account that is managed by Gumroad (Stripe custom account),
+      # not a standalone Stripe Connect account.
+      allow_any_instance_of(MerchantAccount).to receive(:is_managed_by_gumroad?).and_return(false)
+      allow_any_instance_of(MerchantAccount).to receive(:is_a_stripe_connect_account?).and_return(false)
+      purchase.reload
+    end
+
+    it "books the holding amount in the merchant account's settlement currency, not the affiliate leg's USD" do
+      purchase = build_gbp_purchase
+
+      expect(ChargeProcessor).to receive(:get_charge)
+        .with(StripeChargeProcessor.charge_processor_id, purchase.stripe_transaction_id, merchant_account: purchase.merchant_account)
+        .and_return(double(flow_of_funds: gbp_flow_of_funds(purchase)))
+
+      result = described_class.new(dry_run: false, purchase_ids: [purchase.id]).process
+      expect(result[:stats][:credited]).to eq(1)
+
+      seller_leg = purchase.balance_transactions.order(:id).last
+      expect(seller_leg.issued_amount_currency).to eq(Currency::USD)
+      expect(seller_leg.holding_amount_currency).to eq(Currency::GBP)
+      expect(seller_leg.holding_amount_gross_cents).to eq(790)
+      expect(seller_leg.holding_amount_net_cents).to eq(560)
+
+      balance = Balance.find(seller_leg.balance_id)
+      expect(balance.holding_currency).to eq(Currency::GBP)
+      expect(balance.currency).to eq(Currency::USD)
+    end
+
+    it "raises (and records an error, creating no BT) when the processor charge has no flow of funds" do
+      purchase = build_gbp_purchase
+
+      allow(ChargeProcessor).to receive(:get_charge).and_return(double(flow_of_funds: nil))
+
+      result = described_class.new(dry_run: false, purchase_ids: [purchase.id], verbose: true).process
+      expect(result[:stats][:error]).to eq(1)
+      expect(result[:skipped][:error].first[:error]).to include("Could not rebuild flow of funds")
+      expect(purchase.balance_transactions.count).to eq(1)
+    end
+
+    it "does not call the charge processor when Gumroad holds the funds" do
+      build_affected_purchase
+      expect(ChargeProcessor).not_to receive(:get_charge)
+
+      result = described_class.new(dry_run: false).process
+      expect(result[:stats][:credited]).to eq(1)
+    end
+  end
+
   describe "purchase variations preserved by the bug" do
     it "credits subscription / recurring purchases the same way" do
       subscription = create(:subscription, link: product, user: seller)

--- a/spec/services/onetime/backfill_self_affiliate_dropped_proceeds_spec.rb
+++ b/spec/services/onetime/backfill_self_affiliate_dropped_proceeds_spec.rb
@@ -369,10 +369,10 @@ describe Onetime::BackfillSelfAffiliateDroppedProceeds do
     def build_gbp_purchase
       purchase = build_affected_purchase
       purchase.update_columns(merchant_account_id: seller_stripe_account.id)
-      # A seller-owned account that is managed by Gumroad (Stripe custom account),
-      # not a standalone Stripe Connect account.
-      allow_any_instance_of(MerchantAccount).to receive(:is_managed_by_gumroad?).and_return(false)
-      allow_any_instance_of(MerchantAccount).to receive(:is_a_stripe_connect_account?).and_return(false)
+      # No stubs needed: a merchant account created with a user is seller-owned
+      # (is_managed_by_gumroad? is false), and without the stripe_connect metadata flag
+      # it is a Stripe custom account, not a standalone Connect account — exactly the
+      # population affected in production.
       purchase.reload
     end
 


### PR DESCRIPTION
## What

`Onetime::BackfillSelfAffiliateDroppedProceeds` now derives the seller-leg holding amount from the charge processor's settlement data (via `BalanceTransaction::Amount.create_holding_amount_for_seller`) instead of copying the holding currency from the purchase's existing balance transaction.

## Why

The June 3 run of this backfill wrote wrong holding currencies onto non-USD accounts. For a self-affiliate sale the only pre-existing balance transaction is the affiliate leg, and affiliate holding amounts are always denominated in USD. Copying its currency meant sellers whose Stripe accounts settle in GBP/CAD/etc. got `holding_currency: usd` balance rows on non-USD merchant accounts. Payout runs exclude balances whose holding currency doesn't match the account, so those earnings sat stranded as `unpaid` indefinitely (antiwork/gumroad-private#1000).

The fix mirrors the normal purchase flow (`Purchase#increment_sellers_balance!`):

- When Gumroad holds the funds, settlement is always USD — build a simple USD flow, no processor call.
- Otherwise, re-fetch the charge from Stripe to recover the real settlement currency/amounts (`flow_of_funds` isn't persisted post-charge), splitting combined-charge flows per purchase the same way charge processing does.
- The processor fetch happens **before** the row lock is taken, so a network call never runs inside the database transaction; eligibility is re-checked under lock.
- If the flow of funds can't be rebuilt, the purchase is recorded as an error and no balance transaction is created — never a wrong-currency write.

This is the going-forward fix for the script. Correcting the balances already stranded by the June 3 run is a separate live-money ledger correction tracked on the linked issue.

## Test evidence

```
bundle exec rspec spec/services/onetime/backfill_self_affiliate_dropped_proceeds_spec.rb
43 examples, 0 failures
```

New coverage: seller-owned GBP Stripe account gets a GBP holding amount (and GBP `Balance.holding_currency`) sourced from the processor's settlement data; missing flow of funds raises and creates no BT; Gumroad-held funds never trigger a processor call. `rubocop` clean on both files.

Part of antiwork/gumroad-private#1000
