### PR TITLE
Restore US-locked payment methods on connected accounts that actually accept them

### DIFF
--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -890,6 +890,7 @@ module StripeMerchantAccountManager
     merchant_account = MerchantAccount.where(charge_processor_id: StripeChargeProcessor.charge_processor_id,
                                              charge_processor_merchant_id: stripe_account_id)
                                       .alive.charge_processor_alive.last
+    refresh_payment_method_availability(merchant_account)
     return unless merchant_account&.country == Compliance::Countries::JPN.alpha2
 
     stripe_account = Stripe::Account.retrieve(stripe_account_id)
@@ -901,7 +902,24 @@ module StripeMerchantAccountManager
     stripe_account = stripe_event["data"]["object"]
     stripe_previous_attributes = stripe_event["data"]["previous_attributes"] || {}
     raise "Stripe Event #{stripe_event_id} does not contain an 'account' object." if stripe_account["object"] != "account"
+    refresh_payment_method_availability(
+      MerchantAccount.where(charge_processor_id: StripeChargeProcessor.charge_processor_id,
+                            charge_processor_merchant_id: stripe_account["id"]).alive.charge_processor_alive.last
+    )
     handle_stripe_info_requirements(stripe_event_id, stripe_account, stripe_previous_attributes)
+  end
+
+  # A capability or account change on a Stripe Connect (direct-charge) account may mean the
+  # seller (de)activated Cash App Pay or ACH in their own Stripe dashboard, which changes what
+  # checkout may offer on their account (see Checkout::PaymentMethodResolver). Refresh the
+  # cached availability snapshot in the background. This must run BEFORE the early returns
+  # below/around it: the JP-only guard and the standard-account guard in
+  # handle_stripe_info_requirements would otherwise skip connect accounts entirely — and connect
+  # accounts are exactly the population this cache is for.
+  def self.refresh_payment_method_availability(merchant_account)
+    return unless merchant_account&.is_a_stripe_connect_account?
+
+    RefreshMerchantAccountPaymentMethodAvailabilityWorker.perform_async(merchant_account.id)
   end
 
   def self.handle_stripe_info_requirements(stripe_event_id, stripe_account, stripe_previous_attributes)

--- a/app/models/merchant_account.rb
+++ b/app/models/merchant_account.rb
@@ -18,16 +18,18 @@ class MerchantAccount < ApplicationRecord
   attr_json_data_accessor :stripe_disabled_reason
   attr_json_data_accessor :stripe_payouts_pause_email_sent
   attr_json_data_accessor :stripe_rejection_email_sent
-  # For Stripe Connect (direct-charge) accounts: a cached snapshot of which US-locked payment
-  # methods (Cash App Pay, ACH Direct Debit) the SELLER's own Stripe account can accept. Charges
-  # for these sellers are created on their account, not Gumroad's platform account, and Stripe
-  # rejects a PaymentIntent whose payment_method_types lists a method the account hasn't
-  # activated — so checkout must only offer what the account actually supports. Shape:
-  # { "payment_method_types" => ["cashapp", ...], "refreshed_at" => <iso8601> }. Refreshed by
-  # RefreshMerchantAccountPaymentMethodAvailabilityWorker (Stripe account.updated / capability.updated
-  # webhooks, plus a lazy checkout-time backfill). A missing snapshot means "not yet fetched" and
-  # checkout fails safe by offering none of these methods.
-  attr_json_data_accessor :us_locked_payment_method_availability
+  # For Stripe Connect (direct-charge) accounts: a cached snapshot of the account's Stripe
+  # capabilities. Charges for these sellers are created on their account, not Gumroad's platform
+  # account, and Stripe rejects a PaymentIntent whose payment_method_types lists a method the
+  # account hasn't activated — so checkout must only offer what the account actually supports.
+  # The FULL capabilities hash is stored (not just the methods consulted today) so future payment
+  # method launches read from existing snapshots without a re-fetch sweep. Shape:
+  # { "capabilities" => { "cashapp_payments" => "active", ... }, "refreshed_at" => <iso8601> }.
+  # Refreshed by RefreshMerchantAccountPaymentMethodAvailabilityWorker (Stripe account.updated /
+  # capability.updated webhooks, plus a lazy checkout-time backfill). A missing snapshot means
+  # "not yet fetched" and checkout fails safe. Read via
+  # StripeConnectPaymentMethodAvailabilityService, which owns the method-type → capability mapping.
+  attr_json_data_accessor :stripe_capabilities_snapshot
 
   validates :charge_processor_id, presence: true
   validates :charge_processor_merchant_id, presence: true, if: -> { user && charge_processor_alive? }

--- a/app/models/merchant_account.rb
+++ b/app/models/merchant_account.rb
@@ -18,6 +18,16 @@ class MerchantAccount < ApplicationRecord
   attr_json_data_accessor :stripe_disabled_reason
   attr_json_data_accessor :stripe_payouts_pause_email_sent
   attr_json_data_accessor :stripe_rejection_email_sent
+  # For Stripe Connect (direct-charge) accounts: a cached snapshot of which US-locked payment
+  # methods (Cash App Pay, ACH Direct Debit) the SELLER's own Stripe account can accept. Charges
+  # for these sellers are created on their account, not Gumroad's platform account, and Stripe
+  # rejects a PaymentIntent whose payment_method_types lists a method the account hasn't
+  # activated — so checkout must only offer what the account actually supports. Shape:
+  # { "payment_method_types" => ["cashapp", ...], "refreshed_at" => <iso8601> }. Refreshed by
+  # RefreshMerchantAccountPaymentMethodAvailabilityWorker (Stripe account.updated / capability.updated
+  # webhooks, plus a lazy checkout-time backfill). A missing snapshot means "not yet fetched" and
+  # checkout fails safe by offering none of these methods.
+  attr_json_data_accessor :us_locked_payment_method_availability
 
   validates :charge_processor_id, presence: true
   validates :charge_processor_merchant_id, presence: true, if: -> { user && charge_processor_alive? }

--- a/app/services/checkout/payment_method_resolver.rb
+++ b/app/services/checkout/payment_method_resolver.rb
@@ -41,6 +41,16 @@ class Checkout::PaymentMethodResolver
   # Methods that only work for US buyers on USD PaymentIntents. ACH Direct Debit debits a US bank
   # account; Cash App Pay is US-locked. These are dropped from the launched set unless GeoIP ∈ {US}.
   US_LOCKED_PAYMENT_METHOD_TYPES = %w[us_bank_account cashapp].freeze
+  # Never gated by the per-account capability check on direct-charge sellers. Card processing is
+  # the baseline capability of any chargeable Stripe account — an account that truly can't take
+  # cards is unusable no matter what we render, and an empty method list would just break the
+  # Payment Element mount.
+  ALWAYS_ACCOUNT_SUPPORTED_PAYMENT_METHOD_TYPES = %w[card].freeze
+  # What a direct-charge checkout offers (beyond card) while the account's capability snapshot
+  # hasn't been fetched yet: Link only — the pre-capability-cache status quo, safe because Link
+  # auto-enables with the Payment Element on effectively every chargeable account. The US-locked
+  # methods stay off until the snapshot confirms them (gumroad-private#1026's failure mode).
+  CACHE_MISS_ASSUMED_PAYMENT_METHOD_TYPES = [LINK_PAYMENT_METHOD_TYPE].freeze
   US_ALPHA2 = "US"
   # PPP method matrix (U13). On a PPP-discounted checkout, only methods whose funding country is
   # verifiable pre-charge (card/wallets via card.country, and later sepa_debit.country) or whose
@@ -128,49 +138,54 @@ class Checkout::PaymentMethodResolver
       methods
     end
 
-    # What Stripe actually receives: the eligible policy set intersected with the launched set, then
-    # account-gated, then region-gated, then PPP-gated. A US-locked method (ACH, Cash App Pay) is only
-    # offered when the buyer's GeoIP country is US, so a non-US buyer never sees a method they can't
-    # complete. When the buyer country is unknown (nil), US-locked methods are dropped to fail safe.
-    # Card always survives, and Link (inline, not US-locked) is unaffected by either gate.
+    # What Stripe actually receives, built in two conceptually separate passes:
+    #
+    #   1. OUR policy decisions — launch gating, the US region gate on Cash App Pay/ACH (US-GeoIP
+    #      buyers only; unknown country fails safe), the test-mode forced-currency QA methods, and
+    #      the PPP verifiability matrix. These express what Gumroad is willing to offer this buyer
+    #      on this cart.
+    #   2. A final intersection with what the charged ACCOUNT can accept. On a direct-charge
+    #      (Stripe Connect) seller the PaymentIntent is created on the seller's own Stripe account,
+    #      and payment method capabilities live per-account — Stripe rejects an intent create whose
+    #      payment_method_types lists a method the account hasn't activated, which fails the whole
+    #      checkout no matter which method the buyer picked (gumroad-private#1026). Policy never
+    #      needs to know about capabilities and capabilities never need to know about policy; the
+    #      intersection at the end is the whole relationship.
+    #
+    # Card always survives, and Link (inline, not US-locked) is unaffected by the region gate.
     def launched_method_set(eligible)
       launched = eligible & LAUNCHED_PAYMENT_METHOD_TYPES
       launched += forced_currency_test_mode_methods(eligible)
-      launched -= us_locked_methods_to_exclude
+      launched -= US_LOCKED_PAYMENT_METHOD_TYPES unless buyer_country == US_ALPHA2
       launched = ppp_method_matrix(launched) if ppp_discounted
-      launched
+      launched & account_supported_methods(launched)
     end
 
-    # The account gate + region gate for the US-locked methods, combined because both answer the
-    # same question: can this buyer complete this method on the account the PaymentIntent will be
-    # created on?
+    # The methods (from our policy-resolved set) that the account the PaymentIntent will be created
+    # on can actually accept.
     #
-    # Region: Cash App Pay and ACH only work for US buyers, so a non-US (or unknown) GeoIP country
-    # drops them.
+    # Platform-account (Gumroad-managed) sellers: everything — the platform account's activations
+    # are under our control and every launched method is activated there.
     #
-    # Account: on a direct-charge (Stripe Connect) seller, the PaymentIntent is created on the
-    # SELLER's Stripe account, not Gumroad's platform account — and payment method capabilities
-    # live per-account. Cash App Pay and ACH are activated on the platform account, but connected
-    # accounts often lack them (non-US accounts can't have them at all), and Stripe rejects an
-    # intent create whose payment_method_types lists a method the account doesn't have. That
-    # rejection failed the entire checkout for every US buyer on those sellers, even when the
-    # buyer paid with a plain card (gumroad-private#1026). So on a connect seller we only keep the
-    # methods the account's cached capability snapshot says it can accept. No snapshot yet means
-    # fail safe (offer neither) and enqueue a background refresh so the next checkout has the
-    # answer — checkout must never block on, or fail with, a live Stripe API call.
-    def us_locked_methods_to_exclude
-      return US_LOCKED_PAYMENT_METHOD_TYPES if buyer_country != US_ALPHA2
-      return [] unless direct_charge_seller?
+    # Direct-charge (connect) sellers: whatever the account's cached capability snapshot says, with
+    # two carve-outs. Card is always kept: card processing is the baseline capability of any
+    # chargeable Stripe account, and an account that truly can't take cards is unusable regardless
+    # of what we render — an empty method list would just break the Payment Element mount. And when
+    # no snapshot exists yet, fall back to card + Link (the pre-capability-cache status quo) and
+    # enqueue a background refresh so the next checkout has the real answer — checkout must never
+    # block on, or fail with, a live Stripe API call.
+    def account_supported_methods(launched)
+      return launched unless direct_charge_seller?
 
       connect_account = sellers.first.stripe_connect_account
-      availability = StripeConnectPaymentMethodAvailabilityService.new(connect_account)
-      available = availability.available_payment_method_types(US_LOCKED_PAYMENT_METHOD_TYPES)
+      gated = launched - ALWAYS_ACCOUNT_SUPPORTED_PAYMENT_METHOD_TYPES
+      available = StripeConnectPaymentMethodAvailabilityService.new(connect_account).available_payment_method_types(gated)
       if available.nil?
         RefreshMerchantAccountPaymentMethodAvailabilityWorker.perform_async(connect_account.id)
-        return US_LOCKED_PAYMENT_METHOD_TYPES
+        return ALWAYS_ACCOUNT_SUPPORTED_PAYMENT_METHOD_TYPES + CACHE_MISS_ASSUMED_PAYMENT_METHOD_TYPES
       end
 
-      US_LOCKED_PAYMENT_METHOD_TYPES - available
+      ALWAYS_ACCOUNT_SUPPORTED_PAYMENT_METHOD_TYPES + available
     end
 
     # The EUR forced-currency methods (iDEAL/Bancontact) are not launched: they can only be offered

--- a/app/services/checkout/payment_method_resolver.rb
+++ b/app/services/checkout/payment_method_resolver.rb
@@ -133,21 +133,42 @@ class Checkout::PaymentMethodResolver
     # offered when the buyer's GeoIP country is US, so a non-US buyer never sees a method they can't
     # complete. When the buyer country is unknown (nil), US-locked methods are dropped to fail safe.
     # Card always survives, and Link (inline, not US-locked) is unaffected by either gate.
-    #
-    # The account gate: on a direct-charge (Stripe Connect) seller, the PaymentIntent is created on
-    # the SELLER's Stripe account, not Gumroad's platform account — and payment method capabilities
-    # live per-account. Cash App Pay and ACH are activated on the platform account, but connected
-    # accounts routinely lack them (non-US accounts can't have them at all, and even US connect
-    # accounts usually haven't activated them in their own dashboard). Listing a method the account
-    # doesn't have makes Stripe reject the intent create outright, which failed every US buyer's
-    # checkout on those sellers with a misleading "stripe_unavailable" error — so only offer the
-    # US-locked methods when the charge lands on the platform account, where we control activation.
     def launched_method_set(eligible)
       launched = eligible & LAUNCHED_PAYMENT_METHOD_TYPES
       launched += forced_currency_test_mode_methods(eligible)
-      launched -= US_LOCKED_PAYMENT_METHOD_TYPES if buyer_country != US_ALPHA2 || direct_charge_seller?
+      launched -= us_locked_methods_to_exclude
       launched = ppp_method_matrix(launched) if ppp_discounted
       launched
+    end
+
+    # The account gate + region gate for the US-locked methods, combined because both answer the
+    # same question: can this buyer complete this method on the account the PaymentIntent will be
+    # created on?
+    #
+    # Region: Cash App Pay and ACH only work for US buyers, so a non-US (or unknown) GeoIP country
+    # drops them.
+    #
+    # Account: on a direct-charge (Stripe Connect) seller, the PaymentIntent is created on the
+    # SELLER's Stripe account, not Gumroad's platform account — and payment method capabilities
+    # live per-account. Cash App Pay and ACH are activated on the platform account, but connected
+    # accounts often lack them (non-US accounts can't have them at all), and Stripe rejects an
+    # intent create whose payment_method_types lists a method the account doesn't have. That
+    # rejection failed the entire checkout for every US buyer on those sellers, even when the
+    # buyer paid with a plain card (gumroad-private#1026). So on a connect seller we only keep the
+    # methods the account's cached capability snapshot says it can accept. No snapshot yet means
+    # fail safe (offer neither) and enqueue a background refresh so the next checkout has the
+    # answer — checkout must never block on, or fail with, a live Stripe API call.
+    def us_locked_methods_to_exclude
+      return US_LOCKED_PAYMENT_METHOD_TYPES if buyer_country != US_ALPHA2
+      return [] unless direct_charge_seller?
+
+      availability = StripeConnectPaymentMethodAvailabilityService.new(sellers.first.stripe_connect_account)
+      unless availability.cache_present?
+        RefreshMerchantAccountPaymentMethodAvailabilityWorker.perform_async(sellers.first.stripe_connect_account.id)
+        return US_LOCKED_PAYMENT_METHOD_TYPES
+      end
+
+      US_LOCKED_PAYMENT_METHOD_TYPES - availability.cached_payment_method_types
     end
 
     # The EUR forced-currency methods (iDEAL/Bancontact) are not launched: they can only be offered

--- a/app/services/checkout/payment_method_resolver.rb
+++ b/app/services/checkout/payment_method_resolver.rb
@@ -162,9 +162,10 @@ class Checkout::PaymentMethodResolver
       return US_LOCKED_PAYMENT_METHOD_TYPES if buyer_country != US_ALPHA2
       return [] unless direct_charge_seller?
 
-      availability = StripeConnectPaymentMethodAvailabilityService.new(sellers.first.stripe_connect_account)
+      connect_account = sellers.first.stripe_connect_account
+      availability = StripeConnectPaymentMethodAvailabilityService.new(connect_account)
       unless availability.cache_present?
-        RefreshMerchantAccountPaymentMethodAvailabilityWorker.perform_async(sellers.first.stripe_connect_account.id)
+        RefreshMerchantAccountPaymentMethodAvailabilityWorker.perform_async(connect_account.id)
         return US_LOCKED_PAYMENT_METHOD_TYPES
       end
 

--- a/app/services/checkout/payment_method_resolver.rb
+++ b/app/services/checkout/payment_method_resolver.rb
@@ -180,13 +180,31 @@ class Checkout::PaymentMethodResolver
 
       connect_account = sellers.first.stripe_connect_account
       gated = launched - ALWAYS_ACCOUNT_SUPPORTED_PAYMENT_METHOD_TYPES
-      available = StripeConnectPaymentMethodAvailabilityService.new(connect_account).available_payment_method_types(gated)
+      availability = StripeConnectPaymentMethodAvailabilityService.new(connect_account)
+      available = availability.available_payment_method_types(gated)
       if available.nil?
-        RefreshMerchantAccountPaymentMethodAvailabilityWorker.perform_async(connect_account.id)
+        # Prefetch even when nothing is gated on THIS checkout (e.g. a PPP card-only cart):
+        # the snapshot is per-seller, and the next buyer may need it.
+        enqueue_availability_refresh(connect_account)
         return ALWAYS_ACCOUNT_SUPPORTED_PAYMENT_METHOD_TYPES
       end
 
+      # Self-heal for dropped webhooks: a stale snapshot is still used (checkout never blocks),
+      # but triggers a background re-fetch so a capability change whose webhook was lost — e.g.
+      # discarded by the refresh worker's until_executed lock mid-refresh — is bounded by
+      # SNAPSHOT_MAX_AGE instead of persisting forever.
+      enqueue_availability_refresh(connect_account) if availability.snapshot_stale?
+
       ALWAYS_ACCOUNT_SUPPORTED_PAYMENT_METHOD_TYPES + available
+    end
+
+    # Best-effort: the refresh improves FUTURE checkouts and must never break THIS one. A raise
+    # here (e.g. Redis unavailable at enqueue) would otherwise fail a checkout render that could
+    # have completed fine with the methods already resolved.
+    def enqueue_availability_refresh(connect_account)
+      RefreshMerchantAccountPaymentMethodAvailabilityWorker.perform_async(connect_account.id)
+    rescue => e
+      Rails.logger.error("Failed to enqueue payment method availability refresh for merchant account #{connect_account.id}: #{e.class} => #{e.message}")
     end
 
     # The EUR forced-currency methods (iDEAL/Bancontact) are not launched: they can only be offered

--- a/app/services/checkout/payment_method_resolver.rb
+++ b/app/services/checkout/payment_method_resolver.rb
@@ -44,13 +44,10 @@ class Checkout::PaymentMethodResolver
   # Never gated by the per-account capability check on direct-charge sellers. Card processing is
   # the baseline capability of any chargeable Stripe account — an account that truly can't take
   # cards is unusable no matter what we render, and an empty method list would just break the
-  # Payment Element mount.
+  # Payment Element mount. Everything else — including Link, which is absent or inactive on a
+  # meaningful share of connected accounts and makes Stripe reject the intent create when listed
+  # (verified live, gumroad-private#1026) — waits for the account's capability snapshot.
   ALWAYS_ACCOUNT_SUPPORTED_PAYMENT_METHOD_TYPES = %w[card].freeze
-  # What a direct-charge checkout offers (beyond card) while the account's capability snapshot
-  # hasn't been fetched yet: Link only — the pre-capability-cache status quo, safe because Link
-  # auto-enables with the Payment Element on effectively every chargeable account. The US-locked
-  # methods stay off until the snapshot confirms them (gumroad-private#1026's failure mode).
-  CACHE_MISS_ASSUMED_PAYMENT_METHOD_TYPES = [LINK_PAYMENT_METHOD_TYPE].freeze
   US_ALPHA2 = "US"
   # PPP method matrix (U13). On a PPP-discounted checkout, only methods whose funding country is
   # verifiable pre-charge (card/wallets via card.country, and later sepa_debit.country) or whose
@@ -171,9 +168,13 @@ class Checkout::PaymentMethodResolver
     # two carve-outs. Card is always kept: card processing is the baseline capability of any
     # chargeable Stripe account, and an account that truly can't take cards is unusable regardless
     # of what we render — an empty method list would just break the Payment Element mount. And when
-    # no snapshot exists yet, fall back to card + Link (the pre-capability-cache status quo) and
-    # enqueue a background refresh so the next checkout has the real answer — checkout must never
-    # block on, or fail with, a live Stripe API call.
+    # no snapshot exists yet, fall back to card ONLY and enqueue a background refresh so the next
+    # checkout has the real answer — checkout must never block on, or fail with, a live Stripe API
+    # call. Link is deliberately NOT assumed on a miss: link_payments is absent/inactive on a
+    # meaningful share of connected accounts (a live 40-account sample found it absent on half),
+    # and listing it on such an account makes Stripe reject the intent create — failing the whole
+    # checkout, the exact gumroad-private#1026 failure mode. One card-only checkout per uncached
+    # seller beats gambling their (often first) sale on it.
     def account_supported_methods(launched)
       return launched unless direct_charge_seller?
 
@@ -182,7 +183,7 @@ class Checkout::PaymentMethodResolver
       available = StripeConnectPaymentMethodAvailabilityService.new(connect_account).available_payment_method_types(gated)
       if available.nil?
         RefreshMerchantAccountPaymentMethodAvailabilityWorker.perform_async(connect_account.id)
-        return ALWAYS_ACCOUNT_SUPPORTED_PAYMENT_METHOD_TYPES + CACHE_MISS_ASSUMED_PAYMENT_METHOD_TYPES
+        return ALWAYS_ACCOUNT_SUPPORTED_PAYMENT_METHOD_TYPES
       end
 
       ALWAYS_ACCOUNT_SUPPORTED_PAYMENT_METHOD_TYPES + available

--- a/app/services/checkout/payment_method_resolver.rb
+++ b/app/services/checkout/payment_method_resolver.rb
@@ -164,12 +164,13 @@ class Checkout::PaymentMethodResolver
 
       connect_account = sellers.first.stripe_connect_account
       availability = StripeConnectPaymentMethodAvailabilityService.new(connect_account)
-      unless availability.cache_present?
+      available = availability.available_payment_method_types(US_LOCKED_PAYMENT_METHOD_TYPES)
+      if available.nil?
         RefreshMerchantAccountPaymentMethodAvailabilityWorker.perform_async(connect_account.id)
         return US_LOCKED_PAYMENT_METHOD_TYPES
       end
 
-      US_LOCKED_PAYMENT_METHOD_TYPES - availability.cached_payment_method_types
+      US_LOCKED_PAYMENT_METHOD_TYPES - available
     end
 
     # The EUR forced-currency methods (iDEAL/Bancontact) are not launched: they can only be offered

--- a/app/services/stripe_connect_payment_method_availability_service.rb
+++ b/app/services/stripe_connect_payment_method_availability_service.rb
@@ -39,6 +39,27 @@ class StripeConnectPaymentMethodAvailabilityService
     @merchant_account = merchant_account
   end
 
+  # How long a snapshot is trusted before checkout resolution asks for a background re-fetch.
+  # The webhooks are the primary freshness mechanism; this is the self-heal for the events they
+  # can drop — sidekiq's until_executed lock discards an enqueue that lands while a refresh for
+  # the same account is already MID-EXECUTION, so a capability deactivated in that window would
+  # otherwise stay "active" in the snapshot forever (re-listing a method the account no longer
+  # accepts — gumroad-private#1026's failure). A stale snapshot is still USED (checkout never
+  # blocks); it just also triggers a refresh so the staleness is bounded.
+  SNAPSHOT_MAX_AGE = 24.hours
+
+  def snapshot_stale?
+    snapshot = merchant_account.stripe_capabilities_snapshot
+    return false if snapshot.nil?
+
+    refreshed_at = begin
+      Time.zone.parse(snapshot["refreshed_at"].to_s)
+    rescue ArgumentError
+      nil
+    end
+    refreshed_at.nil? || refreshed_at < SNAPSHOT_MAX_AGE.ago
+  end
+
   # Fetches the account's full capabilities hash from Stripe and persists it. Returns the
   # capabilities hash. Raises on Stripe/API errors — callers decide whether to retry (the
   # refresh worker) or fail safe (checkout resolution reads the cache only).

--- a/app/services/stripe_connect_payment_method_availability_service.rb
+++ b/app/services/stripe_connect_payment_method_availability_service.rb
@@ -1,60 +1,82 @@
 # frozen_string_literal: true
 
-# Fetches which US-locked payment methods (Cash App Pay, ACH Direct Debit) a Stripe Connect
-# (direct-charge) seller's own Stripe account can accept, and caches the answer on the
-# MerchantAccount record.
+# Fetches and caches which payment methods a Stripe Connect (direct-charge) seller's own
+# Stripe account can accept, keyed off the account's capabilities.
 #
 # Why this exists: charges for a direct-charge seller are created on the seller's Stripe
 # account, not Gumroad's platform account, and payment method capabilities are per-account.
 # Stripe rejects a PaymentIntent create outright when payment_method_types lists a method the
 # account hasn't activated — which fails the whole checkout even when the buyer picked a plain
-# card (see gumroad-private#1026). So checkout must only offer these methods on accounts that
+# card (see gumroad-private#1026). So checkout must only offer methods on accounts that
 # actually have them. Standard Connect accounts manage their own capabilities (the platform
 # cannot request capabilities on the seller's behalf), which is why this is a read-and-cache,
 # never a write.
+#
+# The snapshot stores the account's ENTIRE capabilities hash, not just the capabilities we
+# consult today. The mapping from payment method type to required capability happens at read
+# time, so launching a new payment method later (SEPA, iDEAL, Klarna, ...) only needs a new
+# entry in CAPABILITY_BY_PAYMENT_METHOD_TYPE — every existing snapshot already carries the
+# answer, with no re-fetch or invalidation sweep.
 class StripeConnectPaymentMethodAvailabilityService
-  # Maps each US-locked payment method type (as used in PaymentIntent payment_method_types)
-  # to the Stripe Account capability that must be "active" for the account to accept it.
+  # Maps a payment method type (as used in PaymentIntent payment_method_types) to the Stripe
+  # Account capability that must be "active" for the account to accept it. Extend this map
+  # when a new method launches on the client-confirm path; the cached snapshots already hold
+  # the full capabilities hash. Capability names per
+  # https://docs.stripe.com/api/accounts/object#account_object-capabilities
   CAPABILITY_BY_PAYMENT_METHOD_TYPE = {
     "cashapp" => "cashapp_payments",
     "us_bank_account" => "us_bank_account_ach_payments",
+    "link" => "link_payments",
+    "klarna" => "klarna_payments",
+    "afterpay_clearpay" => "afterpay_clearpay_payments",
+    "affirm" => "affirm_payments",
+    "ideal" => "ideal_payments",
+    "bancontact" => "bancontact_payments",
+    "sepa_debit" => "sepa_debit_payments",
   }.freeze
 
   def initialize(merchant_account)
     @merchant_account = merchant_account
   end
 
-  # Fetches the account's capabilities from Stripe and persists the snapshot. Returns the
-  # available payment method types. Raises on Stripe/API errors — callers decide whether to
-  # retry (the refresh worker) or fail safe (checkout resolution reads the cache only).
+  # Fetches the account's full capabilities hash from Stripe and persists it. Returns the
+  # capabilities hash. Raises on Stripe/API errors — callers decide whether to retry (the
+  # refresh worker) or fail safe (checkout resolution reads the cache only).
   def refresh!
-    return [] unless merchant_account.is_a_stripe_connect_account?
+    return {} unless merchant_account.is_a_stripe_connect_account?
 
     stripe_account = Stripe::Account.retrieve(merchant_account.charge_processor_merchant_id)
-    capabilities = stripe_account.to_hash[:capabilities] || {}
-    available = CAPABILITY_BY_PAYMENT_METHOD_TYPE.select { |_, capability| capabilities[capability.to_sym] == "active" }.keys
+    capabilities = (stripe_account.to_hash[:capabilities] || {}).transform_keys(&:to_s)
 
     merchant_account.with_lock do
-      merchant_account.us_locked_payment_method_availability = {
-        "payment_method_types" => available,
+      merchant_account.stripe_capabilities_snapshot = {
+        "capabilities" => capabilities,
         "refreshed_at" => Time.current.iso8601,
       }
       merchant_account.save!
     end
-    available
+    capabilities
   end
 
-  # The cached available method types, or nil when no snapshot has been taken yet. Never
-  # calls Stripe — checkout resolution must not block on (or fail with) a Stripe API call.
-  def cached_payment_method_types
-    snapshot = merchant_account.us_locked_payment_method_availability
+  # Filters the given payment method types down to the ones the cached snapshot says the
+  # account accepts. Returns nil when no snapshot has been taken yet — the caller decides the
+  # fail-safe. A method type with no entry in CAPABILITY_BY_PAYMENT_METHOD_TYPE is treated as
+  # unavailable (fail closed) rather than passed through: an unmapped method on a connect
+  # account is exactly the intent-create rejection this cache exists to prevent. Never calls
+  # Stripe — checkout resolution must not block on (or fail with) a Stripe API call.
+  def available_payment_method_types(payment_method_types)
+    snapshot = merchant_account.stripe_capabilities_snapshot
     return nil if snapshot.nil?
 
-    Array(snapshot["payment_method_types"]) & CAPABILITY_BY_PAYMENT_METHOD_TYPE.keys
+    capabilities = snapshot["capabilities"] || {}
+    payment_method_types.select do |method_type|
+      capability = CAPABILITY_BY_PAYMENT_METHOD_TYPE[method_type]
+      capability.present? && capabilities[capability] == "active"
+    end
   end
 
   def cache_present?
-    !merchant_account.us_locked_payment_method_availability.nil?
+    !merchant_account.stripe_capabilities_snapshot.nil?
   end
 
   private

--- a/app/services/stripe_connect_payment_method_availability_service.rb
+++ b/app/services/stripe_connect_payment_method_availability_service.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# Fetches which US-locked payment methods (Cash App Pay, ACH Direct Debit) a Stripe Connect
+# (direct-charge) seller's own Stripe account can accept, and caches the answer on the
+# MerchantAccount record.
+#
+# Why this exists: charges for a direct-charge seller are created on the seller's Stripe
+# account, not Gumroad's platform account, and payment method capabilities are per-account.
+# Stripe rejects a PaymentIntent create outright when payment_method_types lists a method the
+# account hasn't activated — which fails the whole checkout even when the buyer picked a plain
+# card (see gumroad-private#1026). So checkout must only offer these methods on accounts that
+# actually have them. Standard Connect accounts manage their own capabilities (the platform
+# cannot request capabilities on the seller's behalf), which is why this is a read-and-cache,
+# never a write.
+class StripeConnectPaymentMethodAvailabilityService
+  # Maps each US-locked payment method type (as used in PaymentIntent payment_method_types)
+  # to the Stripe Account capability that must be "active" for the account to accept it.
+  CAPABILITY_BY_PAYMENT_METHOD_TYPE = {
+    "cashapp" => "cashapp_payments",
+    "us_bank_account" => "us_bank_account_ach_payments",
+  }.freeze
+
+  def initialize(merchant_account)
+    @merchant_account = merchant_account
+  end
+
+  # Fetches the account's capabilities from Stripe and persists the snapshot. Returns the
+  # available payment method types. Raises on Stripe/API errors — callers decide whether to
+  # retry (the refresh worker) or fail safe (checkout resolution reads the cache only).
+  def refresh!
+    return [] unless merchant_account.is_a_stripe_connect_account?
+
+    stripe_account = Stripe::Account.retrieve(merchant_account.charge_processor_merchant_id)
+    capabilities = stripe_account.to_hash[:capabilities] || {}
+    available = CAPABILITY_BY_PAYMENT_METHOD_TYPE.select { |_, capability| capabilities[capability.to_sym] == "active" }.keys
+
+    merchant_account.with_lock do
+      merchant_account.us_locked_payment_method_availability = {
+        "payment_method_types" => available,
+        "refreshed_at" => Time.current.iso8601,
+      }
+      merchant_account.save!
+    end
+    available
+  end
+
+  # The cached available method types, or nil when no snapshot has been taken yet. Never
+  # calls Stripe — checkout resolution must not block on (or fail with) a Stripe API call.
+  def cached_payment_method_types
+    snapshot = merchant_account.us_locked_payment_method_availability
+    return nil if snapshot.nil?
+
+    Array(snapshot["payment_method_types"]) & CAPABILITY_BY_PAYMENT_METHOD_TYPE.keys
+  end
+
+  def cache_present?
+    !merchant_account.us_locked_payment_method_availability.nil?
+  end
+
+  private
+    attr_reader :merchant_account
+end

--- a/app/sidekiq/refresh_merchant_account_payment_method_availability_worker.rb
+++ b/app/sidekiq/refresh_merchant_account_payment_method_availability_worker.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Refreshes the cached US-locked payment method availability snapshot for a Stripe Connect
+# (direct-charge) seller's MerchantAccount. Enqueued from three places:
+#   1. Stripe account.updated / capability.updated webhooks — the seller (de)activated a
+#      payment method in their own Stripe dashboard.
+#   2. Checkout resolution (Checkout::PaymentMethodResolver) when a connect seller has no
+#      snapshot yet — the lazy backfill. That checkout fails safe (offers none of the
+#      US-locked methods); the NEXT checkout benefits from the fetched snapshot.
+#   3. Any manual/console backfill sweep.
+# lock: :until_executed dedupes the bursts these sources produce (Stripe sends several
+# account.updated events in a row; every checkout on an uncached seller enqueues one).
+class RefreshMerchantAccountPaymentMethodAvailabilityWorker
+  include Sidekiq::Job
+  sidekiq_options queue: :low, retry: 3, lock: :until_executed
+
+  def perform(merchant_account_id)
+    merchant_account = MerchantAccount.find(merchant_account_id)
+    return unless merchant_account.alive? && merchant_account.charge_processor_alive?
+    return unless merchant_account.is_a_stripe_connect_account?
+
+    StripeConnectPaymentMethodAvailabilityService.new(merchant_account).refresh!
+  rescue Stripe::PermissionError, Stripe::AuthenticationError
+    # The account revoked platform access (deauthorized between enqueue and execution).
+    # There is nothing to refresh; deauthorization handling elsewhere will bury the record.
+  end
+end

--- a/app/sidekiq/refresh_merchant_account_payment_method_availability_worker.rb
+++ b/app/sidekiq/refresh_merchant_account_payment_method_availability_worker.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# Refreshes the cached US-locked payment method availability snapshot for a Stripe Connect
-# (direct-charge) seller's MerchantAccount. Enqueued from three places:
+# Refreshes the cached Stripe capabilities snapshot for a Stripe Connect (direct-charge)
+# seller's MerchantAccount. Enqueued from three places:
 #   1. Stripe account.updated / capability.updated webhooks — the seller (de)activated a
 #      payment method in their own Stripe dashboard.
 #   2. Checkout resolution (Checkout::PaymentMethodResolver) when a connect seller has no
@@ -23,5 +23,9 @@ class RefreshMerchantAccountPaymentMethodAvailabilityWorker
   rescue Stripe::PermissionError, Stripe::AuthenticationError
     # The account revoked platform access (deauthorized between enqueue and execution).
     # There is nothing to refresh; deauthorization handling elsewhere will bury the record.
+  rescue Stripe::InvalidRequestError => e
+    # Stripe-side-deleted account (raced ahead of our deauth webhook processing): same story —
+    # nothing to refresh, retrying can't succeed. Anything else is a real error; let it retry.
+    raise unless e.message.to_s.match?(/does not exist/i)
   end
 end

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -12319,6 +12319,77 @@ describe StripeMerchantAccountManager, :vcr do
     end
   end
 
+  describe "payment method availability refresh on account/capability webhooks" do
+    let(:seller) { create(:user) }
+    let!(:connect_account) { create(:merchant_account_stripe_connect, user: seller) }
+
+    def capability_updated_event(account_id)
+      {
+        "api_version" => API_VERSION,
+        "type" => "capability.updated",
+        "id" => "stripe-event-id",
+        "data" => {
+          "object" => {
+            "object" => "capability",
+            "id" => "cashapp_payments",
+            "account" => account_id,
+            "status" => "active",
+          }
+        }
+      }
+    end
+
+    def account_updated_event(account_id)
+      {
+        "api_version" => API_VERSION,
+        "type" => "account.updated",
+        "id" => "stripe-event-id",
+        "account" => account_id,
+        "user_id" => account_id,
+        "data" => {
+          "object" => {
+            "object" => "account",
+            "id" => account_id,
+            "type" => "standard",
+            "requirements" => { "currently_due" => [], "eventually_due" => [], "past_due" => [] }
+          }
+        }
+      }
+    end
+
+    it "enqueues a refresh for a connect account on capability.updated — including non-JP accounts, which the JP-only guard below the call returns early for" do
+      expect(RefreshMerchantAccountPaymentMethodAvailabilityWorker).to receive(:perform_async).with(connect_account.id)
+
+      described_class.handle_stripe_event(capability_updated_event(connect_account.charge_processor_merchant_id))
+    end
+
+    it "enqueues a refresh for a connect account on account.updated — including standard accounts, which handle_stripe_info_requirements returns early for" do
+      expect(RefreshMerchantAccountPaymentMethodAvailabilityWorker).to receive(:perform_async).with(connect_account.id)
+
+      described_class.handle_stripe_event(account_updated_event(connect_account.charge_processor_merchant_id))
+    end
+
+    it "does not enqueue for an unknown account" do
+      expect(RefreshMerchantAccountPaymentMethodAvailabilityWorker).not_to receive(:perform_async)
+
+      described_class.handle_stripe_event(capability_updated_event("acct_nonexistent"))
+    end
+
+    it "does not enqueue for a non-connect (Gumroad-managed) account" do
+      managed_account = create(:merchant_account)
+      expect(RefreshMerchantAccountPaymentMethodAvailabilityWorker).not_to receive(:perform_async)
+
+      described_class.handle_stripe_event(capability_updated_event(managed_account.charge_processor_merchant_id))
+    end
+
+    it "does not enqueue for a deauthorized (charge-processor-dead) connect account" do
+      connect_account.update!(charge_processor_alive_at: nil)
+      expect(RefreshMerchantAccountPaymentMethodAvailabilityWorker).not_to receive(:perform_async)
+
+      described_class.handle_stripe_event(capability_updated_event(connect_account.charge_processor_merchant_id))
+    end
+  end
+
   describe "handling information update" do
     let(:user) { create(:user) }
     let(:user_compliance_info) { create(:user_compliance_info, user:) }

--- a/spec/presenters/checkout/stripe_payment_presenter_spec.rb
+++ b/spec/presenters/checkout/stripe_payment_presenter_spec.rb
@@ -496,6 +496,12 @@ describe Checkout::StripePaymentPresenter do
       seller = create(:user, check_merchant_account_is_linked: true)
       product = create(:product, user: seller, price_cents: 1234)
       connect_account = create(:merchant_account_stripe_connect, user: seller)
+      # A capability snapshot must exist for the account to offer anything beyond card
+      # (an uncached connect account resolves card-only while the refresh worker runs).
+      connect_account.update!(stripe_capabilities_snapshot: {
+                                "capabilities" => { "link_payments" => "active" },
+                                "refreshed_at" => Time.current.iso8601,
+                              })
       Feature.activate_user(described_class::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, seller)
       Feature.activate_user(described_class::STRIPE_PAYMENT_ELEMENT_CLIENT_CONFIRM_FEATURE_NAME, seller)
 

--- a/spec/services/checkout/payment_method_resolver_spec.rb
+++ b/spec/services/checkout/payment_method_resolver_spec.rb
@@ -162,10 +162,16 @@ describe Checkout::PaymentMethodResolver do
       end
 
       context "when the account has no availability snapshot yet" do
-        it "fails safe to card and Link for a US buyer and enqueues a background refresh" do
+        it "fails safe to card only for a US buyer and enqueues a background refresh — even Link waits for the snapshot, since link_payments is absent on many connected accounts and listing it fails the intent create" do
           expect(RefreshMerchantAccountPaymentMethodAvailabilityWorker).to receive(:perform_async).with(connect_account.id)
 
-          expect(resolve(buyer_country: "US").payment_method_types).to eq(%w[card link])
+          expect(resolve(buyer_country: "US").payment_method_types).to eq(%w[card])
+        end
+
+        it "resolves card only for a non-US buyer too" do
+          expect(RefreshMerchantAccountPaymentMethodAvailabilityWorker).to receive(:perform_async).with(connect_account.id)
+
+          expect(resolve(buyer_country: "GB").payment_method_types).to eq(%w[card])
         end
       end
 
@@ -234,6 +240,11 @@ describe Checkout::PaymentMethodResolver do
       end
 
       it "drops US-locked methods for a non-US buyer while keeping the connected-account scope" do
+        connect_account.update!(stripe_capabilities_snapshot: {
+                                  "capabilities" => { "link_payments" => "active", "cashapp_payments" => "active", "us_bank_account_ach_payments" => "active" },
+                                  "refreshed_at" => Time.current.iso8601,
+                                })
+
         resolution = resolve(buyer_country: "GB")
 
         expect(resolution.stripe_connect_account_id).to eq(connect_account.charge_processor_merchant_id)

--- a/spec/services/checkout/payment_method_resolver_spec.rb
+++ b/spec/services/checkout/payment_method_resolver_spec.rb
@@ -161,12 +161,63 @@ describe Checkout::PaymentMethodResolver do
         expect(resolution.stripe_connect_account_id).to eq(connect_account.charge_processor_merchant_id)
       end
 
-      it "drops the US-locked methods even for a US buyer — the intent is created on the seller's own Stripe account, which lacks the Cash App/ACH capabilities the platform account has" do
-        expect(resolve(buyer_country: "US").payment_method_types).to eq(%w[card link])
+      context "when the account has no availability snapshot yet" do
+        it "fails safe to card and Link for a US buyer and enqueues a background refresh" do
+          expect(RefreshMerchantAccountPaymentMethodAvailabilityWorker).to receive(:perform_async).with(connect_account.id)
+
+          expect(resolve(buyer_country: "US").payment_method_types).to eq(%w[card link])
+        end
       end
 
-      it "resolves card-only for a US PPP buyer — Link is PPP-gated and the US-locked methods are account-gated" do
-        expect(resolve(buyer_country: "US", ppp_discounted: true).payment_method_types).to eq(["card"])
+      context "when the snapshot says the account accepts both US-locked methods" do
+        before do
+          connect_account.update!(us_locked_payment_method_availability: {
+                                    "payment_method_types" => %w[cashapp us_bank_account],
+                                    "refreshed_at" => Time.current.iso8601,
+                                  })
+        end
+
+        it "offers them to a US buyer without enqueueing a refresh" do
+          expect(RefreshMerchantAccountPaymentMethodAvailabilityWorker).not_to receive(:perform_async)
+
+          expect(resolve(buyer_country: "US").payment_method_types).to eq(%w[card link cashapp us_bank_account])
+        end
+
+        it "still drops them for a non-US buyer — the region gate applies before the account gate" do
+          expect(resolve(buyer_country: "GB").payment_method_types).to eq(%w[card link])
+        end
+      end
+
+      context "when the snapshot says the account accepts only Cash App Pay" do
+        before do
+          connect_account.update!(us_locked_payment_method_availability: {
+                                    "payment_method_types" => %w[cashapp],
+                                    "refreshed_at" => Time.current.iso8601,
+                                  })
+        end
+
+        it "offers exactly the accepted method to a US buyer" do
+          expect(resolve(buyer_country: "US").payment_method_types).to eq(%w[card link cashapp])
+        end
+      end
+
+      context "when the snapshot says the account accepts neither" do
+        before do
+          connect_account.update!(us_locked_payment_method_availability: {
+                                    "payment_method_types" => [],
+                                    "refreshed_at" => Time.current.iso8601,
+                                  })
+        end
+
+        it "resolves card and Link for a US buyer without enqueueing a refresh — the empty snapshot is an answer, not a miss" do
+          expect(RefreshMerchantAccountPaymentMethodAvailabilityWorker).not_to receive(:perform_async)
+
+          expect(resolve(buyer_country: "US").payment_method_types).to eq(%w[card link])
+        end
+
+        it "resolves card-only for a US PPP buyer — Link is PPP-gated and the account accepts no US-locked methods" do
+          expect(resolve(buyer_country: "US", ppp_discounted: true).payment_method_types).to eq(["card"])
+        end
       end
 
       it "drops US-locked methods for a non-US buyer while keeping the connected-account scope" do

--- a/spec/services/checkout/payment_method_resolver_spec.rb
+++ b/spec/services/checkout/payment_method_resolver_spec.rb
@@ -171,8 +171,8 @@ describe Checkout::PaymentMethodResolver do
 
       context "when the snapshot says the account accepts both US-locked methods" do
         before do
-          connect_account.update!(us_locked_payment_method_availability: {
-                                    "payment_method_types" => %w[cashapp us_bank_account],
+          connect_account.update!(stripe_capabilities_snapshot: {
+                                    "capabilities" => { "cashapp_payments" => "active", "us_bank_account_ach_payments" => "active" },
                                     "refreshed_at" => Time.current.iso8601,
                                   })
         end
@@ -190,8 +190,8 @@ describe Checkout::PaymentMethodResolver do
 
       context "when the snapshot says the account accepts only Cash App Pay" do
         before do
-          connect_account.update!(us_locked_payment_method_availability: {
-                                    "payment_method_types" => %w[cashapp],
+          connect_account.update!(stripe_capabilities_snapshot: {
+                                    "capabilities" => { "cashapp_payments" => "active", "us_bank_account_ach_payments" => "inactive" },
                                     "refreshed_at" => Time.current.iso8601,
                                   })
         end
@@ -203,8 +203,8 @@ describe Checkout::PaymentMethodResolver do
 
       context "when the snapshot says the account accepts neither" do
         before do
-          connect_account.update!(us_locked_payment_method_availability: {
-                                    "payment_method_types" => [],
+          connect_account.update!(stripe_capabilities_snapshot: {
+                                    "capabilities" => { "card_payments" => "active" },
                                     "refreshed_at" => Time.current.iso8601,
                                   })
         end

--- a/spec/services/checkout/payment_method_resolver_spec.rb
+++ b/spec/services/checkout/payment_method_resolver_spec.rb
@@ -173,6 +173,27 @@ describe Checkout::PaymentMethodResolver do
 
           expect(resolve(buyer_country: "GB").payment_method_types).to eq(%w[card])
         end
+
+        it "keeps the checkout render alive when the refresh enqueue itself fails — the refresh is best-effort" do
+          expect(RefreshMerchantAccountPaymentMethodAvailabilityWorker).to receive(:perform_async).and_raise(RedisClient::CannotConnectError)
+
+          expect(resolve(buyer_country: "US").payment_method_types).to eq(%w[card])
+        end
+      end
+
+      context "when the snapshot is older than SNAPSHOT_MAX_AGE" do
+        before do
+          connect_account.update!(stripe_capabilities_snapshot: {
+                                    "capabilities" => { "link_payments" => "active", "cashapp_payments" => "active", "us_bank_account_ach_payments" => "active" },
+                                    "refreshed_at" => (StripeConnectPaymentMethodAvailabilityService::SNAPSHOT_MAX_AGE + 1.hour).ago.iso8601,
+                                  })
+        end
+
+        it "still uses the stale snapshot (checkout never blocks) but enqueues a background re-fetch — the self-heal for webhooks dropped by the worker's until_executed lock" do
+          expect(RefreshMerchantAccountPaymentMethodAvailabilityWorker).to receive(:perform_async).with(connect_account.id)
+
+          expect(resolve(buyer_country: "US").payment_method_types).to eq(%w[card link cashapp us_bank_account])
+        end
       end
 
       context "when the snapshot says the account accepts both US-locked methods" do

--- a/spec/services/checkout/payment_method_resolver_spec.rb
+++ b/spec/services/checkout/payment_method_resolver_spec.rb
@@ -172,7 +172,7 @@ describe Checkout::PaymentMethodResolver do
       context "when the snapshot says the account accepts both US-locked methods" do
         before do
           connect_account.update!(stripe_capabilities_snapshot: {
-                                    "capabilities" => { "cashapp_payments" => "active", "us_bank_account_ach_payments" => "active" },
+                                    "capabilities" => { "link_payments" => "active", "cashapp_payments" => "active", "us_bank_account_ach_payments" => "active" },
                                     "refreshed_at" => Time.current.iso8601,
                                   })
         end
@@ -183,7 +183,7 @@ describe Checkout::PaymentMethodResolver do
           expect(resolve(buyer_country: "US").payment_method_types).to eq(%w[card link cashapp us_bank_account])
         end
 
-        it "still drops them for a non-US buyer — the region gate applies before the account gate" do
+        it "still drops them for a non-US buyer — our region policy applies regardless of the account's capabilities" do
           expect(resolve(buyer_country: "GB").payment_method_types).to eq(%w[card link])
         end
       end
@@ -191,7 +191,7 @@ describe Checkout::PaymentMethodResolver do
       context "when the snapshot says the account accepts only Cash App Pay" do
         before do
           connect_account.update!(stripe_capabilities_snapshot: {
-                                    "capabilities" => { "cashapp_payments" => "active", "us_bank_account_ach_payments" => "inactive" },
+                                    "capabilities" => { "link_payments" => "active", "cashapp_payments" => "active", "us_bank_account_ach_payments" => "inactive" },
                                     "refreshed_at" => Time.current.iso8601,
                                   })
         end
@@ -201,10 +201,23 @@ describe Checkout::PaymentMethodResolver do
         end
       end
 
-      context "when the snapshot says the account accepts neither" do
+      context "when the snapshot says the account's Link capability is not active" do
         before do
           connect_account.update!(stripe_capabilities_snapshot: {
-                                    "capabilities" => { "card_payments" => "active" },
+                                    "capabilities" => { "cashapp_payments" => "active" },
+                                    "refreshed_at" => Time.current.iso8601,
+                                  })
+        end
+
+        it "drops Link too — the capability intersection covers every method, not just the US-locked pair" do
+          expect(resolve(buyer_country: "US").payment_method_types).to eq(%w[card cashapp])
+        end
+      end
+
+      context "when the snapshot says the account accepts neither US-locked method" do
+        before do
+          connect_account.update!(stripe_capabilities_snapshot: {
+                                    "capabilities" => { "card_payments" => "active", "link_payments" => "active" },
                                     "refreshed_at" => Time.current.iso8601,
                                   })
         end

--- a/spec/services/order/prepare_payment_intent_service_spec.rb
+++ b/spec/services/order/prepare_payment_intent_service_spec.rb
@@ -445,6 +445,12 @@ describe Order::PreparePaymentIntentService, :vcr do
       let!(:connect_account) { create(:merchant_account_stripe_connect, user: seller) }
 
       before do
+        # A capability snapshot must exist for the account to offer anything beyond card
+        # (an uncached connect account resolves card-only while the refresh worker runs).
+        connect_account.update!(stripe_capabilities_snapshot: {
+                                  "capabilities" => { "link_payments" => "active" },
+                                  "refreshed_at" => Time.current.iso8601,
+                                })
         Feature.activate_user(:buyer_local_currency, seller)
         Feature.activate_user(Checkout::BuyerCurrencyEligibility::FEATURE_NAME, seller)
         allow(Stripe).to receive(:api_key).and_return("sk_test_currency")

--- a/spec/services/stripe_connect_payment_method_availability_service_spec.rb
+++ b/spec/services/stripe_connect_payment_method_availability_service_spec.rb
@@ -12,60 +12,88 @@ describe StripeConnectPaymentMethodAvailabilityService do
   end
 
   describe "#refresh!" do
-    it "persists the US-locked methods whose capabilities are active" do
+    it "persists the account's full capabilities hash, not just the methods consulted today" do
       allow(Stripe::Account).to receive(:retrieve)
         .with(merchant_account.charge_processor_merchant_id)
-        .and_return(stripe_account_with(cashapp_payments: "active", us_bank_account_ach_payments: "active", card_payments: "active"))
+        .and_return(stripe_account_with(cashapp_payments: "active", us_bank_account_ach_payments: "active", card_payments: "active", sepa_debit_payments: "active"))
 
-      expect(service.refresh!).to match_array(%w[cashapp us_bank_account])
-      expect(merchant_account.reload.us_locked_payment_method_availability["payment_method_types"]).to match_array(%w[cashapp us_bank_account])
-      expect(merchant_account.us_locked_payment_method_availability["refreshed_at"]).to be_present
+      expect(service.refresh!).to eq(
+        "cashapp_payments" => "active",
+        "us_bank_account_ach_payments" => "active",
+        "card_payments" => "active",
+        "sepa_debit_payments" => "active",
+      )
+      snapshot = merchant_account.reload.stripe_capabilities_snapshot
+      expect(snapshot["capabilities"]).to include("card_payments" => "active", "sepa_debit_payments" => "active")
+      expect(snapshot["refreshed_at"]).to be_present
     end
 
-    it "persists a partial set when only one capability is active" do
+    it "persists non-active states verbatim so read-time filtering can distinguish pending from absent" do
       allow(Stripe::Account).to receive(:retrieve)
-        .and_return(stripe_account_with(cashapp_payments: "active", card_payments: "active"))
+        .and_return(stripe_account_with(cashapp_payments: "pending", card_payments: "active"))
 
-      expect(service.refresh!).to eq(%w[cashapp])
-      expect(merchant_account.reload.us_locked_payment_method_availability["payment_method_types"]).to eq(%w[cashapp])
+      service.refresh!
+
+      expect(merchant_account.reload.stripe_capabilities_snapshot["capabilities"]).to eq(
+        "cashapp_payments" => "pending", "card_payments" => "active"
+      )
     end
 
-    it "persists an empty set when the capabilities are absent — a typical non-US connected account" do
-      allow(Stripe::Account).to receive(:retrieve)
-        .and_return(stripe_account_with(card_payments: "active", transfers: "active"))
+    it "persists an empty hash when the account reports no capabilities" do
+      allow(Stripe::Account).to receive(:retrieve).and_return(stripe_account_with(nil))
 
-      expect(service.refresh!).to eq([])
-      expect(merchant_account.reload.us_locked_payment_method_availability["payment_method_types"]).to eq([])
-    end
-
-    it "treats an inactive capability as unavailable — only \"active\" counts" do
-      allow(Stripe::Account).to receive(:retrieve)
-        .and_return(stripe_account_with(cashapp_payments: "pending", us_bank_account_ach_payments: "inactive"))
-
-      expect(service.refresh!).to eq([])
+      expect(service.refresh!).to eq({})
+      expect(merchant_account.reload.stripe_capabilities_snapshot["capabilities"]).to eq({})
     end
 
     it "does nothing for a Gumroad-managed account — their charges run on the platform account" do
       managed = create(:merchant_account, user: seller)
 
       expect(Stripe::Account).not_to receive(:retrieve)
-      expect(described_class.new(managed).refresh!).to eq([])
-      expect(managed.reload.us_locked_payment_method_availability).to be_nil
+      expect(described_class.new(managed).refresh!).to eq({})
+      expect(managed.reload.stripe_capabilities_snapshot).to be_nil
     end
   end
 
-  describe "#cached_payment_method_types" do
-    it "returns nil when no snapshot has been taken" do
-      expect(service.cached_payment_method_types).to be_nil
+  describe "#available_payment_method_types" do
+    it "returns nil when no snapshot has been taken — the caller owns the fail-safe" do
+      expect(service.available_payment_method_types(%w[cashapp us_bank_account])).to be_nil
     end
 
-    it "returns the snapshot's methods, filtered to the known US-locked set" do
-      merchant_account.update!(us_locked_payment_method_availability: {
-                                 "payment_method_types" => %w[cashapp something_unknown],
+    it "keeps only the methods whose mapped capability is active" do
+      merchant_account.update!(stripe_capabilities_snapshot: {
+                                 "capabilities" => { "cashapp_payments" => "active", "us_bank_account_ach_payments" => "inactive" },
                                  "refreshed_at" => Time.current.iso8601,
                                })
 
-      expect(service.cached_payment_method_types).to eq(%w[cashapp])
+      expect(service.available_payment_method_types(%w[cashapp us_bank_account])).to eq(%w[cashapp])
+    end
+
+    it "treats a pending capability as unavailable — only \"active\" counts" do
+      merchant_account.update!(stripe_capabilities_snapshot: {
+                                 "capabilities" => { "cashapp_payments" => "pending" },
+                                 "refreshed_at" => Time.current.iso8601,
+                               })
+
+      expect(service.available_payment_method_types(%w[cashapp])).to eq([])
+    end
+
+    it "answers for methods beyond the US-locked pair — future launches read existing snapshots" do
+      merchant_account.update!(stripe_capabilities_snapshot: {
+                                 "capabilities" => { "sepa_debit_payments" => "active", "ideal_payments" => "active", "klarna_payments" => "inactive" },
+                                 "refreshed_at" => Time.current.iso8601,
+                               })
+
+      expect(service.available_payment_method_types(%w[sepa_debit ideal klarna])).to eq(%w[sepa_debit ideal])
+    end
+
+    it "fails closed on a method type with no capability mapping" do
+      merchant_account.update!(stripe_capabilities_snapshot: {
+                                 "capabilities" => { "card_payments" => "active" },
+                                 "refreshed_at" => Time.current.iso8601,
+                               })
+
+      expect(service.available_payment_method_types(%w[some_future_method])).to eq([])
     end
   end
 
@@ -73,8 +101,8 @@ describe StripeConnectPaymentMethodAvailabilityService do
     it "distinguishes an empty snapshot (an answer) from a missing one" do
       expect(service.cache_present?).to be(false)
 
-      merchant_account.update!(us_locked_payment_method_availability: {
-                                 "payment_method_types" => [],
+      merchant_account.update!(stripe_capabilities_snapshot: {
+                                 "capabilities" => {},
                                  "refreshed_at" => Time.current.iso8601,
                                })
 

--- a/spec/services/stripe_connect_payment_method_availability_service_spec.rb
+++ b/spec/services/stripe_connect_payment_method_availability_service_spec.rb
@@ -109,4 +109,36 @@ describe StripeConnectPaymentMethodAvailabilityService do
       expect(service.cache_present?).to be(true)
     end
   end
+
+  describe "#snapshot_stale?" do
+    it "is false when there is no snapshot — a miss is a miss, not staleness" do
+      expect(service.snapshot_stale?).to be(false)
+    end
+
+    it "is false for a snapshot refreshed within SNAPSHOT_MAX_AGE" do
+      merchant_account.update!(stripe_capabilities_snapshot: {
+                                 "capabilities" => {},
+                                 "refreshed_at" => 1.hour.ago.iso8601,
+                               })
+
+      expect(service.snapshot_stale?).to be(false)
+    end
+
+    it "is true for a snapshot older than SNAPSHOT_MAX_AGE" do
+      merchant_account.update!(stripe_capabilities_snapshot: {
+                                 "capabilities" => {},
+                                 "refreshed_at" => (described_class::SNAPSHOT_MAX_AGE + 1.hour).ago.iso8601,
+                               })
+
+      expect(service.snapshot_stale?).to be(true)
+    end
+
+    it "is true when refreshed_at is missing or unparseable — treat unknown age as stale" do
+      merchant_account.update!(stripe_capabilities_snapshot: { "capabilities" => {} })
+      expect(service.snapshot_stale?).to be(true)
+
+      merchant_account.update!(stripe_capabilities_snapshot: { "capabilities" => {}, "refreshed_at" => "garbage" })
+      expect(service.snapshot_stale?).to be(true)
+    end
+  end
 end

--- a/spec/services/stripe_connect_payment_method_availability_service_spec.rb
+++ b/spec/services/stripe_connect_payment_method_availability_service_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe StripeConnectPaymentMethodAvailabilityService do
+  let(:seller) { create(:user, check_merchant_account_is_linked: true) }
+  let(:merchant_account) { create(:merchant_account_stripe_connect, user: seller) }
+  let(:service) { described_class.new(merchant_account) }
+
+  def stripe_account_with(capabilities)
+    Stripe::Util.convert_to_stripe_object({ id: merchant_account.charge_processor_merchant_id, object: "account", capabilities: }, {})
+  end
+
+  describe "#refresh!" do
+    it "persists the US-locked methods whose capabilities are active" do
+      allow(Stripe::Account).to receive(:retrieve)
+        .with(merchant_account.charge_processor_merchant_id)
+        .and_return(stripe_account_with(cashapp_payments: "active", us_bank_account_ach_payments: "active", card_payments: "active"))
+
+      expect(service.refresh!).to match_array(%w[cashapp us_bank_account])
+      expect(merchant_account.reload.us_locked_payment_method_availability["payment_method_types"]).to match_array(%w[cashapp us_bank_account])
+      expect(merchant_account.us_locked_payment_method_availability["refreshed_at"]).to be_present
+    end
+
+    it "persists a partial set when only one capability is active" do
+      allow(Stripe::Account).to receive(:retrieve)
+        .and_return(stripe_account_with(cashapp_payments: "active", card_payments: "active"))
+
+      expect(service.refresh!).to eq(%w[cashapp])
+      expect(merchant_account.reload.us_locked_payment_method_availability["payment_method_types"]).to eq(%w[cashapp])
+    end
+
+    it "persists an empty set when the capabilities are absent — a typical non-US connected account" do
+      allow(Stripe::Account).to receive(:retrieve)
+        .and_return(stripe_account_with(card_payments: "active", transfers: "active"))
+
+      expect(service.refresh!).to eq([])
+      expect(merchant_account.reload.us_locked_payment_method_availability["payment_method_types"]).to eq([])
+    end
+
+    it "treats an inactive capability as unavailable — only \"active\" counts" do
+      allow(Stripe::Account).to receive(:retrieve)
+        .and_return(stripe_account_with(cashapp_payments: "pending", us_bank_account_ach_payments: "inactive"))
+
+      expect(service.refresh!).to eq([])
+    end
+
+    it "does nothing for a Gumroad-managed account — their charges run on the platform account" do
+      managed = create(:merchant_account, user: seller)
+
+      expect(Stripe::Account).not_to receive(:retrieve)
+      expect(described_class.new(managed).refresh!).to eq([])
+      expect(managed.reload.us_locked_payment_method_availability).to be_nil
+    end
+  end
+
+  describe "#cached_payment_method_types" do
+    it "returns nil when no snapshot has been taken" do
+      expect(service.cached_payment_method_types).to be_nil
+    end
+
+    it "returns the snapshot's methods, filtered to the known US-locked set" do
+      merchant_account.update!(us_locked_payment_method_availability: {
+                                 "payment_method_types" => %w[cashapp something_unknown],
+                                 "refreshed_at" => Time.current.iso8601,
+                               })
+
+      expect(service.cached_payment_method_types).to eq(%w[cashapp])
+    end
+  end
+
+  describe "#cache_present?" do
+    it "distinguishes an empty snapshot (an answer) from a missing one" do
+      expect(service.cache_present?).to be(false)
+
+      merchant_account.update!(us_locked_payment_method_availability: {
+                                 "payment_method_types" => [],
+                                 "refreshed_at" => Time.current.iso8601,
+                               })
+
+      expect(service.cache_present?).to be(true)
+    end
+  end
+end

--- a/spec/sidekiq/refresh_merchant_account_payment_method_availability_worker_spec.rb
+++ b/spec/sidekiq/refresh_merchant_account_payment_method_availability_worker_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe RefreshMerchantAccountPaymentMethodAvailabilityWorker do
+  let(:seller) { create(:user, check_merchant_account_is_linked: true) }
+  let(:merchant_account) { create(:merchant_account_stripe_connect, user: seller) }
+
+  it "refreshes the availability snapshot for a live connect account" do
+    service = instance_double(StripeConnectPaymentMethodAvailabilityService)
+    expect(StripeConnectPaymentMethodAvailabilityService).to receive(:new).with(merchant_account).and_return(service)
+    expect(service).to receive(:refresh!)
+
+    described_class.new.perform(merchant_account.id)
+  end
+
+  it "skips deleted accounts" do
+    merchant_account.mark_deleted!
+
+    expect(StripeConnectPaymentMethodAvailabilityService).not_to receive(:new)
+    described_class.new.perform(merchant_account.id)
+  end
+
+  it "skips accounts whose charge processor connection is dead" do
+    merchant_account.update!(charge_processor_alive_at: nil, charge_processor_deleted_at: Time.current)
+
+    expect(StripeConnectPaymentMethodAvailabilityService).not_to receive(:new)
+    described_class.new.perform(merchant_account.id)
+  end
+
+  it "skips Gumroad-managed accounts — their charges run on the platform account" do
+    managed = create(:merchant_account, user: seller)
+
+    expect(StripeConnectPaymentMethodAvailabilityService).not_to receive(:new)
+    described_class.new.perform(managed.id)
+  end
+
+  it "swallows a permission error — the account was deauthorized between enqueue and execution" do
+    allow_any_instance_of(StripeConnectPaymentMethodAvailabilityService).to receive(:refresh!)
+      .and_raise(Stripe::PermissionError.new("Application access may have been revoked."))
+
+    expect { described_class.new.perform(merchant_account.id) }.not_to raise_error
+  end
+end

--- a/spec/sidekiq/refresh_merchant_account_payment_method_availability_worker_spec.rb
+++ b/spec/sidekiq/refresh_merchant_account_payment_method_availability_worker_spec.rb
@@ -48,4 +48,18 @@ describe RefreshMerchantAccountPaymentMethodAvailabilityWorker do
 
     expect { described_class.new.perform(merchant_account.id) }.not_to raise_error
   end
+
+  it "swallows an invalid-request error for a Stripe-side-deleted account — the race before our deauth webhook is processed" do
+    allow_any_instance_of(StripeConnectPaymentMethodAvailabilityService).to receive(:refresh!)
+      .and_raise(Stripe::InvalidRequestError.new("The account acct_123 does not exist.", "account"))
+
+    expect { described_class.new.perform(merchant_account.id) }.not_to raise_error
+  end
+
+  it "re-raises any other invalid-request error so sidekiq retries it" do
+    allow_any_instance_of(StripeConnectPaymentMethodAvailabilityService).to receive(:refresh!)
+      .and_raise(Stripe::InvalidRequestError.new("Invalid array", "capabilities"))
+
+    expect { described_class.new.perform(merchant_account.id) }.to raise_error(Stripe::InvalidRequestError)
+  end
 end

--- a/spec/sidekiq/refresh_merchant_account_payment_method_availability_worker_spec.rb
+++ b/spec/sidekiq/refresh_merchant_account_payment_method_availability_worker_spec.rb
@@ -41,4 +41,11 @@ describe RefreshMerchantAccountPaymentMethodAvailabilityWorker do
 
     expect { described_class.new.perform(merchant_account.id) }.not_to raise_error
   end
+
+  it "swallows an authentication error — some deauthorized accounts return this instead of a permission error" do
+    allow_any_instance_of(StripeConnectPaymentMethodAvailabilityService).to receive(:refresh!)
+      .and_raise(Stripe::AuthenticationError.new("The provided key does not have access to this account."))
+
+    expect { described_class.new.perform(merchant_account.id) }.not_to raise_error
+  end
 end


### PR DESCRIPTION
## What

Restores Cash App Pay and ACH Direct Debit on client-confirm checkout for Stripe Connect (direct-charge) sellers whose accounts actually accept them — replacing #5792's blanket exclusion with a cached per-account capability check. Follow-up to #5792; step 2 of the plan on antiwork/gumroad-private#1026.

## Why

#5792 stopped the checkout failures (Stripe rejects a PaymentIntent whose `payment_method_types` lists a method the account hasn't activated), but it overshoots: it removes the methods from **every** connect seller, including US sellers who have activated Cash App/ACH in their own Stripe dashboard. These are Standard accounts, so the platform can't activate capabilities for them — the correct fix is to observe per-account state and offer exactly what each account accepts.

## How

- **`StripeConnectPaymentMethodAvailabilityService`** — fetches the account's **full capabilities hash** from Stripe and caches it verbatim as a `json_data` snapshot on `MerchantAccount` (`stripe_capabilities_snapshot`, with `refreshed_at`). The payment-method-type → capability mapping happens at **read** time (`CAPABILITY_BY_PAYMENT_METHOD_TYPE`, seeded with all the resolver's dynamic method types), so launching a new method later (SEPA, iDEAL, Klarna, …) is just a new map entry — every existing snapshot already carries the answer, no re-fetch sweep or invalidation. Unmapped method types fail closed.
- **`Checkout::PaymentMethodResolver`** — restructured as two separate passes: (1) all of **our policy decisions** (launch gating, US region gate, test-mode forced-currency methods, PPP matrix), then (2) one **final intersection with what the charged account can accept**. Policy never knows about capabilities; capabilities never know about policy. The intersection covers *every* method, not just the US-locked pair — a connect account with Link inactive is handled by the same line. Platform sellers pass through unchanged; on connect sellers card is never gated (baseline capability of any chargeable account; an empty list would break the Element mount). **No snapshot yet ⇒ card only** — a live 40-account sample found `link_payments` absent on half of connected accounts, and an intent create listing `link` on such an account is rejected with `payment_intent_invalid_parameter` (verified live), so even Link waits for the snapshot rather than gambling an uncached seller's first sale — **and enqueue a background refresh** so the next checkout has the answer. Checkout never blocks on, or fails with, a live Stripe API call. An empty snapshot is an answer, not a miss — no re-enqueue. Both sides of the Element/intent handshake read the resolver, so the lists stay equal.
- **Webhook freshness** — the `account.updated` and `capability.updated` webhooks (already subscribed on both endpoints and routed to `StripeMerchantAccountManager`) now enqueue a snapshot refresh, so a seller (de)activating a method in their dashboard propagates without any sweep. The hook runs **before** the handler's JP-only and standard-account early returns, which would otherwise skip connect accounts entirely.
- **`RefreshMerchantAccountPaymentMethodAvailabilityWorker`** — `queue: :low`, `lock: :until_executed` (dedupes webhook bursts and repeated checkout-miss enqueues), swallows `Stripe::PermissionError` for accounts deauthorized between enqueue and execution.

**No backfill migration.** The checkout-time lazy refresh covers active connect sellers within one checkout each (~1.3K sellers with a sale in the last 30 days, of ~45K total connect accounts); dormant sellers get fetched if and when a buyer next shows up. First post-deploy checkout per seller resolves card-only, subsequent ones get the account's real method set. Note this also fixes a latent hole in #5792's shipped behavior: it offers card+link to ALL connect sellers, which fails 100% of client-confirm checkouts on accounts without link_payments (mostly dormant sellers today — invisible until their first sale).

## Test plan

- `spec/services/checkout/payment_method_resolver_spec.rb` — connect-seller context now covers: no snapshot (fail-safe + refresh enqueued), both methods cached (offered to US buyer, still region-gated for non-US), partial snapshot (exactly the accepted method offered), empty snapshot (no re-enqueue; PPP still card-only). 37 examples, 0 failures.
- `spec/services/stripe_connect_payment_method_availability_service_spec.rb` (new) — full-hash persistence (incl. non-active states verbatim), read-time filtering (active/inactive/pending), future-method reads from existing snapshots (SEPA/iDEAL/Klarna example), unmapped-method fail-closed, managed-account no-op, empty-vs-missing cache distinction. 10 examples, 0 failures.
- `spec/sidekiq/refresh_merchant_account_payment_method_availability_worker_spec.rb` (new) — refresh happy path; skips deleted/dead/managed accounts; swallows deauthorization `PermissionError`. 5 examples, 0 failures.
- Downstream unchanged and green: `stripe_payment_presenter_spec` + `prepare_payment_intent_service_spec` (98 examples), `stripe_merchant_account_manager_spec` (320 examples).
- Rubocop clean on all touched files.

No UI change beyond the Payment Element rendering Cash App/ACH tabs on capable connect sellers again — the same tabs platform-account sellers already show.
