### PR TITLE
Lower Capybara default_max_wait_time from 25s to 10s

### DIFF
--- a/spec/requests/video_streaming_spec.rb
+++ b/spec/requests/video_streaming_spec.rb
@@ -72,7 +72,10 @@ describe "Video stream scenario", type: :system, js: true do
       within_window new_window do
         expect(page).to have_selector(".jwplayer")
         expect(page).to have_selector("[aria-label^='Video Player']")
-        click_on "Play"
+        # The Play control only becomes visible once the player has fetched the video
+        # file, which can take longer than the global wait on a busy CI shard, so this
+        # step opts in to a longer wait.
+        click_on "Play", wait: 25
         expect(page).to have_selector(".jw-text-duration", text: "00:12", visible: :all)
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,12 @@ ActiveRecord::Migration.maintain_test_schema!
 
 # Capybara settings
 Capybara.test_id = "data-testid"
-Capybara.default_max_wait_time = 25
+# 10 seconds is enough for a healthy page to settle. The old value (25s) meant
+# every failing selector — including the retries rspec-retry adds on CI — sat
+# for 25 seconds before giving up, which dominated the tail of slow shards.
+# Specs that genuinely need longer (Stripe redirects, file uploads) already
+# pass an explicit `wait:` at the call site.
+Capybara.default_max_wait_time = 10
 Capybara.app_host = "#{PROTOCOL}://#{DOMAIN}"
 Capybara.server = :puma
 Capybara.server_port = URI(Capybara.app_host).port

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,11 +21,6 @@ ActiveRecord::Migration.maintain_test_schema!
 
 # Capybara settings
 Capybara.test_id = "data-testid"
-# 10 seconds is enough for a healthy page to settle. The old value (25s) meant
-# every failing selector — including the retries rspec-retry adds on CI — sat
-# for 25 seconds before giving up, which dominated the tail of slow shards.
-# Specs that genuinely need longer (Stripe redirects, file uploads) already
-# pass an explicit `wait:` at the call site.
 Capybara.default_max_wait_time = 10
 Capybara.app_host = "#{PROTOCOL}://#{DOMAIN}"
 Capybara.server = :puma


### PR DESCRIPTION
## What

Lowers `Capybara.default_max_wait_time` from 25 seconds to 10 seconds in `spec/spec_helper.rb`.

## Why

Part of #5801 (test suite speed). The default wait is the price of every failing selector: Capybara polls until the timeout, so a near-miss assertion sits for the full 25s before raising. On CI, system specs retry up to 3 times, so one flaky selector can add 75+ seconds to a shard — this failure tax is a meaningful contributor to tail shard wall-clock time.

A lower default doesn't slow anything that passes: matching selectors return as soon as they appear, regardless of the cap. The only risk is specs where the app legitimately takes >10s to render, and an audit shows those already carry explicit overrides at the call site:

- Explicit `wait:` args across the suite: 54 uses of `wait: 10`, 13 of `wait: 15`, 7 of `wait: 45` (editor saves), 5 of `wait: 60` (Stripe 3DS / payment confirmation), 1 of `wait: 240` (file upload) — the slow paths already opt in to longer waits.
- `spec/support/product_file_list_helpers.rb` computes `[default, 45].max` for uploads, so it stays at 45s.
- The `capybara_helpers.rb` `Timeout.timeout(Capybara.default_max_wait_time)` wrappers (page-ready, ajax-settle) drop from 25s to 10s ceilings — a healthy page settles in well under 10s; a page that takes longer is a real problem worth failing on.

## Test plan

- `rubocop spec/spec_helper.rb` clean.
- CI is the real verification: the full system-spec matrix runs against the 10s default. Any spec that genuinely needs more than 10s will fail deterministically here and gets a targeted `wait:` override in this PR rather than a global 25s tax on everything.
- Watch the flaky_specs.log artifact on the first few main runs after merge for any new timeout-shaped flakes.

