### PR TITLE
Add help center article: Casting videos to your TV

### DIFF
--- a/app/models/help_center/articles.yml
+++ b/app/models/help_center/articles.yml
@@ -620,3 +620,8 @@
   title: "GDPR and data privacy requests"
   description: "Learn about your data privacy rights on Gumroad, including how to request data deletion, access your personal data, and understand what information we retain."
   category_id: <%= HelpCenter::Category::ADVANCED.id %>
+- id: 350
+  slug: "350-casting-videos-to-your-tv"
+  title: "Casting videos to your TV"
+  description: "Gumroad's video player does not support Chromecast or AirPlay casting. Here are the ways that do work to watch a video on your TV: casting a Chrome tab, AirPlay screen mirroring, a smart TV browser, or an HDMI cable."
+  category_id: <%= HelpCenter::Category::ACCESSING_YOUR_PURCHASE.id %>

--- a/app/views/help_center/articles/contents/_350-casting-videos-to-your-tv.html.erb
+++ b/app/views/help_center/articles/contents/_350-casting-videos-to-your-tv.html.erb
@@ -1,0 +1,19 @@
+<div>
+  <p>Gumroad's video player does not support Chromecast or AirPlay casting. Video streams are protected so that only the buyer's signed-in session can access them, and casting devices fetch the stream on their own, so a cast session would connect but never play. Because of this, the player does not show a cast button.</p>
+  <h3 id="watching-on-your-tv">Ways to watch a video on your TV</h3>
+  <p>Here are the options that do work:</p>
+  <ul>
+    <li><strong>Cast a Chrome tab:</strong> Open your <a href="https://gumroad.com/library">Library</a> in the Chrome browser on a computer, start the video, then click Chrome's three-dot menu and choose "Cast" to send the whole tab to a Chromecast or Google TV. If the TV shows a black screen, turn off "Use hardware acceleration when available" in Chrome's settings, restart Chrome, and try again.</li>
+    <li><strong>AirPlay screen mirroring:</strong> On an iPhone, iPad, or Mac, play the video in Safari from your Library, then use Screen Mirroring from Control Center to send your screen to an Apple TV or AirPlay-compatible TV.</li>
+    <li><strong>Smart TV browser:</strong> If your TV has a web browser, log in to <a href="https://gumroad.com/library">gumroad.com/library</a> directly on the TV and play the video there.</li>
+    <li><strong>HDMI cable:</strong> Connect your computer to the TV with an HDMI cable and play the video full screen.</li>
+  </ul>
+</div>
+<div>
+  <h3>Related Articles</h3>
+  <ul>
+    <li><a href="198-your-gumroad-library"><span>Your Gumroad Library</span></a></li>
+    <li><a href="199-how-do-i-access-my-purchase"><span>How do I access my purchase?</span></a></li>
+    <li><a href="195-theres-an-issue-with-my-purchase"><span>There's an issue with my purchase</span></a></li>
+  </ul>
+</div>


### PR DESCRIPTION
## What
Adds a new customer-facing help center article, **Casting videos to your TV** (`350-casting-videos-to-your-tv`, category: Accessing your purchase).

## Why
Direct buyer feedback on the casting bug ticket that led to gumroad-private#1051 / PR #5826: after we removed the broken Chromecast button, the buyer suggested documenting casting on the site — searching "cast" in the help center returned no results. Help center search filters on article titles, so this title makes that search resolve.

## Content
- States the player doesn't support Chromecast/AirPlay (streams are session-authenticated, so a casting device can't fetch them; this is why there's no cast button) — matches the root cause verified in gumroad-private#1051 and the behavior shipped in #5826.
- Lists the four working paths we already give buyers in support: Chrome tab casting (with the hardware-acceleration-off tip for black screens), AirPlay screen mirroring, smart TV browser, HDMI.

## Verification
- `bundle exec rspec spec/models/help_center spec/presenters/help_center_presenter_spec.rb` — 6 examples, 0 failures (guards slug↔partial integrity).
- Rendered the partial in the real view context via rails runner: render OK, article #350 resolves to "Accessing your purchase" (audience: customer).
- Autoreview skipped (docs copy only, no logic).

Request from support: buyer report on Helper ticket cb1221c0e3cb5401135792d2d9117655.