### PR TITLE
Add correction service for balances stranded by the self-affiliate backfill

### DIFF
--- a/app/services/onetime/backfill_self_affiliate_dropped_proceeds.rb
+++ b/app/services/onetime/backfill_self_affiliate_dropped_proceeds.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Onetime::BackfillSelfAffiliateDroppedProceeds
+  include Onetime::RebuildsSellerSettlementAmounts
+
   BUG_INTRODUCED_AT = Time.utc(2026, 4, 28)
   BUG_FIXED_AT = Time.utc(2026, 6, 2)
   REMEDIATION_WINDOW = BUG_INTRODUCED_AT...BUG_FIXED_AT
@@ -210,57 +212,6 @@ class Onetime::BackfillSelfAffiliateDroppedProceeds
         holding_amount:,
         update_user_balance: false,
       )
-    end
-
-    # Builds the seller-leg holding amount from the charge processor's settlement data,
-    # the same way the normal purchase flow does.
-    #
-    # We can NOT copy the holding currency from the purchase's existing balance
-    # transaction: for a self-affiliate sale the only existing transaction is the
-    # affiliate leg, and affiliate holding amounts are always denominated in Gumroad's
-    # own currency (USD). A seller-leg holding amount must instead be in the currency of
-    # the merchant account the funds actually settled into (GBP, CAD, ...). Copying the
-    # affiliate leg's currency wrote "usd" holding amounts onto non-USD merchant
-    # accounts, and payout runs exclude balances whose holding currency does not match
-    # the account — leaving that money permanently stranded as "unpaid".
-    def seller_holding_amount(purchase)
-      missing_net_cents = purchase.payment_cents.to_i - purchase.affiliate_credit_cents.to_i
-
-      BalanceTransaction::Amount.create_holding_amount_for_seller(
-        flow_of_funds: flow_of_funds_for(purchase),
-        issued_net_cents: missing_net_cents,
-        # For buyer-currency (presentment) charges the processor-issued amount is in the
-        # buyer's currency; this substitutes the canonical USD amount, exactly like the
-        # normal purchase flow does. The method is private on Purchase because only
-        # balance-booking code should use it — which is what this is.
-        canonical_issued_amount: purchase.send(:presentment_canonical_issued_amount),
-      )
-    end
-
-    # Rebuilds the flow of funds for an already-settled charge. The purchase's original
-    # in-memory flow_of_funds is not persisted, so when the funds live in the seller's
-    # own Stripe account we re-fetch the charge (and its balance transactions) from
-    # Stripe to recover the real settlement currency and amounts. When Gumroad itself
-    # holds the funds, settlement is always in USD, so a simple USD flow matches what
-    # the normal purchase flow builds and no processor call is needed.
-    def flow_of_funds_for(purchase)
-      if purchase.merchant_account.holder_of_funds == HolderOfFunds::GUMROAD
-        return FlowOfFunds.build_simple_flow_of_funds(Currency::USD, purchase.total_transaction_cents)
-      end
-
-      processor_charge = ChargeProcessor.get_charge(
-        purchase.charge_processor_id,
-        purchase.stripe_transaction_id,
-        merchant_account: purchase.merchant_account,
-      )
-      raise "Could not fetch processor charge for purchase #{purchase.id} (charge #{purchase.stripe_transaction_id})" if processor_charge.nil?
-
-      flow_of_funds = processor_charge.flow_of_funds
-      raise "Could not rebuild flow of funds for purchase #{purchase.id} (charge #{purchase.stripe_transaction_id})" if flow_of_funds.nil?
-
-      # A purchase paid as part of a multi-product charge only owns a slice of the
-      # charge's money; split the combined flow the same way charge processing does.
-      purchase.is_part_of_combined_charge? ? purchase.build_flow_of_funds_from_combined_charge(flow_of_funds) : flow_of_funds
     end
 
     def credit_summary(p)

--- a/app/services/onetime/backfill_self_affiliate_dropped_proceeds.rb
+++ b/app/services/onetime/backfill_self_affiliate_dropped_proceeds.rb
@@ -102,6 +102,7 @@ class Onetime::BackfillSelfAffiliateDroppedProceeds
       # Recover the real settlement amounts from the charge processor BEFORE opening the
       # database transaction — this is a network call and must not run while we hold row
       # locks. Eligibility is re-checked under lock below in case anything changed.
+      prefetched_net_cents = purchase.payment_cents.to_i - purchase.affiliate_credit_cents.to_i
       holding_amount = seller_holding_amount(purchase)
 
       ApplicationRecord.transaction do
@@ -114,7 +115,7 @@ class Onetime::BackfillSelfAffiliateDroppedProceeds
           next
         end
 
-        new_bt = insert_seller_bt!(purchase, holding_amount)
+        new_bt = insert_seller_bt!(purchase, holding_amount, prefetched_net_cents)
       end
 
       return unless new_bt
@@ -192,9 +193,19 @@ class Onetime::BackfillSelfAffiliateDroppedProceeds
       :eligible
     end
 
-    def insert_seller_bt!(p, holding_amount)
+    def insert_seller_bt!(p, holding_amount, prefetched_net_cents)
       existing_bt = p.balance_transactions.first
       missing_net_cents = p.payment_cents.to_i - p.affiliate_credit_cents.to_i
+
+      # The holding amount was built from a read of the purchase taken before this row
+      # lock. If the purchase's fee or affiliate-credit figures changed in that window,
+      # the issued and holding nets would silently disagree — refuse to book rather than
+      # write a mismatched pair. (The holding amount's own net may legitimately be in the
+      # settlement currency, so we compare the USD net it was derived from instead.)
+      if prefetched_net_cents != missing_net_cents
+        raise "Missing net changed between prefetch and lock for purchase #{p.id} " \
+              "(holding built for #{prefetched_net_cents}, locked purchase implies #{missing_net_cents})"
+      end
 
       issued = BalanceTransaction::Amount.new(
         currency: existing_bt.issued_amount_currency,
@@ -245,6 +256,11 @@ class Onetime::BackfillSelfAffiliateDroppedProceeds
     # the normal purchase flow builds and no processor call is needed.
     def flow_of_funds_for(purchase)
       if purchase.merchant_account.holder_of_funds == HolderOfFunds::GUMROAD
+        # For charges presented in the buyer's currency, the gross booked here is the
+        # canonical USD transaction amount rather than a replay of Stripe's exact
+        # post-conversion settled cents, so it can differ from the original booking by
+        # FX rounding. The net cents — the figure balances and payouts actually use —
+        # is computed the same way either way, so payability is unaffected.
         return FlowOfFunds.build_simple_flow_of_funds(Currency::USD, purchase.total_transaction_cents)
       end
 

--- a/app/services/onetime/backfill_self_affiliate_dropped_proceeds.rb
+++ b/app/services/onetime/backfill_self_affiliate_dropped_proceeds.rb
@@ -90,7 +90,19 @@ class Onetime::BackfillSelfAffiliateDroppedProceeds
       end
 
       new_bt = nil
-      purchase = nil
+      purchase = Purchase.find(purchase_id)
+      reason = check_eligibility(purchase)
+
+      if reason != :eligible
+        @stats[reason] += 1
+        @skipped[reason] << purchase_id if @verbose
+        return
+      end
+
+      # Recover the real settlement amounts from the charge processor BEFORE opening the
+      # database transaction — this is a network call and must not run while we hold row
+      # locks. Eligibility is re-checked under lock below in case anything changed.
+      holding_amount = seller_holding_amount(purchase)
 
       ApplicationRecord.transaction do
         purchase = Purchase.lock.find(purchase_id)
@@ -102,7 +114,7 @@ class Onetime::BackfillSelfAffiliateDroppedProceeds
           next
         end
 
-        new_bt = insert_seller_bt!(purchase)
+        new_bt = insert_seller_bt!(purchase, holding_amount)
       end
 
       return unless new_bt
@@ -180,17 +192,12 @@ class Onetime::BackfillSelfAffiliateDroppedProceeds
       :eligible
     end
 
-    def insert_seller_bt!(p)
+    def insert_seller_bt!(p, holding_amount)
       existing_bt = p.balance_transactions.first
       missing_net_cents = p.payment_cents.to_i - p.affiliate_credit_cents.to_i
 
       issued = BalanceTransaction::Amount.new(
         currency: existing_bt.issued_amount_currency,
-        gross_cents: p.total_transaction_cents,
-        net_cents: missing_net_cents,
-      )
-      holding = BalanceTransaction::Amount.new(
-        currency: existing_bt.holding_amount_currency,
         gross_cents: p.total_transaction_cents,
         net_cents: missing_net_cents,
       )
@@ -200,9 +207,58 @@ class Onetime::BackfillSelfAffiliateDroppedProceeds
         merchant_account: p.merchant_account,
         purchase: p,
         issued_amount: issued,
-        holding_amount: holding,
+        holding_amount:,
         update_user_balance: false,
       )
+    end
+
+    # Builds the seller-leg holding amount from the charge processor's settlement data,
+    # the same way the normal purchase flow does.
+    #
+    # We can NOT copy the holding currency from the purchase's existing balance
+    # transaction: for a self-affiliate sale the only existing transaction is the
+    # affiliate leg, and affiliate holding amounts are always denominated in Gumroad's
+    # own currency (USD). A seller-leg holding amount must instead be in the currency of
+    # the merchant account the funds actually settled into (GBP, CAD, ...). Copying the
+    # affiliate leg's currency wrote "usd" holding amounts onto non-USD merchant
+    # accounts, and payout runs exclude balances whose holding currency does not match
+    # the account — leaving that money permanently stranded as "unpaid".
+    def seller_holding_amount(purchase)
+      missing_net_cents = purchase.payment_cents.to_i - purchase.affiliate_credit_cents.to_i
+
+      BalanceTransaction::Amount.create_holding_amount_for_seller(
+        flow_of_funds: flow_of_funds_for(purchase),
+        issued_net_cents: missing_net_cents,
+        # For buyer-currency (presentment) charges the processor-issued amount is in the
+        # buyer's currency; this substitutes the canonical USD amount, exactly like the
+        # normal purchase flow does. The method is private on Purchase because only
+        # balance-booking code should use it — which is what this is.
+        canonical_issued_amount: purchase.send(:presentment_canonical_issued_amount),
+      )
+    end
+
+    # Rebuilds the flow of funds for an already-settled charge. The purchase's original
+    # in-memory flow_of_funds is not persisted, so when the funds live in the seller's
+    # own Stripe account we re-fetch the charge (and its balance transactions) from
+    # Stripe to recover the real settlement currency and amounts. When Gumroad itself
+    # holds the funds, settlement is always in USD, so a simple USD flow matches what
+    # the normal purchase flow builds and no processor call is needed.
+    def flow_of_funds_for(purchase)
+      if purchase.merchant_account.holder_of_funds == HolderOfFunds::GUMROAD
+        return FlowOfFunds.build_simple_flow_of_funds(Currency::USD, purchase.total_transaction_cents)
+      end
+
+      processor_charge = ChargeProcessor.get_charge(
+        purchase.charge_processor_id,
+        purchase.stripe_transaction_id,
+        merchant_account: purchase.merchant_account,
+      )
+      flow_of_funds = processor_charge.flow_of_funds
+      raise "Could not rebuild flow of funds for purchase #{purchase.id} (charge #{purchase.stripe_transaction_id})" if flow_of_funds.nil?
+
+      # A purchase paid as part of a multi-product charge only owns a slice of the
+      # charge's money; split the combined flow the same way charge processing does.
+      purchase.is_part_of_combined_charge? ? purchase.build_flow_of_funds_from_combined_charge(flow_of_funds) : flow_of_funds
     end
 
     def credit_summary(p)

--- a/app/services/onetime/backfill_self_affiliate_dropped_proceeds.rb
+++ b/app/services/onetime/backfill_self_affiliate_dropped_proceeds.rb
@@ -253,6 +253,8 @@ class Onetime::BackfillSelfAffiliateDroppedProceeds
         purchase.stripe_transaction_id,
         merchant_account: purchase.merchant_account,
       )
+      raise "Could not fetch processor charge for purchase #{purchase.id} (charge #{purchase.stripe_transaction_id})" if processor_charge.nil?
+
       flow_of_funds = processor_charge.flow_of_funds
       raise "Could not rebuild flow of funds for purchase #{purchase.id} (charge #{purchase.stripe_transaction_id})" if flow_of_funds.nil?
 

--- a/app/services/onetime/correct_self_affiliate_backfill_holding_currency.rb
+++ b/app/services/onetime/correct_self_affiliate_backfill_holding_currency.rb
@@ -1,0 +1,192 @@
+# frozen_string_literal: true
+
+# Repairs the balances stranded by the June 3 2026 run of
+# Onetime::BackfillSelfAffiliateDroppedProceeds (see gumroad-private#1000).
+#
+# That run copied the holding currency from each purchase's affiliate-leg balance
+# transaction, which is always USD, onto the seller-leg transaction it created. For
+# sellers whose Stripe account settles in another currency (GBP, EUR, CAD, ...) this
+# produced Balance rows labeled as holding USD on a non-USD account. Payout runs refuse
+# to touch a balance whose holding currency does not match the account it would be paid
+# from, so the money has sat in "unpaid" ever since. Nothing was ever over- or under-paid
+# — the mislabeled balances were consistently excluded — so the repair is purely to
+# relabel them with their true settlement currency and amounts, after which they become
+# eligible for the next scheduled payout.
+#
+# For each affected balance this service:
+#   1. Re-fetches the charge from the processor to recover the real settlement currency
+#      and amounts (the same way the fixed backfill now books them; network calls happen
+#      before any row locks are taken).
+#   2. Corrects the holding fields on each mislabeled balance transaction in place.
+#      Balance transactions are normally immutable, and the usual way to change one is
+#      to soft-delete it and write a corrected copy — but this table has no deleted_at
+#      column, so that flow cannot work here. Writing the columns directly (bypassing
+#      the immutability guard) is deliberate: the rows' holding fields were wrong from
+#      the moment they were written, and the original values are preserved in the run's
+#      log output and on the tracking issue.
+#   3. Updates the balance itself: holding currency becomes the merchant account's
+#      currency and the held amount becomes the sum of the corrected settlement amounts.
+#      The USD-issued amount (what the seller earned, and what payout math is based on)
+#      is untouched.
+#
+# Usage (dry run by default; balance ids must be passed explicitly — this service
+# deliberately has no "find everything that looks wrong" mode, the affected set was
+# enumerated and reviewed on the issue):
+#
+#   Onetime::CorrectSelfAffiliateBackfillHoldingCurrency.new(balance_ids: [...]).process
+#   Onetime::CorrectSelfAffiliateBackfillHoldingCurrency.new(balance_ids: [...], dry_run: false).process
+#
+class Onetime::CorrectSelfAffiliateBackfillHoldingCurrency
+  include Onetime::RebuildsSellerSettlementAmounts
+
+  # The five-minute window in which the June 3 backfill wrote its balance transactions.
+  # Used as a guard so this service refuses to touch transactions from any other source.
+  BACKFILL_WINDOW = Time.utc(2026, 6, 3, 12, 0)..Time.utc(2026, 6, 3, 12, 20)
+
+  attr_reader :stats, :corrected, :skipped
+
+  def initialize(balance_ids:, dry_run: true, logger: Rails.logger)
+    @balance_ids = balance_ids
+    @dry_run = dry_run
+    @logger = logger
+    @stats = Hash.new(0)
+    @corrected = []
+    @skipped = []
+  end
+
+  def process
+    log "Starting #{self.class.name} (#{@dry_run ? 'DRY RUN' : 'LIVE'}) for #{@balance_ids.size} balances"
+
+    @balance_ids.each do |balance_id|
+      ReplicaLagWatcher.watch unless @dry_run
+      process_one(balance_id)
+    end
+
+    print_summary
+    { stats: @stats, corrected: @corrected, skipped: @skipped }
+  end
+
+  private
+    def process_one(balance_id)
+      @stats[:scanned] += 1
+
+      balance = Balance.find_by(id: balance_id)
+      reason = check_eligibility(balance)
+      if reason != :eligible
+        skip(balance_id, reason)
+        return
+      end
+
+      # Recover the real settlement amounts for every transaction on this balance
+      # BEFORE opening the database transaction — these are network calls to the charge
+      # processor and must not run while we hold row locks. Eligibility is re-checked
+      # under lock below in case anything changed in between.
+      expected_currency = balance.merchant_account.currency
+      corrections = balance.balance_transactions.map do |bt|
+        holding = seller_holding_amount(bt.purchase)
+        if holding.currency.to_s.downcase != expected_currency.to_s.downcase
+          raise "Rebuilt settlement currency #{holding.currency.inspect} for purchase #{bt.purchase_id} " \
+                "does not match merchant account currency #{expected_currency.inspect} — refusing to relabel"
+        end
+        [bt, holding]
+      end
+
+      if @dry_run
+        @stats[:corrected] += 1
+        @corrected << correction_summary(balance, corrections)
+        return
+      end
+
+      ApplicationRecord.transaction do
+        balance = Balance.lock.find(balance_id)
+        reason = check_eligibility(balance)
+        if reason != :eligible
+          skip(balance_id, reason)
+          raise ActiveRecord::Rollback
+        end
+
+        corrections.each do |bt, holding|
+          # Log the wrong values before overwriting them — with no deleted_at column on
+          # this table there is no soft-deleted original to fall back on, so this log
+          # line (plus the tracking issue) is the audit trail.
+          log "correcting BT #{bt.id} (balance #{balance.id}, purchase #{bt.purchase_id}): " \
+              "holding #{bt.holding_amount_currency} gross=#{bt.holding_amount_gross_cents} net=#{bt.holding_amount_net_cents} " \
+              "-> #{holding.currency} gross=#{holding.gross_cents} net=#{holding.net_cents}"
+          # update_columns skips the Immutable guard on purpose; see the class comment.
+          bt.update_columns(
+            holding_amount_currency: holding.currency,
+            holding_amount_gross_cents: holding.gross_cents,
+            holding_amount_net_cents: holding.net_cents,
+            updated_at: Time.current,
+          )
+        end
+
+        balance.holding_currency = expected_currency
+        balance.holding_amount_cents = corrections.sum { |_, holding| holding.net_cents }
+        balance.save!
+
+        @stats[:corrected] += 1
+        @corrected << correction_summary(balance, corrections)
+      end
+    rescue => e
+      @stats[:error] += 1
+      @skipped << { balance_id:, reason: :error, error: "#{e.class}: #{e.message}" }
+      log "ERROR on balance #{balance_id}: #{e.class}: #{e.message}"
+    end
+
+    def check_eligibility(balance)
+      return :not_found if balance.nil?
+      # Already-corrected balances land here, which makes re-runs after a partial
+      # failure safe: fixed rows are skipped, not double-corrected.
+      return :holding_currency_matches_account if balance.holding_currency.to_s.downcase == balance.merchant_account.currency.to_s.downcase
+      return :not_usd_labeled unless balance.holding_currency.to_s.downcase == Currency::USD
+      # Amounts on a balance are only changeable while it is unpaid. Anything else means
+      # a payout has picked it up since the affected set was enumerated — investigate
+      # rather than touch.
+      return :not_unpaid unless balance.unpaid?
+
+      bts = balance.balance_transactions.to_a
+      return :no_balance_transactions if bts.empty?
+
+      bts.each do |bt|
+        # Only purchase-linked seller-leg rows written inside the backfill's own window
+        # may be relabeled. A transaction from any other source sharing the balance means
+        # the enumeration missed something — leave the whole balance alone and flag it.
+        return :bt_not_purchase_linked if bt.purchase_id.nil?
+        return :bt_outside_backfill_window unless BACKFILL_WINDOW.cover?(bt.created_at)
+        return :bt_wrong_user unless bt.user_id == bt.purchase&.seller_id
+        return :bt_not_usd_labeled unless bt.holding_amount_currency.to_s.downcase == Currency::USD
+      end
+
+      :eligible
+    end
+
+    def skip(balance_id, reason)
+      @stats[reason] += 1
+      @skipped << { balance_id:, reason: }
+    end
+
+    def correction_summary(balance, corrections)
+      {
+        balance_id: balance.id,
+        user_id: balance.user_id,
+        holding_currency: balance.merchant_account.currency,
+        amount_cents: balance.amount_cents,
+        corrected_holding_amount_cents: corrections.sum { |_, holding| holding.net_cents },
+        balance_transaction_ids: corrections.map { |bt, _| bt.id },
+      }
+    end
+
+    def print_summary
+      log "=" * 80
+      log "#{self.class.name}: #{@dry_run ? 'DRY RUN' : 'LIVE'}"
+      log "=" * 80
+      @stats.sort_by { |k, _| k.to_s }.each { |k, v| log "  #{k}: #{v}" }
+      log "  sellers_affected: #{@corrected.map { |c| c[:user_id] }.uniq.size}"
+      @skipped.each { |s| log "  skipped: #{s.inspect}" }
+    end
+
+    def log(msg)
+      @logger.info("[holding-currency correction] #{msg}")
+    end
+end

--- a/app/services/onetime/correct_self_affiliate_backfill_holding_currency.rb
+++ b/app/services/onetime/correct_self_affiliate_backfill_holding_currency.rb
@@ -39,7 +39,7 @@
 class Onetime::CorrectSelfAffiliateBackfillHoldingCurrency
   include Onetime::RebuildsSellerSettlementAmounts
 
-  # The five-minute window in which the June 3 backfill wrote its balance transactions.
+  # The 20-minute window in which the June 3 backfill wrote its balance transactions.
   # Used as a guard so this service refuses to touch transactions from any other source.
   BACKFILL_WINDOW = Time.utc(2026, 6, 3, 12, 0)..Time.utc(2026, 6, 3, 12, 20)
 

--- a/app/services/onetime/rebuilds_seller_settlement_amounts.rb
+++ b/app/services/onetime/rebuilds_seller_settlement_amounts.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+# Shared by the self-affiliate backfill (and its data-correction service) to rebuild the
+# seller-leg holding amount for an already-settled charge.
+#
+# Why this exists: a purchase's flow of funds is only held in memory while the charge is
+# being processed — it is never persisted. When we need to book (or re-book) a seller-leg
+# balance transaction long after the charge settled, the real settlement currency and
+# amounts have to be recovered from the charge processor. When Gumroad itself holds the
+# funds, settlement is always in USD, so a simple USD flow matches what the normal
+# purchase flow builds and no processor call is needed.
+module Onetime::RebuildsSellerSettlementAmounts
+  private
+    # Builds the seller-leg holding amount from the charge processor's settlement data,
+    # the same way the normal purchase flow does.
+    #
+    # We can NOT copy the holding currency from the purchase's existing balance
+    # transaction: for a self-affiliate sale the only existing transaction is the
+    # affiliate leg, and affiliate holding amounts are always denominated in Gumroad's
+    # own currency (USD). A seller-leg holding amount must instead be in the currency of
+    # the merchant account the funds actually settled into (GBP, CAD, ...). Copying the
+    # affiliate leg's currency wrote "usd" holding amounts onto non-USD merchant
+    # accounts, and payout runs exclude balances whose holding currency does not match
+    # the account — leaving that money permanently stranded as "unpaid".
+    def seller_holding_amount(purchase)
+      missing_net_cents = purchase.payment_cents.to_i - purchase.affiliate_credit_cents.to_i
+
+      BalanceTransaction::Amount.create_holding_amount_for_seller(
+        flow_of_funds: flow_of_funds_for(purchase),
+        issued_net_cents: missing_net_cents,
+        # For buyer-currency (presentment) charges the processor-issued amount is in the
+        # buyer's currency; this substitutes the canonical USD amount, exactly like the
+        # normal purchase flow does. The method is private on Purchase because only
+        # balance-booking code should use it — which is what this is.
+        canonical_issued_amount: purchase.send(:presentment_canonical_issued_amount),
+      )
+    end
+
+    # Rebuilds the flow of funds for an already-settled charge, re-fetching the charge
+    # (and its balance transactions) from the processor when the funds live in the
+    # seller's own Stripe account.
+    def flow_of_funds_for(purchase)
+      if purchase.merchant_account.holder_of_funds == HolderOfFunds::GUMROAD
+        return FlowOfFunds.build_simple_flow_of_funds(Currency::USD, purchase.total_transaction_cents)
+      end
+
+      processor_charge = ChargeProcessor.get_charge(
+        purchase.charge_processor_id,
+        purchase.stripe_transaction_id,
+        merchant_account: purchase.merchant_account,
+      )
+      raise "Could not fetch processor charge for purchase #{purchase.id} (charge #{purchase.stripe_transaction_id})" if processor_charge.nil?
+
+      flow_of_funds = processor_charge.flow_of_funds
+      raise "Could not rebuild flow of funds for purchase #{purchase.id} (charge #{purchase.stripe_transaction_id})" if flow_of_funds.nil?
+
+      # A purchase paid as part of a multi-product charge only owns a slice of the
+      # charge's money; split the combined flow the same way charge processing does.
+      purchase.is_part_of_combined_charge? ? purchase.build_flow_of_funds_from_combined_charge(flow_of_funds) : flow_of_funds
+    end
+end

--- a/spec/services/onetime/backfill_self_affiliate_dropped_proceeds_spec.rb
+++ b/spec/services/onetime/backfill_self_affiliate_dropped_proceeds_spec.rb
@@ -408,6 +408,17 @@ describe Onetime::BackfillSelfAffiliateDroppedProceeds do
       expect(purchase.balance_transactions.count).to eq(1)
     end
 
+    it "raises (and records an error, creating no BT) when the processor charge cannot be fetched" do
+      purchase = build_gbp_purchase
+
+      allow(ChargeProcessor).to receive(:get_charge).and_return(nil)
+
+      result = described_class.new(dry_run: false, purchase_ids: [purchase.id], verbose: true).process
+      expect(result[:stats][:error]).to eq(1)
+      expect(result[:skipped][:error].first[:error]).to include("Could not fetch processor charge")
+      expect(purchase.balance_transactions.count).to eq(1)
+    end
+
     it "does not call the charge processor when Gumroad holds the funds" do
       build_affected_purchase
       expect(ChargeProcessor).not_to receive(:get_charge)

--- a/spec/services/onetime/backfill_self_affiliate_dropped_proceeds_spec.rb
+++ b/spec/services/onetime/backfill_self_affiliate_dropped_proceeds_spec.rb
@@ -345,6 +345,78 @@ describe Onetime::BackfillSelfAffiliateDroppedProceeds do
     end
   end
 
+  describe "holding currency for sellers paid through their own Stripe account" do
+    # Sellers outside the US settle into a Stripe account denominated in their local
+    # currency (GBP, CAD, ...). The seller-leg holding amount must be in that currency
+    # or payout runs will exclude the resulting balance forever. The affiliate-leg BT
+    # is always USD, so the service must NOT copy its holding currency — it has to
+    # rebuild the settlement amounts from the charge processor.
+    let(:seller_stripe_account) do
+      create(:merchant_account, user: seller, currency: "gbp",
+                                charge_processor_id: StripeChargeProcessor.charge_processor_id)
+    end
+
+    def gbp_flow_of_funds(purchase)
+      FlowOfFunds.new(
+        issued_amount: FlowOfFunds::Amount.new(currency: Currency::USD, cents: purchase.total_transaction_cents),
+        settled_amount: FlowOfFunds::Amount.new(currency: Currency::USD, cents: purchase.total_transaction_cents),
+        gumroad_amount: FlowOfFunds::Amount.new(currency: Currency::USD, cents: purchase.fee_cents),
+        merchant_account_gross_amount: FlowOfFunds::Amount.new(currency: Currency::GBP, cents: 790),
+        merchant_account_net_amount: FlowOfFunds::Amount.new(currency: Currency::GBP, cents: 560),
+      )
+    end
+
+    def build_gbp_purchase
+      purchase = build_affected_purchase
+      purchase.update_columns(merchant_account_id: seller_stripe_account.id)
+      # A seller-owned account that is managed by Gumroad (Stripe custom account),
+      # not a standalone Stripe Connect account.
+      allow_any_instance_of(MerchantAccount).to receive(:is_managed_by_gumroad?).and_return(false)
+      allow_any_instance_of(MerchantAccount).to receive(:is_a_stripe_connect_account?).and_return(false)
+      purchase.reload
+    end
+
+    it "books the holding amount in the merchant account's settlement currency, not the affiliate leg's USD" do
+      purchase = build_gbp_purchase
+
+      expect(ChargeProcessor).to receive(:get_charge)
+        .with(StripeChargeProcessor.charge_processor_id, purchase.stripe_transaction_id, merchant_account: purchase.merchant_account)
+        .and_return(double(flow_of_funds: gbp_flow_of_funds(purchase)))
+
+      result = described_class.new(dry_run: false, purchase_ids: [purchase.id]).process
+      expect(result[:stats][:credited]).to eq(1)
+
+      seller_leg = purchase.balance_transactions.order(:id).last
+      expect(seller_leg.issued_amount_currency).to eq(Currency::USD)
+      expect(seller_leg.holding_amount_currency).to eq(Currency::GBP)
+      expect(seller_leg.holding_amount_gross_cents).to eq(790)
+      expect(seller_leg.holding_amount_net_cents).to eq(560)
+
+      balance = Balance.find(seller_leg.balance_id)
+      expect(balance.holding_currency).to eq(Currency::GBP)
+      expect(balance.currency).to eq(Currency::USD)
+    end
+
+    it "raises (and records an error, creating no BT) when the processor charge has no flow of funds" do
+      purchase = build_gbp_purchase
+
+      allow(ChargeProcessor).to receive(:get_charge).and_return(double(flow_of_funds: nil))
+
+      result = described_class.new(dry_run: false, purchase_ids: [purchase.id], verbose: true).process
+      expect(result[:stats][:error]).to eq(1)
+      expect(result[:skipped][:error].first[:error]).to include("Could not rebuild flow of funds")
+      expect(purchase.balance_transactions.count).to eq(1)
+    end
+
+    it "does not call the charge processor when Gumroad holds the funds" do
+      build_affected_purchase
+      expect(ChargeProcessor).not_to receive(:get_charge)
+
+      result = described_class.new(dry_run: false).process
+      expect(result[:stats][:credited]).to eq(1)
+    end
+  end
+
   describe "purchase variations preserved by the bug" do
     it "credits subscription / recurring purchases the same way" do
       subscription = create(:subscription, link: product, user: seller)

--- a/spec/services/onetime/backfill_self_affiliate_dropped_proceeds_spec.rb
+++ b/spec/services/onetime/backfill_self_affiliate_dropped_proceeds_spec.rb
@@ -369,10 +369,10 @@ describe Onetime::BackfillSelfAffiliateDroppedProceeds do
     def build_gbp_purchase
       purchase = build_affected_purchase
       purchase.update_columns(merchant_account_id: seller_stripe_account.id)
-      # A seller-owned account that is managed by Gumroad (Stripe custom account),
-      # not a standalone Stripe Connect account.
-      allow_any_instance_of(MerchantAccount).to receive(:is_managed_by_gumroad?).and_return(false)
-      allow_any_instance_of(MerchantAccount).to receive(:is_a_stripe_connect_account?).and_return(false)
+      # No stubs needed: a merchant account created with a user is seller-owned
+      # (is_managed_by_gumroad? is false), and without the stripe_connect metadata flag
+      # it is a Stripe custom account, not a standalone Connect account — exactly the
+      # population affected in production.
       purchase.reload
     end
 

--- a/spec/services/onetime/correct_self_affiliate_backfill_holding_currency_spec.rb
+++ b/spec/services/onetime/correct_self_affiliate_backfill_holding_currency_spec.rb
@@ -1,0 +1,238 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Onetime::CorrectSelfAffiliateBackfillHoldingCurrency do
+  let(:seller) { create(:user) }
+  let(:product) { create(:product, user: seller, price_cents: 1000) }
+  let(:seller_stripe_account) do
+    create(:merchant_account, user: seller, currency: "gbp",
+                              charge_processor_id: StripeChargeProcessor.charge_processor_id)
+  end
+  let(:backfill_written_at) { Time.utc(2026, 6, 3, 12, 10) }
+  let(:purchase_time) { Time.utc(2026, 5, 10) }
+
+  before do
+    # A seller-owned account that is managed by Gumroad (Stripe custom account),
+    # not a standalone Stripe Connect account.
+    allow_any_instance_of(MerchantAccount).to receive(:is_managed_by_gumroad?).and_return(false)
+    allow_any_instance_of(MerchantAccount).to receive(:is_a_stripe_connect_account?).and_return(false)
+  end
+
+  # Recreates what the June 3 backfill wrote: a seller-leg balance transaction whose
+  # holding amount copied the affiliate leg's USD currency onto a non-USD merchant
+  # account, producing a USD-labeled Balance that payout runs exclude.
+  def create_stranded_balance(net_cents: 712, stripe_transaction_id: "ch_stranded_1")
+    purchase = create(:purchase,
+                      seller:,
+                      link: product,
+                      price_cents: 1000,
+                      total_transaction_cents: 1000,
+                      created_at: purchase_time,
+                      succeeded_at: purchase_time)
+    # Each purchase needs its own charge id: the processor-charge stubs match on it, and
+    # the factory would otherwise give every purchase the same one.
+    purchase.update_columns(merchant_account_id: seller_stripe_account.id, stripe_transaction_id:)
+
+    bt = travel_to(backfill_written_at) do
+      BalanceTransaction.create!(
+        user: seller,
+        merchant_account: seller_stripe_account,
+        purchase: purchase.reload,
+        issued_amount: BalanceTransaction::Amount.new(
+          currency: Currency::USD, gross_cents: 1000, net_cents:,
+        ),
+        holding_amount: BalanceTransaction::Amount.new(
+          currency: Currency::USD, gross_cents: 1000, net_cents:,
+        ),
+        update_user_balance: true,
+      )
+    end
+
+    [Balance.find(bt.balance_id), bt, purchase]
+  end
+
+  def gbp_flow_of_funds(purchase, gross_cents: 790, net_cents: 560)
+    FlowOfFunds.new(
+      issued_amount: FlowOfFunds::Amount.new(currency: Currency::USD, cents: purchase.total_transaction_cents),
+      settled_amount: FlowOfFunds::Amount.new(currency: Currency::USD, cents: purchase.total_transaction_cents),
+      gumroad_amount: FlowOfFunds::Amount.new(currency: Currency::USD, cents: purchase.fee_cents),
+      merchant_account_gross_amount: FlowOfFunds::Amount.new(currency: Currency::GBP, cents: gross_cents),
+      merchant_account_net_amount: FlowOfFunds::Amount.new(currency: Currency::GBP, cents: net_cents),
+    )
+  end
+
+  def stub_processor_charge(purchase, flow_of_funds)
+    allow(ChargeProcessor).to receive(:get_charge)
+      .with(StripeChargeProcessor.charge_processor_id, purchase.stripe_transaction_id, merchant_account: purchase.merchant_account)
+      .and_return(double(flow_of_funds:))
+  end
+
+  describe "dry run (default)" do
+    it "reports the correction without changing anything" do
+      balance, bt, purchase = create_stranded_balance
+      stub_processor_charge(purchase, gbp_flow_of_funds(purchase))
+
+      result = nil
+      expect do
+        result = described_class.new(balance_ids: [balance.id]).process
+      end.to not_change { balance.reload.holding_currency }
+        .and not_change { BalanceTransaction.count }
+
+      expect(result[:stats][:corrected]).to eq(1)
+      summary = result[:corrected].first
+      expect(summary[:balance_id]).to eq(balance.id)
+      expect(summary[:holding_currency]).to eq("gbp")
+      expect(summary[:corrected_holding_amount_cents]).to eq(560)
+      expect(summary[:balance_transaction_ids]).to eq([bt.id])
+    end
+  end
+
+  describe "live run" do
+    it "relabels the balance with the merchant account's settlement currency and amounts" do
+      balance, bt, purchase = create_stranded_balance
+      stub_processor_charge(purchase, gbp_flow_of_funds(purchase))
+
+      result = described_class.new(balance_ids: [balance.id], dry_run: false).process
+      expect(result[:stats][:corrected]).to eq(1)
+
+      balance.reload
+      expect(balance.holding_currency).to eq(Currency::GBP)
+      expect(balance.holding_amount_cents).to eq(560)
+      expect(balance.currency).to eq(Currency::USD)
+      # The USD-issued amount payout math depends on is untouched.
+      expect(balance.amount_cents).to eq(712)
+      expect(balance.state).to eq("unpaid")
+
+      # The transaction is corrected in place: holding fields carry the real settlement
+      # values while the USD-issued side is untouched.
+      bt.reload
+      expect(bt.holding_amount_currency).to eq(Currency::GBP)
+      expect(bt.holding_amount_gross_cents).to eq(790)
+      expect(bt.holding_amount_net_cents).to eq(560)
+      expect(bt.issued_amount_currency).to eq(Currency::USD)
+      expect(bt.purchase_id).to eq(purchase.id)
+
+      # The corrected balance now passes the payout eligibility check that excluded it.
+      expect(StripePayoutProcessor.is_balance_payable(balance)).to eq(true)
+    end
+
+    it "sums corrected settlement amounts when a balance has several backfilled transactions" do
+      balance, _bt, purchase = create_stranded_balance
+      second_purchase = create(:purchase,
+                               seller:,
+                               link: product,
+                               price_cents: 1000,
+                               total_transaction_cents: 1000,
+                               created_at: purchase_time,
+                               succeeded_at: purchase_time)
+      second_purchase.update_columns(merchant_account_id: seller_stripe_account.id, stripe_transaction_id: "ch_stranded_2")
+      travel_to(backfill_written_at) do
+        BalanceTransaction.create!(
+          user: seller,
+          merchant_account: seller_stripe_account,
+          purchase: second_purchase.reload,
+          issued_amount: BalanceTransaction::Amount.new(currency: Currency::USD, gross_cents: 1000, net_cents: 500),
+          holding_amount: BalanceTransaction::Amount.new(currency: Currency::USD, gross_cents: 1000, net_cents: 500),
+          update_user_balance: true,
+        )
+      end
+
+      stub_processor_charge(purchase, gbp_flow_of_funds(purchase, gross_cents: 790, net_cents: 560))
+      stub_processor_charge(second_purchase, gbp_flow_of_funds(second_purchase, gross_cents: 400, net_cents: 395))
+
+      result = described_class.new(balance_ids: [balance.id], dry_run: false).process
+      expect(result[:stats][:corrected]).to eq(1)
+
+      balance.reload
+      expect(balance.holding_currency).to eq(Currency::GBP)
+      expect(balance.holding_amount_cents).to eq(560 + 395)
+    end
+
+    it "raises and leaves the balance untouched when the rebuilt settlement currency does not match the merchant account" do
+      balance, _bt, purchase = create_stranded_balance
+      wrong_flow = gbp_flow_of_funds(purchase)
+      wrong_flow.merchant_account_gross_amount.currency = Currency::EUR
+      wrong_flow.merchant_account_net_amount.currency = Currency::EUR
+      stub_processor_charge(purchase, wrong_flow)
+
+      result = described_class.new(balance_ids: [balance.id], dry_run: false).process
+      expect(result[:stats][:error]).to eq(1)
+      expect(result[:skipped].first[:error]).to include("does not match merchant account currency")
+      expect(balance.reload.holding_currency).to eq(Currency::USD)
+    end
+
+    it "records an error and moves on when the processor charge cannot be fetched" do
+      balance, _bt, _purchase = create_stranded_balance
+      allow(ChargeProcessor).to receive(:get_charge).and_return(nil)
+
+      result = described_class.new(balance_ids: [balance.id], dry_run: false).process
+      expect(result[:stats][:error]).to eq(1)
+      expect(result[:skipped].first[:error]).to include("Could not fetch processor charge")
+      expect(balance.reload.holding_currency).to eq(Currency::USD)
+    end
+  end
+
+  describe "eligibility guards" do
+    it "skips balances whose holding currency already matches the account (safe re-runs)" do
+      balance, _bt, purchase = create_stranded_balance
+      stub_processor_charge(purchase, gbp_flow_of_funds(purchase))
+      described_class.new(balance_ids: [balance.id], dry_run: false).process
+
+      result = described_class.new(balance_ids: [balance.id], dry_run: false).process
+      expect(result[:stats][:holding_currency_matches_account]).to eq(1)
+      expect(result[:stats][:corrected]).to eq(0)
+    end
+
+    it "skips balances that are no longer unpaid" do
+      balance, _bt, _purchase = create_stranded_balance
+      balance.mark_processing!
+
+      result = described_class.new(balance_ids: [balance.id], dry_run: false).process
+      expect(result[:stats][:not_unpaid]).to eq(1)
+      expect(balance.reload.holding_currency).to eq(Currency::USD)
+    end
+
+    it "skips balances carrying a transaction written outside the backfill window" do
+      balance, _bt, purchase = create_stranded_balance
+      BalanceTransaction.create!(
+        user: seller,
+        merchant_account: seller_stripe_account,
+        purchase:,
+        issued_amount: BalanceTransaction::Amount.new(currency: Currency::USD, gross_cents: 100, net_cents: 100),
+        holding_amount: BalanceTransaction::Amount.new(currency: Currency::USD, gross_cents: 100, net_cents: 100),
+        update_user_balance: true,
+      )
+
+      result = described_class.new(balance_ids: [balance.id], dry_run: false).process
+      expect(result[:stats][:bt_outside_backfill_window]).to eq(1)
+      expect(balance.reload.holding_currency).to eq(Currency::USD)
+    end
+
+    it "skips balances carrying a transaction that is not purchase-linked" do
+      balance, _bt, _purchase = create_stranded_balance
+      credit = Credit.create!(user: seller, merchant_account: seller_stripe_account, amount_cents: 100, crediting_user: create(:user))
+      travel_to(backfill_written_at) do
+        bt = BalanceTransaction.new(
+          user: seller,
+          merchant_account: seller_stripe_account,
+          credit:,
+          issued_amount_currency: Currency::USD, issued_amount_gross_cents: 100, issued_amount_net_cents: 100,
+          holding_amount_currency: Currency::USD, holding_amount_gross_cents: 100, holding_amount_net_cents: 100,
+        )
+        bt.save!
+        bt.balance = balance
+        bt.save!
+      end
+
+      result = described_class.new(balance_ids: [balance.id], dry_run: false).process
+      expect(result[:stats][:bt_not_purchase_linked]).to eq(1)
+      expect(balance.reload.holding_currency).to eq(Currency::USD)
+    end
+
+    it "skips unknown balance ids" do
+      result = described_class.new(balance_ids: [0], dry_run: false).process
+      expect(result[:stats][:not_found]).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
Adds the ledger-correction service for [gumroad-private#1000](https://github.com/antiwork/gumroad-private/issues/1000): the June 3 run of `Onetime::BackfillSelfAffiliateDroppedProceeds` labeled **391 seller balances across 98 non-USD merchant accounts** as holding USD, so every payout run since has excluded them — **$4,976.44 net is stranded in `unpaid`** (full per-seller worklist is on the issue).

Stacked on #5777, which fixes the backfill going forward. This PR repairs the damage the June 3 run already did.

## What it does

`Onetime::CorrectSelfAffiliateBackfillHoldingCurrency` takes an **explicit list of balance ids** (no "find everything that looks wrong" mode — the affected set was enumerated live and reviewed on the issue) and for each:

1. Re-fetches the charge from the processor to recover the real settlement currency and amounts — the same path the fixed backfill (#5777) now books them through. Network calls happen before any row locks.
2. Corrects the holding fields on each mislabeled balance transaction in place, logging the old values first. (The table has no `deleted_at` column, so the usual dup-and-soft-delete flow for immutable records isn't available; the write deliberately bypasses the immutability guard and the audit trail is the run log + the issue.)
3. Relabels the balance: `holding_currency` becomes the merchant account's currency, `holding_amount_cents` becomes the sum of the corrected settlement amounts. The USD-issued amount that payout math is based on is untouched. The balance then passes `StripePayoutProcessor.is_balance_payable` and rides the next scheduled payout.

## Safety

- **Dry run by default**; live mode requires `dry_run: false`.
- Refuses to touch a balance unless it is `unpaid`, USD-mislabeled on a non-USD account, and *every* transaction on it is purchase-linked, seller-side, USD-labeled, and written inside the backfill's own Jun 3 12:00–12:20 UTC window. Anything else is skipped and reported, not corrected.
- Raises (and skips the balance) if the rebuilt settlement currency doesn't match the merchant account — no relabeling on guesswork.
- **Idempotent**: already-corrected balances skip with `holding_currency_matches_account`, so re-running after a partial failure is safe.
- No payout-history risk: the sweep on the issue verified none of the mislabeled money ever entered a payout — the mismatch consistently excluded these balances, so this is pure relabeling, no clawback or double-pay exposure.

Also extracts the settlement-rebuild logic from #5777 into a shared `Onetime::RebuildsSellerSettlementAmounts` module so the backfill fix and this correction stay on one code path.

## Tests

`bin/rspec spec/services/onetime/` — 54 examples, 0 failures (10 new; the 44 existing backfill specs still pass with the module extraction). Rubocop clean.

## Execution plan (after merge)

1. Dry run against the 391 balance ids from the issue; confirm all report `corrected` in the expected currencies/amounts.
2. Live run (human-approved; relabels the $4,976.44 across 98 sellers per the issue worklist).
3. Verify DECODED's 5 balances (and spot-check the largest cases) ride the next scheduled payout, then close #1000.
