### PR TITLE
Enqueue Friday payout batches in bounded user slices so a worker restart cannot wipe the whole run

### DIFF
--- a/app/business/payments/payouts/payouts.rb
+++ b/app/business/payments/payouts/payouts.rb
@@ -81,16 +81,33 @@ class Payouts
   private_class_method :add_below_minimum_payout_note
 
   def self.create_payments_for_balances_up_to_date(date, processor_type)
-    users = User.holding_balance
+    # Walk the holding-balance cohort in bounded id slices, enqueueing each slice's
+    # payments as we go — the same shape as the bank-account-type path below. The old
+    # `User.holding_balance` relation evaluated the whole ~200k-user cohort in one
+    # `users × balances` GROUP BY and then iterated every user before enqueueing a
+    # single payment. On Fridays (PayPal + Stripe Connect, no bank-account-type
+    # filter) that single pass ran for ~110 minutes; any worker restart mid-pass
+    # (deploys, instance recycling) threw ALL progress away, and sidekiq-pro's
+    # orphan recovery restarted it from the top until the job was buried in the
+    # dead set with the whole cohort unpaid (gumroad-private#1021, 2026-07-10).
+    # Slicing makes progress durable: payments for completed slices are already
+    # enqueued, so a killed pass only re-walks users whose payments were not yet
+    # created — and Payouts.create_payment no-ops once a user's balances leave
+    # `unpaid`, so overlap is safe.
+    holding_balance_user_ids = self.holding_balance_user_ids
 
-    if processor_type == PayoutProcessorType::STRIPE
-      users = users.joins(:merchant_accounts)
-                   .where("merchant_accounts.deleted_at IS NULL")
-                   .where("merchant_accounts.charge_processor_id = ?", StripeChargeProcessor.charge_processor_id)
-                   .where("merchant_accounts.json_data->'$.meta.stripe_connect' = 'true'")
+    holding_balance_user_ids.each_slice(USER_LOOKUP_BATCH_SIZE) do |user_ids_batch|
+      users = User.where(id: user_ids_batch)
+
+      if processor_type == PayoutProcessorType::STRIPE
+        users = users.joins(:merchant_accounts)
+                     .where("merchant_accounts.deleted_at IS NULL")
+                     .where("merchant_accounts.charge_processor_id = ?", StripeChargeProcessor.charge_processor_id)
+                     .where("merchant_accounts.json_data->'$.meta.stripe_connect' = 'true'")
+      end
+
+      self.create_payments_for_balances_up_to_date_for_users(date, processor_type, users, perform_async: true)
     end
-
-    self.create_payments_for_balances_up_to_date_for_users(date, processor_type, users, perform_async: true)
   end
 
   def self.create_payments_for_balances_up_to_date_for_bank_account_types(date, processor_type, bank_account_types)

--- a/spec/business/payments/payouts/payouts_spec.rb
+++ b/spec/business/payments/payouts/payouts_spec.rb
@@ -325,6 +325,24 @@ describe Payouts do
       described_class.create_payments_for_balances_up_to_date(payout_date, payout_processor_type)
     end
 
+    it "walks the cohort in bounded slices so each slice's payments are enqueued before the next slice is evaluated" do
+      # Regression test for gumroad-private#1021: the whole-cohort single pass ran
+      # ~110 minutes before enqueueing anything, so a worker restart mid-pass lost
+      # all progress and the Friday batch produced zero payments. Slicing must
+      # produce one enqueue call per slice, covering every holding-balance user.
+      stub_const("Payouts::USER_LOOKUP_BATCH_SIZE", 2)
+      users = create_list(:user, 5, unpaid_balance_cents: 100)
+
+      enqueued = []
+      expect(described_class).to receive(:create_payments_for_balances_up_to_date_for_users).exactly(3).times do |_date, _processor, slice_users, **|
+        enqueued.concat(slice_users.to_a)
+      end
+
+      described_class.create_payments_for_balances_up_to_date(payout_date, payout_processor_type)
+
+      expect(enqueued).to match_array(users)
+    end
+
     it "calls create_payments_for_balances_up_to_date_for_users with all users holding balance who have an active Stripe Connect account" do
       u1 = create(:user, unpaid_balance_cents: 0) # Has an active Stripe Connect account but no balance
       u2 = create(:user, unpaid_balance_cents: 200) # Has balance and a Stripe account but no Stripe Connect account

--- a/spec/business/payments/payouts/payouts_spec.rb
+++ b/spec/business/payments/payouts/payouts_spec.rb
@@ -334,7 +334,10 @@ describe Payouts do
       users = create_list(:user, 5, unpaid_balance_cents: 100)
 
       enqueued = []
-      expect(described_class).to receive(:create_payments_for_balances_up_to_date_for_users).exactly(3).times do |_date, _processor, slice_users, **|
+      expect(described_class).to receive(:create_payments_for_balances_up_to_date_for_users).exactly(3).times do |_date, _processor, slice_users, **kwargs|
+        # Each slice must be enqueued asynchronously; a synchronous call would
+        # reintroduce the long single pass this test exists to prevent.
+        expect(kwargs[:perform_async]).to eq(true)
         enqueued.concat(slice_users.to_a)
       end
 


### PR DESCRIPTION
Fixes the root cause of antiwork/gumroad-private#1021 (Friday July 10 payout batch produced ~0 payments).

## What

Makes the Friday payout orchestrator path (`Payouts.create_payments_for_balances_up_to_date`, used by the `payouts_paypal` and `payouts_stripe_connect` weekly jobs) walk the holding-balance cohort in bounded 1,000-user id slices and enqueue each slice's payments as it goes — the same shape the Tue–Thu bank-account-type path (`create_payments_for_balances_up_to_date_for_bank_account_types`) already uses.

## Why

On July 10 both Friday buckets silently produced zero payments (74 payments all day vs 1,193 the previous Friday), with no exception anywhere. Root cause, confirmed from live production evidence:

1. **The old code did all-or-nothing work.** It evaluated the entire ~200k-user holding-balance cohort — with per-user eligibility queries — and only enqueued `PayoutUsersWorker` jobs after iterating *every* user. Nothing was durable until the very end.
2. **The pass no longer fits inside a worker's lifetime.** Payout-note write timelines from July 10 show each pass writing ~1,600 notes/minute and dying at 11:40, 13:25, 14:46, and 15:59 UTC — every boundary lining up with production deploys that recycled Sidekiq pods (6 deploys shipped that day; the sidekiq-client instances currently running were launched 19:02 UTC). 479k payout notes were written for 157k distinct users (up to 4–5 duplicates per user) vs 240k notes for 192k users the previous Friday — the fingerprint of the same walk restarting from the top over and over.
3. **sidekiq-pro's orphan recovery then buried the job.** Each kill re-ran the job (the 13:41 UTC "re-run" was an orphan recovery, not a human re-enqueue) until super_fetch gave up: the orchestrator landed in the dead set at 16:04 UTC with `error_class: nil, retry_count: nil` — the "recovered too many times" terminal signature. The worker's `retry: 3` never engaged because no exception was ever raised.

The #5765 per-user overhead (two extra queries in `is_user_payable` via `minimum_payout_amount_cents`) is what tipped the pass duration over the edge this week, but the structural defect is the all-or-nothing pass: any sufficiently long cohort walk will always lose a race against deploys eventually. Slicing fixes the class, not the trigger.

## Safety of re-walks

A killed pass now only loses the current slice; completed slices' payments are already enqueued. Overlapping re-walks are safe end-to-end: `PayoutUsersWorker` carries an `until_executed` uniqueness lock while queued, and `Payouts.create_payment` no-ops once a user's balances leave `unpaid`.

## Test plan

- New spec: with `USER_LOOKUP_BATCH_SIZE` stubbed to 2 and 5 eligible users, the cohort is delivered in 3 slices that exactly cover all 5 users.
- Existing specs for both processor branches (PayPal all-holding-balance, Stripe Connect filtered) pass unchanged — small cohorts fit in one slice, and the Stripe Connect merchant-account filter is applied identically per slice.
- CI runs the full suite.

## Recovery note (ops, not this PR)

Deploying this does not by itself pay the stranded Friday cohort. After deploy: clear the `until_executed` digest for `PerformPayoutsUpToDelayDaysAgoWorker` if still held (the job died in the dead set), take the deploy lock, re-enqueue both buckets (`perform_async("PAYPAL")`, `perform_async("STRIPE")`), verify non-nil jids, and watch payments land per the gp#1021 runbook. ~1,100 sellers are waiting on it.
