### PR TITLE
Fix PPP card-country mismatch showing a generic error instead of the actionable message on client-confirm checkout

### DIFF
--- a/app/javascript/components/Checkout/Receipt.tsx
+++ b/app/javascript/components/Checkout/Receipt.tsx
@@ -321,7 +321,11 @@ export const Receipt = ({
             createAccountData={{
               email: state.email,
               cardParams:
-                state.status.paymentMethod.type === "not-applicable" || state.status.paymentMethod.type === "saved"
+                // Client-confirm methods live in a Stripe ConfirmationToken and carry no
+                // cardParamsResult — reading it crashes the whole receipt view (#5784).
+                state.status.paymentMethod.type === "not-applicable" ||
+                state.status.paymentMethod.type === "saved" ||
+                state.status.paymentMethod.type === "payment-element-client-confirm"
                   ? null
                   : state.status.paymentMethod.cardParamsResult.cardParams,
             }}

--- a/app/javascript/components/Checkout/TemporaryLibrary.tsx
+++ b/app/javascript/components/Checkout/TemporaryLibrary.tsx
@@ -41,8 +41,10 @@ export const TemporaryLibrary = ({ results, canBuyerSignUp }: { results: Result[
                   createAccountData={{
                     email: state.email,
                     cardParams:
+                      // Client-confirm methods carry no cardParamsResult (see Receipt.tsx / #5784).
                       state.status.paymentMethod.type === "not-applicable" ||
-                      state.status.paymentMethod.type === "saved"
+                      state.status.paymentMethod.type === "saved" ||
+                      state.status.paymentMethod.type === "payment-element-client-confirm"
                         ? null
                         : state.status.paymentMethod.cardParamsResult.cardParams,
                   }}

--- a/app/services/order/prepare_payment_intent_service.rb
+++ b/app/services/order/prepare_payment_intent_service.rb
@@ -168,8 +168,13 @@ class Order::PreparePaymentIntentService
 
       purchases_to_charge.each do |purchase|
         purchase.errors.add(:base, GENERIC_CHARGE_ERROR) if purchase.errors.empty?
+        # MarkFailedService saves the purchase, and that save re-runs validations, which clears
+        # `purchase.errors` — so the message must be read before marking failed or the buyer gets
+        # a null error_message (surfaced as a generic "something went wrong") instead of the
+        # actionable validation message (e.g. the PPP card-country explanation, see #5784).
+        error_message = purchase.errors.first&.message
         Purchase::MarkFailedService.new(purchase).perform
-        responses[line_item_uid_for(purchase)] = error_response(purchase.errors.first&.message, purchase:)
+        responses[line_item_uid_for(purchase)] = error_response(error_message, purchase:)
       end
       true
     end
@@ -432,8 +437,10 @@ class Order::PreparePaymentIntentService
       purchases_to_charge.each do |purchase|
         purchase.errors.add(:base, message) if purchase.errors.empty?
         purchase.error_code = PurchaseErrorCode::STRIPE_UNAVAILABLE if purchase.error_code.blank?
+        # Read before MarkFailedService: its save re-runs validations and clears errors (#5784).
+        error_message = purchase.errors.first&.message
         Purchase::MarkFailedService.new(purchase).perform
-        responses[line_item_uid_for(purchase)] = error_response(purchase.errors.first&.message, purchase:)
+        responses[line_item_uid_for(purchase)] = error_response(error_message, purchase:)
       end
     end
 

--- a/spec/services/order/prepare_payment_intent_service_spec.rb
+++ b/spec/services/order/prepare_payment_intent_service_spec.rb
@@ -97,6 +97,9 @@ describe Order::PreparePaymentIntentService, :vcr do
         response = responses["unique-id-0"]
         expect(response[:success]).to eq(false)
         expect(response[:error_code]).to eq(PurchaseErrorCode::PPP_CARD_COUNTRY_NOT_MATCHING)
+        # The buyer must receive the actionable explanation, not a null message that the UI
+        # renders as a generic "something went wrong" (#5784).
+        expect(response[:error_message]).to include("purchasing power parity discount")
         expect(order.charges).to be_empty
         expect(purchase.reload).to be_failed
         expect(ProcessorPaymentIntent.where(purchase:)).to be_empty


### PR DESCRIPTION
Fixes #5784

Buyers hitting the purchasing-power-parity card-country check on the client-confirm checkout saw a bare "Sorry, something went wrong." instead of the actionable explanation. Two stacked bugs:

**1. Server: `error_message` arrived as `null`** — `Order::PreparePaymentIntentService` read `purchase.errors` *after* `Purchase::MarkFailedService` saved the purchase; the save re-runs validations, which clears the errors collection. Fixed by reading the message before marking failed (both `fail_all_purchases_when_any_errored` and `fail_purchases_with`).

**2. Frontend: failed-purchase receipt crashed on this lane** — the receipt's signup form reads `paymentMethod.cardParamsResult.cardParams`, but client-confirm methods carry a ConfirmationToken and have no `cardParamsResult`, so the render threw (`Cannot read properties of undefined (reading 'cardParams')`) and no error UI appeared at all. Guarded in `Receipt.tsx` and `TemporaryLibrary.tsx`.

Strengthened the existing PPP-block spec to assert the response carries the actionable `error_message`, so the server half can't silently regress.

**Manual QA on a preview app** (real Indonesian IP + India-issued test card `4000003560000008`): buyer now sees the full PPP message with correct server-side decision (`card_country="IN"`, `ip_country="Indonesia"`); purchase recorded as failed with `ppp_card_country_not_matching`; cart stays retryable. Buyer-side recording attached in a comment below.
