### PR TITLE
Cache compiled preview-app assets in S3, keyed on content

### DIFF
--- a/.buildkite/scripts/compile_assets.sh
+++ b/.buildkite/scripts/compile_assets.sh
@@ -116,20 +116,24 @@ if [[ ${BUILDKITE_PARALLEL_JOB:-0} = 0 && $BUILDKITE_BRANCH != "main" ]]; then
 
     # Re-sync assets to S3. The compiled files were already uploaded when the
     # cache entry was created, so this is a fast no-op sync — kept as a
-    # safety net in case that earlier upload was interrupted.
+    # safety net in case that earlier upload was interrupted. Best-effort:
+    # the expensive part (the docker commit above) already succeeded, so a
+    # transient S3 failure here is logged but never discards the committed
+    # image or triggers the full recompile.
     logger "Syncing cached assets to S3"
-    local container_id sync_status
+    local container_id
     container_id=$(docker run -d --entrypoint="bash" --volume /app $WEB_REPO:staging-$WEB_TAG) || return 1
-    docker run --rm \
+    if ! docker run --rm \
       -e AWS_ACCESS_KEY_ID=$GUM_AWS_ACCESS_KEY_ID \
       -e AWS_SECRET_ACCESS_KEY=$GUM_AWS_SECRET_ACCESS_KEY \
       -e ASSETS_S3_BUCKET=gumroad-staging-assets \
       --volumes-from $container_id \
       garland/aws-cli-docker \
-      sh /app/docker/web/push_assets_to_s3.sh
-    sync_status=$?
+      sh /app/docker/web/push_assets_to_s3.sh; then
+      logger "S3 asset sync failed — continuing with the cached staging image (assets were already uploaded when the cache entry was created)"
+    fi
     docker rm -f $container_id >/dev/null 2>&1 || true
-    return $sync_status
+    return 0
   }
 
   if [[ $ASSET_CACHE_HIT == true ]]; then

--- a/.buildkite/scripts/compile_assets.sh
+++ b/.buildkite/scripts/compile_assets.sh
@@ -132,7 +132,9 @@ if [[ ${BUILDKITE_PARALLEL_JOB:-0} = 0 && $BUILDKITE_BRANCH != "main" ]]; then
       sh /app/docker/web/push_assets_to_s3.sh; then
       logger "S3 asset sync failed — continuing with the cached staging image (assets were already uploaded when the cache entry was created)"
     fi
-    docker rm -f $container_id >/dev/null 2>&1 || true
+    # -v also removes the anonymous /app volume the data container created,
+    # so cache-hit builds don't leak a volume on the CI agent every deploy.
+    docker rm -fv $container_id >/dev/null 2>&1 || true
     return 0
   }
 

--- a/.buildkite/scripts/compile_assets.sh
+++ b/.buildkite/scripts/compile_assets.sh
@@ -17,6 +17,8 @@ quietly() {
   fi
 }
 
+source .buildkite/scripts/preview_asset_cache.sh
+
 ECR_REGISTRY=${ECR_REGISTRY}
 WEB_REPO=${ECR_REGISTRY}/gumroad/web
 REVISION=${BUILDKITE_COMMIT}
@@ -62,17 +64,104 @@ fi
 # BUILDKITE_PARALLEL_JOB is unset when the step has no parallelism configured
 # (preview.yml runs a single asset job); default to 0 so the staging build runs.
 if [[ ${BUILDKITE_PARALLEL_JOB:-0} = 0 && $BUILDKITE_BRANCH != "main" ]]; then
-  logger "Building staging assets"
-  docker rm staging-assets || :
-  COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME}_staging \
-    NEW_WEB_TAG=$WEB_TAG \
-    NEW_WEB_REPO=$WEB_REPO \
-    BUILDKITE_BRANCH=${BUILDKITE_BRANCH} \
-    GUM_AWS_ACCESS_KEY_ID=${GUM_AWS_ACCESS_KEY_ID} \
-    GUM_AWS_SECRET_ACCESS_KEY=${GUM_AWS_SECRET_ACCESS_KEY} \
-    RAILS_STAGING_MASTER_KEY="$RAILS_STAGING_MASTER_KEY" \
-    PUSH_ASSETS=true \
-    make build_staging
+  # Preview branches first check the content-addressed asset cache. On a hit
+  # we skip the entire compile (npm install, js:export, Vite) and build the
+  # staging image by extracting the previously compiled artifacts into a
+  # fresh web-image container — same shape as the docker-commit the full
+  # build produces, minutes instead of ~13.
+  ASSET_CACHE_HIT=false
+  if preview_asset_cache_enabled; then
+    ASSET_CACHE_TAG=$(preview_asset_cache_tag)
+    logger "Preview asset cache tag: $ASSET_CACHE_TAG"
+    if preview_asset_cache_restore "$ASSET_CACHE_TAG"; then
+      ASSET_CACHE_HIT=true
+      logger "Preview asset cache HIT — skipping asset compile"
+    else
+      logger "Preview asset cache miss — running full asset compile"
+    fi
+  fi
+
+  # Builds the staging image from the restored cache tarball. Mirrors what
+  # `make build_staging` commits: spec/ removed, container labeled
+  # assets_compiled=true, and the SAME -e env as the full build. That last
+  # part matters: docker commit bakes the container's env into the image as
+  # defaults, so a cache-hit image must carry exactly what a full-build image
+  # carries. The tarball is mounted read-only; docker commit ignores mounted
+  # paths, so only the extracted files end up in the image.
+  build_staging_image_from_cache() {
+    docker rm -f staging-assets-from-cache 2>/dev/null || :
+    docker run \
+      --name staging-assets-from-cache \
+      --entrypoint="" \
+      -e RAILS_ENV="staging" \
+      -e RACK_ENV="staging" \
+      -e DATABASE_HOST="db_test" \
+      -e DATABASE_NAME="gumroad_test" \
+      -e DATABASE_USERNAME="root" \
+      -e DATABASE_PASSWORD="password" \
+      -e DEVISE_SECRET_KEY="sample_secret_key" \
+      -e RAILS_MASTER_KEY=$RAILS_STAGING_MASTER_KEY \
+      -e BUILDKITE_BRANCH=$BUILDKITE_BRANCH \
+      -e REVISION=$WEB_TAG \
+      -v "$PWD/$PREVIEW_ASSET_CACHE_TARBALL:/tmp/$PREVIEW_ASSET_CACHE_TARBALL:ro" \
+      --label assets_compiled=true \
+      $WEB_REPO:web-$WEB_TAG \
+      bash -c "cd /app \
+        && tar -xzf /tmp/$PREVIEW_ASSET_CACHE_TARBALL \
+        && chown -R app:app node_modules public \
+        && rm -rf spec/" || return 1
+    docker commit staging-assets-from-cache $WEB_REPO:staging-$WEB_TAG || return 1
+    docker rm staging-assets-from-cache || :
+    rm -f "$PREVIEW_ASSET_CACHE_TARBALL"
+
+    # Re-sync assets to S3. The compiled files were already uploaded when the
+    # cache entry was created, so this is a fast no-op sync — kept as a
+    # safety net in case that earlier upload was interrupted.
+    logger "Syncing cached assets to S3"
+    local container_id sync_status
+    container_id=$(docker run -d --entrypoint="bash" --volume /app $WEB_REPO:staging-$WEB_TAG) || return 1
+    docker run --rm \
+      -e AWS_ACCESS_KEY_ID=$GUM_AWS_ACCESS_KEY_ID \
+      -e AWS_SECRET_ACCESS_KEY=$GUM_AWS_SECRET_ACCESS_KEY \
+      -e ASSETS_S3_BUCKET=gumroad-staging-assets \
+      --volumes-from $container_id \
+      garland/aws-cli-docker \
+      sh /app/docker/web/push_assets_to_s3.sh
+    sync_status=$?
+    docker rm -f $container_id >/dev/null 2>&1 || true
+    return $sync_status
+  }
+
+  if [[ $ASSET_CACHE_HIT == true ]]; then
+    # A corrupt or incomplete cache entry must never fail the deploy — fall
+    # back to the full compile (which then overwrites the bad entry).
+    if ! build_staging_image_from_cache; then
+      logger "Cache-hit image build failed — falling back to full asset compile"
+      ASSET_CACHE_HIT=false
+      docker rm -f staging-assets-from-cache 2>/dev/null || :
+      rm -f "$PREVIEW_ASSET_CACHE_TARBALL"
+    fi
+  fi
+
+  if [[ $ASSET_CACHE_HIT != true ]]; then
+    logger "Building staging assets"
+    docker rm staging-assets || :
+    COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME}_staging \
+      NEW_WEB_TAG=$WEB_TAG \
+      NEW_WEB_REPO=$WEB_REPO \
+      BUILDKITE_BRANCH=${BUILDKITE_BRANCH} \
+      GUM_AWS_ACCESS_KEY_ID=${GUM_AWS_ACCESS_KEY_ID} \
+      GUM_AWS_SECRET_ACCESS_KEY=${GUM_AWS_SECRET_ACCESS_KEY} \
+      RAILS_STAGING_MASTER_KEY="$RAILS_STAGING_MASTER_KEY" \
+      PUSH_ASSETS=true \
+      make build_staging
+
+    # Populate the cache for the next push on this branch. Best-effort: a
+    # failed save never fails the deploy.
+    if preview_asset_cache_enabled; then
+      preview_asset_cache_save "$ASSET_CACHE_TAG" "$WEB_REPO:staging-$WEB_TAG" || true
+    fi
+  fi
 
   push_image staging || exit 1
 fi

--- a/.buildkite/scripts/compile_assets.sh
+++ b/.buildkite/scripts/compile_assets.sh
@@ -122,19 +122,26 @@ if [[ ${BUILDKITE_PARALLEL_JOB:-0} = 0 && $BUILDKITE_BRANCH != "main" ]]; then
     # image or triggers the full recompile.
     logger "Syncing cached assets to S3"
     local container_id
-    container_id=$(docker run -d --entrypoint="bash" --volume /app $WEB_REPO:staging-$WEB_TAG) || return 1
-    if ! docker run --rm \
-      -e AWS_ACCESS_KEY_ID=$GUM_AWS_ACCESS_KEY_ID \
-      -e AWS_SECRET_ACCESS_KEY=$GUM_AWS_SECRET_ACCESS_KEY \
-      -e ASSETS_S3_BUCKET=gumroad-staging-assets \
-      --volumes-from $container_id \
-      garland/aws-cli-docker \
-      sh /app/docker/web/push_assets_to_s3.sh; then
-      logger "S3 asset sync failed — continuing with the cached staging image (assets were already uploaded when the cache entry was created)"
+    if container_id=$(docker run -d --entrypoint="bash" --volume /app $WEB_REPO:staging-$WEB_TAG); then
+      if ! docker run --rm \
+        -e AWS_ACCESS_KEY_ID=$GUM_AWS_ACCESS_KEY_ID \
+        -e AWS_SECRET_ACCESS_KEY=$GUM_AWS_SECRET_ACCESS_KEY \
+        -e ASSETS_S3_BUCKET=gumroad-staging-assets \
+        --volumes-from $container_id \
+        garland/aws-cli-docker \
+        sh /app/docker/web/push_assets_to_s3.sh; then
+        logger "S3 asset sync failed — continuing with the cached staging image (assets were already uploaded when the cache entry was created)"
+      fi
+      # -v also removes the anonymous /app volume the data container created,
+      # so cache-hit builds don't leak a volume on the CI agent every deploy.
+      docker rm -fv $container_id >/dev/null 2>&1 || true
+    else
+      # Even the data container for the sync couldn't be created — still fine.
+      # The staging image is already committed and the assets were uploaded to
+      # S3 when the cache entry was created, so skip the sync rather than
+      # throwing away the committed image with a full recompile.
+      logger "Could not start the S3 sync container — skipping the best-effort asset sync"
     fi
-    # -v also removes the anonymous /app volume the data container created,
-    # so cache-hit builds don't leak a volume on the CI agent every deploy.
-    docker rm -fv $container_id >/dev/null 2>&1 || true
     return 0
   }
 

--- a/.buildkite/scripts/preview_asset_cache.sh
+++ b/.buildkite/scripts/preview_asset_cache.sh
@@ -47,6 +47,8 @@ preview_asset_cache_inputs() {
     app/javascript \
     config \
     lib/json_schemas \
+    lib/tasks \
+    Rakefile \
     public \
     vendor/assets \
     patches \
@@ -86,15 +88,34 @@ preview_asset_cache_url() {
   echo "s3://$PREVIEW_ASSET_CACHE_BUCKET/$PREVIEW_ASSET_CACHE_PREFIX/$1.tar.gz"
 }
 
+# Copies between S3 and a local file. The Buildkite preview agents do all
+# their S3 work through the garland/aws-cli-docker image (see
+# docker/web/push_assets_to_s3.sh) rather than a host-installed aws CLI, so
+# prefer host aws when present but fall back to the container.
+preview_asset_cache_s3_cp() {
+  local src=$1 dst=$2
+  if command -v aws >/dev/null 2>&1; then
+    AWS_ACCESS_KEY_ID=$GUM_AWS_ACCESS_KEY_ID \
+      AWS_SECRET_ACCESS_KEY=$GUM_AWS_SECRET_ACCESS_KEY \
+      aws s3 cp "$src" "$dst"
+  else
+    docker run --rm \
+      -e AWS_ACCESS_KEY_ID=$GUM_AWS_ACCESS_KEY_ID \
+      -e AWS_SECRET_ACCESS_KEY=$GUM_AWS_SECRET_ACCESS_KEY \
+      -v "$PWD:/workdir" \
+      -w /workdir \
+      garland/aws-cli-docker \
+      aws s3 cp "$src" "$dst"
+  fi
+}
+
 # Downloads the tarball for the current tag. Returns non-zero (a miss) when
 # the object doesn't exist or S3 is unreachable — the caller falls back to a
 # full compile either way.
 preview_asset_cache_restore() {
   local tag=$1
   rm -f "$PREVIEW_ASSET_CACHE_TARBALL"
-  AWS_ACCESS_KEY_ID=$GUM_AWS_ACCESS_KEY_ID \
-    AWS_SECRET_ACCESS_KEY=$GUM_AWS_SECRET_ACCESS_KEY \
-    aws s3 cp "$(preview_asset_cache_url "$tag")" "$PREVIEW_ASSET_CACHE_TARBALL"
+  preview_asset_cache_s3_cp "$(preview_asset_cache_url "$tag")" "$PREVIEW_ASSET_CACHE_TARBALL"
 }
 
 # Extracts the compiled artifacts out of the freshly built staging image and
@@ -114,9 +135,7 @@ preview_asset_cache_save() {
     return 1
   fi
 
-  if AWS_ACCESS_KEY_ID=$GUM_AWS_ACCESS_KEY_ID \
-    AWS_SECRET_ACCESS_KEY=$GUM_AWS_SECRET_ACCESS_KEY \
-    aws s3 cp "$PREVIEW_ASSET_CACHE_TARBALL" "$(preview_asset_cache_url "$tag")"; then
+  if preview_asset_cache_s3_cp "$PREVIEW_ASSET_CACHE_TARBALL" "$(preview_asset_cache_url "$tag")"; then
     preview_asset_cache_logger "Uploaded asset cache for tag $tag"
   else
     preview_asset_cache_logger "Failed to upload asset cache for tag $tag"

--- a/.buildkite/scripts/preview_asset_cache.sh
+++ b/.buildkite/scripts/preview_asset_cache.sh
@@ -31,6 +31,8 @@ PREVIEW_ASSET_CACHE_PREFIX="preview-asset-cache"
 # the artifact list below or discovering a missing hash input).
 PREVIEW_ASSET_CACHE_VERSION="v1"
 PREVIEW_ASSET_CACHE_TARBALL="preview-asset-cache.tar.gz"
+# Local scratch file for the SHA-256 sidecar (see restore/save below).
+PREVIEW_ASSET_CACHE_CHECKSUM="preview-asset-cache.tar.gz.sha256"
 
 preview_asset_cache_logger() {
   echo -e "\033[0;32m$(date '+%Y/%m/%d %H:%M:%S') preview_asset_cache.sh: $1\033[0m"
@@ -84,8 +86,10 @@ preview_asset_cache_enabled() {
   [[ -n $BUILDKITE_BRANCH ]] || return 1
   [[ $BUILDKITE_BRANCH != "main" ]] || return 1
   [[ $BUILDKITE_BRANCH != comp-assets-* ]] || return 1
-  # Same escape hatch as the branch cache in ci_scripts/helper.sh.
-  [[ ! $BUILDKITE_MESSAGE =~ no.cache ]] && return 0
+  # Same escape hatch as the branch cache in ci_scripts/helper.sh (which
+  # matches "no.cache" with a regex wildcard dot; here the separator is
+  # spelled out so an unrelated word like "noXcache" can't disable the cache).
+  [[ ! $BUILDKITE_MESSAGE =~ no[-_.[:space:]]cache ]] && return 0
   return 1
 }
 
@@ -114,13 +118,36 @@ preview_asset_cache_s3_cp() {
   fi
 }
 
-# Downloads the tarball for the current tag. Returns non-zero (a miss) when
-# the object doesn't exist or S3 is unreachable — the caller falls back to a
-# full compile either way.
+# Downloads the tarball for the current tag and verifies it against the
+# SHA-256 sidecar uploaded alongside it. Returns non-zero (a miss) when the
+# object doesn't exist, S3 is unreachable, the sidecar is missing, or the
+# checksum doesn't match — the caller falls back to a full compile either way.
+#
+# The check matters because the tarball is extracted into a container that
+# gets committed as the staging image: a truncated download or a tampered
+# object must never make it that far. (The sidecar proves the tarball is the
+# one this pipeline uploaded, byte for byte; keeping the bucket write-locked
+# to CI is what proves who uploaded it.)
 preview_asset_cache_restore() {
   local tag=$1
-  rm -f "$PREVIEW_ASSET_CACHE_TARBALL"
-  preview_asset_cache_s3_cp "$(preview_asset_cache_url "$tag")" "$PREVIEW_ASSET_CACHE_TARBALL"
+  rm -f "$PREVIEW_ASSET_CACHE_TARBALL" "$PREVIEW_ASSET_CACHE_CHECKSUM"
+  preview_asset_cache_s3_cp "$(preview_asset_cache_url "$tag")" "$PREVIEW_ASSET_CACHE_TARBALL" || return 1
+
+  if ! preview_asset_cache_s3_cp "$(preview_asset_cache_url "$tag").sha256" "$PREVIEW_ASSET_CACHE_CHECKSUM"; then
+    preview_asset_cache_logger "No checksum sidecar for tag $tag — treating as a cache miss"
+    rm -f "$PREVIEW_ASSET_CACHE_TARBALL"
+    return 1
+  fi
+
+  local expected actual
+  expected=$(tr -d '[:space:]' < "$PREVIEW_ASSET_CACHE_CHECKSUM")
+  actual=$(sha256sum "$PREVIEW_ASSET_CACHE_TARBALL" | cut -d " " -f1)
+  rm -f "$PREVIEW_ASSET_CACHE_CHECKSUM"
+  if [[ -z $expected || $expected != "$actual" ]]; then
+    preview_asset_cache_logger "Checksum mismatch for tag $tag — treating as a cache miss"
+    rm -f "$PREVIEW_ASSET_CACHE_TARBALL"
+    return 1
+  fi
 }
 
 # Extracts the compiled artifacts out of the freshly built staging image and
@@ -140,10 +167,16 @@ preview_asset_cache_save() {
     return 1
   fi
 
-  if preview_asset_cache_s3_cp "$PREVIEW_ASSET_CACHE_TARBALL" "$(preview_asset_cache_url "$tag")"; then
+  # The sidecar is what restore verifies before extracting the tarball into
+  # the staging image. Upload it after the tarball: restore fetches the
+  # tarball first, so it can never see a sidecar without its tarball, and a
+  # tarball without a sidecar is treated as a miss.
+  sha256sum "$PREVIEW_ASSET_CACHE_TARBALL" | cut -d " " -f1 > "$PREVIEW_ASSET_CACHE_CHECKSUM"
+  if preview_asset_cache_s3_cp "$PREVIEW_ASSET_CACHE_TARBALL" "$(preview_asset_cache_url "$tag")" \
+    && preview_asset_cache_s3_cp "$PREVIEW_ASSET_CACHE_CHECKSUM" "$(preview_asset_cache_url "$tag").sha256"; then
     preview_asset_cache_logger "Uploaded asset cache for tag $tag"
   else
     preview_asset_cache_logger "Failed to upload asset cache for tag $tag"
   fi
-  rm -f "$PREVIEW_ASSET_CACHE_TARBALL"
+  rm -f "$PREVIEW_ASSET_CACHE_TARBALL" "$PREVIEW_ASSET_CACHE_CHECKSUM"
 }

--- a/.buildkite/scripts/preview_asset_cache.sh
+++ b/.buildkite/scripts/preview_asset_cache.sh
@@ -133,7 +133,7 @@ preview_asset_cache_save() {
   # gzip -1: node_modules dominates the tarball and compresses slowly at the
   # default level; speed matters more than a few percent of S3 storage.
   if ! docker run --rm --entrypoint="" "$image" \
-    bash -c 'cd /app && paths=""; for p in node_modules public/vite public/js public/pages-tailwind.css; do [ -e "$p" ] && paths="$paths $p"; done; tar -cf - $paths | gzip -1' \
+    bash -c 'set -o pipefail; cd /app && paths=""; for p in node_modules public/vite public/js public/pages-tailwind.css; do [ -e "$p" ] && paths="$paths $p"; done; tar -cf - $paths | gzip -1' \
     > "$PREVIEW_ASSET_CACHE_TARBALL"; then
     preview_asset_cache_logger "Failed to extract assets from $image; skipping cache save"
     rm -f "$PREVIEW_ASSET_CACHE_TARBALL"

--- a/.buildkite/scripts/preview_asset_cache.sh
+++ b/.buildkite/scripts/preview_asset_cache.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# Content-addressed cache of compiled preview-app assets.
+#
+# Compiling assets is the slowest part of every preview-app deploy (~11 of the
+# ~13 minutes the Compile Assets step takes): npm install, a Rails boot for
+# js:export, the main Vite build, and the two widget builds. None of that work
+# changes unless the files that feed it change, yet the pipeline redid all of
+# it on every push — including backend-only pushes and "merge main into the
+# preview branch" refreshes.
+#
+# This helper caches the compiled artifacts (node_modules, public/vite,
+# public/js, public/pages-tailwind.css) in S3, keyed on a hash of every input
+# that feeds the compile. On a hit, compile_assets.sh restores the artifacts
+# into a fresh web-image container and commits that as the staging image,
+# skipping npm install / js:export / Vite entirely. On a miss it builds
+# normally and uploads the artifacts for next time.
+#
+# The cache key includes the branch name because js:export bakes the preview
+# app's domain (CUSTOM_DOMAIN, derived from the branch) into routes.js, which
+# the Vite bundle then inlines — identical sources on two different branches
+# compile to different assets.
+#
+# Preview-only by design: main and comp-assets-* builds (the production and
+# staging deploy paths) never read or write this cache. Pushing a commit whose
+# message contains "no-cache" bypasses it, mirroring branch_cache_setup in
+# ci_scripts/helper.sh.
+
+PREVIEW_ASSET_CACHE_BUCKET="buildkite-branch-cache"
+PREVIEW_ASSET_CACHE_PREFIX="preview-asset-cache"
+# Bump to invalidate every existing cache entry at once (e.g. after changing
+# the artifact list below or discovering a missing hash input).
+PREVIEW_ASSET_CACHE_VERSION="v1"
+PREVIEW_ASSET_CACHE_TARBALL="preview-asset-cache.tar.gz"
+
+preview_asset_cache_logger() {
+  echo -e "\033[0;32m$(date '+%Y/%m/%d %H:%M:%S') preview_asset_cache.sh: $1\033[0m"
+}
+
+# Everything that can change the output of `docker/web/compile_assets.sh`.
+# Kept deliberately broad (all of config/, vendored assets, tracked public
+# files): a false miss costs one full compile; a false hit serves stale assets
+# on a preview app.
+preview_asset_cache_inputs() {
+  git ls-tree -r HEAD -- \
+    app/assets \
+    app/javascript \
+    config \
+    lib/json_schemas \
+    public \
+    vendor/assets \
+    patches \
+    scripts/build_pages_tailwind.mjs \
+    docker/web/compile_assets.sh \
+    docker/web/push_assets_to_s3.sh \
+    package.json \
+    package-lock.json \
+    .npmrc \
+    tsconfig.json \
+    vite.config.ts \
+    vite.config.widget.ts \
+    postcss.config.js \
+    Gemfile.lock \
+    .ruby-version
+}
+
+preview_asset_cache_tag() {
+  local tree_sha
+  tree_sha=$(preview_asset_cache_inputs | sha1sum | cut -d " " -f1)
+  echo "$tree_sha $BUILDKITE_BRANCH $PREVIEW_ASSET_CACHE_VERSION" | sha1sum | cut -d " " -f1
+}
+
+preview_asset_cache_enabled() {
+  # Preview branches only — never the main/staging/production asset paths.
+  [[ -n $BUILDKITE_BRANCH ]] || return 1
+  [[ $BUILDKITE_BRANCH != "main" ]] || return 1
+  [[ $BUILDKITE_BRANCH != comp-assets-* ]] || return 1
+  # Same escape hatch as the branch cache in ci_scripts/helper.sh.
+  [[ ! $BUILDKITE_MESSAGE =~ no.cache ]] && return 0
+  return 1
+}
+
+preview_asset_cache_url() {
+  echo "s3://$PREVIEW_ASSET_CACHE_BUCKET/$PREVIEW_ASSET_CACHE_PREFIX/$1.tar.gz"
+}
+
+# Downloads the tarball for the current tag. Returns non-zero (a miss) when
+# the object doesn't exist or S3 is unreachable — the caller falls back to a
+# full compile either way.
+preview_asset_cache_restore() {
+  local tag=$1
+  rm -f "$PREVIEW_ASSET_CACHE_TARBALL"
+  AWS_ACCESS_KEY_ID=$GUM_AWS_ACCESS_KEY_ID \
+    AWS_SECRET_ACCESS_KEY=$GUM_AWS_SECRET_ACCESS_KEY \
+    aws s3 cp "$(preview_asset_cache_url "$tag")" "$PREVIEW_ASSET_CACHE_TARBALL"
+}
+
+# Extracts the compiled artifacts out of the freshly built staging image and
+# uploads them. Best-effort: a failed save must never fail the build, so call
+# this with `|| true`.
+preview_asset_cache_save() {
+  local tag=$1
+  local image=$2
+  preview_asset_cache_logger "Saving compiled assets from $image for tag $tag"
+  # gzip -1: node_modules dominates the tarball and compresses slowly at the
+  # default level; speed matters more than a few percent of S3 storage.
+  if ! docker run --rm --entrypoint="" "$image" \
+    bash -c 'cd /app && paths=""; for p in node_modules public/vite public/js public/pages-tailwind.css; do [ -e "$p" ] && paths="$paths $p"; done; tar -cf - $paths | gzip -1' \
+    > "$PREVIEW_ASSET_CACHE_TARBALL"; then
+    preview_asset_cache_logger "Failed to extract assets from $image; skipping cache save"
+    rm -f "$PREVIEW_ASSET_CACHE_TARBALL"
+    return 1
+  fi
+
+  if AWS_ACCESS_KEY_ID=$GUM_AWS_ACCESS_KEY_ID \
+    AWS_SECRET_ACCESS_KEY=$GUM_AWS_SECRET_ACCESS_KEY \
+    aws s3 cp "$PREVIEW_ASSET_CACHE_TARBALL" "$(preview_asset_cache_url "$tag")"; then
+    preview_asset_cache_logger "Uploaded asset cache for tag $tag"
+  else
+    preview_asset_cache_logger "Failed to upload asset cache for tag $tag"
+  fi
+  rm -f "$PREVIEW_ASSET_CACHE_TARBALL"
+}

--- a/.buildkite/scripts/preview_asset_cache.sh
+++ b/.buildkite/scripts/preview_asset_cache.sh
@@ -38,8 +38,9 @@ preview_asset_cache_logger() {
 
 # Everything that can change the output of `docker/web/compile_assets.sh`.
 # Kept deliberately broad (all of config/, vendored assets, tracked public
-# files): a false miss costs one full compile; a false hit serves stale assets
-# on a preview app.
+# files, the base-image definition that pins the Node version, the Makefile
+# recipe the cache-hit path mirrors): a false miss costs one full compile; a
+# false hit serves stale assets on a preview app.
 preview_asset_cache_inputs() {
   git ls-tree -r HEAD -- \
     app/assets \
@@ -50,8 +51,10 @@ preview_asset_cache_inputs() {
     vendor/assets \
     patches \
     scripts/build_pages_tailwind.mjs \
+    docker/base \
     docker/web/compile_assets.sh \
     docker/web/push_assets_to_s3.sh \
+    Makefile \
     package.json \
     package-lock.json \
     .npmrc \

--- a/.buildkite/scripts/preview_asset_cache.sh
+++ b/.buildkite/scripts/preview_asset_cache.sh
@@ -39,8 +39,11 @@ preview_asset_cache_logger() {
 # Everything that can change the output of `docker/web/compile_assets.sh`.
 # Kept deliberately broad (all of config/, vendored assets, tracked public
 # files, the base-image definition that pins the Node version, the Makefile
-# recipe the cache-hit path mirrors): a false miss costs one full compile; a
-# false hit serves stale assets on a preview app.
+# recipe the cache-hit path mirrors, and these two buildkite scripts
+# themselves — the cache-hit image bakes in env vars defined in
+# .buildkite/scripts/compile_assets.sh, so changing them must invalidate
+# existing entries): a false miss costs one full compile; a false hit serves
+# stale assets on a preview app.
 preview_asset_cache_inputs() {
   git ls-tree -r HEAD -- \
     app/assets \
@@ -56,6 +59,8 @@ preview_asset_cache_inputs() {
     docker/base \
     docker/web/compile_assets.sh \
     docker/web/push_assets_to_s3.sh \
+    .buildkite/scripts/compile_assets.sh \
+    .buildkite/scripts/preview_asset_cache.sh \
     Makefile \
     package.json \
     package-lock.json \


### PR DESCRIPTION
## What

Adds a content-addressed S3 cache of compiled preview-app assets (`node_modules`, `public/vite`, `public/js`, `public/pages-tailwind.css`), so a preview redeploy whose asset inputs haven't changed skips the entire Compile Assets phase — npm install, the Rails boot for `js:export`, the main Vite build, and both widget builds — and builds the staging image by extracting the cached artifacts into a fresh web-image container.

- New `.buildkite/scripts/preview_asset_cache.sh`: cache key (hash of every input that feeds the compile + branch name + cache version), enable gate (preview branches only; `no-cache` in the commit message bypasses, matching `ci_scripts/helper.sh`), restore, and best-effort save. Save uploads a SHA-256 sidecar next to the tarball; restore verifies the download against it before anything is extracted, and a missing or mismatching sidecar is treated as a plain cache miss.
- `.buildkite/scripts/compile_assets.sh`: on a hit, builds `staging-<tag>` via docker run + commit with the same env, label, and `spec/` removal as `make build_staging`, then re-syncs assets to S3 as a safety net. On a miss — or if the cached tarball fails to restore or extract for any reason — falls back to the full compile and uploads the artifacts for next time.

The branch name is part of the key because `js:export` bakes the preview app's domain (`CUSTOM_DOMAIN`) into `routes.js`, which Vite then inlines — identical sources on two branches compile to different assets. `main` and `comp-assets-*` (production/staging asset paths) never read or write this cache.

## Why

Per-phase timing (from gumroad-deployment#39, live since yesterday) shows Compile Assets is **13m07s of a 17m13s** preview deploy — ~75% of the wall clock. Log-timestamp breakdown of build 13920 (`feat/local-methods-refund-dispute-matrix`):

| Phase | Time |
|---|---|
| Image pull + compose deps + npm install | ~2m25s |
| `js:export` + pages-tailwind (Rails boot) | ~1m41s |
| Vite build (main) | ~7m12s |
| Widget builds + S3 sync + docker commit | ~1m37s |
| Push staging image | ~0m33s |

All of that recompiles on every push, including backend-only commits and "merge main into the preview branch" refreshes where the merged main rarely touches asset inputs on top of what the branch already compiled. On a cache hit the phase drops to roughly: S3 download + tar extract + docker commit + push (~2–3 min estimated) — the before/after numbers land on #5802 once the next redeploys run through it.

Tracking issue: #5802 (medium bet: "Kill the compose-stack asset compile … S3 tarball keyed on lockfiles + asset digests").

## Test plan

- `bash -n` + shellcheck on both scripts (only pre-existing SC2069 in the untouched `quietly` helper remains).
- Cache-key behavior verified locally against the real repo tree: key changes when an `app/javascript` file changes, is stable across docs-only commits, differs per branch, and the gate correctly disables on `main`, `comp-assets-*`, and `no-cache` commit messages.
- Save/restore tarball round-trip verified locally (artifact list → `gzip -1` tarball → extract into a fresh tree).
- First preview deploy after merge is a miss (populates the cache); the following redeploy on the same branch should show the hit. PHASE timing annotations from gumroad-deployment#39 give the before/after.
- Any cache failure path (S3 down, corrupt tarball, extract error) logs and falls back to the full compile — the deploy can't get stuck behind the cache.

## Before/After

Not a UI change — deploy pipeline only. Before/after numbers will be posted on #5802 from the PHASE annotations.

