### PR TITLE
docs: explain the "previous payment still processing" purchase block

### DIFF
--- a/app/views/help_center/articles/contents/_203-why-did-my-payment-fail.html.erb
+++ b/app/views/help_center/articles/contents/_203-why-did-my-payment-fail.html.erb
@@ -7,6 +7,7 @@
     <li><a href="#Zip-code-errors-VjkqM">Zip code errors</a></li>
     <li><a href="#Proxy-server-issues-5J9hZ">Proxy server issues</a></li>
     <li><a href="#Browser-error-_SZW5">Browser error</a></li>
+    <li><a href="#Previous-payment-still-processing-kQ2pF">Previous payment still processing</a></li>
     <li><a href="#Blocked-by-Gumroads-risk-system-Slrvd">Blocked by Gumroad’s risk system</a></li>
     <li><a href="#Chargeback-against-Gumroad-IvRQH">Chargeback against Gumroad</a></li>
   </ul>
@@ -36,6 +37,9 @@
   <h3 id="Browser-error-_SZW5">Browser error</h3>
   <p>Please try the purchase in a different browser.</p>
   <p>If you still experience errors, please download the <a href="http://www.browsehappy.com/?locale=en">latest version</a> of your Internet browser and try again.</p>
+  <h3 id="Previous-payment-still-processing-kQ2pF">Previous payment still processing</h3>
+  <p>If you see the message "Your previous payment for this product is still processing. We will email you a receipt as soon as it completes — please do not pay again," your earlier purchase went through and is on its way. Some payment methods, like bank debits, can take several business days to complete. To prevent you from being charged twice, we block repeat purchases of the same product while a confirmed payment is settling.</p>
+  <p>There is nothing you need to do. We will email you a receipt as soon as the payment completes, and you will get access to your purchase then.</p>
   <h3 id="Blocked-by-Gumroads-risk-system-Slrvd">Blocked by Gumroad’s risk system</h3>
   <p>Our risk detectors may have accidentally blocked you from purchasing. Please use "incognito" or "private" mode on your browser, and try the purchase using a different email address.</p>
   <h3 id="Chargeback-against-Gumroad-IvRQH">Chargeback against Gumroad</h3>


### PR DESCRIPTION
## What

Adds a "Previous payment still processing" section to the help article [Why did my payment fail?](https://help.gumroad.com/help/article/203-why-did-my-payment-fail), explaining the new checkout block introduced in #5789: repeat purchases of the same product are blocked while an earlier confirmed payment (e.g. an ACH bank debit that takes several business days) is still settling. The section mirrors the exact in-app error message and tells buyers no action is needed — a receipt arrives once the payment completes.

## Why

Merged PR #5789 added a new buyer-facing error message at checkout. Buyers who search the help center for that message would have found nothing. This documents it in the article that already covers checkout failure reasons.

## Changes

- `_203-why-did-my-payment-fail.html.erb`: new `<h3>` section + TOC entry (+4 lines). Existing anchor IDs preserved.
- `articles.yml` untouched — body-only edit, title/description unchanged.

## Test plan

- Partial renders in the real view context: `ApplicationController.render(...)` → render OK, new copy present.
- `bundle exec rspec spec/models/help_center` → 1 example, 0 failures.
- Autoreview skipped (docs copy only, no logic).
