### PR TITLE
Persist purchase url_parameters so PayPal sale webhooks include url_params

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -70,12 +70,6 @@ class Purchase < ApplicationRecord
   attr_json_data_accessor :custom_fee_per_thousand
   attr_json_data_accessor :last_content_page_id
   attr_json_data_accessor :default_offer_code_id
-  # Custom query params the buyer had on the product URL (e.g. ?discord_id=x), minus
-  # reserved ones. Persisted here (not an attr_accessor) because the "purchase
-  # successful" webhook can fire from a freshly loaded Purchase — PayPal captures,
-  # webhook-driven status syncs — long after the checkout request that knew the
-  # params has ended. Sellers rely on these reaching the sale ping as `url_params`.
-  attr_json_data_accessor :url_parameters
   # Buyer-presentment purchases only: the canonical USD gross the dispute-loss balance
   # debit actually booked. Snapshotted at debit time so the dispute-won re-credit books
   # exactly the same amount, even when refunds land between the debit and the win.
@@ -127,6 +121,7 @@ class Purchase < ApplicationRecord
   has_one :recommended_purchase_info, dependent: :destroy
   has_one :purchase_wallet_type
   has_one :purchase_payment_flow, dependent: :destroy, validate: false
+  has_one :purchase_url_parameter, autosave: true, dependent: :destroy
   has_one :purchase_offer_code_discount
   has_one :purchasing_power_parity_info, dependent: :destroy
   has_one :upsell_purchase, dependent: :destroy
@@ -2775,6 +2770,23 @@ class Purchase < ApplicationRecord
 
   def sync_status_with_charge_processor(mark_as_failed: false)
     Purchase::SyncStatusWithChargeProcessorService.new(self, mark_as_failed:).perform
+  end
+
+  # Custom query params the buyer had on the product URL at checkout (e.g. ?discord_id=x),
+  # minus reserved ones. Persisted in an associated record (not an attr_accessor) because
+  # the "purchase successful" webhook can fire from a freshly loaded Purchase — PayPal
+  # captures, webhook-driven status syncs — long after the checkout request that knew the
+  # params has ended. Sellers rely on these reaching the sale ping as `url_params`.
+  def url_parameters
+    purchase_url_parameter&.params
+  end
+
+  def url_parameters=(params)
+    if params.blank?
+      purchase_url_parameter&.mark_for_destruction
+    else
+      (purchase_url_parameter || build_purchase_url_parameter).params = params
+    end
   end
 
   def formatted_error_code

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -2778,12 +2778,21 @@ class Purchase < ApplicationRecord
   # captures, webhook-driven status syncs — long after the checkout request that knew the
   # params has ended. Sellers rely on these reaching the sale ping as `url_params`.
   def url_parameters
-    purchase_url_parameter&.params
+    record = purchase_url_parameter
+    return nil if record.nil? || record.marked_for_destruction?
+    record.params
   end
 
   def url_parameters=(params)
     if params.blank?
-      purchase_url_parameter&.mark_for_destruction
+      # Assigning blank clears any previously assigned value. A record that was
+      # never saved can simply be dropped; a persisted one is marked so autosave
+      # deletes it on the next save.
+      if purchase_url_parameter&.new_record?
+        self.purchase_url_parameter = nil
+      else
+        purchase_url_parameter&.mark_for_destruction
+      end
     else
       (purchase_url_parameter || build_purchase_url_parameter).params = params
     end

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -70,6 +70,12 @@ class Purchase < ApplicationRecord
   attr_json_data_accessor :custom_fee_per_thousand
   attr_json_data_accessor :last_content_page_id
   attr_json_data_accessor :default_offer_code_id
+  # Custom query params the buyer had on the product URL (e.g. ?discord_id=x), minus
+  # reserved ones. Persisted here (not an attr_accessor) because the "purchase
+  # successful" webhook can fire from a freshly loaded Purchase — PayPal captures,
+  # webhook-driven status syncs — long after the checkout request that knew the
+  # params has ended. Sellers rely on these reaching the sale ping as `url_params`.
+  attr_json_data_accessor :url_parameters
   # Buyer-presentment purchases only: the canonical USD gross the dispute-loss balance
   # debit actually booked. Snapshotted at debit time so the dispute-won re-credit books
   # exactly the same amount, even when refunds land between the debit and the win.
@@ -585,7 +591,7 @@ class Purchase < ApplicationRecord
             check_for_column: false
 
   attr_accessor :chargeable, :card_data_handling_error, :save_card, :price_range, :friend_actions,
-                :discount_code, :url_parameters, :purchaser_plugins, :is_automatic_charge, :sales_tax_country_code_election, :business_vat_id,
+                :discount_code, :purchaser_plugins, :is_automatic_charge, :sales_tax_country_code_election, :business_vat_id,
                 :save_shipping_address, :flow_of_funds, :prorated_discount_price_cents,
                 :original_variant_attributes, :original_price, :is_updated_original_subscription_purchase,
                 :is_applying_plan_change, :setup_intent, :charge_intent, :setup_future_charges, :skip_preparing_for_charge,

--- a/app/models/purchase_url_parameter.rb
+++ b/app/models/purchase_url_parameter.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Stores the custom query parameters the buyer had on the product URL at checkout
+# (e.g. ?discord_id=x&plan=y), minus Gumroad's own reserved params. Sellers who
+# deliver products through ping webhooks rely on getting these back as the ping's
+# `url_params` field.
+#
+# This lives in its own table rather than on `purchases` because:
+#   * the value must survive a database reload — asynchronous payment flows
+#     (PayPal captures, webhook-driven status syncs) mark the purchase successful
+#     on a freshly loaded Purchase, long after the checkout request ended, and
+#     an in-memory attribute would be lost by then;
+#   * `purchases.json_data` is a varchar(255), far too small for arbitrary
+#     buyer-supplied params;
+#   * the `purchases` table is too large to ALTER on the deploy path.
+class PurchaseUrlParameter < ApplicationRecord
+  belongs_to :purchase
+
+  validates :params, presence: true
+end

--- a/db/migrate/20261205000003_create_purchase_url_parameters.rb
+++ b/db/migrate/20261205000003_create_purchase_url_parameters.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreatePurchaseUrlParameters < ActiveRecord::Migration[7.1]
+  def change
+    create_table :purchase_url_parameters do |t|
+      t.references :purchase, index: { unique: true }, null: false
+      t.json :params, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_12_05_000002) do
+ActiveRecord::Schema[7.1].define(version: 2026_12_05_000003) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -1898,6 +1898,14 @@ ActiveRecord::Schema[7.1].define(version: 2026_12_05_000002) do
     t.decimal "pst_tax_rate", precision: 8, scale: 7
     t.decimal "qst_tax_rate", precision: 8, scale: 7
     t.index ["purchase_id"], name: "index_purchase_taxjar_infos_on_purchase_id"
+  end
+
+  create_table "purchase_url_parameters", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "purchase_id", null: false
+    t.json "params", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["purchase_id"], name: "index_purchase_url_parameters_on_purchase_id", unique: true
   end
 
   create_table "purchase_wallet_types", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/spec/models/purchase/purchase_notification_spec.rb
+++ b/spec/models/purchase/purchase_notification_spec.rb
@@ -25,6 +25,19 @@ describe "Purchase Notifications", :vcr do
       expect(PostToPingEndpointsWorker).to have_enqueued_sidekiq_job(purchase.id, purchase.url_parameters)
     end
 
+    it "includes the buyer's URL parameters even when the webhook fires from a freshly loaded purchase" do
+      # PayPal (and other asynchronous payment flows) mark the purchase successful on a
+      # Purchase loaded fresh from the database, not the instance built during checkout.
+      # The URL parameters must survive that round trip so the sale ping still carries them.
+      purchase = create(:purchase)
+      purchase.url_parameters = { "discord_id" => "123", "plan" => "pro" }
+      purchase.save!
+
+      Purchase.find(purchase.id).send_notification_webhook
+
+      expect(PostToPingEndpointsWorker).to have_enqueued_sidekiq_job(purchase.id, { "discord_id" => "123", "plan" => "pro" })
+    end
+
     it "does not schedule a PostToPingEndpointsWorker job if the transaction creating the purchase was rolled back" do
       Purchase.transaction do
         create(:purchase).send_notification_webhook

--- a/spec/models/purchase/purchase_notification_spec.rb
+++ b/spec/models/purchase/purchase_notification_spec.rb
@@ -169,5 +169,18 @@ describe "Purchase Notifications", :vcr do
 
       expect(PostToPingEndpointsWorker).to have_enqueued_sidekiq_job(purchase.id, nil, ResourceSubscription::REFUNDED_RESOURCE_NAME)
     end
+
+    it "includes the buyer's URL parameters even when the refund webhook fires from a freshly loaded purchase" do
+      # Refunds are processed long after checkout, so the refund ping always fires from a
+      # Purchase loaded fresh from the database. The URL parameters captured at checkout
+      # must survive that round trip so the refund ping still carries them.
+      purchase = create(:purchase)
+      purchase.url_parameters = { "discord_id" => "123", "plan" => "pro" }
+      purchase.save!
+
+      Purchase.find(purchase.id).send(:send_refunded_notification_webhook)
+
+      expect(PostToPingEndpointsWorker).to have_enqueued_sidekiq_job(purchase.id, { "discord_id" => "123", "plan" => "pro" }, ResourceSubscription::REFUNDED_RESOURCE_NAME)
+    end
   end
 end

--- a/spec/models/purchase_url_parameter_spec.rb
+++ b/spec/models/purchase_url_parameter_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe PurchaseUrlParameter do
+  describe "Purchase#url_parameters accessors" do
+    let(:purchase) { build(:purchase) }
+
+    it "returns nil when nothing has been assigned" do
+      expect(purchase.url_parameters).to be_nil
+    end
+
+    it "stores an assigned hash in the associated record" do
+      purchase.url_parameters = { "discord_id" => "123" }
+
+      expect(purchase.url_parameters).to eq("discord_id" => "123")
+      expect(purchase.purchase_url_parameter.params).to eq("discord_id" => "123")
+    end
+
+    it "returns nil after a previously assigned value is overwritten with nil" do
+      # Purchase::CreateService mass-assigns the raw url_parameters string when
+      # building the purchase, then assigns the parsed value afterwards — which
+      # is nil when the string isn't valid JSON. Clearing must fully discard the
+      # earlier assignment.
+      purchase.url_parameters = "{{"
+      purchase.url_parameters = nil
+
+      expect(purchase.url_parameters).to be_nil
+      expect(purchase.purchase_url_parameter).to be_nil
+    end
+
+    it "persists the value across a database reload" do
+      purchase = create(:purchase)
+      purchase.url_parameters = { "discord_id" => "123", "plan" => "pro" }
+      purchase.save!
+
+      expect(Purchase.find(purchase.id).url_parameters).to eq("discord_id" => "123", "plan" => "pro")
+    end
+
+    it "destroys the persisted record when cleared and saved" do
+      purchase = create(:purchase)
+      purchase.url_parameters = { "discord_id" => "123" }
+      purchase.save!
+
+      reloaded = Purchase.find(purchase.id)
+      reloaded.url_parameters = nil
+
+      expect(reloaded.url_parameters).to be_nil
+
+      reloaded.save!
+
+      expect(Purchase.find(purchase.id).url_parameters).to be_nil
+      expect(PurchaseUrlParameter.where(purchase_id: purchase.id)).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## What

Persists a purchase's `url_parameters` in a new `purchase_url_parameters` table (one row per purchase, `json` column, autosaved association) instead of keeping them in a request-lifetime `attr_accessor`. No call sites change — `purchase.url_parameters` and `purchase.url_parameters=` keep the same interface, but the value now survives a database reload.

## Why

Sellers who deliver products via ping webhooks pass custom query params on the product URL (e.g. `?discord_id=x&plan=y`) and expect them back in the sale ping's `url_params` field. That worked for Stripe card purchases but was **always empty for PayPal purchases**.

Root cause: the sale webhook is enqueued from the `any => successful` state-machine transition, which reads `url_parameters` off whatever Purchase instance runs the transition. Stripe's synchronous path marks success on the same in-memory instance checkout built, so the accessor still holds the params. The PayPal path reloads the purchase (`Purchase.find_by_external_id` in `PaypalChargeProcessor`, PayPal capture/webhook event handling, deferred status syncs) and marks success on the fresh copy — where the `attr_accessor` is `nil`, so `payload[:url_params]` is omitted from the ping.

Persisting the value at checkout means every path that later fires the webhook — PayPal captures, webhook-driven syncs, refund/dispute/dispute-won pings that also pass `purchase.url_parameters` — reads the real value. Refund and dispute pings always fire off reloaded instances, so those were silently dropping the params for every payment method; this fixes them too.

A dedicated table is used rather than `purchases.json_data` because that column is a `varchar(255)` (too small for arbitrary buyer-supplied params) and the `purchases` table is too large to ALTER on the deploy path.

Refs: antiwork/gumroad-private#1049

## Test plan

- New regression specs: set `url_parameters`, save, reload the purchase via `Purchase.find`, fire `send_notification_webhook` / `send_refunded_notification_webhook`, and assert the enqueued `PostToPingEndpointsWorker` job carries the params — exactly the PayPal-shaped lifecycle that was broken.
- Verified the persistence round-trip locally against MySQL with `rails runner`: writer builds the associated record, value survives `Purchase.find`, and setting `nil` marks the record for destruction.
- Migration run locally; `db/schema.rb` updated from the actual migration run.
- `rubocop` clean on all changed files.
- Note: the surrounding examples in `purchase_notification_spec.rb` fail identically on unmodified `origin/main` in this local worktree (missing merchant-account/VCR seed data) — pre-existing environment issue, not introduced by this change. CI is the authoritative run.

## Before/After

Not applicable — backend-only change; no user-facing rendering is affected. The observable change is the webhook payload: PayPal sale pings (and refund/dispute pings) now include `url_params` when the product URL carried custom query params.
