### PR TITLE
Strip the dev asset base path before module graph lookups in the stale-module guard

### DIFF
--- a/config/vite/stale-module-guard.ts
+++ b/config/vite/stale-module-guard.ts
@@ -31,10 +31,19 @@ export function staleModuleGuard(): Plugin {
       return null;
     },
     configureServer(server) {
+      // In development this app serves its assets under a base path
+      // ("/vite-dev/" — see config/vite.json), but Vite's module graph keys
+      // URLs without that prefix. Plugin middlewares run before Vite strips
+      // the base from req.url, so we have to strip it ourselves or every
+      // module graph lookup below silently misses.
+      const base = server.config.base;
       server.middlewares.use((req, _res, next) => {
         void (async () => {
           try {
-            const url = req.url?.split("?")[0];
+            let url = req.url?.split("?")[0];
+            if (url && base !== "/" && url.startsWith(base)) {
+              url = url.slice(base.length - 1);
+            }
             if (url && /\.(?:[jt]sx?|css|scss|json)$/u.test(url)) {
               const mod = await server.moduleGraph.getModuleByUrl(url);
               const file = mod?.file;


### PR DESCRIPTION
## What

Follow-up to #5843. Strips the dev asset base path (`/vite-dev/`) from request URLs before the stale-module guard's module graph lookups, so the guard actually fires in this app.

## Why

#5843 merged before this fix (commit `902d3fd` on the original branch) landed in the squash. The adversarial review on that PR found a P1: this app serves dev assets under a base path (`/vite-dev/`, per `config/vite.json`), but Vite's module graph keys URLs without that prefix. Plugin middlewares run before Vite strips the base from `req.url`, so `getModuleByUrl("/vite-dev/src/...")` returned `undefined` on every request and the guard silently did nothing — the original scratch-project repro used the default base `/`, which masked it.

Reproduced deterministically with watcher events suppressed:

```
base /          : after edit → v2  (guard fired)
base /vite-dev/ : after edit → v1  (stale — guard never matched)
```

With this fix, fresh code is served under both bases.

## Test plan

- Deterministic suppressed-watcher repro against a live Vite 6.4.2 server, verified under both base `/` and base `/vite-dev/` — the guard invalidates and re-serves fresh code in both.
- Dev-only path (`apply: "serve"`); production builds untouched. Fails open on any error, same as before.
- CI green; prettier/eslint clean on the changed file.
