### PR TITLE
Drop US-locked payment methods from client-confirm checkout on connected accounts

### DIFF
--- a/app/services/checkout/payment_method_resolver.rb
+++ b/app/services/checkout/payment_method_resolver.rb
@@ -129,14 +129,23 @@ class Checkout::PaymentMethodResolver
     end
 
     # What Stripe actually receives: the eligible policy set intersected with the launched set, then
-    # region-gated, then PPP-gated. A US-locked method (ACH, Cash App Pay) is only offered when the
-    # buyer's GeoIP country is US, so a non-US buyer never sees a method they can't complete. When the
-    # buyer country is unknown (nil), US-locked methods are dropped to fail safe. Card always survives,
-    # and Link (inline, not US-locked) is unaffected by the region gate.
+    # account-gated, then region-gated, then PPP-gated. A US-locked method (ACH, Cash App Pay) is only
+    # offered when the buyer's GeoIP country is US, so a non-US buyer never sees a method they can't
+    # complete. When the buyer country is unknown (nil), US-locked methods are dropped to fail safe.
+    # Card always survives, and Link (inline, not US-locked) is unaffected by either gate.
+    #
+    # The account gate: on a direct-charge (Stripe Connect) seller, the PaymentIntent is created on
+    # the SELLER's Stripe account, not Gumroad's platform account — and payment method capabilities
+    # live per-account. Cash App Pay and ACH are activated on the platform account, but connected
+    # accounts routinely lack them (non-US accounts can't have them at all, and even US connect
+    # accounts usually haven't activated them in their own dashboard). Listing a method the account
+    # doesn't have makes Stripe reject the intent create outright, which failed every US buyer's
+    # checkout on those sellers with a misleading "stripe_unavailable" error — so only offer the
+    # US-locked methods when the charge lands on the platform account, where we control activation.
     def launched_method_set(eligible)
       launched = eligible & LAUNCHED_PAYMENT_METHOD_TYPES
       launched += forced_currency_test_mode_methods(eligible)
-      launched -= US_LOCKED_PAYMENT_METHOD_TYPES unless buyer_country == US_ALPHA2
+      launched -= US_LOCKED_PAYMENT_METHOD_TYPES if buyer_country != US_ALPHA2 || direct_charge_seller?
       launched = ppp_method_matrix(launched) if ppp_discounted
       launched
     end

--- a/spec/services/checkout/payment_method_resolver_spec.rb
+++ b/spec/services/checkout/payment_method_resolver_spec.rb
@@ -159,7 +159,14 @@ describe Checkout::PaymentMethodResolver do
         expect(resolution.client_confirm_eligible?).to be(true)
         expect(resolution.fallback_reason).to be_nil
         expect(resolution.stripe_connect_account_id).to eq(connect_account.charge_processor_merchant_id)
-        expect(resolution.payment_method_types).to eq(%w[card link cashapp us_bank_account])
+      end
+
+      it "drops the US-locked methods even for a US buyer — the intent is created on the seller's own Stripe account, which lacks the Cash App/ACH capabilities the platform account has" do
+        expect(resolve(buyer_country: "US").payment_method_types).to eq(%w[card link])
+      end
+
+      it "resolves card-only for a US PPP buyer — Link is PPP-gated and the US-locked methods are account-gated" do
+        expect(resolve(buyer_country: "US", ppp_discounted: true).payment_method_types).to eq(["card"])
       end
 
       it "drops US-locked methods for a non-US buyer while keeping the connected-account scope" do


### PR DESCRIPTION
## What

Stops offering Cash App Pay and ACH Direct Debit on client-confirm checkout when the cart resolves to a direct-charge (Stripe Connect) seller. The US-locked methods now require both a US buyer **and** a platform-account charge.

## Why

On a direct-charge seller, the deferred PaymentIntent is created on the **seller's own Stripe account**, and payment method capabilities live per-account. Cash App Pay and ACH are activated on Gumroad's platform account, but connected accounts routinely lack them — non-US accounts can't have them at all, and even US connect accounts usually haven't activated them in their own dashboard.

Stripe validates the whole `payment_method_types` array at intent create, so one missing capability rejects the create outright (`payment_intent_invalid_parameter`) — **before the buyer's chosen method matters**. The result: every US-GeoIP buyer failed 100% of checkout attempts on affected sellers, even paying with a plain card, and the swallowed `InvalidRequestError` surfaced as a misleading `stripe_unavailable` error code.

Reproduced live against an affected connected account (audited console): an intent create with `["card","link","cashapp","us_bank_account"]` is rejected with `payment_intent_invalid_parameter` naming `cashapp`; the identical create with `["card","link"]` succeeds. Since the client-confirm ramp this has been failing roughly 300–570 purchase attempts per day across ~70–100 sellers. Full investigation with purchase-level evidence: antiwork/gumroad-private#1026.

Because the presenter and `Order::PreparePaymentIntentService` both read `Checkout::PaymentMethodResolver`, this one change keeps the Payment Element's method list and the deferred intent's list equal on both sides of the handshake.

**Follow-up (not in this PR):** resolve capabilities dynamically per connected account (cache on `MerchantAccount`, refresh via the `account.updated` webhook) so US connect sellers who have activated Cash App/ACH get them back. This PR is the static exclusion to stop the bleeding first.

## Test plan

- `spec/services/checkout/payment_method_resolver_spec.rb` — updated the connected-account context: US buyers on connect sellers now resolve `["card","link"]`; added a US-buyer example and a US PPP-buyer example (card-only). 33 examples, 0 failures locally.
- `spec/presenters/checkout/stripe_payment_presenter_spec.rb` + `spec/services/order/prepare_payment_intent_service_spec.rb` — unchanged, still green (98 examples, 0 failures locally): their US-locked assertions all use platform-account sellers, which this change doesn't touch.
- No UI change: the Payment Element simply doesn't render the Cash App / ACH tabs for these sellers, same as it already doesn't for non-US buyers.
