### PR TITLE
Add pink New product button to the dashboard header

### DIFF
--- a/app/javascript/components/DashboardPage.tsx
+++ b/app/javascript/components/DashboardPage.tsx
@@ -342,9 +342,19 @@ export const DashboardPage = ({
       <PageHeader
         title="Dashboard"
         actions={
-          tax_center_enabled
-            ? null
-            : Object.keys(tax_forms).length > 0 && <DownloadTaxFormsPopover taxForms={tax_forms} />
+          <>
+            {tax_center_enabled
+              ? null
+              : Object.keys(tax_forms).length > 0 && <DownloadTaxFormsPopover taxForms={tax_forms} />}
+            {/* "accent" is the design system's highlight color (Gumroad pink by default) — the
+                same style as the New product button on the Products page. Hidden for team
+                members whose role can't create products. */}
+            {loggedInUser?.policies.product.create ? (
+              <NavigationButton href={Routes.new_product_path()} color="accent">
+                New product
+              </NavigationButton>
+            ) : null}
+          </>
         }
         className="border-b-0 sm:border-b"
       />


### PR DESCRIPTION
## What

Adds a **New product** button to the top right of the Dashboard header — the dashboard previously had no direct path into product creation.

## How

- Reuses the exact pattern from the Products page header: `NavigationButton` with `color="accent"` (the design system's highlight color — Gumroad pink `#ff90e8` by default) linking to `Routes.new_product_path()`.
- Sits in the `PageHeader` `actions` slot next to the existing tax-forms popover (when present).
- Gated on `loggedInUser?.policies.product.create`, mirroring the Pundit-driven `can_create_product` gate the Products page uses, so team members whose role can't create products don't see it.

## Screenshots (live app)

| Desktop | Mobile |
|---|---|
| ![desktop](https://raw.githubusercontent.com/antiwork/gumroad/screenshots/dashboard-new-product/dash-desktop.png) | ![mobile](https://raw.githubusercontent.com/antiwork/gumroad/screenshots/dashboard-new-product/dash-mobile.png) |

## Verified

- Scripted browser audit at 1440×900 and 390×844: button visible top-right (full-width on mobile via PageHeader's existing responsive actions grid), computed background `rgb(255, 144, 232)` = `#ff90e8`, black text, links to `/products/new`.
- eslint / tsc / prettier clean.
