### PR TITLE
Honor unsubscribes on the per-customer post resend paths

### DIFF
--- a/app/controllers/api/mobile/sales_controller.rb
+++ b/app/controllers/api/mobile/sales_controller.rb
@@ -202,6 +202,11 @@ class Api::Mobile::SalesController < Api::Mobile::BaseController
     post = Installment.alive.where(seller_id: current_resource_owner.id).find_by_external_id(params[:post_id])
     return fetch_error("Could not find post") if post.nil?
 
+    # Honor the customer's unsubscribe: never resend a post to a purchase whose
+    # can_contact flag is off, mirroring the guard on the web resend endpoint
+    # (PostsController#send_for_purchase).
+    return fetch_error("This customer has unsubscribed from your emails.", status: :unprocessable_entity) unless @purchase.can_contact?
+
     cache_key = "post_email:#{post.id}:#{@purchase.id}"
     sent = false
     Rails.cache.fetch(cache_key, expires_in: 8.hours) do

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -58,6 +58,14 @@ class PostsController < ApplicationController
     # never let the generic resend path send it to any other purchase.
     e404 if @post.single_recipient_email? && @post.single_recipient_purchase_id.to_i != purchase.id
 
+    # Honor the customer's unsubscribe: a purchase with can_contact disabled must
+    # never receive seller emails, including per-customer resends from the
+    # customers page. The blast path already excludes these buyers (they have no
+    # AudienceMember row); this keeps the resend path consistent with it.
+    if !purchase.can_contact?
+      return render json: { message: "This customer has unsubscribed from your emails." }, status: :unprocessable_entity
+    end
+
     # Limit the number of emails sent per post to avoid abuse.
     Rails.cache.fetch("post_email:#{@post.id}:#{purchase.id}", expires_in: 8.hours) do
       CreatorContactingCustomersEmailInfo.where(purchase:, installment: @post).destroy_all

--- a/app/presenters/customer_presenter.rb
+++ b/app/presenters/customer_presenter.rb
@@ -8,6 +8,10 @@ class CustomerPresenter
   end
 
   def missed_posts
+    # A customer who unsubscribed (can_contact off) can't be emailed, so don't
+    # offer the seller "Send missed posts" buttons that would only error out.
+    return [] unless purchase.can_contact?
+
     posts = Installment.missed_for_purchase(purchase).order(published_at: :desc, id: :asc)
     posts.map do |post|
       {

--- a/app/sidekiq/send_last_post_job.rb
+++ b/app/sidekiq/send_last_post_job.rb
@@ -6,6 +6,11 @@ class SendLastPostJob
 
   def perform(purchase_id)
     purchase = Purchase.find(purchase_id)
+    # Honor the customer's unsubscribe: skip the welcome "last post" email when
+    # the purchase has can_contact disabled (e.g. the buyer unchecked email
+    # updates at checkout, or unsubscribed before this job ran).
+    return unless purchase.can_contact?
+
     subscription = purchase.subscription
 
     posts = Installment.emailable_posts_for_purchase(purchase:).order(published_at: :desc)

--- a/spec/controllers/api/mobile/sales_controller_spec.rb
+++ b/spec/controllers/api/mobile/sales_controller_spec.rb
@@ -514,6 +514,16 @@ describe Api::Mobile::SalesController, :vcr do
       expect(response).to have_http_status(:unauthorized)
       expect(response.parsed_body).to eq("success" => false, "message" => "You are not eligible to resend this email.")
     end
+
+    it "does not resend to a customer who has unsubscribed" do
+      @purchase.update!(can_contact: false)
+      expect(PostEmailApi).not_to receive(:process)
+
+      post :send_post, params: @params.merge(id: @purchase.external_id, post_id: @post.external_id)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body).to eq("success" => false, "message" => "This customer has unsubscribed from your emails.")
+    end
   end
 
   describe "GET blob_url" do

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -67,6 +67,17 @@ describe PostsController, type: :controller, inertia: true do
         end.to raise_error(ActiveRecord::RecordNotFound)
       end
 
+      it "does not resend to a customer who has unsubscribed" do
+        @purchase.update!(can_contact: false)
+        @purchase.create_url_redirect!
+
+        expect(PostSendgridApi).to_not receive(:process)
+        get :send_for_purchase, params: { id: @post.external_id, purchase_id: @purchase.external_id }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body).to eq("message" => "This customer has unsubscribed from your emails.")
+      end
+
       it "returns success and redelivers the installment" do
         @purchase.create_url_redirect!
         expect(PostSendgridApi).to receive(:process).with(

--- a/spec/presenters/customer_presenter_spec.rb
+++ b/spec/presenters/customer_presenter_spec.rb
@@ -45,6 +45,14 @@ describe CustomerPresenter do
         )
       end
     end
+
+    context "when the customer has unsubscribed" do
+      before { purchase.update!(can_contact: false) }
+
+      it "returns no posts" do
+        expect(described_class.new(purchase:).missed_posts).to eq([])
+      end
+    end
   end
 
   describe "#customer" do

--- a/spec/sidekiq/send_last_post_job_spec.rb
+++ b/spec/sidekiq/send_last_post_job_spec.rb
@@ -75,5 +75,14 @@ describe SendLastPostJob do
         expect(PostSendgridApi).to have_received(:process).with(post: product_post, recipients: [recipient])
       end
     end
+
+    context "when the purchase has opted out of seller emails" do
+      before { purchase.update!(can_contact: false) }
+
+      it "does not send anything" do
+        expect(PostSendgridApi).not_to receive(:process)
+        described_class.new.perform(purchase.id)
+      end
+    end
   end
 end

--- a/spec/support/fixtures/vcr_cassettes/Api_Mobile_SalesController/POST_send_post/does_not_resend_to_a_customer_who_has_unsubscribed.yml
+++ b/spec/support/fixtures/vcr_cassettes/Api_Mobile_SalesController/POST_send_post/does_not_resend_to_a_customer_who_has_unsubscribed.yml
@@ -1,0 +1,659 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_Nl1PPAcn0XGF9q","request_duration_ms":1}}'
+      Idempotency-Key:
+      - 674bc4cd-a036-4285-b924-6bd642c3062f
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 13:27:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Qh90SnP8iGTqVu0bEq8gVBS4yeeAnMIkn7quC2AAVO6xBHSjNWqtIHHEQXkjn91JOQOuXtUt-xixsMij;
+        report-to csp
+      Idempotency-Key:
+      - 674bc4cd-a036-4285-b924-6bd642c3062f
+      Original-Request:
+      - req_a0a9QtzJll3cio
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Qh90SnP8iGTqVu0bEq8gVBS4yeeAnMIkn7quC2AAVO6xBHSjNWqtIHHEQXkjn91JOQOuXtUt-xixsMij&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Qh90SnP8iGTqVu0bEq8gVBS4yeeAnMIkn7quC2AAVO6xBHSjNWqtIHHEQXkjn91JOQOuXtUt-xixsMij&t=1"
+      Request-Id:
+      - req_a0a9QtzJll3cio
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1Ts0waIBOqvOFDrfsshAPTmP",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783776468,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sat, 11 Jul 2026 13:27:48 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1Ts0waIBOqvOFDrfsshAPTmP
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_a0a9QtzJll3cio","request_duration_ms":314}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 13:27:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Qh90SnP8iGTqVu0bEq8gVBS4yeeAnMIkn7quC2AAVO6xBHSjNWqtIHHEQXkjn91JOQOuXtUt-xixsMij;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Qh90SnP8iGTqVu0bEq8gVBS4yeeAnMIkn7quC2AAVO6xBHSjNWqtIHHEQXkjn91JOQOuXtUt-xixsMij&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Qh90SnP8iGTqVu0bEq8gVBS4yeeAnMIkn7quC2AAVO6xBHSjNWqtIHHEQXkjn91JOQOuXtUt-xixsMij&t=1"
+      Request-Id:
+      - req_hoS1qwkVQGrDKR
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1Ts0waIBOqvOFDrfsshAPTmP",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783776468,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sat, 11 Jul 2026 13:27:48 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=You+bought+http%3A%2F%2Fedgar8dbe8dc710.test.gumroad.com%3A31337%2Fl%2Fg%21&metadata[purchase]=8LXoEfQ5DtpQ832aqcF9bw%3D%3D&transfer_group=3577&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1Ts0waIBOqvOFDrfsshAPTmP&statement_descriptor_suffix=edgar8dbe8dc710
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_hoS1qwkVQGrDKR","request_duration_ms":148}}'
+      Idempotency-Key:
+      - 9c64d811-3891-43c6-bffb-b54ac0ed993d
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 13:27:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1640'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Qh90SnP8iGTqVu0bEq8gVBS4yeeAnMIkn7quC2AAVO6xBHSjNWqtIHHEQXkjn91JOQOuXtUt-xixsMij;
+        report-to csp
+      Idempotency-Key:
+      - 9c64d811-3891-43c6-bffb-b54ac0ed993d
+      Original-Request:
+      - req_jtIegKGCil4g35
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Qh90SnP8iGTqVu0bEq8gVBS4yeeAnMIkn7quC2AAVO6xBHSjNWqtIHHEQXkjn91JOQOuXtUt-xixsMij&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Qh90SnP8iGTqVu0bEq8gVBS4yeeAnMIkn7quC2AAVO6xBHSjNWqtIHHEQXkjn91JOQOuXtUt-xixsMij&t=1"
+      Request-Id:
+      - req_jtIegKGCil4g35
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3Ts0waIBOqvOFDrf0vm2edLd",
+          "object": "payment_intent",
+          "amount": 100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 100,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3Ts0waIBOqvOFDrf0vm2edLd_secret_WPBOBwm5uf4z0mwWjVEHmpzYW",
+          "confirmation_method": "automatic",
+          "created": 1783776468,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgar8dbe8dc710.test.gumroad.com:31337/l/g!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3Ts0waIBOqvOFDrf04sDXs2r",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "8LXoEfQ5DtpQ832aqcF9bw=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1Ts0waIBOqvOFDrfsshAPTmP",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar8dbe8dc710",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "3577"
+        }
+  recorded_at: Sat, 11 Jul 2026 13:27:49 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3Ts0waIBOqvOFDrf04sDXs2r?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_jtIegKGCil4g35","request_duration_ms":967}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 11 Jul 2026 13:27:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3761'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Qh90SnP8iGTqVu0bEq8gVBS4yeeAnMIkn7quC2AAVO6xBHSjNWqtIHHEQXkjn91JOQOuXtUt-xixsMij;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Qh90SnP8iGTqVu0bEq8gVBS4yeeAnMIkn7quC2AAVO6xBHSjNWqtIHHEQXkjn91JOQOuXtUt-xixsMij&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Qh90SnP8iGTqVu0bEq8gVBS4yeeAnMIkn7quC2AAVO6xBHSjNWqtIHHEQXkjn91JOQOuXtUt-xixsMij&t=1"
+      Request-Id:
+      - req_PYTTuqAM8lFeqO
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3Ts0waIBOqvOFDrf04sDXs2r",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3Ts0waIBOqvOFDrf0G6VufBK",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1784332800,
+            "balance_type": "payments",
+            "created": 1783776468,
+            "currency": "usd",
+            "description": "You bought http://edgar8dbe8dc710.test.gumroad.com:31337/l/g!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3Ts0waIBOqvOFDrf04sDXs2r",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR8DBE8DC71",
+          "captured": true,
+          "created": 1783776468,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar8dbe8dc710.test.gumroad.com:31337/l/g!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "8LXoEfQ5DtpQ832aqcF9bw=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 36,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3Ts0waIBOqvOFDrf0vm2edLd",
+          "payment_method": "pm_1Ts0waIBOqvOFDrfsshAPTmP",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "311750",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKNWJydIGMgan52uECIk6LBZgVrkS_ibyAtgtcNsQhtbuHS0U0w-G0RaYywB-vOa2QwxKOAOViS6EJFxR",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar8dbe8dc710",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "3577"
+        }
+  recorded_at: Sat, 11 Jul 2026 13:27:49 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## What

Adds a `can_contact?` guard to every per-customer post-send path that was missing it, so sellers can no longer email buyers who have unsubscribed:

- `PostsController#send_for_purchase` (the "Send missed posts" resend button on the customers page) now returns 422 with "This customer has unsubscribed from your emails." instead of sending.
- `Api::Mobile::SalesController#send_post` (the mobile app's resend) gets the same guard.
- `SendLastPostJob` (the post-purchase "last post" welcome email) returns early when the purchase has `can_contact` off.
- `CustomerPresenter#missed_posts` returns `[]` for unsubscribed purchases, so the customers page no longer offers "Send" buttons that would only error.

## Why

Fixes antiwork/gumroad-private#1043. The unsubscribe flag (`purchase.can_contact`) was silently ignored on the resend paths: the single-customer email endpoint gates correctly (`SingleCustomerEmailsController#customer_can_receive_email?`), and blasts exclude unsubscribed buyers via `AudienceMember`, but `send_for_purchase` / `send_post` / `SendLastPostJob` called `PostEmailApi.process` with no check. Live prod evidence in the issue: a buyer with `can_contact = false` (stable since July 2) received 11 seller emails across 4 unsubscribed purchases via the resend path, 5 of them in one morning.

## Test plan

- New controller spec: `send_for_purchase` returns 422 and does not call the email API for an unsubscribed purchase (`spec/controllers/posts_controller_spec.rb`).
- New mobile spec: `send_post` returns 422 for an unsubscribed purchase (`spec/controllers/api/mobile/sales_controller_spec.rb`).
- New job spec: `SendLastPostJob` sends nothing when `can_contact` is off (`spec/sidekiq/send_last_post_job_spec.rb`).
- New presenter spec: `missed_posts` is empty for an unsubscribed purchase (`spec/presenters/customer_presenter_spec.rb`).
- Ran locally: full `send_for_purchase` block (9 examples), `send_post` block (5), `SendLastPostJob` (5), `CustomerPresenter` (18) — all green. Rubocop clean on all touched files.

## Before/After

Not applicable — no visual change beyond the "Send missed posts" card no longer appearing for unsubscribed customers (data-driven, existing empty-state behavior).
