### PR TITLE
Bake the prepared test DB into the test image so shards skip db:prepare

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -277,10 +277,11 @@ jobs:
             # Non-fatal: if the dump fails, shards detect the missing file
             # and fall back to rake db:prepare.
             logger "Baking prepared test database dump into the image"
-            if docker/ci/dump_test_db.sh web_${{ github.run_id }}_${{ github.run_attempt }}_default /tmp/prepared_test_db.sql.gz; then
-              docker cp /tmp/prepared_test_db.sql.gz $CONTAINER:/app/db/prepared_test_db.sql.gz
+            if docker/ci/dump_test_db.sh web_${{ github.run_id }}_${{ github.run_attempt }}_default /tmp/prepared_test_db.sql.gz \
+               && docker cp /tmp/prepared_test_db.sql.gz $CONTAINER:/app/db/prepared_test_db.sql.gz; then
+              logger "Test database dump baked into image"
             else
-              logger "Test database dump failed (non-fatal) — shards will fall back to db:prepare"
+              logger "Test database dump/copy failed (non-fatal) — shards will fall back to db:prepare"
             fi
 
             docker ps -lq \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -269,6 +269,20 @@ jobs:
               docker cp "$CONTAINER:/app/$src" "/tmp/asset-cache/$dst" 2>/dev/null || true
             done
 
+            # Bake the prepared test database into the image. The db:setup
+            # above left a fully prepared gumroad_test in this stack's MySQL;
+            # snapshotting it here lets every test shard restore the dump in
+            # seconds instead of re-running db:prepare from scratch (see
+            # docker/ci/dump_test_db.sh and docker/ci/restore_test_db.sh).
+            # Non-fatal: if the dump fails, shards detect the missing file
+            # and fall back to rake db:prepare.
+            logger "Baking prepared test database dump into the image"
+            if docker/ci/dump_test_db.sh web_${{ github.run_id }}_${{ github.run_attempt }}_default /tmp/prepared_test_db.sql.gz; then
+              docker cp /tmp/prepared_test_db.sql.gz $CONTAINER:/app/db/prepared_test_db.sql.gz
+            else
+              logger "Test database dump failed (non-fatal) — shards will fall back to db:prepare"
+            fi
+
             docker ps -lq \
               --filter='label=routes_compiled=true' \
               --filter='exited=0' \
@@ -346,10 +360,11 @@ jobs:
           command: |
             IMG=$WEB_REPO:${{ needs.build.outputs.test_image_tag }}
             NET=${{ env.COMPOSE_PROJECT_NAME }}_default
-            # db:prepare only needs db_test; ES/minio waits run in parallel.
+            # Restore the baked test database dump (seconds) instead of
+            # re-running db:prepare via Rails; ES/minio waits run in parallel.
             (
               docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh db_test 3306 \
-                && docker run --rm --entrypoint="" --network $NET -e RAILS_ENV=test $IMG bundle exec rake db:prepare
+                && docker/ci/restore_test_db.sh $NET $IMG
             ) &
             DB_PID=$!
             docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh elasticsearch 9200 &
@@ -528,10 +543,11 @@ jobs:
           command: |
             IMG=$WEB_REPO:${{ needs.build.outputs.test_image_tag }}
             NET=${{ env.COMPOSE_PROJECT_NAME }}_default
-            # db:prepare only needs db_test; ES/minio waits run in parallel.
+            # Restore the baked test database dump (seconds) instead of
+            # re-running db:prepare via Rails; ES/minio waits run in parallel.
             (
               docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh db_test 3306 \
-                && docker run --rm --entrypoint="" --network $NET -e RAILS_ENV=test $IMG bundle exec rake db:prepare
+                && docker/ci/restore_test_db.sh $NET $IMG
             ) &
             DB_PID=$!
             docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh elasticsearch 9200 &

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,7 @@ test-branch-creation.log
 .claude/worktrees/
 autoresearch.*
 .codex/
+
+# Baked CI test-database dump (created inside the test image at build time;
+# never committed — see docker/ci/dump_test_db.sh)
+db/prepared_test_db.sql.gz

--- a/docker/ci/dump_test_db.sh
+++ b/docker/ci/dump_test_db.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Dump the prepared test database to a gzipped SQL file so the CI build job
+# can bake it into the test image.
+#
+# Context: the build job runs `rake db:setup` once while building the test
+# image, which leaves a fully prepared `gumroad_test` database (schema +
+# seeds + schema_migrations rows) in the compose stack's MySQL service.
+# Historically every test shard then re-created that same database from
+# scratch with `rake db:prepare` — a fixed cost paid ~68 times per run.
+# Instead, the build job calls this script to snapshot the prepared database,
+# copies the dump into the image before `docker commit`, and each shard
+# restores the dump (seconds) via docker/ci/restore_test_db.sh.
+#
+# The dump always matches the code in the image: the test image tag is
+# content-addressed over the git tree (including db/schema.rb, db/seeds and
+# this script), so any change that affects the prepared database produces a
+# new tag and a fresh image + dump.
+#
+# Usage: docker/ci/dump_test_db.sh <docker-network> <output-file>
+#   <docker-network>  The compose network where the db_test service runs.
+#   <output-file>     Path on the host for the gzipped dump.
+#
+# Runs the MySQL client from the same mysql image the db_test service uses,
+# because the test image itself doesn't ship a mysql client binary.
+
+set -euo pipefail
+
+NETWORK=$1
+OUTPUT=$2
+
+MYSQL_IMAGE=mysql:8.0.32
+
+# --add-drop-database makes the dump idempotent to restore: the CI step that
+# restores it runs under a retry wrapper, so a second attempt must be able to
+# cleanly replace a partially restored database.
+docker run --rm --network "$NETWORK" -e MYSQL_PWD=password "$MYSQL_IMAGE" \
+  mysqldump \
+    --host=db_test \
+    --user=root \
+    --databases gumroad_test \
+    --add-drop-database \
+    --single-transaction \
+    --set-gtid-purged=OFF \
+    --quick \
+  | gzip > "$OUTPUT"
+
+echo "Dumped prepared test database to $OUTPUT ($(du -h "$OUTPUT" | cut -f1))"

--- a/docker/ci/restore_test_db.sh
+++ b/docker/ci/restore_test_db.sh
@@ -46,7 +46,12 @@ LOCAL_DUMP=$(mktemp /tmp/prepared_test_db.XXXXXX.sql.gz)
 # stopped container we can copy files out of.
 CONTAINER_ID=$(docker create "$IMAGE")
 
-if docker cp "$CONTAINER_ID:$DUMP_PATH_IN_IMAGE" "$LOCAL_DUMP" 2>/dev/null; then
+# The dump must both exist in the image AND be a valid gzip file. A truncated
+# or corrupt dump (say, from a build that got interrupted mid-copy) would
+# otherwise make every retry of this step fail the same way; checking validity
+# up front lets us fall back to `rake db:prepare` instead.
+if docker cp "$CONTAINER_ID:$DUMP_PATH_IN_IMAGE" "$LOCAL_DUMP" 2>/dev/null \
+    && gunzip -t "$LOCAL_DUMP" 2>/dev/null; then
   echo "Restoring baked test database dump ($(du -h "$LOCAL_DUMP" | cut -f1))..."
   # The mysql client runs from the same image the db_test service uses,
   # because the test image doesn't ship a mysql client binary. The dump was
@@ -57,7 +62,7 @@ if docker cp "$CONTAINER_ID:$DUMP_PATH_IN_IMAGE" "$LOCAL_DUMP" 2>/dev/null; then
     mysql --host=db_test --user=root
   echo "Test database restored from baked dump"
 else
-  echo "No baked test database dump found in image — falling back to rake db:prepare"
+  echo "No usable baked test database dump in image (missing or corrupt) — falling back to rake db:prepare"
   docker run --rm --entrypoint="" --network "$NETWORK" -e RAILS_ENV=test "$IMAGE" \
     bundle exec rake db:prepare
 fi

--- a/docker/ci/restore_test_db.sh
+++ b/docker/ci/restore_test_db.sh
@@ -24,16 +24,27 @@ IMAGE=$2
 
 MYSQL_IMAGE=mysql:8.0.32
 DUMP_PATH_IN_IMAGE=/app/db/prepared_test_db.sql.gz
+
+# Register the cleanup trap before creating anything it needs to clean up, so
+# a failure partway through setup (for example `docker create` erroring out)
+# still removes whatever did get created.
+CONTAINER_ID=""
+LOCAL_DUMP=""
+cleanup() {
+  if [ -n "$CONTAINER_ID" ]; then
+    docker rm "$CONTAINER_ID" > /dev/null 2>&1 || true
+  fi
+  if [ -n "$LOCAL_DUMP" ]; then
+    rm -f "$LOCAL_DUMP"
+  fi
+}
+trap cleanup EXIT
+
 LOCAL_DUMP=$(mktemp /tmp/prepared_test_db.XXXXXX.sql.gz)
 
 # Extract the dump from the image without running it. `docker create` makes a
 # stopped container we can copy files out of.
 CONTAINER_ID=$(docker create "$IMAGE")
-cleanup() {
-  docker rm "$CONTAINER_ID" > /dev/null 2>&1 || true
-  rm -f "$LOCAL_DUMP"
-}
-trap cleanup EXIT
 
 if docker cp "$CONTAINER_ID:$DUMP_PATH_IN_IMAGE" "$LOCAL_DUMP" 2>/dev/null; then
   echo "Restoring baked test database dump ($(du -h "$LOCAL_DUMP" | cut -f1))..."

--- a/docker/ci/restore_test_db.sh
+++ b/docker/ci/restore_test_db.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Restore the prepared test database that the build job baked into the test
+# image (see docker/ci/dump_test_db.sh for how it gets there).
+#
+# Each test shard boots its own empty MySQL service. Loading the baked dump
+# takes seconds, versus the minutes `rake db:prepare` spends booting Rails
+# and re-creating the schema + seeds from scratch on every one of the ~68
+# shards.
+#
+# If the image does not contain a dump (for example an image built before
+# this mechanism existed, still referenced through the content-addressed
+# cache), we fall back to the old `rake db:prepare` path so the shard still
+# works — just without the speedup.
+#
+# Usage: docker/ci/restore_test_db.sh <docker-network> <test-image>
+#   <docker-network>  The compose network where this shard's db_test runs.
+#   <test-image>      The web test image (may contain the baked dump).
+
+set -euo pipefail
+
+NETWORK=$1
+IMAGE=$2
+
+MYSQL_IMAGE=mysql:8.0.32
+DUMP_PATH_IN_IMAGE=/app/db/prepared_test_db.sql.gz
+LOCAL_DUMP=$(mktemp /tmp/prepared_test_db.XXXXXX.sql.gz)
+
+# Extract the dump from the image without running it. `docker create` makes a
+# stopped container we can copy files out of.
+CONTAINER_ID=$(docker create "$IMAGE")
+cleanup() {
+  docker rm "$CONTAINER_ID" > /dev/null 2>&1 || true
+  rm -f "$LOCAL_DUMP"
+}
+trap cleanup EXIT
+
+if docker cp "$CONTAINER_ID:$DUMP_PATH_IN_IMAGE" "$LOCAL_DUMP" 2>/dev/null; then
+  echo "Restoring baked test database dump ($(du -h "$LOCAL_DUMP" | cut -f1))..."
+  # The mysql client runs from the same image the db_test service uses,
+  # because the test image doesn't ship a mysql client binary. The dump was
+  # taken with --add-drop-database, so re-running this (the CI step retries
+  # on failure) cleanly replaces any partially restored database.
+  gunzip -c "$LOCAL_DUMP" | docker run --rm -i --network "$NETWORK" \
+    -e MYSQL_PWD=password "$MYSQL_IMAGE" \
+    mysql --host=db_test --user=root
+  echo "Test database restored from baked dump"
+else
+  echo "No baked test database dump found in image — falling back to rake db:prepare"
+  docker run --rm --entrypoint="" --network "$NETWORK" -e RAILS_ENV=test "$IMAGE" \
+    bundle exec rake db:prepare
+fi


### PR DESCRIPTION
## What

Bakes a snapshot of the prepared test database into the CI test image, so test shards restore it in seconds instead of each re-running `rake db:prepare`.

- `docker/ci/dump_test_db.sh` — the build job runs this after `db:setup`: it `mysqldump`s the prepared `gumroad_test` database and the dump gets `docker cp`'d into the image before the `docker commit` that finalizes the test image.
- `docker/ci/restore_test_db.sh` — each shard runs this instead of `rake db:prepare`: it extracts the dump from the image and pipes it through the `mysql` client into the shard's fresh MySQL service. If the image has no baked dump (older content-addressed images built before this change), it falls back to the old `rake db:prepare` path, so cached images keep working.
- `tests.yml` — the build job bakes the dump (non-fatal on failure, shards fall back), and both `test_fast` and `test_slow` "prepare test database" steps call the restore script.

## Why

`rake db:prepare` boots the full Rails app and replays schema + seeds — a fixed cost paid once per shard, ~68 times per run (18 fast + 50 slow). The build job has already produced exactly that database once via `db:setup`; every shard was redoing identical work. Loading a mysqldump through the mysql client skips the Rails boot entirely and takes seconds.

Correctness holds because the test image tag is content-addressed over the git tree (`docker/base/generate_tag_for_test_image.sh`), which includes `db/schema.rb`, `db/seeds` and these scripts — any change that affects the prepared database produces a new tag, a fresh image build, and a fresh dump. `spec/spec_helper.rb` still runs `ActiveRecord::Migration.maintain_test_schema!` as a safety net.

The dump was taken with `--add-drop-database`, so the restore is idempotent — the CI step runs under a retry wrapper and a second attempt cleanly replaces a partially restored database.

Part of #5801 (item 2 of the plan on that issue).

## Test plan

- Verified the dump/restore round-trip locally against a prepared `gumroad_test` on MySQL 8.0: dump with the exact flags in `dump_test_db.sh`, restore twice in a row (idempotency), table count (200) and `schema_migrations` rows (1164) identical before/after.
- `shellcheck` clean on both scripts; workflow YAML parses; `actionlint` shows no new findings (pre-existing custom-runner-label notices only).
- CI on this PR exercises the full path end to end: the tree change produces a new image tag, so the build job bakes a dump and all 68 shards restore from it. The "Wait for services and prepare test database" step logs show `Restoring baked test database dump` (or the explicit fallback message).
- Before/after per-shard timing for the prepare step will be posted on #5801 once this run completes.
