### PR TITLE
Push web image straight from the BuildKit builder instead of load-then-push

### DIFF
--- a/.buildkite/scripts/build_web.sh
+++ b/.buildkite/scripts/build_web.sh
@@ -36,11 +36,18 @@ build_web_image() {
 }
 
 logger "Building $WEB_REPO:web-$WEB_TAG"
+WEB_IMAGE_PUSHED=false
 if buildkit_cache_available; then
-  logger "Using BuildKit registry cache ($WEB_REPO:buildcache)"
-  if ! build_web_image \
-    DOCKER_BUILD="$(buildkit_docker_build)" \
+  logger "Using BuildKit registry cache ($WEB_REPO:buildcache); pushing web-$WEB_TAG straight from the builder"
+  if build_web_image \
+    DOCKER_BUILD="$(buildkit_docker_build_push)" \
+    WEB_OUTPUT_OPTS="-t $WEB_REPO:web-$WEB_TAG" \
+    WEB_POST_BUILD=":" \
     WEB_CACHE_OPTS="$(buildkit_cache_opts $WEB_REPO:buildcache)"; then
+    # --push already uploaded web-$WEB_TAG to ECR as part of the build, so the
+    # separate push loop below would be a redundant (if cheap) re-upload.
+    WEB_IMAGE_PUSHED=true
+  else
     buildkit_fallback_notice "web" "buildx build failed"
     build_web_image
   fi
@@ -49,20 +56,24 @@ else
   build_web_image
 fi
 
-# Push web image
-logger "Pushing $WEB_REPO:web-$WEB_TAG"
-for i in {1..3}; do
-  logger "Push attempt $i"
-  if docker push --quiet $WEB_REPO:web-$WEB_TAG; then
-    logger "Pushed $WEB_REPO:web-$WEB_TAG"
-    break
-  elif [ $i -eq 3 ]; then
-    logger "Failed to push $WEB_REPO:web-$WEB_TAG after 3 attempts"
-    exit 1
-  else
-    sleep 5
-  fi
-done
+# Push web image (already done by the builder on the BuildKit path above)
+if [ "$WEB_IMAGE_PUSHED" = "true" ]; then
+  logger "$WEB_REPO:web-$WEB_TAG already pushed by the builder"
+else
+  logger "Pushing $WEB_REPO:web-$WEB_TAG"
+  for i in {1..3}; do
+    logger "Push attempt $i"
+    if docker push --quiet $WEB_REPO:web-$WEB_TAG; then
+      logger "Pushed $WEB_REPO:web-$WEB_TAG"
+      break
+    elif [ $i -eq 3 ]; then
+      logger "Failed to push $WEB_REPO:web-$WEB_TAG after 3 attempts"
+      exit 1
+    else
+      sleep 5
+    fi
+  done
+fi
 
 function generate_nginx_tag() {
   local paths=()

--- a/.buildkite/scripts/buildkit_cache.sh
+++ b/.buildkite/scripts/buildkit_cache.sh
@@ -56,6 +56,17 @@ buildkit_docker_build() {
   echo "docker buildx build --builder ${BUILDX_BUILDER_NAME} --load"
 }
 
+# Like buildkit_docker_build, but pushes the tagged image straight from the
+# builder to the registry (--push) instead of exporting it back into the local
+# docker engine (--load). For the multi-GB web image the --load export alone
+# costs about a minute per build, and the image was going to be pushed right
+# after anyway — pushing from the builder does the upload once and skips the
+# export entirely. Downstream steps that need the image locally (asset compile
+# on another agent, for example) already pull it from ECR when it is missing.
+buildkit_docker_build_push() {
+  echo "docker buildx build --builder ${BUILDX_BUILDER_NAME} --push"
+}
+
 # buildkit_fallback_notice <image-name> <reason>
 # The plain-docker-build fallback is safe but slow (no registry cache). Log it,
 # and surface a Buildkite annotation so persistent degradation on an agent is

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,13 @@ DOCKER_BUILD ?= $(DOCKER_CMD) build --compress
 # CI overrides them with --cache-from/--cache-to type=registry against ECR.
 BASE_CACHE_OPTS ?= --cache-from $(NEW_BASE_REPO):latest
 WEB_CACHE_OPTS ?= --cache-from $(NEW_BASE_REPO):$(shell ./docker/base/generate_tag_for_web_base.sh) --cache-from $(NEW_WEB_REPO):web-$(NEW_WEB_TAG)
+# How the built web image leaves the builder, and what runs after. The defaults
+# reproduce the classic flow: build into the local Docker engine tagged
+# :latest, then add the commit-specific web-<sha> tag (the caller pushes it).
+# CI's BuildKit path overrides these to push the web-<sha> tag straight from
+# the builder to ECR, skipping the slow export back into the local engine.
+WEB_OUTPUT_OPTS ?= -t $(NEW_WEB_REPO):latest
+WEB_POST_BUILD ?= $(DOCKER_CMD) tag $(NEW_WEB_REPO):latest $(NEW_WEB_REPO):web-$(NEW_WEB_TAG)
 NGINX_CACHE_OPTS ?=
 BRANCH_APP_NGINX_CACHE_OPTS ?=
 DOCKER_COMPOSE_CMD ?= docker compose
@@ -58,13 +65,13 @@ build:
 	: $${BUNDLE_GEMS__CONTRIBSYS__COM?"Need to set BUNDLE_GEMS__CONTRIBSYS__COM for sidekiq-pro"}
 	echo $(NEW_WEB_TAG) > revision
 	WEB_DOCKERFILE_FROM=$(NEW_BASE_REPO):$(shell ./docker/base/generate_tag_for_web_base.sh) \
-	$(DOCKER_BUILD) -t $(NEW_WEB_REPO):latest \
+	$(DOCKER_BUILD) $(WEB_OUTPUT_OPTS) \
 		--build-arg BUNDLE_GEMS__CONTRIBSYS__COM \
 		$(WEB_CACHE_OPTS) \
 		--build-arg WEB_DOCKERFILE_FROM \
 		--file docker/web/Dockerfile \
 		.
-	$(DOCKER_CMD) tag $(NEW_WEB_REPO):latest $(NEW_WEB_REPO):web-$(NEW_WEB_TAG)
+	$(WEB_POST_BUILD)
 
 build_nginx:
 	$(DOCKER_BUILD) -t $(NGINX_REPO):$(NGINX_TAG) \


### PR DESCRIPTION
## What

Pushes the web image to ECR straight from the BuildKit builder (`--push`) instead of exporting it back into the local Docker engine (`--load`) and running a separate `docker push`. The Makefile `build` target gains overridable `WEB_OUTPUT_OPTS` / `WEB_POST_BUILD` variables whose defaults reproduce the classic `docker build` flow byte-for-byte; only the CI BuildKit path overrides them to tag the image with its final `web-<sha>` name and push from the builder.

## Why

#5828 moved Buildkite image builds to a docker-container BuildKit builder with an ECR registry cache. Layer caching works (45 CACHED steps on today's preview builds, gems + GeoIP all hit), but `--load` re-exports the multi-GB image into the local engine on every build — measured at ~70s of "exporting to docker image format" in preview build 13916, which pushed the Build Web Image step from ~1.9 min pre-#5828 to 3.1–3.8 min after. The image was being uploaded to ECR immediately afterwards anyway, so the export is pure overhead: `--push` uploads once from the builder and skips it.

Nothing downstream needs the local copy: `compile_assets.sh` already pulls `web-<sha>` from ECR when it's not in the local engine (line 58), which is the normal case when assets run on a different agent. When assets happen to land on the same agent this shifts a pull into that step — the PHASE instrumentation from gumroad-deployment#39 will show the net effect.

Part of #5802.

## Test plan

- `bash -n` + shellcheck on both scripts (only pre-existing info-level notes).
- `make -n build` dry-runs verified for both paths:
  - default: identical command to main (`docker build --compress -t …:latest`, then `docker tag`)
  - CI override: `docker buildx build --builder … --push -t REG/gumroad/web:web-<sha> …` with cache opts, post-build no-op
- Fallback path (buildx unavailable / build failed) unchanged: classic build + the existing retry push loop still runs (`WEB_IMAGE_PUSHED` stays false).
- After merge: compare Build Web Image duration on the next preview redeploys against today's 3.1–3.8 min (target: back under ~2.5 min) and confirm Deploy Preview App still finds `web-<sha>` in ECR.

## Before/After

Not a UI change — CI build pipeline only.
