### PR TITLE
Guard preview_qa:backdate_purchase against subscriptions with no recurrence

### DIFF
--- a/lib/tasks/preview_qa.rake
+++ b/lib/tasks/preview_qa.rake
@@ -99,7 +99,7 @@ if PreviewQa.safe_environment?
         # Subscription#period would raise — so those need an explicit days argument instead.
         days = (purchase.subscription.period / 1.day).ceil + 1
       end
-      abort "Pass a positive number of days (this purchase has no subscription with a recurrence to derive a billing period from)." if days.nil? || days <= 0
+      abort "Pass a positive number of days (this purchase #{purchase.subscription.present? ? "has a subscription with no recurrence" : "has no subscription"} to derive a billing period from)." if days.nil? || days <= 0
 
       purchases_to_shift = [purchase]
       if purchase.subscription.present?

--- a/lib/tasks/preview_qa.rake
+++ b/lib/tasks/preview_qa.rake
@@ -91,12 +91,15 @@ if PreviewQa.safe_environment?
       purchase = PreviewQa.find_record!(Purchase, args[:purchase_id])
 
       days = args[:days].presence&.to_i
-      if days.nil? && purchase.subscription.present?
+      if days.nil? && purchase.subscription&.recurrence.present?
         # Default to just past the subscription's billing period, which is the common case:
         # make the subscription look overdue so RecurringChargeWorker will actually charge it.
+        # The recurrence check matters: a bare subscription without a price/recurrence (possible
+        # for hand-built records in dev/test) can't have a billing period computed —
+        # Subscription#period would raise — so those need an explicit days argument instead.
         days = (purchase.subscription.period / 1.day).ceil + 1
       end
-      abort "Pass a positive number of days (this purchase has no subscription to derive a billing period from)." if days.nil? || days <= 0
+      abort "Pass a positive number of days (this purchase has no subscription with a recurrence to derive a billing period from)." if days.nil? || days <= 0
 
       purchases_to_shift = [purchase]
       if purchase.subscription.present?

--- a/spec/lib/tasks/preview_qa_spec.rb
+++ b/spec/lib/tasks/preview_qa_spec.rb
@@ -147,6 +147,20 @@ describe "preview_qa rake tasks" do
       end.to raise_error(SystemExit)
     end
 
+    it "aborts with a clear message instead of crashing when the subscription has no recurrence" do
+      purchase = create(:membership_purchase)
+      # A subscription without a recurrence (possible for hand-built records in dev/test) has no
+      # billing period to derive a default from — Subscription#period would raise. The task should
+      # ask for an explicit days argument instead of blowing up.
+      allow_any_instance_of(Subscription).to receive(:recurrence).and_return(nil)
+
+      expect do
+        expect do
+          run_task("preview_qa:backdate_purchase", purchase.external_id)
+        end.to raise_error(SystemExit)
+      end.to output(/no subscription with a recurrence/).to_stderr
+    end
+
     it "aborts when the purchase cannot be found" do
       expect do
         run_task("preview_qa:backdate_purchase", "nonexistent")

--- a/spec/lib/tasks/preview_qa_spec.rb
+++ b/spec/lib/tasks/preview_qa_spec.rb
@@ -158,7 +158,7 @@ describe "preview_qa rake tasks" do
         expect do
           run_task("preview_qa:backdate_purchase", purchase.external_id)
         end.to raise_error(SystemExit)
-      end.to output(/no subscription with a recurrence/).to_stderr
+      end.to output(/has a subscription with no recurrence/).to_stderr
     end
 
     it "aborts when the purchase cannot be found" do


### PR DESCRIPTION
Follow-up to #5821, addressing Greptile's final review on that PR (it landed after the merge). The review flagged one remaining edge: `preview_qa:backdate_purchase` derived a default day count from `subscription.period` without checking that the subscription has a recurrence.

## What

`preview_qa:backdate_purchase` now checks `subscription&.recurrence` before deriving the default backdate window from the billing period. A subscription without a price/recurrence (possible for hand-built records in development/test) has no billing period — `Subscription#period` raises `NoMethodError` on the nil recurrence. The task now aborts with a clear message asking for an explicit days argument instead of crashing, matching how `preview_qa:inspect_subscription` already handles nil recurrence.

## Why

The nil-recurrence edge only surfaces with bare dev/test records (the exact environments these tasks run in), so a confusing `undefined method 'months' for nil` stack trace is what a QA user would hit. An explicit "pass a positive number of days" abort is the intended failure mode.

## Test plan

- New spec: `aborts with a clear message instead of crashing when the subscription has no recurrence` (stubs `recurrence` to nil, asserts the abort message)
- Full spec file run locally: 22 examples, 0 failures
- rubocop clean on both files
