### PR TITLE
Disable the video player Chromecast button (casting can't work with session-authenticated streams)

### DIFF
--- a/app/javascript/utils/jwPlayer.ts
+++ b/app/javascript/utils/jwPlayer.ts
@@ -1,7 +1,9 @@
 type Optional<T> = { [k in keyof T]?: T[k] | undefined };
 
-// Patch the options from @types/jwplayer as they do not match the documentation
-export type JWPlayerOptions = Omit<jwplayer.SetupConfig, "playlist"> & {
+// Patch the options from @types/jwplayer as they do not match the documentation.
+// "cast" is omitted because casting is force-disabled in createJWPlayer below —
+// callers must not re-enable it per-player.
+export type JWPlayerOptions = Omit<jwplayer.SetupConfig, "playlist" | "cast"> & {
   playlist: (Omit<Optional<jwplayer.PlaylistItem>, "file" | "sources"> & {
     sources: (Optional<jwplayer.Source> & Pick<jwplayer.Source, "file">)[];
   })[];
@@ -11,6 +13,18 @@ export const createJWPlayer = async (containerId: string, options: JWPlayerOptio
   // @ts-expect-error no types for dynamic import, but we're not using the return value anyway
   await import(/* @vite-ignore */ "https://cdn.jwplayer.com/libraries/3vz4Z4wu.js");
 
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- see type above
-  return jwplayer(containerId).setup(options as jwplayer.SetupConfig);
+  // JW Player merges our setup options over the cloud player config (window.jwplayer.defaults,
+  // from the library script above), which currently ships with casting enabled ("cast": {}).
+  // That renders a Chromecast button that can never actually play our videos: purchased streams
+  // are served through session-authenticated endpoints (UrlRedirectsController#hls_playlist /
+  // #smil plus signed URLs the client assembles at render time), and a Chromecast receiver
+  // fetches the stream itself, without the buyer's cookies — so the cast session connects and
+  // then stays black. Until streams are servable via cookie-free tokenized URLs, hide the
+  // button instead of shipping a control that silently fails. A falsy "cast" makes the player
+  // skip cast setup entirely, so no cast button is rendered.
+  // See https://github.com/antiwork/gumroad-private/issues/1051
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- "cast: false" is the documented way to leave casting un-configured, but the @types/jwplayer CastConfig type doesn't model it
+  const setupConfig = { ...options, cast: false } as unknown as jwplayer.SetupConfig;
+
+  return jwplayer(containerId).setup(setupConfig);
 };


### PR DESCRIPTION
## What

Forces `cast: false` in `createJWPlayer` (and omits `cast` from `JWPlayerOptions`) so the JW Player Chromecast button no longer renders on any of our video players.

## Why

The JW cloud player config (library `3vz4Z4wu`) ships `"cast": {}` in `jwplayer.defaults`, which enables casting for every player we create — nothing in the repo passes a `cast:` block, the button comes entirely from the cloud config. But casting structurally cannot work with our stream architecture:

- Purchased streams are served through session-authenticated endpoints: `UrlRedirectsController#hls_playlist` / `#smil` sit behind the `check_permissions` before_action chain, and `Stream.tsx` swaps a fake GUID for the real one client-side before handing the signed URL to the player.
- A Chromecast device fetches the stream **itself**, from the receiver app, with none of the buyer's cookies or session — so the playlist request fails and the cast screen stays black.

The result is a cast button shipped to every video buyer that connects a cast session and then silently plays nothing (buyer report with screenshot in antiwork/gumroad-private#1051; the buyer tried two Chromecast devices plus tab-casting).

This implements the "honest UI" fix from the issue: don't render a control that can't work. In JW Player 8, a falsy `cast` value makes the setup skip cast configuration entirely, so no button is rendered (confirmed against the player's config merge: setup options override `window.jwplayer.defaults`, and the cast module only initializes when `model.get("cast")` is truthy). Real casting support would require serving the HLS playlist + segments via cookie-free tokenized signed URLs — tracked as the follow-up option on the issue.

An alternative was flipping the setting in the JW dashboard for library `3vz4Z4wu`, but that's unversioned console state anyone can flip back; pinning it in code keeps the behavior reviewable and permanent.

## Affected surfaces

All five `createJWPlayer` call sites (stream page, download-page file embeds, product cover videos, product-edit preview, review videos) — the button disappears from each; no other player behavior changes.

## Test plan

- `prettier` + `eslint` clean on the changed file.
- CI.
- Manual: load a purchased video's stream page in Chrome on a network with a Chromecast device — the cast icon no longer appears in the control bar (before: icon present, casting connects to a black screen).

Fixes antiwork/gumroad-private#1051
