### PR TITLE
Fix lint errors in the license API docs component

### DIFF
--- a/app/javascript/components/ApiDocumentation/Endpoints/Licenses.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/Licenses.tsx
@@ -27,9 +27,7 @@ export const VerifyLicense = () => (
     <ApiParameters>
       <ApiParameter
         name="product_id"
-        description={
-          "(the unique ID of the product — copy it from the license key block on the product's Content tab, or use the id field returned by the GET /products endpoint)"
-        }
+        description="(the unique ID of the product — copy it from the license key block on the product's Content tab, or use the id field returned by the GET /products endpoint)"
       />
       <ApiParameter name="license_key" description="(the license key provided by your customer)" />
       <ApiParameter name="increment_uses_count" description='("true"/"false", optional, default: "true")' />
@@ -99,9 +97,7 @@ export const EnableLicense = () => (
     <ApiParameters>
       <ApiParameter
         name="product_id"
-        description={
-          "(the unique ID of the product — copy it from the license key block on the product's Content tab, or use the id field returned by the GET /products endpoint)"
-        }
+        description="(the unique ID of the product — copy it from the license key block on the product's Content tab, or use the id field returned by the GET /products endpoint)"
       />
       <ApiParameter name="license_key" description="(the license key provided by your customer)" />
     </ApiParameters>
@@ -171,9 +167,7 @@ export const DisableLicense = () => (
     <ApiParameters>
       <ApiParameter
         name="product_id"
-        description={
-          "(the unique ID of the product — copy it from the license key block on the product's Content tab, or use the id field returned by the GET /products endpoint)"
-        }
+        description="(the unique ID of the product — copy it from the license key block on the product's Content tab, or use the id field returned by the GET /products endpoint)"
       />
       <ApiParameter name="license_key" description="(the license key provided by your customer)" />
     </ApiParameters>
@@ -243,9 +237,7 @@ export const DecrementUsesCount = () => (
     <ApiParameters>
       <ApiParameter
         name="product_id"
-        description={
-          "(the unique ID of the product — copy it from the license key block on the product's Content tab, or use the id field returned by the GET /products endpoint)"
-        }
+        description="(the unique ID of the product — copy it from the license key block on the product's Content tab, or use the id field returned by the GET /products endpoint)"
       />
       <ApiParameter name="license_key" description="(the license key provided by your customer)" />
     </ApiParameters>
@@ -319,9 +311,7 @@ export const RotateLicense = () => (
     <ApiParameters>
       <ApiParameter
         name="product_id"
-        description={
-          "(the unique ID of the product — copy it from the license key block on the product's Content tab, or use the id field returned by the GET /products endpoint)"
-        }
+        description="(the unique ID of the product — copy it from the license key block on the product's Content tab, or use the id field returned by the GET /products endpoint)"
       />
       <ApiParameter name="license_key" description="(the license key provided by your customer)" />
     </ApiParameters>


### PR DESCRIPTION
## What

Removes unnecessary curly braces around five string `description` props in `app/javascript/components/ApiDocumentation/Endpoints/Licenses.tsx`. Pure `eslint --fix` output — no wording or rendering changes.

## Why

The license API docs update (#5842) merged with five `react/jsx-curly-brace-presence` errors, so the Lint JS/TS check is failing on main and on every branch cut from it (e.g. #5843's red lint check comes from this, not from its own diff).

## Test plan

- `DISABLE_TYPE_CHECKED=1 npx eslint app/javascript/components/ApiDocumentation/Endpoints/Licenses.tsx` — clean locally
- `prettier --write` — no further changes
- CI Lint JS/TS goes green on this PR and, once merged, on main
