### PR TITLE
Dev server: auto-invalidate stale Vite modules (stop trusting the file watcher)

### DIFF
--- a/app/javascript/components/ApiDocumentation/Endpoints/Licenses.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/Licenses.tsx
@@ -27,9 +27,7 @@ export const VerifyLicense = () => (
     <ApiParameters>
       <ApiParameter
         name="product_id"
-        description={
-          "(the unique ID of the product — copy it from the license key block on the product's Content tab, or use the id field returned by the GET /products endpoint)"
-        }
+        description="(the unique ID of the product — copy it from the license key block on the product's Content tab, or use the id field returned by the GET /products endpoint)"
       />
       <ApiParameter name="license_key" description="(the license key provided by your customer)" />
       <ApiParameter name="increment_uses_count" description='("true"/"false", optional, default: "true")' />
@@ -99,9 +97,7 @@ export const EnableLicense = () => (
     <ApiParameters>
       <ApiParameter
         name="product_id"
-        description={
-          "(the unique ID of the product — copy it from the license key block on the product's Content tab, or use the id field returned by the GET /products endpoint)"
-        }
+        description="(the unique ID of the product — copy it from the license key block on the product's Content tab, or use the id field returned by the GET /products endpoint)"
       />
       <ApiParameter name="license_key" description="(the license key provided by your customer)" />
     </ApiParameters>
@@ -171,9 +167,7 @@ export const DisableLicense = () => (
     <ApiParameters>
       <ApiParameter
         name="product_id"
-        description={
-          "(the unique ID of the product — copy it from the license key block on the product's Content tab, or use the id field returned by the GET /products endpoint)"
-        }
+        description="(the unique ID of the product — copy it from the license key block on the product's Content tab, or use the id field returned by the GET /products endpoint)"
       />
       <ApiParameter name="license_key" description="(the license key provided by your customer)" />
     </ApiParameters>
@@ -243,9 +237,7 @@ export const DecrementUsesCount = () => (
     <ApiParameters>
       <ApiParameter
         name="product_id"
-        description={
-          "(the unique ID of the product — copy it from the license key block on the product's Content tab, or use the id field returned by the GET /products endpoint)"
-        }
+        description="(the unique ID of the product — copy it from the license key block on the product's Content tab, or use the id field returned by the GET /products endpoint)"
       />
       <ApiParameter name="license_key" description="(the license key provided by your customer)" />
     </ApiParameters>
@@ -319,9 +311,7 @@ export const RotateLicense = () => (
     <ApiParameters>
       <ApiParameter
         name="product_id"
-        description={
-          "(the unique ID of the product — copy it from the license key block on the product's Content tab, or use the id field returned by the GET /products endpoint)"
-        }
+        description="(the unique ID of the product — copy it from the license key block on the product's Content tab, or use the id field returned by the GET /products endpoint)"
       />
       <ApiParameter name="license_key" description="(the license key provided by your customer)" />
     </ApiParameters>

--- a/config/vite/stale-module-guard.ts
+++ b/config/vite/stale-module-guard.ts
@@ -1,0 +1,60 @@
+import fs from "node:fs";
+import type { Plugin } from "vite";
+
+/**
+ * Dev-only guard against the Vite dev server serving stale modules.
+ *
+ * Vite's dev server caches each module's transform result and relies on file
+ * watcher events (chokidar/FSEvents) to invalidate that cache. On macOS the
+ * watcher misses events in real situations — most commonly when git rewrites
+ * many files at once (branch switch, rebase, stash pop) — and the server then
+ * keeps serving old code until someone restarts it. That failure mode is
+ * silent: the page loads fine, it's just not running the code on disk.
+ *
+ * This plugin removes the trust in watcher events: it records when each file
+ * was last transformed, and a request middleware stats the file before Vite's
+ * transform middleware serves it. If the file on disk is newer than the
+ * cached transform, the module (and its importers) are invalidated so the
+ * request re-transforms from disk. Cost is one fs.stat per module request in
+ * dev; production builds are untouched (apply: "serve").
+ */
+export function staleModuleGuard(): Plugin {
+  // file path -> epoch ms when we last transformed it
+  const transformedAt = new Map<string, number>();
+
+  return {
+    name: "stale-module-guard",
+    apply: "serve",
+    transform(_code, id) {
+      // id may carry a query (e.g. ?v=hash); key by the bare file path
+      transformedAt.set(id.split("?")[0], Date.now());
+      return null;
+    },
+    configureServer(server) {
+      server.middlewares.use((req, _res, next) => {
+        void (async () => {
+          try {
+            const url = req.url?.split("?")[0];
+            if (url && /\.(?:[jt]sx?|css|scss|json)$/u.test(url)) {
+              const mod = await server.moduleGraph.getModuleByUrl(url);
+              const file = mod?.file;
+              if (mod && file && mod.transformResult) {
+                const t = transformedAt.get(file);
+                const { mtimeMs } = await fs.promises.stat(file);
+                if (t !== undefined && mtimeMs > t) {
+                  // File changed after we transformed it but no invalidation
+                  // happened — the watcher missed it. Invalidate so this
+                  // request gets fresh output.
+                  server.moduleGraph.invalidateModule(mod);
+                }
+              }
+            }
+          } catch {
+            // Never let the guard break serving (e.g. stat on a deleted file).
+          }
+          next();
+        })();
+      });
+    },
+  };
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -135,7 +135,7 @@ const tsxConfig = tseslint.config({
 });
 
 const nodeConfig = {
-  files: ["eslint.config.js", "vite.config.ts", "vite.config.widget.ts"],
+  files: ["eslint.config.js", "vite.config.ts", "vite.config.widget.ts", "config/vite/**/*.ts"],
   languageOptions: {
     globals: {
       ...globals.node,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,8 @@ import AutoImport from "unplugin-auto-import/vite";
 import { defineConfig } from "vite";
 import RubyPlugin from "vite-plugin-ruby";
 
+import { staleModuleGuard } from "./config/vite/stale-module-guard";
+
 const rootPath = path.dirname(fileURLToPath(import.meta.url));
 
 function stripCjsExportsPlugin() {
@@ -62,6 +64,7 @@ export default defineConfig(({ mode }) => ({
   plugins: [
     RubyPlugin(),
     react(),
+    staleModuleGuard(),
     UnpluginTypia({ cache: true }),
     AutoImport({
       imports: [


### PR DESCRIPTION
## Problem

Vite's dev server caches each module's transform and relies entirely on file-watcher events to invalidate it. On macOS the watcher (FSEvents/chokidar) misses events in real situations — most commonly when git rewrites many files at once (branch switch, rebase, stash pop). After a miss, the dev server **silently serves stale code until someone restarts it**: the page loads fine, it just isn't running what's on disk.

This hit us three separate times today while iterating on #5840/#5841 — each time the symptom was "my change has no effect," and the diagnosis (curl the module off the dev server, diff against disk) is not something anyone should have to know.

## Fix

A ~40-line dev-only plugin (`config/vite/stale-module-guard.ts`) that removes the trust in watcher events:

- `transform` hook records when each file was last transformed.
- A request middleware stats the file before Vite serves it; if disk mtime > last transform, the module is invalidated so the request re-transforms from disk.

Cost: one `fs.stat` per module request, dev only (`apply: "serve"`). Production builds untouched. Fails open (any stat error → serve as before).

## Verification

Deterministic repro in a scratch project — watcher events suppressed via `server.watch.ignored` (simulating the macOS miss), then edit the file and re-request:

```
WITHOUT-guard first request: v1
WITHOUT-guard after edit:    v1   ← stale, silently
WITH-guard    first request: v1
WITH-guard    after edit:    v2   ← correct
```

Also booted the real app with the plugin: normal serving, HMR unaffected, no errors.

Also adds `config/vite/**/*.ts` to eslint's node-globals block (same treatment as `vite.config.ts`).
