### PR TITLE
Follow-up to #5805: unless guard + drop dead spec setup

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -62,7 +62,7 @@ class PostsController < ApplicationController
     # never receive seller emails, including per-customer resends from the
     # customers page. The blast path already excludes these buyers (they have no
     # AudienceMember row); this keeps the resend path consistent with it.
-    if !purchase.can_contact?
+    unless purchase.can_contact?
       return render json: { message: "This customer has unsubscribed from your emails." }, status: :unprocessable_entity
     end
 

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -69,7 +69,6 @@ describe PostsController, type: :controller, inertia: true do
 
       it "does not resend to a customer who has unsubscribed" do
         @purchase.update!(can_contact: false)
-        @purchase.create_url_redirect!
 
         expect(PostSendgridApi).to_not receive(:process)
         get :send_for_purchase, params: { id: @post.external_id, purchase_id: @purchase.external_id }


### PR DESCRIPTION
## What

Follow-up to #5805, addressing Greptile's review on that PR (both P2 findings, which landed after the merge):

- `PostsController#send_for_purchase`: the negated `can_contact?` guard now uses `unless`, matching the mobile sibling endpoint's style for the same check.
- `spec/controllers/posts_controller_spec.rb`: removes a `create_url_redirect!` call from the unsubscribed-customer example — the guard returns before the controller ever reads the redirect, so the setup was dead and implied a requirement that doesn't exist.

## Why

#5805 merged before its review landed, so the branch was frozen. Both findings are valid style/clarity fixes with no behavior change.

## Test plan

- Ran locally: full `send_for_purchase` block — 9 examples, 0 failures.
- Rubocop clean on both touched files.

## Before/After

Not applicable — no user-facing change.
