### PR TITLE
Route the store agent's LLM traffic through OpenRouter with a GPT fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -210,6 +210,11 @@ OPENAI_ACCESS_TOKEN=
 # Anthropic (Claude — powers the conversational store Agent tab)
 ANTHROPIC_API_KEY=
 
+# OpenRouter (optional AI gateway for the store Agent's Claude traffic — when set, requests route
+# through OpenRouter for provider failover, retries, and cross-provider fallback to GPT)
+OPENROUTER_API_KEY=
+OPENROUTER_FALLBACK_MODEL=
+
 # Dropbox
 DROPBOX_API_KEY=
 DROPBOX_PICKER_API_KEY=

--- a/app/services/ai/anthropic_client.rb
+++ b/app/services/ai/anthropic_client.rb
@@ -145,6 +145,10 @@ class Ai::AnthropicClient
 
       each_sse_event(response.body) do |event, data|
         case event
+        when "message_start"
+          # The first stream event names the model actually generating this reply — the only
+          # place a fallback shows up on a stream. Log it so fallback turns are visible in app logs.
+          log_served_model(data.dig("message", "model"))
         when "content_block_start"
           index = data["index"]
           block = data["content_block"] || {}
@@ -355,6 +359,19 @@ class Ai::AnthropicClient
       GlobalConfig.get("OPENROUTER_FALLBACK_MODEL").presence || DEFAULT_FALLBACK_MODEL
     end
 
+    # Warn when the model that generated the response isn't the one we asked for — i.e. OpenRouter
+    # fell back to GPT because Claude errored. Without this, time spent on the fallback would be
+    # invisible in app logs (OpenRouter's dashboard would be the only place to see it). The
+    # comparison is a substring match, not equality, because the served name can carry provider
+    # prefixes or version suffixes (e.g. "anthropic/claude-opus-4-7-20260115") while still being
+    # the requested model — only a genuinely different family should warn.
+    def log_served_model(served_model)
+      return if served_model.blank?
+      return if served_model.include?(model) || model.include?(served_model)
+
+      Rails.logger.warn("Anthropic request served by fallback model #{served_model} (requested #{model})")
+    end
+
     # Normalize a buffered Messages response into a Result. Content is an array of typed blocks; we
     # pull the joined text and any tool_use blocks (each with parsed input).
     #
@@ -366,6 +383,8 @@ class Ai::AnthropicClient
     def parse_message(body)
       return Result.new(text: "", tool_uses: [], stop_reason: nil) unless body.is_a?(Hash)
       raise embedded_error(body, kind: "response") if body["error"].is_a?(Hash)
+
+      log_served_model(body["model"])
 
       content = Array(body["content"])
       text = content.filter_map { |b| b["text"].to_s if b.is_a?(Hash) && b["type"] == "text" }.join

--- a/app/services/ai/anthropic_client.rb
+++ b/app/services/ai/anthropic_client.rb
@@ -361,15 +361,22 @@ class Ai::AnthropicClient
 
     # Warn when the model that generated the response isn't the one we asked for — i.e. OpenRouter
     # fell back to GPT because Claude errored. Without this, time spent on the fallback would be
-    # invisible in app logs (OpenRouter's dashboard would be the only place to see it). The
-    # comparison is a substring match, not equality, because the served name can carry provider
-    # prefixes or version suffixes (e.g. "anthropic/claude-opus-4-7-20260115") while still being
-    # the requested model — only a genuinely different family should warn.
+    # invisible in app logs (OpenRouter's dashboard would be the only place to see it). The names
+    # are normalized before comparing because providers restyle the same model: we request
+    # "claude-opus-4-7" and OpenRouter reports "anthropic/claude-opus-4.7" (provider prefix, dotted
+    # version) — still the requested model, not a fallback. Only a genuinely different model warns.
     def log_served_model(served_model)
       return if served_model.blank?
-      return if served_model.include?(model) || model.include?(served_model)
+
+      requested = normalize_model_name(model)
+      served = normalize_model_name(served_model)
+      return if served.include?(requested) || requested.include?(served)
 
       Rails.logger.warn("Anthropic request served by fallback model #{served_model} (requested #{model})")
+    end
+
+    def normalize_model_name(name)
+      name.to_s.downcase.tr(".", "-")
     end
 
     # Normalize a buffered Messages response into a Result. Content is an array of typed blocks; we

--- a/app/services/ai/anthropic_client.rb
+++ b/app/services/ai/anthropic_client.rb
@@ -310,8 +310,15 @@ class Ai::AnthropicClient
 
     # Normalize a buffered Messages response into a Result. Content is an array of typed blocks; we
     # pull the joined text and any tool_use blocks (each with parsed input).
+    #
+    # OpenRouter can return HTTP 200 with an error object in the body when the failure happened
+    # after the upstream model started processing (Anthropic directly never does this for buffered
+    # requests). Without the check below, such a response would silently become an empty Result and
+    # the agent would render a blank reply; classifying it through the same transient-vs-real logic
+    # as mid-stream errors lets the retry loop recover from the transient ones.
     def parse_message(body)
       return Result.new(text: "", tool_uses: [], stop_reason: nil) unless body.is_a?(Hash)
+      raise stream_error(body) if body["error"].is_a?(Hash)
 
       content = Array(body["content"])
       text = content.filter_map { |b| b["text"].to_s if b.is_a?(Hash) && b["type"] == "text" }.join

--- a/app/services/ai/anthropic_client.rb
+++ b/app/services/ai/anthropic_client.rb
@@ -18,6 +18,10 @@
 # lives entirely in StoreAgentApiClient, which this never touches.
 class Ai::AnthropicClient
   class Error < StandardError; end
+  # A failure that is safe and worthwhile to retry: the upstream was momentarily overloaded, rate
+  # limited, returned a 5xx, or the network dropped. Distinct from Error so callers (and our own
+  # retry loop) never retry a real bug like a malformed tool call.
+  class TransientError < Error; end
 
   API_URL = "https://api.anthropic.com/v1/messages"
   API_VERSION = "2023-06-01"
@@ -26,8 +30,32 @@ class Ai::AnthropicClient
   DEFAULT_MODEL = "claude-opus-4-7"
   DEFAULT_MAX_TOKENS = 1024
 
+  # How long we wait to open the connection and to send the request. These are short on purpose:
+  # if Anthropic isn't reachable quickly, we want to fail fast and retry rather than sit on a dead
+  # socket while the seller stares at a spinner.
+  CONNECT_TIMEOUT_IN_SECONDS = 10
+  WRITE_TIMEOUT_IN_SECONDS = 30
+
+  # Total attempts per request (1 original + up to 2 retries) and the base delay between them
+  # (attempt N sleeps N * base). Retries only fire for TransientError, and a streaming request is
+  # never retried once any output has reached the caller — the seller would see the reply restart.
+  MAX_ATTEMPTS = 3
+  RETRY_BASE_DELAY_IN_SECONDS = 1
+
+  # Response statuses worth a retry: rate limit (429), server errors (5xx), and Anthropic's
+  # "overloaded" status (529). Anything else (400 bad request, 401 bad key, ...) is deterministic —
+  # retrying would just repeat the same failure slower.
+  RETRYABLE_STATUS_CODES = [429, 500, 502, 503, 504, 529].freeze
+  # Mid-stream `error` events with these types are the streaming equivalents of the statuses above.
+  RETRYABLE_STREAM_ERROR_TYPES = %w[overloaded_error api_error rate_limit_error timeout_error].freeze
+
   Result = Struct.new(:text, :tool_uses, :stop_reason, keyword_init: true)
 
+  # `timeout` is the READ timeout: how long a single read from Anthropic may block before we give
+  # up. For a streaming request that means "seconds of silence between chunks", not the total
+  # duration of the response — a healthy stream that takes minutes to finish is fine as long as
+  # tokens keep arriving. For a buffered request it bounds the wait for the response to start,
+  # which is effectively the model's full generation time (nothing is sent until it finishes).
   def initialize(timeout: 60, model: DEFAULT_MODEL)
     @timeout = timeout
     @model = model
@@ -35,69 +63,120 @@ class Ai::AnthropicClient
 
   # Buffered request. `system` is Anthropic's top-level system prompt; `messages` is the Anthropic
   # message array (role + content); `tools` is the Anthropic tool-schema array (optional).
+  # Transient upstream failures (timeouts, 5xx/429/529) are retried a couple of times before
+  # surfacing, because a buffered call has no partial output to worry about.
   # @return [Result]
   def messages(system:, messages:, tools: nil, max_tokens: DEFAULT_MAX_TOKENS)
     body = request_body(system:, messages:, tools:, max_tokens:, stream: false)
-    response = http.post(API_URL, json: body)
-    raise Error, "Anthropic request failed: #{response.status} — #{error_detail(response)}" unless response.status.success?
+    with_retries do
+      response = http.post(API_URL, json: body)
+      raise_for_status!(response, kind: "request")
 
-    parse_message(response.parse)
-  rescue HTTP::Error => e
-    raise Error, "Anthropic network error: #{e.message}"
+      parse_message(response.parse)
+    rescue HTTP::Error => e
+      raise TransientError, "Anthropic network error: #{e.message}"
+    end
   end
 
   # Streaming request. Yields each text delta (String) to the block as it arrives, and returns the
   # assembled Result once the stream ends. Tool-use blocks are streamed as a `content_block_start`
   # (carrying id + name) followed by `input_json_delta` fragments we concatenate and JSON-parse.
+  #
+  # Transient failures are retried ONLY while nothing has been yielded to the caller yet (a failed
+  # connect, an immediate 529, silence before the first token). Once any delta has reached the
+  # caller a retry would replay the reply from the start on the seller's screen, so mid-stream
+  # failures surface immediately instead.
   # @yieldparam text [String] a chunk of assistant text
   # @return [Result]
   def stream_messages(system:, messages:, tools: nil, max_tokens: DEFAULT_MAX_TOKENS, &on_text)
     body = request_body(system:, messages:, tools:, max_tokens:, stream: true)
-    text = +""
-    # Content blocks accumulate by index: text blocks grow `text`, tool_use blocks grow a JSON string
-    # we parse when the block closes.
-    blocks = {}
-    stop_reason = nil
+    yielded_any = false
 
-    response = http.post(API_URL, json: body)
-    raise Error, "Anthropic stream failed: #{response.status} — #{error_detail(response)}" unless response.status.success?
+    with_retries(retryable: -> { !yielded_any }) do
+      text = +""
+      # Content blocks accumulate by index: text blocks grow `text`, tool_use blocks grow a JSON string
+      # we parse when the block closes.
+      blocks = {}
+      stop_reason = nil
 
-    each_sse_event(response.body) do |event, data|
-      case event
-      when "content_block_start"
-        index = data["index"]
-        block = data["content_block"] || {}
-        if block["type"] == "tool_use"
-          blocks[index] = { type: "tool_use", id: block["id"], name: block["name"], json: +"" }
-        else
-          blocks[index] = { type: "text" }
-        end
-      when "content_block_delta"
-        delta = data["delta"] || {}
-        case delta["type"]
-        when "text_delta"
-          chunk = delta["text"].to_s
-          next if chunk.empty?
-          text << chunk
-          on_text&.call(chunk)
-        when "input_json_delta"
+      response = http.post(API_URL, json: body)
+      raise_for_status!(response, kind: "stream")
+
+      each_sse_event(response.body) do |event, data|
+        case event
+        when "content_block_start"
           index = data["index"]
-          blocks[index][:json] << delta["partial_json"].to_s if blocks[index]
+          block = data["content_block"] || {}
+          if block["type"] == "tool_use"
+            blocks[index] = { type: "tool_use", id: block["id"], name: block["name"], json: +"" }
+          else
+            blocks[index] = { type: "text" }
+          end
+        when "content_block_delta"
+          delta = data["delta"] || {}
+          case delta["type"]
+          when "text_delta"
+            chunk = delta["text"].to_s
+            next if chunk.empty?
+            text << chunk
+            yielded_any = true
+            on_text&.call(chunk)
+          when "input_json_delta"
+            index = data["index"]
+            blocks[index][:json] << delta["partial_json"].to_s if blocks[index]
+          end
+        when "message_delta"
+          stop_reason = data.dig("delta", "stop_reason") || stop_reason
+        when "error"
+          raise stream_error(data)
         end
-      when "message_delta"
-        stop_reason = data.dig("delta", "stop_reason") || stop_reason
-      when "error"
-        raise Error, "Anthropic stream error: #{data.dig("error", "message") || "unknown"}"
       end
-    end
 
-    Result.new(text:, tool_uses: assemble_tool_uses(blocks, stop_reason:), stop_reason:)
-  rescue HTTP::Error => e
-    raise Error, "Anthropic network error: #{e.message}"
+      Result.new(text:, tool_uses: assemble_tool_uses(blocks, stop_reason:), stop_reason:)
+    rescue HTTP::Error => e
+      raise TransientError, "Anthropic network error: #{e.message}"
+    end
   end
 
   private
     attr_reader :timeout, :model
+
+    # Run the block, retrying on TransientError with a short linear backoff. `retryable` lets the
+    # caller veto a retry at failure time — the streaming path uses it to stop retrying once any
+    # output has already reached the seller.
+    def with_retries(retryable: -> { true })
+      attempt = 1
+      begin
+        yield
+      rescue TransientError
+        raise if attempt >= MAX_ATTEMPTS || !retryable.call
+
+        sleep(attempt * RETRY_BASE_DELAY_IN_SECONDS)
+        attempt += 1
+        retry
+      end
+    end
+
+    # Raise the right error class for a non-success response: TransientError for statuses a retry
+    # can plausibly fix, plain Error for deterministic failures (bad request, bad key, ...).
+    def raise_for_status!(response, kind:)
+      return if response.status.success?
+
+      message = "Anthropic #{kind} failed: #{response.status} — #{error_detail(response)}"
+      raise TransientError, message if RETRYABLE_STATUS_CODES.include?(response.status.code)
+
+      raise Error, message
+    end
+
+    # Classify a mid-stream `error` event. Overload/rate-limit/server errors are transient (the
+    # retry loop may replay the request if nothing was yielded yet); anything else is a real error.
+    def stream_error(data)
+      error = data["error"] || {}
+      message = "Anthropic stream error: #{error["message"] || "unknown"}"
+      return TransientError.new(message) if RETRYABLE_STREAM_ERROR_TYPES.include?(error["type"])
+
+      Error.new(message)
+    end
 
     # A concise failure detail for an error response. Anthropic returns { "error": { "message": ... } };
     # surface just that message rather than dumping the raw body (which can be large and may echo
@@ -117,16 +196,46 @@ class Ai::AnthropicClient
       body = {
         model:,
         max_tokens:,
-        system:,
+        system: cacheable_system(system),
         messages:,
         stream:,
       }
-      body[:tools] = tools if tools.present?
+      body[:tools] = cacheable_tools(tools) if tools.present?
       body
     end
 
+    # Mark the system prompt as cacheable. The store agent's system prompt embeds the full endpoint
+    # manifest, so it is large and byte-identical across requests; letting Anthropic cache it means
+    # subsequent requests skip re-processing those tokens, which meaningfully cuts time-to-first-token
+    # and cost. Prompts too short to cache are simply not cached — the marker is harmless. A caller
+    # already passing structured content blocks is left untouched.
+    def cacheable_system(system)
+      return system unless system.is_a?(String)
+
+      [{ type: "text", text: system, cache_control: { type: "ephemeral" } }]
+    end
+
+    # Cache the tool schemas too. Anthropic caches the prefix up to each cache_control marker, so
+    # tagging the LAST tool covers the whole (static) tool list. Tools already carrying a
+    # cache_control are left alone.
+    def cacheable_tools(tools)
+      tools = tools.map { |tool| tool.deep_symbolize_keys }
+      last = tools.last
+      last[:cache_control] = { type: "ephemeral" } unless last.key?(:cache_control)
+      tools
+    end
+
+    # Per-operation timeouts instead of one global deadline. A global timeout (the old behavior)
+    # counts the ENTIRE request — for a streamed reply that killed healthy generations that simply
+    # took longer than the budget even while tokens were still arriving. With per-operation
+    # timeouts, `read` bounds each individual read (i.e. silence), so a slow-but-alive stream can
+    # finish while a genuinely stalled connection still fails after `timeout` seconds of nothing.
     def http
-      HTTP.timeout(timeout).headers(
+      HTTP.timeout(
+        connect: CONNECT_TIMEOUT_IN_SECONDS,
+        write: WRITE_TIMEOUT_IN_SECONDS,
+        read: timeout,
+      ).headers(
         "x-api-key" => api_key,
         "anthropic-version" => API_VERSION,
         "content-type" => "application/json",

--- a/app/services/ai/anthropic_client.rb
+++ b/app/services/ai/anthropic_client.rb
@@ -16,6 +16,12 @@
 #
 # The API key stays server-side (GlobalConfig). Nothing here is creator-specific; the seller scoping
 # lives entirely in StoreAgentApiClient, which this never touches.
+#
+# When OPENROUTER_API_KEY is configured, all traffic routes through OpenRouter's
+# Anthropic-compatible endpoint instead of Anthropic directly. OpenRouter acts as a gateway:
+# it fails over between Anthropic's hosting providers, and falls back to GPT (via the request's
+# `fallbacks` parameter) when Claude is entirely unavailable — so an Anthropic outage degrades
+# the agent instead of taking it down. Without the key, behavior is byte-identical to before.
 class Ai::AnthropicClient
   class Error < StandardError; end
   # A failure that is safe and worthwhile to retry: the upstream was momentarily overloaded, rate
@@ -24,11 +30,24 @@ class Ai::AnthropicClient
   class TransientError < Error; end
 
   API_URL = "https://api.anthropic.com/v1/messages"
+  # OpenRouter exposes an endpoint compatible with Anthropic's Messages API — same request and
+  # response shapes, same streaming protocol — so routing through it is just a different URL and
+  # API key. We use it as a reliability layer: OpenRouter fails over between Anthropic's own
+  # providers and, via the `fallbacks` request parameter below, to a non-Anthropic model when
+  # Anthropic is entirely down. Routing is opt-in: it turns on only when OPENROUTER_API_KEY is
+  # configured, and without it every request goes straight to Anthropic exactly as before.
+  OPENROUTER_API_URL = "https://openrouter.ai/api/v1/messages"
   API_VERSION = "2023-06-01"
   # Claude Opus 4.7 — top of the vending-bench leaderboard for autonomous commercial operation, which
   # is exactly the store-management job the agent does for creators.
   DEFAULT_MODEL = "claude-opus-4-7"
   DEFAULT_MAX_TOKENS = 1024
+  # When requests go through OpenRouter, this model is tried if Claude itself errors out (provider
+  # down, rate limited, overloaded). OpenRouter translates the Anthropic-format request for the
+  # fallback provider, so no OpenAI-specific code is needed here. The `~` prefix is OpenRouter's
+  # "latest in this family" resolution, so we always fall back to the current GPT flagship without
+  # having to bump a pinned version. Overridable via the OPENROUTER_FALLBACK_MODEL config.
+  DEFAULT_FALLBACK_MODEL = "~openai/gpt-latest"
 
   # How long we wait to open the connection and to send the request. These are short on purpose:
   # if Anthropic isn't reachable quickly, we want to fail fast and retry rather than sit on a dead
@@ -42,10 +61,11 @@ class Ai::AnthropicClient
   MAX_ATTEMPTS = 3
   RETRY_BASE_DELAY_IN_SECONDS = 1
 
-  # Response statuses worth a retry: rate limit (429), server errors (5xx), and Anthropic's
-  # "overloaded" status (529). Anything else (400 bad request, 401 bad key, ...) is deterministic —
-  # retrying would just repeat the same failure slower.
-  RETRYABLE_STATUS_CODES = [429, 500, 502, 503, 504, 529].freeze
+  # Response statuses worth a retry: request timeout (408 — OpenRouter returns it when the upstream
+  # timed out; Anthropic itself doesn't use it), rate limit (429), server errors (5xx), and
+  # Anthropic's "overloaded" status (529). Anything else (400 bad request, 401 bad key, ...) is
+  # deterministic — retrying would just repeat the same failure slower.
+  RETRYABLE_STATUS_CODES = [408, 429, 500, 502, 503, 504, 529].freeze
   # Mid-stream `error` events with these types are the streaming equivalents of the statuses above.
   RETRYABLE_STREAM_ERROR_TYPES = %w[overloaded_error api_error rate_limit_error timeout_error].freeze
 
@@ -69,7 +89,7 @@ class Ai::AnthropicClient
   def messages(system:, messages:, tools: nil, max_tokens: DEFAULT_MAX_TOKENS)
     body = request_body(system:, messages:, tools:, max_tokens:, stream: false)
     with_retries do
-      response = http.post(API_URL, json: body)
+      response = http.post(api_url, json: body)
       raise_for_status!(response, kind: "request")
 
       parse_message(response.parse)
@@ -99,7 +119,7 @@ class Ai::AnthropicClient
       blocks = {}
       stop_reason = nil
 
-      response = http.post(API_URL, json: body)
+      response = http.post(api_url, json: body)
       raise_for_status!(response, kind: "stream")
 
       each_sse_event(response.body) do |event, data|
@@ -201,6 +221,12 @@ class Ai::AnthropicClient
         stream:,
       }
       body[:tools] = cacheable_tools(tools) if tools.present?
+      # OpenRouter's Anthropic-compatible endpoint accepts a `fallbacks` list (same shape as
+      # Anthropic's SDKs): if Claude errors — rate limit, overload, provider downtime — OpenRouter
+      # retries the request against the fallback model and translates the wire format for it, so
+      # the agent stays up on GPT when Anthropic is down. Sent only when routing through
+      # OpenRouter; Anthropic's own API would reject the unknown parameter.
+      body[:fallbacks] = [{ model: fallback_model }] if openrouter? && fallback_model.present?
       body
     end
 
@@ -249,12 +275,37 @@ class Ai::AnthropicClient
     # generic "Sorry, I ran into a problem" error. Remove the fallback once ANTHROPIC_API_KEY is set.
     # Failing fast here with a clear message (rather than shipping a blank key upstream) keeps a future
     # config gap legible instead of surfacing as a confusing upstream 401.
+    #
+    # When OPENROUTER_API_KEY is configured, requests route through OpenRouter instead and that key
+    # is sent in the same x-api-key header — OpenRouter's Anthropic-compatible endpoint accepts it
+    # there, so nothing else about the request changes.
     def api_key
+      return openrouter_api_key if openrouter?
+
       key = GlobalConfig.get("ANTHROPIC_API_KEY").presence ||
             GlobalConfig.get("WALKS_ANTHROPIC_API_KEY").presence
       raise Error, "Anthropic API key is not configured (set ANTHROPIC_API_KEY)." if key.blank?
 
       key
+    end
+
+    # OpenRouter routing is on when its key is configured, off otherwise. A plain config check (no
+    # feature flag) keeps the switch trivially auditable: delete the key and traffic is back on
+    # Anthropic directly.
+    def openrouter?
+      openrouter_api_key.present?
+    end
+
+    def openrouter_api_key
+      GlobalConfig.get("OPENROUTER_API_KEY").presence
+    end
+
+    def api_url
+      openrouter? ? OPENROUTER_API_URL : API_URL
+    end
+
+    def fallback_model
+      GlobalConfig.get("OPENROUTER_FALLBACK_MODEL").presence || DEFAULT_FALLBACK_MODEL
     end
 
     # Normalize a buffered Messages response into a Result. Content is an array of typed blocks; we

--- a/app/services/ai/anthropic_client.rb
+++ b/app/services/ai/anthropic_client.rb
@@ -61,12 +61,15 @@ class Ai::AnthropicClient
   MAX_ATTEMPTS = 3
   RETRY_BASE_DELAY_IN_SECONDS = 1
 
-  # Response statuses worth a retry: request timeout (408 — OpenRouter returns it when the upstream
-  # timed out; Anthropic itself doesn't use it), rate limit (429), server errors (5xx), and
-  # Anthropic's "overloaded" status (529). Anything else (400 bad request, 401 bad key, ...) is
-  # deterministic — retrying would just repeat the same failure slower.
+  # Response statuses worth a retry: request timeout (408), rate limit (429), server errors (5xx),
+  # and Anthropic's "overloaded" status (529). 408 was added for OpenRouter (it returns 408 when the
+  # upstream model times out; Anthropic itself doesn't use it today), but the list applies to both
+  # routing modes — so if a proxy in front of api.anthropic.com ever returned a 408, we'd retry that
+  # too, which is the right call for a timeout either way. Anything else (400 bad request, 401 bad
+  # key, ...) is deterministic — retrying would just repeat the same failure slower.
   RETRYABLE_STATUS_CODES = [408, 429, 500, 502, 503, 504, 529].freeze
-  # Mid-stream `error` events with these types are the streaming equivalents of the statuses above.
+  # `error` objects with these types — arriving mid-stream or inside a buffered 200 body — are the
+  # embedded equivalents of the retryable statuses above.
   RETRYABLE_STREAM_ERROR_TYPES = %w[overloaded_error api_error rate_limit_error timeout_error].freeze
 
   Result = Struct.new(:text, :tool_uses, :stop_reason, keyword_init: true)
@@ -148,7 +151,7 @@ class Ai::AnthropicClient
         when "message_delta"
           stop_reason = data.dig("delta", "stop_reason") || stop_reason
         when "error"
-          raise stream_error(data)
+          raise embedded_error(data, kind: "stream")
         end
       end
 
@@ -188,11 +191,14 @@ class Ai::AnthropicClient
       raise Error, message
     end
 
-    # Classify a mid-stream `error` event. Overload/rate-limit/server errors are transient (the
-    # retry loop may replay the request if nothing was yielded yet); anything else is a real error.
-    def stream_error(data)
+    # Classify an `error` object embedded in an otherwise-successful response — either a mid-stream
+    # `error` event, or (OpenRouter only) an HTTP 200 whose buffered body carries an error object.
+    # Overload/rate-limit/server errors are transient (the retry loop may replay the request if
+    # nothing was yielded yet); anything else is a real error. `kind` keeps the raised message
+    # accurate for the path it came from ("stream" vs "response").
+    def embedded_error(data, kind:)
       error = data["error"] || {}
-      message = "Anthropic stream error: #{error["message"] || "unknown"}"
+      message = "Anthropic #{kind} error: #{error["message"] || "unknown"}"
       return TransientError.new(message) if RETRYABLE_STREAM_ERROR_TYPES.include?(error["type"])
 
       Error.new(message)
@@ -226,7 +232,7 @@ class Ai::AnthropicClient
       # retries the request against the fallback model and translates the wire format for it, so
       # the agent stays up on GPT when Anthropic is down. Sent only when routing through
       # OpenRouter; Anthropic's own API would reject the unknown parameter.
-      body[:fallbacks] = [{ model: fallback_model }] if openrouter? && fallback_model.present?
+      body[:fallbacks] = [{ model: fallback_model }] if openrouter?
       body
     end
 
@@ -318,7 +324,7 @@ class Ai::AnthropicClient
     # as mid-stream errors lets the retry loop recover from the transient ones.
     def parse_message(body)
       return Result.new(text: "", tool_uses: [], stop_reason: nil) unless body.is_a?(Hash)
-      raise stream_error(body) if body["error"].is_a?(Hash)
+      raise embedded_error(body, kind: "response") if body["error"].is_a?(Hash)
 
       content = Array(body["content"])
       text = content.filter_map { |b| b["text"].to_s if b.is_a?(Hash) && b["type"] == "text" }.join

--- a/app/services/ai/store_agent_service.rb
+++ b/app/services/ai/store_agent_service.rb
@@ -24,7 +24,12 @@ class Ai::StoreAgentService
   class Error < StandardError; end
 
   MODEL = Ai::AnthropicClient::DEFAULT_MODEL
-  REQUEST_TIMEOUT_IN_SECONDS = 60
+  # Passed to Ai::AnthropicClient as its READ timeout. For the streamed reply this bounds silence
+  # between chunks (not the total generation time — a long healthy stream is fine); for the buffered
+  # calls it bounds the wait for the full response. Production showed a steady stream of 60-second
+  # network timeouts on real (slow but working) generations, so this is deliberately generous — the
+  # client fails fast on connect problems and retries transient failures on its own.
+  REQUEST_TIMEOUT_IN_SECONDS = 120
   MAX_TOOL_ITERATIONS = 5
   MAX_MESSAGE_LENGTH = 2_000
   # Anthropic requires max_tokens on every request. This cap has to fit more than a brief chat

--- a/spec/services/ai/anthropic_client_spec.rb
+++ b/spec/services/ai/anthropic_client_spec.rb
@@ -346,10 +346,11 @@ describe Ai::AnthropicClient do
         expect(Rails.logger).to have_received(:warn).with(/served by fallback model openai\/gpt-5/)
       end
 
-      it "does not warn when the served model is the requested one, even with a version suffix" do
-        # Providers report the fully-versioned name (e.g. a dated snapshot of the requested model);
-        # that's still the model we asked for, not a fallback.
-        body = { "model" => "#{described_class::DEFAULT_MODEL}-20260115", "content" => [], "stop_reason" => "end_turn" }
+      it "does not warn when the served model is the requested one restyled by the provider" do
+        # OpenRouter reports the model as "anthropic/claude-opus-4.7" (provider prefix, dotted
+        # version) for a request naming "claude-opus-4-7" — same model, so no warning. Verified
+        # against the live endpoint 2026-07-13.
+        body = { "model" => "anthropic/#{described_class::DEFAULT_MODEL.tr("-", ".")}", "content" => [], "stop_reason" => "end_turn" }
         stub_request(:post, openrouter_url).to_return(status: 200, body: body.to_json, headers: { "Content-Type" => "application/json" })
 
         client.messages(system: "s", messages: [{ role: "user", content: "x" }])

--- a/spec/services/ai/anthropic_client_spec.rb
+++ b/spec/services/ai/anthropic_client_spec.rb
@@ -18,7 +18,7 @@ describe Ai::AnthropicClient do
       stub = stub_request(:post, url)
         .with(
           headers: { "x-api-key" => "sk-ant-test", "anthropic-version" => "2023-06-01" },
-          body: hash_including("model" => described_class::DEFAULT_MODEL, "system" => "be helpful", "stream" => false),
+          body: hash_including("model" => described_class::DEFAULT_MODEL, "stream" => false),
         )
         .to_return(status: 200, body: body.to_json, headers: { "Content-Type" => "application/json" })
 
@@ -28,6 +28,23 @@ describe Ai::AnthropicClient do
       expect(result.text).to eq("You have 3 products.")
       expect(result.tool_uses).to eq([])
       expect(result.stop_reason).to eq("end_turn")
+    end
+
+    it "marks the system prompt and the last tool as cacheable so Anthropic can reuse the shared prefix" do
+      captured = nil
+      stub_request(:post, url)
+        .with { |request| captured = JSON.parse(request.body); true }
+        .to_return(status: 200, body: { "content" => [], "stop_reason" => "end_turn" }.to_json, headers: { "Content-Type" => "application/json" })
+
+      client.messages(
+        system: "be helpful",
+        messages: [{ role: "user", content: "x" }],
+        tools: [{ name: "api_read" }, { name: "api_write" }],
+      )
+
+      expect(captured["system"]).to eq([{ "type" => "text", "text" => "be helpful", "cache_control" => { "type" => "ephemeral" } }])
+      expect(captured["tools"][0]).not_to have_key("cache_control")
+      expect(captured["tools"][1]["cache_control"]).to eq("type" => "ephemeral")
     end
 
     it "parses tool_use blocks with their input" do
@@ -47,10 +64,89 @@ describe Ai::AnthropicClient do
     end
 
     it "raises Error on a non-success status" do
-      stub_request(:post, url).to_return(status: 500, body: "boom")
+      stub_request(:post, url).to_return(status: 400, body: "boom")
 
       expect { client.messages(system: "s", messages: [{ role: "user", content: "x" }]) }
         .to raise_error(described_class::Error, /failed/i)
+    end
+  end
+
+  describe "retries" do
+    before { allow(client).to receive(:sleep) } # keep specs fast; retry delays are exercised via the stub
+
+    it "retries a buffered request on a retryable status and succeeds" do
+      body = { "content" => [{ "type" => "text", "text" => "ok" }], "stop_reason" => "end_turn" }
+      stub_request(:post, url)
+        .to_return({ status: 529, body: { error: { type: "overloaded_error", message: "Overloaded" } }.to_json },
+                   { status: 200, body: body.to_json, headers: { "Content-Type" => "application/json" } })
+
+      result = client.messages(system: "s", messages: [{ role: "user", content: "x" }])
+
+      expect(result.text).to eq("ok")
+      expect(client).to have_received(:sleep).once
+    end
+
+    it "retries a network timeout and surfaces TransientError after exhausting attempts" do
+      stub_request(:post, url).to_timeout
+
+      expect { client.messages(system: "s", messages: [{ role: "user", content: "x" }]) }
+        .to raise_error(described_class::TransientError, /network error/i)
+      expect(client).to have_received(:sleep).twice # MAX_ATTEMPTS - 1 backoffs
+    end
+
+    it "does not retry a deterministic failure like a 400" do
+      stub = stub_request(:post, url).to_return(status: 400, body: { error: { message: "bad request" } }.to_json)
+
+      expect { client.messages(system: "s", messages: [{ role: "user", content: "x" }]) }
+        .to raise_error(described_class::Error, /bad request/)
+      expect(stub).to have_been_requested.once
+    end
+
+    it "retries a streaming request that fails before any output reached the caller" do
+      good_stream = "event: content_block_start\ndata: #{{ index: 0, content_block: { type: "text" } }.to_json}\n\n" \
+                    "event: content_block_delta\ndata: #{{ index: 0, delta: { type: "text_delta", text: "hi" } }.to_json}\n\n" \
+                    "event: message_delta\ndata: #{{ delta: { stop_reason: "end_turn" } }.to_json}\n\n"
+      stub_request(:post, url)
+        .to_return({ status: 529, body: { error: { type: "overloaded_error", message: "Overloaded" } }.to_json },
+                   { status: 200, body: good_stream, headers: { "Content-Type" => "text/event-stream" } })
+
+      chunks = []
+      result = client.stream_messages(system: "s", messages: [{ role: "user", content: "x" }]) { |text| chunks << text }
+
+      expect(chunks).to eq(["hi"])
+      expect(result.text).to eq("hi")
+    end
+
+    it "does not retry a stream that already yielded output to the caller" do
+      # The first token has already rendered on the seller's screen when the overload event arrives;
+      # replaying the request would restart the reply mid-sentence, so the failure must surface.
+      broken_stream = "event: content_block_start\ndata: #{{ index: 0, content_block: { type: "text" } }.to_json}\n\n" \
+                      "event: content_block_delta\ndata: #{{ index: 0, delta: { type: "text_delta", text: "partial" } }.to_json}\n\n" \
+                      "event: error\ndata: #{{ error: { type: "overloaded_error", message: "Overloaded" } }.to_json}\n\n"
+      stub = stub_request(:post, url).to_return(status: 200, body: broken_stream, headers: { "Content-Type" => "text/event-stream" })
+
+      expect { client.stream_messages(system: "s", messages: [{ role: "user", content: "x" }]) { |_| } }
+        .to raise_error(described_class::TransientError, /overloaded/i)
+      expect(stub).to have_been_requested.once
+    end
+  end
+
+  describe "timeouts" do
+    it "uses per-operation timeouts with the configured value as the read (silence) timeout" do
+      # A per-operation read timeout bounds silence between chunks, not total stream duration — the
+      # old single global timeout killed healthy long generations mid-stream.
+      chain = HTTP.timeout(connect: 1) # any chainable; we only assert what the client requests
+      allow(HTTP).to receive(:timeout).and_return(chain)
+      allow(chain).to receive(:headers).and_call_original
+
+      stub_request(:post, url).to_return(status: 200, body: { "content" => [], "stop_reason" => "end_turn" }.to_json, headers: { "Content-Type" => "application/json" })
+      described_class.new(timeout: 45).messages(system: "s", messages: [{ role: "user", content: "x" }])
+
+      expect(HTTP).to have_received(:timeout).with(
+        connect: described_class::CONNECT_TIMEOUT_IN_SECONDS,
+        write: described_class::WRITE_TIMEOUT_IN_SECONDS,
+        read: 45,
+      )
     end
   end
 

--- a/spec/services/ai/anthropic_client_spec.rb
+++ b/spec/services/ai/anthropic_client_spec.rb
@@ -321,6 +321,42 @@ describe Ai::AnthropicClient do
       expect(stub).to have_been_requested
       expect(captured).not_to have_key("fallbacks")
     end
+
+    describe "served-model logging" do
+      before { allow(Rails.logger).to receive(:warn) }
+
+      it "warns when a buffered response was served by a different model than requested" do
+        body = { "model" => "openai/gpt-5", "content" => [{ "type" => "text", "text" => "ok" }], "stop_reason" => "end_turn" }
+        stub_request(:post, openrouter_url).to_return(status: 200, body: body.to_json, headers: { "Content-Type" => "application/json" })
+
+        client.messages(system: "s", messages: [{ role: "user", content: "x" }])
+
+        expect(Rails.logger).to have_received(:warn).with(/served by fallback model openai\/gpt-5 \(requested #{described_class::DEFAULT_MODEL}\)/o)
+      end
+
+      it "warns when a stream's message_start names a different model than requested" do
+        stream = "event: message_start\ndata: #{{ message: { model: "openai/gpt-5" } }.to_json}\n\n" \
+                 "event: content_block_start\ndata: #{{ index: 0, content_block: { type: "text" } }.to_json}\n\n" \
+                 "event: content_block_delta\ndata: #{{ index: 0, delta: { type: "text_delta", text: "hi" } }.to_json}\n\n" \
+                 "event: message_delta\ndata: #{{ delta: { stop_reason: "end_turn" } }.to_json}\n\n"
+        stub_request(:post, openrouter_url).to_return(status: 200, body: stream, headers: { "Content-Type" => "text/event-stream" })
+
+        client.stream_messages(system: "s", messages: [{ role: "user", content: "x" }]) { |_| }
+
+        expect(Rails.logger).to have_received(:warn).with(/served by fallback model openai\/gpt-5/)
+      end
+
+      it "does not warn when the served model is the requested one, even with a version suffix" do
+        # Providers report the fully-versioned name (e.g. a dated snapshot of the requested model);
+        # that's still the model we asked for, not a fallback.
+        body = { "model" => "#{described_class::DEFAULT_MODEL}-20260115", "content" => [], "stop_reason" => "end_turn" }
+        stub_request(:post, openrouter_url).to_return(status: 200, body: body.to_json, headers: { "Content-Type" => "application/json" })
+
+        client.messages(system: "s", messages: [{ role: "user", content: "x" }])
+
+        expect(Rails.logger).not_to have_received(:warn)
+      end
+    end
   end
 
   describe "#stream_messages" do

--- a/spec/services/ai/anthropic_client_spec.rb
+++ b/spec/services/ai/anthropic_client_spec.rb
@@ -253,6 +253,21 @@ describe Ai::AnthropicClient do
       expect(client).to have_received(:sleep).once
     end
 
+    it "treats a 200 response carrying an error body as a failure instead of a blank reply" do
+      # OpenRouter returns HTTP 200 with an error object when the failure happened after the
+      # upstream model started processing; a transient error type there gets retried like any other.
+      allow(client).to receive(:sleep)
+      good = { "content" => [{ "type" => "text", "text" => "ok" }], "stop_reason" => "end_turn" }
+      stub_request(:post, openrouter_url)
+        .to_return({ status: 200, body: { error: { type: "overloaded_error", message: "Overloaded" } }.to_json, headers: { "Content-Type" => "application/json" } },
+                   { status: 200, body: good.to_json, headers: { "Content-Type" => "application/json" } })
+
+      result = client.messages(system: "s", messages: [{ role: "user", content: "x" }])
+
+      expect(result.text).to eq("ok")
+      expect(client).to have_received(:sleep).once
+    end
+
     it "does not send fallbacks or touch OpenRouter when the key is not configured" do
       allow(GlobalConfig).to receive(:get).with("OPENROUTER_API_KEY").and_return("")
       captured = nil

--- a/spec/services/ai/anthropic_client_spec.rb
+++ b/spec/services/ai/anthropic_client_spec.rb
@@ -10,6 +10,9 @@ describe Ai::AnthropicClient do
   before do
     allow(GlobalConfig).to receive(:get).and_call_original
     allow(GlobalConfig).to receive(:get).with("ANTHROPIC_API_KEY").and_return("sk-ant-test")
+    # Pin OpenRouter routing OFF by default so these specs exercise the direct-to-Anthropic path
+    # regardless of what the host machine's environment has configured.
+    allow(GlobalConfig).to receive(:get).with("OPENROUTER_API_KEY").and_return(nil)
   end
 
   describe "#messages" do
@@ -184,6 +187,83 @@ describe Ai::AnthropicClient do
       expect { client.messages(system: "s", messages: [{ role: "user", content: "x" }]) }
         .to raise_error(described_class::Error, /not configured/i)
       expect(request).not_to have_been_requested
+    end
+  end
+
+  describe "OpenRouter gateway routing" do
+    let(:openrouter_url) { "https://openrouter.ai/api/v1/messages" }
+
+    before do
+      allow(GlobalConfig).to receive(:get).with("OPENROUTER_API_KEY").and_return("sk-or-test")
+      allow(GlobalConfig).to receive(:get).with("OPENROUTER_FALLBACK_MODEL").and_return(nil)
+    end
+
+    it "routes requests to OpenRouter with its key and a GPT fallback when OPENROUTER_API_KEY is set" do
+      captured = nil
+      stub = stub_request(:post, openrouter_url)
+        .with(headers: { "x-api-key" => "sk-or-test", "anthropic-version" => "2023-06-01" }) { |request| captured = JSON.parse(request.body); true }
+        .to_return(status: 200, body: { "content" => [{ "type" => "text", "text" => "ok" }], "stop_reason" => "end_turn" }.to_json, headers: { "Content-Type" => "application/json" })
+
+      result = client.messages(system: "s", messages: [{ role: "user", content: "x" }])
+
+      expect(stub).to have_been_requested
+      expect(result.text).to eq("ok")
+      expect(captured["model"]).to eq(described_class::DEFAULT_MODEL)
+      expect(captured["fallbacks"]).to eq([{ "model" => described_class::DEFAULT_FALLBACK_MODEL }])
+    end
+
+    it "streams through OpenRouter with the same Anthropic SSE protocol" do
+      stream = "event: content_block_start\ndata: #{{ index: 0, content_block: { type: "text" } }.to_json}\n\n" \
+               "event: content_block_delta\ndata: #{{ index: 0, delta: { type: "text_delta", text: "hi" } }.to_json}\n\n" \
+               "event: message_delta\ndata: #{{ delta: { stop_reason: "end_turn" } }.to_json}\n\n"
+      stub = stub_request(:post, openrouter_url)
+        .with(body: hash_including("stream" => true, "fallbacks" => [{ "model" => described_class::DEFAULT_FALLBACK_MODEL }]))
+        .to_return(status: 200, body: stream, headers: { "Content-Type" => "text/event-stream" })
+
+      chunks = []
+      result = client.stream_messages(system: "s", messages: [{ role: "user", content: "x" }]) { |text| chunks << text }
+
+      expect(stub).to have_been_requested
+      expect(chunks).to eq(["hi"])
+      expect(result.stop_reason).to eq("end_turn")
+    end
+
+    it "honors an OPENROUTER_FALLBACK_MODEL override" do
+      allow(GlobalConfig).to receive(:get).with("OPENROUTER_FALLBACK_MODEL").and_return("openai/gpt-4o")
+      captured = nil
+      stub_request(:post, openrouter_url)
+        .with { |request| captured = JSON.parse(request.body); true }
+        .to_return(status: 200, body: { "content" => [], "stop_reason" => "end_turn" }.to_json, headers: { "Content-Type" => "application/json" })
+
+      client.messages(system: "s", messages: [{ role: "user", content: "x" }])
+
+      expect(captured["fallbacks"]).to eq([{ "model" => "openai/gpt-4o" }])
+    end
+
+    it "retries OpenRouter's 408 upstream-timeout status like other transient failures" do
+      allow(client).to receive(:sleep)
+      body = { "content" => [{ "type" => "text", "text" => "ok" }], "stop_reason" => "end_turn" }
+      stub_request(:post, openrouter_url)
+        .to_return({ status: 408, body: { error: { code: 408, message: "Your request timed out" } }.to_json },
+                   { status: 200, body: body.to_json, headers: { "Content-Type" => "application/json" } })
+
+      result = client.messages(system: "s", messages: [{ role: "user", content: "x" }])
+
+      expect(result.text).to eq("ok")
+      expect(client).to have_received(:sleep).once
+    end
+
+    it "does not send fallbacks or touch OpenRouter when the key is not configured" do
+      allow(GlobalConfig).to receive(:get).with("OPENROUTER_API_KEY").and_return("")
+      captured = nil
+      stub = stub_request(:post, url)
+        .with(headers: { "x-api-key" => "sk-ant-test" }) { |request| captured = JSON.parse(request.body); true }
+        .to_return(status: 200, body: { "content" => [], "stop_reason" => "end_turn" }.to_json, headers: { "Content-Type" => "application/json" })
+
+      client.messages(system: "s", messages: [{ role: "user", content: "x" }])
+
+      expect(stub).to have_been_requested
+      expect(captured).not_to have_key("fallbacks")
     end
   end
 


### PR DESCRIPTION
## What

Routes the store agent's Claude traffic through OpenRouter (opt-in via `OPENROUTER_API_KEY`), with automatic fallback to GPT when Claude is unavailable.

`Ai::AnthropicClient` gains a config-gated gateway mode:
- When `OPENROUTER_API_KEY` is set, requests go to OpenRouter's Anthropic-compatible Messages endpoint (`https://openrouter.ai/api/v1/messages`) instead of `api.anthropic.com`. Same request/response shapes, same SSE streaming protocol — the only changes are the URL and the key in the `x-api-key` header.
- Each request carries a `fallbacks` parameter (OpenRouter-native, matching Anthropic's SDK shape): if Claude errors — rate limit, overload, provider downtime — OpenRouter retries against `~openai/gpt-latest` (overridable via `OPENROUTER_FALLBACK_MODEL`) and translates the wire format, so no OpenAI-specific translation code is needed on our side.
- 408 (OpenRouter's upstream-timeout status; Anthropic doesn't use it) is added to the retryable status codes.
- A warning is logged whenever the model that served a response differs from the one requested (the `model` field on buffered responses, the `message_start` event on streams) — so time spent on the GPT fallback is visible in app logs, not just on OpenRouter's dashboard.
- Without the key, nothing changes: requests go straight to Anthropic exactly as today.

## Why

The store agent has a single hard dependency on Anthropic's API, and it's been the dominant failure driver: ~1,391 stream failures since Jul 6 were Anthropic-side timeouts/errors surfacing to sellers as "Something went wrong" (see the linked issue). #5832 fixes the timeout semantics and adds client-side retries; this adds the layer above that — provider failover between Anthropic's hosts, and cross-provider fallback to GPT when Anthropic is genuinely down — so an upstream outage degrades the agent instead of taking it down. OpenRouter also gives per-request observability (activity dashboard), which matters right now with Sentry ingestion dead.

Kept the loop server-side: the agent's safety model (seller-scoped API client, propose/confirm gate) lives in Rails, and the gateway solves the reliability problem without exposing the system prompt or tool catalog to the browser.

Refs antiwork/gumroad-private#1054.

## Test plan

- New specs cover: routing + key + `fallbacks` payload when the key is set; streaming through OpenRouter over the same SSE protocol; the `OPENROUTER_FALLBACK_MODEL` override; 408 retry; served-model logging (buffered + stream, and the no-warn case for a versioned name of the requested model); and the off state (no key → direct to Anthropic, no `fallbacks` sent).
- Full client spec run locally: 30 examples, 0 failures.
- Forced-fallback smoke test against the live OpenRouter account (BYOK, own Anthropic + OpenAI keys): result posted in the PR comments.
- Rollout: set `OPENROUTER_API_KEY` in production config, watch the OpenRouter activity dashboard + app logs for `Anthropic … failed` counts and `served by fallback model` warnings. Rollback is deleting the key.
- Rollout note: the OpenRouter account runs BYOK with zero credit balance and "never fall back to OpenRouter endpoints" enabled — everything runs on our own provider keys. BYOK is free for the first 1M requests/month; past that, OpenRouter charges a 5% BYOK fee against the credit balance, which we don't keep. If the store agent's traffic ever approaches 1M requests/month, the account needs a small credit balance topped up (or auto-top-up enabled) before that point, or requests start failing at OpenRouter.

