### PR TITLE
Multiple storefronts per account ("many Gumroads, one payout")

### DIFF
--- a/app/models/storefront.rb
+++ b/app/models/storefront.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# A storefront is a separately-branded "Gumroad" that lives under one account: the account (User)
+# is the person — login, identity, payout details — while each storefront carries its own public
+# name, username, and bio. This lets a creator run multiple brands that all pay out through the
+# same account, instead of juggling separate accounts with duplicated bank details.
+#
+# v1 keeps this additive: the account's own username/profile keeps working unchanged as the first
+# brand, and extra storefronts are created on top. Products are assigned to at most one storefront;
+# unassigned products keep showing on the account's main profile.
+class Storefront < ApplicationRecord
+  include ExternalId, Deletable
+
+  belongs_to :seller, class_name: "User"
+
+  has_many :storefront_products, dependent: :destroy
+  has_many :products, through: :storefront_products, source: :link
+
+  validates :username, presence: true,
+                       length: { minimum: 3, maximum: 20 },
+                       exclusion: { in: DENYLIST },
+                       # Same shape as account usernames: lower case letters and numbers only,
+                       # at least one letter — the username becomes a subdomain, so the rules
+                       # must match what account usernames allow.
+                       format: { with: /\A[a-z0-9]*[a-z][a-z0-9]*\z/, message: "has to contain at least one letter and may only contain lower case letters and numbers." }
+  validates :username, uniqueness: { case_sensitive: true, conditions: -> { alive } }, if: :username_changed?
+  validate :username_not_taken_by_an_account, if: :username_changed?
+  validates :name, length: { maximum: 100 }
+  validates :bio, length: { maximum: 3_000 }
+
+  def self.find_by_username(username, scope: alive)
+    username = username.to_s
+    return if username.blank?
+
+    # Hostnames use hyphens where usernames use underscores (same convention as account
+    # subdomains), so convert before looking up.
+    scope.find_by(username: username.tr("-", "_"))
+  end
+
+  def subdomain
+    Subdomain.from_username(username)
+  end
+
+  def subdomain_with_protocol
+    "#{PROTOCOL}://#{subdomain}"
+  end
+
+  def profile_url
+    subdomain_with_protocol
+  end
+
+  private
+    # Storefront usernames and account usernames share one public namespace — both resolve at
+    # <username>.gumroad.com — so a storefront can never claim a handle an account already uses.
+    def username_not_taken_by_an_account
+      return if username.blank?
+
+      errors.add(:username, "is already taken.") if User.exists?(username:)
+    end
+end

--- a/app/models/storefront_product.rb
+++ b/app/models/storefront_product.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Assigns a product to a storefront (see Storefront). A product can belong to at most one
+# storefront — enforced by a unique index on link_id — and products with no assignment keep
+# showing on the account's main profile, which preserves the behavior of every existing product.
+class StorefrontProduct < ApplicationRecord
+  belongs_to :storefront
+  belongs_to :product, class_name: "Link", foreign_key: :link_id
+
+  validates :link_id, uniqueness: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -107,6 +107,9 @@ class User < ApplicationRecord
   has_many :available_cross_sells, -> { cross_sell.alive.available_to_customers }, foreign_key: :seller_id, class_name: "Upsell"
   has_many :blocked_customer_objects, foreign_key: :seller_id
   has_one :seller_profile, foreign_key: :seller_id
+  # Additional branded storefronts under this account ("multiple Gumroads, one payout"). The
+  # account's own username/profile continues to act as the first brand; these are extra ones.
+  has_many :storefronts, foreign_key: :seller_id
   has_one :page, as: :pageable, dependent: :destroy, autosave: true
   delegate :custom_html, to: :page, allow_nil: true
   has_many :seller_profile_sections, foreign_key: :seller_id

--- a/db/migrate/20261206000000_create_storefronts.rb
+++ b/db/migrate/20261206000000_create_storefronts.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# First slice of "multiple storefronts per account": an account (User) keeps login, identity, and
+# payout details, while each storefront is a separately-named brand the account sells under. This
+# creates the storefront records themselves plus the assignment of products to a storefront.
+# Existing accounts are untouched — their current username/profile keeps working as-is, and
+# storefronts are purely additive on top.
+class CreateStorefronts < ActiveRecord::Migration[7.1]
+  def change
+    create_table :storefronts do |t|
+      t.references :seller, null: false
+      # The storefront's public handle: it resolves at <username>.gumroad.com and
+      # gumroad.com/<username>, so it must be unique. Uniqueness against account usernames
+      # (the users table) is enforced in the model since it spans two tables.
+      t.string :username, null: false
+      t.string :name
+      t.text :bio
+      # Soft delete (Deletable concern) so a removed storefront is recoverable and its
+      # username can be audited.
+      t.datetime :deleted_at
+
+      t.timestamps
+    end
+
+    add_index :storefronts, :username, unique: true
+
+    create_table :storefront_products do |t|
+      t.references :storefront, null: false
+      t.references :link, null: false
+
+      t.timestamps
+    end
+
+    # A product belongs to at most one storefront. Products with no row here keep showing on
+    # the account's main profile, which is how every existing product behaves.
+    add_index :storefront_products, :link_id, unique: true
+  end
+end


### PR DESCRIPTION
## What

v1 of multiple storefronts per account: the account is the person (login, identity, payouts), and each storefront is "a Gumroad" — its own brand name, username, and public page, all paying out through the one account.

Direction per antiwork/gumroad-private#1045: storefronts are the core interface, not a managed list — you switch between them like team accounts, and you create products in the context of the storefront you're in.

## Plan

- [x] `Storefront` + `StorefrontProduct` models and migration (username shares the public namespace with account usernames)
- [ ] Public page resolution: `<storefront-username>.gumroad.com` renders the storefront's profile + its products
- [ ] Storefront switcher in the nav (same pattern as team switcher) with inline "Create a new Gumroad"
- [ ] Product creation scoped to the active storefront
- [ ] Account's existing username/profile acts as the first storefront — no migration of existing data
- [ ] Everything behind the `multiple_storefronts` feature flag
- [ ] Screenshots

Draft until clickable end-to-end with screenshots.
