### PR TITLE
Mobile product editor: floating Preview button + full-screen preview sheet (was: no preview at all below lg)

### DIFF
--- a/app/javascript/components/PreviewSidebar.tsx
+++ b/app/javascript/components/PreviewSidebar.tsx
@@ -110,7 +110,7 @@ export const PreviewSidebar = ({
             <div
               role="tablist"
               aria-label="Edit or preview"
-              className="flex gap-1 rounded-full border border-border bg-background p-1 shadow"
+              className="flex gap-1 rounded-full border border-border bg-background p-1"
             >
               <Button
                 role="tab"

--- a/app/javascript/components/PreviewSidebar.tsx
+++ b/app/javascript/components/PreviewSidebar.tsx
@@ -1,5 +1,5 @@
 import { ArrowUpRight, Eye, X } from "@boxicons/react";
-import { Close as DialogClose } from "@radix-ui/react-dialog";
+import { Close as DialogClose, Title as DialogTitle } from "@radix-ui/react-dialog";
 import cx from "classnames";
 import * as React from "react";
 
@@ -25,7 +25,7 @@ export const PreviewSidebar = ({
   // compact icon button, while the mobile sheet asks for a regular button with a visible text
   // label (icon-only buttons aren't intuitive enough on their own).
   previewLink?: (
-    props: React.AriaAttributes & { children: React.ReactNode; size?: "default" | "icon" },
+    props: React.AriaAttributes & { children: React.ReactNode; size?: "default" | "sm" | "icon" },
   ) => React.ReactNode;
 } & React.ComponentProps<"aside">) => {
   const uid = React.useId();
@@ -57,7 +57,9 @@ export const PreviewSidebar = ({
           Give them the same live preview in a full-screen sheet, opened from a floating button. */}
       {!isDesktop ? (
         <>
-          <div className="fixed right-4 z-30 lg:hidden" style={{ bottom: "calc(1rem + env(safe-area-inset-bottom))" }}>
+          {/* z-[9] keeps the button above page content but below the mobile nav menu (z-10),
+              so it doesn't float over the opened hamburger menu. */}
+          <div className="fixed right-4 z-[9] lg:hidden" style={{ bottom: "calc(1rem + env(safe-area-inset-bottom))" }}>
             <Button color="primary" onClick={() => setMobilePreviewOpen(true)}>
               <Eye className="size-5" />
               Preview
@@ -66,22 +68,26 @@ export const PreviewSidebar = ({
           <Sheet modal open={mobilePreviewOpen} onOpenChange={setMobilePreviewOpen} className="lg:hidden">
             {/* Buttons here carry visible text labels rather than bare icons — icon-only
                 buttons aren't intuitive, especially for the mobile sellers this sheet serves. */}
-            <div className="flex items-center gap-4">
-              <h2>Preview</h2>
+            <div className="flex items-center gap-2">
+              {/* Radix wires the dialog's accessible name through Dialog.Title — a bare h2 would
+                  leave the modal unlabeled for screen readers (and log a dev-mode warning). */}
+              <DialogTitle asChild>
+                <h2 className="mr-auto">Preview</h2>
+              </DialogTitle>
               {previewLink
                 ? previewLink({
-                    size: "default",
+                    size: "sm",
                     children: (
                       <>
-                        <ArrowUpRight className="size-5" />
+                        <ArrowUpRight className="size-4" />
                         Open in new tab
                       </>
                     ),
                   })
                 : null}
               <DialogClose asChild>
-                <Button className="ml-auto">
-                  <X className="size-5" />
+                <Button size="sm">
+                  <X className="size-4" />
                   Close
                 </Button>
               </DialogClose>

--- a/app/javascript/components/PreviewSidebar.tsx
+++ b/app/javascript/components/PreviewSidebar.tsx
@@ -1,6 +1,7 @@
 import { ArrowUpRight, Eye, Pencil } from "@boxicons/react";
 import cx from "classnames";
 import * as React from "react";
+import { createPortal } from "react-dom";
 
 import { Button } from "$app/components/Button";
 import { useIsAboveBreakpoint } from "$app/components/useIsAboveBreakpoint";
@@ -24,6 +25,11 @@ export const WithPreviewSidebar = ({ children, className, ...props }: React.Comp
       <div
         className={cx(
           "squished lg:grid lg:grid-cols-[1fr_30vw]",
+          // Reserve space at the bottom on phones so the fixed Edit/Preview pill never covers
+          // the last form field or button at max scroll (applies in both modes). The `!` is
+          // needed because the `squished` utility's own `&:last-child { padding-bottom: 0 }`
+          // rule has higher specificity and would zero this out again.
+          "max-lg:pb-24!",
           // In mobile preview mode, hide everything except the preview pane and the mode
           // toggle (both marked with data-mobile-preview). The window scroll position is
           // deliberately kept when switching, so the preview lands roughly where you were
@@ -102,40 +108,45 @@ export const PreviewSidebar = ({
               {children}
             </section>
           ) : null}
-          <div
-            data-mobile-preview
-            className="fixed inset-x-0 z-[9] flex justify-center lg:hidden"
-            style={{ bottom: "calc(1rem + env(safe-area-inset-bottom))" }}
-          >
+          {/* Portaled to <body>: the page's <main> scroller uses [contain:paint], which turns it
+              into the containing block for position:fixed descendants — a pill rendered inline
+              here would scroll away with the form instead of staying pinned to the viewport. */}
+          {createPortal(
             <div
-              role="tablist"
-              aria-label="Edit or preview"
-              className="flex gap-1 rounded-full border border-border bg-background p-1"
+              className="fixed inset-x-0 z-[9] flex justify-center lg:hidden"
+              style={{ bottom: "calc(1rem + env(safe-area-inset-bottom))" }}
             >
-              <Button
-                role="tab"
-                aria-selected={mode === "edit"}
-                color={mode === "edit" ? "primary" : undefined}
-                size="sm"
-                className={cx("rounded-full", mode !== "edit" && "border-transparent")}
-                onClick={() => modeContext.setMode("edit")}
+              <div
+                role="tablist"
+                aria-label="Edit or preview"
+                className="flex gap-1 rounded-full border border-border bg-background p-1"
               >
-                <Pencil className="size-4" />
-                Edit
-              </Button>
-              <Button
-                role="tab"
-                aria-selected={mode === "preview"}
-                color={mode === "preview" ? "primary" : undefined}
-                size="sm"
-                className={cx("rounded-full", mode !== "preview" && "border-transparent")}
-                onClick={() => modeContext.setMode("preview")}
-              >
-                <Eye className="size-4" />
-                Preview
-              </Button>
-            </div>
-          </div>
+                <Button
+                  role="tab"
+                  aria-selected={mode === "edit"}
+                  color={mode === "edit" ? "primary" : undefined}
+                  size="sm"
+                  className={cx("rounded-full", mode !== "edit" && "border-transparent")}
+                  onClick={() => modeContext.setMode("edit")}
+                >
+                  <Pencil className="size-4" />
+                  Edit
+                </Button>
+                <Button
+                  role="tab"
+                  aria-selected={mode === "preview"}
+                  color={mode === "preview" ? "primary" : undefined}
+                  size="sm"
+                  className={cx("rounded-full", mode !== "preview" && "border-transparent")}
+                  onClick={() => modeContext.setMode("preview")}
+                >
+                  <Eye className="size-4" />
+                  Preview
+                </Button>
+              </div>
+            </div>,
+            document.body,
+          )}
         </>
       ) : null}
     </>

--- a/app/javascript/components/PreviewSidebar.tsx
+++ b/app/javascript/components/PreviewSidebar.tsx
@@ -1,7 +1,11 @@
-import { ArrowUpRight } from "@boxicons/react";
+import { ArrowUpRight, Eye, X } from "@boxicons/react";
+import { Close as DialogClose } from "@radix-ui/react-dialog";
 import cx from "classnames";
 import * as React from "react";
 
+import { Button } from "$app/components/Button";
+import { Sheet } from "$app/components/ui/Sheet";
+import { useIsAboveBreakpoint } from "$app/components/useIsAboveBreakpoint";
 import { WithTooltip } from "$app/components/WithTooltip";
 
 export const WithPreviewSidebar = ({ children, className, ...props }: React.ComponentProps<"div">) => (
@@ -20,24 +24,56 @@ export const PreviewSidebar = ({
   previewLink?: (props: React.AriaAttributes & { children: React.ReactNode }) => React.ReactNode;
 } & React.ComponentProps<"aside">) => {
   const uid = React.useId();
+  const isDesktop = useIsAboveBreakpoint("lg");
+  const [mobilePreviewOpen, setMobilePreviewOpen] = React.useState(false);
+
   return (
-    <aside
-      className={cx(
-        "sticky top-0 hidden h-screen flex-col gap-4 self-start overflow-y-auto bg-background p-6 lg:flex lg:border-l lg:border-border",
-        className,
-      )}
-      aria-labelledby={`${uid}-title`}
-      {...props}
-    >
-      <div className="flex items-start justify-between gap-4">
-        <h2 id={`${uid}-title`}>Preview</h2>
-        {previewLink ? (
-          <WithTooltip tip="Preview">
-            {previewLink({ "aria-label": "Preview", children: <ArrowUpRight className="size-5" /> })}
-          </WithTooltip>
-        ) : null}
-      </div>
-      {children}
-    </aside>
+    <>
+      <aside
+        className={cx(
+          "sticky top-0 hidden h-screen flex-col gap-4 self-start overflow-y-auto bg-background p-6 lg:flex lg:border-l lg:border-border",
+          className,
+        )}
+        aria-labelledby={`${uid}-title`}
+        {...props}
+      >
+        <div className="flex items-start justify-between gap-4">
+          <h2 id={`${uid}-title`}>Preview</h2>
+          {previewLink ? (
+            <WithTooltip tip="Preview">
+              {previewLink({ "aria-label": "Preview", children: <ArrowUpRight className="size-5" /> })}
+            </WithTooltip>
+          ) : null}
+        </div>
+        {children}
+      </aside>
+      {/* On narrow screens the sidebar above is hidden entirely, which used to mean mobile
+          sellers had NO way to see the preview (support tickets: "there's no preview button").
+          Give them the same live preview in a full-screen sheet, opened from a floating button. */}
+      {!isDesktop ? (
+        <>
+          <div className="fixed right-4 z-30 lg:hidden" style={{ bottom: "calc(1rem + env(safe-area-inset-bottom))" }}>
+            <Button color="primary" onClick={() => setMobilePreviewOpen(true)} aria-label="Preview">
+              <Eye className="size-5" />
+              Preview
+            </Button>
+          </div>
+          <Sheet modal open={mobilePreviewOpen} onOpenChange={setMobilePreviewOpen} className="lg:hidden">
+            <div className="flex items-start gap-4">
+              <h2>Preview</h2>
+              {previewLink ? (
+                <WithTooltip tip="Open in new tab">
+                  {previewLink({ "aria-label": "Open in new tab", children: <ArrowUpRight className="size-5" /> })}
+                </WithTooltip>
+              ) : null}
+              <DialogClose className="ml-auto cursor-pointer all-unset" aria-label="Close">
+                <X className="size-5" />
+              </DialogClose>
+            </div>
+            <div className="flex flex-1 flex-col gap-4">{children}</div>
+          </Sheet>
+        </>
+      ) : null}
+    </>
   );
 };

--- a/app/javascript/components/PreviewSidebar.tsx
+++ b/app/javascript/components/PreviewSidebar.tsx
@@ -1,18 +1,43 @@
-import { ArrowUpRight, Eye, X } from "@boxicons/react";
-import { Close as DialogClose, Title as DialogTitle } from "@radix-ui/react-dialog";
+import { ArrowUpRight, Eye, Pencil } from "@boxicons/react";
 import cx from "classnames";
 import * as React from "react";
 
 import { Button } from "$app/components/Button";
-import { Sheet } from "$app/components/ui/Sheet";
 import { useIsAboveBreakpoint } from "$app/components/useIsAboveBreakpoint";
 import { WithTooltip } from "$app/components/WithTooltip";
 
-export const WithPreviewSidebar = ({ children, className, ...props }: React.ComponentProps<"div">) => (
-  <div className={cx("squished lg:grid lg:grid-cols-[1fr_30vw]", className)} {...props}>
-    {children}
-  </div>
-);
+// On desktop the preview renders as a persistent sidebar next to the edit form. Below the lg
+// breakpoint there is no room for both, so the page becomes two modes — Edit and Preview —
+// switched by a floating segmented control. The mode state lives here so WithPreviewSidebar
+// (which wraps the edit form) and PreviewSidebar (which owns the preview) stay in sync.
+const MobilePreviewModeContext = React.createContext<{
+  mode: "edit" | "preview";
+  setMode: (mode: "edit" | "preview") => void;
+} | null>(null);
+
+export const WithPreviewSidebar = ({ children, className, ...props }: React.ComponentProps<"div">) => {
+  const [mode, setMode] = React.useState<"edit" | "preview">("edit");
+  const contextValue = React.useMemo(() => ({ mode, setMode }), [mode]);
+
+  return (
+    <MobilePreviewModeContext.Provider value={contextValue}>
+      <div
+        className={cx(
+          "squished lg:grid lg:grid-cols-[1fr_30vw]",
+          // In mobile preview mode, hide everything except the preview pane and the mode
+          // toggle (both marked with data-mobile-preview). The window scroll position is
+          // deliberately kept when switching, so the preview lands roughly where you were
+          // editing instead of jumping back to the top.
+          mode === "preview" && "max-lg:[&>*:not([data-mobile-preview])]:hidden",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    </MobilePreviewModeContext.Provider>
+  );
+};
 
 export const PreviewSidebar = ({
   children,
@@ -22,15 +47,16 @@ export const PreviewSidebar = ({
 }: {
   children: React.ReactNode;
   // `size` lets each rendering context pick the button shape: the desktop sidebar keeps its
-  // compact icon button, while the mobile sheet asks for a regular button with a visible text
-  // label (icon-only buttons aren't intuitive enough on their own).
+  // compact icon button, while the mobile preview pane asks for a regular button with a
+  // visible text label (icon-only buttons aren't intuitive enough on their own).
   previewLink?: (
-    props: React.AriaAttributes & { children: React.ReactNode; size?: "default" | "sm" | "icon" },
+    props: React.AriaAttributes & { children: React.ReactNode; size?: "default" | "icon" },
   ) => React.ReactNode;
 } & React.ComponentProps<"aside">) => {
   const uid = React.useId();
   const isDesktop = useIsAboveBreakpoint("lg");
-  const [mobilePreviewOpen, setMobilePreviewOpen] = React.useState(false);
+  const modeContext = React.useContext(MobilePreviewModeContext);
+  const mode = modeContext?.mode ?? "edit";
 
   return (
     <>
@@ -52,48 +78,64 @@ export const PreviewSidebar = ({
         </div>
         {children}
       </aside>
-      {/* On narrow screens the sidebar above is hidden entirely, which used to mean mobile
-          sellers had NO way to see the preview (support tickets: "there's no preview button").
-          Give them the same live preview in a full-screen sheet, opened from a floating button. */}
-      {!isDesktop ? (
+      {/* The desktop sidebar above is display:none below lg, which used to mean mobile sellers
+          had NO way to see the preview at all (real support tickets). Below lg the page instead
+          gets an Edit / Preview mode toggle, and this pane renders the same live preview inline
+          when Preview mode is active. */}
+      {!isDesktop && modeContext ? (
         <>
-          {/* z-[9] keeps the button above page content but below the mobile nav menu (z-10),
-              so it doesn't float over the opened hamburger menu. */}
-          <div className="fixed right-4 z-[9] lg:hidden" style={{ bottom: "calc(1rem + env(safe-area-inset-bottom))" }}>
-            <Button color="primary" onClick={() => setMobilePreviewOpen(true)}>
-              <Eye className="size-5" />
-              Preview
-            </Button>
-          </div>
-          <Sheet modal open={mobilePreviewOpen} onOpenChange={setMobilePreviewOpen} className="lg:hidden">
-            {/* Buttons here carry visible text labels rather than bare icons — icon-only
-                buttons aren't intuitive, especially for the mobile sellers this sheet serves. */}
-            <div className="flex items-center gap-2">
-              {/* Radix wires the dialog's accessible name through Dialog.Title — a bare h2 would
-                  leave the modal unlabeled for screen readers (and log a dev-mode warning). */}
-              <DialogTitle asChild>
-                <h2 className="mr-auto">Preview</h2>
-              </DialogTitle>
-              {previewLink
-                ? previewLink({
-                    size: "sm",
+          {mode === "preview" ? (
+            <section data-mobile-preview aria-label="Preview" className="flex flex-col gap-4 p-4 pb-24 lg:hidden">
+              {previewLink ? (
+                <div className="flex justify-end">
+                  {previewLink({
+                    size: "default",
                     children: (
                       <>
-                        <ArrowUpRight className="size-4" />
+                        <ArrowUpRight className="size-5" />
                         Open in new tab
                       </>
                     ),
-                  })
-                : null}
-              <DialogClose asChild>
-                <Button size="sm">
-                  <X className="size-4" />
-                  Close
-                </Button>
-              </DialogClose>
+                  })}
+                </div>
+              ) : null}
+              {children}
+            </section>
+          ) : null}
+          <div
+            data-mobile-preview
+            className="fixed inset-x-0 z-[9] flex justify-center lg:hidden"
+            style={{ bottom: "calc(1rem + env(safe-area-inset-bottom))" }}
+          >
+            <div
+              role="tablist"
+              aria-label="Edit or preview"
+              className="flex gap-1 rounded-full border border-border bg-background p-1 shadow"
+            >
+              <Button
+                role="tab"
+                aria-selected={mode === "edit"}
+                color={mode === "edit" ? "primary" : undefined}
+                size="sm"
+                className={cx("rounded-full", mode !== "edit" && "border-transparent")}
+                onClick={() => modeContext.setMode("edit")}
+              >
+                <Pencil className="size-4" />
+                Edit
+              </Button>
+              <Button
+                role="tab"
+                aria-selected={mode === "preview"}
+                color={mode === "preview" ? "primary" : undefined}
+                size="sm"
+                className={cx("rounded-full", mode !== "preview" && "border-transparent")}
+                onClick={() => modeContext.setMode("preview")}
+              >
+                <Eye className="size-4" />
+                Preview
+              </Button>
             </div>
-            <div className="flex flex-1 flex-col gap-4">{children}</div>
-          </Sheet>
+          </div>
         </>
       ) : null}
     </>

--- a/app/javascript/components/PreviewSidebar.tsx
+++ b/app/javascript/components/PreviewSidebar.tsx
@@ -21,7 +21,12 @@ export const PreviewSidebar = ({
   ...props
 }: {
   children: React.ReactNode;
-  previewLink?: (props: React.AriaAttributes & { children: React.ReactNode }) => React.ReactNode;
+  // `size` lets each rendering context pick the button shape: the desktop sidebar keeps its
+  // compact icon button, while the mobile sheet asks for a regular button with a visible text
+  // label (icon-only buttons aren't intuitive enough on their own).
+  previewLink?: (
+    props: React.AriaAttributes & { children: React.ReactNode; size?: "default" | "icon" },
+  ) => React.ReactNode;
 } & React.ComponentProps<"aside">) => {
   const uid = React.useId();
   const isDesktop = useIsAboveBreakpoint("lg");
@@ -53,21 +58,32 @@ export const PreviewSidebar = ({
       {!isDesktop ? (
         <>
           <div className="fixed right-4 z-30 lg:hidden" style={{ bottom: "calc(1rem + env(safe-area-inset-bottom))" }}>
-            <Button color="primary" onClick={() => setMobilePreviewOpen(true)} aria-label="Preview">
+            <Button color="primary" onClick={() => setMobilePreviewOpen(true)}>
               <Eye className="size-5" />
               Preview
             </Button>
           </div>
           <Sheet modal open={mobilePreviewOpen} onOpenChange={setMobilePreviewOpen} className="lg:hidden">
-            <div className="flex items-start gap-4">
+            {/* Buttons here carry visible text labels rather than bare icons — icon-only
+                buttons aren't intuitive, especially for the mobile sellers this sheet serves. */}
+            <div className="flex items-center gap-4">
               <h2>Preview</h2>
-              {previewLink ? (
-                <WithTooltip tip="Open in new tab">
-                  {previewLink({ "aria-label": "Open in new tab", children: <ArrowUpRight className="size-5" /> })}
-                </WithTooltip>
-              ) : null}
-              <DialogClose className="ml-auto cursor-pointer all-unset" aria-label="Close">
-                <X className="size-5" />
+              {previewLink
+                ? previewLink({
+                    size: "default",
+                    children: (
+                      <>
+                        <ArrowUpRight className="size-5" />
+                        Open in new tab
+                      </>
+                    ),
+                  })
+                : null}
+              <DialogClose asChild>
+                <Button className="ml-auto">
+                  <X className="size-5" />
+                  Close
+                </Button>
               </DialogClose>
             </div>
             <div className="flex flex-1 flex-col gap-4">{children}</div>

--- a/app/javascript/components/ProductEdit/Layout.tsx
+++ b/app/javascript/components/ProductEdit/Layout.tsx
@@ -337,8 +337,10 @@ export const Layout = ({
             {...(showNavigationButton && {
               previewLink: (props) => (
                 <NavigationButton
-                  {...props}
+                  // Icon size is only a default: the preview sidebar/sheet overrides it via
+                  // props (the mobile sheet asks for a full-size button with a text label).
                   size="icon"
+                  {...props}
                   disabled={isBusy}
                   href={url}
                   onClick={(evt) => {

--- a/app/javascript/components/ProductEdit/Layout.tsx
+++ b/app/javascript/components/ProductEdit/Layout.tsx
@@ -345,7 +345,16 @@ export const Layout = ({
                   href={url}
                   onClick={(evt) => {
                     evt.preventDefault();
-                    void save().then(() => window.open(url, "_blank"));
+                    // Open the tab NOW, while we still have the user's click activation, then
+                    // point it at the product page once the save finishes. Calling window.open
+                    // after the await instead gets popup-blocked on iOS Safari (the async gap
+                    // consumes the transient activation), which matters because the mobile
+                    // preview sheet is this button's main audience.
+                    const previewWindow = window.open("about:blank", "_blank");
+                    void save().then(() => {
+                      if (previewWindow) previewWindow.location.href = url;
+                      else window.open(url, "_blank");
+                    });
                   }}
                 />
               ),

--- a/app/javascript/components/ProductEdit/Layout.tsx
+++ b/app/javascript/components/ProductEdit/Layout.tsx
@@ -1,4 +1,3 @@
-import { CartPlus, Link as LinkIcon } from "@boxicons/react";
 import cx from "classnames";
 import * as React from "react";
 import { Link, useMatches, useNavigate } from "react-router-dom";
@@ -10,7 +9,6 @@ import { getContrastColor, hexToRgb } from "$app/utils/color";
 import { assertResponseError } from "$app/utils/request";
 
 import { Button, NavigationButton } from "$app/components/Button";
-import { CopyToClipboard } from "$app/components/CopyToClipboard";
 import { useCurrentSeller } from "$app/components/CurrentSeller";
 import { useDomains } from "$app/components/DomainSettings";
 import { Preview } from "$app/components/Preview";
@@ -143,7 +141,6 @@ export const Layout = ({
   const rootPath = Routes.edit_link_path(uniquePermalink);
 
   const url = useProductUrl();
-  const checkoutUrl = useProductUrl({ wanted: true });
 
   const [match] = useMatches();
   const tab = match?.handle ?? "product";
@@ -249,24 +246,13 @@ export const Layout = ({
         actions={
           product.is_published ? (
             <>
+              {/* Just these two actions, on desktop and mobile alike. Copying the product /
+                  checkout links lives at the top of the Share tab instead of crowding the
+                  header. */}
               <Button disabled={isBusy} onClick={() => void setPublished(false)}>
                 {isPublishing ? "Unpublishing..." : "Unpublish"}
               </Button>
               {saveButton}
-              {/* Hidden on mobile: the form's URL field already has a Copy URL affordance there,
-                  and four header actions render as an awkward 2x2 grid on small screens. */}
-              <CopyToClipboard text={url} copyTooltip="Copy product URL">
-                <Button className="max-lg:hidden">
-                  <LinkIcon className="size-5" />
-                  Copy link
-                </Button>
-              </CopyToClipboard>
-              <CopyToClipboard text={checkoutUrl} copyTooltip="Copy checkout URL" tooltipPosition="left">
-                <Button className="max-lg:hidden">
-                  <CartPlus className="size-5" />
-                  Copy checkout link
-                </Button>
-              </CopyToClipboard>
             </>
           ) : tab === "product" && !isCoffee ? (
             <Button

--- a/app/javascript/components/ProductEdit/Layout.tsx
+++ b/app/javascript/components/ProductEdit/Layout.tsx
@@ -253,14 +253,18 @@ export const Layout = ({
                 {isPublishing ? "Unpublishing..." : "Unpublish"}
               </Button>
               {saveButton}
+              {/* Hidden on mobile: the form's URL field already has a Copy URL affordance there,
+                  and four header actions render as an awkward 2x2 grid on small screens. */}
               <CopyToClipboard text={url} copyTooltip="Copy product URL">
-                <Button size="icon">
+                <Button className="max-lg:hidden">
                   <LinkIcon className="size-5" />
+                  Copy link
                 </Button>
               </CopyToClipboard>
               <CopyToClipboard text={checkoutUrl} copyTooltip="Copy checkout URL" tooltipPosition="left">
-                <Button size="icon">
+                <Button className="max-lg:hidden">
                   <CartPlus className="size-5" />
+                  Copy checkout link
                 </Button>
               </CopyToClipboard>
             </>

--- a/app/javascript/components/ProductEdit/ShareTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ShareTab/index.tsx
@@ -1,5 +1,8 @@
+import { CartPlus } from "@boxicons/react";
 import * as React from "react";
 
+import { Button } from "$app/components/Button";
+import { CopyToClipboard } from "$app/components/CopyToClipboard";
 import { useCurrentSeller } from "$app/components/CurrentSeller";
 import { useDiscoverUrl } from "$app/components/DomainSettings";
 import { Layout, useProductUrl } from "$app/components/ProductEdit/Layout";
@@ -23,6 +26,7 @@ export const ShareTab = () => {
   const { product, updateProduct, profileSections, taxonomies, isListedOnDiscover } = useProductEditContext();
 
   const url = useProductUrl();
+  const checkoutUrl = useProductUrl({ wanted: true });
   const discoverUrl = useDiscoverUrl();
 
   if (!currentSeller) return;
@@ -38,7 +42,16 @@ export const ShareTab = () => {
             <header>
               <h2>Share</h2>
             </header>
-            <ShareButtons url={url} twitterText={`Buy ${product.name} on @Gumroad`} facebookText={product.name} />
+            <ShareButtons url={url} twitterText={`Buy ${product.name} on @Gumroad`} facebookText={product.name}>
+              {/* The header used to carry a "Copy checkout link" button; it lives here now so the
+                  header stays at just Unpublish + Save changes. */}
+              <CopyToClipboard text={checkoutUrl} copyTooltip="Copy checkout URL" tooltipPosition="top">
+                <Button>
+                  <CartPlus className="size-5" />
+                  Copy checkout URL
+                </Button>
+              </CopyToClipboard>
+            </ShareButtons>
           </section>
           <LandingPageEditor />
           <ProfileSectionsEditor

--- a/app/javascript/components/ShareButtons.tsx
+++ b/app/javascript/components/ShareButtons.tsx
@@ -21,7 +21,7 @@ export const ShareButtons = ({
     <TwitterShareButton url={url} text={twitterText} />
     <FacebookShareButton url={url} text={facebookText} />
     <CopyToClipboard text={url} tooltipPosition="top">
-      <Button color="primary">
+      <Button>
         <LinkIcon className="size-5" />
         Copy URL
       </Button>

--- a/app/javascript/components/ShareButtons.tsx
+++ b/app/javascript/components/ShareButtons.tsx
@@ -10,10 +10,12 @@ export const ShareButtons = ({
   url,
   twitterText,
   facebookText,
+  children,
 }: {
   url: string;
   twitterText: string;
   facebookText: string;
+  children?: React.ReactNode;
 }) => (
   <div className="flex flex-wrap gap-2">
     <TwitterShareButton url={url} text={twitterText} />
@@ -24,5 +26,6 @@ export const ShareButtons = ({
         Copy URL
       </Button>
     </CopyToClipboard>
+    {children}
   </div>
 );

--- a/app/javascript/pages/Settings/Profile/Show.tsx
+++ b/app/javascript/pages/Settings/Profile/Show.tsx
@@ -309,13 +309,19 @@ export default function SettingsPage() {
             // Persist pending edits before previewing, but only when there's something to save -
             // settings (name/bio/avatar) are sent on every save with no freshness check, so an
             // unconditional save from a stale, locally-clean tab would revert changes made elsewhere.
-            // Open only after a successful save so a failed save doesn't surface a stale preview.
-            const openProfile = () => window.open(profileUrl, "_blank");
-            if (canSave)
+            if (canSave) {
+              // Open the tab NOW, while we still have the user's click activation, then point it
+              // at the profile once the save finishes. Calling window.open after the await instead
+              // gets popup-blocked on iOS Safari (the async gap consumes the transient activation),
+              // which matters because the mobile preview sheet is this button's main audience.
+              // On a failed save, close the reserved tab so we don't surface a stale preview.
+              const previewWindow = window.open("about:blank", "_blank");
               void save().then((saved) => {
-                if (saved) openProfile();
+                if (!saved) previewWindow?.close();
+                else if (previewWindow) previewWindow.location.href = profileUrl;
+                else window.open(profileUrl, "_blank");
               });
-            else openProfile();
+            } else window.open(profileUrl, "_blank");
           }}
         />
       )}

--- a/app/javascript/pages/Settings/Profile/Show.tsx
+++ b/app/javascript/pages/Settings/Profile/Show.tsx
@@ -298,8 +298,10 @@ export default function SettingsPage() {
     <PreviewSidebar
       previewLink={(props) => (
         <NavigationButton
-          {...props}
+          // Icon size is only a default: the preview sidebar/sheet overrides it via props
+          // (the mobile sheet asks for a full-size button with a text label).
           size="icon"
+          {...props}
           disabled={isSaving}
           href={profileUrl}
           onClick={(evt) => {


### PR DESCRIPTION
## Problem

On phones, the product editor has **no way to see a preview at all**. The preview lives in a sidebar `<aside>` that is `hidden … lg:flex` — below the `lg` breakpoint it's `display:none` with no mobile alternative. This came in as a real support ticket: a new seller was told there's a "Preview button next to Save," and she was right that no such thing exists on her phone.

## Fix

Below `lg`, the page has two modes — **Edit** and **Preview** — switched by a pill segmented control fixed at the bottom center. Preview mode hides the edit form and renders the same live preview inline; switching back restores the form exactly as you left it (nothing unmounts, scroll position kept). The preview pane carries an "Open in new tab" action that reserves the tab synchronously on click so iOS Safari's popup blocker allows it, then navigates it after the save succeeds.

Because the change is in `PreviewSidebar` itself, all consumers get it: product edit, bundle edit, workflows, checkout form/upsells, and profile settings.

The published-product header is trimmed to just **Unpublish + Save changes** on desktop and mobile alike. The Copy link / Copy checkout link buttons moved to the top of the Share tab: Copy URL was already there next to the X/Facebook share buttons, and Copy checkout URL joins it.

Desktop keeps its persistent preview sidebar — no toggle, no hidden content.

## Screenshots (real app, dev DB)

| Mobile 390×844 — Edit mode | Mobile — Preview mode | Mobile — Share tab (copy buttons) |
|---|---|---|
| ![edit](https://raw.githubusercontent.com/antiwork/gumroad/screenshots/mobile-preview-2026-07-12/v3-mobile-header-edit.png) | ![preview](https://raw.githubusercontent.com/antiwork/gumroad/screenshots/mobile-preview-2026-07-12/v3-mobile-preview-mode.png) | ![share](https://raw.githubusercontent.com/antiwork/gumroad/screenshots/mobile-preview-2026-07-12/v3-mobile-share-tab-top.png) |

| Desktop 1440px — header (two buttons) | Desktop — Share tab |
|---|---|
| ![desktop](https://raw.githubusercontent.com/antiwork/gumroad/screenshots/mobile-preview-2026-07-12/v3-desktop-header.png) | ![desktop-share](https://raw.githubusercontent.com/antiwork/gumroad/screenshots/mobile-preview-2026-07-12/v3-desktop-share-tab.png) |

## Verification (scripted browser audit, both viewports)

- @390px edit mode: header shows Unpublish + Save changes only; Edit/Preview toggle present (no shadow); no Copy link buttons in the header DOM.
- @390px preview mode: form hidden, live preview rendered inline, Open in new tab reachable; back to Edit restores the form.
- @390px Share tab: Copy URL + Copy checkout URL render next to the share buttons.
- @1440px: preview sidebar rendered, no toggle; header shows only the two buttons; Copy checkout URL present on the Share tab.
- tsc, eslint, prettier clean on all touched files.

Part of the broader mobile-editor modernization; this restores a missing core capability rather than restyling.
