### PR TITLE
Store agent: per-operation Anthropic timeouts, transient-failure retries, prompt caching

### DIFF
--- a/app/services/ai/anthropic_client.rb
+++ b/app/services/ai/anthropic_client.rb
@@ -20,8 +20,25 @@ class Ai::AnthropicClient
   class Error < StandardError; end
   # A failure that is safe and worthwhile to retry: the upstream was momentarily overloaded, rate
   # limited, returned a 5xx, or the network dropped. Distinct from Error so callers (and our own
-  # retry loop) never retry a real bug like a malformed tool call.
-  class TransientError < Error; end
+  # retry loop) never retry a real bug like a malformed tool call. `retry_after` carries the
+  # server's own back-off hint (the Retry-After header on a 429) in seconds, when it sent one.
+  class TransientError < Error
+    attr_reader :retry_after
+
+    def initialize(message, retry_after: nil)
+      super(message)
+      @retry_after = retry_after
+    end
+  end
+  # the retry loop uses it so we don't retry into the same rate-limit window and waste an attempt.
+  class TransientError < Error
+    attr_reader :retry_after
+
+    def initialize(message, retry_after: nil)
+      super(message)
+      @retry_after = retry_after
+    end
+  end
 
   API_URL = "https://api.anthropic.com/v1/messages"
   API_VERSION = "2023-06-01"
@@ -41,6 +58,13 @@ class Ai::AnthropicClient
   # never retried once any output has reached the caller — the seller would see the reply restart.
   MAX_ATTEMPTS = 3
   RETRY_BASE_DELAY_IN_SECONDS = 1
+
+  # Ceiling on the TOTAL seconds one client instance may spend asleep between retries, across all
+  # of its calls. The agent's buffered tool loop makes several requests on one client from the web
+  # request thread (which Rack::Timeout is watching), so without a shared cap each request could
+  # add its own retry delays and stack up many seconds of blocked time. Once the budget is spent,
+  # failures surface immediately instead of sleeping.
+  RETRY_SLEEP_BUDGET_IN_SECONDS = 6
 
   # Response statuses worth a retry: rate limit (429), server errors (5xx), and Anthropic's
   # "overloaded" status (529). Anything else (400 bad request, 401 bad key, ...) is deterministic —

--- a/app/services/ai/anthropic_client.rb
+++ b/app/services/ai/anthropic_client.rb
@@ -18,6 +18,10 @@
 # lives entirely in StoreAgentApiClient, which this never touches.
 class Ai::AnthropicClient
   class Error < StandardError; end
+  # A failure that is safe and worthwhile to retry: the upstream was momentarily overloaded, rate
+  # limited, returned a 5xx, or the network dropped. Distinct from Error so callers (and our own
+  # retry loop) never retry a real bug like a malformed tool call.
+  class TransientError < Error; end
 
   API_URL = "https://api.anthropic.com/v1/messages"
   API_VERSION = "2023-06-01"
@@ -26,8 +30,32 @@ class Ai::AnthropicClient
   DEFAULT_MODEL = "claude-opus-4-7"
   DEFAULT_MAX_TOKENS = 1024
 
+  # How long we wait to open the connection and to send the request. These are short on purpose:
+  # if Anthropic isn't reachable quickly, we want to fail fast and retry rather than sit on a dead
+  # socket while the seller stares at a spinner.
+  CONNECT_TIMEOUT_IN_SECONDS = 10
+  WRITE_TIMEOUT_IN_SECONDS = 30
+
+  # Total attempts per request (1 original + up to 2 retries) and the base delay between them
+  # (attempt N sleeps N * base). Retries only fire for TransientError, and a streaming request is
+  # never retried once any output has reached the caller — the seller would see the reply restart.
+  MAX_ATTEMPTS = 3
+  RETRY_BASE_DELAY_IN_SECONDS = 1
+
+  # Response statuses worth a retry: rate limit (429), server errors (5xx), and Anthropic's
+  # "overloaded" status (529). Anything else (400 bad request, 401 bad key, ...) is deterministic —
+  # retrying would just repeat the same failure slower.
+  RETRYABLE_STATUS_CODES = [429, 500, 502, 503, 504, 529].freeze
+  # Mid-stream `error` events with these types are the streaming equivalents of the statuses above.
+  RETRYABLE_STREAM_ERROR_TYPES = %w[overloaded_error api_error rate_limit_error timeout_error].freeze
+
   Result = Struct.new(:text, :tool_uses, :stop_reason, keyword_init: true)
 
+  # `timeout` is the READ timeout: how long a single read from Anthropic may block before we give
+  # up. For a streaming request that means "seconds of silence between chunks", not the total
+  # duration of the response — a healthy stream that takes minutes to finish is fine as long as
+  # tokens keep arriving. For a buffered request it bounds the wait for the response to start,
+  # which is effectively the model's full generation time (nothing is sent until it finishes).
   def initialize(timeout: 60, model: DEFAULT_MODEL)
     @timeout = timeout
     @model = model
@@ -35,69 +63,120 @@ class Ai::AnthropicClient
 
   # Buffered request. `system` is Anthropic's top-level system prompt; `messages` is the Anthropic
   # message array (role + content); `tools` is the Anthropic tool-schema array (optional).
+  # Transient upstream failures (timeouts, 5xx/429/529) are retried a couple of times before
+  # surfacing, because a buffered call has no partial output to worry about.
   # @return [Result]
   def messages(system:, messages:, tools: nil, max_tokens: DEFAULT_MAX_TOKENS)
     body = request_body(system:, messages:, tools:, max_tokens:, stream: false)
-    response = http.post(API_URL, json: body)
-    raise Error, "Anthropic request failed: #{response.status} — #{error_detail(response)}" unless response.status.success?
+    with_retries do
+      response = http.post(API_URL, json: body)
+      raise_for_status!(response, kind: "request")
 
-    parse_message(response.parse)
-  rescue HTTP::Error => e
-    raise Error, "Anthropic network error: #{e.message}"
+      parse_message(response.parse)
+    rescue HTTP::Error => e
+      raise TransientError, "Anthropic network error: #{e.message}"
+    end
   end
 
   # Streaming request. Yields each text delta (String) to the block as it arrives, and returns the
   # assembled Result once the stream ends. Tool-use blocks are streamed as a `content_block_start`
   # (carrying id + name) followed by `input_json_delta` fragments we concatenate and JSON-parse.
+  #
+  # Transient failures are retried ONLY while nothing has been yielded to the caller yet (a failed
+  # connect, an immediate 529, silence before the first token). Once any delta has reached the
+  # caller a retry would replay the reply from the start on the seller's screen, so mid-stream
+  # failures surface immediately instead.
   # @yieldparam text [String] a chunk of assistant text
   # @return [Result]
   def stream_messages(system:, messages:, tools: nil, max_tokens: DEFAULT_MAX_TOKENS, &on_text)
     body = request_body(system:, messages:, tools:, max_tokens:, stream: true)
-    text = +""
-    # Content blocks accumulate by index: text blocks grow `text`, tool_use blocks grow a JSON string
-    # we parse when the block closes.
-    blocks = {}
-    stop_reason = nil
+    yielded_any = false
 
-    response = http.post(API_URL, json: body)
-    raise Error, "Anthropic stream failed: #{response.status} — #{error_detail(response)}" unless response.status.success?
+    with_retries(retryable: -> { !yielded_any }) do
+      text = +""
+      # Content blocks accumulate by index: text blocks grow `text`, tool_use blocks grow a JSON string
+      # we parse when the block closes.
+      blocks = {}
+      stop_reason = nil
 
-    each_sse_event(response.body) do |event, data|
-      case event
-      when "content_block_start"
-        index = data["index"]
-        block = data["content_block"] || {}
-        if block["type"] == "tool_use"
-          blocks[index] = { type: "tool_use", id: block["id"], name: block["name"], json: +"" }
-        else
-          blocks[index] = { type: "text" }
-        end
-      when "content_block_delta"
-        delta = data["delta"] || {}
-        case delta["type"]
-        when "text_delta"
-          chunk = delta["text"].to_s
-          next if chunk.empty?
-          text << chunk
-          on_text&.call(chunk)
-        when "input_json_delta"
+      response = http.post(API_URL, json: body)
+      raise_for_status!(response, kind: "stream")
+
+      each_sse_event(response.body) do |event, data|
+        case event
+        when "content_block_start"
           index = data["index"]
-          blocks[index][:json] << delta["partial_json"].to_s if blocks[index]
+          block = data["content_block"] || {}
+          if block["type"] == "tool_use"
+            blocks[index] = { type: "tool_use", id: block["id"], name: block["name"], json: +"" }
+          else
+            blocks[index] = { type: "text" }
+          end
+        when "content_block_delta"
+          delta = data["delta"] || {}
+          case delta["type"]
+          when "text_delta"
+            chunk = delta["text"].to_s
+            next if chunk.empty?
+            text << chunk
+            yielded_any = true
+            on_text&.call(chunk)
+          when "input_json_delta"
+            index = data["index"]
+            blocks[index][:json] << delta["partial_json"].to_s if blocks[index]
+          end
+        when "message_delta"
+          stop_reason = data.dig("delta", "stop_reason") || stop_reason
+        when "error"
+          raise stream_error(data)
         end
-      when "message_delta"
-        stop_reason = data.dig("delta", "stop_reason") || stop_reason
-      when "error"
-        raise Error, "Anthropic stream error: #{data.dig("error", "message") || "unknown"}"
       end
-    end
 
-    Result.new(text:, tool_uses: assemble_tool_uses(blocks, stop_reason:), stop_reason:)
-  rescue HTTP::Error => e
-    raise Error, "Anthropic network error: #{e.message}"
+      Result.new(text:, tool_uses: assemble_tool_uses(blocks, stop_reason:), stop_reason:)
+    rescue HTTP::Error => e
+      raise TransientError, "Anthropic network error: #{e.message}"
+    end
   end
 
   private
     attr_reader :timeout, :model
+
+    # Run the block, retrying on TransientError with a short linear backoff. `retryable` lets the
+    # caller veto a retry at failure time — the streaming path uses it to stop retrying once any
+    # output has already reached the seller.
+    def with_retries(retryable: -> { true })
+      attempt = 1
+      begin
+        yield
+      rescue TransientError
+        raise if attempt >= MAX_ATTEMPTS || !retryable.call
+
+        sleep(attempt * RETRY_BASE_DELAY_IN_SECONDS)
+        attempt += 1
+        retry
+      end
+    end
+
+    # Raise the right error class for a non-success response: TransientError for statuses a retry
+    # can plausibly fix, plain Error for deterministic failures (bad request, bad key, ...).
+    def raise_for_status!(response, kind:)
+      return if response.status.success?
+
+      message = "Anthropic #{kind} failed: #{response.status} — #{error_detail(response)}"
+      raise TransientError, message if RETRYABLE_STATUS_CODES.include?(response.status.code)
+
+      raise Error, message
+    end
+
+    # Classify a mid-stream `error` event. Overload/rate-limit/server errors are transient (the
+    # retry loop may replay the request if nothing was yielded yet); anything else is a real error.
+    def stream_error(data)
+      error = data["error"] || {}
+      message = "Anthropic stream error: #{error["message"] || "unknown"}"
+      return TransientError.new(message) if RETRYABLE_STREAM_ERROR_TYPES.include?(error["type"])
+
+      Error.new(message)
+    end
 
     # A concise failure detail for an error response. Anthropic returns { "error": { "message": ... } };
     # surface just that message rather than dumping the raw body (which can be large and may echo
@@ -117,16 +196,46 @@ class Ai::AnthropicClient
       body = {
         model:,
         max_tokens:,
-        system:,
+        system: cacheable_system(system),
         messages:,
         stream:,
       }
-      body[:tools] = tools if tools.present?
+      body[:tools] = cacheable_tools(tools) if tools.present?
       body
     end
 
+    # Mark the system prompt as cacheable. The store agent's system prompt embeds the full endpoint
+    # manifest, so it is large and byte-identical across requests; letting Anthropic cache it means
+    # subsequent requests skip re-processing those tokens, which meaningfully cuts time-to-first-token
+    # and cost. Prompts too short to cache are simply not cached — the marker is harmless. A caller
+    # already passing structured content blocks is left untouched.
+    def cacheable_system(system)
+      return system unless system.is_a?(String)
+
+      [{ type: "text", text: system, cache_control: { type: "ephemeral" } }]
+    end
+
+    # Cache the tool schemas too. Anthropic caches the prefix up to each cache_control marker, so
+    # tagging the LAST tool covers the whole (static) tool list. Tools already carrying a
+    # cache_control are left alone.
+    def cacheable_tools(tools)
+      tools = tools.map { |tool| tool.deep_symbolize_keys }
+      last = tools.last
+      last[:cache_control] = { type: "ephemeral" } unless last.key?(:cache_control)
+      tools
+    end
+
+    # Per-operation timeouts instead of one global deadline. A global timeout (the old behavior)
+    # counts the ENTIRE request — for a streamed reply that killed healthy generations that simply
+    # took longer than the budget even while tokens were still arriving. With per-operation
+    # timeouts, `read` bounds each individual read (i.e. silence), so a slow-but-alive stream can
+    # finish while a genuinely stalled connection still fails after `timeout` seconds of nothing.
     def http
-      HTTP.timeout(timeout).headers(
+      HTTP.timeout(
+        connect: CONNECT_TIMEOUT_IN_SECONDS,
+        write: WRITE_TIMEOUT_IN_SECONDS,
+        read: timeout,
+      ).headers(
         "x-api-key" => api_key,
         "anthropic-version" => API_VERSION,
         "content-type" => "application/json",

--- a/app/services/ai/anthropic_client.rb
+++ b/app/services/ai/anthropic_client.rb
@@ -18,19 +18,11 @@
 # lives entirely in StoreAgentApiClient, which this never touches.
 class Ai::AnthropicClient
   class Error < StandardError; end
+
   # A failure that is safe and worthwhile to retry: the upstream was momentarily overloaded, rate
   # limited, returned a 5xx, or the network dropped. Distinct from Error so callers (and our own
   # retry loop) never retry a real bug like a malformed tool call. `retry_after` carries the
   # server's own back-off hint (the Retry-After header on a 429) in seconds, when it sent one.
-  class TransientError < Error
-    attr_reader :retry_after
-
-    def initialize(message, retry_after: nil)
-      super(message)
-      @retry_after = retry_after
-    end
-  end
-  # the retry loop uses it so we don't retry into the same rate-limit window and waste an attempt.
   class TransientError < Error
     attr_reader :retry_after
 
@@ -83,6 +75,8 @@ class Ai::AnthropicClient
   def initialize(timeout: 60, model: DEFAULT_MODEL)
     @timeout = timeout
     @model = model
+    # Seconds already spent sleeping between retries; compared against RETRY_SLEEP_BUDGET_IN_SECONDS.
+    @retry_sleep_spent = 0.0
   end
 
   # Buffered request. `system` is Anthropic's top-level system prompt; `messages` is the Anthropic
@@ -165,17 +159,29 @@ class Ai::AnthropicClient
   private
     attr_reader :timeout, :model
 
-    # Run the block, retrying on TransientError with a short linear backoff. `retryable` lets the
-    # caller veto a retry at failure time — the streaming path uses it to stop retrying once any
-    # output has already reached the seller.
+    # Run the block, retrying on TransientError. The wait between attempts is the server's own
+    # Retry-After hint when it sent one (a rate-limited 429 says exactly how long to back off —
+    # retrying sooner just burns an attempt on another guaranteed 429), otherwise a short linear
+    # backoff. `retryable` lets the caller veto a retry at failure time — the streaming path uses
+    # it to stop retrying once any output has already reached the seller.
+    #
+    # Every sleep is charged against the instance-wide RETRY_SLEEP_BUDGET_IN_SECONDS, so a web
+    # request that chains several calls on one client (the agent's tool loop) can never accumulate
+    # more than that much blocked time. If the next wait would blow the budget — including a
+    # Retry-After longer than we're willing to hold the request thread — the failure surfaces
+    # immediately instead.
     def with_retries(retryable: -> { true })
       attempt = 1
       begin
         yield
-      rescue TransientError
+      rescue TransientError => e
         raise if attempt >= MAX_ATTEMPTS || !retryable.call
 
-        sleep(attempt * RETRY_BASE_DELAY_IN_SECONDS)
+        delay = e.retry_after || attempt * RETRY_BASE_DELAY_IN_SECONDS
+        raise if @retry_sleep_spent + delay > RETRY_SLEEP_BUDGET_IN_SECONDS
+
+        @retry_sleep_spent += delay
+        sleep(delay)
         attempt += 1
         retry
       end
@@ -187,9 +193,20 @@ class Ai::AnthropicClient
       return if response.status.success?
 
       message = "Anthropic #{kind} failed: #{response.status} — #{error_detail(response)}"
-      raise TransientError, message if RETRYABLE_STATUS_CODES.include?(response.status.code)
+      if RETRYABLE_STATUS_CODES.include?(response.status.code)
+        raise TransientError.new(message, retry_after: parse_retry_after(response))
+      end
 
       raise Error, message
+    end
+
+    # The Retry-After header on a rate-limited response, as a number of seconds. Anthropic sends the
+    # numeric form; the header can technically also be an HTTP date, which we treat the same as "no
+    # hint" and fall back to the linear backoff.
+    def parse_retry_after(response)
+      Float(response.headers["Retry-After"])
+    rescue ArgumentError, TypeError
+      nil
     end
 
     # Classify a mid-stream `error` event. Overload/rate-limit/server errors are transient (the

--- a/app/services/ai/store_agent_service.rb
+++ b/app/services/ai/store_agent_service.rb
@@ -24,7 +24,12 @@ class Ai::StoreAgentService
   class Error < StandardError; end
 
   MODEL = Ai::AnthropicClient::DEFAULT_MODEL
-  REQUEST_TIMEOUT_IN_SECONDS = 60
+  # Passed to Ai::AnthropicClient as its READ timeout. For the streamed reply this bounds silence
+  # between chunks (not the total generation time — a long healthy stream is fine); for the buffered
+  # calls it bounds the wait for the full response. Production showed a steady stream of 60-second
+  # network timeouts on real (slow but working) generations, so this is deliberately generous — the
+  # client fails fast on connect problems and retries transient failures on its own.
+  REQUEST_TIMEOUT_IN_SECONDS = 120
   MAX_TOOL_ITERATIONS = 5
   MAX_MESSAGE_LENGTH = 2_000
   # Anthropic requires max_tokens on every request. This cap has to fit more than a brief chat

--- a/spec/services/ai/anthropic_client_spec.rb
+++ b/spec/services/ai/anthropic_client_spec.rb
@@ -102,6 +102,47 @@ describe Ai::AnthropicClient do
       expect(stub).to have_been_requested.once
     end
 
+    it "sleeps the Retry-After header value on a 429 instead of the default backoff" do
+      body = { "content" => [{ "type" => "text", "text" => "ok" }], "stop_reason" => "end_turn" }
+      stub_request(:post, url)
+        .to_return({ status: 429, body: { error: { type: "rate_limit_error", message: "rate limited" } }.to_json, headers: { "Retry-After" => "4" } },
+                   { status: 200, body: body.to_json, headers: { "Content-Type" => "application/json" } })
+
+      result = client.messages(system: "s", messages: [{ role: "user", content: "x" }])
+
+      expect(result.text).to eq("ok")
+      expect(client).to have_received(:sleep).with(4.0)
+    end
+
+    it "gives up instead of sleeping when Retry-After exceeds the retry sleep budget" do
+      # A long server-mandated wait would block the calling (Rack request) thread; surfacing the
+      # failure immediately is better than holding the request hostage.
+      stub = stub_request(:post, url)
+        .to_return(status: 429, body: { error: { type: "rate_limit_error", message: "rate limited" } }.to_json, headers: { "Retry-After" => "30" })
+
+      expect { client.messages(system: "s", messages: [{ role: "user", content: "x" }]) }
+        .to raise_error(described_class::TransientError, /rate limited/)
+      expect(stub).to have_been_requested.once
+      expect(client).not_to have_received(:sleep)
+    end
+
+    it "caps total retry sleep across calls on the same client instance" do
+      # The agent's tool loop chains several buffered calls on one client inside a single web
+      # request; the shared budget keeps repeated transient failures from stacking up blocked time.
+      failure = { status: 529, body: { error: { type: "overloaded_error", message: "Overloaded" } }.to_json }
+      success = { status: 200, body: { "content" => [], "stop_reason" => "end_turn" }.to_json, headers: { "Content-Type" => "application/json" } }
+      stub_request(:post, url).to_return(failure, success, failure, success, failure, failure)
+
+      slept = 0.0
+      allow(client).to receive(:sleep) { |seconds| slept += seconds }
+
+      2.times { client.messages(system: "s", messages: [{ role: "user", content: "x" }]) } # 1s + 1s spent
+      expect { 3.times { client.messages(system: "s", messages: [{ role: "user", content: "x" }]) } }
+        .to raise_error(described_class::TransientError)
+
+      expect(slept).to be <= described_class::RETRY_SLEEP_BUDGET_IN_SECONDS
+    end
+
     it "retries a streaming request that fails before any output reached the caller" do
       good_stream = "event: content_block_start\ndata: #{{ index: 0, content_block: { type: "text" } }.to_json}\n\n" \
                     "event: content_block_delta\ndata: #{{ index: 0, delta: { type: "text_delta", text: "hi" } }.to_json}\n\n" \

--- a/spec/services/ai/anthropic_client_spec.rb
+++ b/spec/services/ai/anthropic_client_spec.rb
@@ -18,7 +18,7 @@ describe Ai::AnthropicClient do
       stub = stub_request(:post, url)
         .with(
           headers: { "x-api-key" => "sk-ant-test", "anthropic-version" => "2023-06-01" },
-          body: hash_including("model" => described_class::DEFAULT_MODEL, "system" => "be helpful", "stream" => false),
+          body: hash_including("model" => described_class::DEFAULT_MODEL, "stream" => false),
         )
         .to_return(status: 200, body: body.to_json, headers: { "Content-Type" => "application/json" })
 
@@ -28,6 +28,23 @@ describe Ai::AnthropicClient do
       expect(result.text).to eq("You have 3 products.")
       expect(result.tool_uses).to eq([])
       expect(result.stop_reason).to eq("end_turn")
+    end
+
+    it "marks the system prompt and the last tool as cacheable so Anthropic can reuse the shared prefix" do
+      captured = nil
+      stub_request(:post, url)
+        .with { |request| captured = JSON.parse(request.body); true }
+        .to_return(status: 200, body: { "content" => [], "stop_reason" => "end_turn" }.to_json, headers: { "Content-Type" => "application/json" })
+
+      client.messages(
+        system: "be helpful",
+        messages: [{ role: "user", content: "x" }],
+        tools: [{ name: "api_read" }, { name: "api_write" }],
+      )
+
+      expect(captured["system"]).to eq([{ "type" => "text", "text" => "be helpful", "cache_control" => { "type" => "ephemeral" } }])
+      expect(captured["tools"][0]).not_to have_key("cache_control")
+      expect(captured["tools"][1]["cache_control"]).to eq("type" => "ephemeral")
     end
 
     it "parses tool_use blocks with their input" do
@@ -47,10 +64,89 @@ describe Ai::AnthropicClient do
     end
 
     it "raises Error on a non-success status" do
-      stub_request(:post, url).to_return(status: 500, body: "boom")
+      stub_request(:post, url).to_return(status: 400, body: "boom")
 
       expect { client.messages(system: "s", messages: [{ role: "user", content: "x" }]) }
         .to raise_error(described_class::Error, /failed/i)
+    end
+  end
+
+  describe "retries" do
+    before { allow(client).to receive(:sleep) } # keep specs fast; retry delays are exercised via the stub
+
+    it "retries a buffered request on a retryable status and succeeds" do
+      body = { "content" => [{ "type" => "text", "text" => "ok" }], "stop_reason" => "end_turn" }
+      stub_request(:post, url)
+        .to_return({ status: 529, body: { error: { type: "overloaded_error", message: "Overloaded" } }.to_json },
+                   { status: 200, body: body.to_json, headers: { "Content-Type" => "application/json" } })
+
+      result = client.messages(system: "s", messages: [{ role: "user", content: "x" }])
+
+      expect(result.text).to eq("ok")
+      expect(client).to have_received(:sleep).once
+    end
+
+    it "retries a network timeout and surfaces TransientError after exhausting attempts" do
+      stub_request(:post, url).to_timeout
+
+      expect { client.messages(system: "s", messages: [{ role: "user", content: "x" }]) }
+        .to raise_error(described_class::TransientError, /network error/i)
+      expect(client).to have_received(:sleep).twice # MAX_ATTEMPTS - 1 backoffs
+    end
+
+    it "does not retry a deterministic failure like a 400" do
+      stub = stub_request(:post, url).to_return(status: 400, body: { error: { message: "bad request" } }.to_json)
+
+      expect { client.messages(system: "s", messages: [{ role: "user", content: "x" }]) }
+        .to raise_error(described_class::Error, /bad request/)
+      expect(stub).to have_been_requested.once
+    end
+
+    it "retries a streaming request that fails before any output reached the caller" do
+      good_stream = "event: content_block_start\ndata: #{{ index: 0, content_block: { type: "text" } }.to_json}\n\n" \
+                    "event: content_block_delta\ndata: #{{ index: 0, delta: { type: "text_delta", text: "hi" } }.to_json}\n\n" \
+                    "event: message_delta\ndata: #{{ delta: { stop_reason: "end_turn" } }.to_json}\n\n"
+      stub_request(:post, url)
+        .to_return({ status: 529, body: { error: { type: "overloaded_error", message: "Overloaded" } }.to_json },
+                   { status: 200, body: good_stream, headers: { "Content-Type" => "text/event-stream" } })
+
+      chunks = []
+      result = client.stream_messages(system: "s", messages: [{ role: "user", content: "x" }]) { |text| chunks << text }
+
+      expect(chunks).to eq(["hi"])
+      expect(result.text).to eq("hi")
+    end
+
+    it "does not retry a stream that already yielded output to the caller" do
+      # The first token has already rendered on the seller's screen when the overload event arrives;
+      # replaying the request would restart the reply mid-sentence, so the failure must surface.
+      broken_stream = "event: content_block_start\ndata: #{{ index: 0, content_block: { type: "text" } }.to_json}\n\n" \
+                      "event: content_block_delta\ndata: #{{ index: 0, delta: { type: "text_delta", text: "partial" } }.to_json}\n\n" \
+                      "event: error\ndata: #{{ error: { type: "overloaded_error", message: "Overloaded" } }.to_json}\n\n"
+      stub = stub_request(:post, url).to_return(status: 200, body: broken_stream, headers: { "Content-Type" => "text/event-stream" })
+
+      expect { client.stream_messages(system: "s", messages: [{ role: "user", content: "x" }]) { |_| } }
+        .to raise_error(described_class::TransientError, /overloaded/i)
+      expect(stub).to have_been_requested.once
+    end
+  end
+
+  describe "timeouts" do
+    it "uses per-operation timeouts with the configured value as the read (silence) timeout" do
+      # A per-operation read timeout bounds silence between chunks, not total stream duration — the
+      # old single global timeout killed healthy long generations mid-stream.
+      chain = HTTP.timeout(connect: 1) # any chainable; we only assert what the client requests
+      allow(HTTP).to receive(:timeout).and_return(chain)
+      allow(chain).to receive(:headers).and_call_original
+
+      stub_request(:post, url).to_return(status: 200, body: { "content" => [], "stop_reason" => "end_turn" }.to_json, headers: { "Content-Type" => "application/json" })
+      described_class.new(timeout: 45).messages(system: "s", messages: [{ role: "user", content: "x" }])
+
+      expect(HTTP).to have_received(:timeout).with(
+        connect: described_class::CONNECT_TIMEOUT_IN_SECONDS,
+        write: described_class::WRITE_TIMEOUT_IN_SECONDS,
+        read: 45,
+      )
     end
   end
 


### PR DESCRIPTION
## What

Makes the store agent's Anthropic client resilient to slow and flaky upstream responses, and speeds up its turns:

- **Per-operation timeouts instead of one global deadline.** The client previously used `HTTP.timeout(60)`, which is a *global* budget covering the entire request. A streamed reply that was healthy — tokens still arriving — got killed at 60 seconds simply because the full generation took longer. Now connect (10s) and write (30s) fail fast, and the read timeout bounds *silence between chunks*, raised to 120s. A long-but-alive stream can finish; a genuinely stalled connection still fails after 120s of nothing.
- **Retries for transient failures.** Network errors, 429/5xx/529 responses, and overload stream events now get up to 2 retries, via a new `TransientError` class so deterministic failures (400, bad key, malformed tool calls) are never retried. The wait between attempts honors the server's `Retry-After` header when a 429 sends one, otherwise a short linear backoff; all retry sleeps are charged against a 6-second per-client budget so the agent's tool loop can never stack up long blocked waits on the Rack request thread — once the budget is spent (or `Retry-After` asks for more than it allows), the failure surfaces immediately. A streaming request is only retried while nothing has been yielded to the caller yet — once a token reached the seller's screen, a retry would visibly restart the reply, so mid-stream failures surface immediately.
- **Anthropic prompt caching.** The system prompt (which embeds the full read/write endpoint manifest, identical across requests) and the tool schemas are marked `cache_control: ephemeral`. Cache hits skip re-processing the shared prefix, cutting time-to-first-token on every turn after the first and reducing cost.

## Why

Production logs show `Ai::AnthropicClient` timeouts are the dominant failure behind the agent's generic "Something went wrong" error: ~1,400 stream failures + 34 buffered-message failures since Jul 6 (peak 368/day on Jul 6, still ~74/day now). These weren't dead connections — they were real generations that exceeded the 60-second global deadline, or transient upstream overloads that failed the whole turn on the first hiccup.

Tracking: antiwork/gumroad-private#1054 (Anthropic timeout storm on the propose/stream side).

The new 120s read timeout stays within `Rack::Timeout`'s 120s `service_timeout`, and applies per read on the streaming path (where turns run under `ActionController::Live` in a dedicated thread), so the change doesn't push the web request past middleware limits.

## Test plan

- `bundle exec rspec spec/services/ai/anthropic_client_spec.rb` — 21 examples, 0 failures (10 new: retry on 529 then success, timeout retry exhaustion surfaces `TransientError`, no retry on 400, Retry-After honored on a 429, give-up when Retry-After exceeds the sleep budget, budget shared across calls on one client, stream retried only before first yield, no retry after output reached the caller, cache_control markers on system + last tool, per-operation timeout wiring).
- `bundle exec rspec spec/services/ai/store_agent_service_spec.rb` — 31 examples, 0 failures.
- After deploy: watch `Store agent stream failed` / `Anthropic network error` counts in the logs — expect the daily timeout volume (~74/day currently) to drop sharply; residual failures should be genuine upstream overloads that exhausted retries.

Not a UI change — no pixels move; the fix is entirely in the LLM client's transport behavior.

