### PR TITLE
Normalize 'L-' prefixed Luxembourg postal codes before sending to Stripe

### DIFF
--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -431,6 +431,24 @@ module StripeMerchantAccountManager
     error.is_a?(Stripe::InvalidRequestError) && error.respond_to?(:code) && error.code == "postal_code_invalid"
   end
 
+  # Luxembourg postal codes are four digits, but residents habitually write them with the
+  # conventional "L-" prefix (e.g. "L-9767"). Stripe rejects the prefixed form with
+  # `postal_code_invalid`, and the resulting account-creation failure is invisible to the
+  # seller at save time (creation runs async), so strip the prefix at the Stripe boundary.
+  # Normalizing here (rather than at input time) also repairs already-saved compliance
+  # records when the retry job re-attempts account creation.
+  private_class_method
+  def self.normalize_postal_code(postal_code, country_code)
+    return postal_code if postal_code.blank?
+
+    if country_code == Compliance::Countries::LUX.alpha2
+      normalized = postal_code.to_s.strip[/\AL[-\s]?(\d{4})\z/i, 1]
+      return normalized if normalized.present?
+    end
+
+    postal_code
+  end
+
   private_class_method
   def self.bank_account_invalid_error?(error)
     return true if error.is_a?(Stripe::CardError)
@@ -716,7 +734,7 @@ module StripeMerchantAccountManager
                              line2: nil,
                              city: user_compliance_info.city,
                              state: user_compliance_info.state,
-                             postal_code: user_compliance_info.zip_code,
+                             postal_code: normalize_postal_code(user_compliance_info.zip_code, country_code),
                              country: country_code
                            },
                          })
@@ -763,7 +781,7 @@ module StripeMerchantAccountManager
           line2: nil,
           city: user_compliance_info.legal_entity_city,
           state: user_compliance_info.legal_entity_state,
-          postal_code: user_compliance_info.legal_entity_zip_code,
+          postal_code: normalize_postal_code(user_compliance_info.legal_entity_zip_code, user_compliance_info.legal_entity_country_code),
           country: user_compliance_info.legal_entity_country_code
         },
         tax_id: business_tax_id.presence,

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -591,6 +591,57 @@ describe StripeMerchantAccountManager, :vcr do
       end
     end
 
+    describe "Luxembourg postal codes written with the conventional 'L-' prefix" do
+      # Regression coverage for gumroad-private#1014: LU residents habitually write postal
+      # codes as "L-9767". Stripe only accepts the bare four digits and rejects the prefixed
+      # form with `postal_code_invalid`, which (because account creation runs async) left the
+      # seller silently unable to publish. Normalize at the Stripe boundary so both fresh
+      # saves and retry-job re-attempts of already-saved records succeed.
+      let(:user_compliance_info) do
+        create(:user_compliance_info,
+               user:,
+               street_address: "2 Rue du Château",
+               city: "Ettelbruck",
+               state: nil,
+               zip_code: "L-9767",
+               country: "Luxembourg")
+      end
+
+      it "strips the 'L-' prefix from the individual address postal code" do
+        person_hash = described_class.send(:person_hash, user_compliance_info, GlobalConfig.get("STRONGBOX_GENERAL_PASSWORD"))
+        expect(person_hash[:address]).to include(country: "LU", postal_code: "9767")
+      end
+
+      it "strips the prefix from the legal-entity address on business accounts" do
+        business_info = create(:user_compliance_info_business,
+                               user:,
+                               business_street_address: "2 Rue du Château",
+                               business_city: "Ettelbruck",
+                               business_state: nil,
+                               business_zip_code: "l 9767",
+                               business_country: "Luxembourg")
+        company_hash = described_class.send(:company_hash, business_info, GlobalConfig.get("STRONGBOX_GENERAL_PASSWORD"))
+        expect(company_hash[:company][:address]).to include(country: "LU", postal_code: "9767")
+      end
+
+      describe ".normalize_postal_code" do
+        it "normalizes prefixed LU postal codes and leaves everything else untouched" do
+          expect(described_class.send(:normalize_postal_code, "L-9767", "LU")).to eq("9767")
+          expect(described_class.send(:normalize_postal_code, "l-9767", "LU")).to eq("9767")
+          expect(described_class.send(:normalize_postal_code, "L 9767", "LU")).to eq("9767")
+          expect(described_class.send(:normalize_postal_code, " L-9767 ", "LU")).to eq("9767")
+          expect(described_class.send(:normalize_postal_code, "9767", "LU")).to eq("9767")
+          # Not the L-prefix shape: pass through so Stripe can report its own validation error.
+          expect(described_class.send(:normalize_postal_code, "L-97", "LU")).to eq("L-97")
+          expect(described_class.send(:normalize_postal_code, "Lot 5", "LU")).to eq("Lot 5")
+          # Other countries are untouched, even when the value looks prefixed.
+          expect(described_class.send(:normalize_postal_code, "L-1234", "FR")).to eq("L-1234")
+          expect(described_class.send(:normalize_postal_code, "94107", "US")).to eq("94107")
+          expect(described_class.send(:normalize_postal_code, nil, "LU")).to be_nil
+        end
+      end
+    end
+
     describe "Bangladesh business with a rep resident outside Bangladesh (person_hash)" do
       # Reverse direction of the foreign-rep fix: gating nationality on the account country instead
       # of the rep's residential country also means BGD/SGP/PAK/UAE *accounts* keep submitting

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -629,6 +629,7 @@ describe StripeMerchantAccountManager, :vcr do
           expect(described_class.send(:normalize_postal_code, "L-9767", "LU")).to eq("9767")
           expect(described_class.send(:normalize_postal_code, "l-9767", "LU")).to eq("9767")
           expect(described_class.send(:normalize_postal_code, "L 9767", "LU")).to eq("9767")
+          expect(described_class.send(:normalize_postal_code, "L9767", "LU")).to eq("9767")
           expect(described_class.send(:normalize_postal_code, " L-9767 ", "LU")).to eq("9767")
           expect(described_class.send(:normalize_postal_code, "9767", "LU")).to eq("9767")
           # Not the L-prefix shape: pass through so Stripe can report its own validation error.


### PR DESCRIPTION
## What

Normalizes Luxembourg postal codes written with the conventional `L-` prefix (e.g. `L-9767` → `9767`) before sending them to Stripe in `StripeMerchantAccountManager` — applied to the person address, company address, and legal-entity address hashes.

## Why

Root cause: confirmed — LU residents habitually write postal codes as `L-9767`, but Stripe only accepts the bare four digits and rejects the prefixed form with `postal_code_invalid — Invalid LU postal code`. Because merchant-account creation runs asynchronously after the settings save, the seller sees a successful save while account creation fails silently. In the reported case the seller retried 13 times over ~25 minutes (13 dead `MerchantAccount` rows, 13 identical System payout_note comments) and remained blocked from publishing for days.

Fixes antiwork/gumroad-private#1014 (the postal-code-normalization half; the error-surfacing half of that issue is covered by the existing payout-note breadcrumb + retry-job pipeline from #5473/#5515, which this normalization also feeds — the retry job re-runs `create_account` against the already-saved compliance record, so prefixed codes now heal automatically on the next retry with no re-entry needed).

Design notes:

- Normalization happens at the Stripe boundary rather than input time so already-saved compliance records are repaired when `RetryStripeRejectedPayoutSetupForSellerJob` re-attempts creation.
- Only the unambiguous shape `L-`/`L `/`L` + exactly 4 digits (case-insensitive) is rewritten; anything else passes through unchanged so Stripe can report its own validation errors. Other countries are untouched.

## Verification

- `bundle exec rspec spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb -e "Luxembourg postal codes"` — 3 examples, 0 failures (individual address, legal-entity address, and an 11-case normalization table incl. pass-through negatives).
- `rubocop -a` on both files: no offenses.

## Before/After

Not applicable — backend-only change to the Stripe request payload; no UI change.
