### PR TITLE
Block duplicate purchases while a confirmed payment is still settling

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -4233,6 +4233,43 @@ class Purchase < ApplicationRecord
       end
 
       add_errors_for_existing_purchase(already)
+      return if errors.present?
+
+      not_double_charged_while_payment_settling(recipient_email)
+    end
+
+    # Blocks a repeat purchase while an earlier attempt's payment is still settling.
+    #
+    # The time-boxed check above assumes payments resolve within minutes, which is true for
+    # cards but not for delayed-notification methods like ACH bank debits: those stay
+    # `in_progress` for several business days while the debit clears, leaving a window where
+    # the same buyer can accidentally pay for the same product twice.
+    #
+    # We only want to block attempts whose payment was actually confirmed and is now settling —
+    # not attempts the buyer started and walked away from. The differentiator is
+    # `stripe_status`: it is only ever written once Stripe acknowledges a real payment
+    # (the checkout return page sets it to "processing", and every subsequent Stripe webhook
+    # updates it), so an abandoned attempt keeps it nil until FailAbandonedPurchaseWorker
+    # fails the purchase ~15 minutes in. That means a buyer who abandoned checkout can always
+    # come back and buy, while a buyer whose bank debit is mid-flight is told to wait.
+    def not_double_charged_while_payment_settling(recipient_email)
+      settling = self.class.in_progress.where(
+        email: recipient_email,
+        link_id: link.id
+      ).where.not(stripe_status: nil)
+
+      settling = settling.where("purchases.id != ?", id) if id
+      settling = settling.not_is_gift_sender_purchase unless is_gift_sender_purchase
+
+      if variant_attributes.present?
+        settling = settling.select do |purchase|
+          purchase.variant_attributes.sort == variant_attributes.sort
+        end
+      end
+
+      if settling.any?
+        errors.add :base, "Your previous payment for this product is still processing. We will email you a receipt as soon as it completes — please do not pay again."
+      end
     end
 
     def cancel_parallel_charge_intents

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -600,6 +600,14 @@ class Purchase < ApplicationRecord
   scope :successful, -> { where(purchase_state: "successful") }
   scope :test_successful, -> { where(purchase_state: "test_successful") }
   scope :in_progress, -> { where(purchase_state: "in_progress") }
+  # A payment the processor has confirmed but that hasn't settled yet — e.g. an ACH bank
+  # debit that takes several business days to clear. Both conditions matter: `stripe_status`
+  # is only ever written once Stripe acknowledges a real payment (the checkout return page
+  # sets it to "processing", and every subsequent Stripe webhook updates it), so an attempt
+  # the buyer abandoned before confirming payment keeps it nil and is NOT settling. And a
+  # purchase must still be in_progress — once it reaches a terminal state (failed,
+  # successful), stripe_status remains set but the payment is no longer in flight.
+  scope :payment_settling, -> { in_progress.where.not(stripe_status: nil) }
   scope :in_progress_or_successful_including_test, -> { where(purchase_state: %w(in_progress successful test_successful)) }
   scope :not_in_progress, -> { where.not(purchase_state: "in_progress") }
   scope :not_successful, -> { without_purchase_state(:successful) }
@@ -4245,18 +4253,15 @@ class Purchase < ApplicationRecord
     # `in_progress` for several business days while the debit clears, leaving a window where
     # the same buyer can accidentally pay for the same product twice.
     #
-    # We only want to block attempts whose payment was actually confirmed and is now settling —
-    # not attempts the buyer started and walked away from. The differentiator is
-    # `stripe_status`: it is only ever written once Stripe acknowledges a real payment
-    # (the checkout return page sets it to "processing", and every subsequent Stripe webhook
-    # updates it), so an abandoned attempt keeps it nil until FailAbandonedPurchaseWorker
-    # fails the purchase ~15 minutes in. That means a buyer who abandoned checkout can always
-    # come back and buy, while a buyer whose bank debit is mid-flight is told to wait.
+    # The `payment_settling` scope only matches attempts whose payment was actually confirmed
+    # and is now clearing — not attempts the buyer started and walked away from (see the scope
+    # definition for how the two are told apart). That means a buyer who abandoned checkout
+    # can always come back and buy, while a buyer whose bank debit is mid-flight is told to wait.
     def not_double_charged_while_payment_settling(recipient_email)
-      settling = self.class.in_progress.where(
+      settling = self.class.payment_settling.where(
         email: recipient_email,
         link_id: link.id
-      ).where.not(stripe_status: nil)
+      )
 
       settling = settling.where("purchases.id != ?", id) if id
       settling = settling.not_is_gift_sender_purchase unless is_gift_sender_purchase

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -4261,6 +4261,12 @@ class Purchase < ApplicationRecord
       settling = settling.where("purchases.id != ?", id) if id
       settling = settling.not_is_gift_sender_purchase unless is_gift_sender_purchase
 
+      # No gift join is needed here, even though gift purchases are stored under the sender's
+      # email rather than the giftee's. The gift lookup in `not_double_charged` above
+      # (`joins(:gift_given).where(gifts: { giftee_email: ... })`) has no created_at window,
+      # so an in_progress gift — including one settling over a bank debit for days — already
+      # blocks repeat gifts to the same giftee until it resolves.
+
       if variant_attributes.present?
         settling = settling.select do |purchase|
           purchase.variant_attributes.sort == variant_attributes.sort

--- a/app/services/purchase/create_service.rb
+++ b/app/services/purchase/create_service.rb
@@ -231,18 +231,17 @@ class Purchase::CreateService < Purchase::BaseService
       # debit) stays "in progress" for several business days before the subscription becomes
       # active. The active-subscription check above can't see it, so without this check the
       # buyer could accidentally start (and pay for) the same membership twice while the
-      # first payment settles. `stripe_status` is only ever set once the payment processor
-      # confirms a real payment, so abandoned checkout attempts (which never get that far)
-      # don't block the buyer from trying again.
+      # first payment settles. The `payment_settling` scope only matches attempts whose
+      # payment the processor actually confirmed, so abandoned checkout attempts don't block
+      # the buyer from trying again.
       #
       # The Purchase-level `not_double_charged` validation already covers repeat attempts
       # from the same checkout email; matching on the buyer account here additionally covers
       # a signed-in buyer retrying with a different email.
       if buyer.present?
-        settling_membership_purchase = Purchase.in_progress
+        settling_membership_purchase = Purchase.payment_settling
           .is_original_subscription_purchase
           .where(link_id: product.id, purchaser_id: buyer.id)
-          .where.not(stripe_status: nil)
 
         if settling_membership_purchase.exists?
           return nil, "Your payment for this membership is still processing. We will email you a receipt as soon as it completes — please do not pay again."

--- a/app/services/purchase/create_service.rb
+++ b/app/services/purchase/create_service.rb
@@ -227,6 +227,28 @@ class Purchase::CreateService < Purchase::BaseService
         return nil, error_message
       end
 
+      # A brand-new membership purchase paid with a slow payment method (like an ACH bank
+      # debit) stays "in progress" for several business days before the subscription becomes
+      # active. The active-subscription check above can't see it, so without this check the
+      # buyer could accidentally start (and pay for) the same membership twice while the
+      # first payment settles. `stripe_status` is only ever set once the payment processor
+      # confirms a real payment, so abandoned checkout attempts (which never get that far)
+      # don't block the buyer from trying again.
+      #
+      # The Purchase-level `not_double_charged` validation already covers repeat attempts
+      # from the same checkout email; matching on the buyer account here additionally covers
+      # a signed-in buyer retrying with a different email.
+      if buyer.present?
+        settling_membership_purchase = Purchase.in_progress
+          .is_original_subscription_purchase
+          .where(link_id: product.id, purchaser_id: buyer.id)
+          .where.not(stripe_status: nil)
+
+        if settling_membership_purchase.exists?
+          return nil, "Your payment for this membership is still processing. We will email you a receipt as soon as it completes — please do not pay again."
+        end
+      end
+
       # Then check for restartable subscriptions
       restartable_subscription = buyer.present? ?
         Subscription.restartable_for_product_and_buyer(product:, buyer:) :

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -43,6 +43,25 @@ describe Purchase, :vcr do
       end
     end
 
+    describe "payment_settling" do
+      it "returns in-progress purchases whose payment the processor has confirmed" do
+        settling = create(:purchase, purchase_state: "in_progress", stripe_status: "processing")
+        expect(Purchase.payment_settling).to include settling
+      end
+
+      it "does not return abandoned attempts, which never receive a processor confirmation" do
+        abandoned = create(:purchase, purchase_state: "in_progress", stripe_status: nil)
+        expect(Purchase.payment_settling).to_not include abandoned
+      end
+
+      it "does not return purchases that reached a terminal state, even though stripe_status remains set" do
+        failed = create(:purchase, purchase_state: "failed", stripe_status: "payment_intent.payment_failed")
+        successful = create(:purchase, purchase_state: "successful", stripe_status: "charge.succeeded")
+        expect(Purchase.payment_settling).to_not include failed
+        expect(Purchase.payment_settling).to_not include successful
+      end
+    end
+
     describe "successful" do
       before do
         @successful_purchase = create(:purchase, purchase_state: "successful")

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -2556,6 +2556,60 @@ describe Purchase, :vcr do
       end
     end
 
+    context "when an earlier purchase's payment is still settling" do
+      # A delayed-notification payment (like an ACH bank debit) leaves the purchase
+      # in_progress for days with stripe_status set once the processor confirms it.
+      it "disallows a repeat purchase while a confirmed payment is settling, even outside the recent-purchase window" do
+        create(:purchase, link: @product, seller: @product.user, email: "bob@gumroad.com", ip_address: @ip_address,
+                          purchase_state: "in_progress", stripe_status: "processing", created_at: 2.days.ago)
+        purchase2 = build(:purchase, link: @product, email: "bob@gumroad.com", ip_address: @ip_address, created_at: Time.current)
+        expect(purchase2).to_not be_valid
+        expect(purchase2.errors[:base]).to eq ["Your previous payment for this product is still processing. We will email you a receipt as soon as it completes — please do not pay again."]
+      end
+
+      it "disallows the repeat purchase from a different IP address" do
+        create(:purchase, link: @product, seller: @product.user, email: "bob@gumroad.com", ip_address: @ip_address,
+                          purchase_state: "in_progress", stripe_status: "processing", created_at: 1.day.ago)
+        purchase2 = build(:purchase, link: @product, email: "bob@gumroad.com", ip_address: generate(:ip), created_at: Time.current)
+        expect(purchase2).to_not be_valid
+      end
+
+      it "allows a repeat purchase when the earlier attempt was abandoned before payment confirmation" do
+        # An abandoned attempt never gets a stripe_status; the buyer should be able to try again.
+        create(:purchase, link: @product, seller: @product.user, email: "bob@gumroad.com", ip_address: @ip_address,
+                          purchase_state: "in_progress", stripe_status: nil, created_at: 1.hour.ago)
+        purchase2 = build(:purchase, link: @product, email: "bob@gumroad.com", ip_address: @ip_address, created_at: Time.current)
+        expect(purchase2).to be_valid
+      end
+
+      it "allows a repeat purchase once the earlier attempt has failed" do
+        create(:purchase, link: @product, seller: @product.user, email: "bob@gumroad.com", ip_address: @ip_address,
+                          purchase_state: "failed", stripe_status: "payment_intent.payment_failed", created_at: 1.day.ago)
+        purchase2 = build(:purchase, link: @product, email: "bob@gumroad.com", ip_address: @ip_address, created_at: Time.current)
+        expect(purchase2).to be_valid
+      end
+
+      it "allows a purchase from a different buyer email" do
+        create(:purchase, link: @product, seller: @product.user, email: "bob@gumroad.com", ip_address: @ip_address,
+                          purchase_state: "in_progress", stripe_status: "processing", created_at: 1.day.ago)
+        purchase2 = build(:purchase, link: @product, email: "alice@gumroad.com", ip_address: @ip_address, created_at: Time.current)
+        expect(purchase2).to be_valid
+      end
+
+      it "allows a repeat purchase of a different variant" do
+        product = create(:product)
+        category = create(:variant_category, link: product)
+        variant_a = create(:variant, variant_category: category)
+        variant_b = create(:variant, variant_category: category)
+        settling = create(:purchase, link: product, seller: product.user, email: "bob@gumroad.com", ip_address: @ip_address,
+                                     purchase_state: "in_progress", stripe_status: "processing", created_at: 1.day.ago)
+        settling.variant_attributes << variant_a
+        purchase2 = build(:purchase, link: product, email: "bob@gumroad.com", ip_address: @ip_address, created_at: Time.current)
+        purchase2.variant_attributes << variant_b
+        expect(purchase2).to be_valid
+      end
+    end
+
     context "purchasing physical products" do
       let(:product) { create(:physical_product) }
 

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -2608,6 +2608,31 @@ describe Purchase, :vcr do
         purchase2.variant_attributes << variant_b
         expect(purchase2).to be_valid
       end
+
+      it "already blocks a repeat gift to the same giftee via the gift join in the parent check, without any time window" do
+        # Gift purchases are stored under the sender's email, so the settling check's email
+        # match can't see them. They don't need it: the gift join in `not_double_charged`
+        # has no created_at window, so an in_progress gift (including one settling over ACH
+        # for days) blocks repeat gifts to the same giftee until it resolves.
+        gift = create(:gift, giftee_email: "giftee@gumroad.com", link: @product)
+        create(:purchase, link: @product, seller: @product.user, email: "sender@gumroad.com", ip_address: @ip_address,
+                          gift_given: gift, is_gift_sender_purchase: true,
+                          purchase_state: "in_progress", stripe_status: "processing", created_at: 2.days.ago)
+        second_gift = build(:gift, giftee_email: "giftee@gumroad.com", link: @product)
+        purchase2 = build(:purchase, link: @product, email: "another-sender@gumroad.com", ip_address: @ip_address,
+                                     gift_given: second_gift, is_gift_sender_purchase: true, created_at: Time.current)
+        expect(purchase2).to_not be_valid
+        expect(purchase2.errors[:base]).to eq ["You have already attempted to purchase this product. We will email you shortly if the purchase is successful."]
+      end
+
+      it "already blocks a direct purchase by the giftee while a gift to them is in progress" do
+        gift = create(:gift, giftee_email: "giftee@gumroad.com", link: @product)
+        create(:purchase, link: @product, seller: @product.user, email: "sender@gumroad.com", ip_address: @ip_address,
+                          gift_given: gift, is_gift_sender_purchase: true,
+                          purchase_state: "in_progress", stripe_status: "processing", created_at: 2.days.ago)
+        purchase2 = build(:purchase, link: @product, email: "giftee@gumroad.com", ip_address: @ip_address, created_at: Time.current)
+        expect(purchase2).to_not be_valid
+      end
     end
 
     context "purchasing physical products" do

--- a/spec/services/purchase/create_service_spec.rb
+++ b/spec/services/purchase/create_service_spec.rb
@@ -3585,6 +3585,49 @@ describe Purchase::CreateService, :vcr do
       end
     end
 
+    context "when buyer has a membership purchase whose payment is still settling" do
+      # A slow payment method (like an ACH bank debit) leaves the original membership
+      # purchase in_progress for days before the subscription becomes active, so the
+      # active-subscription check can't catch a second attempt on its own.
+      before do
+        create(:membership_purchase,
+               link: membership_product,
+               purchaser: buyer,
+               email: "other-email@example.com", # a different checkout email must not bypass the block
+               purchase_state: "in_progress",
+               stripe_status: "processing",
+               created_at: 2.days.ago)
+      end
+
+      it "returns an error and does not create a new purchase" do
+        expect do
+          purchase, error = Purchase::CreateService.new(product: membership_product, params: membership_params, buyer:).perform
+
+          expect(purchase).to be_nil
+          expect(error).to eq("Your payment for this membership is still processing. We will email you a receipt as soon as it completes — please do not pay again.")
+        end.not_to change(Purchase, :count)
+      end
+    end
+
+    context "when buyer has an abandoned in-progress membership purchase" do
+      before do
+        create(:membership_purchase,
+               link: membership_product,
+               purchaser: buyer,
+               email: email,
+               purchase_state: "in_progress",
+               stripe_status: nil,
+               created_at: 2.days.ago)
+      end
+
+      it "allows the purchase" do
+        purchase, error = Purchase::CreateService.new(product: membership_product, params: membership_params, buyer:).perform
+
+        expect(error).to be_nil
+        expect(purchase).to be_present
+      end
+    end
+
     context "when buyer has a restartable subscription" do
       let!(:subscription) do
         create_subscription_for(

--- a/spec/support/fixtures/vcr_cassettes/Purchase_CreateService/existing_subscription_handling/when_buyer_has_a_membership_purchase_whose_payment_is_still_settling/returns_an_error_and_does_not_create_a_new_purchase.yml
+++ b/spec/support/fixtures/vcr_cassettes/Purchase_CreateService/existing_subscription_handling/when_buyer_has_a_membership_purchase_whose_payment_is_still_settling/returns_an_error_and_does_not_create_a_new_purchase.yml
@@ -1,0 +1,147 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa&billing_details[address][postal_code]=<STRONGBOX_GENERAL_PASSWORD>5
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_K0x77X3WOtCcJz","request_duration_ms":6}}'
+      Idempotency-Key:
+      - 13f43543-5c2a-4cc5-9da1-2450d2330b51
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 10 Jul 2026 13:54:43 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1132'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=6xXLU5GNXXHeLPTHTlIAtiWH1cy7YcoT8cTyVZq9_bs9c2LChMyx6dYo2JHn9DFrpXHOwG0SVK5HWw2j;
+        report-to csp
+      Idempotency-Key:
+      - 13f43543-5c2a-4cc5-9da1-2450d2330b51
+      Original-Request:
+      - req_gFDt8ygRJYISmP
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=6xXLU5GNXXHeLPTHTlIAtiWH1cy7YcoT8cTyVZq9_bs9c2LChMyx6dYo2JHn9DFrpXHOwG0SVK5HWw2j&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=6xXLU5GNXXHeLPTHTlIAtiWH1cy7YcoT8cTyVZq9_bs9c2LChMyx6dYo2JHn9DFrpXHOwG0SVK5HWw2j&t=1"
+      Request-Id:
+      - req_gFDt8ygRJYISmP
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1Tret5IBOqvOFDrfl1mhURqF",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": "<STRONGBOX_GENERAL_PASSWORD>5",
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": "unchecked",
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783691683,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Fri, 10 Jul 2026 13:54:43 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/Purchase_CreateService/existing_subscription_handling/when_buyer_has_an_abandoned_in-progress_membership_purchase/allows_the_purchase.yml
+++ b/spec/support/fixtures/vcr_cassettes/Purchase_CreateService/existing_subscription_handling/when_buyer_has_an_abandoned_in-progress_membership_purchase/allows_the_purchase.yml
@@ -1,0 +1,932 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa&billing_details[address][postal_code]=<STRONGBOX_GENERAL_PASSWORD>5
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_gFDt8ygRJYISmP","request_duration_ms":289}}'
+      Idempotency-Key:
+      - 9c748d03-541b-4b53-a294-6b344977c083
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 10 Jul 2026 13:54:43 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1132'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=6xXLU5GNXXHeLPTHTlIAtiWH1cy7YcoT8cTyVZq9_bs9c2LChMyx6dYo2JHn9DFrpXHOwG0SVK5HWw2j;
+        report-to csp
+      Idempotency-Key:
+      - 9c748d03-541b-4b53-a294-6b344977c083
+      Original-Request:
+      - req_YPGrbUfAr4kqiM
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=6xXLU5GNXXHeLPTHTlIAtiWH1cy7YcoT8cTyVZq9_bs9c2LChMyx6dYo2JHn9DFrpXHOwG0SVK5HWw2j&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=6xXLU5GNXXHeLPTHTlIAtiWH1cy7YcoT8cTyVZq9_bs9c2LChMyx6dYo2JHn9DFrpXHOwG0SVK5HWw2j&t=1"
+      Request-Id:
+      - req_YPGrbUfAr4kqiM
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1Tret5IBOqvOFDrfMS0wC4Qv",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": "<STRONGBOX_GENERAL_PASSWORD>5",
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": "unchecked",
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783691683,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Fri, 10 Jul 2026 13:54:43 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1Tret5IBOqvOFDrfMS0wC4Qv
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_YPGrbUfAr4kqiM","request_duration_ms":246}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 10 Jul 2026 13:54:44 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1132'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=6xXLU5GNXXHeLPTHTlIAtiWH1cy7YcoT8cTyVZq9_bs9c2LChMyx6dYo2JHn9DFrpXHOwG0SVK5HWw2j;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=6xXLU5GNXXHeLPTHTlIAtiWH1cy7YcoT8cTyVZq9_bs9c2LChMyx6dYo2JHn9DFrpXHOwG0SVK5HWw2j&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=6xXLU5GNXXHeLPTHTlIAtiWH1cy7YcoT8cTyVZq9_bs9c2LChMyx6dYo2JHn9DFrpXHOwG0SVK5HWw2j&t=1"
+      Request-Id:
+      - req_6es7y3YCwkKNje
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1Tret5IBOqvOFDrfMS0wC4Qv",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": "<STRONGBOX_GENERAL_PASSWORD>5",
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": "unchecked",
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783691683,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Fri, 10 Jul 2026 13:54:44 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: description=3893&email=sahil%40gumroad.com&payment_method=pm_1Tret5IBOqvOFDrfMS0wC4Qv
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_6es7y3YCwkKNje","request_duration_ms":150}}'
+      Idempotency-Key:
+      - 9cb3d4a3-409e-42db-b501-e6675683e950
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 10 Jul 2026 13:54:44 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '659'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=6xXLU5GNXXHeLPTHTlIAtiWH1cy7YcoT8cTyVZq9_bs9c2LChMyx6dYo2JHn9DFrpXHOwG0SVK5HWw2j;
+        report-to csp
+      Idempotency-Key:
+      - 9cb3d4a3-409e-42db-b501-e6675683e950
+      Original-Request:
+      - req_s4i8ZGxG0KLbgH
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=6xXLU5GNXXHeLPTHTlIAtiWH1cy7YcoT8cTyVZq9_bs9c2LChMyx6dYo2JHn9DFrpXHOwG0SVK5HWw2j&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=6xXLU5GNXXHeLPTHTlIAtiWH1cy7YcoT8cTyVZq9_bs9c2LChMyx6dYo2JHn9DFrpXHOwG0SVK5HWw2j&t=1"
+      Request-Id:
+      - req_s4i8ZGxG0KLbgH
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "cus_UrNeuEoa7sOgDO",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1783691684,
+          "currency": null,
+          "customer_account": null,
+          "default_source": null,
+          "delinquent": false,
+          "description": "3893",
+          "discount": null,
+          "email": "sahil@gumroad.com",
+          "invoice_prefix": "WFYGFZK6",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null,
+            "rendering_options": null
+          },
+          "livemode": false,
+          "metadata": {},
+          "name": null,
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [],
+          "shipping": null,
+          "tax_exempt": "none",
+          "test_clock": null
+        }
+  recorded_at: Fri, 10 Jul 2026 13:54:44 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=600&currency=usd&description=You+bought+http%3A%2F%2Fedgarf0b28c356.test.gumroad.com%3A31337%2Fl%2Fn%21&metadata[purchase]=0N-4kkD5oQRkEzMBfHnPQw%3D%3D&transfer_group=1109&payment_method_types[0]=card&setup_future_usage=off_session&customer=cus_UrNeuEoa7sOgDO&payment_method=pm_1Tret5IBOqvOFDrfMS0wC4Qv&statement_descriptor_suffix=edgarf0b28c356
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_s4i8ZGxG0KLbgH","request_duration_ms":927}}'
+      Idempotency-Key:
+      - bb68dd50-04ea-46e4-9bd6-9e3aa4e6ca08
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 10 Jul 2026 13:54:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1648'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=6xXLU5GNXXHeLPTHTlIAtiWH1cy7YcoT8cTyVZq9_bs9c2LChMyx6dYo2JHn9DFrpXHOwG0SVK5HWw2j;
+        report-to csp
+      Idempotency-Key:
+      - bb68dd50-04ea-46e4-9bd6-9e3aa4e6ca08
+      Original-Request:
+      - req_njUATJMO58u73L
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=6xXLU5GNXXHeLPTHTlIAtiWH1cy7YcoT8cTyVZq9_bs9c2LChMyx6dYo2JHn9DFrpXHOwG0SVK5HWw2j&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=6xXLU5GNXXHeLPTHTlIAtiWH1cy7YcoT8cTyVZq9_bs9c2LChMyx6dYo2JHn9DFrpXHOwG0SVK5HWw2j&t=1"
+      Request-Id:
+      - req_njUATJMO58u73L
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3Tret7IBOqvOFDrf01fnk3Nl",
+          "object": "payment_intent",
+          "amount": 600,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 0,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3Tret7IBOqvOFDrf01fnk3Nl_secret_zdoumkOi7fb9o4ycM27ZDyG5Q",
+          "confirmation_method": "automatic",
+          "created": 1783691685,
+          "currency": "usd",
+          "customer": "cus_UrNeuEoa7sOgDO",
+          "customer_account": null,
+          "description": "You bought http://edgarf0b28c356.test.gumroad.com:31337/l/n!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": null,
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "0N-4kkD5oQRkEzMBfHnPQw=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1Tret5IBOqvOFDrfMS0wC4Qv",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": "off_session",
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgarf0b28c356",
+          "status": "requires_confirmation",
+          "transfer_data": null,
+          "transfer_group": "1109"
+        }
+  recorded_at: Fri, 10 Jul 2026 13:54:45 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents/pi_3Tret7IBOqvOFDrf01fnk3Nl/confirm
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_njUATJMO58u73L","request_duration_ms":212}}'
+      Idempotency-Key:
+      - 944d7835-0f7e-46ca-83b6-094e74726184
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 10 Jul 2026 13:54:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1663'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=6xXLU5GNXXHeLPTHTlIAtiWH1cy7YcoT8cTyVZq9_bs9c2LChMyx6dYo2JHn9DFrpXHOwG0SVK5HWw2j;
+        report-to csp
+      Idempotency-Key:
+      - 944d7835-0f7e-46ca-83b6-094e74726184
+      Original-Request:
+      - req_F7AhJy0gXyjOyF
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=6xXLU5GNXXHeLPTHTlIAtiWH1cy7YcoT8cTyVZq9_bs9c2LChMyx6dYo2JHn9DFrpXHOwG0SVK5HWw2j&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=6xXLU5GNXXHeLPTHTlIAtiWH1cy7YcoT8cTyVZq9_bs9c2LChMyx6dYo2JHn9DFrpXHOwG0SVK5HWw2j&t=1"
+      Request-Id:
+      - req_F7AhJy0gXyjOyF
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3Tret7IBOqvOFDrf01fnk3Nl",
+          "object": "payment_intent",
+          "amount": 600,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 600,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3Tret7IBOqvOFDrf01fnk3Nl_secret_zdoumkOi7fb9o4ycM27ZDyG5Q",
+          "confirmation_method": "automatic",
+          "created": 1783691685,
+          "currency": "usd",
+          "customer": "cus_UrNeuEoa7sOgDO",
+          "customer_account": null,
+          "description": "You bought http://edgarf0b28c356.test.gumroad.com:31337/l/n!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3Tret7IBOqvOFDrf07Ulojfc",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "0N-4kkD5oQRkEzMBfHnPQw=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1Tret5IBOqvOFDrfMS0wC4Qv",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": "off_session",
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgarf0b28c356",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "1109"
+        }
+  recorded_at: Fri, 10 Jul 2026 13:54:46 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3Tret7IBOqvOFDrf07Ulojfc?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_F7AhJy0gXyjOyF","request_duration_ms":955}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 10 Jul 2026 13:54:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3779'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=6xXLU5GNXXHeLPTHTlIAtiWH1cy7YcoT8cTyVZq9_bs9c2LChMyx6dYo2JHn9DFrpXHOwG0SVK5HWw2j;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=6xXLU5GNXXHeLPTHTlIAtiWH1cy7YcoT8cTyVZq9_bs9c2LChMyx6dYo2JHn9DFrpXHOwG0SVK5HWw2j&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=6xXLU5GNXXHeLPTHTlIAtiWH1cy7YcoT8cTyVZq9_bs9c2LChMyx6dYo2JHn9DFrpXHOwG0SVK5HWw2j&t=1"
+      Request-Id:
+      - req_NzIKJzybrsqs0r
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3Tret7IBOqvOFDrf07Ulojfc",
+          "object": "charge",
+          "amount": 600,
+          "amount_captured": 600,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3Tret7IBOqvOFDrf05H4OR3k",
+            "object": "balance_transaction",
+            "amount": 600,
+            "available_on": 1784246400,
+            "balance_type": "payments",
+            "created": 1783691685,
+            "currency": "usd",
+            "description": "You bought http://edgarf0b28c356.test.gumroad.com:31337/l/n!",
+            "exchange_rate": null,
+            "fee": 47,
+            "fee_details": [
+              {
+                "amount": 47,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 553,
+            "reporting_category": "charge",
+            "source": "ch_3Tret7IBOqvOFDrf07Ulojfc",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": "<STRONGBOX_GENERAL_PASSWORD>5",
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGARF0B28C356",
+          "captured": true,
+          "created": 1783691685,
+          "currency": "usd",
+          "customer": "cus_UrNeuEoa7sOgDO",
+          "description": "You bought http://edgarf0b28c356.test.gumroad.com:31337/l/n!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "0N-4kkD5oQRkEzMBfHnPQw=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 8,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3Tret7IBOqvOFDrf01fnk3Nl",
+          "payment_method": "pm_1Tret5IBOqvOFDrfMS0wC4Qv",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 600,
+              "authorization_code": "364988",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": "pass",
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 600,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKKbzw9IGMgZdxf4waVU6LBZrqM14urn4wmQeNG1RXKfiC6NcVOQou4080GhTd9IsGvPhu3SpYoRPbVUi",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgarf0b28c356",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "1109"
+        }
+  recorded_at: Fri, 10 Jul 2026 13:54:46 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## What

Blocks duplicate purchases while an earlier attempt's payment is still settling, for both one-time products and memberships.

- **`Purchase#not_double_charged`** (model validation): in addition to the existing few-minutes lookback, a repeat purchase is now blocked whenever the buyer has an `in_progress` purchase of the same product (same email + variants) whose payment was **confirmed by the processor** — detected via `stripe_status`, which is only ever written once Stripe acknowledges a real payment (checkout return page sets `processing`; webhooks update it afterward). No time limit, because ACH debits settle over several business days.
- **`Purchase::CreateService#handle_existing_subscription`** (memberships): a signed-in buyer with a settling original membership purchase of the same product is now blocked from starting a second subscription, closing the gap before the subscription becomes active (where the existing already-subscribed check takes over). Matching on `purchaser_id` here also covers a retry with a different checkout email.

Buyers see: *"Your previous payment for this product is still processing. We will email you a receipt as soon as it completes — please do not pay again."* (membership variant accordingly).

**Abandoned attempts are deliberately not blocked**: an attempt the buyer walked away from before confirming payment never gets a `stripe_status`, and `FailAbandonedPurchaseWorker` fails it ~15 minutes in — so those buyers can always retry immediately.

## Why

The existing `not_double_charged` guard was built as a double-click guard for card payments that settle in seconds: it only blocks repeats within 3 minutes (10 seconds for quantity/physical/licensed products). Delayed-notification methods like ACH bank debits keep the purchase `in_progress` for ~4 business days, so a buyer who resubmits checkout after a few minutes gets charged twice and then has to wait days for a refund. That exact double-charge happened in production — see antiwork/gumroad-private#1013.

Memberships had a related hole: `handle_existing_subscription` only blocks when a subscription is already **active**, but the subscription doesn't activate until the original purchase settles, leaving the same multi-day double-buy window.

## Test plan

- New model specs (`spec/models/purchase_spec.rb`, "when an earlier purchase's payment is still settling"):
  - blocks a repeat while a confirmed payment is settling, even days later and from a different IP
  - allows retry after an **abandoned** attempt (`stripe_status: nil`)
  - allows retry once the earlier attempt failed
  - allows a different buyer email and a different variant
- New service specs (`spec/services/purchase/create_service_spec.rb`):
  - settling original membership purchase blocks a second subscription start, including with a different checkout email
  - abandoned in-progress membership purchase does not block
- Full existing `not_double_charged` group: **25 examples, 0 failures** locally
- Full `spec/services/purchase/create_service_spec.rb`: run locally (regression)
- Rubocop: no offenses on all 4 touched files

No UI changes — the block surfaces through the existing checkout error path.
