### PR TITLE
Record deterministic processor rejections as processor_invalid_request instead of stripe_unavailable

### DIFF
--- a/app/business/payments/charging/errors/charge_processor_invalid_request_error.rb
+++ b/app/business/payments/charging/errors/charge_processor_invalid_request_error.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
 
 class ChargeProcessorInvalidRequestError < ChargeProcessorError
+  # The processor's own error code (e.g. Stripe's "payment_intent_invalid_parameter"), when
+  # the wrapped error exposes one. Rescue sites persist this into stripe_error_code so a
+  # failed purchase records *why* the processor rejected the request instead of leaving the
+  # column blank.
+  def processor_error_code
+    original_error.code if original_error.respond_to?(:code)
+  end
 end

--- a/app/models/credit_card.rb
+++ b/app/models/credit_card.rb
@@ -72,7 +72,14 @@ class CreditCard < ApplicationRecord
       end
 
       credit_card.save!
-    rescue ChargeProcessorInvalidRequestError, ChargeProcessorUnavailableError => e
+    rescue ChargeProcessorInvalidRequestError => e
+      # The processor rejected our request as malformed — a deterministic failure on our side,
+      # not an outage. Record it distinctly so callers don't treat it as transient.
+      logger.error("Error while persisting card with #{credit_card.charge_processor_id}: #{e.message} - card visual: #{credit_card.visual}")
+      credit_card.errors.add(:base, "There is a temporary problem, please try again (your card was not charged).")
+      credit_card.error_code = PurchaseErrorCode::PROCESSOR_INVALID_REQUEST
+      credit_card.stripe_error_code = e.processor_error_code if credit_card.stripe_error_code.blank?
+    rescue ChargeProcessorUnavailableError => e
       logger.error("Error while persisting card with #{credit_card.charge_processor_id}: #{e.message} - card visual: #{credit_card.visual}")
       credit_card.errors.add(:base, "There is a temporary problem, please try again (your card was not charged).")
       credit_card.error_code = credit_card.charge_processor_unavailable_error

--- a/app/models/credit_card.rb
+++ b/app/models/credit_card.rb
@@ -74,7 +74,8 @@ class CreditCard < ApplicationRecord
       credit_card.save!
     rescue ChargeProcessorInvalidRequestError => e
       # The processor rejected our request as malformed — a deterministic failure on our side,
-      # not an outage. Record it distinctly so callers don't treat it as transient.
+      # not an outage. Record it under its own code so a code regression shows up in monitoring
+      # instead of hiding inside Stripe-outage noise. Retry behavior is unchanged.
       logger.error("Error while persisting card with #{credit_card.charge_processor_id}: #{e.message} - card visual: #{credit_card.visual}")
       credit_card.errors.add(:base, "There is a temporary problem, please try again (your card was not charged).")
       credit_card.error_code = PurchaseErrorCode::PROCESSOR_INVALID_REQUEST

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -1973,7 +1973,15 @@ class Purchase < ApplicationRecord
     errors.add :base, Charge::CreateService::BUYER_CURRENCY_QUOTE_INVALID_MESSAGE
     self.error_code = PurchaseErrorCode::BUYER_CURRENCY_QUOTE_INVALID
     nil
-  rescue ChargeProcessorInvalidRequestError, ChargeProcessorUnavailableError => e
+  rescue ChargeProcessorInvalidRequestError => e
+    # The processor rejected our request as malformed — a deterministic failure on our side,
+    # not an outage. Record it distinctly so retry logic doesn't treat it as transient.
+    logger.error "Error while confirming charge intent: #{e.message} in purchase: #{external_id}"
+    errors.add :base, "There is a temporary problem, please try again (your card was not charged)."
+    self.error_code = PurchaseErrorCode::PROCESSOR_INVALID_REQUEST
+    self.stripe_error_code = e.processor_error_code if stripe_error_code.blank?
+    nil
+  rescue ChargeProcessorUnavailableError => e
     logger.error "Error while confirming charge intent: #{e.message} in purchase: #{external_id}"
     errors.add :base, "There is a temporary problem, please try again (your card was not charged)."
     self.error_code = PurchaseErrorCode::STRIPE_UNAVAILABLE
@@ -3551,7 +3559,14 @@ class Purchase < ApplicationRecord
         self.card_visual = chargeable.visual
         self.card_expiry_month = chargeable.expiry_month
         self.card_expiry_year = chargeable.expiry_year
-      rescue ChargeProcessorInvalidRequestError, ChargeProcessorUnavailableError => e
+      rescue ChargeProcessorInvalidRequestError => e
+        # The processor rejected our request as malformed — a deterministic failure on our
+        # side, not an outage. Record it distinctly so retry logic doesn't treat it as transient.
+        logger.error "Error while preparing chargeable: #{e.message} in purchase: #{external_id}"
+        errors.add :base, "There is a temporary problem, please try again (your card was not charged)."
+        self.error_code = PurchaseErrorCode::PROCESSOR_INVALID_REQUEST
+        self.stripe_error_code = e.processor_error_code if stripe_error_code.blank?
+      rescue ChargeProcessorUnavailableError => e
         logger.error "Error while preparing chargeable: #{e.message} in purchase: #{external_id}"
         errors.add :base, "There is a temporary problem, please try again (your card was not charged)."
         self.error_code = charge_processor_unavailable_error
@@ -3643,7 +3658,15 @@ class Purchase < ApplicationRecord
 
     def with_charge_processor_error_handler
       yield
-    rescue ChargeProcessorInvalidRequestError, ChargeProcessorUnavailableError => e
+    rescue ChargeProcessorInvalidRequestError => e
+      # The processor rejected our request as malformed — a deterministic failure on our side,
+      # not an outage. Record it distinctly so retry logic doesn't treat it as transient.
+      logger.error "Charge processor error: #{e.message} in purchase: #{external_id}"
+      errors.add :base, "There is a temporary problem, please try again (your card was not charged)."
+      self.error_code = PurchaseErrorCode::PROCESSOR_INVALID_REQUEST
+      self.stripe_error_code = e.processor_error_code if stripe_error_code.blank?
+      nil
+    rescue ChargeProcessorUnavailableError => e
       logger.error "Charge processor error: #{e.message} in purchase: #{external_id}"
       errors.add :base, "There is a temporary problem, please try again (your card was not charged)."
       self.error_code = charge_processor_unavailable_error

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -1975,7 +1975,8 @@ class Purchase < ApplicationRecord
     nil
   rescue ChargeProcessorInvalidRequestError => e
     # The processor rejected our request as malformed — a deterministic failure on our side,
-    # not an outage. Record it distinctly so retry logic doesn't treat it as transient.
+    # not an outage. Record it under its own code so a code regression shows up in monitoring
+    # instead of hiding inside Stripe-outage noise. Retry behavior is unchanged.
     logger.error "Error while confirming charge intent: #{e.message} in purchase: #{external_id}"
     errors.add :base, "There is a temporary problem, please try again (your card was not charged)."
     self.error_code = PurchaseErrorCode::PROCESSOR_INVALID_REQUEST
@@ -3561,7 +3562,8 @@ class Purchase < ApplicationRecord
         self.card_expiry_year = chargeable.expiry_year
       rescue ChargeProcessorInvalidRequestError => e
         # The processor rejected our request as malformed — a deterministic failure on our
-        # side, not an outage. Record it distinctly so retry logic doesn't treat it as transient.
+        # side, not an outage. Record it under its own code so a code regression shows up in
+        # monitoring instead of hiding inside Stripe-outage noise. Retry behavior is unchanged.
         logger.error "Error while preparing chargeable: #{e.message} in purchase: #{external_id}"
         errors.add :base, "There is a temporary problem, please try again (your card was not charged)."
         self.error_code = PurchaseErrorCode::PROCESSOR_INVALID_REQUEST
@@ -3660,7 +3662,8 @@ class Purchase < ApplicationRecord
       yield
     rescue ChargeProcessorInvalidRequestError => e
       # The processor rejected our request as malformed — a deterministic failure on our side,
-      # not an outage. Record it distinctly so retry logic doesn't treat it as transient.
+      # not an outage. Record it under its own code so a code regression shows up in monitoring
+      # instead of hiding inside Stripe-outage noise. Retry behavior is unchanged.
       logger.error "Charge processor error: #{e.message} in purchase: #{external_id}"
       errors.add :base, "There is a temporary problem, please try again (your card was not charged)."
       self.error_code = PurchaseErrorCode::PROCESSOR_INVALID_REQUEST

--- a/app/modules/purchase_error_code.rb
+++ b/app/modules/purchase_error_code.rb
@@ -14,6 +14,11 @@ module PurchaseErrorCode
   SUSPENDED_BUYER = "suspended_buyer"
   STRIPE_UNAVAILABLE = "stripe_unavailable"
   PAYPAL_UNAVAILABLE = "paypal_unavailable"
+  # The processor rejected our request as malformed (e.g. Stripe's InvalidRequestError) —
+  # a deterministic failure caused by a bug on our side, NOT a processor outage. Kept
+  # separate from STRIPE_UNAVAILABLE/PAYPAL_UNAVAILABLE so retries and monitoring don't
+  # treat a request we built wrong as transient network trouble.
+  PROCESSOR_INVALID_REQUEST = "processor_invalid_request"
   PROCESSING_ERROR = "processing_error"
   HIGH_PROXY_SCORE_AND_ADDITIONAL_CONTRIBUTION = "high_proxy_score_can_only_buy_once"
   BUYER_CHARGED_BACK = "buyer_has_charged_back"
@@ -213,6 +218,7 @@ module PurchaseErrorCode
                                           .concat([
                                                     STRIPE_UNAVAILABLE,
                                                     PAYPAL_UNAVAILABLE,
+                                                    PROCESSOR_INVALID_REQUEST,
                                                     PROCESSING_ERROR,
                                                     CREDIT_CARD_NOT_PROVIDED,
                                                   ])

--- a/app/modules/purchase_error_code.rb
+++ b/app/modules/purchase_error_code.rb
@@ -16,8 +16,9 @@ module PurchaseErrorCode
   PAYPAL_UNAVAILABLE = "paypal_unavailable"
   # The processor rejected our request as malformed (e.g. Stripe's InvalidRequestError) —
   # a deterministic failure caused by a bug on our side, NOT a processor outage. Kept
-  # separate from STRIPE_UNAVAILABLE/PAYPAL_UNAVAILABLE so retries and monitoring don't
-  # treat a request we built wrong as transient network trouble.
+  # separate from STRIPE_UNAVAILABLE/PAYPAL_UNAVAILABLE so monitoring can tell a code
+  # regression apart from Stripe being down (a regression shows up as a spike in this
+  # code against a near-zero baseline, instead of hiding inside outage noise).
   PROCESSOR_INVALID_REQUEST = "processor_invalid_request"
   PROCESSING_ERROR = "processing_error"
   HIGH_PROXY_SCORE_AND_ADDITIONAL_CONTRIBUTION = "high_proxy_score_can_only_buy_once"
@@ -230,7 +231,13 @@ module PurchaseErrorCode
   end
 
   def self.is_temporary_network_error?(error_code)
-    error_code == STRIPE_UNAVAILABLE || error_code == PAYPAL_UNAVAILABLE || error_code == PROCESSING_ERROR
+    # PROCESSOR_INVALID_REQUEST is deliberately included: it keeps subscription and preorder
+    # retry behavior identical to when these failures were labeled stripe_unavailable. The
+    # rejection is deterministic for a given request, but the code that BUILDS the request can
+    # be fixed (these usually come from a short-lived deploy bug), so retrying lets renewals
+    # self-heal once the bug is reverted instead of terminating subscriptions. Tightening the
+    # retry policy is a separate decision from the observability split this code exists for.
+    error_code == STRIPE_UNAVAILABLE || error_code == PAYPAL_UNAVAILABLE || error_code == PROCESSING_ERROR || error_code == PROCESSOR_INVALID_REQUEST
   end
 
   def self.is_error_retryable?(error_code)

--- a/app/services/charge/create_service.rb
+++ b/app/services/charge/create_service.rb
@@ -99,10 +99,21 @@ class Charge::CreateService
       purchase.error_code = PurchaseErrorCode::BUYER_CURRENCY_QUOTE_INVALID
     end
     nil
-  rescue ChargeProcessorInvalidRequestError, ChargeProcessorUnavailableError => e
+  rescue ChargeProcessorInvalidRequestError => e
+    # The processor rejected our request as malformed — a deterministic failure on our side,
+    # not an outage. The intent was never created, so the outcome is known. Record it
+    # distinctly so retry logic and monitoring don't treat it as transient network trouble.
+    logger.error "Charge processor error: #{e.message} in charge: #{charge.external_id}"
+    purchases.each do |purchase|
+      purchase.errors.add :base, "There is a temporary problem, please try again (your card was not charged)."
+      purchase.error_code = PurchaseErrorCode::PROCESSOR_INVALID_REQUEST
+      purchase.stripe_error_code = e.processor_error_code if purchase.stripe_error_code.blank?
+    end
+    nil
+  rescue ChargeProcessorUnavailableError => e
     # ChargeProcessorUnavailableError wraps connection failures, where the PaymentIntent
     # may have been created (or confirmed) before the response was lost.
-    @processor_outcome_unknown = e.is_a?(ChargeProcessorUnavailableError)
+    @processor_outcome_unknown = true
     logger.error "Charge processor error: #{e.message} in charge: #{charge.external_id}"
     purchases.each do |purchase|
       purchase.errors.add :base, "There is a temporary problem, please try again (your card was not charged)."

--- a/app/services/charge/create_service.rb
+++ b/app/services/charge/create_service.rb
@@ -101,8 +101,9 @@ class Charge::CreateService
     nil
   rescue ChargeProcessorInvalidRequestError => e
     # The processor rejected our request as malformed — a deterministic failure on our side,
-    # not an outage. The intent was never created, so the outcome is known. Record it
-    # distinctly so retry logic and monitoring don't treat it as transient network trouble.
+    # not an outage. The intent was never created, so the outcome is known. Record it under its
+    # own code so a code regression shows up in monitoring instead of hiding inside
+    # Stripe-outage noise. Retry behavior is unchanged.
     logger.error "Charge processor error: #{e.message} in charge: #{charge.external_id}"
     purchases.each do |purchase|
       purchase.errors.add :base, "There is a temporary problem, please try again (your card was not charged)."

--- a/app/services/order/prepare_payment_intent_service.rb
+++ b/app/services/order/prepare_payment_intent_service.rb
@@ -105,6 +105,7 @@ class Order::PreparePaymentIntentService
       Stripe::ConfirmationToken.retrieve(confirmation_token, confirmation_token_request_options).payment_method_preview
     rescue Stripe::StripeError => e
       Rails.logger.error("Error retrieving ConfirmationToken for order #{order.id}: #{e.class} => #{e.message} => #{e.backtrace&.first(15)&.join("\n")}")
+      stamp_stripe_error_details(e)
       fail_purchases_with(GENERIC_CHARGE_ERROR)
       nil
     end
@@ -337,11 +338,16 @@ class Order::PreparePaymentIntentService
       # fail_purchases_with runs (it only fills error_code when blank). An invalid-request
       # rejection is a deterministic bug on our side — labeling it stripe_unavailable made a
       # code regression look like a Stripe outage (issue #1026), so record it distinctly and
-      # keep the processor's own error code for debugging.
+      # keep the processor's own error code for debugging. A genuine connection failure is
+      # the one case that actually IS "Stripe unavailable", so it keeps that code.
       if e.is_a?(ChargeProcessorInvalidRequestError)
         purchases_to_charge.each do |purchase|
           purchase.error_code = PurchaseErrorCode::PROCESSOR_INVALID_REQUEST if purchase.error_code.blank?
           purchase.stripe_error_code = e.processor_error_code if purchase.stripe_error_code.blank?
+        end
+      elsif e.is_a?(ChargeProcessorUnavailableError)
+        purchases_to_charge.each do |purchase|
+          purchase.error_code = PurchaseErrorCode::STRIPE_UNAVAILABLE if purchase.error_code.blank?
         end
       end
       nil
@@ -447,11 +453,38 @@ class Order::PreparePaymentIntentService
     def fail_purchases_with(message)
       purchases_to_charge.each do |purchase|
         purchase.errors.add(:base, message) if purchase.errors.empty?
-        purchase.error_code = PurchaseErrorCode::STRIPE_UNAVAILABLE if purchase.error_code.blank?
+        # This is the catch-all for every prepare-time failure (missing confirmation token,
+        # blocked carts, unexpected exceptions), almost none of which mean Stripe is down.
+        # Stamp the generic processing_error here so stripe_unavailable stays a clean
+        # "Stripe is actually unreachable" signal; paths that know the real cause (invalid
+        # request, connection failure) set a more specific code before this filler runs.
+        # processing_error keeps the same retry semantics (is_temporary_network_error?).
+        purchase.error_code = PurchaseErrorCode::PROCESSING_ERROR if purchase.error_code.blank?
         # Read before MarkFailedService: its save re-runs validations and clears errors (#5784).
         error_message = purchase.errors.first&.message
         Purchase::MarkFailedService.new(purchase).perform
         responses[line_item_uid_for(purchase)] = error_response(error_message, purchase:)
+      end
+    end
+
+    # For raw Stripe errors caught before the charge processor wraps them (the
+    # ConfirmationToken retrieve), classify the failure the same way StripeErrorHandler
+    # would so the recorded code means the same thing everywhere: invalid request =
+    # deterministic bug on our side, connection failure = Stripe actually unreachable.
+    # Runs before fail_purchases_with, which only fills error_code when blank.
+    def stamp_stripe_error_details(error)
+      error_code, stripe_error_code =
+        case error
+        when Stripe::InvalidRequestError
+          [PurchaseErrorCode::PROCESSOR_INVALID_REQUEST, error.code]
+        when Stripe::APIConnectionError, Stripe::APIError
+          [PurchaseErrorCode::STRIPE_UNAVAILABLE, nil]
+        end
+      return if error_code.nil?
+
+      purchases_to_charge.each do |purchase|
+        purchase.error_code = error_code if purchase.error_code.blank?
+        purchase.stripe_error_code = stripe_error_code if stripe_error_code.present? && purchase.stripe_error_code.blank?
       end
     end
 

--- a/app/services/order/prepare_payment_intent_service.rb
+++ b/app/services/order/prepare_payment_intent_service.rb
@@ -333,6 +333,17 @@ class Order::PreparePaymentIntentService
       )
     rescue ChargeProcessorError => e
       Rails.logger.error("Error preparing client-confirm PaymentIntent for order #{order.id} charge #{charge.external_id}: #{e.class} => #{e.message} => #{e.backtrace&.first(15)&.join("\n")}")
+      # Stamp the failure details on the purchases now, before the caller's generic
+      # fail_purchases_with runs (it only fills error_code when blank). An invalid-request
+      # rejection is a deterministic bug on our side — labeling it stripe_unavailable made a
+      # code regression look like a Stripe outage (issue #1026), so record it distinctly and
+      # keep the processor's own error code for debugging.
+      if e.is_a?(ChargeProcessorInvalidRequestError)
+        purchases_to_charge.each do |purchase|
+          purchase.error_code = PurchaseErrorCode::PROCESSOR_INVALID_REQUEST if purchase.error_code.blank?
+          purchase.stripe_error_code = e.processor_error_code if purchase.stripe_error_code.blank?
+        end
+      end
       nil
     end
 

--- a/lib/errors/gumroad_runtime_error.rb
+++ b/lib/errors/gumroad_runtime_error.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 class GumroadRuntimeError < RuntimeError
+  # The lower-level error this one wraps (e.g. a Stripe::InvalidRequestError), kept so
+  # rescue sites can persist details like the processor's error code for debugging.
+  attr_reader :original_error
+
   def initialize(message = nil, original_error: nil)
+    @original_error = original_error
     super(message || original_error)
     set_backtrace(original_error.backtrace) if original_error
   end

--- a/spec/business/payments/charging/errors/charge_processor_invalid_request_error_spec.rb
+++ b/spec/business/payments/charging/errors/charge_processor_invalid_request_error_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ChargeProcessorInvalidRequestError do
+  describe "#processor_error_code" do
+    it "returns the wrapped Stripe error's code" do
+      stripe_error = Stripe::InvalidRequestError.new("Invalid parameter.", nil, code: "payment_intent_invalid_parameter")
+      error = described_class.new(original_error: stripe_error)
+
+      expect(error.processor_error_code).to eq("payment_intent_invalid_parameter")
+    end
+
+    it "returns nil when raised with only a message and no wrapped error" do
+      # Braintree and PayPal call sites raise this class with a plain message
+      # (e.g. "could not find transient client token") and no original_error.
+      error = described_class.new("could not find transient client token")
+
+      expect(error.processor_error_code).to be_nil
+    end
+
+    it "returns nil when the wrapped error does not expose a code" do
+      # Braintree's error objects don't respond to #code the way Stripe's do.
+      error = described_class.new(original_error: StandardError.new("boom"))
+
+      expect(error.processor_error_code).to be_nil
+    end
+  end
+end

--- a/spec/models/credit_card_spec.rb
+++ b/spec/models/credit_card_spec.rb
@@ -69,7 +69,7 @@ describe CreditCard do
         it "stores errors in 'errors'" do
           credit_card = CreditCard.create(chargeable)
           expect(credit_card.errors).to be_present
-          expect(credit_card.error_code).to be_present
+          expect(credit_card.error_code).to eq PurchaseErrorCode::PROCESSOR_INVALID_REQUEST
         end
       end
     end

--- a/spec/models/purchase/purchase_process_spec.rb
+++ b/spec/models/purchase/purchase_process_spec.rb
@@ -272,7 +272,7 @@ describe "Purchase Process", :vcr do
                 purchase.process!
               end
               it "sets error code" do
-                expect(purchase.error_code).to eq PurchaseErrorCode::STRIPE_UNAVAILABLE
+                expect(purchase.error_code).to eq PurchaseErrorCode::PROCESSOR_INVALID_REQUEST
               end
               it "sets errors" do
                 expect(purchase.errors).to be_present
@@ -317,7 +317,7 @@ describe "Purchase Process", :vcr do
                 purchase.process!
               end
               it "sets error code" do
-                expect(purchase.error_code).to eq PurchaseErrorCode::STRIPE_UNAVAILABLE
+                expect(purchase.error_code).to eq PurchaseErrorCode::PROCESSOR_INVALID_REQUEST
               end
               it "sets errors" do
                 expect(purchase.errors).to be_present
@@ -387,7 +387,7 @@ describe "Purchase Process", :vcr do
                 purchase.process!
               end
               it "sets error code" do
-                expect(purchase.error_code).to eq PurchaseErrorCode::STRIPE_UNAVAILABLE
+                expect(purchase.error_code).to eq PurchaseErrorCode::PROCESSOR_INVALID_REQUEST
               end
               it "sets errors" do
                 expect(purchase.errors).to be_present
@@ -432,7 +432,7 @@ describe "Purchase Process", :vcr do
                 purchase.process!
               end
               it "sets error code" do
-                expect(purchase.error_code).to eq PurchaseErrorCode::STRIPE_UNAVAILABLE
+                expect(purchase.error_code).to eq PurchaseErrorCode::PROCESSOR_INVALID_REQUEST
               end
               it "sets errors" do
                 expect(purchase.errors).to be_present

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -4704,9 +4704,9 @@ describe Purchase, :vcr do
       expect(purchase.has_payment_network_error?).to eq true
     end
 
-    it "returns false if error_code is PROCESSOR_INVALID_REQUEST — a deterministic rejection, not a network problem" do
+    it "returns true if error_code is PROCESSOR_INVALID_REQUEST, keeping subscription/preorder retries so a fixed deploy bug can self-heal" do
       purchase = build(:purchase, error_code: PurchaseErrorCode::PROCESSOR_INVALID_REQUEST)
-      expect(purchase.has_payment_network_error?).to eq false
+      expect(purchase.has_payment_network_error?).to eq true
     end
 
     it "returns false if error_code or stripe_error_code are other errors" do

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -4704,6 +4704,11 @@ describe Purchase, :vcr do
       expect(purchase.has_payment_network_error?).to eq true
     end
 
+    it "returns false if error_code is PROCESSOR_INVALID_REQUEST — a deterministic rejection, not a network problem" do
+      purchase = build(:purchase, error_code: PurchaseErrorCode::PROCESSOR_INVALID_REQUEST)
+      expect(purchase.has_payment_network_error?).to eq false
+    end
+
     it "returns false if error_code or stripe_error_code are other errors" do
       purchase = build(:purchase, error_code: "foo")
       expect(purchase.has_payment_network_error?).to eq false

--- a/spec/services/charge/create_service_spec.rb
+++ b/spec/services/charge/create_service_spec.rb
@@ -376,6 +376,40 @@ describe Charge::CreateService, :vcr do
       expect(PurchasePresentment.count).to eq(1)
     end
 
+    it "marks purchases with processor_invalid_request and Stripe's error code when Stripe rejects the request synchronously" do
+      order = create(:order)
+      merchant_account = create(:merchant_account_stripe_connect, user: seller_1)
+      chargeable = instance_double(Chargeable, fingerprint: "card_fp")
+      purchase = create(:purchase,
+                        link: product_1,
+                        seller: seller_1,
+                        merchant_account:,
+                        purchase_state: "in_progress",
+                        total_transaction_cents: 10_00)
+      # An invalid-request rejection is deterministic — our request was malformed, Stripe is
+      # healthy — so it must not be recorded as stripe_unavailable (a transient outage code
+      # that retry logic keys on).
+      stripe_error = Stripe::InvalidRequestError.new("Invalid parameter.", nil, code: "payment_intent_invalid_parameter")
+      allow(ChargeProcessor).to receive(:create_payment_intent_or_charge!)
+        .and_raise(ChargeProcessorInvalidRequestError.new(original_error: stripe_error))
+
+      Charge::CreateService.new(order:,
+                                seller: seller_1,
+                                merchant_account:,
+                                chargeable:,
+                                purchases: [purchase],
+                                amount_cents: 10_00,
+                                gumroad_amount_cents: 3_00,
+                                setup_future_charges: false,
+                                off_session: false,
+                                statement_description: seller_1.name_or_username,
+                                params: {}).perform
+
+      expect(purchase.error_code).to eq(PurchaseErrorCode::PROCESSOR_INVALID_REQUEST)
+      expect(purchase.stripe_error_code).to eq("payment_intent_invalid_parameter")
+      expect(purchase.has_payment_network_error?).to eq(false)
+    end
+
     it "stops before Stripe and marks purchases when the locked buyer-currency quote is invalid" do
       order = create(:order)
       merchant_account = create(:merchant_account_stripe_connect, user: seller_1)

--- a/spec/services/charge/create_service_spec.rb
+++ b/spec/services/charge/create_service_spec.rb
@@ -387,8 +387,8 @@ describe Charge::CreateService, :vcr do
                         purchase_state: "in_progress",
                         total_transaction_cents: 10_00)
       # An invalid-request rejection is deterministic — our request was malformed, Stripe is
-      # healthy — so it must not be recorded as stripe_unavailable (a transient outage code
-      # that retry logic keys on).
+      # healthy — so it gets its own error code instead of stripe_unavailable (the transient
+      # outage code monitoring keys on).
       stripe_error = Stripe::InvalidRequestError.new("Invalid parameter.", nil, code: "payment_intent_invalid_parameter")
       allow(ChargeProcessor).to receive(:create_payment_intent_or_charge!)
         .and_raise(ChargeProcessorInvalidRequestError.new(original_error: stripe_error))
@@ -407,7 +407,7 @@ describe Charge::CreateService, :vcr do
 
       expect(purchase.error_code).to eq(PurchaseErrorCode::PROCESSOR_INVALID_REQUEST)
       expect(purchase.stripe_error_code).to eq("payment_intent_invalid_parameter")
-      expect(purchase.has_payment_network_error?).to eq(false)
+      expect(purchase.has_payment_network_error?).to eq(true)
     end
 
     it "stops before Stripe and marks purchases when the locked buyer-currency quote is invalid" do

--- a/spec/services/order/prepare_payment_intent_service_spec.rb
+++ b/spec/services/order/prepare_payment_intent_service_spec.rb
@@ -211,14 +211,71 @@ describe Order::PreparePaymentIntentService, :vcr do
     context "when no confirmation token is supplied" do
       before { create(:merchant_account, user: seller) }
 
-      it "fails the purchases without creating an intent" do
+      it "fails the purchases with the generic processing_error, not stripe_unavailable" do
         order, params = build_order
 
         responses = described_class.new(order:, params:, confirmation_token: nil).perform
 
         expect(responses["unique-id-0"][:success]).to eq(false)
         expect(order.charges).to be_empty
-        expect(order.purchases.first.reload).to be_failed
+        purchase = order.purchases.first.reload
+        expect(purchase).to be_failed
+        expect(purchase.error_code).to eq(PurchaseErrorCode::PROCESSING_ERROR)
+      end
+    end
+
+    context "when Stripe rejects the ConfirmationToken retrieve as an invalid request" do
+      before { create(:merchant_account, user: seller) }
+
+      it "fails the purchases with processor_invalid_request and keeps Stripe's error code" do
+        order, params = build_order
+        stripe_error = Stripe::InvalidRequestError.new("No such confirmation token", nil, code: "resource_missing")
+        allow(Stripe::ConfirmationToken).to receive(:retrieve).and_raise(stripe_error)
+
+        responses = described_class.new(order:, params:, confirmation_token: "ctoken_test").perform
+
+        expect(responses["unique-id-0"][:success]).to eq(false)
+        purchase = order.purchases.first.reload
+        expect(purchase).to be_failed
+        expect(purchase.error_code).to eq(PurchaseErrorCode::PROCESSOR_INVALID_REQUEST)
+        expect(purchase.stripe_error_code).to eq("resource_missing")
+      end
+    end
+
+    context "when Stripe is unreachable during the ConfirmationToken retrieve" do
+      before { create(:merchant_account, user: seller) }
+
+      it "fails the purchases with stripe_unavailable" do
+        order, params = build_order
+        allow(Stripe::ConfirmationToken).to receive(:retrieve).and_raise(Stripe::APIConnectionError.new("Connection reset"))
+
+        responses = described_class.new(order:, params:, confirmation_token: "ctoken_test").perform
+
+        expect(responses["unique-id-0"][:success]).to eq(false)
+        purchase = order.purchases.first.reload
+        expect(purchase).to be_failed
+        expect(purchase.error_code).to eq(PurchaseErrorCode::STRIPE_UNAVAILABLE)
+      end
+    end
+
+    context "when Stripe is unreachable during the intent create" do
+      before { create(:merchant_account, user: seller) }
+
+      it "fails the purchases with stripe_unavailable" do
+        order, params = build_order
+        preview = Stripe::StripeObject.construct_from(card: { country: "US" })
+        allow(Stripe::ConfirmationToken).to receive(:retrieve)
+          .and_return(Stripe::StripeObject.construct_from(payment_method_preview: preview))
+        stripe_error = Stripe::APIConnectionError.new("Connection reset")
+        allow(StripeDeferredPaymentIntent).to receive(:create)
+          .and_raise(ChargeProcessorUnavailableError.new(original_error: stripe_error))
+
+        responses = described_class.new(order:, params:, confirmation_token: "ctoken_test").perform
+
+        expect(responses["unique-id-0"][:success]).to eq(false)
+        purchase = order.purchases.first.reload
+        expect(purchase).to be_failed
+        expect(purchase.error_code).to eq(PurchaseErrorCode::STRIPE_UNAVAILABLE)
       end
     end
 

--- a/spec/services/order/prepare_payment_intent_service_spec.rb
+++ b/spec/services/order/prepare_payment_intent_service_spec.rb
@@ -222,6 +222,28 @@ describe Order::PreparePaymentIntentService, :vcr do
       end
     end
 
+    context "when Stripe synchronously rejects the intent create as an invalid request" do
+      before { create(:merchant_account, user: seller) }
+
+      it "fails the purchases with processor_invalid_request and keeps Stripe's error code, not stripe_unavailable" do
+        order, params = build_order
+        preview = Stripe::StripeObject.construct_from(card: { country: "US" })
+        allow(Stripe::ConfirmationToken).to receive(:retrieve)
+          .and_return(Stripe::StripeObject.construct_from(payment_method_preview: preview))
+        stripe_error = Stripe::InvalidRequestError.new("The payment method type \"cashapp\" is invalid.", nil, code: "payment_intent_invalid_parameter")
+        allow(StripeDeferredPaymentIntent).to receive(:create)
+          .and_raise(ChargeProcessorInvalidRequestError.new(original_error: stripe_error))
+
+        responses = described_class.new(order:, params:, confirmation_token: "ctoken_test").perform
+
+        expect(responses["unique-id-0"][:success]).to eq(false)
+        purchase = order.purchases.first.reload
+        expect(purchase).to be_failed
+        expect(purchase.error_code).to eq(PurchaseErrorCode::PROCESSOR_INVALID_REQUEST)
+        expect(purchase.stripe_error_code).to eq("payment_intent_invalid_parameter")
+      end
+    end
+
     context "with a multi-seller cart" do
       let(:other_seller) { create(:user) }
       let(:other_product) { create(:product, user: other_seller, price_cents: 5_00) }


### PR DESCRIPTION
## What

Splits deterministic processor rejections out of the `stripe_unavailable` error code. This is a pure observability change — retry behavior and buyer-facing messages are byte-for-byte unchanged.

- New `PurchaseErrorCode::PROCESSOR_INVALID_REQUEST` (`"processor_invalid_request"`), stamped wherever a `ChargeProcessorInvalidRequestError` was previously recorded as `stripe_unavailable`/`paypal_unavailable`:
  - `Order::PreparePaymentIntentService#create_unconfirmed_intent` (the client-confirm prepare path)
  - `Charge::CreateService#create_payment_intent_or_charge!`
  - `Purchase#confirm_charge_intent!`, `Purchase#prepare_chargeable`, `Purchase#with_charge_processor_error_handler`
  - `CreditCard.create`
- The processor's own error code (e.g. Stripe's `payment_intent_invalid_parameter`) is now persisted into `stripe_error_code` at those sites, via a new `ChargeProcessorInvalidRequestError#processor_error_code` reader (backed by exposing `original_error` on `GumroadRuntimeError`). Previously the column was left blank, erasing the forensic trail.
- The new code is included in both `PAYMENT_ERROR_CODES` and `is_temporary_network_error?`, so `has_payment_error?`, subscription-renewal retries, and preorder retries all behave exactly as they did when these failures were labeled `stripe_unavailable`. Invalid-request rejections are deterministic for a given request, but they usually come from a short-lived deploy bug — keeping the retries lets renewals self-heal once the bug is reverted. Tightening retry policy for this class is deliberately left as a separate decision.

## Why

`stripe_unavailable` has always meant "Stripe is down / unreachable" — a transient network problem. But the combined `rescue ChargeProcessorInvalidRequestError, ChargeProcessorUnavailableError` blocks also stamped it for synchronous invalid-request rejections, where Stripe is healthy and *our request* is malformed. That conflation:

- sent the antiwork/gumroad-private#1026 investigation toward "outage" first, and let a client-confirm regression (~$20K attempted GMV over 3 days) hide inside the platform-wide `stripe_unavailable` baseline — the failures were deterministic, but the DB made them look like ambient Stripe weather;
- left `stripe_error_code` blank, so the actual Stripe rejection reason was unrecoverable from the purchase row and had to be reconstructed with live console probes.

After this change, `stripe_unavailable` volume is a clean Stripe-health signal, and `processor_invalid_request` has a near-zero baseline — any sustained nonzero rate is by definition a regression on our side, which makes it directly alertable.

Follow-up filed from antiwork/gumroad-private#1026 (see the root-cause comment there; details stay in the private issue).

## Test plan

- New spec: `Order::PreparePaymentIntentService` — Stripe synchronously rejects the deferred intent create → purchases fail with `processor_invalid_request` and `stripe_error_code: payment_intent_invalid_parameter` (the exact antiwork/gumroad-private#1026 shape).
- New spec: `Charge::CreateService` — invalid-request rejection stamps the new code, keeps Stripe's error code, and `has_payment_network_error?` stays true (retry behavior preserved).
- New spec: `ChargeProcessorInvalidRequestError#processor_error_code` — Stripe code extraction, message-only raises (Braintree/PayPal sites), and wrapped errors without `#code` all return safely.
- New spec: `Purchase#has_payment_network_error?` returns true for the new code (retries preserved).
- Updated: `purchase_process_spec.rb` invalid-request contexts now expect `PROCESSOR_INVALID_REQUEST`; `credit_card_spec.rb` pins the new code.
- Ran locally: `prepare_payment_intent_service_spec.rb`, `charge/create_service_spec.rb`, `credit_card_spec.rb`, `purchase/purchase_process_spec.rb`, the new error spec — all green (135 examples in the two big files, 0 failures).
- No UI changes (buyer-facing messages untouched).
