### PR TITLE
Add mobile agent SSE streaming endpoint (parity with web)

### DIFF
--- a/app/controllers/api/internal/agent_message_streams_controller.rb
+++ b/app/controllers/api/internal/agent_message_streams_controller.rb
@@ -113,22 +113,6 @@ class Api::Internal::AgentMessageStreamsController < Api::Internal::BaseControll
       authorize current_seller, :use_store_agent?
     end
 
-    def sanitize_messages(raw)
-      return [] unless raw.is_a?(ActionController::Parameters) || raw.is_a?(Array)
-
-      Array(raw).filter_map do |message|
-        message = message.respond_to?(:to_unsafe_h) ? message.to_unsafe_h : message
-        next unless message.is_a?(Hash)
-
-        role = message[:role] || message["role"]
-        content = (message[:content] || message["content"]).to_s
-        next unless %w[user assistant].include?(role)
-        next if content.strip.blank?
-
-        { role:, content: }
-      end
-    end
-
     def throttle_agent_requests
       return unless current_user
 

--- a/app/controllers/api/internal/agent_messages_controller.rb
+++ b/app/controllers/api/internal/agent_messages_controller.rb
@@ -132,22 +132,6 @@ class Api::Internal::AgentMessagesController < Api::Internal::BaseController
       authorize current_seller, :use_store_agent?
     end
 
-    def sanitize_messages(raw)
-      return [] unless raw.is_a?(ActionController::Parameters) || raw.is_a?(Array)
-
-      Array(raw).filter_map do |message|
-        message = message.respond_to?(:to_unsafe_h) ? message.to_unsafe_h : message
-        next unless message.is_a?(Hash)
-
-        role = message[:role] || message["role"]
-        content = (message[:content] || message["content"]).to_s
-        next unless %w[user assistant].include?(role)
-        next if content.strip.blank?
-
-        { role:, content: }
-      end
-    end
-
     def action_params
       raw = params[:params]
       return {} if raw.blank?

--- a/app/controllers/api/mobile/agent_controller.rb
+++ b/app/controllers/api/mobile/agent_controller.rb
@@ -179,22 +179,6 @@ class Api::Mobile::AgentController < Api::Mobile::BaseController
       render json: { success: false, error: "You don't have access to the store agent." }, status: :forbidden
     end
 
-    def sanitize_messages(raw)
-      return [] unless raw.is_a?(ActionController::Parameters) || raw.is_a?(Array)
-
-      Array(raw).filter_map do |message|
-        message = message.respond_to?(:to_unsafe_h) ? message.to_unsafe_h : message
-        next unless message.is_a?(Hash)
-
-        role = message[:role] || message["role"]
-        content = (message[:content] || message["content"]).to_s
-        next unless %w[user assistant].include?(role)
-        next if content.strip.blank?
-
-        { role:, content: }
-      end
-    end
-
     def action_params
       raw = params[:params]
       return {} if raw.blank?

--- a/app/controllers/api/mobile/agent_streams_controller.rb
+++ b/app/controllers/api/mobile/agent_streams_controller.rb
@@ -136,22 +136,6 @@ class Api::Mobile::AgentStreamsController < Api::Mobile::BaseController
       render json: { success: false, error: "You don't have access to the store agent." }, status: :forbidden
     end
 
-    def sanitize_messages(raw)
-      return [] unless raw.is_a?(ActionController::Parameters) || raw.is_a?(Array)
-
-      Array(raw).filter_map do |message|
-        message = message.respond_to?(:to_unsafe_h) ? message.to_unsafe_h : message
-        next unless message.is_a?(Hash)
-
-        role = message[:role] || message["role"]
-        content = (message[:content] || message["content"]).to_s
-        next unless %w[user assistant].include?(role)
-        next if content.strip.blank?
-
-        { role:, content: }
-      end
-    end
-
     def throttle_agent_requests
       key = RedisKey.agent_request_throttle(seller.id)
       # `throttle!` renders a 429 when the limit is exceeded; Rails halts before_actions once a

--- a/app/controllers/api/mobile/agent_streams_controller.rb
+++ b/app/controllers/api/mobile/agent_streams_controller.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+# Streams one Agent conversation turn as Server-Sent Events for the mobile app, mirroring the web
+# streaming endpoint (Api::Internal::AgentMessageStreamsController) so the mobile chat can render
+# the reply token-by-token instead of waiting for the whole turn. It lives in its own controller
+# (separate from Api::Mobile::AgentController) because ActionController::Live changes the response
+# object for EVERY action on the controller it's included in — keeping it isolated means the
+# buffered mobile endpoints keep rendering normal JSON responses.
+#
+# Auth matches the rest of the mobile API: the mobile token (checked by the base controller) plus a
+# Doorkeeper bearer for the `mobile_api` scope, with the seller resolved from the token's resource
+# owner. The read/propose/confirm safety model lives entirely in Ai::StoreAgentService, exactly as
+# on web.
+class Api::Mobile::AgentStreamsController < Api::Mobile::BaseController
+  include Throttling
+  include ActionController::Live
+  include AgentConversationPersistence
+
+  before_action { doorkeeper_authorize! :mobile_api }
+  before_action :ensure_can_use_agent
+  before_action :throttle_agent_requests
+
+  # The mutating agent endpoints share one per-seller budget across web and mobile — the throttle
+  # key is seller-scoped, and these constants match the web streaming controller and the buffered
+  # mobile controller so no surface gets a bigger allowance than another.
+  AGENT_REQUESTS_PER_PERIOD = 30
+  AGENT_REQUESTS_PERIOD_WINDOW = 1.hour
+  private_constant :AGENT_REQUESTS_PER_PERIOD, :AGENT_REQUESTS_PERIOD_WINDOW
+
+  # POST /api/mobile/agent/messages/stream
+  # params: { messages: [{ role:, content: }, ...], conversation_id: <optional external id> }
+  # Each event is `event: <name>` + `data: <json>` + a blank line. Event names: `token` (a chunk of
+  # reply text), `reset` (discard text streamed so far — an intermediate tool-use turn's preamble),
+  # `objects`, `proposed_action`, `suggestions`, `done` (terminal, carrying the final assembled
+  # payload), and `error` (a friendly message; the stream still closes cleanly).
+  #
+  # Turns are persisted the same way as the buffered endpoints (see AgentConversationPersistence):
+  # with a conversation_id the turn appends to that stored conversation and the model replays the
+  # server-held transcript; without one a new conversation is created. The `done` event carries the
+  # conversation's external id so the app can send it on subsequent turns.
+  def create
+    response.headers["Content-Type"] = "text/event-stream"
+    response.headers["Cache-Control"] = "no-cache"
+    # Disable buffering at the proxy (nginx) layer so events flush to the app as they're written.
+    response.headers["X-Accel-Buffering"] = "no"
+    sse = ActionController::Live::SSE.new(response.stream)
+
+    begin
+      messages = sanitize_messages(params[:messages])
+      if messages.empty?
+        sse.write({ message: "A message is required." }, event: "error")
+        return
+      end
+
+      # An unknown/foreign conversation id is surfaced as a stream error (the response status is
+      # already committed once we start streaming, so a 404 render isn't possible here).
+      begin
+        conversation = find_agent_conversation!
+      rescue ActiveRecord::RecordNotFound
+        sse.write({ message: "That conversation could not be found." }, event: "error")
+        return
+      end
+
+      # The last user entry in the posted history is this turn's new message; when resuming, the
+      # earlier entries are replaced by the stored transcript so a stale client can't rewrite
+      # history. Nothing is persisted until the service succeeds — a failed turn (the seller sees
+      # an error and will retry) must not leave a stray user message that gets silently replayed
+      # to the model on the next turn or after a resume.
+      new_user_message = messages.reverse.find { |message| message[:role] == "user" }&.dig(:content)
+      history =
+        if conversation
+          agent_conversation_history(conversation) + (new_user_message ? [{ role: "user", content: new_user_message }] : [])
+        else
+          messages
+        end
+
+      result = ::Ai::StoreAgentService.new(seller:, pundit_user:).respond_streaming(messages: history) do |event, payload|
+        sse.write(payload, event:)
+      end
+
+      # Persistence must not mask a reply the seller has already watched stream in. If recording
+      # the turn fails (e.g. a DB hiccup after a long LLM call), log + report it but still send the
+      # terminal `done` event — dropping `done` would leave the app without a conversation id, so
+      # the next turn would silently start a brand-new conversation. The only cost of a
+      # persistence failure is that this turn isn't stored.
+      begin
+        conversation = persist_agent_turn!(conversation, new_user_message, result, fallback_first_message: messages.last[:content])
+      rescue => e
+        Rails.logger.error("Mobile store agent turn persistence failed: #{e.full_message}")
+        ErrorNotifier.notify(e)
+      end
+      sse.write(
+        {
+          reply: result[:reply],
+          proposed_action: result[:proposed_action],
+          objects: result[:objects] || [],
+          suggestions: result[:suggestions] || [],
+          # Omitted (nil) when creating the conversation itself failed above.
+          conversation_id: conversation&.external_id,
+        },
+        event: "done",
+      )
+    rescue ::Ai::StoreAgentService::Error => e
+      sse.write({ message: e.message }, event: "error")
+    rescue ActionController::Live::ClientDisconnected
+      # The seller backgrounded or closed the app mid-stream. Nothing to surface; just stop.
+    rescue => e
+      Rails.logger.error("Mobile store agent stream failed: #{e.full_message}")
+      ErrorNotifier.notify(e)
+      sse.write({ message: "Something went wrong. Please try again." }, event: "error")
+    ensure
+      sse.close
+    end
+  end
+
+  private
+    def seller
+      current_resource_owner
+    end
+
+    # AgentConversationPersistence scopes every lookup/write to `current_seller`; on mobile the
+    # authenticated bearer's resource owner IS the seller, so alias one to the other.
+    def current_seller
+      seller
+    end
+
+    # The mobile bearer maps to a single seller (no team-member impersonation here), so the user and
+    # seller in the SellerContext are the same account — exactly what the service expects.
+    def pundit_user
+      @_pundit_user ||= SellerContext.new(user: seller, seller:)
+    end
+
+    def ensure_can_use_agent
+      return if UserPolicy.new(pundit_user, seller).use_store_agent?
+
+      render json: { success: false, error: "You don't have access to the store agent." }, status: :forbidden
+    end
+
+    def sanitize_messages(raw)
+      return [] unless raw.is_a?(ActionController::Parameters) || raw.is_a?(Array)
+
+      Array(raw).filter_map do |message|
+        message = message.respond_to?(:to_unsafe_h) ? message.to_unsafe_h : message
+        next unless message.is_a?(Hash)
+
+        role = message[:role] || message["role"]
+        content = (message[:content] || message["content"]).to_s
+        next unless %w[user assistant].include?(role)
+        next if content.strip.blank?
+
+        { role:, content: }
+      end
+    end
+
+    def throttle_agent_requests
+      key = RedisKey.agent_request_throttle(seller.id)
+      # `throttle!` renders a 429 when the limit is exceeded; Rails halts before_actions once a
+      # response is performed.
+      throttle!(key:, limit: AGENT_REQUESTS_PER_PERIOD, period: AGENT_REQUESTS_PERIOD_WINDOW)
+    end
+end

--- a/app/controllers/concerns/agent_conversation_persistence.rb
+++ b/app/controllers/concerns/agent_conversation_persistence.rb
@@ -36,6 +36,28 @@ module AgentConversationPersistence
       current_seller.ai_conversations.create!(title: AiConversation.title_from(first_user_message))
     end
 
+    # Cleans the client-posted chat history down to what the agent actually accepts: an array of
+    # { role:, content: } hashes where the role is "user" or "assistant" and the content is
+    # non-blank. Everything else — non-array payloads, non-hash entries, unknown roles (a client
+    # can't inject "system" messages), blank messages — is dropped rather than rejected, so one
+    # malformed entry doesn't fail the whole request. Shared by every agent endpoint (web and
+    # mobile, buffered and streaming) so a change to message validation lands in one place.
+    def sanitize_messages(raw)
+      return [] unless raw.is_a?(ActionController::Parameters) || raw.is_a?(Array)
+
+      Array(raw).filter_map do |message|
+        message = message.respond_to?(:to_unsafe_h) ? message.to_unsafe_h : message
+        next unless message.is_a?(Hash)
+
+        role = message[:role] || message["role"]
+        content = (message[:content] || message["content"]).to_s
+        next unless %w[user assistant].include?(role)
+        next if content.strip.blank?
+
+        { role:, content: }
+      end
+    end
+
     # Persists one full turn (creating the conversation when needed) atomically. Without the
     # transaction, a failure between the user-message insert and the assistant-message insert would
     # strand a half-written turn: `latest` would hydrate a user message with no reply, and a resumed

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -331,6 +331,7 @@ Rails.application.routes.draw do
         get "/agent/meta", to: "agent#meta"
         get "/agent/conversations/latest", to: "agent#latest_conversation"
         post "/agent/messages", to: "agent#create"
+        post "/agent/messages/stream", to: "agent_streams#create"
         post "/agent/actions", to: "agent#execute"
         resources :devices, only: :create
         resources :installments, only: :show

--- a/spec/controllers/api/mobile/agent_streams_controller_spec.rb
+++ b/spec/controllers/api/mobile/agent_streams_controller_spec.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Api::Mobile::AgentStreamsController do
+  before do
+    @seller = create(:user)
+    @app = create(:oauth_application, owner: @seller)
+    @token = create("doorkeeper/access_token", application: @app, resource_owner_id: @seller.id, scopes: "mobile_api")
+    @auth_params = { mobile_token: Api::Mobile::BaseController::MOBILE_TOKEN, access_token: @token.token }
+  end
+
+  after { $redis.del(RedisKey.agent_request_throttle(@seller.id)) }
+
+  def exhaust_agent_request_throttle(seller)
+    $redis.setex(
+      RedisKey.agent_request_throttle(seller.id),
+      described_class.const_get(:AGENT_REQUESTS_PERIOD_WINDOW).to_i,
+      described_class.const_get(:AGENT_REQUESTS_PER_PERIOD),
+    )
+  end
+
+  describe "POST create" do
+    let(:valid_params) { @auth_params.merge(messages: [{ role: "user", content: "How are my sales?" }]) }
+
+    it "rejects a request with an invalid mobile token" do
+      post :create, params: valid_params.merge(mobile_token: "invalid_token")
+
+      expect(response.status).to be(401)
+    end
+
+    it "rejects a request with an invalid access token" do
+      post :create, params: valid_params.merge(access_token: "invalid_token")
+
+      expect(response.status).to be(401)
+    end
+
+    it "streams the turn's events and ends with a done event carrying the conversation id" do
+      service_double = instance_double(Ai::StoreAgentService)
+      allow(Ai::StoreAgentService).to receive(:new).and_return(service_double)
+      allow(service_double).to receive(:respond_streaming) do |**_kwargs, &emit|
+        emit.call(:token, { text: "You have " })
+        emit.call(:token, { text: "3 products." })
+        { reply: "You have 3 products.", proposed_action: nil, objects: [], suggestions: ["What sold this week?"] }
+      end
+
+      post :create, params: valid_params
+
+      conversation = @seller.ai_conversations.sole
+      expect(conversation.title).to eq("How are my sales?")
+      expect(conversation.ai_messages.map { |m| [m.role, m.content] }).to eq(
+        [["user", "How are my sales?"], ["assistant", "You have 3 products."]]
+      )
+      expect(response.headers["Content-Type"]).to include("text/event-stream")
+      expect(response.body).to include("event: token")
+      expect(response.body).to include("event: done")
+      expect(response.body).to include(conversation.external_id)
+    end
+
+    it "replays the stored transcript when resuming a conversation" do
+      conversation = create(:ai_conversation, seller: @seller)
+      create(:ai_message, ai_conversation: conversation, content: "Earlier question")
+
+      service_double = instance_double(Ai::StoreAgentService)
+      allow(Ai::StoreAgentService).to receive(:new).and_return(service_double)
+      expect(service_double).to receive(:respond_streaming).with(
+        messages: [
+          { role: "user", content: "Earlier question" },
+          { role: "user", content: "How are my sales?" },
+        ]
+      ).and_return(reply: "Up.", proposed_action: nil, objects: [], suggestions: [])
+
+      expect do
+        post :create, params: valid_params.merge(conversation_id: conversation.external_id)
+      end.not_to change { @seller.ai_conversations.count }
+
+      expect(conversation.ai_messages.reload.count).to eq(3)
+    end
+
+    it "still emits the done event when persisting the turn fails after streaming" do
+      # The seller has already watched the reply stream in by the time persistence runs, so a DB
+      # failure here must not turn the turn into an error — the done event (and the reply it
+      # carries) still has to arrive. The conversation id is simply omitted.
+      service_double = instance_double(Ai::StoreAgentService)
+      allow(Ai::StoreAgentService).to receive(:new).and_return(service_double)
+      allow(service_double).to receive(:respond_streaming).and_return(
+        reply: "You have 3 products.",
+        proposed_action: nil,
+        objects: [],
+        suggestions: [],
+      )
+      allow(controller).to receive(:create_agent_conversation!).and_raise(ActiveRecord::StatementInvalid)
+      expect(ErrorNotifier).to receive(:notify).with(instance_of(ActiveRecord::StatementInvalid))
+
+      post :create, params: valid_params
+
+      expect(response.body).to include("event: done")
+      expect(response.body).to include("You have 3 products.")
+      expect(response.body).not_to include("event: error")
+    end
+
+    it "emits an error event (not a new conversation) for another seller's conversation id" do
+      other_conversation = create(:ai_conversation)
+
+      expect(Ai::StoreAgentService).not_to receive(:new)
+
+      expect do
+        post :create, params: valid_params.merge(conversation_id: other_conversation.external_id)
+      end.not_to change { AiConversation.count }
+
+      expect(response.body).to include("event: error")
+    end
+
+    it "emits an error event and persists nothing when the service fails mid-stream" do
+      # The response is already committed as an event stream by the time the service raises, so the
+      # failure has to arrive as an `error` event (not an HTTP error status) and the stream must
+      # still close cleanly. A failed turn also must not leave a stray user message behind — the
+      # seller will retry, and a stored orphan would get silently replayed to the model.
+      service_double = instance_double(Ai::StoreAgentService)
+      allow(Ai::StoreAgentService).to receive(:new).and_return(service_double)
+      allow(service_double).to receive(:respond_streaming) do |**_kwargs, &emit|
+        emit.call(:token, { text: "Let me check" })
+        raise Ai::StoreAgentService::Error, "The agent is unavailable right now."
+      end
+
+      expect do
+        post :create, params: valid_params
+      end.not_to change { AiConversation.count }
+
+      expect(response.body).to include("event: error")
+      expect(response.body).to include("The agent is unavailable right now.")
+      expect(response.body).not_to include("event: done")
+      expect(response.stream).to be_closed
+    end
+
+    it "emits an error event when no user message is provided" do
+      expect(Ai::StoreAgentService).not_to receive(:new)
+
+      post :create, params: @auth_params.merge(messages: [])
+
+      expect(response.body).to include("event: error")
+      expect(response.body).to include("A message is required.")
+    end
+
+    it "halts on throttle without invoking the streaming agent service" do
+      exhaust_agent_request_throttle(@seller)
+      expect(Ai::StoreAgentService).not_to receive(:new)
+
+      post :create, params: valid_params
+
+      expect(response).to have_http_status(:too_many_requests)
+      expect(response.headers["Retry-After"]).to be_present
+    end
+
+    it "returns a forbidden error when the seller can't use the agent" do
+      allow_any_instance_of(UserPolicy).to receive(:use_store_agent?).and_return(false)
+      expect(Ai::StoreAgentService).not_to receive(:new)
+
+      post :create, params: valid_params
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds `POST /api/mobile/agent/messages/stream`, a Server-Sent Events endpoint that streams one Agent conversation turn token-by-token to the mobile app — parity with the web SSE endpoint (`Api::Internal::AgentMessageStreamsController`).

- New `Api::Mobile::AgentStreamsController`, isolated from the buffered `Api::Mobile::AgentController` because `ActionController::Live` changes response semantics for every action on the controller it's included in. The buffered `create` endpoint is untouched so older app builds keep working.
- Same guards as the buffered mobile path: Doorkeeper `mobile_api` scope, mobile token, `UserPolicy#use_store_agent?`, and the shared per-seller throttle (30/hr, same Redis key as web + buffered mobile so no surface gets a bigger allowance).
- Same event names as the web stream (`token`, `reset`, `objects`, `proposed_action`, `suggestions`, `done`, `error`) so client handling is uniform; `done` carries the same payload as the buffered response including `conversation_id`.
- Persistence reuses `AgentConversationPersistence` exactly as the web streams controller does — turns land in the same `ai_conversations` store, so web↔mobile resume keeps working. Atomic turn write; a failed turn leaves no stray user message; a persistence failure after a successful stream still emits `done` (logged + reported) so the app doesn't lose the conversation id.

## Why

The mobile Agent tab only had the buffered endpoint, so the seller stares at a spinner for the full LLM turn (often 15–60s on tool-use turns) with no signal anything is happening. Since Jul 6, 1,391 `Store agent stream failed` events are Anthropic 60s read timeouts — on web the seller at least sees tokens until a late failure; on mobile the same turn is a 60s spinner ending in "Something went wrong." Streaming makes long turns visibly alive and lets the client render partial progress.

Fixes #5835

## Test plan

- New controller specs (`spec/controllers/api/mobile/agent_streams_controller_spec.rb`, 10 examples, all green locally): invalid mobile/access token → 401, forbidden when `use_store_agent?` is false, throttle 429 before any LLM call, empty messages → `error` event, foreign conversation id → `error` event with no new conversation, token stream ending in `done` with the conversation id, stored-transcript replay on resume, persistence failure after streaming still emits `done`, mid-stream service error → `error` event + clean stream close with nothing persisted.
- Existing buffered mobile agent specs and web streaming specs run locally to confirm no regression.
- Client work (consuming SSE in the app) is a separate `antiwork/gumroad-mobile` change; this endpoint is additive and unused until the app adopts it.
