### PR TITLE
Reorder web Dockerfile layers so the full-tree COPY comes last

### DIFF
--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -16,24 +16,6 @@ RUN useradd -ms /bin/bash app \
   && mkdir -p $APP_DIR/log \
   && mkdir -p $APP_DIR/tmp
 
-COPY . $APP_DIR/
-
-# Dowload latest GeoIP DB
-RUN cd /tmp \
-  && curl -J -L -o GeoIP2-City.tar.gz https://download.maxmind.com/app/geoip_download\?edition_id\=GeoIP2-City\&license_key\=fxN7iBPUYfTS76V5\&suffix\=tar.gz \
-  && tar xzf GeoIP2-City.tar.gz \
-  && mv GeoIP2-City_* GeoIP2-City \
-  && mv GeoIP2-City/GeoIP2-City.mmdb $APP_DIR/lib/GeoIP2-City.mmdb \
-  && rm -rf /tmp/*
-
-# TODO: look into solutions that prevent image bloating and/or avoids --squash
-RUN chmod -R 755 $BUNDLE_PATH \
-  && chmod -R 755 $APP_DIR \
-  && chmod -R 770 $APP_DIR/tmp \
-  && chmod -R 770 $APP_DIR/log \
-  && chown -R app:app $APP_DIR \
-  && chown -R root:app $BUNDLE_PATH
-
 # Update ImageMagick configuration
 # Set memory limit to 1GiB
 RUN sed -r 's/(name="memory" value=")[^"]+"/\11GiB"/' -i /etc/ImageMagick-6/policy.xml \
@@ -44,10 +26,38 @@ RUN sed -r 's/(name="memory" value=")[^"]+"/\11GiB"/' -i /etc/ImageMagick-6/poli
   # Change height limit from 10KP to 50KP
   && sed -r 's/(name="height" value=")[^"]+"/\150KP"/' -i /etc/ImageMagick-6/policy.xml
 
+# Dowload latest GeoIP DB
+# Staged outside $APP_DIR so this layer stays cached across source changes;
+# moved into place after the full-tree COPY below.
+RUN cd /tmp \
+  && curl -J -L -o GeoIP2-City.tar.gz https://download.maxmind.com/app/geoip_download\?edition_id\=GeoIP2-City\&license_key\=fxN7iBPUYfTS76V5\&suffix\=tar.gz \
+  && tar xzf GeoIP2-City.tar.gz \
+  && mv GeoIP2-City_* GeoIP2-City \
+  && mkdir -p /usr/local/share/geoip \
+  && mv GeoIP2-City/GeoIP2-City.mmdb /usr/local/share/geoip/GeoIP2-City.mmdb \
+  && rm -rf /tmp/*
+
+# Install gems using only the dependency manifests so this (slow) layer is
+# cached unless the Gemfile/lockfile changes.
 ARG BUNDLE_GEMS__CONTRIBSYS__COM
+COPY Gemfile Gemfile.lock .ruby-version $APP_DIR/
 RUN cd $APP_DIR \
   && bundle config set without 'development test' \
   && BUNDLE_GEMS__CONTRIBSYS__COM=$BUNDLE_GEMS__CONTRIBSYS__COM bundle install
+
+# Full source tree last: changes here only invalidate the layers below.
+COPY . $APP_DIR/
+
+RUN mv /usr/local/share/geoip/GeoIP2-City.mmdb $APP_DIR/lib/GeoIP2-City.mmdb \
+  && rmdir /usr/local/share/geoip
+
+# TODO: look into solutions that prevent image bloating and/or avoids --squash
+RUN chmod -R 755 $BUNDLE_PATH \
+  && chmod -R 755 $APP_DIR \
+  && chmod -R 770 $APP_DIR/tmp \
+  && chmod -R 770 $APP_DIR/log \
+  && chown -R app:app $APP_DIR \
+  && chown -R root:app $BUNDLE_PATH
 
 ENV DATABASE_HOST="db" \
   DATABASE_NAME="gumroad_development" \


### PR DESCRIPTION
## What

Reorders `docker/web/Dockerfile` so the full source-tree `COPY . $APP_DIR/` is the last cache-sensitive layer instead of the third. Refs #5802.

New layer order:

1. User/dir setup (unchanged)
2. ImageMagick policy edits — independent of the source tree
3. GeoIP2-City download — staged to `/usr/local/share/geoip`, moved into `$APP_DIR/lib` after the source COPY
4. `bundle install` — copies only `Gemfile`, `Gemfile.lock`, and `.ruby-version` first, so the layer is reused unless dependencies change (`.ruby-version` is needed because the Gemfile declares `ruby file: ".ruby-version"`)
5. `COPY . $APP_DIR/` (full tree)
6. GeoIP mmdb move + permissions/chown (must follow the tree COPY)

## Why

Previously the full-tree COPY sat above the GeoIP download, ImageMagick config, and `bundle install`, so **every commit invalidated all of them** — including an external MaxMind network fetch and a full gem install — even when neither the dependencies nor anything those layers use had changed. With this ordering, a source-only commit reuses the cached download and dependency layers and only re-runs the COPY and the permissions layer, cutting preview/deploy image build time (#5802).

No behavior change to the final image: same files end up in the same places (`$APP_DIR/lib/GeoIP2-City.mmdb`, bundled gems in `$BUNDLE_PATH`), same ENV/WORKDIR/CMD.

## Test plan

- `Gemfile`/`Gemfile.lock`/`.ruby-version` verified present at the build-context root (repo root, per the `Makefile` `--file docker/web/Dockerfile` invocation)
- Verified the Gemfile has no `path:`/local-gem references, so `bundle install` needs only the three copied manifest files
- Build verification via the deploy pipeline: first build after merge populates the cache; a subsequent source-only commit should show `CACHED` for the ImageMagick/GeoIP/bundle layers
- Note: `docker/web/Dockerfile.test` (used by CI `tests.yml`) is untouched — this file is only used by the Makefile/deploy image build
