### PR TITLE
Derive the upcoming payout's currency from the payout destination

### DIFF
--- a/app/helpers/payouts_helper.rb
+++ b/app/helpers/payouts_helper.rb
@@ -60,7 +60,6 @@ module PayoutsHelper
       payout_period_end_date = current_payout_end_date(user)
 
       payout_period_data[:displayable_payout_period_range] = displayable_payout_period_range(previous_payment, payout_period_end_date)
-      payout_period_data[:payout_currency] = user.currency_type
       payout_period_data[:payout_cents] = user.unpaid_balance_cents_up_to_date(payout_period_end_date)
       payout_period_data[:payout_displayed_amount] = formatted_dollar_amount(payout_period_data[:payout_cents])
       payout_period_data[:payout_date_formatted] = formatted_payout_date(user.next_payout_date)
@@ -191,6 +190,7 @@ module PayoutsHelper
 
     bank_account = payment.present? ? payment.bank_account : user.active_bank_account
     stripe_connect_account_id = nil
+    merchant_account = nil
 
     if payment.present?
       merchant_account = payment.user.merchant_accounts.find_by(charge_processor_merchant_id: payment.stripe_connect_account_id)
@@ -201,7 +201,7 @@ module PayoutsHelper
       stripe_connect_account_id = merchant_account.charge_processor_merchant_id if merchant_account&.is_a_stripe_connect_account?
     end
 
-    if stripe_connect_account_id
+    details = if stripe_connect_account_id
       { payout_method_type: "stripe_connect", stripe_connect_account_id: }
     elsif bank_account.present?
       bank_account.to_hash.merge(payout_method_type: "bank")
@@ -217,5 +217,23 @@ module PayoutsHelper
         end
       end
     end
+
+    # For the upcoming payout there is no Payment record to read the currency
+    # from yet, so we derive it from the destination itself: bank payouts go
+    # out in the bank's local currency and Stripe Connect payouts in the
+    # connected account's default currency, while PayPal payouts are always
+    # sent in USD. The seller's selling currency (user.currency_type) is
+    # unrelated to where the money lands, so it must not be used here — it
+    # made the "Will be converted to X" notice disappear for sellers who
+    # sell in USD but are paid out in another currency.
+    if payment.blank?
+      details[:payout_currency] = case details[:payout_method_type]
+                                  when "bank" then bank_account.currency
+                                  when "stripe_connect" then merchant_account&.currency || Currency::USD
+                                  else Currency::USD
+      end
+    end
+
+    details
   end
 end

--- a/spec/helpers/payouts_helper_spec.rb
+++ b/spec/helpers/payouts_helper_spec.rb
@@ -306,6 +306,36 @@ describe PayoutsHelper do
       end
     end
 
+    describe "payout currency for the upcoming payout" do
+      # Regression coverage: the upcoming payout's currency must come from the
+      # payout destination, not from the seller's selling currency. A seller
+      # who sells in USD but is paid to a European bank still gets converted
+      # to EUR, so the "Will be converted to EUR" notice must stay visible.
+      it "uses the bank account's local currency even when the seller sells in USD" do
+        user = create(:user, currency_type: Currency::USD)
+        create(:european_bank_account, user:)
+        create(:balance, user:, amount_cents: 100_00, date: Date.current)
+
+        expect(self.payout_period_data(user)[:payout_currency]).to eq(Currency::EUR)
+      end
+
+      it "stays USD for a US bank account regardless of the selling currency" do
+        user = create(:user, currency_type: Currency::GBP)
+        create(:ach_account, user:)
+        create(:balance, user:, amount_cents: 100_00, date: Date.current)
+        create(:bank, routing_number: "110000000", name: "Bank of America")
+
+        expect(self.payout_period_data(user)[:payout_currency]).to eq(Currency::USD)
+      end
+
+      it "uses USD for PayPal payouts, which are always sent in USD" do
+        user = create(:user, currency_type: Currency::EUR, payment_address: "seller-paypal@example.com")
+        create(:balance, user:, amount_cents: 100_00, date: Date.current)
+
+        expect(self.payout_period_data(user)[:payout_currency]).to eq(Currency::USD)
+      end
+    end
+
     it "shows payout data without payout given and previous payouts" do
       travel_to(Time.find_zone("UTC").local(2015, 3, 1)) do
         user = create(:user)

--- a/spec/helpers/payouts_helper_spec.rb
+++ b/spec/helpers/payouts_helper_spec.rb
@@ -334,6 +334,23 @@ describe PayoutsHelper do
 
         expect(self.payout_period_data(user)[:payout_currency]).to eq(Currency::USD)
       end
+
+      it "uses the connected Stripe account's default currency for Stripe Connect payouts" do
+        user = create(:user, currency_type: Currency::USD, check_merchant_account_is_linked: true)
+        create(:merchant_account_stripe_connect, user:, currency: Currency::CAD)
+        create(:balance, user:, amount_cents: 100_00, date: Date.current)
+
+        expect(self.payout_period_data(user)[:payout_currency]).to eq(Currency::CAD)
+      end
+
+      it "falls back to USD when the connected Stripe account has no currency recorded" do
+        user = create(:user, currency_type: Currency::USD, check_merchant_account_is_linked: true)
+        merchant_account = create(:merchant_account_stripe_connect, user:)
+        merchant_account.update_column(:currency, nil)
+        create(:balance, user:, amount_cents: 100_00, date: Date.current)
+
+        expect(self.payout_period_data(user)[:payout_currency]).to eq(Currency::USD)
+      end
     end
 
     it "shows payout data without payout given and previous payouts" do


### PR DESCRIPTION
## What

Makes the upcoming payout's "Will be converted to X and sent to:" notice on the Payouts page reflect the currency the money will actually arrive in.

## Why

`current_payout_period_data` set `payout_currency` from `user.currency_type` — the seller's **selling** currency, which is unrelated to the payout destination. A Spain-based seller paid to an ES IBAN is always paid in EUR (`Country#payout_currency` / the bank-account subclass currency), but as soon as they set "I sell in USD" the banner in `pages/Payouts/Index.tsx` compared `"usd" !== "USD"` and dropped the conversion notice, misleading them into thinking USD would land in their bank (the originating support ticket: a seller expecting USD into a multi-currency Revolut account).

Historical payouts were already correct (they read `payment.currency`, which `StripePayoutProcessor` sets from `merchant_account.currency`). Only the upcoming-payout path was wrong.

Fixes antiwork/gumroad-private#1033.

## How

`payout_method_details` now sets `payout_currency` for the upcoming payout (when there is no `Payment` record yet) from the destination it just resolved:

- bank payouts → the bank account's local currency (`BankAccount#currency`, the same per-country subclass value `StripePayoutProcessor` pays in)
- Stripe Connect payouts → the connected account's default currency (`merchant_account.currency`)
- PayPal / none → USD (`PaypalPayoutProcessor` always pays in USD)

This matches the existing correct source used by Settings → Payments (`settings_presenter.rb` shows "Payouts will be made in {payout_currency}" from the compliance country), and the historical-payout path is untouched.

## Test plan

New regression specs in `spec/helpers/payouts_helper_spec.rb`:
- USD-selling seller with a European bank account → `payout_currency` is EUR (the bug case)
- non-USD-selling seller with a US ACH account → stays USD
- PayPal payout → USD

Local run: full `payouts_helper_spec` 24 examples 0 failures; `payouts_presenter_spec` + `user_balance_stats_service_spec` 26 examples 0 failures. Rubocop clean.

## Before/After

Not a UI-markup change — the banner components in `Payouts/Index.tsx` are unchanged; only the value they receive is corrected. Before: ES-IBAN seller selling in USD saw "Will be sent to:" (no conversion notice). After: "Will be converted to EUR and sent to:".
