### PR TITLE
Make payout CSV subtotal headings ASCII-only and comma-free

### DIFF
--- a/app/services/exports/payouts/csv.rb
+++ b/app/services/exports/payouts/csv.rb
@@ -10,9 +10,16 @@ class Exports::Payouts::Csv < Exports::Payouts::Base
   # their rows (sales, refunds, fees, and the offsetting "Payouts" deduction) add up to
   # zero within this payout. Splitting the subtotals out lets a seller verify each group's
   # math on its own instead of reading one blind grand total. See gumroad-private#999.
-  CARD_SALES_SUBTOTAL_HEADING = "Subtotal — activity paid out by Gumroad"
-  PAYPAL_SALES_SUBTOTAL_HEADING = "Subtotal — PayPal sales (paid out by PayPal, nets to zero here)"
-  STRIPE_CONNECT_SALES_SUBTOTAL_HEADING = "Subtotal — Stripe Connect sales (paid out by Stripe, nets to zero here)"
+  # These headings are deliberately ASCII-only and comma-free. The CSV writer quotes
+  # fields correctly, but many sellers re-parse the file with Excel's "Text to Columns"
+  # using a comma delimiter (the standard workaround in locales where Excel's list
+  # separator is a semicolon), which splits inside quoted fields, so a comma in a heading
+  # misaligns the subtotal row. Also, because this export is UTF-8 without a BOM, Windows
+  # Excel reads non-ASCII characters (like an em dash) as cp1252 mojibake.
+  # See gumroad-private#1028.
+  CARD_SALES_SUBTOTAL_HEADING = "Subtotal - activity paid out by Gumroad"
+  PAYPAL_SALES_SUBTOTAL_HEADING = "Subtotal - PayPal sales (paid out by PayPal; nets to zero here)"
+  STRIPE_CONNECT_SALES_SUBTOTAL_HEADING = "Subtotal - Stripe Connect sales (paid out by Stripe; nets to zero here)"
 
   # One-line explanation placed in the "Item Name" column of the deduction rows, so the
   # negative amount is self-explanatory: the fee shown on each PayPal / Stripe Connect

--- a/spec/services/exports/payouts/csv_spec.rb
+++ b/spec/services/exports/payouts/csv_spec.rb
@@ -179,6 +179,26 @@ describe Exports::Payouts::Csv, :vcr do
     end
   end
 
+  # Regression for gumroad-private#1028: sellers re-parse this CSV with Excel's
+  # "Text to Columns" (comma delimiter), which splits inside quoted fields, and
+  # Windows Excel reads non-ASCII bytes in this BOM-less UTF-8 file as cp1252
+  # mojibake. Every free-text label we add must therefore be ASCII-only and
+  # comma-free.
+  describe "subtotal headings and deduction notes" do
+    it "keeps all label constants ASCII-only and comma-free" do
+      [
+        Exports::Payouts::Csv::CARD_SALES_SUBTOTAL_HEADING,
+        Exports::Payouts::Csv::PAYPAL_SALES_SUBTOTAL_HEADING,
+        Exports::Payouts::Csv::STRIPE_CONNECT_SALES_SUBTOTAL_HEADING,
+        Exports::Payouts::Csv::PAYPAL_PAYOUTS_NOTE,
+        Exports::Payouts::Csv::STRIPE_CONNECT_PAYOUTS_NOTE,
+      ].each do |label|
+        expect(label).to match(/\A[[:ascii:]]+\z/), "expected ASCII-only label, got: #{label}"
+        expect(label).not_to include(","), "expected comma-free label, got: #{label}"
+      end
+    end
+  end
+
   describe "affiliate credits involving several balances" do
     let!(:now) { Time.current }
     let!(:payout_date) { 1.week.ago }


### PR DESCRIPTION
## What

Makes the payout-CSV subtotal headings introduced in #5775 ASCII-only and comma-free:

- `Subtotal — activity paid out by Gumroad` → `Subtotal - activity paid out by Gumroad`
- `Subtotal — PayPal sales (paid out by PayPal, nets to zero here)` → `Subtotal - PayPal sales (paid out by PayPal; nets to zero here)`
- `Subtotal — Stripe Connect sales (paid out by Stripe, nets to zero here)` → `Subtotal - Stripe Connect sales (paid out by Stripe; nets to zero here)`

Adds a regression spec asserting every free-text label constant in the export (the three subtotal headings plus the two deduction-row notes) stays ASCII-only and comma-free.

## Why

The seller who requested the reconciliation feature reported the new rows break parsing in Excel (gumroad-private#1028):

1. **Comma inside a quoted heading.** The CSV writer quotes correctly, but Excel's "Text to Columns" with a comma delimiter — the standard workaround in locales where Excel's list separator is a semicolon (e.g. Spanish/Argentina) — splits inside quoted fields, so the subtotal row misaligns to 12 fields instead of 11.
2. **Em dash in a BOM-less UTF-8 file.** The export was pure ASCII before #5775, so Windows Excel's cp1252 default never mattered. The em dash now renders as `Subtotal â€”`.

The deduction-row notes were already comma-free and ASCII; the headings were the only offenders.

## Test plan

- `bundle exec rubocop` on both files: no offenses.
- `bundle exec rspec spec/services/exports/payouts/csv_spec.rb`: the new regression spec and the existing subtotal expectations pass (the constants are referenced symbolically in the spec, so the expectations follow the new text).
- Note: `spec/services/exports/payouts/csv_spec.rb:91` ("shows all activity related to the payout") fails identically on `origin/main` without this change (row-ordering diff between two same-date Credit/Sale rows) — pre-existing, not introduced here.

Fixes the parsing bug tracked in antiwork/gumroad-private#1028 (follow-up to #5775 / gumroad-private#999).
