### PR TITLE
Require city server-side for Japanese address submissions

### DIFF
--- a/app/services/update_user_compliance_info.rb
+++ b/app/services/update_user_compliance_info.rb
@@ -9,15 +9,17 @@ class UpdateUserComplianceInfo
     street_address: [:country],
     business_street_address: [:business_country, :country],
   }.freeze
-  # The fields that make up a Japanese address, including the city pair. A submission is treated
+  # The fields that make up a Japanese address, including the city pair and the prefecture
+  # (state) / postal code — changing only the prefecture or postal code still re-syncs the
+  # address to Stripe, so it must count as an address change. A submission is treated
   # as (re)entering the Japanese address only when one of these fields actually CHANGES compared
   # to the stored record — the Payments settings form echoes back every stored field on save, so
   # a value merely being present does not mean the seller touched their address. Older records
   # can still update unrelated fields (phone, payout frequency, ...) without a city — many legacy
   # Japanese records were created before the form collected one, and blocking every save until
   # they re-enter their address would strand them.
-  JAPAN_INDIVIDUAL_ADDRESS_FIELDS = %i[building_number building_number_kana street_address_kanji street_address_kana city city_kana].freeze
-  JAPAN_BUSINESS_ADDRESS_FIELDS = %i[business_building_number business_building_number_kana business_street_address_kanji business_street_address_kana business_city business_city_kana].freeze
+  JAPAN_INDIVIDUAL_ADDRESS_FIELDS = %i[building_number building_number_kana street_address_kanji street_address_kana city city_kana state zip_code].freeze
+  JAPAN_BUSINESS_ADDRESS_FIELDS = %i[business_building_number business_building_number_kana business_street_address_kanji business_street_address_kana business_city business_city_kana business_state business_zip_code].freeze
 
   attr_reader :compliance_params, :user
 

--- a/app/services/update_user_compliance_info.rb
+++ b/app/services/update_user_compliance_info.rb
@@ -9,6 +9,13 @@ class UpdateUserComplianceInfo
     street_address: [:country],
     business_street_address: [:business_country, :country],
   }.freeze
+  # The fields the Japanese address form submits alongside the city. If any of these arrive in a
+  # submission, the seller is (re)entering their Japanese address, so the city fields must be
+  # present too. Older records can still update unrelated fields (phone, tax id, ...) without a
+  # city — many legacy Japanese records were created before the form collected one, and blocking
+  # every update until they re-enter their address would strand them.
+  JAPAN_INDIVIDUAL_ADDRESS_FIELDS = %i[building_number building_number_kana street_address_kanji street_address_kana].freeze
+  JAPAN_BUSINESS_ADDRESS_FIELDS = %i[business_building_number business_building_number_kana business_street_address_kanji business_street_address_kana].freeze
 
   attr_reader :compliance_params, :user
 
@@ -66,6 +73,9 @@ class UpdateUserComplianceInfo
     if compliance_params.present?
       po_box_error = po_box_error_message
       return { success: false, error_message: po_box_error } if po_box_error.present?
+
+      japan_city_error = japan_city_error_message
+      return { success: false, error_message: japan_city_error } if japan_city_error.present?
 
       ENCRYPTED_FIELD_LABELS.each do |field, label|
         value = compliance_params[field]
@@ -284,6 +294,40 @@ class UpdateUserComplianceInfo
       return value.decrypt(GlobalConfig.get("STRONGBOX_GENERAL_PASSWORD")) if ENCRYPTED_COMPLIANCE_INFO_FIELDS.include?(field) && value.is_a?(Strongbox::Lock)
 
       value
+    end
+
+    # A Japanese address is only valid for our payment partner when it includes the city/ward as
+    # its own field. The onboarding form collects it, but a page loaded before the form gained the
+    # city fields (or any client that skips the form) can still submit a Japanese address without
+    # one — and that address shows the city duplicated inside the street line on Stripe's side.
+    # So when a submission carries Japanese address fields, require the matching city fields too.
+    # Submissions that don't touch the address (phone, tax id, ...) are left alone so legacy
+    # records without a city can still update unrelated fields.
+    def japan_city_error_message
+      if japan_address_submitted_for?(:individual)
+        city = compliance_params[:city].presence || current_compliance_info.city.presence
+        city_kana = compliance_params[:city_kana].presence || current_compliance_info.city_kana.presence
+        return "City/Ward is required for Japanese addresses. Please re-enter your address including the city/ward." if city.blank? || city_kana.blank?
+      end
+
+      if japan_address_submitted_for?(:business)
+        business_city = compliance_params[:business_city].presence || current_compliance_info.business_city.presence
+        business_city_kana = compliance_params[:business_city_kana].presence || current_compliance_info.business_city_kana.presence
+        return "Business city/Ward is required for Japanese addresses. Please re-enter your business address including the city/ward." if business_city.blank? || business_city_kana.blank?
+      end
+
+      nil
+    end
+
+    def japan_address_submitted_for?(entity)
+      if entity == :individual
+        return false unless effective_country_code_for(:street_address) == Compliance::Countries::JPN.alpha2
+        JAPAN_INDIVIDUAL_ADDRESS_FIELDS.any? { |field| compliance_params[field].present? }
+      else
+        return false unless effective_is_business?
+        return false unless effective_country_code_for(:business_street_address) == Compliance::Countries::JPN.alpha2
+        JAPAN_BUSINESS_ADDRESS_FIELDS.any? { |field| compliance_params[field].present? }
+      end
     end
 
     def po_box_error_message

--- a/app/services/update_user_compliance_info.rb
+++ b/app/services/update_user_compliance_info.rb
@@ -9,13 +9,15 @@ class UpdateUserComplianceInfo
     street_address: [:country],
     business_street_address: [:business_country, :country],
   }.freeze
-  # The fields the Japanese address form submits alongside the city. If any of these arrive in a
-  # submission, the seller is (re)entering their Japanese address, so the city fields must be
-  # present too. Older records can still update unrelated fields (phone, tax id, ...) without a
-  # city — many legacy Japanese records were created before the form collected one, and blocking
-  # every update until they re-enter their address would strand them.
-  JAPAN_INDIVIDUAL_ADDRESS_FIELDS = %i[building_number building_number_kana street_address_kanji street_address_kana].freeze
-  JAPAN_BUSINESS_ADDRESS_FIELDS = %i[business_building_number business_building_number_kana business_street_address_kanji business_street_address_kana].freeze
+  # The fields that make up a Japanese address, including the city pair. A submission is treated
+  # as (re)entering the Japanese address only when one of these fields actually CHANGES compared
+  # to the stored record — the Payments settings form echoes back every stored field on save, so
+  # a value merely being present does not mean the seller touched their address. Older records
+  # can still update unrelated fields (phone, payout frequency, ...) without a city — many legacy
+  # Japanese records were created before the form collected one, and blocking every save until
+  # they re-enter their address would strand them.
+  JAPAN_INDIVIDUAL_ADDRESS_FIELDS = %i[building_number building_number_kana street_address_kanji street_address_kana city city_kana].freeze
+  JAPAN_BUSINESS_ADDRESS_FIELDS = %i[business_building_number business_building_number_kana business_street_address_kanji business_street_address_kana business_city business_city_kana].freeze
 
   attr_reader :compliance_params, :user
 
@@ -300,9 +302,10 @@ class UpdateUserComplianceInfo
     # its own field. The onboarding form collects it, but a page loaded before the form gained the
     # city fields (or any client that skips the form) can still submit a Japanese address without
     # one — and that address shows the city duplicated inside the street line on Stripe's side.
-    # So when a submission carries Japanese address fields, require the matching city fields too.
-    # Submissions that don't touch the address (phone, tax id, ...) are left alone so legacy
-    # records without a city can still update unrelated fields.
+    # So when a submission actually changes the Japanese address (see
+    # japan_address_change_detected?), require the matching city fields too. Saves that don't
+    # touch the address are left alone so legacy records without a city can still update
+    # unrelated fields.
     def japan_city_error_message
       if japan_address_submitted_for?(:individual)
         city = compliance_params[:city].presence || current_compliance_info.city.presence
@@ -322,12 +325,26 @@ class UpdateUserComplianceInfo
     def japan_address_submitted_for?(entity)
       if entity == :individual
         return false unless effective_country_code_for(:street_address) == Compliance::Countries::JPN.alpha2
-        JAPAN_INDIVIDUAL_ADDRESS_FIELDS.any? { |field| compliance_params[field].present? }
+        japan_address_change_detected?(JAPAN_INDIVIDUAL_ADDRESS_FIELDS, :street_address)
       else
         return false unless effective_is_business?
         return false unless effective_country_code_for(:business_street_address) == Compliance::Countries::JPN.alpha2
-        JAPAN_BUSINESS_ADDRESS_FIELDS.any? { |field| compliance_params[field].present? }
+        japan_address_change_detected?(JAPAN_BUSINESS_ADDRESS_FIELDS, :business_street_address)
       end
+    end
+
+    # The Payments settings form loads every stored compliance field and submits them all back on
+    # save, so a Japanese address field merely being present in the params does not mean the
+    # seller touched their address. Treat the address as (re)submitted only when a submitted field
+    # actually differs from what's stored, or when the validation context changed (the country
+    # switched to Japan, or the account switched between individual and business) while a Japanese
+    # address is on the record — in both cases the address is about to be synced to Stripe under
+    # rules it wasn't checked against before.
+    def japan_address_change_detected?(fields, address_field)
+      return true if fields.any? { |field| address_changed?(field) }
+
+      validation_context_changed_for?(address_field) &&
+        fields.any? { |field| compliance_params[field].present? || current_compliance_info.public_send(field).present? }
     end
 
     def po_box_error_message

--- a/spec/services/update_user_compliance_info_spec.rb
+++ b/spec/services/update_user_compliance_info_spec.rb
@@ -342,6 +342,28 @@ describe UpdateUserComplianceInfo do
         expect(new_compliance_info.business_city).to eq("千代田区")
         expect(new_compliance_info.business_city_kana).to eq("チヨダク")
       end
+
+      it "accepts a business address submission without business city params when the record already has a business city" do
+        _result, with_business_city = japan_business_compliance_info.dup_and_save! do |n|
+          n.business_city = "千代田区"
+          n.business_city_kana = "チヨダク"
+          n.skip_stripe_job_on_create = true
+        end
+        expect(with_business_city.business_city).to eq("千代田区")
+
+        params = ActionController::Parameters.new(
+          is_business: true,
+          business_street_address_kanji: "丸の内2丁目",
+          business_street_address_kana: "マルノウチ2チョウメ",
+        )
+
+        allow(StripeMerchantAccountManager).to receive(:handle_new_user_compliance_info)
+
+        result = described_class.new(compliance_params: params, user: japan_business_user).process
+
+        expect(result[:success]).to be true
+        expect(japan_business_user.reload.alive_user_compliance_info.business_street_address_kanji).to eq("丸の内2丁目")
+      end
     end
 
     context "with a US business that already has a 9-digit business_tax_id saved" do

--- a/spec/services/update_user_compliance_info_spec.rb
+++ b/spec/services/update_user_compliance_info_spec.rb
@@ -146,10 +146,10 @@ describe UpdateUserComplianceInfo do
 
       it "rejects an address submission without a city" do
         params = ActionController::Parameters.new(
-          street_address_kanji: "文京区千駄木3丁目",
-          street_address_kana: "ブンキョウクセンダギ3チョウメ",
-          building_number: "1-1",
-          building_number_kana: "1-1",
+          street_address_kanji: "文京区千駄木4丁目",
+          street_address_kana: "ブンキョウクセンダギ4チョウメ",
+          building_number: "2-2",
+          building_number_kana: "2-2",
         )
 
         expect(StripeMerchantAccountManager).not_to receive(:handle_new_user_compliance_info)
@@ -158,6 +158,19 @@ describe UpdateUserComplianceInfo do
         expect do
           result = described_class.new(compliance_params: params, user: japan_user).process
         end.not_to change { UserComplianceInfo.count }
+
+        expect(result[:success]).to be false
+        expect(result[:error_message]).to eq("City/Ward is required for Japanese addresses. Please re-enter your address including the city/ward.")
+      end
+
+      it "rejects a submission that fills in only one of the city pair" do
+        # A direct request (bypassing the form) that sets `city` without `city_kana` would
+        # otherwise sync a half-populated address to Stripe.
+        params = ActionController::Parameters.new(city: "文京区")
+
+        expect(StripeMerchantAccountManager).not_to receive(:handle_new_user_compliance_info)
+
+        result = described_class.new(compliance_params: params, user: japan_user).process
 
         expect(result[:success]).to be false
         expect(result[:error_message]).to eq("City/Ward is required for Japanese addresses. Please re-enter your address including the city/ward.")
@@ -184,8 +197,29 @@ describe UpdateUserComplianceInfo do
         expect(new_compliance_info.street_address_kanji).to eq("千駄木3丁目")
       end
 
-      it "accepts a non-address update on a legacy record that has no city" do
-        params = ActionController::Parameters.new(phone: "+81312345678")
+      it "accepts a full settings-form save that changes only the phone on a legacy record with no city" do
+        # The Payments settings form echoes back every stored compliance field on save, so a
+        # phone-only change still arrives with the whole stored (city-less) Japanese address.
+        # That must not trip the city requirement — the seller didn't touch their address.
+        params = ActionController::Parameters.new(
+          is_business: false,
+          first_name: japan_compliance_info.first_name,
+          last_name: japan_compliance_info.last_name,
+          street_address: japan_compliance_info.street_address,
+          building_number: "1-1",
+          building_number_kana: "1-1",
+          street_address_kanji: "文京区千駄木3丁目",
+          street_address_kana: "ブンキョウクセンダギ3チョウメ",
+          city: "",
+          city_kana: "",
+          state: "東京都",
+          zip_code: "1130022",
+          country: "JP",
+          dob_month: japan_compliance_info.birthday.month.to_s,
+          dob_day: japan_compliance_info.birthday.day.to_s,
+          dob_year: japan_compliance_info.birthday.year.to_s,
+          phone: "+81312345678",
+        )
 
         allow(StripeMerchantAccountManager).to receive(:handle_new_user_compliance_info)
 

--- a/spec/services/update_user_compliance_info_spec.rb
+++ b/spec/services/update_user_compliance_info_spec.rb
@@ -125,6 +125,159 @@ describe UpdateUserComplianceInfo do
       end
     end
 
+    context "with a Japanese individual account" do
+      let(:japan_user) { create(:user) }
+      let!(:japan_compliance_info) do
+        create(
+          :user_compliance_info,
+          user: japan_user,
+          country: "Japan",
+          city: nil,
+          state: "東京都",
+          zip_code: "1130022",
+          json_data: {
+            street_address_kanji: "文京区千駄木3丁目",
+            street_address_kana: "ブンキョウクセンダギ3チョウメ",
+            building_number: "1-1",
+            building_number_kana: "1-1",
+          }
+        )
+      end
+
+      it "rejects an address submission without a city" do
+        params = ActionController::Parameters.new(
+          street_address_kanji: "文京区千駄木3丁目",
+          street_address_kana: "ブンキョウクセンダギ3チョウメ",
+          building_number: "1-1",
+          building_number_kana: "1-1",
+        )
+
+        expect(StripeMerchantAccountManager).not_to receive(:handle_new_user_compliance_info)
+
+        result = nil
+        expect do
+          result = described_class.new(compliance_params: params, user: japan_user).process
+        end.not_to change { UserComplianceInfo.count }
+
+        expect(result[:success]).to be false
+        expect(result[:error_message]).to eq("City/Ward is required for Japanese addresses. Please re-enter your address including the city/ward.")
+      end
+
+      it "accepts an address submission that includes the city fields" do
+        params = ActionController::Parameters.new(
+          street_address_kanji: "千駄木3丁目",
+          street_address_kana: "センダギ3チョウメ",
+          building_number: "1-1",
+          building_number_kana: "1-1",
+          city: "文京区",
+          city_kana: "ブンキョウク",
+        )
+
+        allow(StripeMerchantAccountManager).to receive(:handle_new_user_compliance_info)
+
+        result = described_class.new(compliance_params: params, user: japan_user).process
+
+        expect(result[:success]).to be true
+        new_compliance_info = japan_user.reload.alive_user_compliance_info
+        expect(new_compliance_info.city).to eq("文京区")
+        expect(new_compliance_info.city_kana).to eq("ブンキョウク")
+        expect(new_compliance_info.street_address_kanji).to eq("千駄木3丁目")
+      end
+
+      it "accepts a non-address update on a legacy record that has no city" do
+        params = ActionController::Parameters.new(phone: "+81312345678")
+
+        allow(StripeMerchantAccountManager).to receive(:handle_new_user_compliance_info)
+
+        result = described_class.new(compliance_params: params, user: japan_user).process
+
+        expect(result[:success]).to be true
+        expect(japan_user.reload.alive_user_compliance_info.phone).to eq("+81312345678")
+      end
+
+      it "accepts an address submission without city params when the record already has a city" do
+        _result, with_city = japan_compliance_info.dup_and_save! do |n|
+          n.city = "文京区"
+          n.city_kana = "ブンキョウク"
+          n.skip_stripe_job_on_create = true
+        end
+        expect(with_city.city).to eq("文京区")
+
+        params = ActionController::Parameters.new(
+          street_address_kanji: "千駄木4丁目",
+          street_address_kana: "センダギ4チョウメ",
+        )
+
+        allow(StripeMerchantAccountManager).to receive(:handle_new_user_compliance_info)
+
+        result = described_class.new(compliance_params: params, user: japan_user).process
+
+        expect(result[:success]).to be true
+        expect(japan_user.reload.alive_user_compliance_info.street_address_kanji).to eq("千駄木4丁目")
+      end
+    end
+
+    context "with a Japanese business account" do
+      let(:japan_business_user) { create(:user) }
+      let!(:japan_business_compliance_info) do
+        create(
+          :user_compliance_info,
+          user: japan_business_user,
+          country: "Japan",
+          city: "文京区",
+          state: "東京都",
+          zip_code: "1130022",
+          is_business: true,
+          business_name: "Buy More KK",
+          business_country: "Japan",
+          business_city: nil,
+          business_state: "東京都",
+          business_zip_code: "1130022",
+          business_type: UserComplianceInfo::BusinessTypes::LLC,
+          business_tax_id: "0000000000000",
+          json_data: {
+            city_kana: "ブンキョウク",
+            street_address_kanji: "千駄木3丁目",
+            street_address_kana: "センダギ3チョウメ",
+          }
+        )
+      end
+
+      it "rejects a business address submission without a business city" do
+        params = ActionController::Parameters.new(
+          is_business: true,
+          business_street_address_kanji: "千代田区丸の内1丁目",
+          business_street_address_kana: "チヨダクマルノウチ1チョウメ",
+        )
+
+        expect(StripeMerchantAccountManager).not_to receive(:handle_new_user_compliance_info)
+
+        result = described_class.new(compliance_params: params, user: japan_business_user).process
+
+        expect(result[:success]).to be false
+        expect(result[:error_message]).to eq("Business city/Ward is required for Japanese addresses. Please re-enter your business address including the city/ward.")
+      end
+
+      it "accepts a business address submission that includes the business city fields" do
+        params = ActionController::Parameters.new(
+          is_business: true,
+          business_street_address_kanji: "丸の内1丁目",
+          business_street_address_kana: "マルノウチ1チョウメ",
+          business_city: "千代田区",
+          business_city_kana: "チヨダク",
+        )
+
+        allow(StripeMerchantAccountManager).to receive(:handle_new_user_compliance_info)
+
+        result = described_class.new(compliance_params: params, user: japan_business_user).process
+
+        expect(result[:success]).to be true
+        new_compliance_info = japan_business_user.reload.alive_user_compliance_info
+        expect(new_compliance_info.business_city).to eq("千代田区")
+        expect(new_compliance_info.business_city_kana).to eq("チヨダク")
+      end
+    end
+
     context "with a US business that already has a 9-digit business_tax_id saved" do
       let(:us_business_user) do
         create(:user).tap { |u| create(:user_compliance_info_business, user: u) }

--- a/spec/services/update_user_compliance_info_spec.rb
+++ b/spec/services/update_user_compliance_info_spec.rb
@@ -176,6 +176,21 @@ describe UpdateUserComplianceInfo do
         expect(result[:error_message]).to eq("City/Ward is required for Japanese addresses. Please re-enter your address including the city/ward.")
       end
 
+      it "rejects a postal-code-only update on a record with no city" do
+        # Changing just the postal code (or prefecture) still re-syncs the whole address to
+        # Stripe, so it must count as an address change and require the city like any other
+        # address edit — otherwise a legacy no-city record can keep updating its address
+        # piecemeal without ever entering one.
+        params = ActionController::Parameters.new(zip_code: "1130023")
+
+        expect(StripeMerchantAccountManager).not_to receive(:handle_new_user_compliance_info)
+
+        result = described_class.new(compliance_params: params, user: japan_user).process
+
+        expect(result[:success]).to be false
+        expect(result[:error_message]).to eq("City/Ward is required for Japanese addresses. Please re-enter your address including the city/ward.")
+      end
+
       it "accepts an address submission that includes the city fields" do
         params = ActionController::Parameters.new(
           street_address_kanji: "千駄木3丁目",
@@ -282,6 +297,23 @@ describe UpdateUserComplianceInfo do
           is_business: true,
           business_street_address_kanji: "千代田区丸の内1丁目",
           business_street_address_kana: "チヨダクマルノウチ1チョウメ",
+        )
+
+        expect(StripeMerchantAccountManager).not_to receive(:handle_new_user_compliance_info)
+
+        result = described_class.new(compliance_params: params, user: japan_business_user).process
+
+        expect(result[:success]).to be false
+        expect(result[:error_message]).to eq("Business city/Ward is required for Japanese addresses. Please re-enter your business address including the city/ward.")
+      end
+
+      it "rejects a business postal-code-only update on a record with no business city" do
+        # Same reasoning as the individual case: a postal code (or prefecture) change alone
+        # still re-syncs the business address to Stripe, so the business city pair must be
+        # present before it goes through.
+        params = ActionController::Parameters.new(
+          is_business: true,
+          business_zip_code: "1000005",
         )
 
         expect(StripeMerchantAccountManager).not_to receive(:handle_new_user_compliance_info)


### PR DESCRIPTION
## What

Server-side validation: when a payout compliance submission actually changes a Japanese address (a submitted address field differs from the stored record, or the country/business context switches while a Japanese address is on file), the matching city fields (`city` + `city_kana`, or `business_city` + `business_city_kana` for businesses) must be present — either in the submission or already on the record. The Payments settings form echoes back every stored field on save, so change detection diffs against `current_compliance_info` rather than treating field presence as a resubmission — saves that only change the phone, payout frequency, or payout pause on a legacy no-city record are unaffected.

## Why

#5739 added the city fields to the Japanese onboarding form and made them required, but only in the browser. A page loaded on the pre-#5739 frontend bundle and submitted after the deploy (or any client that skips the form) can still create a Japanese compliance record with no city — the seller types the city at the start of the street line, Stripe auto-fills `city` from the postal code, and the address presents to our JP payment partner with the city repeated. One such stale-session record showed up in production two days after the #5739 deploy (antiwork/gumroad-private#1002).

Requiring the city outright at the model level would break unrelated updates to un-backfilled legacy records, so this check fires only when the submission is actually (re)entering a Japanese address.

## Test plan

- `bundle exec rspec spec/services/update_user_compliance_info_spec.rb` — 33 examples, 0 failures (11 new: reject missing individual/business city, reject a half-filled city pair, reject individual/business postal-code-only updates on no-city records, accept with city, accept when record already has a city (individual and business), accept a full UI-shaped settings-form save that changes only the phone on a legacy no-city record)
- `rubocop` clean on both touched files

Not a UI change — no visual difference; the form already requires these fields client-side.

Part of antiwork/gumroad-private#1002.



