### PR TITLE
Redirect bundle purchases to the library on the main app domain

### DIFF
--- a/app/controllers/url_redirects_controller.rb
+++ b/app/controllers/url_redirects_controller.rb
@@ -324,7 +324,17 @@ class UrlRedirectsController < ApplicationController
     def redirect_bundle_purchase_to_library_if_needed
       return unless @url_redirect.purchase&.is_bundle_purchase?
 
-      redirect_to library_url(bundles: @url_redirect.purchase.link.external_id, purchase_id: params[:receipt] && @url_redirect.purchase.external_id)
+      # Build the library URL on the main app domain explicitly. This redirect can run after
+      # redirect_to_custom_domain_if_needed has already moved the request onto the seller's
+      # subdomain (or custom domain), and /library requires authentication. A signed-out buyer
+      # would get bounced to /login on the seller's host, which isn't routed there and 404s.
+      # Pinning the host to the app domain keeps the login redirect on a host that routes it.
+      redirect_to library_url(
+        bundles: @url_redirect.purchase.link.external_id,
+        purchase_id: params[:receipt] && @url_redirect.purchase.external_id,
+        host: DOMAIN,
+        protocol: PROTOCOL
+      ), allow_other_host: true
     end
 
     def redirect_to_coffee_page_if_needed

--- a/spec/controllers/url_redirects_controller_spec.rb
+++ b/spec/controllers/url_redirects_controller_spec.rb
@@ -281,7 +281,16 @@ describe UrlRedirectsController, inertia: true do
           expect do
             get :download_page, params: { id: purchase.url_redirect.token }
           end.not_to change(ConsumptionEvent, :count)
-          expect(response).to redirect_to(library_url({ bundles: purchase.link.external_id }))
+          expect(response).to redirect_to(library_url({ bundles: purchase.link.external_id, host: DOMAIN, protocol: PROTOCOL }))
+        end
+
+        it "redirects to the library page on the app domain even when requested from the seller's subdomain" do
+          # Regression test: /library requires authentication, and /login is not routed on
+          # seller subdomains or custom domains. If this redirect kept the seller's host, a
+          # signed-out buyer would be bounced to /login on that host and get a 404.
+          @request.host = "#{purchase.seller.username}.test.gumroad.com"
+          get :download_page, params: { id: purchase.url_redirect.token }
+          expect(response).to redirect_to(library_url({ bundles: purchase.link.external_id, host: DOMAIN, protocol: PROTOCOL }))
         end
 
         context "when the url_redirect doesn't belong to a product" do
@@ -295,14 +304,14 @@ describe UrlRedirectsController, inertia: true do
             expect do
               get :download_page, params: { id: purchase.url_redirect.token }
             end.not_to change(ConsumptionEvent, :count)
-            expect(response).to redirect_to(library_url({ bundles: purchase.link.external_id }))
+            expect(response).to redirect_to(library_url({ bundles: purchase.link.external_id, host: DOMAIN, protocol: PROTOCOL }))
           end
         end
 
         context "when the receipt parameter is present" do
           it "includes the purchase_id parameter when redirecting" do
             get :download_page, params: { id: purchase.url_redirect.token, receipt: true }
-            expect(response).to redirect_to(library_url({ bundles: purchase.link.external_id, purchase_id: purchase.external_id }))
+            expect(response).to redirect_to(library_url({ bundles: purchase.link.external_id, purchase_id: purchase.external_id, host: DOMAIN, protocol: PROTOCOL }))
           end
         end
       end


### PR DESCRIPTION
## What

Builds the bundle-purchase library redirect URL explicitly on the main app domain (`host: DOMAIN`), instead of the current request host, in `UrlRedirectsController#redirect_bundle_purchase_to_library_if_needed`.

## Why

A signed-out buyer clicking "View content" in a bundle receipt dead-ends in a 404:

```
GET https://<seller>.gumroad.com/d/<token>        (custom_domain_download moved the request to the seller subdomain)
→ 302 https://<seller>.gumroad.com/library?bundles=...
→ 302 https://<seller>.gumroad.com/login?next=%2Flibrary%3F...
→ 404
```

The chain:

1. `redirect_to_custom_domain_if_needed` moves `/d/<token>` onto the seller's subdomain.
2. `redirect_bundle_purchase_to_library_if_needed` then redirects to `library_url(...)`, which `default_url_options` builds on the **current** host — the seller subdomain.
3. `/library` requires authentication, so unauthenticated buyers get bounced to `/login?next=...` on the same subdomain.
4. `/login` is only routed inside `GumroadDomainConstraint` (`gumroad.com` / `app.gumroad.com`), not in `UserCustomDomainConstraint` — so seller subdomains and custom domains 404 it.

Non-bundle purchases don't hit this because their download page renders directly on the subdomain without requiring login. Pinning the library URL to `DOMAIN` keeps the login redirect on a host that actually routes `/login`; after sign-in the buyer lands in their library with the bundle filter applied.

Reproduced live on production before this change (redirect chain above, ending in Page Not Found).

Tracking issue: antiwork/gumroad-private#1048

## Test plan

- Updated the three existing bundle-redirect controller specs to expect the app-domain URL.
- Added a regression spec that issues the request from a seller-subdomain host and asserts the redirect targets the main app domain.
- Note: the whole "with a bundle purchase" describe group (including the pre-existing examples) currently fails in my local worktree at the shared top-level `before` (purchase factory card tokenization, `Validation failed: We couldn't charge your card`) — verified the identical failure on unmodified `origin/main`, so it's a local environment issue, not this diff. CI is the verifier for this group.
- Rubocop clean on both changed files.

## Before/After

Not applicable — no UI change; a broken redirect chain (404) now lands on the buyer's library page.
