### PR TITLE
Percent-encode store-agent path params: non-ASCII ids 500 the confirm flow

### DIFF
--- a/app/services/ai/store_agent_api_catalog.rb
+++ b/app/services/ai/store_agent_api_catalog.rb
@@ -52,7 +52,13 @@ module Ai::StoreAgentApiCatalog
         if value.match?(%r{[/\\]}) || value.include?("..") || value.include?("%")
           raise ArgumentError, "Invalid path parameter :#{key}"
         end
-        value
+        # Percent-encode the value before it is spliced into the URL. LLM-proposed ids sometimes
+        # carry stray non-ASCII characters (e.g. "GJs2આ"), and Ruby's URI.parse — which rack-test
+        # runs on the internal request path — raises URI::InvalidURIError on any non-ASCII URI,
+        # turning a merely-wrong id into a 500 at confirm time (gumroad-private#1054). Encoded,
+        # the request routes normally and the API answers with its own clean "not found" message.
+        # Encoding happens AFTER the validations above so their view of the raw value is unchanged.
+        ERB::Util.url_encode(value)
       end
     end
 

--- a/spec/services/ai/store_agent_api_catalog_spec.rb
+++ b/spec/services/ai/store_agent_api_catalog_spec.rb
@@ -31,6 +31,20 @@ describe Ai::StoreAgentApiCatalog do
     it "rejects a percent-encoded path param (could decode to a separator)" do
       expect { endpoint.expand_path("id" => "%2e%2e%2fadmin") }.to raise_error(ArgumentError, /invalid path parameter/i)
     end
+
+    # Regression: gumroad-private#1054. LLM-proposed ids sometimes carry non-ASCII characters;
+    # unencoded, URI.parse raises URI::InvalidURIError inside the internal rack-test dispatch and
+    # the seller sees a 500 "Something went wrong" instead of the API's clean "not found".
+    it "percent-encodes a non-ASCII path param so the internal URI stays ascii-only" do
+      expanded = endpoint.expand_path("id" => "GJs2આ")
+      expect(expanded).to eq("/products/GJs2%E0%AA%86")
+      expect { URI.parse("http://api.gumroad.com#{expanded}") }.not_to raise_error
+    end
+
+    it "percent-encodes other URI-hostile characters (spaces) without altering safe ids" do
+      expect(endpoint.expand_path("id" => "a b")).to eq("/products/a%20b")
+      expect(endpoint.expand_path("id" => "abc-DEF_123")).to eq("/products/abc-DEF_123")
+    end
   end
 
   describe ".find" do


### PR DESCRIPTION
## Root cause (gumroad-private#1054)

The agent confirm path (`AgentMessagesController#execute` → `StoreAgentActionExecutor` → `StoreAgentApiClient`) replays the confirmed write through the real v2 API via an in-process `ActionDispatch::Integration::Session`. rack-test calls `URI.parse` on the internal URL, and Ruby's URI parser raises `URI::InvalidURIError` on **any non-ASCII byte** — so a proposal whose product id carries a stray non-ASCII character 500s at confirm with the generic "Something went wrong", and the proposal card dismisses.

Production evidence (ES logs, request `001d3d14`): `URI must be ascii only "http://api.gumroad.com:80/v2/products/GJs2\u0A86"` → `Api::Internal::AgentMessagesController#execute status=500`. Mobile agent path shows the same signature (Jul 9–10) — both share `Endpoint#expand_path`.

## Fix

`ERB::Util.url_encode` each substituted path param in `Endpoint#expand_path`, **after** the existing path-injection guards (separators/traversal/%-escapes) so their view of the raw value is unchanged. Well-formed ids (`[A-Za-z0-9_-]`) pass through byte-identical; a wrong-but-non-ASCII id now routes to the API and comes back as the API's own clean "not found" message the seller can act on.

## Test plan

- New regression specs: non-ASCII id (`GJs2આ` → `/products/GJs2%E0%AA%86`, parseable by URI), space encoding, safe-id passthrough. **Red-green verified**: 2 failures without the app change, 0 with.
- Full `store_agent_api_catalog` + `store_agent_action_executor` suites: 30 examples, 0 failures.
- Rubocop clean.

## Note on scale of impact

Retained logs (Jul 6+) show only ~6 confirm failures with this signature — the "26 of 30 confirms never applied" figure in #1054 likely mixes in the (much noisier) Anthropic-timeout failure mode on the propose/stream side, which is a separate issue. This PR fixes the deterministic confirm 500; the timeout noise and the dead Sentry ingestion remain open in #1054.