### PR TITLE
Parallelize preview pipeline: nginx image build alongside assets, drop wasted asset job

### DIFF
--- a/.buildkite/preview.yml
+++ b/.buildkite/preview.yml
@@ -18,12 +18,24 @@ steps:
           username: gumroadteam
           password-env: DOCKERHUB_PASSWORD
 
+  # The branch app nginx image is content-addressed (tagged by the last commit
+  # touching docker/branch_app_nginx) and has no dependency on the base/web
+  # images or compiled assets, so it builds in parallel with the rest of the
+  # pipeline instead of serially inside the deploy step.
+  - label: ":docker: Build Branch App Nginx Image"
+    key: preview-build-nginx-image
+    command: ".buildkite/scripts/build_branch_app_nginx.sh"
+    timeout_in_minutes: 15
+    plugins:
+      - docker-login#v3.0.0:
+          username: gumroadteam
+          password-env: DOCKERHUB_PASSWORD
+
   - label: ":gear: Compile Assets"
     key: preview-compile-assets
     depends_on: preview-build-web-image
     command: ".buildkite/scripts/compile_assets.sh"
     artifact_paths: "log/**/*"
-    parallelism: 2
     timeout_in_minutes: 25
     plugins:
       - docker-login#v3.0.0:
@@ -36,7 +48,9 @@ steps:
 
   - label: ":rocket: Deploy Preview App"
     key: build-and-deploy-preview
-    depends_on: preview-compile-assets
+    depends_on:
+      - preview-compile-assets
+      - preview-build-nginx-image
     command: ".buildkite/scripts/deploy_branch.sh"
     timeout_in_minutes: 45
     plugins:

--- a/.buildkite/scripts/build_branch_app_nginx.sh
+++ b/.buildkite/scripts/build_branch_app_nginx.sh
@@ -28,7 +28,7 @@ function generate_nginx_tag(){
 
 BRANCH_APP_NGINX_TAG=$(generate_nginx_tag "docker/branch_app_nginx")
 
-if ! docker manifest inspect $AWS_BRANCH_APP_NGINX_REPO:$BRANCH_APP_NGINX_TAG > /dev/null 2>&1; then
+if ! docker manifest inspect "$AWS_BRANCH_APP_NGINX_REPO:$BRANCH_APP_NGINX_TAG" > /dev/null 2>&1; then
   logger "Building $AWS_BRANCH_APP_NGINX_REPO:$BRANCH_APP_NGINX_TAG"
   BRANCH_APP_NGINX_REPO=$AWS_BRANCH_APP_NGINX_REPO \
     BRANCH_APP_NGINX_TAG=$BRANCH_APP_NGINX_TAG \
@@ -37,7 +37,7 @@ if ! docker manifest inspect $AWS_BRANCH_APP_NGINX_REPO:$BRANCH_APP_NGINX_TAG > 
   logger "Pushing $AWS_BRANCH_APP_NGINX_REPO:$BRANCH_APP_NGINX_TAG"
   for i in {1..3}; do
     logger "Attempt $i"
-    if docker push $AWS_BRANCH_APP_NGINX_REPO:$BRANCH_APP_NGINX_TAG; then
+    if docker push "$AWS_BRANCH_APP_NGINX_REPO:$BRANCH_APP_NGINX_TAG"; then
       logger "Pushed $AWS_BRANCH_APP_NGINX_REPO:$BRANCH_APP_NGINX_TAG"
       break
     elif [ $i -eq 3 ]; then

--- a/.buildkite/scripts/build_branch_app_nginx.sh
+++ b/.buildkite/scripts/build_branch_app_nginx.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
-set -e
+set -euo pipefail
+
+# The nginx tag function lives in ci_scripts/helper.sh so this build step and
+# the nomad deploy scripts always compute the same tag from the same commit —
+# a drifted copy here would push an image the deploy never looks for.
+# (Sourced first: helper.sh also defines a generic logger; ours below wins.)
+source "$(git rev-parse --show-toplevel)/ci_scripts/helper.sh"
 
 GREEN="\033[0;32m"
 NC="\033[0m"
@@ -11,20 +17,6 @@ logger() {
 # touching docker/branch_app_nginx), so it does not depend on compiled assets
 # or the web image and can run in parallel with the rest of the pipeline.
 AWS_BRANCH_APP_NGINX_REPO=${ECR_REGISTRY}/gumroad/branch_app_nginx
-
-function generate_nginx_tag(){
-  local paths=()
-  local app_dir
-  app_dir=$(git rev-parse --show-toplevel)
-
-  # Change relative paths to absolute paths
-  for arg in "$@"; do
-    paths+=("${app_dir}/${arg}")
-  done
-
-  # Get short SHA of the latest commit affecting the paths
-  git rev-list --abbrev-commit --abbrev=12 HEAD -1 -- "${paths[@]}"
-}
 
 BRANCH_APP_NGINX_TAG=$(generate_nginx_tag "docker/branch_app_nginx")
 

--- a/.buildkite/scripts/build_branch_app_nginx.sh
+++ b/.buildkite/scripts/build_branch_app_nginx.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -e
+
+GREEN="\033[0;32m"
+NC="\033[0m"
+logger() {
+  echo -e "${GREEN}$(date "+%Y/%m/%d %H:%M:%S") build_branch_app_nginx.sh: $1${NC}"
+}
+
+# Build the preview app nginx image. Its tag is content-addressed (last commit
+# touching docker/branch_app_nginx), so it does not depend on compiled assets
+# or the web image and can run in parallel with the rest of the pipeline.
+AWS_BRANCH_APP_NGINX_REPO=${ECR_REGISTRY}/gumroad/branch_app_nginx
+
+function generate_nginx_tag(){
+  local paths=()
+  local app_dir
+  app_dir=$(git rev-parse --show-toplevel)
+
+  # Change relative paths to absolute paths
+  for arg in "$@"; do
+    paths+=("${app_dir}/${arg}")
+  done
+
+  # Get short SHA of the latest commit affecting the paths
+  git rev-list --abbrev-commit --abbrev=12 HEAD -1 -- "${paths[@]}"
+}
+
+BRANCH_APP_NGINX_TAG=$(generate_nginx_tag "docker/branch_app_nginx")
+
+if ! docker manifest inspect $AWS_BRANCH_APP_NGINX_REPO:$BRANCH_APP_NGINX_TAG > /dev/null 2>&1; then
+  logger "Building $AWS_BRANCH_APP_NGINX_REPO:$BRANCH_APP_NGINX_TAG"
+  BRANCH_APP_NGINX_REPO=$AWS_BRANCH_APP_NGINX_REPO \
+    BRANCH_APP_NGINX_TAG=$BRANCH_APP_NGINX_TAG \
+    make build_branch_app_nginx
+
+  logger "Pushing $AWS_BRANCH_APP_NGINX_REPO:$BRANCH_APP_NGINX_TAG"
+  for i in {1..3}; do
+    logger "Attempt $i"
+    if docker push $AWS_BRANCH_APP_NGINX_REPO:$BRANCH_APP_NGINX_TAG; then
+      logger "Pushed $AWS_BRANCH_APP_NGINX_REPO:$BRANCH_APP_NGINX_TAG"
+      break
+    elif [ $i -eq 3 ]; then
+      logger "All push attempts failed"
+      exit 1
+    else
+      sleep 5
+    fi
+  done
+else
+  logger "Image $AWS_BRANCH_APP_NGINX_REPO:$BRANCH_APP_NGINX_TAG already exists"
+fi

--- a/.buildkite/scripts/compile_assets.sh
+++ b/.buildkite/scripts/compile_assets.sh
@@ -59,7 +59,9 @@ if [[ ! $(docker images -q --filter "reference=$WEB_REPO:web-$WEB_TAG") ]]; then
   pull_web_image || exit 1
 fi
 
-if [[ $BUILDKITE_PARALLEL_JOB = 0 && $BUILDKITE_BRANCH != "main" ]]; then
+# BUILDKITE_PARALLEL_JOB is unset when the step has no parallelism configured
+# (preview.yml runs a single asset job); default to 0 so the staging build runs.
+if [[ ${BUILDKITE_PARALLEL_JOB:-0} = 0 && $BUILDKITE_BRANCH != "main" ]]; then
   logger "Building staging assets"
   docker rm staging-assets || :
   COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME}_staging \

--- a/.buildkite/scripts/deploy_branch.sh
+++ b/.buildkite/scripts/deploy_branch.sh
@@ -7,52 +7,11 @@ logger() {
   echo -e "${GREEN}$(date "+%Y/%m/%d %H:%M:%S") deploy_branch.sh: $1${NC}"
 }
 
-# Build preview app nginx image
-AWS_BRANCH_APP_NGINX_REPO=${ECR_REGISTRY}/gumroad/branch_app_nginx
+# The branch app nginx image is built and pushed by the parallel
+# "Build Branch App Nginx Image" step (.buildkite/scripts/build_branch_app_nginx.sh),
+# which this step depends on via the pipeline topology in .buildkite/preview.yml.
 REVISION=${BUILDKITE_COMMIT}
-
-function generate_nginx_tag(){
-  local paths=()
-  local app_dir
-  app_dir=$(git rev-parse --show-toplevel)
-
-  # Change relative paths to absolute paths
-  for arg in "$@"; do
-    paths+=("${app_dir}/${arg}")
-  done
-
-  # Get short SHA of the latest commit affecting the paths
-  git rev-list --abbrev-commit --abbrev=12 HEAD -1 -- "${paths[@]}"
-}
-
-BRANCH_APP_NGINX_TAG=$(generate_nginx_tag "docker/branch_app_nginx")
-
-logger "Checking if web image exists"
 WEB_TAG=$(echo $REVISION | cut -c1-12)
-WEB_REPO=${ECR_REGISTRY}/gumroad/web
-
-if ! docker manifest inspect $AWS_BRANCH_APP_NGINX_REPO:$BRANCH_APP_NGINX_TAG > /dev/null 2>&1; then
-  logger "Building $AWS_BRANCH_APP_NGINX_REPO:$BRANCH_APP_NGINX_TAG"
-  BRANCH_APP_NGINX_REPO=$AWS_BRANCH_APP_NGINX_REPO \
-    BRANCH_APP_NGINX_TAG=$BRANCH_APP_NGINX_TAG \
-    make build_branch_app_nginx
-
-  logger "Pushing $AWS_BRANCH_APP_NGINX_REPO:$BRANCH_APP_NGINX_TAG"
-  for i in {1..3}; do
-    logger "Attempt $i"
-    if docker push $AWS_BRANCH_APP_NGINX_REPO:$BRANCH_APP_NGINX_TAG; then
-      logger "Pushed $AWS_BRANCH_APP_NGINX_REPO:$BRANCH_APP_NGINX_TAG"
-      break
-    elif [ $i -eq 3 ]; then
-      logger "All push attempts failed"
-      exit 1
-    else
-      sleep 5
-    fi
-  done
-else
-  logger "Image $AWS_BRANCH_APP_NGINX_REPO:$BRANCH_APP_NGINX_TAG already exists"
-fi
 
 # Deploy preview app
 logger "Starting preview app deployment"


### PR DESCRIPTION
Reworks `.buildkite/preview.yml` topology to cut preview deploy wall-clock time. Item 2 of the #5802 checklist (item 1, per-phase timing, merged as antiwork/gumroad-deployment#39).

## What changed

**1. Nginx image build runs in parallel with base → web → assets.**
The branch app nginx image is content-addressed — its tag is `git rev-list -1 HEAD -- docker/branch_app_nginx` (verified: the tag depends only on `docker/branch_app_nginx/`, and its Dockerfile builds from `openresty/openresty:alpine-fat` + a COPY of its own conf; it consumes nothing from the base image, web image, or compiled assets). It previously ran serially inside `deploy_branch.sh`, i.e. only after the entire base → web → assets chain, by accident of placement. It's now its own root step (`.buildkite/scripts/build_branch_app_nginx.sh`, extracted verbatim from `deploy_branch.sh`), and the deploy step `depends_on` both it and `preview-compile-assets`.

**2. Dropped the wasted second asset agent on PR builds.**
`compile_assets.sh` job 1 (`BUILDKITE_PARALLEL_JOB = 1`) only builds production assets on `main` / `comp-assets-*` branches — but `preview.yml` is only ever uploaded by the preview gate on PR branches (`branches: "!main !comp-assets-*"` in `pipeline.yml`), so job 1 was guaranteed to no-op while occupying an agent. Removed `parallelism: 2` from the preview Compile Assets step. `compile_assets.sh` now defaults `BUILDKITE_PARALLEL_JOB` to 0 when unset (non-parallel steps don't set it) so the staging asset build still runs. `pipeline.yml` (main branch) is untouched and keeps `parallelism: 2`.

### Step graph

Before (fully serial):
```
base image → web image → assets (×2, job 1 no-ops) → deploy (nginx build inside)
```

After:
```
base image → web image → assets (×1) ─┐
nginx image ──────────────────────────┴→ deploy
```

Expected saving: the nginx build/manifest-check time is fully overlapped (it usually short-circuits on the `docker manifest inspect` cache hit, but on cache misses it was pure serial overhead), plus one fewer agent occupied per PR preview build.

## Test plan

- `python3 -c yaml.safe_load` passes on `.buildkite/preview.yml` and `.buildkite/pipeline.yml`; dependency graph rendered from the parsed YAML matches the "after" diagram above. Pipeline upload path checked: `preview_gate.sh` does a static `buildkite-agent pipeline upload .buildkite/preview.yml` — no dynamic generation to re-render.
- `bash -n` passes on all three touched scripts.
- Stub-ran `build_branch_app_nginx.sh` with stubbed `docker`/`make`: both branches exercised — image-missing path builds and pushes (EXIT=0, real content-addressed tag `ec7905578e24` computed from git), image-exists path skips (EXIT=0).
- Verified the `compile_assets.sh` guard with `BUILDKITE_PARALLEL_JOB` unset + PR branch → staging assets still build.
- The `PHASE` timing lines from antiwork/gumroad-deployment#39 will quantify the win on the first few preview deploys after merge.

Part of #5802
