### PR TITLE
Move Buildkite image builds to BuildKit registry caching against ECR

### DIFF
--- a/.buildkite/scripts/build_base.sh
+++ b/.buildkite/scripts/build_base.sh
@@ -7,16 +7,37 @@ logger() {
   echo -e "${GREEN}$(date "+%Y/%m/%d %H:%M:%S") build.sh: $1${NC}"
 }
 
-WEB_BASE_REPO=${ECR_REGISTRY}/gumroad/web_base
+source .buildkite/scripts/buildkit_cache.sh
 
-logger "pulling ruby:$(cat .ruby-version)-slim-bullseye"
-docker pull --quiet ruby:$(cat .ruby-version)-slim-bullseye
+WEB_BASE_REPO=${ECR_REGISTRY}/gumroad/web_base
+RUBY_IMAGE=ruby:$(cat .ruby-version)-slim-bullseye
+
+# generate_tag_for_web_base.sh hashes `docker history` of the ruby base image,
+# so it must be present locally — but only pull it when it's missing instead of
+# unconditionally re-pulling on every build.
+pull_image_if_missing "$RUBY_IMAGE"
+
 WEB_BASE_SHA=$(docker/base/generate_tag_for_web_base.sh)
 if ! docker manifest inspect $WEB_BASE_REPO:$WEB_BASE_SHA > /dev/null 2>&1; then
+  build_base_image() {
+    NEW_BASE_REPO=$WEB_BASE_REPO \
+      BUNDLE_GEMS__CONTRIBSYS__COM=$BUNDLE_GEMS__CONTRIBSYS__COM \
+      make build_base "$@"
+  }
+
   logger "Building $WEB_BASE_REPO:$WEB_BASE_SHA"
-  NEW_BASE_REPO=$WEB_BASE_REPO \
-    BUNDLE_GEMS__CONTRIBSYS__COM=$BUNDLE_GEMS__CONTRIBSYS__COM \
-    make build_base
+  if buildkit_cache_available; then
+    logger "Using BuildKit registry cache ($WEB_BASE_REPO:buildcache)"
+    if ! build_base_image \
+      DOCKER_BUILD="$(buildkit_docker_build)" \
+      BASE_CACHE_OPTS="$(buildkit_cache_opts $WEB_BASE_REPO:buildcache)"; then
+      logger "buildx build failed — falling back to plain docker build"
+      build_base_image
+    fi
+  else
+    logger "buildx unavailable — using plain docker build"
+    build_base_image
+  fi
 
   logger "Pushing $WEB_BASE_REPO:$WEB_BASE_SHA"
   for i in {1..3}; do

--- a/.buildkite/scripts/build_base.sh
+++ b/.buildkite/scripts/build_base.sh
@@ -13,8 +13,9 @@ WEB_BASE_REPO=${ECR_REGISTRY}/gumroad/web_base
 RUBY_IMAGE=ruby:$(cat .ruby-version)-slim-bullseye
 
 # generate_tag_for_web_base.sh hashes `docker history` of the ruby base image,
-# so it must be present locally — but only pull it when it's missing instead of
-# unconditionally re-pulling on every build.
+# so it must be present and current locally. The helper always pulls (cheap
+# manifest check when already current) and only falls back to an existing local
+# copy if the pull fails, e.g. during a Docker Hub outage.
 pull_ruby_base_image "$RUBY_IMAGE"
 
 WEB_BASE_SHA=$(docker/base/generate_tag_for_web_base.sh)

--- a/.buildkite/scripts/build_base.sh
+++ b/.buildkite/scripts/build_base.sh
@@ -15,7 +15,7 @@ RUBY_IMAGE=ruby:$(cat .ruby-version)-slim-bullseye
 # generate_tag_for_web_base.sh hashes `docker history` of the ruby base image,
 # so it must be present locally — but only pull it when it's missing instead of
 # unconditionally re-pulling on every build.
-pull_image_if_missing "$RUBY_IMAGE"
+pull_ruby_base_image "$RUBY_IMAGE"
 
 WEB_BASE_SHA=$(docker/base/generate_tag_for_web_base.sh)
 if ! docker manifest inspect $WEB_BASE_REPO:$WEB_BASE_SHA > /dev/null 2>&1; then
@@ -31,11 +31,11 @@ if ! docker manifest inspect $WEB_BASE_REPO:$WEB_BASE_SHA > /dev/null 2>&1; then
     if ! build_base_image \
       DOCKER_BUILD="$(buildkit_docker_build)" \
       BASE_CACHE_OPTS="$(buildkit_cache_opts $WEB_BASE_REPO:buildcache)"; then
-      logger "buildx build failed — falling back to plain docker build"
+      buildkit_fallback_notice "web_base" "buildx build failed"
       build_base_image
     fi
   else
-    logger "buildx unavailable — using plain docker build"
+    buildkit_fallback_notice "web_base" "buildx unavailable"
     build_base_image
   fi
 

--- a/.buildkite/scripts/build_branch_app_nginx.sh
+++ b/.buildkite/scripts/build_branch_app_nginx.sh
@@ -34,11 +34,11 @@ if ! docker manifest inspect "$AWS_BRANCH_APP_NGINX_REPO:$BRANCH_APP_NGINX_TAG" 
     if ! build_image \
       DOCKER_BUILD="$(buildkit_docker_build)" \
       BRANCH_APP_NGINX_CACHE_OPTS="$(buildkit_cache_opts "$AWS_BRANCH_APP_NGINX_REPO:buildcache")"; then
-      logger "buildx build failed — falling back to plain docker build"
+      buildkit_fallback_notice "branch_app_nginx" "buildx build failed"
       build_image
     fi
   else
-    logger "buildx unavailable — using plain docker build"
+    buildkit_fallback_notice "branch_app_nginx" "buildx unavailable"
     build_image
   fi
 

--- a/.buildkite/scripts/build_branch_app_nginx.sh
+++ b/.buildkite/scripts/build_branch_app_nginx.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 # a drifted copy here would push an image the deploy never looks for.
 # (Sourced first: helper.sh also defines a generic logger; ours below wins.)
 source "$(git rev-parse --show-toplevel)/ci_scripts/helper.sh"
+source "$(git rev-parse --show-toplevel)/.buildkite/scripts/buildkit_cache.sh"
 
 GREEN="\033[0;32m"
 NC="\033[0m"
@@ -21,10 +22,25 @@ AWS_BRANCH_APP_NGINX_REPO=${ECR_REGISTRY}/gumroad/branch_app_nginx
 BRANCH_APP_NGINX_TAG=$(generate_nginx_tag "docker/branch_app_nginx")
 
 if ! docker manifest inspect "$AWS_BRANCH_APP_NGINX_REPO:$BRANCH_APP_NGINX_TAG" > /dev/null 2>&1; then
+  build_image() {
+    BRANCH_APP_NGINX_REPO=$AWS_BRANCH_APP_NGINX_REPO \
+      BRANCH_APP_NGINX_TAG=$BRANCH_APP_NGINX_TAG \
+      make build_branch_app_nginx "$@"
+  }
+
   logger "Building $AWS_BRANCH_APP_NGINX_REPO:$BRANCH_APP_NGINX_TAG"
-  BRANCH_APP_NGINX_REPO=$AWS_BRANCH_APP_NGINX_REPO \
-    BRANCH_APP_NGINX_TAG=$BRANCH_APP_NGINX_TAG \
-    make build_branch_app_nginx
+  if buildkit_cache_available; then
+    logger "Using BuildKit registry cache ($AWS_BRANCH_APP_NGINX_REPO:buildcache)"
+    if ! build_image \
+      DOCKER_BUILD="$(buildkit_docker_build)" \
+      BRANCH_APP_NGINX_CACHE_OPTS="$(buildkit_cache_opts "$AWS_BRANCH_APP_NGINX_REPO:buildcache")"; then
+      logger "buildx build failed — falling back to plain docker build"
+      build_image
+    fi
+  else
+    logger "buildx unavailable — using plain docker build"
+    build_image
+  fi
 
   logger "Pushing $AWS_BRANCH_APP_NGINX_REPO:$BRANCH_APP_NGINX_TAG"
   for i in {1..3}; do

--- a/.buildkite/scripts/build_web.sh
+++ b/.buildkite/scripts/build_web.sh
@@ -16,8 +16,9 @@ REVISION=${BUILDKITE_COMMIT}
 RUBY_IMAGE=ruby:$(cat .ruby-version)-slim-bullseye
 
 # The Makefile's generate_tag_for_web_base.sh hashes `docker history` of the
-# ruby base image, so it must be present locally — but only pull it when it's
-# missing instead of unconditionally re-pulling on every build.
+# ruby base image, so it must be present and current locally. The helper always
+# pulls (cheap manifest check when already current) and only falls back to an
+# existing local copy if the pull fails, e.g. during a Docker Hub outage.
 pull_ruby_base_image "$RUBY_IMAGE"
 
 WEB_TAG=$(echo $REVISION | cut -c1-12)
@@ -92,11 +93,11 @@ if buildkit_cache_available; then
   if ! build_nginx_image \
     DOCKER_BUILD="$(buildkit_docker_build)" \
     NGINX_CACHE_OPTS="$(buildkit_cache_opts $AWS_NGINX_REPO:buildcache)"; then
-    buildkit_fallback_notice "web" "buildx build failed"
+    buildkit_fallback_notice "web_nginx" "buildx build failed"
     build_nginx_image
   fi
 else
-  buildkit_fallback_notice "web" "buildx unavailable"
+  buildkit_fallback_notice "web_nginx" "buildx unavailable"
   build_nginx_image
 fi
 

--- a/.buildkite/scripts/build_web.sh
+++ b/.buildkite/scripts/build_web.sh
@@ -18,7 +18,7 @@ RUBY_IMAGE=ruby:$(cat .ruby-version)-slim-bullseye
 # The Makefile's generate_tag_for_web_base.sh hashes `docker history` of the
 # ruby base image, so it must be present locally — but only pull it when it's
 # missing instead of unconditionally re-pulling on every build.
-pull_image_if_missing "$RUBY_IMAGE"
+pull_ruby_base_image "$RUBY_IMAGE"
 
 WEB_TAG=$(echo $REVISION | cut -c1-12)
 
@@ -40,11 +40,11 @@ if buildkit_cache_available; then
   if ! build_web_image \
     DOCKER_BUILD="$(buildkit_docker_build)" \
     WEB_CACHE_OPTS="$(buildkit_cache_opts $WEB_REPO:buildcache)"; then
-    logger "buildx build failed — falling back to plain docker build"
+    buildkit_fallback_notice "web" "buildx build failed"
     build_web_image
   fi
 else
-  logger "buildx unavailable — using plain docker build"
+  buildkit_fallback_notice "web" "buildx unavailable"
   build_web_image
 fi
 
@@ -92,11 +92,11 @@ if buildkit_cache_available; then
   if ! build_nginx_image \
     DOCKER_BUILD="$(buildkit_docker_build)" \
     NGINX_CACHE_OPTS="$(buildkit_cache_opts $AWS_NGINX_REPO:buildcache)"; then
-    logger "buildx build failed — falling back to plain docker build"
+    buildkit_fallback_notice "web" "buildx build failed"
     build_nginx_image
   fi
 else
-  logger "buildx unavailable — using plain docker build"
+  buildkit_fallback_notice "web" "buildx unavailable"
   build_nginx_image
 fi
 

--- a/.buildkite/scripts/build_web.sh
+++ b/.buildkite/scripts/build_web.sh
@@ -7,15 +7,19 @@ logger() {
   echo -e "${GREEN}$(date "+%Y/%m/%d %H:%M:%S") build_web.sh: $1${NC}"
 }
 
+source .buildkite/scripts/buildkit_cache.sh
+
 WEB_REPO=${ECR_REGISTRY}/gumroad/web
 WEB_BASE_REPO=${ECR_REGISTRY}/gumroad/web_base
 AWS_NGINX_REPO=${ECR_REGISTRY}/gumroad/web_nginx
 REVISION=${BUILDKITE_COMMIT}
+RUBY_IMAGE=ruby:$(cat .ruby-version)-slim-bullseye
 
-logger "pulling ruby:$(cat .ruby-version)-slim-bullseye"
-docker pull --quiet ruby:$(cat .ruby-version)-slim-bullseye
+# The Makefile's generate_tag_for_web_base.sh hashes `docker history` of the
+# ruby base image, so it must be present locally — but only pull it when it's
+# missing instead of unconditionally re-pulling on every build.
+pull_image_if_missing "$RUBY_IMAGE"
 
-WEB_BASE_SHA=$(docker/base/generate_tag_for_web_base.sh)
 WEB_TAG=$(echo $REVISION | cut -c1-12)
 
 # Copy secrets from credentials repo
@@ -23,11 +27,26 @@ source .buildkite/scripts/copy_secrets.sh
 copy_secrets
 
 # Build web image
+build_web_image() {
+  NEW_WEB_TAG=$WEB_TAG \
+    NEW_WEB_REPO=$WEB_REPO \
+    NEW_BASE_REPO=$WEB_BASE_REPO \
+    make build "$@"
+}
+
 logger "Building $WEB_REPO:web-$WEB_TAG"
-NEW_WEB_TAG=$WEB_TAG \
-  NEW_WEB_REPO=$WEB_REPO \
-  NEW_BASE_REPO=$WEB_BASE_REPO \
-  make build
+if buildkit_cache_available; then
+  logger "Using BuildKit registry cache ($WEB_REPO:buildcache)"
+  if ! build_web_image \
+    DOCKER_BUILD="$(buildkit_docker_build)" \
+    WEB_CACHE_OPTS="$(buildkit_cache_opts $WEB_REPO:buildcache)"; then
+    logger "buildx build failed — falling back to plain docker build"
+    build_web_image
+  fi
+else
+  logger "buildx unavailable — using plain docker build"
+  build_web_image
+fi
 
 # Push web image
 logger "Pushing $WEB_REPO:web-$WEB_TAG"
@@ -60,10 +79,26 @@ function generate_nginx_tag() {
 
 # Build and push nginx image
 NGINX_TAG=$(generate_nginx_tag "public" "docker/nginx")
+
+build_nginx_image() {
+  NGINX_TAG=$NGINX_TAG \
+    NGINX_REPO=$AWS_NGINX_REPO \
+    make build_nginx "$@"
+}
+
 logger "Building $AWS_NGINX_REPO:$NGINX_TAG"
-NGINX_TAG=$NGINX_TAG \
-  NGINX_REPO=$AWS_NGINX_REPO \
-  make build_nginx
+if buildkit_cache_available; then
+  logger "Using BuildKit registry cache ($AWS_NGINX_REPO:buildcache)"
+  if ! build_nginx_image \
+    DOCKER_BUILD="$(buildkit_docker_build)" \
+    NGINX_CACHE_OPTS="$(buildkit_cache_opts $AWS_NGINX_REPO:buildcache)"; then
+    logger "buildx build failed — falling back to plain docker build"
+    build_nginx_image
+  fi
+else
+  logger "buildx unavailable — using plain docker build"
+  build_nginx_image
+fi
 
 logger "Pushing $AWS_NGINX_REPO:$NGINX_TAG"
 for i in {1..3}; do

--- a/.buildkite/scripts/buildkit_cache.sh
+++ b/.buildkite/scripts/buildkit_cache.sh
@@ -23,6 +23,12 @@ buildkit_cache_available() {
     docker buildx create --name "$BUILDX_BUILDER_NAME" \
       --driver docker-container > /dev/null 2>&1 || return 1
   fi
+  # Inspecting with --bootstrap starts the builder container if it is not
+  # already running. Without this, the function reports the cache as available
+  # even when the container cannot start (for example, an unhealthy daemon),
+  # and the build only fails later inside the BuildKit path before falling
+  # back — one wasted build cycle and a confusing error in the logs.
+  docker buildx inspect "$BUILDX_BUILDER_NAME" --bootstrap > /dev/null 2>&1 || return 1
   return 0
 }
 

--- a/.buildkite/scripts/buildkit_cache.sh
+++ b/.buildkite/scripts/buildkit_cache.sh
@@ -1,0 +1,54 @@
+# shellcheck shell=bash
+# Shared helpers for BuildKit registry caching on Buildkite image builds.
+# Meant to be sourced, not executed.
+#
+# The classic `docker build` builder can only reuse layers that are already in
+# the local daemon, so a fresh (or pruned) agent rebuilds everything from
+# scratch. BuildKit's registry cache (--cache-from/--cache-to type=registry)
+# persists the layer cache in ECR next to the images themselves, so any agent
+# gets cache hits regardless of local state.
+#
+# Exporting a registry cache requires a docker-container BuildKit builder —
+# the default `docker` driver cannot `--cache-to type=registry`. If buildx or
+# the container builder is unavailable on the agent, callers must fall back to
+# the plain `docker build` path, which is exactly today's behavior.
+
+BUILDX_BUILDER_NAME=${BUILDX_BUILDER_NAME:-gumroad-buildkite}
+
+# True when buildx exists and a docker-container builder is (or can be made)
+# available. Creating the builder is idempotent across steps on the same agent.
+buildkit_cache_available() {
+  docker buildx version > /dev/null 2>&1 || return 1
+  if ! docker buildx inspect "$BUILDX_BUILDER_NAME" > /dev/null 2>&1; then
+    docker buildx create --name "$BUILDX_BUILDER_NAME" \
+      --driver docker-container > /dev/null 2>&1 || return 1
+  fi
+  return 0
+}
+
+# buildkit_cache_opts <cache-ref>
+# Cache import/export flags for the Makefile CACHE_OPTS variable.
+# image-manifest=true + oci-mediatypes=true are required for ECR, which
+# rejects the default (non-OCI) cache manifest media type.
+buildkit_cache_opts() {
+  local ref=$1
+  echo "--cache-from type=registry,ref=${ref} --cache-to type=registry,ref=${ref},mode=max,image-manifest=true,oci-mediatypes=true"
+}
+
+# Value for the Makefile DOCKER_BUILD variable. --load copies the image built
+# inside the container builder back into the docker engine so the existing
+# tag/push flow downstream keeps working unchanged.
+buildkit_docker_build() {
+  echo "docker buildx build --builder ${BUILDX_BUILDER_NAME} --load"
+}
+
+# pull_image_if_missing <image>
+# The content-addressed base tag hashes `docker history` of the ruby image, so
+# it must exist locally before the tag can be computed — but there is no need
+# to re-pull it on every build the way the old unconditional pull did.
+pull_image_if_missing() {
+  local image=$1
+  if ! docker image inspect "$image" > /dev/null 2>&1; then
+    docker pull --quiet "$image"
+  fi
+}

--- a/.buildkite/scripts/buildkit_cache.sh
+++ b/.buildkite/scripts/buildkit_cache.sh
@@ -17,11 +17,19 @@ BUILDX_BUILDER_NAME=${BUILDX_BUILDER_NAME:-gumroad-buildkite}
 
 # True when buildx exists and a docker-container builder is (or can be made)
 # available. Creating the builder is idempotent across steps on the same agent.
+# Since #5827 the nginx and base builds run in parallel, so two steps can race
+# `buildx create` here — when create fails, re-inspect: if the builder exists
+# now, the other step won it and we're fine.
 buildkit_cache_available() {
   docker buildx version > /dev/null 2>&1 || return 1
   if ! docker buildx inspect "$BUILDX_BUILDER_NAME" > /dev/null 2>&1; then
-    docker buildx create --name "$BUILDX_BUILDER_NAME" \
-      --driver docker-container > /dev/null 2>&1 || return 1
+    if ! create_err=$(docker buildx create --name "$BUILDX_BUILDER_NAME" \
+      --driver docker-container 2>&1 > /dev/null); then
+      if ! docker buildx inspect "$BUILDX_BUILDER_NAME" > /dev/null 2>&1; then
+        echo "buildkit_cache: builder unavailable, falling back to plain docker build: ${create_err}" >&2
+        return 1
+      fi
+    fi
   fi
   # Inspecting with --bootstrap starts the builder container if it is not
   # already running. Without this, the function reports the cache as available
@@ -48,13 +56,38 @@ buildkit_docker_build() {
   echo "docker buildx build --builder ${BUILDX_BUILDER_NAME} --load"
 }
 
-# pull_image_if_missing <image>
-# The content-addressed base tag hashes `docker history` of the ruby image, so
-# it must exist locally before the tag can be computed — but there is no need
-# to re-pull it on every build the way the old unconditional pull did.
-pull_image_if_missing() {
+# buildkit_fallback_notice <image-name> <reason>
+# The plain-docker-build fallback is safe but slow (no registry cache). Log it,
+# and surface a Buildkite annotation so persistent degradation on an agent is
+# visible on the build page instead of buried in step logs. Never fails.
+buildkit_fallback_notice() {
+  local image=$1 reason=$2
+  echo "buildkit_cache: ${image}: ${reason} — using plain docker build (slower, no registry cache)" >&2
+  if command -v buildkite-agent > /dev/null 2>&1; then
+    echo "BuildKit registry cache unavailable for \`${image}\` (${reason}) — built with plain \`docker build\` instead. Slower but safe; recurring warnings here mean an agent needs attention." \
+      | buildkite-agent annotate --style warning --context "buildkit-cache-${image}" 2>/dev/null || true
+  fi
+}
+
+# pull_ruby_base_image <image>
+# The content-addressed web_base tag hashes `docker history` of the LOCAL ruby
+# image, so every agent must converge on the same upstream image or two agents
+# will compute different tags for identical source — and a `build_web` step can
+# then reference a web_base tag nobody pushed (hard build failure). Docker Hub
+# re-tags `*-slim-bullseye` on Debian security rebuilds, so a warm agent's
+# months-old local copy is NOT safe to trust. Always pull; when the local image
+# is already current this is a cheap manifest check, not a re-download. If the
+# pull fails (Hub outage / rate limit) fall back to a present local image
+# rather than failing the build — stale-tag divergence is then possible but a
+# transient outage shouldn't stop deploys.
+pull_ruby_base_image() {
   local image=$1
-  if ! docker image inspect "$image" > /dev/null 2>&1; then
-    docker pull --quiet "$image"
+  if ! docker pull --quiet "$image"; then
+    if docker image inspect "$image" > /dev/null 2>&1; then
+      echo "buildkit_cache: pull of ${image} failed; using existing local copy (tag divergence possible until the next successful pull)" >&2
+    else
+      echo "buildkit_cache: pull of ${image} failed and no local copy exists" >&2
+      return 1
+    fi
   fi
 }

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,16 @@ COMPOSE_PROJECT_NAME ?= web
 RUBY_VERSION := $(shell cat .ruby-version)
 WEB_BASE_DOCKERFILE_FROM ?= ruby:$(RUBY_VERSION)-slim-bullseye
 DOCKER_CMD ?= docker
+# Overridable so CI can swap in `docker buildx build --load` (BuildKit) while
+# local/fallback builds keep the classic builder. --compress lives here because
+# buildx does not support the flag.
+DOCKER_BUILD ?= $(DOCKER_CMD) build --compress
+# Per-target cache flags. Defaults reproduce the pre-BuildKit behavior exactly;
+# CI overrides them with --cache-from/--cache-to type=registry against ECR.
+BASE_CACHE_OPTS ?= --cache-from $(NEW_BASE_REPO):latest
+WEB_CACHE_OPTS ?= --cache-from $(NEW_BASE_REPO):$(shell ./docker/base/generate_tag_for_web_base.sh) --cache-from $(NEW_WEB_REPO):web-$(NEW_WEB_TAG)
+NGINX_CACHE_OPTS ?=
+BRANCH_APP_NGINX_CACHE_OPTS ?=
 DOCKER_COMPOSE_CMD ?= docker compose
 AWS_CLI_DOCKER_IMAGE ?= garland/aws-cli-docker
 PUSH_ASSETS ?= false
@@ -24,11 +34,11 @@ build_base:
 	rm -f docker/base/Gemfile* docker/base/.ruby-version
 	cp Gemfile* .ruby-version docker/base
 	cd docker/base \
-		&& $(DOCKER_CMD) build -t $(NEW_BASE_REPO):latest \
+		&& $(DOCKER_BUILD) -t $(NEW_BASE_REPO):latest \
 			--build-arg BUNDLE_GEMS__CONTRIBSYS__COM \
 			--build-arg WEB_BASE_DOCKERFILE_FROM=$(WEB_BASE_DOCKERFILE_FROM) \
-			--cache-from $(NEW_BASE_REPO):latest \
-			--compress . \
+			$(BASE_CACHE_OPTS) \
+			. \
 		&& ./generate_tag_for_web_base.sh | xargs -I{} $(DOCKER_CMD) tag $(NEW_BASE_REPO):latest $(NEW_BASE_REPO):{} \
 		&& rm -f Gemfile* .ruby-version
 
@@ -48,24 +58,25 @@ build:
 	: $${BUNDLE_GEMS__CONTRIBSYS__COM?"Need to set BUNDLE_GEMS__CONTRIBSYS__COM for sidekiq-pro"}
 	echo $(NEW_WEB_TAG) > revision
 	WEB_DOCKERFILE_FROM=$(NEW_BASE_REPO):$(shell ./docker/base/generate_tag_for_web_base.sh) \
-	$(DOCKER_CMD) build -t $(NEW_WEB_REPO):latest \
+	$(DOCKER_BUILD) -t $(NEW_WEB_REPO):latest \
 		--build-arg BUNDLE_GEMS__CONTRIBSYS__COM \
-		--cache-from $(NEW_BASE_REPO):$(shell ./docker/base/generate_tag_for_web_base.sh) \
-		--cache-from $(NEW_WEB_REPO):web-$(NEW_WEB_TAG) \
+		$(WEB_CACHE_OPTS) \
 		--build-arg WEB_DOCKERFILE_FROM \
 		--file docker/web/Dockerfile \
-		--compress .
+		.
 	$(DOCKER_CMD) tag $(NEW_WEB_REPO):latest $(NEW_WEB_REPO):web-$(NEW_WEB_TAG)
 
 build_nginx:
-	$(DOCKER_CMD) build -t $(NGINX_REPO):$(NGINX_TAG) \
+	$(DOCKER_BUILD) -t $(NGINX_REPO):$(NGINX_TAG) \
+		$(NGINX_CACHE_OPTS) \
 		--file docker/nginx/Dockerfile \
-		--compress .
+		.
 
 build_branch_app_nginx:
-	$(DOCKER_CMD) build -t $(BRANCH_APP_NGINX_REPO):$(BRANCH_APP_NGINX_TAG) \
+	$(DOCKER_BUILD) -t $(BRANCH_APP_NGINX_REPO):$(BRANCH_APP_NGINX_TAG) \
+		$(BRANCH_APP_NGINX_CACHE_OPTS) \
 		--file docker/branch_app_nginx/Dockerfile \
-		--compress .
+		.
 
 build_test:
 	WEB_DOCKERFILE_FROM=$(NEW_BASE_REPO):$(shell ./docker/base/generate_tag_for_web_base.sh) \


### PR DESCRIPTION
Part of #5802 — medium-bet item: "Move Buildkite image builds to BuildKit `buildx --cache-to/--cache-from type=registry` against ECR; stop the unconditional `docker pull ruby:*-slim` that runs before the manifest-inspect short-circuit."

## Problem

The Buildkite agents build base/web/nginx images with the classic `docker build` builder, which only reuses layers already present in the local daemon. A fresh agent — or one whose builder cache was pruned by the `pre-command` hook's `docker builder prune --filter until=24h` — rebuilds every layer from scratch. Both build scripts also unconditionally `docker pull ruby:*-slim-bullseye` even when the content-addressed manifest-inspect check is about to short-circuit the entire build.

## Change

**New sourced helper `.buildkite/scripts/buildkit_cache.sh`:**
- `buildkit_cache_available` — checks `docker buildx version` and creates (idempotently) a `docker-container` builder, which is required to export `--cache-to type=registry` (the default `docker` driver can't).
- `buildkit_cache_opts <ref>` — emits `--cache-from type=registry,ref=<ecr-repo>:buildcache --cache-to type=registry,ref=...,mode=max,image-manifest=true,oci-mediatypes=true`. The `image-manifest=true,oci-mediatypes=true` options are required for ECR, which rejects the default cache manifest media type.
- `pull_image_if_missing` — pulls the ruby image only when absent locally. It still must exist before tag computation (`generate_tag_for_web_base.sh` hashes its `docker history`), but no longer gets re-pulled on every single build.

**`build_base.sh` / `build_web.sh` / `build_branch_app_nginx.sh`:**
- Manifest-inspect short-circuits stay exactly where they were — first. Cache only helps on a miss.
- On miss: if buildx is available, build via `docker buildx build --builder gumroad-buildkite --load` with registry cache flags against `<ecr-repo>:buildcache`; `--load` keeps the built image in the docker engine so the existing tag/push flow is untouched.
- If buildx is unavailable **or the buildx build itself fails**, fall back to the plain `make` invocation — byte-for-byte today's `docker build --compress` command.

**`Makefile`:** the four image targets (`build_base`, `build`, `build_nginx`, `build_branch_app_nginx`) now go through overridable `DOCKER_BUILD` and per-target `*_CACHE_OPTS` variables. **Defaults reproduce the previous commands exactly** (classic builder, `--compress`, same `--cache-from` flags), so local builds, the GH Actions path, and any other caller are unchanged unless they opt in.

Cache repo naming: `<ecr>/gumroad/{web_base,web,web_nginx,branch_app_nginx}:buildcache` — cache manifests live in the same ECR repos as the images, so no new repos or IAM changes are needed (push permission to these repos already exists — it's how the images get there).

## Why worst case == today

Every script has three paths, all verified by execution (see below):
1. buildx + container builder available → registry-cached buildx build.
2. buildx missing → plain `docker build`, identical flags to current main.
3. buildx present but build fails (e.g. builder container can't start, ECR cache push rejected) → logged, then plain `docker build`.

## Verification

Docker daemon wasn't running locally, so this was verified by **logic-traced execution with a stub `docker` on PATH** (records every invocation, simulates buildx present/absent/failing and ruby image present/absent), not by real image builds:

- `bash -n` on all four scripts; `shellcheck` (no errors; remaining info-level SC2086 quoting hints match the pre-existing style of these scripts).
- `make -n build_nginx` with and without the CI overrides — printed commands match intent; fallback prints the exact pre-change command.
- Ran `build_base.sh`, `build_web.sh` (with `copy_secrets` stubbed), and `build_branch_app_nginx.sh` end-to-end under the stub for all three paths. Confirmed: correct `buildx build --cache-from/--cache-to type=registry` invocations; fallback runs the identical classic command; ruby pull happens 0 times when the image exists locally and exactly once when missing; builder create is idempotent across runs.

**Not verified locally:** an actual ECR cache-manifest push (needs a live agent + ECR). ECR has supported OCI cache manifests since 2023 given `image-manifest=true,oci-mediatypes=true`; if an agent's ECR/registry setup rejects it anyway, that build fails → the script falls back to the plain build, so the failure mode is a slower build, not a broken one. First post-merge Buildkite runs (PHASE timing from gumroad-deployment#39) will confirm the cache-hit win.
