### PR TITLE
Add permanent preview_qa rake tasks for seeding QA state on preview apps

### DIFF
--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -198,29 +198,48 @@ Deployments are removed automatically when the associated branch is deleted in t
 
 ### Rails console on a preview app
 
-Preview apps have Rails console access — see [Connect to Rails console](https://github.com/antiwork/gumroad-deployment/blob/main/docs/ssh.md#connect-to-rails-console) in the deployment repo. The `console.sh` script there resolves the preview instance and opens `rails c` in the running container; it also supports `COMMAND=...` for one-shot commands and a `-w` flag for a writable database connection (the default is a read-only replica).
+Preview apps have Rails console access — see [Connect to Rails console](https://github.com/antiwork/gumroad-deployment/blob/main/docs/ssh.md#connect-to-rails-console) in the deployment repo. The `console.sh` script there resolves the preview instance from the `BRANCH=<branch name>` environment variable (it falls back to the deployment repo's own checked-out branch, so always set it explicitly) and opens `rails c` in the running container. It also supports `COMMAND=...` for one-shot commands — the value is executed directly as the container command, so it must be a runnable program like `bundle exec rake "..."`, not a bare Ruby snippet — and a standalone `-w` flag for a writable database connection (the default is a read-only replica).
 
 ### Seeding QA state with `preview_qa` rake tasks
 
 Use the permanent tasks in `lib/tasks/preview_qa.rake` to seed edge-case state on a preview app instead of adding temporary, param-gated seed hooks to your PR ("TEMP: revert before merge" commits). The tasks only run on preview apps, development, and the test suite — they are unavailable in production and on shared staging (staging.gumroad.com), where mutating records would interfere with other people's testing.
 
-Run them through the console one-shot path with a writable connection, for example:
+Run them through the preview app's Rails console (see the section above for how `console.sh` resolves the branch and the `-w` writable flag — the seeding tasks write, so they need `-w`).
+
+The simplest path is to open an interactive writable console and shell out to rake from the prompt (rake tasks aren't preloaded in a console session, so `bundle exec rake` in a subprocess is the entrypoint):
+
+```shell
+cd nomad/staging/deploy_branch && BRANCH=<branch name> ./console.sh -w
+# then, at the console prompt:
+system 'bundle exec rake "preview_qa:backdate_purchase[<purchase external_id>]"'
+```
+
+Alternatively, run a task as a one-shot. `COMMAND` is executed directly in the container as a shell command (not evaluated as Ruby), so it must be a full `bundle exec rake` invocation:
+
+```shell
+cd nomad/staging/deploy_branch && \
+  BRANCH=<branch name> \
+  COMMAND='bundle exec rake "preview_qa:backdate_purchase[<purchase external_id>]"' \
+  ./console.sh -w
+```
+
+The available tasks (all need the writable connection except `inspect_subscription`, which is read-only):
 
 ```shell
 # Backdate a subscription purchase past its billing period so a renewal charge is due
-COMMAND='Rake::Task["preview_qa:backdate_purchase"].invoke("<purchase external_id>")' ./console.sh -w <branch>
+bundle exec rake "preview_qa:backdate_purchase[<purchase external_id>]"
 
 # Remove the e-mandate linkage from the card charged for a subscription (Indian card QA)
-COMMAND='Rake::Task["preview_qa:clear_mandate"].invoke("<subscription external_id>")' ./console.sh -w <branch>
+bundle exec rake "preview_qa:clear_mandate[<subscription external_id>]"
 
 # Seed a job into the Sidekiq dead set (morgue)
-COMMAND='Rake::Task["preview_qa:seed_dead_job"].invoke("RecurringChargeWorker", "123")' ./console.sh -w <branch>
+bundle exec rake "preview_qa:seed_dead_job[RecurringChargeWorker,123]"
 
 # Run a worker inline, e.g. to force a renewal charge attempt
-COMMAND='Rake::Task["preview_qa:run_worker"].invoke("RecurringChargeWorker", "123")' ./console.sh -w <branch>
+bundle exec rake "preview_qa:run_worker[RecurringChargeWorker,123]"
 
 # Inspect a subscription after a QA run: renewal timing, mandate linkage, recent charges (read-only)
-COMMAND='Rake::Task["preview_qa:inspect_subscription"].invoke("<subscription external_id>")' ./console.sh <branch>
+bundle exec rake "preview_qa:inspect_subscription[<subscription external_id>]"
 ```
 
 Record ids can be passed as either database ids or external ids. If a QA scenario you need isn't covered, add a task to the namespace (with specs) rather than shipping a temporary hook in your feature PR.

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -11,6 +11,8 @@
   - [Logs](#logs)
   - [Hotfixing workers only](#hotfixing-workers-only)
 - [Deploying to a preview app](#deploying-to-a-preview-app)
+  - [Rails console on a preview app](#rails-console-on-a-preview-app)
+  - [Seeding QA state with `preview_qa` rake tasks](#seeding-qa-state-with-preview_qa-rake-tasks)
 - [Deploying to staging](#deploying-to-staging)
 
 ---
@@ -193,3 +195,29 @@ Adding the label triggers a Buildkite build that deploys the branch. Each subseq
 The preview app URL is posted on the pull request as a GitHub deployment: look for the "View deployment" button (and the Deployments section), which shows the deploy in progress and links to the running app once it is ready.
 
 Deployments are removed automatically when the associated branch is deleted in the repository.
+
+### Rails console on a preview app
+
+Preview apps have Rails console access — see [Connect to Rails console](https://github.com/antiwork/gumroad-deployment/blob/main/docs/ssh.md#connect-to-rails-console) in the deployment repo. The `console.sh` script there resolves the preview instance and opens `rails c` in the running container; it also supports `COMMAND=...` for one-shot commands and a `-w` flag for a writable database connection (the default is a read-only replica).
+
+### Seeding QA state with `preview_qa` rake tasks
+
+Use the permanent tasks in `lib/tasks/preview_qa.rake` to seed edge-case state on a preview app instead of adding temporary, param-gated seed hooks to your PR ("TEMP: revert before merge" commits). The tasks are unavailable in production.
+
+Run them through the console one-shot path with a writable connection, for example:
+
+```shell
+# Backdate a subscription purchase past its billing period so a renewal charge is due
+COMMAND='Rake::Task["preview_qa:backdate_purchase"].invoke("<purchase external_id>")' ./console.sh -w <branch>
+
+# Remove the e-mandate linkage from the card charged for a subscription (Indian card QA)
+COMMAND='Rake::Task["preview_qa:clear_mandate"].invoke("<subscription external_id>")' ./console.sh -w <branch>
+
+# Seed a job into the Sidekiq dead set (morgue)
+COMMAND='Rake::Task["preview_qa:seed_dead_job"].invoke("RecurringChargeWorker", "123")' ./console.sh -w <branch>
+
+# Run a worker inline, e.g. to force a renewal charge attempt
+COMMAND='Rake::Task["preview_qa:run_worker"].invoke("RecurringChargeWorker", "123")' ./console.sh -w <branch>
+```
+
+Record ids can be passed as either database ids or external ids. If a QA scenario you need isn't covered, add a task to the namespace (with specs) rather than shipping a temporary hook in your feature PR.

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -218,6 +218,9 @@ COMMAND='Rake::Task["preview_qa:seed_dead_job"].invoke("RecurringChargeWorker", 
 
 # Run a worker inline, e.g. to force a renewal charge attempt
 COMMAND='Rake::Task["preview_qa:run_worker"].invoke("RecurringChargeWorker", "123")' ./console.sh -w <branch>
+
+# Inspect a subscription after a QA run: renewal timing, mandate linkage, recent charges (read-only)
+COMMAND='Rake::Task["preview_qa:inspect_subscription"].invoke("<subscription external_id>")' ./console.sh <branch>
 ```
 
 Record ids can be passed as either database ids or external ids. If a QA scenario you need isn't covered, add a task to the namespace (with specs) rather than shipping a temporary hook in your feature PR.

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -202,7 +202,7 @@ Preview apps have Rails console access — see [Connect to Rails console](https:
 
 ### Seeding QA state with `preview_qa` rake tasks
 
-Use the permanent tasks in `lib/tasks/preview_qa.rake` to seed edge-case state on a preview app instead of adding temporary, param-gated seed hooks to your PR ("TEMP: revert before merge" commits). The tasks are unavailable in production.
+Use the permanent tasks in `lib/tasks/preview_qa.rake` to seed edge-case state on a preview app instead of adding temporary, param-gated seed hooks to your PR ("TEMP: revert before merge" commits). The tasks only run on preview apps, development, and the test suite — they are unavailable in production and on shared staging (staging.gumroad.com), where mutating records would interfere with other people's testing.
 
 Run them through the console one-shot path with a writable connection, for example:
 

--- a/lib/tasks/preview_qa.rake
+++ b/lib/tasks/preview_qa.rake
@@ -172,6 +172,46 @@ if PreviewQa.safe_environment?
       puts "Seeded dead job #{worker_class.name}(#{job_args.map(&:inspect).join(', ')}) into the Sidekiq dead set."
     end
 
+    desc "Print a read-only snapshot of a subscription for QA verification: renewal timing, the charged card's mandate linkage, and recent purchases with charge ids"
+    task :inspect_subscription, [:subscription_id] => :environment do |_task, args|
+      PreviewQa.ensure_safe_environment!
+
+      subscription = PreviewQa.find_record!(Subscription, args[:subscription_id])
+
+      puts "Subscription #{subscription.external_id} (id #{subscription.id})"
+      puts "  alive?: #{subscription.alive?}"
+      puts "  cancelled_at: #{subscription.cancelled_at.inspect}  failed_at: #{subscription.failed_at.inspect}  ended_at: #{subscription.ended_at.inspect}"
+      recurrence = subscription.recurrence
+      if recurrence.present?
+        puts "  recurrence: #{recurrence}  (period: #{(subscription.period / 1.day).round(2)} days)"
+        puts "  free_trial_ends_at: #{subscription.free_trial_ends_at.inspect}" if subscription.free_trial_ends_at.present?
+        puts "  last successful charge at: #{subscription.last_successful_charge_at.inspect}"
+        puts "  end of current period: #{subscription.end_time_of_subscription.inspect}"
+        puts "  overdue_for_charge?: #{subscription.overdue_for_charge?}"
+      else
+        # A subscription without a price/recurrence (possible for bare records in dev/test)
+        # can't have its renewal timing computed — Subscription#period would raise. Note it
+        # instead of crashing the whole snapshot.
+        puts "  recurrence: none (cannot compute renewal timing)"
+      end
+
+      credit_card = subscription.credit_card_to_charge
+      if credit_card.nil?
+        puts "  card to charge: none"
+      else
+        puts "  card to charge: CreditCard #{credit_card.id} (#{credit_card.card_type} #{credit_card.visual})"
+        puts "    stripe_setup_intent_id (e-mandate linkage): #{credit_card.stripe_setup_intent_id.inspect}"
+        puts "    stripe_payment_intent_id: #{credit_card.stripe_payment_intent_id.inspect}"
+      end
+
+      puts "  recent purchases (newest first):"
+      subscription.purchases.order(created_at: :desc).limit(10).each do |record|
+        puts "    #{record.external_id} (id #{record.id})  state=#{record.purchase_state}  " \
+             "succeeded_at=#{record.succeeded_at.inspect}  charge=#{record.stripe_transaction_id.inspect}  " \
+             "#{record.formatted_total_price}"
+      end
+    end
+
     desc "Run a Sidekiq worker inline (synchronously). Usage: preview_qa:run_worker[RecurringChargeWorker,123]"
     task :run_worker, [:worker_class] => :environment do |_task, args|
       PreviewQa.ensure_safe_environment!

--- a/lib/tasks/preview_qa.rake
+++ b/lib/tasks/preview_qa.rake
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+# Permanent QA seed tasks for preview apps (https://github.com/antiwork/gumroad/issues/5806).
+#
+# Before these existed, seeding edge-case state on a preview app (a backdated purchase to force a
+# subscription renewal, a card with no e-mandate, a dead Sidekiq job) meant shipping temporary
+# param-gated hooks in the PR itself, marked "TEMP: revert before merge" — extra commits, review
+# noise, and a real risk of the hook leaking into main. These tasks are reviewed once and reused
+# forever instead.
+#
+# Run them through the preview app's Rails console one-shot path (see "Deploying to a preview app"
+# in docs/deploying.md), for example:
+#
+#   COMMAND='Rake::Task["preview_qa:backdate_purchase"].invoke("<purchase external_id>")' ./console.sh -w <branch>
+#
+# Every task hard-aborts in production; the guard is intentionally belt-and-braces (the whole
+# namespace is skipped when the file loads in production, and each task re-checks at run time in
+# case the file is ever loaded by other means).
+
+module PreviewQa
+  module_function
+
+  def ensure_not_production!
+    abort "preview_qa tasks are for preview/staging QA only and cannot run in production." if Rails.env.production?
+  end
+
+  # Accepts either a numeric database id or an external_id, so you can paste whichever
+  # identifier you have on hand (URLs and admin pages expose external ids).
+  def find_record!(klass, identifier)
+    identifier = identifier.to_s.strip
+    abort "Missing #{klass.name} identifier." if identifier.blank?
+
+    record = if identifier.match?(/\A\d+\z/)
+      klass.find_by(id: identifier)
+    end
+    record ||= klass.find_by_external_id(identifier)
+    abort "Could not find #{klass.name} with id or external_id #{identifier.inspect}." if record.nil?
+    record
+  end
+
+  # Resolves a worker class name and verifies it is actually a Sidekiq job, so the run_worker
+  # task can't be used to instantiate and call arbitrary application classes.
+  def worker_class!(name)
+    abort "Missing worker class name (e.g. preview_qa:run_worker[RecurringChargeWorker,123])." if name.blank?
+
+    klass = name.to_s.safe_constantize
+    unless klass.is_a?(Class) && klass.include?(Sidekiq::Job)
+      abort "#{name.inspect} is not a Sidekiq worker class."
+    end
+    klass
+  end
+
+  # Rake passes every argument as a string; workers usually expect integer ids and booleans.
+  # Casts the obvious scalar types and leaves everything else as a string.
+  def cast_argument(value)
+    case value
+    when /\A-?\d+\z/ then Integer(value)
+    when /\A-?\d+\.\d+\z/ then Float(value)
+    when "true" then true
+    when "false" then false
+    when "nil", "null" then nil
+    else value
+    end
+  end
+end
+
+unless Rails.env.production?
+  namespace :preview_qa do
+    desc "Backdate a purchase's created_at/succeeded_at by N days (default: one billing period + 1 day for subscription purchases) so renewal paths can be exercised"
+    task :backdate_purchase, [:purchase_id, :days] => :environment do |_task, args|
+      PreviewQa.ensure_not_production!
+
+      purchase = PreviewQa.find_record!(Purchase, args[:purchase_id])
+
+      days = args[:days].presence&.to_i
+      if days.nil? && purchase.subscription.present?
+        # Default to just past the subscription's billing period, which is the common case:
+        # make the subscription look overdue so RecurringChargeWorker will actually charge it.
+        days = (purchase.subscription.period / 1.day).ceil + 1
+      end
+      abort "Pass a positive number of days (this purchase has no subscription to derive a billing period from)." if days.nil? || days <= 0
+
+      backdated_to = days.days.ago
+      # update_columns on purpose: this is a QA time-travel edit, and running the full
+      # callback/validation stack against a doctored timestamp is exactly what we don't want.
+      purchase.update_columns(
+        created_at: backdated_to,
+        succeeded_at: (backdated_to if purchase.succeeded_at.present?)
+      )
+
+      puts "Backdated purchase #{purchase.external_id} (id #{purchase.id}) by #{days} days: created_at/succeeded_at now #{backdated_to}."
+    end
+
+    desc "Remove the Stripe e-mandate linkage (stripe_setup_intent_id) from the card charged for a subscription, to QA the missing-mandate path for Indian cards"
+    task :clear_mandate, [:subscription_id] => :environment do |_task, args|
+      PreviewQa.ensure_not_production!
+
+      subscription = PreviewQa.find_record!(Subscription, args[:subscription_id])
+      credit_card = subscription.credit_card_to_charge
+      abort "Subscription #{subscription.external_id} has no chargeable credit card." if credit_card.nil?
+
+      json_data = (credit_card.json_data || {}).deep_stringify_keys
+      removed = json_data.delete("stripe_setup_intent_id")
+      if removed.nil?
+        puts "Credit card #{credit_card.id} for subscription #{subscription.external_id} has no stripe_setup_intent_id; nothing to clear."
+      else
+        credit_card.update!(json_data:)
+        puts "Cleared stripe_setup_intent_id #{removed.inspect} from credit card #{credit_card.id} (subscription #{subscription.external_id})."
+      end
+    end
+
+    desc "Seed a job into the Sidekiq dead set (morgue), e.g. to QA dead-job alerting/UI. Usage: preview_qa:seed_dead_job[WorkerClass,arg1,arg2,...]"
+    task :seed_dead_job, [:worker_class] => :environment do |_task, args|
+      PreviewQa.ensure_not_production!
+
+      worker_class = PreviewQa.worker_class!(args[:worker_class])
+      job_args = args.extras.map { |value| PreviewQa.cast_argument(value) }
+
+      now = Time.current.to_f
+      payload = Sidekiq.dump_json(
+        "class" => worker_class.name,
+        "args" => job_args,
+        "queue" => worker_class.get_sidekiq_options["queue"] || "default",
+        "jid" => SecureRandom.hex(12),
+        "created_at" => now,
+        "enqueued_at" => now,
+        "failed_at" => now,
+        "retry_count" => 0,
+        "error_class" => "RuntimeError",
+        "error_message" => "Seeded by preview_qa:seed_dead_job for QA"
+      )
+      # notify_failure: false skips Sidekiq's death handlers — we want a corpse in the morgue,
+      # not a real error-tracker alert.
+      Sidekiq::DeadSet.new.kill(payload, notify_failure: false)
+
+      puts "Seeded dead job #{worker_class.name}(#{job_args.map(&:inspect).join(', ')}) into the Sidekiq dead set."
+    end
+
+    desc "Run a Sidekiq worker inline (synchronously). Usage: preview_qa:run_worker[RecurringChargeWorker,123]"
+    task :run_worker, [:worker_class] => :environment do |_task, args|
+      PreviewQa.ensure_not_production!
+
+      worker_class = PreviewQa.worker_class!(args[:worker_class])
+      job_args = args.extras.map { |value| PreviewQa.cast_argument(value) }
+
+      puts "Running #{worker_class.name}#perform(#{job_args.map(&:inspect).join(', ')}) inline..."
+      worker_class.new.perform(*job_args)
+      puts "Done."
+    end
+  end
+end

--- a/lib/tasks/preview_qa.rake
+++ b/lib/tasks/preview_qa.rake
@@ -63,6 +63,10 @@ module PreviewQa
 
   # Rake passes every argument as a string; workers usually expect integer ids and booleans.
   # Casts the obvious scalar types and leaves everything else as a string.
+  #
+  # Heads-up: the literal strings "nil" and "null" become Ruby nil, so there is no way to pass
+  # those exact strings through to a worker. That trade-off is fine for a QA convenience tool —
+  # if a worker ever needs the string "nil", run it from the console instead of this task.
   def cast_argument(value)
     case value
     when /\A-?\d+\z/ then Integer(value)
@@ -117,7 +121,10 @@ if PreviewQa.safe_environment?
 
       siblings = purchases_to_shift.size - 1
       sibling_note = siblings.positive? ? " (plus #{siblings} other successful charge(s) on its subscription)" : ""
-      puts "Backdated purchase #{purchase.external_id} (id #{purchase.id})#{sibling_note} by #{days} days."
+      # Spell out when succeeded_at was untouched, so the output doesn't imply a purchase that
+      # never succeeded now has a success timestamp.
+      succeeded_at_note = purchase.succeeded_at.present? ? "" : " succeeded_at was nil and stays nil."
+      puts "Backdated purchase #{purchase.external_id} (id #{purchase.id})#{sibling_note} by #{days} days.#{succeeded_at_note}"
     end
 
     desc "Remove the Stripe e-mandate linkage (stripe_setup_intent_id) from the card charged for a subscription, to QA the missing-mandate path for Indian cards"

--- a/lib/tasks/preview_qa.rake
+++ b/lib/tasks/preview_qa.rake
@@ -13,15 +13,26 @@
 #
 #   COMMAND='Rake::Task["preview_qa:backdate_purchase"].invoke("<purchase external_id>")' ./console.sh -w <branch>
 #
-# Every task hard-aborts in production; the guard is intentionally belt-and-braces (the whole
-# namespace is skipped when the file loads in production, and each task re-checks at run time in
-# case the file is ever loaded by other means).
+# These tasks mutate data, so they only exist where mutating data is safe: preview apps,
+# development, and the test suite. Production is obviously off-limits, but so is shared staging
+# (staging.gumroad.com) — it runs the same staging Rails env as preview apps and is shared by QA
+# and reviewers, so doctoring records there would trample other people's testing. Preview apps
+# are told apart from shared staging by ENV["BRANCH_DEPLOYMENT"], the same flag the rest of the
+# app uses for per-branch deploys (see config/domain.rb and
+# config/initializers/prefix_for_branch_apps_es_index.rb). The guard is intentionally
+# belt-and-braces: the whole namespace is skipped when the file loads in a disallowed
+# environment, and each task re-checks at run time in case the file is ever loaded by other means.
 
 module PreviewQa
   module_function
 
-  def ensure_not_production!
-    abort "preview_qa tasks are for preview/staging QA only and cannot run in production." if Rails.env.production?
+  def safe_environment?
+    return true if Rails.env.development? || Rails.env.test?
+    Rails.env.staging? && ENV["BRANCH_DEPLOYMENT"] == "true"
+  end
+
+  def ensure_safe_environment!
+    abort "preview_qa tasks mutate data and only run on preview apps, development, or the test suite." unless safe_environment?
   end
 
   # Accepts either a numeric database id or an external_id, so you can paste whichever
@@ -64,11 +75,11 @@ module PreviewQa
   end
 end
 
-unless Rails.env.production?
+if PreviewQa.safe_environment?
   namespace :preview_qa do
     desc "Backdate a purchase's created_at/succeeded_at by N days (default: one billing period + 1 day for subscription purchases) so renewal paths can be exercised"
     task :backdate_purchase, [:purchase_id, :days] => :environment do |_task, args|
-      PreviewQa.ensure_not_production!
+      PreviewQa.ensure_safe_environment!
 
       purchase = PreviewQa.find_record!(Purchase, args[:purchase_id])
 
@@ -80,20 +91,38 @@ unless Rails.env.production?
       end
       abort "Pass a positive number of days (this purchase has no subscription to derive a billing period from)." if days.nil? || days <= 0
 
-      backdated_to = days.days.ago
-      # update_columns on purpose: this is a QA time-travel edit, and running the full
-      # callback/validation stack against a doctored timestamp is exactly what we don't want.
-      purchase.update_columns(
-        created_at: backdated_to,
-        succeeded_at: (backdated_to if purchase.succeeded_at.present?)
-      )
+      purchases_to_shift = [purchase]
+      if purchase.subscription.present?
+        # Backdating only the named purchase is not enough once a subscription has renewal
+        # charges: the different "is a renewal due?" code paths don't all look at the same
+        # purchase. RecurringChargeWorker's own gate reads the latest successful purchase's
+        # created_at, while Subscription#overdue_for_charge? (and the renewal scheduling
+        # paths) read the newest succeeded_at across ALL successful, non-refunded charges.
+        # A newer sibling charge left untouched would keep the subscription looking
+        # not-yet-due to those paths. Shifting every successful charge by the same offset
+        # keeps their relative order intact and makes the subscription overdue by every
+        # code path.
+        purchases_to_shift |= purchase.subscription.purchases.successful.to_a
+      end
 
-      puts "Backdated purchase #{purchase.external_id} (id #{purchase.id}) by #{days} days: created_at/succeeded_at now #{backdated_to}."
+      offset = days.days
+      purchases_to_shift.each do |record|
+        # update_columns on purpose: this is a QA time-travel edit, and running the full
+        # callback/validation stack against a doctored timestamp is exactly what we don't want.
+        record.update_columns(
+          created_at: record.created_at - offset,
+          succeeded_at: (record.succeeded_at - offset if record.succeeded_at.present?)
+        )
+      end
+
+      siblings = purchases_to_shift.size - 1
+      sibling_note = siblings.positive? ? " (plus #{siblings} other successful charge(s) on its subscription)" : ""
+      puts "Backdated purchase #{purchase.external_id} (id #{purchase.id})#{sibling_note} by #{days} days."
     end
 
     desc "Remove the Stripe e-mandate linkage (stripe_setup_intent_id) from the card charged for a subscription, to QA the missing-mandate path for Indian cards"
     task :clear_mandate, [:subscription_id] => :environment do |_task, args|
-      PreviewQa.ensure_not_production!
+      PreviewQa.ensure_safe_environment!
 
       subscription = PreviewQa.find_record!(Subscription, args[:subscription_id])
       credit_card = subscription.credit_card_to_charge
@@ -111,7 +140,7 @@ unless Rails.env.production?
 
     desc "Seed a job into the Sidekiq dead set (morgue), e.g. to QA dead-job alerting/UI. Usage: preview_qa:seed_dead_job[WorkerClass,arg1,arg2,...]"
     task :seed_dead_job, [:worker_class] => :environment do |_task, args|
-      PreviewQa.ensure_not_production!
+      PreviewQa.ensure_safe_environment!
 
       worker_class = PreviewQa.worker_class!(args[:worker_class])
       job_args = args.extras.map { |value| PreviewQa.cast_argument(value) }
@@ -138,7 +167,7 @@ unless Rails.env.production?
 
     desc "Run a Sidekiq worker inline (synchronously). Usage: preview_qa:run_worker[RecurringChargeWorker,123]"
     task :run_worker, [:worker_class] => :environment do |_task, args|
-      PreviewQa.ensure_not_production!
+      PreviewQa.ensure_safe_environment!
 
       worker_class = PreviewQa.worker_class!(args[:worker_class])
       job_args = args.extras.map { |value| PreviewQa.cast_argument(value) }

--- a/lib/tasks/preview_qa.rake
+++ b/lib/tasks/preview_qa.rake
@@ -8,10 +8,13 @@
 # noise, and a real risk of the hook leaking into main. These tasks are reviewed once and reused
 # forever instead.
 #
-# Run them through the preview app's Rails console one-shot path (see "Deploying to a preview app"
-# in docs/deploying.md), for example:
+# Run them through the preview app's Rails console (see "Deploying to a preview app" in
+# docs/deploying.md). The deployment repo's console.sh takes the branch via the BRANCH env var
+# and needs -w for a writable connection (these tasks write; the default is a read-only replica):
 #
-#   COMMAND='Rake::Task["preview_qa:backdate_purchase"].invoke("<purchase external_id>")' ./console.sh -w <branch>
+#   cd nomad/staging/deploy_branch && BRANCH=<branch name> ./console.sh -w
+#   # then, at the console prompt:
+#   system 'bundle exec rake "preview_qa:backdate_purchase[<purchase external_id>]"'
 #
 # These tasks mutate data, so they only exist where mutating data is safe: preview apps,
 # development, and the test suite. Production is obviously off-limits, but so is shared staging

--- a/spec/lib/tasks/preview_qa_spec.rb
+++ b/spec/lib/tasks/preview_qa_spec.rb
@@ -46,6 +46,7 @@ describe "preview_qa rake tasks" do
         preview_qa:clear_mandate
         preview_qa:seed_dead_job
         preview_qa:run_worker
+        preview_qa:inspect_subscription
       ]
     end
 
@@ -210,6 +211,45 @@ describe "preview_qa rake tasks" do
     it "aborts for an unknown class name" do
       expect do
         run_task("preview_qa:seed_dead_job", "TotallyNotARealWorker")
+      end.to raise_error(SystemExit)
+    end
+  end
+
+  describe "preview_qa:inspect_subscription" do
+    def capture_stdout
+      original = $stdout
+      $stdout = StringIO.new
+      yield
+      $stdout.string
+    ensure
+      $stdout = original
+    end
+
+    it "prints renewal timing, the card's mandate linkage, and recent purchases without mutating anything" do
+      credit_card = build_saved_credit_card(json_data: { stripe_setup_intent_id: "seti_123" })
+      purchase = create(:membership_purchase)
+      subscription = purchase.subscription
+      subscription.update!(credit_card:)
+
+      output = capture_stdout { run_task("preview_qa:inspect_subscription", subscription.external_id) }
+
+      expect(output).to include("Subscription #{subscription.external_id}")
+      expect(output).to include("overdue_for_charge?: #{subscription.reload.overdue_for_charge?}")
+      expect(output).to include('stripe_setup_intent_id (e-mandate linkage): "seti_123"')
+      expect(output).to include(purchase.external_id)
+    end
+
+    it "reports when the subscription has no chargeable card instead of aborting" do
+      subscription = create(:subscription, user: nil, credit_card: nil)
+
+      expect do
+        run_task("preview_qa:inspect_subscription", subscription.external_id)
+      end.to output(/card to charge: none/).to_stdout
+    end
+
+    it "aborts when the subscription cannot be found" do
+      expect do
+        run_task("preview_qa:inspect_subscription", "nonexistent")
       end.to raise_error(SystemExit)
     end
   end

--- a/spec/lib/tasks/preview_qa_spec.rb
+++ b/spec/lib/tasks/preview_qa_spec.rb
@@ -1,0 +1,191 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "preview_qa rake tasks" do
+  before(:all) do
+    # Load the task file once for the whole suite. The tasks are only defined for
+    # non-production environments, which is what the test environment is. Guard against
+    # a double load: re-loading a .rake file appends a second action to each task, which
+    # would make every invocation run twice.
+    unless Rake::Task.task_defined?("preview_qa:backdate_purchase")
+      Rake::Task.define_task(:environment) unless Rake::Task.task_defined?(:environment)
+      load Rails.root.join("lib", "tasks", "preview_qa.rake")
+    end
+  end
+
+  def run_task(name, *args)
+    task = Rake::Task[name]
+    # Rake memoizes task execution; re-enable so each example can invoke it fresh.
+    task.reenable
+    task.invoke(*args)
+  end
+
+  # The credit_card factory goes through CreditCard.create(chargeable), which makes real
+  # Stripe HTTP calls (and would therefore need VCR cassettes). These specs only care about
+  # json_data plumbing, so build the record directly instead.
+  def build_saved_credit_card(json_data: nil)
+    card = CreditCard.new(
+      card_type: "visa",
+      visual: "**** **** **** 4062",
+      stripe_fingerprint: "preview_qa_fingerprint",
+      stripe_customer_id: "cus_preview_qa",
+      expiry_month: 12,
+      expiry_year: 5.years.from_now.year,
+      charge_processor_id: StripeChargeProcessor.charge_processor_id,
+      json_data:
+    )
+    card.save!
+    card
+  end
+
+  describe "the production guard" do
+    it "aborts every task before doing any work when running in production" do
+      allow(Rails.env).to receive(:production?).and_return(true)
+
+      %w[
+        preview_qa:backdate_purchase
+        preview_qa:clear_mandate
+        preview_qa:seed_dead_job
+        preview_qa:run_worker
+      ].each do |task_name|
+        expect do
+          run_task(task_name, "irrelevant")
+        end.to raise_error(SystemExit), "expected #{task_name} to abort in production"
+      end
+    end
+  end
+
+  describe "preview_qa:backdate_purchase" do
+    it "backdates a subscription purchase by one billing period plus a day by default" do
+      purchase = create(:membership_purchase)
+
+      expect do
+        run_task("preview_qa:backdate_purchase", purchase.external_id)
+      end.to output(/Backdated purchase #{purchase.external_id}/).to_stdout
+
+      expected_days = (purchase.subscription.period / 1.day).ceil + 1
+      purchase.reload
+      expect(purchase.created_at).to be_within(1.minute).of(expected_days.days.ago)
+      expect(purchase.succeeded_at).to be_within(1.minute).of(expected_days.days.ago)
+    end
+
+    it "backdates by an explicit number of days and accepts a numeric database id" do
+      purchase = create(:free_purchase)
+
+      expect do
+        run_task("preview_qa:backdate_purchase", purchase.id.to_s, "45")
+      end.to output(/by 45 days/).to_stdout
+
+      purchase.reload
+      expect(purchase.created_at).to be_within(1.minute).of(45.days.ago)
+    end
+
+    it "leaves succeeded_at nil for purchases that never succeeded" do
+      purchase = create(:purchase_in_progress, succeeded_at: nil)
+
+      expect do
+        run_task("preview_qa:backdate_purchase", purchase.external_id, "10")
+      end.to output(/by 10 days/).to_stdout
+
+      expect(purchase.reload.succeeded_at).to be_nil
+    end
+
+    it "aborts when no day count is given and the purchase has no subscription" do
+      purchase = create(:free_purchase)
+
+      expect do
+        run_task("preview_qa:backdate_purchase", purchase.external_id)
+      end.to raise_error(SystemExit)
+    end
+
+    it "aborts when the purchase cannot be found" do
+      expect do
+        run_task("preview_qa:backdate_purchase", "nonexistent")
+      end.to raise_error(SystemExit)
+    end
+  end
+
+  describe "preview_qa:clear_mandate" do
+    it "removes the stripe_setup_intent_id from the subscription's chargeable card" do
+      credit_card = build_saved_credit_card(json_data: { stripe_setup_intent_id: "seti_123", stripe_payment_intent_id: "pi_456" })
+      subscription = create(:subscription, credit_card:)
+
+      expect do
+        run_task("preview_qa:clear_mandate", subscription.external_id)
+      end.to output(/Cleared stripe_setup_intent_id "seti_123"/).to_stdout
+
+      credit_card.reload
+      expect(credit_card.stripe_setup_intent_id).to be_nil
+      # Only the mandate linkage should be touched; other json_data keys must survive.
+      expect(credit_card.stripe_payment_intent_id).to eq("pi_456")
+    end
+
+    it "is a no-op with a helpful message when the card has no mandate linkage" do
+      credit_card = build_saved_credit_card
+      subscription = create(:subscription, credit_card:)
+
+      expect do
+        run_task("preview_qa:clear_mandate", subscription.external_id)
+      end.to output(/has no stripe_setup_intent_id; nothing to clear/).to_stdout
+    end
+
+    it "aborts when the subscription has no chargeable credit card" do
+      subscription = create(:subscription, user: nil, credit_card: nil)
+
+      expect do
+        run_task("preview_qa:clear_mandate", subscription.external_id)
+      end.to raise_error(SystemExit)
+    end
+  end
+
+  describe "preview_qa:seed_dead_job" do
+    it "adds a job for the given worker to the Sidekiq dead set without notifying death handlers" do
+      expect_any_instance_of(Sidekiq::DeadSet).to receive(:kill) do |_dead_set, payload, opts|
+        job = Sidekiq.load_json(payload)
+        expect(job["class"]).to eq("RecurringChargeWorker")
+        expect(job["args"]).to eq([123, true])
+        expect(job["error_message"]).to match(/Seeded by preview_qa:seed_dead_job/)
+        expect(opts).to eq(notify_failure: false)
+      end
+
+      expect do
+        run_task("preview_qa:seed_dead_job", "RecurringChargeWorker", "123", "true")
+      end.to output(/Seeded dead job RecurringChargeWorker\(123, true\)/).to_stdout
+    end
+
+    it "aborts for a class that is not a Sidekiq worker" do
+      expect do
+        run_task("preview_qa:seed_dead_job", "User")
+      end.to raise_error(SystemExit)
+    end
+
+    it "aborts for an unknown class name" do
+      expect do
+        run_task("preview_qa:seed_dead_job", "TotallyNotARealWorker")
+      end.to raise_error(SystemExit)
+    end
+  end
+
+  describe "preview_qa:run_worker" do
+    it "runs the worker inline with type-cast arguments" do
+      expect_any_instance_of(RecurringChargeWorker).to receive(:perform).with(42, false)
+
+      expect do
+        run_task("preview_qa:run_worker", "RecurringChargeWorker", "42", "false")
+      end.to output(/Running RecurringChargeWorker#perform\(42, false\) inline/).to_stdout
+    end
+
+    it "aborts for a class that is not a Sidekiq worker" do
+      expect do
+        run_task("preview_qa:run_worker", "Purchase", "1")
+      end.to raise_error(SystemExit)
+    end
+
+    it "aborts when no worker class is given" do
+      expect do
+        run_task("preview_qa:run_worker")
+      end.to raise_error(SystemExit)
+    end
+  end
+end

--- a/spec/lib/tasks/preview_qa_spec.rb
+++ b/spec/lib/tasks/preview_qa_spec.rb
@@ -39,20 +39,50 @@ describe "preview_qa rake tasks" do
     card
   end
 
-  describe "the production guard" do
-    it "aborts every task before doing any work when running in production" do
-      allow(Rails.env).to receive(:production?).and_return(true)
-
+  describe "the environment guard" do
+    let(:all_tasks) do
       %w[
         preview_qa:backdate_purchase
         preview_qa:clear_mandate
         preview_qa:seed_dead_job
         preview_qa:run_worker
-      ].each do |task_name|
+      ]
+    end
+
+    # Make Rails.env report the given environment instead of "test", so we can exercise
+    # the guard as it would behave on each deployed environment.
+    def stub_rails_env(env)
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new(env))
+    end
+
+    it "aborts every task before doing any work when running in production" do
+      stub_rails_env("production")
+
+      all_tasks.each do |task_name|
         expect do
           run_task(task_name, "irrelevant")
         end.to raise_error(SystemExit), "expected #{task_name} to abort in production"
       end
+    end
+
+    it "aborts every task on shared staging (staging Rails env without the preview-app flag)" do
+      stub_rails_env("staging")
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("BRANCH_DEPLOYMENT").and_return(nil)
+
+      all_tasks.each do |task_name|
+        expect do
+          run_task(task_name, "irrelevant")
+        end.to raise_error(SystemExit), "expected #{task_name} to abort on shared staging"
+      end
+    end
+
+    it "allows tasks on preview apps (staging Rails env with BRANCH_DEPLOYMENT set)" do
+      stub_rails_env("staging")
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("BRANCH_DEPLOYMENT").and_return("true")
+
+      expect(PreviewQa.safe_environment?).to be(true)
     end
   end
 

--- a/spec/lib/tasks/preview_qa_spec.rb
+++ b/spec/lib/tasks/preview_qa_spec.rb
@@ -100,6 +100,23 @@ describe "preview_qa rake tasks" do
       expect(purchase.succeeded_at).to be_within(1.minute).of(expected_days.days.ago)
     end
 
+    it "shifts every successful charge on the subscription, so the renewal is due by every code path" do
+      original_purchase = create(:membership_purchase)
+      subscription = original_purchase.subscription
+      renewal_purchase = create(:membership_purchase, link: subscription.link, subscription:, is_original_subscription_purchase: false)
+
+      expect do
+        run_task("preview_qa:backdate_purchase", original_purchase.external_id)
+      end.to output(/plus 1 other successful charge/).to_stdout
+
+      expected_days = (subscription.period / 1.day).ceil + 1
+      expect(original_purchase.reload.succeeded_at).to be_within(1.minute).of(expected_days.days.ago)
+      expect(renewal_purchase.reload.succeeded_at).to be_within(1.minute).of(expected_days.days.ago)
+      # This is the point of shifting siblings: overdue_for_charge? keys off the newest
+      # succeeded_at across all successful charges, not the one purchase named on the task.
+      expect(subscription.reload.overdue_for_charge?).to be(true)
+    end
+
     it "backdates by an explicit number of days and accepts a numeric database id" do
       purchase = create(:free_purchase)
 

--- a/spec/lib/tasks/preview_qa_spec.rb
+++ b/spec/lib/tasks/preview_qa_spec.rb
@@ -133,7 +133,7 @@ describe "preview_qa rake tasks" do
 
       expect do
         run_task("preview_qa:backdate_purchase", purchase.external_id, "10")
-      end.to output(/by 10 days/).to_stdout
+      end.to output(/succeeded_at was nil and stays nil/).to_stdout
 
       expect(purchase.reload.succeeded_at).to be_nil
     end


### PR DESCRIPTION
Closes the remaining piece of #5806: permanent, environment-guarded QA seed tasks so preview-app QA no longer needs temporary param-gated seed hooks shipped inside feature PRs ("TEMP: revert before merge" commits).

## What

New `lib/tasks/preview_qa.rake` namespace, restricted to preview apps, development, and the test suite. The guard blocks production and shared staging (`staging.gumroad.com`): shared staging runs the staging Rails env too, so an env check alone isn't enough — the tasks additionally require the `BRANCH_DEPLOYMENT` flag that already distinguishes per-branch preview deploys from shared staging. The namespace is skipped entirely when the file loads in a disallowed environment, and every task re-checks at run time.

- `preview_qa:backdate_purchase[purchase_id,days]` — backdates a purchase's `created_at`/`succeeded_at`; defaults to one billing period + 1 day for subscription purchases so `RecurringChargeWorker` sees the subscription as due. When the purchase belongs to a subscription, every successful charge on that subscription is shifted by the same offset — the renewal-due checks read the latest successful charge, so shifting only an older purchase wouldn't flip them.
- `preview_qa:clear_mandate[subscription_id]` — removes `stripe_setup_intent_id` from the card charged for a subscription, to QA the Indian-card missing-e-mandate path from #5795 (other `json_data` keys are preserved).
- `preview_qa:seed_dead_job[WorkerClass,args...]` — seeds a job into the Sidekiq dead set without firing death handlers.
- `preview_qa:run_worker[WorkerClass,args...]` — runs a Sidekiq worker inline (e.g. force a renewal charge attempt).
- `preview_qa:inspect_subscription[subscription_id]` — read-only snapshot for verifying state after a QA run: renewal timing (`overdue_for_charge?`, end of current period), the charged card's e-mandate linkage, and the recent purchase history with charge ids. Mutates nothing, so it runs on the default read-only console connection.

Record identifiers accept either database ids or external ids. Worker tasks verify the constant is actually a `Sidekiq::Job` before touching it, and rake's string args are cast to integers/booleans.

Also documents preview-app console access (linking [gumroad-deployment/docs/ssh.md](https://github.com/antiwork/gumroad-deployment/blob/main/docs/ssh.md#connect-to-rails-console)) and the new tasks in `docs/deploying.md`, closing the "not linked from the preview-app workflow docs" gap.

## Usage

Interactive writable console (from the deployment repo; `BRANCH` is an env var and `-w` gives a writable connection — the seeding tasks write):

```shell
cd nomad/staging/deploy_branch && BRANCH=<branch name> ./console.sh -w
# then, at the console prompt:
system 'bundle exec rake "preview_qa:backdate_purchase[<purchase external_id>]"'
```

Or as a one-shot (`COMMAND` runs as the container command, so it must be a real `bundle exec rake` invocation):

```shell
cd nomad/staging/deploy_branch && \
  BRANCH=<branch name> \
  COMMAND='bundle exec rake "preview_qa:backdate_purchase[<purchase external_id>]"' \
  ./console.sh -w
```

## Tests

`spec/lib/tasks/preview_qa_spec.rb` — 21 examples, 0 failures locally:

- environment guard aborts every task in production and on shared staging (staging env without `BRANCH_DEPLOYMENT`), and allows preview apps (staging env with the flag)
- backdating: default period derivation, explicit days, numeric-id lookup, nil `succeeded_at` preserved, missing-record/missing-days aborts
- mandate clearing: removes only the mandate key, no-op message when absent, aborts without a chargeable card
- dead-job seeding: payload shape + `notify_failure: false`, rejects non-worker/unknown classes
- inline worker run: type-cast args, rejects non-worker classes / missing class
- subscription inspection: prints renewal timing, mandate linkage, and purchase history; reports a missing card without aborting; aborts on unknown records


