### PR TITLE
Email creators when Gumroad support/admin refunds a sale on their behalf

### DIFF
--- a/app/controllers/admin/purchases_controller.rb
+++ b/app/controllers/admin/purchases_controller.rb
@@ -14,7 +14,7 @@ class Admin::PurchasesController < Admin::BaseController
   end
 
   def refund
-    if @purchase.refund_and_save!(current_user.id)
+    if @purchase.refund_and_save!(current_user.id, reason: params[:reason].presence)
       render json: { success: true }
     else
       render json: { success: false }

--- a/app/controllers/admin/purchases_controller.rb
+++ b/app/controllers/admin/purchases_controller.rb
@@ -17,7 +17,7 @@ class Admin::PurchasesController < Admin::BaseController
     if @purchase.refund_and_save!(current_user.id, reason: params[:reason].presence)
       render json: { success: true }
     else
-      render json: { success: false }
+      render json: { success: false, message: @purchase.errors.full_messages.presence&.to_sentence }.compact
     end
   end
 

--- a/app/controllers/api/internal/admin/purchases_controller.rb
+++ b/app/controllers/api/internal/admin/purchases_controller.rb
@@ -141,6 +141,12 @@ class Api::Internal::Admin::PurchasesController < Api::Internal::Admin::BaseCont
     buyer_email = params[:email].to_s.strip.downcase
     return render json: { success: false, message: "email is required" }, status: :bad_request if buyer_email.blank?
 
+    # Refunds through this endpoint are made on the creator's behalf, so a reason is
+    # required — it is stored on the refund and emailed to the creator so they know why
+    # their sale was refunded.
+    reason = params[:reason].to_s.strip.presence
+    return render json: { success: false, message: "reason is required" }, status: :bad_request if reason.blank?
+
     purchase = fetch_purchase
     if purchase.blank? || purchase.email.to_s.downcase != buyer_email
       return render json: { success: false, message: "Purchase not found or email doesn't match" }, status: :not_found
@@ -180,7 +186,7 @@ class Api::Internal::Admin::PurchasesController < Api::Internal::Admin::BaseCont
         amount = amount_cents / unit_scaling_factor(purchase.displayed_price_currency_type).to_f
       end
 
-      unless purchase.refund!(refunding_user_id: current_admin_actor_id, amount:, reason: params[:reason].presence)
+      unless purchase.refund!(refunding_user_id: current_admin_actor_id, amount:, reason:)
         message = purchase.errors.full_messages.presence&.to_sentence || "Refund failed for purchase number #{purchase.external_id_numeric}"
         return render json: { success: false, message: }, status: :unprocessable_entity
       end

--- a/app/controllers/api/internal/admin/purchases_controller.rb
+++ b/app/controllers/api/internal/admin/purchases_controller.rb
@@ -180,7 +180,7 @@ class Api::Internal::Admin::PurchasesController < Api::Internal::Admin::BaseCont
         amount = amount_cents / unit_scaling_factor(purchase.displayed_price_currency_type).to_f
       end
 
-      unless purchase.refund!(refunding_user_id: current_admin_actor_id, amount:)
+      unless purchase.refund!(refunding_user_id: current_admin_actor_id, amount:, reason: params[:reason].presence)
         message = purchase.errors.full_messages.presence&.to_sentence || "Refund failed for purchase number #{purchase.external_id_numeric}"
         return render json: { success: false, message: }, status: :unprocessable_entity
       end

--- a/app/javascript/components/Admin/ActionButton.tsx
+++ b/app/javascript/components/Admin/ActionButton.tsx
@@ -25,10 +25,12 @@ type AdminActionButtonProps = {
   color?: ButtonColor | null;
   class?: string | null;
   // When set, a text prompt is shown after the confirm dialog and the entered value is
-  // sent to the server under `prompt_field_name`. Leaving the prompt empty still submits
-  // (the field is simply omitted); cancelling the prompt aborts the action.
+  // sent to the server under `prompt_field_name`. Cancelling the prompt aborts the action.
+  // With `prompt_required`, an empty value also aborts (with an error alert); otherwise an
+  // empty value just omits the field.
   prompt_message?: string | null;
   prompt_field_name?: string | null;
+  prompt_required?: boolean | null;
 };
 
 export const AdminActionButton = ({
@@ -45,6 +47,7 @@ export const AdminActionButton = ({
   class: className,
   prompt_message,
   prompt_field_name,
+  prompt_required,
 }: AdminActionButtonProps) => {
   const [state, setState] = React.useState<"initial" | "loading" | "done">("initial");
 
@@ -58,9 +61,15 @@ export const AdminActionButton = ({
     if (prompt_message && prompt_field_name) {
       // eslint-disable-next-line no-alert
       const promptValue = prompt(prompt_message);
-      // Cancelling the prompt cancels the whole action; an empty value just omits the field.
+      // Cancelling the prompt cancels the whole action.
       if (promptValue === null) return;
-      if (promptValue.trim() !== "") data[prompt_field_name] = promptValue.trim();
+      if (promptValue.trim() !== "") {
+        data[prompt_field_name] = promptValue.trim();
+      } else if (prompt_required) {
+        // A required prompt (e.g. the refund reason emailed to the creator) can't be blank.
+        showAlert("This action requires a reason.", "error");
+        return;
+      }
     }
 
     setState("loading");

--- a/app/javascript/components/Admin/ActionButton.tsx
+++ b/app/javascript/components/Admin/ActionButton.tsx
@@ -24,6 +24,11 @@ type AdminActionButtonProps = {
   outline?: boolean | null;
   color?: ButtonColor | null;
   class?: string | null;
+  // When set, a text prompt is shown after the confirm dialog and the entered value is
+  // sent to the server under `prompt_field_name`. Leaving the prompt empty still submits
+  // (the field is simply omitted); cancelling the prompt aborts the action.
+  prompt_message?: string | null;
+  prompt_field_name?: string | null;
 };
 
 export const AdminActionButton = ({
@@ -38,6 +43,8 @@ export const AdminActionButton = ({
   outline,
   color,
   class: className,
+  prompt_message,
+  prompt_field_name,
 }: AdminActionButtonProps) => {
   const [state, setState] = React.useState<"initial" | "loading" | "done">("initial");
 
@@ -45,6 +52,15 @@ export const AdminActionButton = ({
     // eslint-disable-next-line no-alert
     if (!confirm(confirm_message || `Are you sure you want to ${label}?`)) {
       return;
+    }
+
+    const data: Record<string, string> = {};
+    if (prompt_message && prompt_field_name) {
+      // eslint-disable-next-line no-alert
+      const promptValue = prompt(prompt_message);
+      // Cancelling the prompt cancels the whole action; an empty value just omits the field.
+      if (promptValue === null) return;
+      if (promptValue.trim() !== "") data[prompt_field_name] = promptValue.trim();
     }
 
     setState("loading");
@@ -56,7 +72,7 @@ export const AdminActionButton = ({
         url,
         method: method || "POST",
         accept: "json",
-        data: { authenticity_token: csrfToken },
+        data: { ...data, authenticity_token: csrfToken },
       });
 
       if (!response.ok) throw new ResponseError("Something went wrong.");

--- a/app/javascript/components/Admin/Purchases/index.tsx
+++ b/app/javascript/components/Admin/Purchases/index.tsx
@@ -576,8 +576,9 @@ const ActionButtons = ({ purchase }: { purchase: Purchase }) => (
           loading="Refunding..."
           done="Refunded!"
           confirm_message="Are you sure you want to refund this purchase?"
-          prompt_message="Reason for the refund (shared with the creator; leave blank to skip):"
+          prompt_message="Reason for the refund (required — it is emailed to the creator):"
           prompt_field_name="reason"
+          prompt_required
           success_message="Refunded!"
         />
         <AdminActionButton

--- a/app/javascript/components/Admin/Purchases/index.tsx
+++ b/app/javascript/components/Admin/Purchases/index.tsx
@@ -576,6 +576,8 @@ const ActionButtons = ({ purchase }: { purchase: Purchase }) => (
           loading="Refunding..."
           done="Refunded!"
           confirm_message="Are you sure you want to refund this purchase?"
+          prompt_message="Reason for the refund (shared with the creator; leave blank to skip):"
+          prompt_field_name="reason"
           success_message="Refunded!"
         />
         <AdminActionButton

--- a/app/mailers/contacting_creator_mailer.rb
+++ b/app/mailers/contacting_creator_mailer.rb
@@ -322,9 +322,13 @@ class ContactingCreatorMailer < ApplicationMailer
     @subject = "Fraud was detected on your Gumroad account."
   end
 
-  def purchase_refunded(purchase_id)
+  # refund_id is optional: when the refund carries a note (the reason a team member
+  # entered when refunding on the creator's behalf), the email shows it so the creator
+  # knows why the sale was refunded without having to write in to support.
+  def purchase_refunded(purchase_id, refund_id = nil)
     @purchase = Purchase.find_by(id: purchase_id)
     @seller = @purchase.seller
+    @refund_reason = Refund.find_by(id: refund_id)&.note
     @subject = "A sale has been refunded"
   end
 

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -169,11 +169,11 @@ class Charge < ApplicationRecord
     purchase_with_gumroad_tax_as_chargeable.present?
   end
 
-  def refund_and_save!(refunding_user_id)
+  def refund_and_save!(refunding_user_id, reason: nil)
     transaction do
       refunded_all_purchases = true
       successful_purchases.each do |purchase|
-        refunded = purchase.refund_and_save!(refunding_user_id)
+        refunded = purchase.refund_and_save!(refunding_user_id, reason:)
         unless refunded
           copy_refund_errors_from(purchase)
           refunded_all_purchases = false

--- a/app/modules/purchase/refundable.rb
+++ b/app/modules/purchase/refundable.rb
@@ -58,12 +58,17 @@ class Purchase
       # creator-notification email after the refund succeeds.
       refunded_by_team_member = refunding_user_id.present? && User.find(refunding_user_id).is_team_member?
 
+      # A team member refunding a sale THEY made as the seller is just a creator refunding
+      # their own sale — no reason needed and no email, because they already know about it.
+      # This matters for Gumroad staff who also sell on Gumroad.
+      refunded_on_creators_behalf = refunded_by_team_member && refunding_user_id != seller_id
+
       # A refund made on the creator's behalf must always carry a reason — it is shown in
       # the email that tells the creator their sale was refunded, and "A sale has been
       # refunded" with no explanation is exactly the kind of message that sends the creator
       # to support asking what happened. Fraud refunds are exempt because that path sends
       # its own dedicated email (see refund_for_fraud!).
-      if refunded_by_team_member && !is_for_fraud && reason.blank?
+      if refunded_on_creators_behalf && !is_for_fraud && reason.blank?
         errors.add :base, "A reason is required when refunding on the creator's behalf."
         return false
       end
@@ -152,7 +157,7 @@ class Purchase
         # this method — Charge::Refundable handles the creator email for those.
         # The refund record just created (refunds.last) carries the optional reason so the
         # email can tell the creator why the sale was refunded.
-        if refunded && !is_for_fraud && refunded_by_team_member && !seller.suspended?
+        if refunded && !is_for_fraud && refunded_on_creators_behalf && !seller.suspended?
           ContactingCreatorMailer.purchase_refunded(id, refunds.last&.id).deliver_later(queue: "default")
         end
         refunded

--- a/app/modules/purchase/refundable.rb
+++ b/app/modules/purchase/refundable.rb
@@ -119,9 +119,22 @@ class Purchase
         if charge_refund.flow_of_funds.nil? && StripeChargeProcessor.charge_processor_id != charge_processor_id
           charge_refund.flow_of_funds = FlowOfFunds.build_simple_flow_of_funds(Currency::USD, -(gross_amount_cents.presence || gross_amount_refundable_cents))
         end
-        refund_purchase!(charge_refund.flow_of_funds, refunding_user_id, charge_refund.refund, is_for_fraud,
-                         canonical_gross_refund_cents: (presentment_refund ? (gross_amount_cents.presence || gross_amount_refundable_cents) : nil),
-                         presentment_refund:)
+        refunded = refund_purchase!(charge_refund.flow_of_funds, refunding_user_id, charge_refund.refund, is_for_fraud,
+                                    canonical_gross_refund_cents: (presentment_refund ? (gross_amount_cents.presence || gross_amount_refundable_cents) : nil),
+                                    presentment_refund:)
+        # When a Gumroad team member (support/admin) refunds a sale on the creator's
+        # behalf, tell the creator by email — otherwise they only discover the refund by
+        # stumbling on the refunded row in their dashboard. Creator-initiated refunds stay
+        # silent (they did it themselves), fraud refunds already send their own email
+        # (see refund_for_fraud!), and suspended sellers are skipped to match that path.
+        # Processor-initiated refunds (issued from the Stripe dashboard) don't go through
+        # this method — Charge::Refundable handles the creator email for those.
+        if refunded && !is_for_fraud &&
+            refunding_user_id.present? && User.find_by(id: refunding_user_id)&.is_team_member? &&
+            !seller.suspended?
+          ContactingCreatorMailer.purchase_refunded(id).deliver_later(queue: "default")
+        end
+        refunded
       rescue ChargeProcessorAlreadyRefundedError => e
         logger.error "Charge was already refunded in purchase: #{external_id}. Response: #{e.message}"
         false

--- a/app/modules/purchase/refundable.rb
+++ b/app/modules/purchase/refundable.rb
@@ -9,10 +9,10 @@ class Purchase
     BUYER_PRESENTMENT_REFUND_ERROR_MESSAGE = "Refunds are temporarily unavailable for buyer-local-currency purchases."
 
     # * amount - the amount to refund (out of `Purchase#price_cents`, VAT-exclusive). VAT will be refunded proportinally to this amount.
-    # * reason - optional free-text explanation of why the sale is being refunded. It is
-    #   stored on the refund record and shown to the creator in the notification email
-    #   when a Gumroad team member issues the refund. A missing reason never blocks a
-    #   refund — the email simply omits it.
+    # * reason - free-text explanation of why the sale is being refunded. It is stored on
+    #   the refund record and shown to the creator in the notification email when a Gumroad
+    #   team member issues the refund. Required for team-member refunds (except fraud
+    #   refunds, which send their own dedicated email); optional otherwise.
     def refund!(refunding_user_id:, amount: nil, reason: nil)
       if amount.blank?
         refund_and_save!(refunding_user_id, reason:)
@@ -54,9 +54,19 @@ class Purchase
 
       # A refund can be initiated by the creator themselves, by a Gumroad team member
       # (support/admin), or from the console with no user at all. Look the user up once
-      # here; the answer gates both the balance checks below and the creator-notification
-      # email after the refund succeeds.
+      # here; the answer gates the reason requirement and balance checks below, and the
+      # creator-notification email after the refund succeeds.
       refunded_by_team_member = refunding_user_id.present? && User.find(refunding_user_id).is_team_member?
+
+      # A refund made on the creator's behalf must always carry a reason — it is shown in
+      # the email that tells the creator their sale was refunded, and "A sale has been
+      # refunded" with no explanation is exactly the kind of message that sends the creator
+      # to support asking what happened. Fraud refunds are exempt because that path sends
+      # its own dedicated email (see refund_for_fraud!).
+      if refunded_by_team_member && !is_for_fraud && reason.blank?
+        errors.add :base, "A reason is required when refunding on the creator's behalf."
+        return false
+      end
 
       unless refunded_by_team_member
         if seller.refunds_disabled?

--- a/app/modules/purchase/refundable.rb
+++ b/app/modules/purchase/refundable.rb
@@ -48,7 +48,13 @@ class Purchase
         return false
       end
 
-      if refunding_user_id.blank? || !User.find(refunding_user_id)&.is_team_member?
+      # A refund can be initiated by the creator themselves, by a Gumroad team member
+      # (support/admin), or from the console with no user at all. Look the user up once
+      # here; the answer gates both the balance checks below and the creator-notification
+      # email after the refund succeeds.
+      refunded_by_team_member = refunding_user_id.present? && User.find(refunding_user_id).is_team_member?
+
+      unless refunded_by_team_member
         if seller.refunds_disabled?
           errors.add :base, "Refunds are temporarily disabled in your account."
           return false
@@ -129,9 +135,7 @@ class Purchase
         # (see refund_for_fraud!), and suspended sellers are skipped to match that path.
         # Processor-initiated refunds (issued from the Stripe dashboard) don't go through
         # this method — Charge::Refundable handles the creator email for those.
-        if refunded && !is_for_fraud &&
-            refunding_user_id.present? && User.find_by(id: refunding_user_id)&.is_team_member? &&
-            !seller.suspended?
+        if refunded && !is_for_fraud && refunded_by_team_member && !seller.suspended?
           ContactingCreatorMailer.purchase_refunded(id).deliver_later(queue: "default")
         end
         refunded

--- a/app/modules/purchase/refundable.rb
+++ b/app/modules/purchase/refundable.rb
@@ -9,9 +9,13 @@ class Purchase
     BUYER_PRESENTMENT_REFUND_ERROR_MESSAGE = "Refunds are temporarily unavailable for buyer-local-currency purchases."
 
     # * amount - the amount to refund (out of `Purchase#price_cents`, VAT-exclusive). VAT will be refunded proportinally to this amount.
-    def refund!(refunding_user_id:, amount: nil)
+    # * reason - optional free-text explanation of why the sale is being refunded. It is
+    #   stored on the refund record and shown to the creator in the notification email
+    #   when a Gumroad team member issues the refund. A missing reason never blocks a
+    #   refund — the email simply omits it.
+    def refund!(refunding_user_id:, amount: nil, reason: nil)
       if amount.blank?
-        refund_and_save!(refunding_user_id)
+        refund_and_save!(refunding_user_id, reason:)
       else
         refund_amount_cents = refunding_amount_cents(amount)
         if refund_amount_cents > amount_refundable_cents
@@ -21,9 +25,9 @@ class Purchase
           # User attempted a partial refund with same amount as total purchase or
           # remaining refundable amount.
           # Short-circuit this, so we don't need to handle edge cases about taxes
-          refund_and_save!(refunding_user_id)
+          refund_and_save!(refunding_user_id, reason:)
         else
-          refund_and_save!(refunding_user_id, amount_cents: refund_amount_cents)
+          refund_and_save!(refunding_user_id, amount_cents: refund_amount_cents, reason:)
         end
       end
     end
@@ -32,7 +36,7 @@ class Purchase
     # refunding_user_id can't be enforced from console, in which case it will be nil
     #
     # * amount - the amount to refund (out of `Purchase#price_cents`, VAT-exclusive). VAT will be refunded proportinally to this amount.
-    def refund_and_save!(refunding_user_id, amount_cents: nil, is_for_fraud: false)
+    def refund_and_save!(refunding_user_id, amount_cents: nil, is_for_fraud: false, reason: nil)
       return if stripe_transaction_id.blank? || stripe_refunded || amount_refundable_cents <= 0
 
       if chargedback_not_reversed?
@@ -127,7 +131,8 @@ class Purchase
         end
         refunded = refund_purchase!(charge_refund.flow_of_funds, refunding_user_id, charge_refund.refund, is_for_fraud,
                                     canonical_gross_refund_cents: (presentment_refund ? (gross_amount_cents.presence || gross_amount_refundable_cents) : nil),
-                                    presentment_refund:)
+                                    presentment_refund:,
+                                    note: reason)
         # When a Gumroad team member (support/admin) refunds a sale on the creator's
         # behalf, tell the creator by email — otherwise they only discover the refund by
         # stumbling on the refunded row in their dashboard. Creator-initiated refunds stay
@@ -135,8 +140,10 @@ class Purchase
         # (see refund_for_fraud!), and suspended sellers are skipped to match that path.
         # Processor-initiated refunds (issued from the Stripe dashboard) don't go through
         # this method — Charge::Refundable handles the creator email for those.
+        # The refund record just created (refunds.last) carries the optional reason so the
+        # email can tell the creator why the sale was refunded.
         if refunded && !is_for_fraud && refunded_by_team_member && !seller.suspended?
-          ContactingCreatorMailer.purchase_refunded(id).deliver_later(queue: "default")
+          ContactingCreatorMailer.purchase_refunded(id, refunds.last&.id).deliver_later(queue: "default")
         end
         refunded
       rescue ChargeProcessorAlreadyRefundedError => e
@@ -233,7 +240,7 @@ class Purchase
   # consistent derivation is possible the refund fails closed rather than booking buyer-currency
   # cents as canonical USD.
   def refund_purchase!(flow_of_funds, refunding_user_id, stripe_refund = nil, is_for_fraud = false,
-                       canonical_gross_refund_cents: nil, presentment_refund: nil)
+                       canonical_gross_refund_cents: nil, presentment_refund: nil, note: nil)
     if buyer_presentment? && canonical_gross_refund_cents.nil?
       derived = derive_presentment_refund_from_flow_of_funds(flow_of_funds)
       return false if derived.blank?
@@ -273,6 +280,9 @@ class Purchase
         end
       end
       refund.is_for_fraud = is_for_fraud
+      # Free-text explanation of why the refund happened (e.g. "Buyer was charged twice").
+      # Shown to the creator in the notification email when a team member issued the refund.
+      refund.note = note if note.present?
       refunds << refund
       self.is_refund_chargeback_fee_waived = !charged_using_gumroad_merchant_account? || is_for_fraud
       mark_giftee_purchase_as_refunded(is_partially_refunded: self.stripe_partially_refunded?) if is_gift_sender_purchase

--- a/app/sidekiq/refund_purchase_worker.rb
+++ b/app/sidekiq/refund_purchase_worker.rb
@@ -4,13 +4,16 @@ class RefundPurchaseWorker
   include Sidekiq::Job
   sidekiq_options retry: 5, queue: :default
 
+  # reason is either Refund::FRAUD (which routes to the dedicated fraud path) or a
+  # free-text explanation. The explanation is stored on the refund and emailed to the
+  # creator; the refund model requires it for team-member refunds that aren't for fraud.
   def perform(purchase_id, admin_user_id, reason = nil)
     purchase = Purchase.find(purchase_id)
 
     if reason == Refund::FRAUD
       purchase.refund_for_fraud_and_block_buyer!(admin_user_id)
     else
-      purchase.refund_and_save!(admin_user_id)
+      purchase.refund_and_save!(admin_user_id, reason:)
     end
   end
 end

--- a/app/sidekiq/refund_unpaid_purchases_worker.rb
+++ b/app/sidekiq/refund_unpaid_purchases_worker.rb
@@ -36,7 +36,11 @@ class RefundUnpaidPurchasesWorker
     return unless user.suspended?
 
     self.class.unpaid_purchases_for(user).ids.each do |purchase_id|
-      RefundPurchaseWorker.perform_async(purchase_id, admin_user_id)
+      # A reason is required for any refund made on the creator's behalf. The seller is
+      # suspended here, so the creator-notification email is skipped, but the reason is
+      # still stored on the refund record for the audit trail.
+      RefundPurchaseWorker.perform_async(purchase_id, admin_user_id,
+                                         "Account suspended; unpaid sale refunded to the buyer")
     end
 
     admin = User.find(admin_user_id)

--- a/app/sidekiq/sync_stuck_purchases_job.rb
+++ b/app/sidekiq/sync_stuck_purchases_job.rb
@@ -21,7 +21,7 @@ class SyncStuckPurchasesJob
         .where("created_at > ?", purchase.created_at)
         .any? { |subsequent_purchase| subsequent_purchase.variant_attributes.pluck(:id).sort == purchase.variant_attributes.pluck(:id).sort }
 
-        success = purchase.refund_and_save!(GUMROAD_ADMIN_ID)
+        success = purchase.refund_and_save!(GUMROAD_ADMIN_ID, reason: "Duplicate purchase detected and refunded automatically")
 
         unless success
           Rails.logger.warn("SyncStuckPurchasesJob: Did not refund purchase with ID #{purchase.id}")

--- a/app/views/contacting_creator_mailer/purchase_refunded.html.erb
+++ b/app/views/contacting_creator_mailer/purchase_refunded.html.erb
@@ -1,4 +1,7 @@
 <%= header_section("A sale has been refunded.") %>
 <div>
   <p><%= @purchase.email %>'s purchase of <%= @purchase.link.name %> for <%= @purchase.formatted_display_price %> has been refunded.</p>
+  <% if @refund_reason.present? %>
+    <p>Reason: <%= @refund_reason %></p>
+  <% end %>
 </div>

--- a/spec/controllers/admin/purchases_controller_spec.rb
+++ b/spec/controllers/admin/purchases_controller_spec.rb
@@ -61,6 +61,30 @@ describe Admin::PurchasesController, :vcr, inertia: true do
     end
   end
 
+  describe "POST refund" do
+    before do
+      @purchase = create(:purchase_in_progress, chargeable: create(:chargeable), purchaser: create(:user))
+      @purchase.process!
+      @purchase.mark_successful!
+    end
+
+    it "refunds the purchase and stores the reason when one is given" do
+      post :refund, params: { external_id: @purchase.external_id, reason: "Buyer reported being charged twice" }
+
+      expect(response.parsed_body["success"]).to be(true)
+      expect(@purchase.reload.stripe_refunded).to be(true)
+      expect(@purchase.refunds.last.note).to eq("Buyer reported being charged twice")
+    end
+
+    it "rejects the refund when no reason is given" do
+      post :refund, params: { external_id: @purchase.external_id }
+
+      expect(response.parsed_body["success"]).to be(false)
+      expect(response.parsed_body["message"]).to eq("A reason is required when refunding on the creator's behalf.")
+      expect(@purchase.reload.stripe_refunded).to be(false)
+    end
+  end
+
   describe "POST refund_for_fraud" do
     before do
       @purchase = create(:purchase_in_progress, chargeable: create(:chargeable), purchaser: create(:user))

--- a/spec/controllers/api/internal/admin/purchases_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/purchases_controller_spec.rb
@@ -700,7 +700,7 @@ describe Api::Internal::Admin::PurchasesController do
   describe "POST refund" do
     let(:admin_user) { create(:admin_user) }
     let(:purchase) { create(:free_purchase, email: "buyer@example.com") }
-    let(:params) { { id: purchase.external_id_numeric.to_s, email: purchase.email } }
+    let(:params) { { id: purchase.external_id_numeric.to_s, email: purchase.email, reason: "Refund requested by the buyer" } }
     let(:refund_policy) { double("PurchaseRefundPolicy", fine_print: nil) }
 
     include_examples "admin api authorization required", :post, :refund, { id: "123", email: "buyer@example.com" }
@@ -716,16 +716,30 @@ describe Api::Internal::Admin::PurchasesController do
       expect(response.parsed_body).to eq({ success: false, message: "email is required" }.as_json)
     end
 
+    it "returns 400 when reason is missing" do
+      post :refund, params: { id: purchase.external_id_numeric.to_s, email: purchase.email }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "reason is required" }.as_json)
+    end
+
+    it "returns 400 when reason is blank" do
+      post :refund, params: { id: purchase.external_id_numeric.to_s, email: purchase.email, reason: "   " }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "reason is required" }.as_json)
+    end
+
     context "when the purchase is not found or the email does not match" do
       it "returns 404 for a missing purchase" do
-        post :refund, params: { id: "999999999", email: "buyer@example.com" }
+        post :refund, params: { id: "999999999", email: "buyer@example.com", reason: "Refund requested by the buyer" }
 
         expect(response).to have_http_status(:not_found)
         expect(response.parsed_body).to eq({ success: false, message: "Purchase not found or email doesn't match" }.as_json)
       end
 
       it "returns 404 for a non-numeric purchase ID" do
-        post :refund, params: { id: "abc", email: "buyer@example.com" }
+        post :refund, params: { id: "abc", email: "buyer@example.com", reason: "Refund requested by the buyer" }
 
         expect(response).to have_http_status(:not_found)
         expect(response.parsed_body).to eq({ success: false, message: "Purchase not found or email doesn't match" }.as_json)
@@ -745,7 +759,7 @@ describe Api::Internal::Admin::PurchasesController do
         allow(purchase).to receive(:stripe_transaction_id).and_return("ch_test")
         allow(purchase).to receive(:amount_refundable_cents).and_return(1000)
         purchase.errors.clear
-        expect(purchase).to receive(:refund!).with(refunding_user_id: admin_user.id, amount: nil).and_return(true)
+        expect(purchase).to receive(:refund!).with(refunding_user_id: admin_user.id, amount: nil, reason: "Refund requested by the buyer").and_return(true)
 
         post :refund, params: params.merge(email: purchase.email.upcase)
 
@@ -765,7 +779,7 @@ describe Api::Internal::Admin::PurchasesController do
       end
 
       it "fully refunds the purchase when amount_cents is omitted" do
-        expect(purchase).to receive(:refund!).with(refunding_user_id: admin_user.id, amount: nil).and_return(true)
+        expect(purchase).to receive(:refund!).with(refunding_user_id: admin_user.id, amount: nil, reason: "Refund requested by the buyer").and_return(true)
 
         post :refund, params: params
 
@@ -777,7 +791,7 @@ describe Api::Internal::Admin::PurchasesController do
       end
 
       it "performs a partial refund when amount_cents is provided" do
-        expect(purchase).to receive(:refund!).with(refunding_user_id: admin_user.id, amount: 5.0).and_return(true)
+        expect(purchase).to receive(:refund!).with(refunding_user_id: admin_user.id, amount: 5.0, reason: "Refund requested by the buyer").and_return(true)
 
         post :refund, params: params.merge(amount_cents: "500")
 
@@ -786,7 +800,7 @@ describe Api::Internal::Admin::PurchasesController do
       end
 
       it "passes amount_cents equal to the full price through to refund! (model short-circuits to a full refund)" do
-        expect(purchase).to receive(:refund!).with(refunding_user_id: admin_user.id, amount: 10.0).and_return(true)
+        expect(purchase).to receive(:refund!).with(refunding_user_id: admin_user.id, amount: 10.0, reason: "Refund requested by the buyer").and_return(true)
 
         post :refund, params: params.merge(amount_cents: "1000")
 
@@ -795,7 +809,7 @@ describe Api::Internal::Admin::PurchasesController do
       end
 
       it "returns 422 with the model error when amount_cents exceeds the refundable amount" do
-        allow(purchase).to receive(:refund!).with(refunding_user_id: admin_user.id, amount: 50.0) do
+        allow(purchase).to receive(:refund!).with(refunding_user_id: admin_user.id, amount: 50.0, reason: "Refund requested by the buyer") do
           purchase.errors.add :base, "Refund amount cannot be greater than the purchase price."
           false
         end
@@ -881,7 +895,7 @@ describe Api::Internal::Admin::PurchasesController do
         end
 
         it "succeeds with force=true" do
-          expect(purchase).to receive(:refund!).with(refunding_user_id: admin_user.id, amount: nil).and_return(true)
+          expect(purchase).to receive(:refund!).with(refunding_user_id: admin_user.id, amount: nil, reason: "Refund requested by the buyer").and_return(true)
 
           post :refund, params: params.merge(force: "true")
 
@@ -904,7 +918,7 @@ describe Api::Internal::Admin::PurchasesController do
         end
 
         it "succeeds with force=true" do
-          expect(purchase).to receive(:refund!).with(refunding_user_id: admin_user.id, amount: nil).and_return(true)
+          expect(purchase).to receive(:refund!).with(refunding_user_id: admin_user.id, amount: nil, reason: "Refund requested by the buyer").and_return(true)
 
           post :refund, params: params.merge(force: "true")
 
@@ -914,7 +928,7 @@ describe Api::Internal::Admin::PurchasesController do
       end
 
       it "still surfaces an active chargeback error even when force=true" do
-        allow(purchase).to receive(:refund!).with(refunding_user_id: admin_user.id, amount: nil) do
+        allow(purchase).to receive(:refund!).with(refunding_user_id: admin_user.id, amount: nil, reason: "Refund requested by the buyer") do
           purchase.errors.add :base, Purchase::Refundable::ACTIVE_DISPUTE_REFUND_ERROR_MESSAGE
           false
         end
@@ -931,7 +945,7 @@ describe Api::Internal::Admin::PurchasesController do
 
         it "cancels the subscription with admin/seller semantics after a successful refund" do
           allow(purchase).to receive(:subscription).and_return(subscription)
-          expect(purchase).to receive(:refund!).with(refunding_user_id: admin_user.id, amount: nil).and_return(true)
+          expect(purchase).to receive(:refund!).with(refunding_user_id: admin_user.id, amount: nil, reason: "Refund requested by the buyer").and_return(true)
           expect(subscription).to receive(:cancel!).with(by_seller: true, by_admin: true) do
             allow(subscription).to receive(:cancelled_at).and_return(Time.current)
           end
@@ -946,7 +960,7 @@ describe Api::Internal::Admin::PurchasesController do
 
         it "succeeds with subscription_cancelled: false when there is no subscription" do
           allow(purchase).to receive(:subscription).and_return(nil)
-          expect(purchase).to receive(:refund!).with(refunding_user_id: admin_user.id, amount: nil).and_return(true)
+          expect(purchase).to receive(:refund!).with(refunding_user_id: admin_user.id, amount: nil, reason: "Refund requested by the buyer").and_return(true)
 
           post :refund, params: params.merge(cancel_subscription: "true")
 
@@ -959,7 +973,7 @@ describe Api::Internal::Admin::PurchasesController do
         it "does not re-cancel a subscription that is already deactivated" do
           deactivated_subscription = instance_double(Subscription, deactivated?: true, cancelled_at: 1.hour.ago, price: nil)
           allow(purchase).to receive(:subscription).and_return(deactivated_subscription)
-          expect(purchase).to receive(:refund!).with(refunding_user_id: admin_user.id, amount: nil).and_return(true)
+          expect(purchase).to receive(:refund!).with(refunding_user_id: admin_user.id, amount: nil, reason: "Refund requested by the buyer").and_return(true)
           expect(deactivated_subscription).not_to receive(:cancel!)
 
           post :refund, params: params.merge(cancel_subscription: "true")
@@ -971,7 +985,7 @@ describe Api::Internal::Admin::PurchasesController do
         it "does not re-cancel a subscription that is already pending cancellation" do
           pending_subscription = instance_double(Subscription, deactivated?: false, cancelled_at: 1.day.from_now, price: nil)
           allow(purchase).to receive(:subscription).and_return(pending_subscription)
-          expect(purchase).to receive(:refund!).with(refunding_user_id: admin_user.id, amount: nil).and_return(true)
+          expect(purchase).to receive(:refund!).with(refunding_user_id: admin_user.id, amount: nil, reason: "Refund requested by the buyer").and_return(true)
           expect(pending_subscription).not_to receive(:cancel!)
 
           post :refund, params: params.merge(cancel_subscription: "true")
@@ -982,7 +996,7 @@ describe Api::Internal::Admin::PurchasesController do
 
         it "still returns success with subscription_cancel_error when cancel! raises after a successful refund" do
           allow(purchase).to receive(:subscription).and_return(subscription)
-          expect(purchase).to receive(:refund!).with(refunding_user_id: admin_user.id, amount: nil).and_return(true)
+          expect(purchase).to receive(:refund!).with(refunding_user_id: admin_user.id, amount: nil, reason: "Refund requested by the buyer").and_return(true)
           expect(subscription).to receive(:cancel!).with(by_seller: true, by_admin: true).and_raise(StandardError, "stripe blew up")
 
           post :refund, params: params.merge(cancel_subscription: "true")
@@ -996,7 +1010,7 @@ describe Api::Internal::Admin::PurchasesController do
 
       context "with whitespace in the email parameter" do
         it "strips whitespace before comparing against the purchase email" do
-          expect(purchase).to receive(:refund!).with(refunding_user_id: admin_user.id, amount: nil).and_return(true)
+          expect(purchase).to receive(:refund!).with(refunding_user_id: admin_user.id, amount: nil, reason: "Refund requested by the buyer").and_return(true)
 
           post :refund, params: params.merge(email: "  #{purchase.email.upcase}  ")
 
@@ -1096,7 +1110,7 @@ describe Api::Internal::Admin::PurchasesController do
   describe "POST refund_taxes" do
     let(:admin_user) { create(:admin_user) }
     let(:purchase) { create(:free_purchase, email: "buyer@example.com") }
-    let(:params) { { id: purchase.external_id_numeric.to_s, email: purchase.email } }
+    let(:params) { { id: purchase.external_id_numeric.to_s, email: purchase.email, reason: "Refund requested by the buyer" } }
 
     include_examples "admin api authorization required", :post, :refund_taxes, { id: "123", email: "buyer@example.com" }
 
@@ -1250,7 +1264,7 @@ describe Api::Internal::Admin::PurchasesController do
   describe "POST cancel_subscription" do
     let(:admin_user) { create(:admin_user) }
     let(:purchase) { create(:free_purchase, email: "buyer@example.com") }
-    let(:params) { { id: purchase.external_id_numeric.to_s, email: purchase.email } }
+    let(:params) { { id: purchase.external_id_numeric.to_s, email: purchase.email, reason: "Refund requested by the buyer" } }
 
     include_examples "admin api authorization required", :post, :cancel_subscription, { id: "123", email: "buyer@example.com" }
 
@@ -1378,7 +1392,7 @@ describe Api::Internal::Admin::PurchasesController do
   describe "POST block_buyer" do
     let(:admin_user) { create(:admin_user) }
     let(:purchase) { create(:free_purchase, email: "buyer@example.com") }
-    let(:params) { { id: purchase.external_id_numeric.to_s, email: purchase.email } }
+    let(:params) { { id: purchase.external_id_numeric.to_s, email: purchase.email, reason: "Refund requested by the buyer" } }
 
     include_examples "admin api authorization required", :post, :block_buyer, { id: "123", email: "buyer@example.com" }
 
@@ -1476,7 +1490,7 @@ describe Api::Internal::Admin::PurchasesController do
   describe "POST unblock_buyer" do
     let(:admin_user) { create(:admin_user) }
     let(:purchase) { create(:free_purchase, email: "buyer@example.com") }
-    let(:params) { { id: purchase.external_id_numeric.to_s, email: purchase.email } }
+    let(:params) { { id: purchase.external_id_numeric.to_s, email: purchase.email, reason: "Refund requested by the buyer" } }
 
     include_examples "admin api authorization required", :post, :unblock_buyer, { id: "123", email: "buyer@example.com" }
 
@@ -1550,7 +1564,7 @@ describe Api::Internal::Admin::PurchasesController do
   describe "POST refund_for_fraud" do
     let(:admin_user) { create(:admin_user) }
     let(:purchase) { create(:free_purchase, email: "buyer@example.com") }
-    let(:params) { { id: purchase.external_id_numeric.to_s, email: purchase.email } }
+    let(:params) { { id: purchase.external_id_numeric.to_s, email: purchase.email, reason: "Refund requested by the buyer" } }
 
     include_examples "admin api authorization required", :post, :refund_for_fraud, { id: "123", email: "buyer@example.com" }
 

--- a/spec/mailers/contacting_creator_mailer_spec.rb
+++ b/spec/mailers/contacting_creator_mailer_spec.rb
@@ -32,7 +32,24 @@ describe ContactingCreatorMailer do
       expect(mail.to).to eq [purchase.seller.email]
       expect(mail.subject).to eq("A sale has been refunded")
       expect(mail.body.encoded).to include "test@example.com's purchase of Digital Membership for $10 has been refunded."
+      expect(mail.body.encoded).not_to include "Reason:"
       expect(mail.from).to eq([ApplicationMailer::SUPPORT_EMAIL])
+    end
+
+    it "includes the refund reason when the refund has a note" do
+      purchase = create(:purchase, link: create(:product, name: "Digital Membership"), email: "test@example.com", price_cents: 10_00)
+      refund = create(:refund, purchase:, note: "Buyer reported being charged twice")
+
+      mail = ContactingCreatorMailer.purchase_refunded(purchase.id, refund.id)
+      expect(mail.body.encoded).to include "Reason: Buyer reported being charged twice"
+    end
+
+    it "omits the reason when the refund has no note" do
+      purchase = create(:purchase, link: create(:product, name: "Digital Membership"), email: "test@example.com", price_cents: 10_00)
+      refund = create(:refund, purchase:)
+
+      mail = ContactingCreatorMailer.purchase_refunded(purchase.id, refund.id)
+      expect(mail.body.encoded).not_to include "Reason:"
     end
   end
 

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -127,10 +127,10 @@ describe Charge, :vcr do
       successful_purchase = instance_double(Purchase, refund_and_save!: true)
       allow(charge).to receive(:successful_purchases).and_return([failed_purchase, successful_purchase])
 
-      expect(charge.refund_and_save!(123)).to be(false)
+      expect(charge.refund_and_save!(123, reason: "Refund requested by the buyer")).to be(false)
 
-      expect(failed_purchase).to have_received(:refund_and_save!).with(123)
-      expect(successful_purchase).to have_received(:refund_and_save!).with(123)
+      expect(failed_purchase).to have_received(:refund_and_save!).with(123, reason: "Refund requested by the buyer")
+      expect(successful_purchase).to have_received(:refund_and_save!).with(123, reason: "Refund requested by the buyer")
       expect(charge.errors[:base]).to include("First refund failed")
     end
   end

--- a/spec/models/product_review_stat_spec.rb
+++ b/spec/models/product_review_stat_spec.rb
@@ -149,7 +149,7 @@ describe ProductReviewStat do
       "average_rating" => 2.3
     )
 
-    purchase.refund_and_save!(create(:admin_user).id)
+    purchase.refund_and_save!(create(:admin_user).id, reason: "Refund requested by the buyer")
 
     expect(review_stat.reload.attributes).to include(
       "ratings_of_one_count" => 1,

--- a/spec/models/purchase/purchase_balances_spec.rb
+++ b/spec/models/purchase/purchase_balances_spec.rb
@@ -61,14 +61,14 @@ describe "PurchaseBalances", :vcr  do
         purchase_balance_1 = @purchase_1.purchase_success_balance
 
         travel_to(Time.zone.local(2023, 11, 27)) do
-          @purchase_1.refund_and_save!(admin_user.id)
+          @purchase_1.refund_and_save!(admin_user.id, reason: "Refund requested by the buyer")
         end
 
         refund_balance_1 = @purchase_1.reload.purchase_refund_balance
         expect(refund_balance_1).to eq purchase_balance_1
 
         purchase_balance_2 = @purchase_2.purchase_success_balance
-        @purchase_2.refund_and_save!(admin_user.id)
+        @purchase_2.refund_and_save!(admin_user.id, reason: "Refund requested by the buyer")
         refund_balance_2 = @purchase_2.reload.purchase_refund_balance
         expect(refund_balance_2).to eq purchase_balance_2
       end
@@ -85,14 +85,14 @@ describe "PurchaseBalances", :vcr  do
         create(:balance, user: @user, merchant_account: @purchase_2.merchant_account, date: Date.today)
 
         travel_to(Time.zone.local(2023, 11, 27)) do
-          @purchase_1.refund_and_save!(admin_user.id)
+          @purchase_1.refund_and_save!(admin_user.id, reason: "Refund requested by the buyer")
         end
 
         refund_balance_1 = @purchase_1.reload.purchase_refund_balance
         expect(refund_balance_1).to eq old_unpaid_balance_1
 
         travel_to(Time.zone.local(2023, 11, 27)) do
-          @purchase_2.refund_and_save!(admin_user.id)
+          @purchase_2.refund_and_save!(admin_user.id, reason: "Refund requested by the buyer")
         end
 
         refund_balance_2 = @purchase_2.reload.purchase_refund_balance
@@ -117,14 +117,14 @@ describe "PurchaseBalances", :vcr  do
         today_unpaid_balance_2 = create(:balance, user: @user, merchant_account: @purchase_2.merchant_account, date: Date.today)
 
         travel_to(Time.zone.local(2023, 11, 27)) do
-          @purchase_1.refund_and_save!(admin_user.id)
+          @purchase_1.refund_and_save!(admin_user.id, reason: "Refund requested by the buyer")
         end
 
         refund_balance_1 = @purchase_1.reload.purchase_refund_balance
         expect(refund_balance_1).to eq today_unpaid_balance_1
 
         travel_to(Time.zone.local(2023, 11, 27)) do
-          @purchase_2.refund_and_save!(admin_user.id)
+          @purchase_2.refund_and_save!(admin_user.id, reason: "Refund requested by the buyer")
         end
 
         refund_balance_2 = @purchase_2.reload.purchase_refund_balance
@@ -154,14 +154,14 @@ describe "PurchaseBalances", :vcr  do
       it "uses the same balance for refund/chargeback as the one used for the original purchase (if unpaid)" do
         purchase_balance_1 = @purchase_1.purchase_success_balance
         travel_to(Time.zone.local(2023, 11, 27)) do
-          @purchase_1.refund_and_save!(admin_user.id)
+          @purchase_1.refund_and_save!(admin_user.id, reason: "Refund requested by the buyer")
         end
         refund_balance_1 = @purchase_1.reload.purchase_refund_balance
         expect(refund_balance_1).to eq purchase_balance_1
 
         purchase_balance_2 = @purchase_2.purchase_success_balance
         travel_to(Time.zone.local(2023, 11, 27)) do
-          @purchase_2.refund_and_save!(admin_user.id)
+          @purchase_2.refund_and_save!(admin_user.id, reason: "Refund requested by the buyer")
         end
         refund_balance_2 = @purchase_2.reload.purchase_refund_balance
         expect(refund_balance_2).to eq purchase_balance_2
@@ -179,13 +179,13 @@ describe "PurchaseBalances", :vcr  do
         create(:balance, user: @user, merchant_account: @purchase_2.merchant_account, date: Date.today)
 
         travel_to(Time.zone.local(2023, 11, 27)) do
-          @purchase_1.refund_and_save!(admin_user.id)
+          @purchase_1.refund_and_save!(admin_user.id, reason: "Refund requested by the buyer")
         end
         refund_balance_1 = @purchase_1.reload.purchase_refund_balance
         expect(refund_balance_1).to eq old_unpaid_balance_1
 
         travel_to(Time.zone.local(2023, 11, 27)) do
-          @purchase_2.refund_and_save!(admin_user.id)
+          @purchase_2.refund_and_save!(admin_user.id, reason: "Refund requested by the buyer")
         end
         refund_balance_2 = @purchase_2.reload.purchase_refund_balance
         expect(refund_balance_2).to eq old_unpaid_balance_2
@@ -209,13 +209,13 @@ describe "PurchaseBalances", :vcr  do
         today_unpaid_balance_2 = create(:balance, user: @user, merchant_account: @purchase_2.merchant_account, date: Date.today)
 
         travel_to(Time.zone.local(2023, 11, 27)) do
-          @purchase_1.refund_and_save!(admin_user.id)
+          @purchase_1.refund_and_save!(admin_user.id, reason: "Refund requested by the buyer")
         end
         refund_balance_1 = @purchase_1.reload.purchase_refund_balance
         expect(refund_balance_1).to eq today_unpaid_balance_1
 
         travel_to(Time.zone.local(2023, 11, 27)) do
-          @purchase_2.refund_and_save!(admin_user.id)
+          @purchase_2.refund_and_save!(admin_user.id, reason: "Refund requested by the buyer")
         end
         refund_balance_2 = @purchase_2.reload.purchase_refund_balance
         expect(refund_balance_2).to eq today_unpaid_balance_2

--- a/spec/models/purchase/purchase_gifts_spec.rb
+++ b/spec/models/purchase/purchase_gifts_spec.rb
@@ -35,7 +35,7 @@ describe "PurchaseGifts", :vcr do
 
     it "sets the state of the giftee purchase to refunded when refunding gifter purchase" do
       @giftee_purchase.mark_gift_receiver_purchase_successful
-      @gifter_purchase.reload.refund_and_save!(create(:admin_user).id)
+      @gifter_purchase.reload.refund_and_save!(create(:admin_user).id, reason: "Refund requested by the buyer")
       @giftee_purchase.reload
       expect(@giftee_purchase.purchase_state).to eq("gift_receiver_purchase_successful")
       expect(@giftee_purchase.stripe_refunded).to be(true)

--- a/spec/models/purchase/purchase_refunds_spec.rb
+++ b/spec/models/purchase/purchase_refunds_spec.rb
@@ -625,6 +625,45 @@ describe "PurchaseRefunds", :vcr do
       expect(@purchase.refund_and_save!(@user.id)).to be(false)
     end
 
+    describe "notifying the creator when a team member refunds on their behalf" do
+      it "emails the creator when a Gumroad team member issues the refund" do
+        admin = create(:admin_user)
+
+        expect do
+          expect(@purchase.refund_and_save!(admin.id)).to be(true)
+        end.to have_enqueued_mail(ContactingCreatorMailer, :purchase_refunded).with(@purchase.id)
+      end
+
+      it "does not email the creator when they refund their own sale" do
+        expect(ContactingCreatorMailer).not_to receive(:purchase_refunded)
+
+        expect(@purchase.refund_and_save!(@user.id)).to be(true)
+      end
+
+      it "does not email the creator when there is no refunding user (console refund)" do
+        expect(ContactingCreatorMailer).not_to receive(:purchase_refunded)
+
+        expect(@purchase.refund_and_save!(nil)).to be(true)
+      end
+
+      it "does not email the creator for fraud refunds (the fraud path sends its own email)" do
+        admin = create(:admin_user)
+
+        expect(ContactingCreatorMailer).not_to receive(:purchase_refunded)
+
+        expect(@purchase.refund_and_save!(admin.id, is_for_fraud: true)).to be(true)
+      end
+
+      it "does not email the creator when the seller is suspended" do
+        admin = create(:admin_user)
+        @user.update!(user_risk_state: "suspended_for_tos_violation")
+
+        expect(ContactingCreatorMailer).not_to receive(:purchase_refunded)
+
+        expect(@purchase.refund_and_save!(admin.id)).to be(true)
+      end
+    end
+
     describe "refund with tax" do
       describe "with sales tax" do
         before do

--- a/spec/models/purchase/purchase_refunds_spec.rb
+++ b/spec/models/purchase/purchase_refunds_spec.rb
@@ -631,7 +631,30 @@ describe "PurchaseRefunds", :vcr do
 
         expect do
           expect(@purchase.refund_and_save!(admin.id)).to be(true)
-        end.to have_enqueued_mail(ContactingCreatorMailer, :purchase_refunded).with(@purchase.id)
+        end.to have_enqueued_mail(ContactingCreatorMailer, :purchase_refunded).with { |purchase_id, refund_id|
+          expect(purchase_id).to eq(@purchase.id)
+          expect(refund_id).to eq(@purchase.refunds.last.id)
+        }
+      end
+
+      it "stores the reason on the refund and passes the refund to the email" do
+        admin = create(:admin_user)
+
+        expect do
+          expect(@purchase.refund_and_save!(admin.id, reason: "Buyer reported being charged twice")).to be(true)
+        end.to have_enqueued_mail(ContactingCreatorMailer, :purchase_refunded).with { |purchase_id, refund_id|
+          expect(purchase_id).to eq(@purchase.id)
+          expect(refund_id).to eq(@purchase.refunds.last.id)
+        }
+
+        expect(@purchase.refunds.last.note).to eq("Buyer reported being charged twice")
+      end
+
+      it "leaves the refund note empty when no reason is given" do
+        admin = create(:admin_user)
+
+        expect(@purchase.refund_and_save!(admin.id)).to be(true)
+        expect(@purchase.refunds.last.note).to be_nil
       end
 
       it "does not email the creator when they refund their own sale" do

--- a/spec/models/purchase/purchase_refunds_spec.rb
+++ b/spec/models/purchase/purchase_refunds_spec.rb
@@ -526,7 +526,7 @@ describe "PurchaseRefunds", :vcr do
                                                           is_for_fraud: false, purchase:).and_call_original
         expect(purchase).to receive(:debit_processor_fee_from_merchant_account!)
 
-        purchase.refund_and_save!(create(:admin_user).id)
+        purchase.refund_and_save!(create(:admin_user).id, reason: "Refund requested by the buyer")
 
         expect(charge_refund.transfer_reversal).to be nil
       end
@@ -630,7 +630,7 @@ describe "PurchaseRefunds", :vcr do
         admin = create(:admin_user)
 
         expect do
-          expect(@purchase.refund_and_save!(admin.id)).to be(true)
+          expect(@purchase.refund_and_save!(admin.id, reason: "Refund requested by the buyer")).to be(true)
         end.to have_enqueued_mail(ContactingCreatorMailer, :purchase_refunded).with { |purchase_id, refund_id|
           expect(purchase_id).to eq(@purchase.id)
           expect(refund_id).to eq(@purchase.refunds.last.id)
@@ -650,11 +650,14 @@ describe "PurchaseRefunds", :vcr do
         expect(@purchase.refunds.last.note).to eq("Buyer reported being charged twice")
       end
 
-      it "leaves the refund note empty when no reason is given" do
+      it "fails the refund when a team member gives no reason" do
         admin = create(:admin_user)
 
-        expect(@purchase.refund_and_save!(admin.id)).to be(true)
-        expect(@purchase.refunds.last.note).to be_nil
+        expect(ContactingCreatorMailer).not_to receive(:purchase_refunded)
+
+        expect(@purchase.refund_and_save!(admin.id)).to be(false)
+        expect(@purchase.errors.full_messages).to include("A reason is required when refunding on the creator's behalf.")
+        expect(@purchase.reload.stripe_refunded?).to be(false)
       end
 
       it "does not email the creator when they refund their own sale" do
@@ -683,7 +686,7 @@ describe "PurchaseRefunds", :vcr do
 
         expect(ContactingCreatorMailer).not_to receive(:purchase_refunded)
 
-        expect(@purchase.refund_and_save!(admin.id)).to be(true)
+        expect(@purchase.refund_and_save!(admin.id, reason: "Refund requested by the buyer")).to be(true)
       end
     end
 
@@ -1100,7 +1103,7 @@ describe "PurchaseRefunds", :vcr do
         it "does not issue a refund while the dispute is still active" do
           expect(ChargeProcessor).not_to receive(:refund!)
 
-          expect(purchase.refund_and_save!(create(:admin_user).id)).to be(false)
+          expect(purchase.refund_and_save!(create(:admin_user).id, reason: "Refund requested by the buyer")).to be(false)
           expect(purchase.errors[:base]).to include(Purchase::Refundable::ACTIVE_DISPUTE_REFUND_ERROR_MESSAGE)
           expect(purchase.reload.refunds).to be_empty
         end
@@ -1117,13 +1120,13 @@ describe "PurchaseRefunds", :vcr do
           expect(purchase).to_not receive(:process_refund_or_chargeback_for_purchase_balance)
           expect(purchase).to_not receive(:process_refund_or_chargeback_for_affiliate_credit_balance)
 
-          purchase.refund_and_save!(create(:admin_user).id)
+          purchase.refund_and_save!(create(:admin_user).id, reason: "Refund requested by the buyer")
         end
       end
 
       describe "dispute after a refund event does not decrement seller balance" do
         before do
-          purchase.refund_and_save!(create(:admin_user).id)
+          purchase.refund_and_save!(create(:admin_user).id, reason: "Refund requested by the buyer")
         end
 
         it "does not decrement balance from the user on such an event" do
@@ -1169,7 +1172,7 @@ describe "PurchaseRefunds", :vcr do
         it "issues a refund" do
           expect(ChargeProcessor).to receive(:refund!).with(@purchase.charge_processor_id, @purchase.stripe_transaction_id, anything).and_call_original
 
-          @purchase.refund_and_save!(@admin_user.id)
+          @purchase.refund_and_save!(@admin_user.id, reason: "Refund requested by the buyer")
         end
       end
     end
@@ -1252,7 +1255,7 @@ describe "PurchaseRefunds", :vcr do
           purchase.mark_successful!
 
           expect(ChargeProcessor).to receive(:refund!).with(purchase.charge_processor_id, purchase.stripe_transaction_id, anything).and_call_original
-          purchase.reload.refund_and_save!(admin_user.id)
+          purchase.reload.refund_and_save!(admin_user.id, reason: "Refund requested by the buyer")
           expect(purchase.errors[:base].first).to be nil
           expect(purchase.reload.stripe_refunded).to be true
           expect(purchase.refunds.last.total_transaction_cents).to eq(25_00)
@@ -1267,7 +1270,7 @@ describe "PurchaseRefunds", :vcr do
           purchase.mark_successful!
 
           expect(ChargeProcessor).to receive(:refund!).with(purchase.charge_processor_id, purchase.stripe_transaction_id, anything).and_call_original
-          purchase.reload.refund_and_save!(admin_user.id)
+          purchase.reload.refund_and_save!(admin_user.id, reason: "Refund requested by the buyer")
           expect(purchase.errors[:base].first).to be nil
           expect(purchase.reload.stripe_refunded).to be true
           expect(purchase.refunds.last.total_transaction_cents).to eq(25_00)
@@ -1283,7 +1286,7 @@ describe "PurchaseRefunds", :vcr do
           purchase.mark_successful!
           expect(ChargeProcessor).to receive(:refund!).with(purchase.charge_processor_id, purchase.stripe_transaction_id, anything).and_call_original
 
-          purchase.reload.refund_and_save!(admin_user.id)
+          purchase.reload.refund_and_save!(admin_user.id, reason: "Refund requested by the buyer")
           expect(purchase.errors[:base].first).to be nil
           expect(purchase.reload.stripe_refunded).to be true
           expect(purchase.refunds.last.total_transaction_cents).to eq(25_00)
@@ -1423,7 +1426,7 @@ describe "PurchaseRefunds", :vcr do
 
         it "excludes the subscriber's review when refunding the first charge" do
           expect do
-            first_charge.refund_and_save!(create(:admin_user).id)
+            first_charge.refund_and_save!(create(:admin_user).id, reason: "Refund requested by the buyer")
           end.to change { original_purchase.reload.should_exclude_product_review? }.from(false).to(true)
         end
 
@@ -1824,7 +1827,7 @@ describe "PurchaseRefunds", :vcr do
     end
 
     it "updates balance of affiliate user as well as seller", :vcr do
-      purchase.refund_and_save!(create(:admin_user).id)
+      purchase.refund_and_save!(create(:admin_user).id, reason: "Refund requested by the buyer")
       seller.reload
       affiliate_user.reload
       verify_balance(affiliate_user, 0)
@@ -1851,7 +1854,7 @@ describe "PurchaseRefunds", :vcr do
       end
       expect(purchase).to receive(:debit_processor_fee_from_merchant_account!)
 
-      purchase.refund_and_save!(create(:admin_user).id)
+      purchase.refund_and_save!(create(:admin_user).id, reason: "Refund requested by the buyer")
       flow_of_funds = charge_refund.flow_of_funds
 
       balance_transaction_1 = BalanceTransaction.where(user_id: affiliate_user.id).last
@@ -1888,7 +1891,7 @@ describe "PurchaseRefunds", :vcr do
       let(:affiliate) { create(:collaborator, affiliate_user:, seller:, affiliate_basis_points: 5000, products: [product]) }
 
       it "refunds the full affiliate credit (net of fees)" do
-        purchase.refund_and_save!(create(:admin_user).id)
+        purchase.refund_and_save!(create(:admin_user).id, reason: "Refund requested by the buyer")
         verify_balance(affiliate_user.reload, 0)
       end
     end
@@ -1898,7 +1901,7 @@ describe "PurchaseRefunds", :vcr do
         expect(purchase).to receive(:debit_processor_fee_from_merchant_account!).and_call_original
 
         seller_balance = seller.unpaid_balance_cents
-        purchase.refund_and_save!(create(:admin_user).id, amount_cents: 600)
+        purchase.refund_and_save!(create(:admin_user).id, amount_cents: 600, reason: "Refund requested by the buyer")
         seller.reload
         affiliate_user.reload
         # affiliate_basis_points: 1000, on 1000 cents, 600 cents refunded => 100 - 60% of 100 = 100 - 60 = 40
@@ -1967,7 +1970,7 @@ describe "PurchaseRefunds", :vcr do
         seller.reload
         affiliate_user.reload
 
-        purchase.refund_and_save!(create(:admin_user).id)
+        purchase.refund_and_save!(create(:admin_user).id, reason: "Refund requested by the buyer")
 
         # affiliate_partial_refunds total sum should tally up to actual credits
         expect(affiliate_user.affiliate_partial_refunds.sum(:amount_cents)).to eq(80)
@@ -1993,7 +1996,7 @@ describe "PurchaseRefunds", :vcr do
         it "refunds part of the fees" do
           seller_balance = seller.unpaid_balance_cents
 
-          purchase.refund_and_save!(create(:admin_user).id, amount_cents: 400)
+          purchase.refund_and_save!(create(:admin_user).id, amount_cents: 400, reason: "Refund requested by the buyer")
           seller.reload
           affiliate_user.reload
 
@@ -2051,7 +2054,7 @@ describe "PurchaseRefunds", :vcr do
 
       it "updates balance of affiliate user as well as seller" do
         travel_to(Time.zone.local(2023, 10, 6)) do
-          purchase.refund_and_save!(create(:admin_user).id)
+          purchase.refund_and_save!(create(:admin_user).id, reason: "Refund requested by the buyer")
         end
         seller.reload
         affiliate_user.reload
@@ -2079,7 +2082,7 @@ describe "PurchaseRefunds", :vcr do
         end
 
         travel_to(Time.zone.local(2023, 10, 6)) do
-          purchase.refund_and_save!(create(:admin_user).id)
+          purchase.refund_and_save!(create(:admin_user).id, reason: "Refund requested by the buyer")
         end
         flow_of_funds = charge_refund.flow_of_funds
 

--- a/spec/models/purchase/purchase_refunds_spec.rb
+++ b/spec/models/purchase/purchase_refunds_spec.rb
@@ -666,6 +666,16 @@ describe "PurchaseRefunds", :vcr do
         expect(@purchase.refund_and_save!(@user.id)).to be(true)
       end
 
+      it "lets a team member refund their own sale without a reason and without an email" do
+        # Gumroad staff can also sell on Gumroad. Refunding their own sale is a
+        # creator refund, not a support action — no reason required, no email sent.
+        @user.update!(is_team_member: true)
+
+        expect(ContactingCreatorMailer).not_to receive(:purchase_refunded)
+
+        expect(@purchase.refund_and_save!(@user.id)).to be(true)
+      end
+
       it "does not email the creator when there is no refunding user (console refund)" do
         expect(ContactingCreatorMailer).not_to receive(:purchase_refunded)
 

--- a/spec/sidekiq/refund_purchase_worker_spec.rb
+++ b/spec/sidekiq/refund_purchase_worker_spec.rb
@@ -21,10 +21,18 @@ describe RefundPurchaseWorker do
     end
 
     context "when the reason is not supplied" do
-      it "calls #refund_and_save! on the purchase" do
-        expect(purchase_double).to receive(:refund_and_save!).with(admin_user.id)
+      it "calls #refund_and_save! on the purchase with no reason" do
+        expect(purchase_double).to receive(:refund_and_save!).with(admin_user.id, reason: nil)
 
         described_class.new.perform(purchase.id, admin_user.id)
+      end
+    end
+
+    context "when a free-text reason is supplied" do
+      it "passes the reason through to #refund_and_save!" do
+        expect(purchase_double).to receive(:refund_and_save!).with(admin_user.id, reason: "Buyer was charged twice")
+
+        described_class.new.perform(purchase.id, admin_user.id, "Buyer was charged twice")
       end
     end
   end

--- a/spec/sidekiq/refund_unpaid_purchases_worker_spec.rb
+++ b/spec/sidekiq/refund_unpaid_purchases_worker_spec.rb
@@ -65,17 +65,17 @@ describe RefundUnpaidPurchasesWorker, :vcr do
     it "does not refund purchases if the user is not suspended" do
       @user.mark_compliant!(author_id: @admin_user.id)
       described_class.new.perform(@user.id, @admin_user.id)
-      expect(RefundPurchaseWorker).not_to have_enqueued_sidekiq_job(@purchase.id, @admin_user.id)
+      expect(RefundPurchaseWorker).not_to have_enqueued_sidekiq_job(@purchase.id, @admin_user.id, "Account suspended; unpaid sale refunded to the buyer")
     end
 
     it "queues the refund of unpaid purchases" do
       @user.flag_for_fraud!(author_id: @admin_user.id)
       @user.suspend_for_fraud!(author_id: @admin_user.id)
       described_class.new.perform(@user.id, @admin_user.id)
-      expect(RefundPurchaseWorker).to have_enqueued_sidekiq_job(@purchase.id, @admin_user.id)
+      expect(RefundPurchaseWorker).to have_enqueued_sidekiq_job(@purchase.id, @admin_user.id, "Account suspended; unpaid sale refunded to the buyer")
       expect(@purchase.purchase_success_balance.unpaid?).to be(true)
-      expect(RefundPurchaseWorker).not_to have_enqueued_sidekiq_job(@purchase_without_balance.id, @admin_user.id)
-      expect(RefundPurchaseWorker).not_to have_enqueued_sidekiq_job(@purchase_with_paid_balance.id, @admin_user.id)
+      expect(RefundPurchaseWorker).not_to have_enqueued_sidekiq_job(@purchase_without_balance.id, @admin_user.id, "Account suspended; unpaid sale refunded to the buyer")
+      expect(RefundPurchaseWorker).not_to have_enqueued_sidekiq_job(@purchase_with_paid_balance.id, @admin_user.id, "Account suspended; unpaid sale refunded to the buyer")
 
       comment = @user.comments.where(comment_type: Comment::COMMENT_TYPE_REFUND_BALANCE).last
       expect(comment.content).to eq("Refund balance initiated by #{@admin_user.username}.")

--- a/spec/support/fixtures/vcr_cassettes/Admin_PurchasesController/POST_refund/refunds_the_purchase_and_stores_the_reason_when_one_is_given.yml
+++ b/spec/support/fixtures/vcr_cassettes/Admin_PurchasesController/POST_refund/refunds_the_purchase_and_stores_the_reason_when_one_is_given.yml
@@ -1,0 +1,1327 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_7q42OmHLYFJvep","request_duration_ms":0}}'
+      Idempotency-Key:
+      - 1d2adfed-d630-49f0-b6c9-66abd5816dfa
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 12:08:12 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz;
+        report-to csp
+      Idempotency-Key:
+      - 1d2adfed-d630-49f0-b6c9-66abd5816dfa
+      Original-Request:
+      - req_JRbHneuFLCyPsI
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz&t=1"
+      Request-Id:
+      - req_JRbHneuFLCyPsI
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TrzhYIBOqvOFDrf4Nm3Ci7V",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783771692,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sat, 11 Jul 2026 12:08:12 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TrzhYIBOqvOFDrf4Nm3Ci7V
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_JRbHneuFLCyPsI","request_duration_ms":274}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 12:08:12 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz&t=1"
+      Request-Id:
+      - req_YfcrCl6z9VxVVA
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TrzhYIBOqvOFDrf4Nm3Ci7V",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783771692,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sat, 11 Jul 2026 12:08:12 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=You+bought+http%3A%2F%2Fedgar82e76501464.test.gumroad.com%3A31337%2Fl%2Fe%21&metadata[purchase]=JA44j8JoZVKbLDN1vurgxg%3D%3D&transfer_group=3242&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1TrzhYIBOqvOFDrf4Nm3Ci7V&statement_descriptor_suffix=edgar82e76501464
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_YfcrCl6z9VxVVA","request_duration_ms":152}}'
+      Idempotency-Key:
+      - db413a8c-ca4b-4efe-99e8-ebb6a2cec031
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 12:08:13 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1642'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz;
+        report-to csp
+      Idempotency-Key:
+      - db413a8c-ca4b-4efe-99e8-ebb6a2cec031
+      Original-Request:
+      - req_bJp578hhPz0fu4
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz&t=1"
+      Request-Id:
+      - req_bJp578hhPz0fu4
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3TrzhYIBOqvOFDrf0DtsSadd",
+          "object": "payment_intent",
+          "amount": 100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 100,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3TrzhYIBOqvOFDrf0DtsSadd_secret_XMnYms9E898bU4Pn9TiMCvvOf",
+          "confirmation_method": "automatic",
+          "created": 1783771692,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgar82e76501464.test.gumroad.com:31337/l/e!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3TrzhYIBOqvOFDrf0aGr9e9c",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "JA44j8JoZVKbLDN1vurgxg=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1TrzhYIBOqvOFDrf4Nm3Ci7V",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar82e76501464",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "3242"
+        }
+  recorded_at: Sat, 11 Jul 2026 12:08:13 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TrzhYIBOqvOFDrf0aGr9e9c?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_bJp578hhPz0fu4","request_duration_ms":869}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 12:08:13 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3764'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz&t=1"
+      Request-Id:
+      - req_S5R6CgoIAw9yyr
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TrzhYIBOqvOFDrf0aGr9e9c",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TrzhYIBOqvOFDrf0IABSTYR",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1784332800,
+            "balance_type": "payments",
+            "created": 1783771692,
+            "currency": "usd",
+            "description": "You bought http://edgar82e76501464.test.gumroad.com:31337/l/e!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3TrzhYIBOqvOFDrf0aGr9e9c",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR82E765014",
+          "captured": true,
+          "created": 1783771692,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar82e76501464.test.gumroad.com:31337/l/e!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "JA44j8JoZVKbLDN1vurgxg=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 26,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TrzhYIBOqvOFDrf0DtsSadd",
+          "payment_method": "pm_1TrzhYIBOqvOFDrf4Nm3Ci7V",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "234052",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKK3kyNIGMgZ0BTwLwXc6LBbEfR5_PyfqM39YcC0v67Vd4NAvyO7BWvh2n6X0WoVhUnefeodhM7E6oECa",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar82e76501464",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "3242"
+        }
+  recorded_at: Sat, 11 Jul 2026 12:08:13 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TrzhYIBOqvOFDrf0aGr9e9c
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_S5R6CgoIAw9yyr","request_duration_ms":222}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 12:08:13 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3108'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz&t=1"
+      Request-Id:
+      - req_ghybt1Z2JGUp4F
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TrzhYIBOqvOFDrf0aGr9e9c",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3TrzhYIBOqvOFDrf0IABSTYR",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR82E765014",
+          "captured": true,
+          "created": 1783771692,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar82e76501464.test.gumroad.com:31337/l/e!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "JA44j8JoZVKbLDN1vurgxg=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 26,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TrzhYIBOqvOFDrf0DtsSadd",
+          "payment_method": "pm_1TrzhYIBOqvOFDrf4Nm3Ci7V",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "234052",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKK3kyNIGMgbmlyHQEPk6LBa40a26EiF9qT8SYqzfdAsLml7cee7bV80udUzN3JlMFBS-EPeKJOUNA9Wq",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar82e76501464",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "3242"
+        }
+  recorded_at: Sat, 11 Jul 2026 12:08:13 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/refunds
+    body:
+      encoding: UTF-8
+      string: charge=ch_3TrzhYIBOqvOFDrf0aGr9e9c
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_ghybt1Z2JGUp4F","request_duration_ms":174}}'
+      Idempotency-Key:
+      - b4bd7c6a-69ec-472a-952c-7795689f7722
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 12:08:14 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '713'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz;
+        report-to csp
+      Idempotency-Key:
+      - b4bd7c6a-69ec-472a-952c-7795689f7722
+      Original-Request:
+      - req_nXNgtXYbvrZtw4
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz&t=1"
+      Request-Id:
+      - req_nXNgtXYbvrZtw4
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "re_3TrzhYIBOqvOFDrf0H14Joax",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": "txn_3TrzhYIBOqvOFDrf0SFcapvJ",
+          "charge": "ch_3TrzhYIBOqvOFDrf0aGr9e9c",
+          "created": 1783771694,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "destination_details": {
+            "card": {
+              "reference_status": "pending",
+              "reference_type": "acquirer_reference_number",
+              "type": "refund"
+            },
+            "type": "card"
+          },
+          "metadata": {},
+          "payment_intent": "pi_3TrzhYIBOqvOFDrf0DtsSadd",
+          "payment_method": "pm_1TrzhYIBOqvOFDrf4Nm3Ci7V",
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Sat, 11 Jul 2026 12:08:14 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/refunds/re_3TrzhYIBOqvOFDrf0H14Joax?expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_nXNgtXYbvrZtw4","request_duration_ms":807}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 12:08:14 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1214'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz&t=1"
+      Request-Id:
+      - req_XTI2Q7rLtuZkwR
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "re_3TrzhYIBOqvOFDrf0H14Joax",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": {
+            "id": "txn_3TrzhYIBOqvOFDrf0SFcapvJ",
+            "object": "balance_transaction",
+            "amount": -100,
+            "available_on": 1784332800,
+            "balance_type": "payments",
+            "created": 1783771694,
+            "currency": "usd",
+            "description": "REFUND FOR CHARGE (You bought http://edgar82e76501464.test.gumroad.com:31337/l/e!)",
+            "exchange_rate": null,
+            "fee": 0,
+            "fee_details": [],
+            "net": -100,
+            "reporting_category": "refund",
+            "source": "re_3TrzhYIBOqvOFDrf0H14Joax",
+            "status": "pending",
+            "type": "refund"
+          },
+          "charge": "ch_3TrzhYIBOqvOFDrf0aGr9e9c",
+          "created": 1783771694,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "destination_details": {
+            "card": {
+              "reference_status": "pending",
+              "reference_type": "acquirer_reference_number",
+              "type": "refund"
+            },
+            "type": "card"
+          },
+          "metadata": {},
+          "payment_intent": "pi_3TrzhYIBOqvOFDrf0DtsSadd",
+          "payment_method": "pm_1TrzhYIBOqvOFDrf4Nm3Ci7V",
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Sat, 11 Jul 2026 12:08:14 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TrzhYIBOqvOFDrf0aGr9e9c?expand%5B%5D=application_fee.refunds.data.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_XTI2Q7rLtuZkwR","request_duration_ms":312}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 12:08:15 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3765'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz&t=1"
+      Request-Id:
+      - req_VHGIGd7vYtepZ1
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TrzhYIBOqvOFDrf0aGr9e9c",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 100,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TrzhYIBOqvOFDrf0IABSTYR",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1784332800,
+            "balance_type": "payments",
+            "created": 1783771692,
+            "currency": "usd",
+            "description": "You bought http://edgar82e76501464.test.gumroad.com:31337/l/e!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3TrzhYIBOqvOFDrf0aGr9e9c",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR82E765014",
+          "captured": true,
+          "created": 1783771692,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar82e76501464.test.gumroad.com:31337/l/e!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "JA44j8JoZVKbLDN1vurgxg=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 26,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TrzhYIBOqvOFDrf0DtsSadd",
+          "payment_method": "pm_1TrzhYIBOqvOFDrf4Nm3Ci7V",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "234052",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKK_kyNIGMgauAVs-plk6LBaEtsEozWsQA9W56-5l0l9dePa8Wfiit3UfkzXNbDsTIgyWUhh8M9zTEkYC",
+          "refunded": true,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar82e76501464",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "3242"
+        }
+  recorded_at: Sat, 11 Jul 2026 12:08:15 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/Admin_PurchasesController/POST_refund/rejects_the_refund_when_no_reason_is_given.yml
+++ b/spec/support/fixtures/vcr_cassettes/Admin_PurchasesController/POST_refund/rejects_the_refund_when_no_reason_is_given.yml
@@ -1,0 +1,659 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_VHGIGd7vYtepZ1","request_duration_ms":190}}'
+      Idempotency-Key:
+      - 8a61c826-cde2-4bac-8cfb-d4f405a448dc
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 12:08:15 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz;
+        report-to csp
+      Idempotency-Key:
+      - 8a61c826-cde2-4bac-8cfb-d4f405a448dc
+      Original-Request:
+      - req_qGbXym4D1H5PcO
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz&t=1"
+      Request-Id:
+      - req_qGbXym4D1H5PcO
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TrzhbIBOqvOFDrfiDJgrEFo",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783771695,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sat, 11 Jul 2026 12:08:15 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TrzhbIBOqvOFDrfiDJgrEFo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_qGbXym4D1H5PcO","request_duration_ms":180}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 12:08:15 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz&t=1"
+      Request-Id:
+      - req_m5NUt7Z1qxg8R6
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TrzhbIBOqvOFDrfiDJgrEFo",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783771695,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sat, 11 Jul 2026 12:08:15 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=You+bought+http%3A%2F%2Fedgarabab848a467.test.gumroad.com%3A31337%2Fl%2Fu%21&metadata[purchase]=wSw1hMEXv5n3mow2QlIPfA%3D%3D&transfer_group=3243&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1TrzhbIBOqvOFDrfiDJgrEFo&statement_descriptor_suffix=edgarabab848a467
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_m5NUt7Z1qxg8R6","request_duration_ms":176}}'
+      Idempotency-Key:
+      - ecfc8bdf-1470-4736-850d-e4a37af4e89f
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 12:08:16 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1642'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz;
+        report-to csp
+      Idempotency-Key:
+      - ecfc8bdf-1470-4736-850d-e4a37af4e89f
+      Original-Request:
+      - req_eAarzdaV6JoPSN
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz&t=1"
+      Request-Id:
+      - req_eAarzdaV6JoPSN
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3TrzhbIBOqvOFDrf1C9l3Rx2",
+          "object": "payment_intent",
+          "amount": 100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 100,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3TrzhbIBOqvOFDrf1C9l3Rx2_secret_9nLCypL9Ufyx7CDyex0t3xa5h",
+          "confirmation_method": "automatic",
+          "created": 1783771695,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgarabab848a467.test.gumroad.com:31337/l/u!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3TrzhbIBOqvOFDrf1TnYdWQr",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "wSw1hMEXv5n3mow2QlIPfA=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1TrzhbIBOqvOFDrfiDJgrEFo",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgarabab848a467",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "3243"
+        }
+  recorded_at: Sat, 11 Jul 2026 12:08:16 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TrzhbIBOqvOFDrf1TnYdWQr?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_eAarzdaV6JoPSN","request_duration_ms":823}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 12:08:16 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3764'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=IiXf-K3gTkUrYUzSZefBNQym33ePb6RJGfMe4EBszyGarbqM7x7exorD0pMx1S2uLNqapt_J9RZoPjhz&t=1"
+      Request-Id:
+      - req_87swy0W3U2FIvT
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TrzhbIBOqvOFDrf1TnYdWQr",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TrzhbIBOqvOFDrf1kpuNxlK",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1784332800,
+            "balance_type": "payments",
+            "created": 1783771696,
+            "currency": "usd",
+            "description": "You bought http://edgarabab848a467.test.gumroad.com:31337/l/u!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3TrzhbIBOqvOFDrf1TnYdWQr",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGARABAB848A4",
+          "captured": true,
+          "created": 1783771696,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgarabab848a467.test.gumroad.com:31337/l/u!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "wSw1hMEXv5n3mow2QlIPfA=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 25,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TrzhbIBOqvOFDrf1C9l3Rx2",
+          "payment_method": "pm_1TrzhbIBOqvOFDrfiDJgrEFo",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "328596",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKLDkyNIGMgacr2Uaffo6LBaGt8Iiy2NaCdyUpSIhgsarWxJyrycReQ2QcwiZf5NxLAvK8aYS3JzkaHCD",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgarabab848a467",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "3243"
+        }
+  recorded_at: Sat, 11 Jul 2026 12:08:16 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/notifying_the_creator_when_a_team_member_refunds_on_their_behalf/does_not_email_the_creator_for_fraud_refunds_the_fraud_path_sends_its_own_email_.yml
+++ b/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/notifying_the_creator_when_a_team_member_refunds_on_their_behalf/does_not_email_the_creator_for_fraud_refunds_the_fraud_path_sends_its_own_email_.yml
@@ -1,0 +1,1328 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_5Jfe0EYubQ3iK0","request_duration_ms":200}}'
+      Idempotency-Key:
+      - 0b66bf22-b661-455a-b530-97a3447f3865
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:14 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Idempotency-Key:
+      - 0b66bf22-b661-455a-b530-97a3447f3865
+      Original-Request:
+      - req_G4dtSzoEaXCRX8
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_G4dtSzoEaXCRX8
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TryoQIBOqvOFDrffK7DUGol",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783768274,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:14 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TryoQIBOqvOFDrffK7DUGol
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_G4dtSzoEaXCRX8","request_duration_ms":209}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:15 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_rXhUeqoATxwAfO
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TryoQIBOqvOFDrffK7DUGol",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783768274,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:15 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=You+bought+http%3A%2F%2Fedgarb1f16a015.test.gumroad.com%3A31337%2Fl%2Fq%21&metadata[purchase]=cc3klpPPdiR1UXlNc0KgsQ%3D%3D&transfer_group=2072&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1TryoQIBOqvOFDrffK7DUGol&statement_descriptor_suffix=edgarb1f16a015
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_rXhUeqoATxwAfO","request_duration_ms":163}}'
+      Idempotency-Key:
+      - a0287c32-ca03-4048-86e8-b589f3c99b9c
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:16 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1638'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Idempotency-Key:
+      - a0287c32-ca03-4048-86e8-b589f3c99b9c
+      Original-Request:
+      - req_a1tJOxyswRFkBI
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_a1tJOxyswRFkBI
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3TryoRIBOqvOFDrf0Wxhe5wC",
+          "object": "payment_intent",
+          "amount": 100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 100,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3TryoRIBOqvOFDrf0Wxhe5wC_secret_6D36wF3h9PULd4H2NVbiNV9OO",
+          "confirmation_method": "automatic",
+          "created": 1783768275,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgarb1f16a015.test.gumroad.com:31337/l/q!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3TryoRIBOqvOFDrf0S96rcet",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "cc3klpPPdiR1UXlNc0KgsQ=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1TryoQIBOqvOFDrffK7DUGol",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgarb1f16a015",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "2072"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:16 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TryoRIBOqvOFDrf0S96rcet?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_a1tJOxyswRFkBI","request_duration_ms":1084}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:16 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3758'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_0Oq4gxmGPOncXe
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TryoRIBOqvOFDrf0S96rcet",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TryoRIBOqvOFDrf02wM0bXr",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1784332800,
+            "balance_type": "payments",
+            "created": 1783768275,
+            "currency": "usd",
+            "description": "You bought http://edgarb1f16a015.test.gumroad.com:31337/l/q!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3TryoRIBOqvOFDrf0S96rcet",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGARB1F16A015",
+          "captured": true,
+          "created": 1783768275,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgarb1f16a015.test.gumroad.com:31337/l/q!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "cc3klpPPdiR1UXlNc0KgsQ=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 27,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TryoRIBOqvOFDrf0Wxhe5wC",
+          "payment_method": "pm_1TryoQIBOqvOFDrffK7DUGol",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "219221",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKNTJyNIGMgYFmQHpW6I6LBZtaYoExAEbtOv-0QVe2tbp8SLZSF6PRLs37W4nh4VeyMwdEHnMEpLeonuH",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgarb1f16a015",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "2072"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:16 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TryoRIBOqvOFDrf0S96rcet
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_0Oq4gxmGPOncXe","request_duration_ms":204}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:16 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3104'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_bbHi5I8DLq2VrD
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TryoRIBOqvOFDrf0S96rcet",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3TryoRIBOqvOFDrf02wM0bXr",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGARB1F16A015",
+          "captured": true,
+          "created": 1783768275,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgarb1f16a015.test.gumroad.com:31337/l/q!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "cc3klpPPdiR1UXlNc0KgsQ=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 27,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TryoRIBOqvOFDrf0Wxhe5wC",
+          "payment_method": "pm_1TryoQIBOqvOFDrffK7DUGol",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "219221",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKNTJyNIGMgYLd-LeIjI6LBZVgLy5w4vXkWL1BFNbWA9dYbMz01So34mFROl2mDz3_jEJW5HZBC1scWGE",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgarb1f16a015",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "2072"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:16 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/refunds
+    body:
+      encoding: UTF-8
+      string: charge=ch_3TryoRIBOqvOFDrf0S96rcet&reason=fraudulent
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_bbHi5I8DLq2VrD","request_duration_ms":161}}'
+      Idempotency-Key:
+      - e49f5f6d-d797-4f55-9d36-1204077b4be8
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:17 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '721'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Idempotency-Key:
+      - e49f5f6d-d797-4f55-9d36-1204077b4be8
+      Original-Request:
+      - req_hDwmDBuLQhv67a
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_hDwmDBuLQhv67a
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "re_3TryoRIBOqvOFDrf0i5dVzpt",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": "txn_3TryoRIBOqvOFDrf0wCvwyfc",
+          "charge": "ch_3TryoRIBOqvOFDrf0S96rcet",
+          "created": 1783768276,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "destination_details": {
+            "card": {
+              "reference_status": "pending",
+              "reference_type": "acquirer_reference_number",
+              "type": "refund"
+            },
+            "type": "card"
+          },
+          "metadata": {},
+          "payment_intent": "pi_3TryoRIBOqvOFDrf0Wxhe5wC",
+          "payment_method": "pm_1TryoQIBOqvOFDrffK7DUGol",
+          "reason": "fraudulent",
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:17 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/refunds/re_3TryoRIBOqvOFDrf0i5dVzpt?expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_hDwmDBuLQhv67a","request_duration_ms":937}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:18 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1261'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_0XM21EXfx4AVP8
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "re_3TryoRIBOqvOFDrf0i5dVzpt",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": {
+            "id": "txn_3TryoRIBOqvOFDrf0wCvwyfc",
+            "object": "balance_transaction",
+            "amount": -100,
+            "available_on": 1784332800,
+            "balance_type": "payments",
+            "created": 1783768276,
+            "currency": "usd",
+            "description": "REFUND FOR CHARGE (You bought http://edgarb1f16a015.test.gumroad.com:31337/l/q!)",
+            "exchange_rate": null,
+            "fee": 0,
+            "fee_details": [],
+            "net": -100,
+            "reporting_category": "refund",
+            "source": "re_3TryoRIBOqvOFDrf0i5dVzpt",
+            "status": "pending",
+            "type": "refund"
+          },
+          "charge": "ch_3TryoRIBOqvOFDrf0S96rcet",
+          "created": 1783768276,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "destination_details": {
+            "card": {
+              "reference": "3752272676533709",
+              "reference_status": "available",
+              "reference_type": "acquirer_reference_number",
+              "type": "refund"
+            },
+            "type": "card"
+          },
+          "metadata": {},
+          "payment_intent": "pi_3TryoRIBOqvOFDrf0Wxhe5wC",
+          "payment_method": "pm_1TryoQIBOqvOFDrffK7DUGol",
+          "reason": "fraudulent",
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:18 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TryoRIBOqvOFDrf0S96rcet?expand%5B%5D=application_fee.refunds.data.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_0XM21EXfx4AVP8","request_duration_ms":287}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:18 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3759'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_FQEfqLNM6FyuaU
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TryoRIBOqvOFDrf0S96rcet",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 100,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TryoRIBOqvOFDrf02wM0bXr",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1784332800,
+            "balance_type": "payments",
+            "created": 1783768275,
+            "currency": "usd",
+            "description": "You bought http://edgarb1f16a015.test.gumroad.com:31337/l/q!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3TryoRIBOqvOFDrf0S96rcet",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGARB1F16A015",
+          "captured": true,
+          "created": 1783768275,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgarb1f16a015.test.gumroad.com:31337/l/q!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "cc3klpPPdiR1UXlNc0KgsQ=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 27,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TryoRIBOqvOFDrf0Wxhe5wC",
+          "payment_method": "pm_1TryoQIBOqvOFDrffK7DUGol",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "219221",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKNbJyNIGMgbBcTLBtVw6LBYZRh-NLxKjYTlID8j0DovvzagZYvI36CyNRGMGF3fOjS0hHsJANrgYkOBw",
+          "refunded": true,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgarb1f16a015",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "2072"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:18 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/notifying_the_creator_when_a_team_member_refunds_on_their_behalf/does_not_email_the_creator_when_the_seller_is_suspended.yml
+++ b/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/notifying_the_creator_when_a_team_member_refunds_on_their_behalf/does_not_email_the_creator_when_the_seller_is_suspended.yml
@@ -1,0 +1,1327 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_FQEfqLNM6FyuaU","request_duration_ms":200}}'
+      Idempotency-Key:
+      - 4edf4423-5b9a-46c9-a75a-798f87c44af2
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:18 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Idempotency-Key:
+      - 4edf4423-5b9a-46c9-a75a-798f87c44af2
+      Original-Request:
+      - req_O3Gh4FW1miaHjq
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_O3Gh4FW1miaHjq
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TryoUIBOqvOFDrfX3QAK9fx",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783768278,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:18 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TryoUIBOqvOFDrfX3QAK9fx
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_O3Gh4FW1miaHjq","request_duration_ms":180}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:18 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_7GMMNIQUyrdKRS
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TryoUIBOqvOFDrfX3QAK9fx",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783768278,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:18 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=You+bought+http%3A%2F%2Fedgara554b8237.test.gumroad.com%3A31337%2Fl%2Fg%21&metadata[purchase]=oTX6Z__cOZc8QesgzxgXWQ%3D%3D&transfer_group=2073&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1TryoUIBOqvOFDrfX3QAK9fx&statement_descriptor_suffix=edgara554b8237
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_7GMMNIQUyrdKRS","request_duration_ms":156}}'
+      Idempotency-Key:
+      - 1e1e33bc-71c8-4cab-9d1f-38bff6e12e9a
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:19 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1638'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Idempotency-Key:
+      - 1e1e33bc-71c8-4cab-9d1f-38bff6e12e9a
+      Original-Request:
+      - req_UnnCdyFiw9HHGM
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_UnnCdyFiw9HHGM
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3TryoUIBOqvOFDrf10jtcirA",
+          "object": "payment_intent",
+          "amount": 100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 100,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3TryoUIBOqvOFDrf10jtcirA_secret_UiyyhZBEASiuFs2bYDWiGdOHm",
+          "confirmation_method": "automatic",
+          "created": 1783768278,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgara554b8237.test.gumroad.com:31337/l/g!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3TryoUIBOqvOFDrf18d81A7C",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "oTX6Z__cOZc8QesgzxgXWQ=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1TryoUIBOqvOFDrfX3QAK9fx",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgara554b8237",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "2073"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:19 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TryoUIBOqvOFDrf18d81A7C?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_UnnCdyFiw9HHGM","request_duration_ms":982}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:19 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3757'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_bPdXVErwOxFRKx
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TryoUIBOqvOFDrf18d81A7C",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TryoUIBOqvOFDrf1QYRulCr",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1784332800,
+            "balance_type": "payments",
+            "created": 1783768278,
+            "currency": "usd",
+            "description": "You bought http://edgara554b8237.test.gumroad.com:31337/l/g!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3TryoUIBOqvOFDrf18d81A7C",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGARA554B8237",
+          "captured": true,
+          "created": 1783768278,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgara554b8237.test.gumroad.com:31337/l/g!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "oTX6Z__cOZc8QesgzxgXWQ=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 3,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TryoUIBOqvOFDrf10jtcirA",
+          "payment_method": "pm_1TryoUIBOqvOFDrfX3QAK9fx",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "324408",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKNfJyNIGMgZ3Zp_r6DU6LBaDFMOUnzvozR1rgMb67xJSlvIpWJHsdkCP0E7KrszFuTCgcM9ogsHkgJiA",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgara554b8237",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "2073"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:19 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TryoUIBOqvOFDrf18d81A7C
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_bPdXVErwOxFRKx","request_duration_ms":197}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:20 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3103'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_3PIiREtA3G9xTb
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TryoUIBOqvOFDrf18d81A7C",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3TryoUIBOqvOFDrf1QYRulCr",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGARA554B8237",
+          "captured": true,
+          "created": 1783768278,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgara554b8237.test.gumroad.com:31337/l/g!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "oTX6Z__cOZc8QesgzxgXWQ=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 3,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TryoUIBOqvOFDrf10jtcirA",
+          "payment_method": "pm_1TryoUIBOqvOFDrfX3QAK9fx",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "324408",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKNjJyNIGMgZ1SkVTHJ86LBZRIHn3xGrBVvkeXuKXrnlYTCOXakzn9ybBMAGnW4wyQVP6yWGtEx6sqXta",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgara554b8237",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "2073"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:20 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/refunds
+    body:
+      encoding: UTF-8
+      string: charge=ch_3TryoUIBOqvOFDrf18d81A7C
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_3PIiREtA3G9xTb","request_duration_ms":222}}'
+      Idempotency-Key:
+      - fee01a27-4411-46d4-822f-87b4e0b50430
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:20 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '713'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Idempotency-Key:
+      - fee01a27-4411-46d4-822f-87b4e0b50430
+      Original-Request:
+      - req_uNq6uEn8lWRYuZ
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_uNq6uEn8lWRYuZ
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "re_3TryoUIBOqvOFDrf1yj8P8D0",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": "txn_3TryoUIBOqvOFDrf1wspMBWE",
+          "charge": "ch_3TryoUIBOqvOFDrf18d81A7C",
+          "created": 1783768280,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "destination_details": {
+            "card": {
+              "reference_status": "pending",
+              "reference_type": "acquirer_reference_number",
+              "type": "refund"
+            },
+            "type": "card"
+          },
+          "metadata": {},
+          "payment_intent": "pi_3TryoUIBOqvOFDrf10jtcirA",
+          "payment_method": "pm_1TryoUIBOqvOFDrfX3QAK9fx",
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:20 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/refunds/re_3TryoUIBOqvOFDrf1yj8P8D0?expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_uNq6uEn8lWRYuZ","request_duration_ms":811}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:21 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1212'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_5ZkumeD2CuiEr7
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "re_3TryoUIBOqvOFDrf1yj8P8D0",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": {
+            "id": "txn_3TryoUIBOqvOFDrf1wspMBWE",
+            "object": "balance_transaction",
+            "amount": -100,
+            "available_on": 1784332800,
+            "balance_type": "payments",
+            "created": 1783768280,
+            "currency": "usd",
+            "description": "REFUND FOR CHARGE (You bought http://edgara554b8237.test.gumroad.com:31337/l/g!)",
+            "exchange_rate": null,
+            "fee": 0,
+            "fee_details": [],
+            "net": -100,
+            "reporting_category": "refund",
+            "source": "re_3TryoUIBOqvOFDrf1yj8P8D0",
+            "status": "pending",
+            "type": "refund"
+          },
+          "charge": "ch_3TryoUIBOqvOFDrf18d81A7C",
+          "created": 1783768280,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "destination_details": {
+            "card": {
+              "reference_status": "pending",
+              "reference_type": "acquirer_reference_number",
+              "type": "refund"
+            },
+            "type": "card"
+          },
+          "metadata": {},
+          "payment_intent": "pi_3TryoUIBOqvOFDrf10jtcirA",
+          "payment_method": "pm_1TryoUIBOqvOFDrfX3QAK9fx",
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:21 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TryoUIBOqvOFDrf18d81A7C?expand%5B%5D=application_fee.refunds.data.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_5ZkumeD2CuiEr7","request_duration_ms":286}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:21 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3758'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_PaHLJ0BbMuCle4
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TryoUIBOqvOFDrf18d81A7C",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 100,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TryoUIBOqvOFDrf1QYRulCr",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1784332800,
+            "balance_type": "payments",
+            "created": 1783768278,
+            "currency": "usd",
+            "description": "You bought http://edgara554b8237.test.gumroad.com:31337/l/g!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3TryoUIBOqvOFDrf18d81A7C",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGARA554B8237",
+          "captured": true,
+          "created": 1783768278,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgara554b8237.test.gumroad.com:31337/l/g!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "oTX6Z__cOZc8QesgzxgXWQ=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 3,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TryoUIBOqvOFDrf10jtcirA",
+          "payment_method": "pm_1TryoUIBOqvOFDrfX3QAK9fx",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "324408",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKNnJyNIGMgZVLGIZyeA6LBb48MF7cRhdAVhXCwD_n1rr0GMXEQa17AuZ4i_n3lgUWICvYFFx-zf3Z8aL",
+          "refunded": true,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgara554b8237",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "2073"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:21 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/notifying_the_creator_when_a_team_member_refunds_on_their_behalf/does_not_email_the_creator_when_there_is_no_refunding_user_console_refund_.yml
+++ b/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/notifying_the_creator_when_a_team_member_refunds_on_their_behalf/does_not_email_the_creator_when_there_is_no_refunding_user_console_refund_.yml
@@ -1,0 +1,1327 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_Qw0qyaO2alUyZT","request_duration_ms":197}}'
+      Idempotency-Key:
+      - 718936f4-319e-421b-be40-1df11ff81cdc
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:11 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Idempotency-Key:
+      - 718936f4-319e-421b-be40-1df11ff81cdc
+      Original-Request:
+      - req_WpjUdqsvmE9wFT
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_WpjUdqsvmE9wFT
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TryoNIBOqvOFDrf9latwJY9",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783768271,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:11 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TryoNIBOqvOFDrf9latwJY9
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_WpjUdqsvmE9wFT","request_duration_ms":179}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:11 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_KJuJJ0QngGs43U
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TryoNIBOqvOFDrf9latwJY9",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783768271,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:11 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=You+bought+http%3A%2F%2Fedgarb1f920094.test.gumroad.com%3A31337%2Fl%2Fh%21&metadata[purchase]=H45ino3j8UAlZmIxE9a8gA%3D%3D&transfer_group=2071&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1TryoNIBOqvOFDrf9latwJY9&statement_descriptor_suffix=edgarb1f920094
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_KJuJJ0QngGs43U","request_duration_ms":147}}'
+      Idempotency-Key:
+      - 2dca3869-db67-4de1-928a-af4a52eef839
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:12 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1638'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Idempotency-Key:
+      - 2dca3869-db67-4de1-928a-af4a52eef839
+      Original-Request:
+      - req_9Isgr9sQXCArFz
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_9Isgr9sQXCArFz
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3TryoNIBOqvOFDrf0BmIvbSH",
+          "object": "payment_intent",
+          "amount": 100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 100,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3TryoNIBOqvOFDrf0BmIvbSH_secret_cBeSXKcvOx77g4ZdmVPX8Lb3f",
+          "confirmation_method": "automatic",
+          "created": 1783768271,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgarb1f920094.test.gumroad.com:31337/l/h!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3TryoNIBOqvOFDrf0fQ9pkyR",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "H45ino3j8UAlZmIxE9a8gA=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1TryoNIBOqvOFDrf9latwJY9",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgarb1f920094",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "2071"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:12 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TryoNIBOqvOFDrf0fQ9pkyR?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_9Isgr9sQXCArFz","request_duration_ms":988}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:12 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3758'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_DJuu2QQv4vUh4I
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TryoNIBOqvOFDrf0fQ9pkyR",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TryoNIBOqvOFDrf06enN1av",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1784332800,
+            "balance_type": "payments",
+            "created": 1783768271,
+            "currency": "usd",
+            "description": "You bought http://edgarb1f920094.test.gumroad.com:31337/l/h!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3TryoNIBOqvOFDrf0fQ9pkyR",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGARB1F920094",
+          "captured": true,
+          "created": 1783768271,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgarb1f920094.test.gumroad.com:31337/l/h!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "H45ino3j8UAlZmIxE9a8gA=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 19,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TryoNIBOqvOFDrf0BmIvbSH",
+          "payment_method": "pm_1TryoNIBOqvOFDrf9latwJY9",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "231193",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKNDJyNIGMgbfQZuCiBc6LBb1PETQQH-PkYQS3czMnhIJt0NFoggSkeKl7lGflEttVHL6O-9QDod93CI-",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgarb1f920094",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "2071"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:12 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TryoNIBOqvOFDrf0fQ9pkyR
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_DJuu2QQv4vUh4I","request_duration_ms":298}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:12 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3104'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_Yts7v3U3yW3sum
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TryoNIBOqvOFDrf0fQ9pkyR",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3TryoNIBOqvOFDrf06enN1av",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGARB1F920094",
+          "captured": true,
+          "created": 1783768271,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgarb1f920094.test.gumroad.com:31337/l/h!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "H45ino3j8UAlZmIxE9a8gA=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 19,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TryoNIBOqvOFDrf0BmIvbSH",
+          "payment_method": "pm_1TryoNIBOqvOFDrf9latwJY9",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "231193",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKNDJyNIGMgYtT4YW4II6LBZ1eOA1uFyDvuK-GTyYUq-ZHdPzIZ9uJmn-UW7zt_yjZGx-tks70sfu2XyJ",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgarb1f920094",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "2071"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:12 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/refunds
+    body:
+      encoding: UTF-8
+      string: charge=ch_3TryoNIBOqvOFDrf0fQ9pkyR
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_Yts7v3U3yW3sum","request_duration_ms":239}}'
+      Idempotency-Key:
+      - 02a5d128-d052-463f-afe4-f3db41274b81
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:13 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '713'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Idempotency-Key:
+      - 02a5d128-d052-463f-afe4-f3db41274b81
+      Original-Request:
+      - req_6bBDFyulBYdjVp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_6bBDFyulBYdjVp
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "re_3TryoNIBOqvOFDrf0xajRVTE",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": "txn_3TryoNIBOqvOFDrf06emMkXG",
+          "charge": "ch_3TryoNIBOqvOFDrf0fQ9pkyR",
+          "created": 1783768273,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "destination_details": {
+            "card": {
+              "reference_status": "pending",
+              "reference_type": "acquirer_reference_number",
+              "type": "refund"
+            },
+            "type": "card"
+          },
+          "metadata": {},
+          "payment_intent": "pi_3TryoNIBOqvOFDrf0BmIvbSH",
+          "payment_method": "pm_1TryoNIBOqvOFDrf9latwJY9",
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:13 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/refunds/re_3TryoNIBOqvOFDrf0xajRVTE?expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_6bBDFyulBYdjVp","request_duration_ms":875}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:14 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1212'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_r0NUfTGVNcM4GN
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "re_3TryoNIBOqvOFDrf0xajRVTE",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": {
+            "id": "txn_3TryoNIBOqvOFDrf06emMkXG",
+            "object": "balance_transaction",
+            "amount": -100,
+            "available_on": 1784332800,
+            "balance_type": "payments",
+            "created": 1783768273,
+            "currency": "usd",
+            "description": "REFUND FOR CHARGE (You bought http://edgarb1f920094.test.gumroad.com:31337/l/h!)",
+            "exchange_rate": null,
+            "fee": 0,
+            "fee_details": [],
+            "net": -100,
+            "reporting_category": "refund",
+            "source": "re_3TryoNIBOqvOFDrf0xajRVTE",
+            "status": "pending",
+            "type": "refund"
+          },
+          "charge": "ch_3TryoNIBOqvOFDrf0fQ9pkyR",
+          "created": 1783768273,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "destination_details": {
+            "card": {
+              "reference_status": "pending",
+              "reference_type": "acquirer_reference_number",
+              "type": "refund"
+            },
+            "type": "card"
+          },
+          "metadata": {},
+          "payment_intent": "pi_3TryoNIBOqvOFDrf0BmIvbSH",
+          "payment_method": "pm_1TryoNIBOqvOFDrf9latwJY9",
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:14 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TryoNIBOqvOFDrf0fQ9pkyR?expand%5B%5D=application_fee.refunds.data.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_r0NUfTGVNcM4GN","request_duration_ms":308}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:14 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3759'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_5Jfe0EYubQ3iK0
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TryoNIBOqvOFDrf0fQ9pkyR",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 100,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TryoNIBOqvOFDrf06enN1av",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1784332800,
+            "balance_type": "payments",
+            "created": 1783768271,
+            "currency": "usd",
+            "description": "You bought http://edgarb1f920094.test.gumroad.com:31337/l/h!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3TryoNIBOqvOFDrf0fQ9pkyR",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGARB1F920094",
+          "captured": true,
+          "created": 1783768271,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgarb1f920094.test.gumroad.com:31337/l/h!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "H45ino3j8UAlZmIxE9a8gA=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 19,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TryoNIBOqvOFDrf0BmIvbSH",
+          "payment_method": "pm_1TryoNIBOqvOFDrf9latwJY9",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "231193",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKNLJyNIGMgYCcS9-elM6LBZfGuaFPbJNkSXze5K67j40yrZXcU0wkHcIJhXOhbmCeYsIgF-VE8iqz_CV",
+          "refunded": true,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgarb1f920094",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "2071"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:14 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/notifying_the_creator_when_a_team_member_refunds_on_their_behalf/does_not_email_the_creator_when_they_refund_their_own_sale.yml
+++ b/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/notifying_the_creator_when_a_team_member_refunds_on_their_behalf/does_not_email_the_creator_when_they_refund_their_own_sale.yml
@@ -1,0 +1,1327 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_CHLpAT6wUJ44tv","request_duration_ms":214}}'
+      Idempotency-Key:
+      - 785830e7-9f8b-4f32-8e97-c8fc0d4d98bb
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:07 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Idempotency-Key:
+      - 785830e7-9f8b-4f32-8e97-c8fc0d4d98bb
+      Original-Request:
+      - req_G0U6fyPQG5GV2R
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_G0U6fyPQG5GV2R
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TryoJIBOqvOFDrfnB3QGReq",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783768267,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:07 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TryoJIBOqvOFDrfnB3QGReq
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_G0U6fyPQG5GV2R","request_duration_ms":220}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:07 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_zWswmT5Gd7xJ0B
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TryoJIBOqvOFDrfnB3QGReq",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783768267,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:07 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=You+bought+http%3A%2F%2Fedgarbdbeb4d03.test.gumroad.com%3A31337%2Fl%2Fu%21&metadata[purchase]=F6hnlnrNBd_GqdxRD1Ki9Q%3D%3D&transfer_group=2070&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1TryoJIBOqvOFDrfnB3QGReq&statement_descriptor_suffix=edgarbdbeb4d03
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_zWswmT5Gd7xJ0B","request_duration_ms":149}}'
+      Idempotency-Key:
+      - fa197466-2095-47f3-8b46-c726ee9e3db1
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:08 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1638'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Idempotency-Key:
+      - fa197466-2095-47f3-8b46-c726ee9e3db1
+      Original-Request:
+      - req_k7sIAT4EyWEXzd
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_k7sIAT4EyWEXzd
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3TryoKIBOqvOFDrf15CxVDCX",
+          "object": "payment_intent",
+          "amount": 100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 100,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3TryoKIBOqvOFDrf15CxVDCX_secret_fKMIHUD0EmqWUROf5kPQARCvv",
+          "confirmation_method": "automatic",
+          "created": 1783768268,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgarbdbeb4d03.test.gumroad.com:31337/l/u!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3TryoKIBOqvOFDrf14EuJJFb",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "F6hnlnrNBd_GqdxRD1Ki9Q=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1TryoJIBOqvOFDrfnB3QGReq",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgarbdbeb4d03",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "2070"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:08 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TryoKIBOqvOFDrf14EuJJFb?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_k7sIAT4EyWEXzd","request_duration_ms":895}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:09 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3758'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_Yd145llVYgaL5x
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TryoKIBOqvOFDrf14EuJJFb",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TryoKIBOqvOFDrf1Ih5qTWk",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1784332800,
+            "balance_type": "payments",
+            "created": 1783768268,
+            "currency": "usd",
+            "description": "You bought http://edgarbdbeb4d03.test.gumroad.com:31337/l/u!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3TryoKIBOqvOFDrf14EuJJFb",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGARBDBEB4D03",
+          "captured": true,
+          "created": 1783768268,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgarbdbeb4d03.test.gumroad.com:31337/l/u!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "F6hnlnrNBd_GqdxRD1Ki9Q=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 10,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TryoKIBOqvOFDrf15CxVDCX",
+          "payment_method": "pm_1TryoJIBOqvOFDrfnB3QGReq",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "806449",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKM3JyNIGMgbnzpqAi7A6LBb6BbQ0MNdlwHYpjhDiRAkJYeMbuc-GEJKDotR92zvkE3YJLCttpbEqrQPS",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgarbdbeb4d03",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "2070"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:09 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TryoKIBOqvOFDrf14EuJJFb
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_Yd145llVYgaL5x","request_duration_ms":342}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:09 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3104'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_lq1XTEYkvHj65q
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TryoKIBOqvOFDrf14EuJJFb",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3TryoKIBOqvOFDrf1Ih5qTWk",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGARBDBEB4D03",
+          "captured": true,
+          "created": 1783768268,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgarbdbeb4d03.test.gumroad.com:31337/l/u!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "F6hnlnrNBd_GqdxRD1Ki9Q=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 10,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TryoKIBOqvOFDrf15CxVDCX",
+          "payment_method": "pm_1TryoJIBOqvOFDrfnB3QGReq",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "806449",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKM3JyNIGMga3OqlbjTI6LBYmoD31jmLrDFw1UfOfzouqResMW6xvR2DlVwcdarej1iE3md-0BPkX5hln",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgarbdbeb4d03",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "2070"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:09 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/refunds
+    body:
+      encoding: UTF-8
+      string: charge=ch_3TryoKIBOqvOFDrf14EuJJFb
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_lq1XTEYkvHj65q","request_duration_ms":175}}'
+      Idempotency-Key:
+      - 8b0d74cd-5678-4ab7-8db5-665e9d8676a0
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:10 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '713'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Idempotency-Key:
+      - 8b0d74cd-5678-4ab7-8db5-665e9d8676a0
+      Original-Request:
+      - req_YdEiotqrrw5P7l
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_YdEiotqrrw5P7l
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "re_3TryoKIBOqvOFDrf1qrgE7Xt",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": "txn_3TryoKIBOqvOFDrf1gzswLQi",
+          "charge": "ch_3TryoKIBOqvOFDrf14EuJJFb",
+          "created": 1783768269,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "destination_details": {
+            "card": {
+              "reference_status": "pending",
+              "reference_type": "acquirer_reference_number",
+              "type": "refund"
+            },
+            "type": "card"
+          },
+          "metadata": {},
+          "payment_intent": "pi_3TryoKIBOqvOFDrf15CxVDCX",
+          "payment_method": "pm_1TryoJIBOqvOFDrfnB3QGReq",
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:10 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/refunds/re_3TryoKIBOqvOFDrf1qrgE7Xt?expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_YdEiotqrrw5P7l","request_duration_ms":773}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:10 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1212'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_6wcijiKNMLiz4S
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "re_3TryoKIBOqvOFDrf1qrgE7Xt",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": {
+            "id": "txn_3TryoKIBOqvOFDrf1gzswLQi",
+            "object": "balance_transaction",
+            "amount": -100,
+            "available_on": 1784332800,
+            "balance_type": "payments",
+            "created": 1783768269,
+            "currency": "usd",
+            "description": "REFUND FOR CHARGE (You bought http://edgarbdbeb4d03.test.gumroad.com:31337/l/u!)",
+            "exchange_rate": null,
+            "fee": 0,
+            "fee_details": [],
+            "net": -100,
+            "reporting_category": "refund",
+            "source": "re_3TryoKIBOqvOFDrf1qrgE7Xt",
+            "status": "pending",
+            "type": "refund"
+          },
+          "charge": "ch_3TryoKIBOqvOFDrf14EuJJFb",
+          "created": 1783768269,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "destination_details": {
+            "card": {
+              "reference_status": "pending",
+              "reference_type": "acquirer_reference_number",
+              "type": "refund"
+            },
+            "type": "card"
+          },
+          "metadata": {},
+          "payment_intent": "pi_3TryoKIBOqvOFDrf15CxVDCX",
+          "payment_method": "pm_1TryoJIBOqvOFDrfnB3QGReq",
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:10 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TryoKIBOqvOFDrf14EuJJFb?expand%5B%5D=application_fee.refunds.data.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_6wcijiKNMLiz4S","request_duration_ms":298}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:10 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3759'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_Qw0qyaO2alUyZT
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TryoKIBOqvOFDrf14EuJJFb",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 100,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TryoKIBOqvOFDrf1Ih5qTWk",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1784332800,
+            "balance_type": "payments",
+            "created": 1783768268,
+            "currency": "usd",
+            "description": "You bought http://edgarbdbeb4d03.test.gumroad.com:31337/l/u!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3TryoKIBOqvOFDrf14EuJJFb",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGARBDBEB4D03",
+          "captured": true,
+          "created": 1783768268,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgarbdbeb4d03.test.gumroad.com:31337/l/u!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "F6hnlnrNBd_GqdxRD1Ki9Q=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 10,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TryoKIBOqvOFDrf15CxVDCX",
+          "payment_method": "pm_1TryoJIBOqvOFDrfnB3QGReq",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "806449",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKM7JyNIGMgaXbYWtOx86LBYdhyANVNmTQWUfyH4asJLFwcHVhL8U-F7iaWL0EbNsg0Zwz1h2pWi6fkxk",
+          "refunded": true,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgarbdbeb4d03",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "2070"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:10 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/notifying_the_creator_when_a_team_member_refunds_on_their_behalf/emails_the_creator_when_a_Gumroad_team_member_issues_the_refund.yml
+++ b/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/notifying_the_creator_when_a_team_member_refunds_on_their_behalf/emails_the_creator_when_a_Gumroad_team_member_issues_the_refund.yml
@@ -1,0 +1,1325 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Idempotency-Key:
+      - 7c356b21-8cf5-4d65-a592-ecc675ed2fd9
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:03 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=TdwK9QwogYc47sGhVh-ydBOlxrX8bRJzb_qw0HUEOlGKWHBWXK8F_IrCeuT1d4mNKh1rzjk2j00s0vjB;
+        report-to csp
+      Idempotency-Key:
+      - 7c356b21-8cf5-4d65-a592-ecc675ed2fd9
+      Original-Request:
+      - req_cHM7TLIv39g0cd
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=TdwK9QwogYc47sGhVh-ydBOlxrX8bRJzb_qw0HUEOlGKWHBWXK8F_IrCeuT1d4mNKh1rzjk2j00s0vjB&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=TdwK9QwogYc47sGhVh-ydBOlxrX8bRJzb_qw0HUEOlGKWHBWXK8F_IrCeuT1d4mNKh1rzjk2j00s0vjB&t=1"
+      Request-Id:
+      - req_cHM7TLIv39g0cd
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TryoFIBOqvOFDrfaHfnuhk7",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783768263,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:03 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TryoFIBOqvOFDrfaHfnuhk7
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_cHM7TLIv39g0cd","request_duration_ms":273}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:03 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_uskp6FEOACrGsG
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TryoFIBOqvOFDrfaHfnuhk7",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783768263,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:03 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=You+bought+http%3A%2F%2Fedgardb371f211.test.gumroad.com%3A31337%2Fl%2Fx%21&metadata[purchase]=7WpKxZRt33rUwjcQ_uBBiw%3D%3D&transfer_group=2069&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1TryoFIBOqvOFDrfaHfnuhk7&statement_descriptor_suffix=edgardb371f211
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_uskp6FEOACrGsG","request_duration_ms":181}}'
+      Idempotency-Key:
+      - 3c40b0ca-a397-40ea-903f-7870cb556e89
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:04 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1638'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Idempotency-Key:
+      - 3c40b0ca-a397-40ea-903f-7870cb556e89
+      Original-Request:
+      - req_cBOrEx6DwvyRLX
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_cBOrEx6DwvyRLX
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3TryoGIBOqvOFDrf1Zn0YCuK",
+          "object": "payment_intent",
+          "amount": 100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 100,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3TryoGIBOqvOFDrf1Zn0YCuK_secret_VfJhZYQ3LTLIFVM9lNlOVH8vc",
+          "confirmation_method": "automatic",
+          "created": 1783768264,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgardb371f211.test.gumroad.com:31337/l/x!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3TryoGIBOqvOFDrf1MSoD4Tw",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "7WpKxZRt33rUwjcQ_uBBiw=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1TryoFIBOqvOFDrfaHfnuhk7",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgardb371f211",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "2069"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:04 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TryoGIBOqvOFDrf1MSoD4Tw?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_cBOrEx6DwvyRLX","request_duration_ms":877}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:05 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3758'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_Zje4XeS0YOnamS
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TryoGIBOqvOFDrf1MSoD4Tw",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TryoGIBOqvOFDrf1TS0vH5C",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1784332800,
+            "balance_type": "payments",
+            "created": 1783768264,
+            "currency": "usd",
+            "description": "You bought http://edgardb371f211.test.gumroad.com:31337/l/x!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3TryoGIBOqvOFDrf1MSoD4Tw",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGARDB371F211",
+          "captured": true,
+          "created": 1783768264,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgardb371f211.test.gumroad.com:31337/l/x!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "7WpKxZRt33rUwjcQ_uBBiw=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 36,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TryoGIBOqvOFDrf1Zn0YCuK",
+          "payment_method": "pm_1TryoFIBOqvOFDrfaHfnuhk7",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "939512",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKMjJyNIGMgYVcOkfQOA6LBadzfUtuHTSyaVA1tKMjPzZqFp2_uGA3qKtf8whBT8lFxjEqGnGFcMaA4qp",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgardb371f211",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "2069"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:05 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TryoGIBOqvOFDrf1MSoD4Tw
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_Zje4XeS0YOnamS","request_duration_ms":230}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:05 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3104'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_Vjl45x6RSjnX1V
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TryoGIBOqvOFDrf1MSoD4Tw",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3TryoGIBOqvOFDrf1TS0vH5C",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGARDB371F211",
+          "captured": true,
+          "created": 1783768264,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgardb371f211.test.gumroad.com:31337/l/x!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "7WpKxZRt33rUwjcQ_uBBiw=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 36,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TryoGIBOqvOFDrf1Zn0YCuK",
+          "payment_method": "pm_1TryoFIBOqvOFDrfaHfnuhk7",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "939512",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKMnJyNIGMgYnobKXFWE6LBbei3NpLmNA3Alz0sqeKnriNvOfwHhtjcs4hXp0k8Rwm9napljpdM85cI7d",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgardb371f211",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "2069"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:05 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/refunds
+    body:
+      encoding: UTF-8
+      string: charge=ch_3TryoGIBOqvOFDrf1MSoD4Tw
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_Vjl45x6RSjnX1V","request_duration_ms":192}}'
+      Idempotency-Key:
+      - 470cf23b-defe-4c95-9777-0fcf7a5a93f8
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:06 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '713'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Idempotency-Key:
+      - 470cf23b-defe-4c95-9777-0fcf7a5a93f8
+      Original-Request:
+      - req_bNMvgHJTGidzLm
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_bNMvgHJTGidzLm
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "re_3TryoGIBOqvOFDrf1Spf49Oc",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": "txn_3TryoGIBOqvOFDrf1F1St3Bw",
+          "charge": "ch_3TryoGIBOqvOFDrf1MSoD4Tw",
+          "created": 1783768265,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "destination_details": {
+            "card": {
+              "reference_status": "pending",
+              "reference_type": "acquirer_reference_number",
+              "type": "refund"
+            },
+            "type": "card"
+          },
+          "metadata": {},
+          "payment_intent": "pi_3TryoGIBOqvOFDrf1Zn0YCuK",
+          "payment_method": "pm_1TryoFIBOqvOFDrfaHfnuhk7",
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:06 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/refunds/re_3TryoGIBOqvOFDrf1Spf49Oc?expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_bNMvgHJTGidzLm","request_duration_ms":1011}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:06 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1212'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_aFvoKL6F670dX4
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "re_3TryoGIBOqvOFDrf1Spf49Oc",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": {
+            "id": "txn_3TryoGIBOqvOFDrf1F1St3Bw",
+            "object": "balance_transaction",
+            "amount": -100,
+            "available_on": 1784332800,
+            "balance_type": "payments",
+            "created": 1783768265,
+            "currency": "usd",
+            "description": "REFUND FOR CHARGE (You bought http://edgardb371f211.test.gumroad.com:31337/l/x!)",
+            "exchange_rate": null,
+            "fee": 0,
+            "fee_details": [],
+            "net": -100,
+            "reporting_category": "refund",
+            "source": "re_3TryoGIBOqvOFDrf1Spf49Oc",
+            "status": "pending",
+            "type": "refund"
+          },
+          "charge": "ch_3TryoGIBOqvOFDrf1MSoD4Tw",
+          "created": 1783768265,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "destination_details": {
+            "card": {
+              "reference_status": "pending",
+              "reference_type": "acquirer_reference_number",
+              "type": "refund"
+            },
+            "type": "card"
+          },
+          "metadata": {},
+          "payment_intent": "pi_3TryoGIBOqvOFDrf1Zn0YCuK",
+          "payment_method": "pm_1TryoFIBOqvOFDrfaHfnuhk7",
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:06 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TryoGIBOqvOFDrf1MSoD4Tw?expand%5B%5D=application_fee.refunds.data.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_aFvoKL6F670dX4","request_duration_ms":291}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:11:07 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3759'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nbhf7um5pjiFhJhKK32BTuuOiVscG7iGk6scynJRIq6MxaTNGTGtWACgGLdqOLxQ2K46NP35Epf8emSz&t=1"
+      Request-Id:
+      - req_CHLpAT6wUJ44tv
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TryoGIBOqvOFDrf1MSoD4Tw",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 100,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TryoGIBOqvOFDrf1TS0vH5C",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1784332800,
+            "balance_type": "payments",
+            "created": 1783768264,
+            "currency": "usd",
+            "description": "You bought http://edgardb371f211.test.gumroad.com:31337/l/x!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3TryoGIBOqvOFDrf1MSoD4Tw",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGARDB371F211",
+          "captured": true,
+          "created": 1783768264,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgardb371f211.test.gumroad.com:31337/l/x!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "7WpKxZRt33rUwjcQ_uBBiw=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 36,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TryoGIBOqvOFDrf1Zn0YCuK",
+          "payment_method": "pm_1TryoFIBOqvOFDrfaHfnuhk7",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "939512",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKMrJyNIGMgY6WdzT6486LBZUUaBTuubtPK3may0Z9b2-TNq7exznHgkibvnTGIpMri85M_cBEDvggovq",
+          "refunded": true,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgardb371f211",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "2069"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:11:07 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/notifying_the_creator_when_a_team_member_refunds_on_their_behalf/fails_the_refund_when_a_team_member_gives_no_reason.yml
+++ b/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/notifying_the_creator_when_a_team_member_refunds_on_their_behalf/fails_the_refund_when_a_team_member_gives_no_reason.yml
@@ -1,0 +1,659 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_wqgOEhNmzzYvDn","request_duration_ms":0}}'
+      Idempotency-Key:
+      - f039c81f-a343-4da1-979e-59bda0f6ff21
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 12:06:07 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=y86TS1w3pbyQ1HGPae63K28hcDgED8po21iaFzMUdZpX4z8pnQbjRW2DRTefhwew95ewQoEonC4yj9jV;
+        report-to csp
+      Idempotency-Key:
+      - f039c81f-a343-4da1-979e-59bda0f6ff21
+      Original-Request:
+      - req_WbwkxXpv2byiae
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=y86TS1w3pbyQ1HGPae63K28hcDgED8po21iaFzMUdZpX4z8pnQbjRW2DRTefhwew95ewQoEonC4yj9jV&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=y86TS1w3pbyQ1HGPae63K28hcDgED8po21iaFzMUdZpX4z8pnQbjRW2DRTefhwew95ewQoEonC4yj9jV&t=1"
+      Request-Id:
+      - req_WbwkxXpv2byiae
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TrzfXIBOqvOFDrfAkPU5FJa",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783771567,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sat, 11 Jul 2026 12:06:07 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TrzfXIBOqvOFDrfAkPU5FJa
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_WbwkxXpv2byiae","request_duration_ms":279}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 12:06:07 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=y86TS1w3pbyQ1HGPae63K28hcDgED8po21iaFzMUdZpX4z8pnQbjRW2DRTefhwew95ewQoEonC4yj9jV;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=y86TS1w3pbyQ1HGPae63K28hcDgED8po21iaFzMUdZpX4z8pnQbjRW2DRTefhwew95ewQoEonC4yj9jV&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=y86TS1w3pbyQ1HGPae63K28hcDgED8po21iaFzMUdZpX4z8pnQbjRW2DRTefhwew95ewQoEonC4yj9jV&t=1"
+      Request-Id:
+      - req_PPXo2DqTlTvaDb
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TrzfXIBOqvOFDrfAkPU5FJa",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783771567,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sat, 11 Jul 2026 12:06:07 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=You+bought+http%3A%2F%2Fedgarcc899ba35.test.gumroad.com%3A31337%2Fl%2Fp%21&metadata[purchase]=zrjczYhIHlrRllhWrZibBQ%3D%3D&transfer_group=2928&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1TrzfXIBOqvOFDrfAkPU5FJa&statement_descriptor_suffix=edgarcc899ba35
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_PPXo2DqTlTvaDb","request_duration_ms":185}}'
+      Idempotency-Key:
+      - 8dfd2984-041b-4019-8381-7d9ebf8294d4
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 12:06:09 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1638'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=y86TS1w3pbyQ1HGPae63K28hcDgED8po21iaFzMUdZpX4z8pnQbjRW2DRTefhwew95ewQoEonC4yj9jV;
+        report-to csp
+      Idempotency-Key:
+      - 8dfd2984-041b-4019-8381-7d9ebf8294d4
+      Original-Request:
+      - req_FqsbMfbx4xJEg6
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=y86TS1w3pbyQ1HGPae63K28hcDgED8po21iaFzMUdZpX4z8pnQbjRW2DRTefhwew95ewQoEonC4yj9jV&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=y86TS1w3pbyQ1HGPae63K28hcDgED8po21iaFzMUdZpX4z8pnQbjRW2DRTefhwew95ewQoEonC4yj9jV&t=1"
+      Request-Id:
+      - req_FqsbMfbx4xJEg6
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3TrzfYIBOqvOFDrf0eNQB5kG",
+          "object": "payment_intent",
+          "amount": 100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 100,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3TrzfYIBOqvOFDrf0eNQB5kG_secret_XfB0v7EB4IRZFjS4NaKnWBPHq",
+          "confirmation_method": "automatic",
+          "created": 1783771568,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgarcc899ba35.test.gumroad.com:31337/l/p!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3TrzfYIBOqvOFDrf0bUkAgfs",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "zrjczYhIHlrRllhWrZibBQ=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1TrzfXIBOqvOFDrfAkPU5FJa",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgarcc899ba35",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "2928"
+        }
+  recorded_at: Sat, 11 Jul 2026 12:06:09 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TrzfYIBOqvOFDrf0bUkAgfs?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_FqsbMfbx4xJEg6","request_duration_ms":1193}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 12:06:09 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3758'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=y86TS1w3pbyQ1HGPae63K28hcDgED8po21iaFzMUdZpX4z8pnQbjRW2DRTefhwew95ewQoEonC4yj9jV;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=y86TS1w3pbyQ1HGPae63K28hcDgED8po21iaFzMUdZpX4z8pnQbjRW2DRTefhwew95ewQoEonC4yj9jV&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=y86TS1w3pbyQ1HGPae63K28hcDgED8po21iaFzMUdZpX4z8pnQbjRW2DRTefhwew95ewQoEonC4yj9jV&t=1"
+      Request-Id:
+      - req_mHmdN2GhxarDOh
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TrzfYIBOqvOFDrf0bUkAgfs",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TrzfYIBOqvOFDrf0BykrdpQ",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1784332800,
+            "balance_type": "payments",
+            "created": 1783771568,
+            "currency": "usd",
+            "description": "You bought http://edgarcc899ba35.test.gumroad.com:31337/l/p!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3TrzfYIBOqvOFDrf0bUkAgfs",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGARCC899BA35",
+          "captured": true,
+          "created": 1783771568,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgarcc899ba35.test.gumroad.com:31337/l/p!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "zrjczYhIHlrRllhWrZibBQ=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 58,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TrzfYIBOqvOFDrf0eNQB5kG",
+          "payment_method": "pm_1TrzfXIBOqvOFDrfAkPU5FJa",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "025312",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKLHjyNIGMga2PEN4bZY6LBb5Rq1H_PFM_qDeVfvWR3qL9CACD9oEiilPZn2F5WEAGt2cl_tmcZpyLMJo",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgarcc899ba35",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "2928"
+        }
+  recorded_at: Sat, 11 Jul 2026 12:06:09 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/notifying_the_creator_when_a_team_member_refunds_on_their_behalf/leaves_the_refund_note_empty_when_no_reason_is_given.yml
+++ b/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/notifying_the_creator_when_a_team_member_refunds_on_their_behalf/leaves_the_refund_note_empty_when_no_reason_is_given.yml
@@ -1,0 +1,1327 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_wqgOEhNmzzYvDn","request_duration_ms":195}}'
+      Idempotency-Key:
+      - ba56a1ff-c3f7-4ac1-a35d-8a8866326328
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:44:11 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1;
+        report-to csp
+      Idempotency-Key:
+      - ba56a1ff-c3f7-4ac1-a35d-8a8866326328
+      Original-Request:
+      - req_u5LPvJbqjpvHoC
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1&t=1"
+      Request-Id:
+      - req_u5LPvJbqjpvHoC
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TrzKJIBOqvOFDrfQhV3kIut",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783770251,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:44:11 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TrzKJIBOqvOFDrfQhV3kIut
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_u5LPvJbqjpvHoC","request_duration_ms":181}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:44:11 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1&t=1"
+      Request-Id:
+      - req_onn02Obi3kmRYK
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TrzKJIBOqvOFDrfQhV3kIut",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783770251,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:44:11 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=You+bought+http%3A%2F%2Fedgarf18d617e74.test.gumroad.com%3A31337%2Fl%2Fp%21&metadata[purchase]=LVw3JljX6pc26QO0641sfA%3D%3D&transfer_group=2676&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1TrzKJIBOqvOFDrfQhV3kIut&statement_descriptor_suffix=edgarf18d617e74
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_onn02Obi3kmRYK","request_duration_ms":152}}'
+      Idempotency-Key:
+      - 183d9122-0d76-470f-9a34-c5cce4e3cb1f
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:44:12 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1640'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1;
+        report-to csp
+      Idempotency-Key:
+      - 183d9122-0d76-470f-9a34-c5cce4e3cb1f
+      Original-Request:
+      - req_fx1wn9RgLykJxW
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1&t=1"
+      Request-Id:
+      - req_fx1wn9RgLykJxW
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3TrzKJIBOqvOFDrf0Ep9RLMk",
+          "object": "payment_intent",
+          "amount": 100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 100,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3TrzKJIBOqvOFDrf0Ep9RLMk_secret_pZPjNWKCYMUyXUlDqOawtwwwG",
+          "confirmation_method": "automatic",
+          "created": 1783770251,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgarf18d617e74.test.gumroad.com:31337/l/p!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3TrzKJIBOqvOFDrf0gMK6G2s",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "LVw3JljX6pc26QO0641sfA=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1TrzKJIBOqvOFDrfQhV3kIut",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgarf18d617e74",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "2676"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:44:12 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TrzKJIBOqvOFDrf0gMK6G2s?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_fx1wn9RgLykJxW","request_duration_ms":872}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:44:12 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3761'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1&t=1"
+      Request-Id:
+      - req_BCbVdOZMfyEohL
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TrzKJIBOqvOFDrf0gMK6G2s",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TrzKJIBOqvOFDrf0FkddePP",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1784332800,
+            "balance_type": "payments",
+            "created": 1783770252,
+            "currency": "usd",
+            "description": "You bought http://edgarf18d617e74.test.gumroad.com:31337/l/p!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3TrzKJIBOqvOFDrf0gMK6G2s",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGARF18D617E7",
+          "captured": true,
+          "created": 1783770252,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgarf18d617e74.test.gumroad.com:31337/l/p!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "LVw3JljX6pc26QO0641sfA=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 27,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TrzKJIBOqvOFDrf0Ep9RLMk",
+          "payment_method": "pm_1TrzKJIBOqvOFDrfQhV3kIut",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "373492",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKIzZyNIGMgZcprV4Ze86LBaGS2V5aDwB_UZorPCK4uQHXAqGeM1GfpngJi06lEaU5Lz5fe6Oa8m0XEuo",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgarf18d617e74",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "2676"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:44:12 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TrzKJIBOqvOFDrf0gMK6G2s
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_BCbVdOZMfyEohL","request_duration_ms":201}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:44:13 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3106'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1&t=1"
+      Request-Id:
+      - req_0YsltlliKKsFm0
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TrzKJIBOqvOFDrf0gMK6G2s",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3TrzKJIBOqvOFDrf0FkddePP",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGARF18D617E7",
+          "captured": true,
+          "created": 1783770252,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgarf18d617e74.test.gumroad.com:31337/l/p!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "LVw3JljX6pc26QO0641sfA=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 27,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TrzKJIBOqvOFDrf0Ep9RLMk",
+          "payment_method": "pm_1TrzKJIBOqvOFDrfQhV3kIut",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "373492",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKI3ZyNIGMgZblDMZrEQ6LBbygDwPDK20LiBT6R90bY3ubC5OJ2CS6YlsJWdvALM2_tUYZQ3Q2RkXCgBs",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgarf18d617e74",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "2676"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:44:13 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/refunds
+    body:
+      encoding: UTF-8
+      string: charge=ch_3TrzKJIBOqvOFDrf0gMK6G2s
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_0YsltlliKKsFm0","request_duration_ms":177}}'
+      Idempotency-Key:
+      - f9c0b83e-4229-4fa1-b1c7-2ae862d225d4
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:44:13 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '713'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1;
+        report-to csp
+      Idempotency-Key:
+      - f9c0b83e-4229-4fa1-b1c7-2ae862d225d4
+      Original-Request:
+      - req_Zhq4QexwFJ0KTu
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1&t=1"
+      Request-Id:
+      - req_Zhq4QexwFJ0KTu
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "re_3TrzKJIBOqvOFDrf0UL9AVeB",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": "txn_3TrzKJIBOqvOFDrf0SqNMZUE",
+          "charge": "ch_3TrzKJIBOqvOFDrf0gMK6G2s",
+          "created": 1783770253,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "destination_details": {
+            "card": {
+              "reference_status": "pending",
+              "reference_type": "acquirer_reference_number",
+              "type": "refund"
+            },
+            "type": "card"
+          },
+          "metadata": {},
+          "payment_intent": "pi_3TrzKJIBOqvOFDrf0Ep9RLMk",
+          "payment_method": "pm_1TrzKJIBOqvOFDrfQhV3kIut",
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Sat, 11 Jul 2026 11:44:13 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/refunds/re_3TrzKJIBOqvOFDrf0UL9AVeB?expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_Zhq4QexwFJ0KTu","request_duration_ms":779}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:44:14 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1213'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1&t=1"
+      Request-Id:
+      - req_lNrFhslrPGkkv4
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "re_3TrzKJIBOqvOFDrf0UL9AVeB",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": {
+            "id": "txn_3TrzKJIBOqvOFDrf0SqNMZUE",
+            "object": "balance_transaction",
+            "amount": -100,
+            "available_on": 1784332800,
+            "balance_type": "payments",
+            "created": 1783770253,
+            "currency": "usd",
+            "description": "REFUND FOR CHARGE (You bought http://edgarf18d617e74.test.gumroad.com:31337/l/p!)",
+            "exchange_rate": null,
+            "fee": 0,
+            "fee_details": [],
+            "net": -100,
+            "reporting_category": "refund",
+            "source": "re_3TrzKJIBOqvOFDrf0UL9AVeB",
+            "status": "pending",
+            "type": "refund"
+          },
+          "charge": "ch_3TrzKJIBOqvOFDrf0gMK6G2s",
+          "created": 1783770253,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "destination_details": {
+            "card": {
+              "reference_status": "pending",
+              "reference_type": "acquirer_reference_number",
+              "type": "refund"
+            },
+            "type": "card"
+          },
+          "metadata": {},
+          "payment_intent": "pi_3TrzKJIBOqvOFDrf0Ep9RLMk",
+          "payment_method": "pm_1TrzKJIBOqvOFDrfQhV3kIut",
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Sat, 11 Jul 2026 11:44:14 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TrzKJIBOqvOFDrf0gMK6G2s?expand%5B%5D=application_fee.refunds.data.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_lNrFhslrPGkkv4","request_duration_ms":304}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:44:14 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3762'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1&t=1"
+      Request-Id:
+      - req_AYidj2UMj8h4JZ
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TrzKJIBOqvOFDrf0gMK6G2s",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 100,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TrzKJIBOqvOFDrf0FkddePP",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1784332800,
+            "balance_type": "payments",
+            "created": 1783770252,
+            "currency": "usd",
+            "description": "You bought http://edgarf18d617e74.test.gumroad.com:31337/l/p!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3TrzKJIBOqvOFDrf0gMK6G2s",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGARF18D617E7",
+          "captured": true,
+          "created": 1783770252,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgarf18d617e74.test.gumroad.com:31337/l/p!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "LVw3JljX6pc26QO0641sfA=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 27,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TrzKJIBOqvOFDrf0Ep9RLMk",
+          "payment_method": "pm_1TrzKJIBOqvOFDrfQhV3kIut",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "373492",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKI7ZyNIGMgZ2LJp5Jfk6LBYi3oKxnFhP0nS1nip_GQiWEKE6DHm02Qtmz0R3mh9qKCVuil08mv3sijx4",
+          "refunded": true,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgarf18d617e74",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "2676"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:44:14 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/notifying_the_creator_when_a_team_member_refunds_on_their_behalf/lets_a_team_member_refund_their_own_sale_without_a_reason_and_without_an_email.yml
+++ b/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/notifying_the_creator_when_a_team_member_refunds_on_their_behalf/lets_a_team_member_refund_their_own_sale_without_a_reason_and_without_an_email.yml
@@ -1,0 +1,1325 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Idempotency-Key:
+      - 77c5e61d-b360-4d40-90c4-36a24b88ca93
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 12:34:16 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=EbAGmGQh1ysMdC7MmwSOSwffwGqja7fTxiS1rTM28HQUaYkc9kaVX08zhboc-b_Qt6vQPMLGsPxqPgH_;
+        report-to csp
+      Idempotency-Key:
+      - 77c5e61d-b360-4d40-90c4-36a24b88ca93
+      Original-Request:
+      - req_5lljbneE07Irc7
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=EbAGmGQh1ysMdC7MmwSOSwffwGqja7fTxiS1rTM28HQUaYkc9kaVX08zhboc-b_Qt6vQPMLGsPxqPgH_&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=EbAGmGQh1ysMdC7MmwSOSwffwGqja7fTxiS1rTM28HQUaYkc9kaVX08zhboc-b_Qt6vQPMLGsPxqPgH_&t=1"
+      Request-Id:
+      - req_5lljbneE07Irc7
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1Ts06mIBOqvOFDrfoSMrCD2M",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783773256,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sat, 11 Jul 2026 12:34:16 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1Ts06mIBOqvOFDrfoSMrCD2M
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_5lljbneE07Irc7","request_duration_ms":285}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 12:34:17 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=PSHRbfnIKJiOzFDFo3waqGAuf-PqtIxJ9qMJedGFqCKJlqw61aZJLPiCKPl0IiWHSQUInkMrlk94ONll;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=PSHRbfnIKJiOzFDFo3waqGAuf-PqtIxJ9qMJedGFqCKJlqw61aZJLPiCKPl0IiWHSQUInkMrlk94ONll&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=PSHRbfnIKJiOzFDFo3waqGAuf-PqtIxJ9qMJedGFqCKJlqw61aZJLPiCKPl0IiWHSQUInkMrlk94ONll&t=1"
+      Request-Id:
+      - req_9cYk1fkZzM0Dk9
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1Ts06mIBOqvOFDrfoSMrCD2M",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783773256,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sat, 11 Jul 2026 12:34:17 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=You+bought+http%3A%2F%2Fedgar1aac617b1.test.gumroad.com%3A31337%2Fl%2Fm%21&metadata[purchase]=XcAaRLIv0i1vVKOiETccgQ%3D%3D&transfer_group=3460&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1Ts06mIBOqvOFDrfoSMrCD2M&statement_descriptor_suffix=edgar1aac617b1
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_9cYk1fkZzM0Dk9","request_duration_ms":185}}'
+      Idempotency-Key:
+      - aef0e851-61d4-483f-8c1e-e945d514022f
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 12:34:18 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1638'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=PSHRbfnIKJiOzFDFo3waqGAuf-PqtIxJ9qMJedGFqCKJlqw61aZJLPiCKPl0IiWHSQUInkMrlk94ONll;
+        report-to csp
+      Idempotency-Key:
+      - aef0e851-61d4-483f-8c1e-e945d514022f
+      Original-Request:
+      - req_CT6iEfoxkC8Qxz
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=PSHRbfnIKJiOzFDFo3waqGAuf-PqtIxJ9qMJedGFqCKJlqw61aZJLPiCKPl0IiWHSQUInkMrlk94ONll&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=PSHRbfnIKJiOzFDFo3waqGAuf-PqtIxJ9qMJedGFqCKJlqw61aZJLPiCKPl0IiWHSQUInkMrlk94ONll&t=1"
+      Request-Id:
+      - req_CT6iEfoxkC8Qxz
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3Ts06nIBOqvOFDrf113VA0Qm",
+          "object": "payment_intent",
+          "amount": 100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 100,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3Ts06nIBOqvOFDrf113VA0Qm_secret_eFXCfB8ERPMGP2jDEZd8QKK4D",
+          "confirmation_method": "automatic",
+          "created": 1783773257,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgar1aac617b1.test.gumroad.com:31337/l/m!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3Ts06nIBOqvOFDrf1eE266VR",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "XcAaRLIv0i1vVKOiETccgQ=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1Ts06mIBOqvOFDrfoSMrCD2M",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar1aac617b1",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "3460"
+        }
+  recorded_at: Sat, 11 Jul 2026 12:34:18 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3Ts06nIBOqvOFDrf1eE266VR?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_CT6iEfoxkC8Qxz","request_duration_ms":871}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 12:34:18 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3758'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=PSHRbfnIKJiOzFDFo3waqGAuf-PqtIxJ9qMJedGFqCKJlqw61aZJLPiCKPl0IiWHSQUInkMrlk94ONll;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=PSHRbfnIKJiOzFDFo3waqGAuf-PqtIxJ9qMJedGFqCKJlqw61aZJLPiCKPl0IiWHSQUInkMrlk94ONll&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=PSHRbfnIKJiOzFDFo3waqGAuf-PqtIxJ9qMJedGFqCKJlqw61aZJLPiCKPl0IiWHSQUInkMrlk94ONll&t=1"
+      Request-Id:
+      - req_RbSLTKUUoQYR81
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3Ts06nIBOqvOFDrf1eE266VR",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3Ts06nIBOqvOFDrf134WxL6F",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1784332800,
+            "balance_type": "payments",
+            "created": 1783773257,
+            "currency": "usd",
+            "description": "You bought http://edgar1aac617b1.test.gumroad.com:31337/l/m!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3Ts06nIBOqvOFDrf1eE266VR",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR1AAC617B1",
+          "captured": true,
+          "created": 1783773257,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar1aac617b1.test.gumroad.com:31337/l/m!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "XcAaRLIv0i1vVKOiETccgQ=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 22,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3Ts06nIBOqvOFDrf113VA0Qm",
+          "payment_method": "pm_1Ts06mIBOqvOFDrfoSMrCD2M",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "407560",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKMrwyNIGMgZmF59b14Y6LBaEjGUoZ8R7IpIbg0htoeZ6LLovsaNEOAzqXfQE5RNtEubgEhZBXVSl_F2r",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar1aac617b1",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "3460"
+        }
+  recorded_at: Sat, 11 Jul 2026 12:34:18 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3Ts06nIBOqvOFDrf1eE266VR
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_RbSLTKUUoQYR81","request_duration_ms":306}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 12:34:18 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3104'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=PSHRbfnIKJiOzFDFo3waqGAuf-PqtIxJ9qMJedGFqCKJlqw61aZJLPiCKPl0IiWHSQUInkMrlk94ONll;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=PSHRbfnIKJiOzFDFo3waqGAuf-PqtIxJ9qMJedGFqCKJlqw61aZJLPiCKPl0IiWHSQUInkMrlk94ONll&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=PSHRbfnIKJiOzFDFo3waqGAuf-PqtIxJ9qMJedGFqCKJlqw61aZJLPiCKPl0IiWHSQUInkMrlk94ONll&t=1"
+      Request-Id:
+      - req_2HQc7Gg6Tp1z33
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3Ts06nIBOqvOFDrf1eE266VR",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3Ts06nIBOqvOFDrf134WxL6F",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR1AAC617B1",
+          "captured": true,
+          "created": 1783773257,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar1aac617b1.test.gumroad.com:31337/l/m!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "XcAaRLIv0i1vVKOiETccgQ=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 22,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3Ts06nIBOqvOFDrf113VA0Qm",
+          "payment_method": "pm_1Ts06mIBOqvOFDrfoSMrCD2M",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "407560",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKMrwyNIGMgY3Lxgm9cc6LBaVpUfFJEdDCoShxKN2GEFKVjcezh-8xxvXXZ_A5Qq9AUGrzvd5vTmX-Nqo",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar1aac617b1",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "3460"
+        }
+  recorded_at: Sat, 11 Jul 2026 12:34:18 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/refunds
+    body:
+      encoding: UTF-8
+      string: charge=ch_3Ts06nIBOqvOFDrf1eE266VR
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_2HQc7Gg6Tp1z33","request_duration_ms":167}}'
+      Idempotency-Key:
+      - 98c2d88b-71fe-4288-84f5-6ef127ebb5c5
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 12:34:19 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '713'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=PSHRbfnIKJiOzFDFo3waqGAuf-PqtIxJ9qMJedGFqCKJlqw61aZJLPiCKPl0IiWHSQUInkMrlk94ONll;
+        report-to csp
+      Idempotency-Key:
+      - 98c2d88b-71fe-4288-84f5-6ef127ebb5c5
+      Original-Request:
+      - req_iwWrpUyVXLFgxH
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=PSHRbfnIKJiOzFDFo3waqGAuf-PqtIxJ9qMJedGFqCKJlqw61aZJLPiCKPl0IiWHSQUInkMrlk94ONll&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=PSHRbfnIKJiOzFDFo3waqGAuf-PqtIxJ9qMJedGFqCKJlqw61aZJLPiCKPl0IiWHSQUInkMrlk94ONll&t=1"
+      Request-Id:
+      - req_iwWrpUyVXLFgxH
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "re_3Ts06nIBOqvOFDrf1eazW6uX",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": "txn_3Ts06nIBOqvOFDrf1h8sezFb",
+          "charge": "ch_3Ts06nIBOqvOFDrf1eE266VR",
+          "created": 1783773258,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "destination_details": {
+            "card": {
+              "reference_status": "pending",
+              "reference_type": "acquirer_reference_number",
+              "type": "refund"
+            },
+            "type": "card"
+          },
+          "metadata": {},
+          "payment_intent": "pi_3Ts06nIBOqvOFDrf113VA0Qm",
+          "payment_method": "pm_1Ts06mIBOqvOFDrfoSMrCD2M",
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Sat, 11 Jul 2026 12:34:19 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/refunds/re_3Ts06nIBOqvOFDrf1eazW6uX?expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_iwWrpUyVXLFgxH","request_duration_ms":798}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 12:34:19 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1212'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=PSHRbfnIKJiOzFDFo3waqGAuf-PqtIxJ9qMJedGFqCKJlqw61aZJLPiCKPl0IiWHSQUInkMrlk94ONll;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=PSHRbfnIKJiOzFDFo3waqGAuf-PqtIxJ9qMJedGFqCKJlqw61aZJLPiCKPl0IiWHSQUInkMrlk94ONll&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=PSHRbfnIKJiOzFDFo3waqGAuf-PqtIxJ9qMJedGFqCKJlqw61aZJLPiCKPl0IiWHSQUInkMrlk94ONll&t=1"
+      Request-Id:
+      - req_a9af4qoME8SZCh
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "re_3Ts06nIBOqvOFDrf1eazW6uX",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": {
+            "id": "txn_3Ts06nIBOqvOFDrf1h8sezFb",
+            "object": "balance_transaction",
+            "amount": -100,
+            "available_on": 1784332800,
+            "balance_type": "payments",
+            "created": 1783773258,
+            "currency": "usd",
+            "description": "REFUND FOR CHARGE (You bought http://edgar1aac617b1.test.gumroad.com:31337/l/m!)",
+            "exchange_rate": null,
+            "fee": 0,
+            "fee_details": [],
+            "net": -100,
+            "reporting_category": "refund",
+            "source": "re_3Ts06nIBOqvOFDrf1eazW6uX",
+            "status": "pending",
+            "type": "refund"
+          },
+          "charge": "ch_3Ts06nIBOqvOFDrf1eE266VR",
+          "created": 1783773258,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "destination_details": {
+            "card": {
+              "reference_status": "pending",
+              "reference_type": "acquirer_reference_number",
+              "type": "refund"
+            },
+            "type": "card"
+          },
+          "metadata": {},
+          "payment_intent": "pi_3Ts06nIBOqvOFDrf113VA0Qm",
+          "payment_method": "pm_1Ts06mIBOqvOFDrfoSMrCD2M",
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Sat, 11 Jul 2026 12:34:19 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3Ts06nIBOqvOFDrf1eE266VR?expand%5B%5D=application_fee.refunds.data.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_a9af4qoME8SZCh","request_duration_ms":305}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 12:34:19 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3759'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=PSHRbfnIKJiOzFDFo3waqGAuf-PqtIxJ9qMJedGFqCKJlqw61aZJLPiCKPl0IiWHSQUInkMrlk94ONll;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=PSHRbfnIKJiOzFDFo3waqGAuf-PqtIxJ9qMJedGFqCKJlqw61aZJLPiCKPl0IiWHSQUInkMrlk94ONll&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=PSHRbfnIKJiOzFDFo3waqGAuf-PqtIxJ9qMJedGFqCKJlqw61aZJLPiCKPl0IiWHSQUInkMrlk94ONll&t=1"
+      Request-Id:
+      - req_rR9oX3BSGNOPT3
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3Ts06nIBOqvOFDrf1eE266VR",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 100,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3Ts06nIBOqvOFDrf134WxL6F",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1784332800,
+            "balance_type": "payments",
+            "created": 1783773257,
+            "currency": "usd",
+            "description": "You bought http://edgar1aac617b1.test.gumroad.com:31337/l/m!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3Ts06nIBOqvOFDrf1eE266VR",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR1AAC617B1",
+          "captured": true,
+          "created": 1783773257,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar1aac617b1.test.gumroad.com:31337/l/m!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "XcAaRLIv0i1vVKOiETccgQ=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 22,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3Ts06nIBOqvOFDrf113VA0Qm",
+          "payment_method": "pm_1Ts06mIBOqvOFDrfoSMrCD2M",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "407560",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKMvwyNIGMgZoBQtDpSU6LBaI8di9rn3xjyIG6D2uVh8iugjVFmqLXYR8kX4V8pDQxnlAxa3pxc7VqAnM",
+          "refunded": true,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar1aac617b1",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "3460"
+        }
+  recorded_at: Sat, 11 Jul 2026 12:34:20 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/notifying_the_creator_when_a_team_member_refunds_on_their_behalf/stores_the_reason_on_the_refund_and_passes_the_refund_to_the_email.yml
+++ b/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/notifying_the_creator_when_a_team_member_refunds_on_their_behalf/stores_the_reason_on_the_refund_and_passes_the_refund_to_the_email.yml
@@ -1,0 +1,1328 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_CHLpAT6wUJ44tv","request_duration_ms":0}}'
+      Idempotency-Key:
+      - d2a623a8-cb5c-4bb1-a5be-48a835904677
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:44:07 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1;
+        report-to csp
+      Idempotency-Key:
+      - d2a623a8-cb5c-4bb1-a5be-48a835904677
+      Original-Request:
+      - req_igaJwid4CBbs4n
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1&t=1"
+      Request-Id:
+      - req_igaJwid4CBbs4n
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TrzKFIBOqvOFDrfhYojVKXR",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783770247,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:44:07 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TrzKFIBOqvOFDrfhYojVKXR
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_igaJwid4CBbs4n","request_duration_ms":219}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:44:08 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1&t=1"
+      Request-Id:
+      - req_5PJ9U3ZxHTuGsc
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TrzKFIBOqvOFDrfhYojVKXR",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783770247,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:44:08 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=You+bought+http%3A%2F%2Fedgar93e2a06a72.test.gumroad.com%3A31337%2Fl%2Fk%21&metadata[purchase]=gZLzRbDjmJWuxJo6jPRb6Q%3D%3D&transfer_group=2675&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1TrzKFIBOqvOFDrfhYojVKXR&statement_descriptor_suffix=edgar93e2a06a72
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_5PJ9U3ZxHTuGsc","request_duration_ms":143}}'
+      Idempotency-Key:
+      - '09e78aed-301a-422b-bbdc-e840ba2eb24f'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:44:08 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1640'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1;
+        report-to csp
+      Idempotency-Key:
+      - '09e78aed-301a-422b-bbdc-e840ba2eb24f'
+      Original-Request:
+      - req_zZmjgNOiJiLW32
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1&t=1"
+      Request-Id:
+      - req_zZmjgNOiJiLW32
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3TrzKGIBOqvOFDrf0g1fiher",
+          "object": "payment_intent",
+          "amount": 100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 100,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3TrzKGIBOqvOFDrf0g1fiher_secret_vjMafGKCYPlasTUDlsJSRd6Xv",
+          "confirmation_method": "automatic",
+          "created": 1783770248,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgar93e2a06a72.test.gumroad.com:31337/l/k!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3TrzKGIBOqvOFDrf09RsKYdB",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "gZLzRbDjmJWuxJo6jPRb6Q=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1TrzKFIBOqvOFDrfhYojVKXR",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar93e2a06a72",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "2675"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:44:08 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TrzKGIBOqvOFDrf09RsKYdB?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_zZmjgNOiJiLW32","request_duration_ms":849}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:44:09 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3761'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1&t=1"
+      Request-Id:
+      - req_IVqof6s5RZkM9Q
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TrzKGIBOqvOFDrf09RsKYdB",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TrzKGIBOqvOFDrf08T4RHyS",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1784332800,
+            "balance_type": "payments",
+            "created": 1783770248,
+            "currency": "usd",
+            "description": "You bought http://edgar93e2a06a72.test.gumroad.com:31337/l/k!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3TrzKGIBOqvOFDrf09RsKYdB",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR93E2A06A7",
+          "captured": true,
+          "created": 1783770248,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar93e2a06a72.test.gumroad.com:31337/l/k!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "gZLzRbDjmJWuxJo6jPRb6Q=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 38,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TrzKGIBOqvOFDrf0g1fiher",
+          "payment_method": "pm_1TrzKFIBOqvOFDrfhYojVKXR",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "775694",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKInZyNIGMgYoc9K2Sos6LBYUL6UHRQSq0vLwhQpMoH8MvA1cfE91OutMjKcumPsHnleLg93ieKeWtTOb",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar93e2a06a72",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "2675"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:44:09 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TrzKGIBOqvOFDrf09RsKYdB
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_IVqof6s5RZkM9Q","request_duration_ms":209}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:44:09 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3106'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1&t=1"
+      Request-Id:
+      - req_YT07TKubeNN7WE
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TrzKGIBOqvOFDrf09RsKYdB",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3TrzKGIBOqvOFDrf08T4RHyS",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR93E2A06A7",
+          "captured": true,
+          "created": 1783770248,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar93e2a06a72.test.gumroad.com:31337/l/k!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "gZLzRbDjmJWuxJo6jPRb6Q=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 38,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TrzKGIBOqvOFDrf0g1fiher",
+          "payment_method": "pm_1TrzKFIBOqvOFDrfhYojVKXR",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "775694",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKInZyNIGMgaCgbWaAb46LBb4TSuoveuiNi7Ir3mr_affLVgjCqaqBNJ3Yj2MbVqvsLg_kc_3zD_ogruu",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar93e2a06a72",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "2675"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:44:09 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/refunds
+    body:
+      encoding: UTF-8
+      string: charge=ch_3TrzKGIBOqvOFDrf09RsKYdB
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_YT07TKubeNN7WE","request_duration_ms":193}}'
+      Idempotency-Key:
+      - 91738245-f715-4ae2-a9aa-a5d14a946e0f
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:44:10 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '713'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1;
+        report-to csp
+      Idempotency-Key:
+      - 91738245-f715-4ae2-a9aa-a5d14a946e0f
+      Original-Request:
+      - req_QS89n5iVnV5CSF
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1&t=1"
+      Request-Id:
+      - req_QS89n5iVnV5CSF
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "re_3TrzKGIBOqvOFDrf0vP5Iceq",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": "txn_3TrzKGIBOqvOFDrf06mmBev4",
+          "charge": "ch_3TrzKGIBOqvOFDrf09RsKYdB",
+          "created": 1783770249,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "destination_details": {
+            "card": {
+              "reference_status": "pending",
+              "reference_type": "acquirer_reference_number",
+              "type": "refund"
+            },
+            "type": "card"
+          },
+          "metadata": {},
+          "payment_intent": "pi_3TrzKGIBOqvOFDrf0g1fiher",
+          "payment_method": "pm_1TrzKFIBOqvOFDrfhYojVKXR",
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Sat, 11 Jul 2026 11:44:10 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/refunds/re_3TrzKGIBOqvOFDrf0vP5Iceq?expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_QS89n5iVnV5CSF","request_duration_ms":1052}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:44:10 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1254'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1&t=1"
+      Request-Id:
+      - req_gMTBKf3R4Fgjlo
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "re_3TrzKGIBOqvOFDrf0vP5Iceq",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": {
+            "id": "txn_3TrzKGIBOqvOFDrf06mmBev4",
+            "object": "balance_transaction",
+            "amount": -100,
+            "available_on": 1784332800,
+            "balance_type": "payments",
+            "created": 1783770249,
+            "currency": "usd",
+            "description": "REFUND FOR CHARGE (You bought http://edgar93e2a06a72.test.gumroad.com:31337/l/k!)",
+            "exchange_rate": null,
+            "fee": 0,
+            "fee_details": [],
+            "net": -100,
+            "reporting_category": "refund",
+            "source": "re_3TrzKGIBOqvOFDrf0vP5Iceq",
+            "status": "pending",
+            "type": "refund"
+          },
+          "charge": "ch_3TrzKGIBOqvOFDrf09RsKYdB",
+          "created": 1783770249,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "destination_details": {
+            "card": {
+              "reference": "4258747232905912",
+              "reference_status": "available",
+              "reference_type": "acquirer_reference_number",
+              "type": "refund"
+            },
+            "type": "card"
+          },
+          "metadata": {},
+          "payment_intent": "pi_3TrzKGIBOqvOFDrf0g1fiher",
+          "payment_method": "pm_1TrzKFIBOqvOFDrfhYojVKXR",
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Sat, 11 Jul 2026 11:44:10 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TrzKGIBOqvOFDrf09RsKYdB?expand%5B%5D=application_fee.refunds.data.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_gMTBKf3R4Fgjlo","request_duration_ms":305}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 11:44:11 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3762'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Nw0GmVDw8eudYYh_24XVSn2HhqgerXO0vsZNi3K_nLtAQJ1wM7FKOlNMcF2VfVeFWF24ljn0pst08HA1&t=1"
+      Request-Id:
+      - req_wqgOEhNmzzYvDn
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TrzKGIBOqvOFDrf09RsKYdB",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 100,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TrzKGIBOqvOFDrf08T4RHyS",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1784332800,
+            "balance_type": "payments",
+            "created": 1783770248,
+            "currency": "usd",
+            "description": "You bought http://edgar93e2a06a72.test.gumroad.com:31337/l/k!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3TrzKGIBOqvOFDrf09RsKYdB",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR93E2A06A7",
+          "captured": true,
+          "created": 1783770248,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar93e2a06a72.test.gumroad.com:31337/l/k!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "gZLzRbDjmJWuxJo6jPRb6Q=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 38,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TrzKGIBOqvOFDrf0g1fiher",
+          "payment_method": "pm_1TrzKFIBOqvOFDrfhYojVKXR",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "775694",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKIvZyNIGMgYDpjRYJck6LBYVzDztVcz8hkxYnz40rZ6nPIiAecvonXDavqgdFc876t-76SVvRXMDWmYG",
+          "refunded": true,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar93e2a06a72",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "2675"
+        }
+  recorded_at: Sat, 11 Jul 2026 11:44:11 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## What

When a Gumroad team member (support/admin) refunds a purchase on a creator's behalf, the creator now gets the existing `ContactingCreatorMailer.purchase_refunded` email ("A sale has been refunded"). Enqueued from `Purchase::Refundable#refund_and_save!` after a successful refund, only when:

- the refunding user is a team member (`is_team_member?`), and
- it's not a fraud refund (the fraud path already sends `purchase_refunded_for_fraud`), and
- the seller isn't suspended (matching the fraud path's guard).

Creator-initiated refunds and console refunds with no refunding user stay silent, as before.

Every team-member refund must carry a **reason**, shown to the creator in the email ("Reason: Buyer reported being charged twice"):

- `refund!` / `refund_and_save!` accept a `reason:` and persist it as the refund's `note` (the same `Refund#note` field the taxes-only refund path already uses)
- a team-member refund with no reason **fails validation** — "A sale has been refunded" with no explanation is exactly the kind of email that sends the creator to support asking what happened. Fraud refunds are exempt (they send their own dedicated email), and creator/console refunds don't require a reason.
- `ContactingCreatorMailer.purchase_refunded` takes an optional refund id and renders the reason when the refund has a note
- the admin **Refund** button prompts for a reason after the confirm dialog; the prompt is required — a blank value aborts with an error alert, cancel aborts the refund
- the internal admin refund API (`api/internal/admin/purchases#refund`) requires a `reason` param (400 when missing) so AI/support tooling passes the reason from the ticket
- automated stuck-duplicate refunds (`SyncStuckPurchasesJob`) use a canned reason: "Duplicate purchase detected and refunded automatically"

## Why

The buyer is emailed on every refund, but the creator only found out about a support-initiated refund by stumbling on the refunded row in their dashboard. A creator wrote in confused about who refunded their sale. The mailer already existed (`ContactingCreatorMailer.purchase_refunded`) but was only wired to the processor-initiated refund path in `Charge::Refundable`; this closes the gap for the admin/support-initiated path — exactly the case where the creator most needs to be told.

A bare "A sale has been refunded" with no context generates a confused support ticket, so the reason is required whenever a team member (human or automated) refunds on the creator's behalf.

Note: automated admin refunds (e.g. `SyncStuckPurchasesJob` refunding stuck duplicate purchases via `GUMROAD_ADMIN_ID`) also flow through this path and will now notify the creator, which is consistent with the intent — any refund the creator didn't initiate should be visible to them.

Fixes antiwork/gumroad-private#1041

## Test plan

- `bundle exec rspec spec/models/purchase/purchase_refunds_spec.rb spec/models/charge_spec.rb spec/sidekiq/refund_purchase_worker_spec.rb spec/sidekiq/refund_unpaid_purchases_worker_spec.rb spec/controllers/admin/purchases_controller_spec.rb` — 201 examples, 0 failures
- `bundle exec rspec spec/controllers/api/internal/admin/purchases_controller_spec.rb spec/models/product_review_stat_spec.rb spec/models/purchase/purchase_balances_spec.rb spec/models/purchase/purchase_gifts_spec.rb` — 197 examples, 0 failures
- New examples cover: team-member refund emails the creator; the reason is stored on the refund and passed to the email; a team-member refund with no reason fails; fraud refunds succeed without a reason; email renders "Reason: …" when the refund has a note and omits it otherwise; self-refund / nil refunding user / suspended seller stay silent; admin API rejects a missing reason with 400.
- `rubocop` clean on all touched Ruby files; `prettier` + `tsc` + `eslint` clean on the touched TSX.

## Before/After

Backend email behavior plus a small admin-UI addition: the admin Refund button now shows a required browser prompt for the reason after the existing confirm dialog. The email is the existing `purchase_refunded` template with an added "Reason: …" line.
