### PR TITLE
Scope checkout already-purchased checks to candidate products (fixes checkout 504 for buyers with large purchase histories)

### DIFF
--- a/app/presenters/checkout_presenter.rb
+++ b/app/presenters/checkout_presenter.rb
@@ -373,18 +373,24 @@ class CheckoutPresenter
       end
     end
 
-    def purchases
-      @_purchases ||= logged_in_user&.purchases&.includes(:link, :variant_attributes)&.map { |purchase| { product: purchase.link, variant: purchase.variant_attributes.first } } || []
-    end
-
-    def purchased_product_variant_set
-      @_purchased_product_variant_set ||= purchases.each_with_object(Set.new) do |purchase, set|
-        set.add([purchase[:product]&.id, purchase[:variant]&.id])
-      end
-    end
-
+    # Answers "has the logged-in buyer already bought this exact product + variant
+    # combination?" for upsell and cross-sell filtering. We only ever check the handful
+    # of upsell/cross-sell candidates attached to the cart, so we query the buyer's
+    # purchases of each candidate product individually instead of loading their entire
+    # purchase history. Buyers with thousands of purchases used to time out the whole
+    # checkout page when a cart item had a cross-sell, because the old implementation
+    # materialized every purchase (with products and variants) just to build a lookup set.
     def already_purchased?(product, variant)
-      purchased_product_variant_set.include?([product&.id, variant&.id])
+      return false if logged_in_user.nil? || product.nil?
+      purchased_variant_ids_for(product).include?(variant&.id)
+    end
+
+    # For one product, returns the set of variant ids the buyer's purchases were made
+    # with (nil when a purchase had no variant). Memoized per product so repeated checks
+    # for the same product (e.g. several upsell variants) reuse the single query.
+    def purchased_variant_ids_for(product)
+      @_purchased_variant_ids_by_product ||= {}
+      @_purchased_variant_ids_by_product[product.id] ||= logged_in_user.purchases.where(link_id: product.id).includes(:variant_attributes).map { |purchase| purchase.variant_attributes.first&.id }.to_set
     end
 
     def subscription_discount_for_next_charge(subscription, buyer: logged_in_user)

--- a/spec/presenters/checkout_presenter_spec.rb
+++ b/spec/presenters/checkout_presenter_spec.rb
@@ -683,6 +683,57 @@ describe CheckoutPresenter do
       purchase_queries = queries.select { |sql| sql.match?(/purchases/i) }
       expect(purchase_queries.size).to be <= 2
     end
+
+    it "hides a cross-sell the buyer has already purchased" do
+      seller = create(:named_user)
+      product = create(:product, user: seller)
+      offered_product = create(:product, user: seller)
+      create(:upsell, selected_products: [product], seller:, product: offered_product, cross_sell: true)
+
+      buyer = create(:user)
+      instance = described_class.new(logged_in_user: buyer, ip: "127.0.0.1")
+      cart_item = product.cart_item({})
+
+      expect(instance.checkout_product(product, cart_item, {})[:product][:cross_sells]).to be_present
+
+      create(:purchase, link: offered_product, purchaser: buyer)
+
+      instance = described_class.new(logged_in_user: buyer, ip: "127.0.0.1")
+      expect(instance.checkout_product(product, cart_item, {})[:product][:cross_sells]).to be_empty
+    end
+
+    it "only queries purchases of the cross-sell candidate products, not the buyer's whole history" do
+      seller = create(:named_user)
+      product = create(:product, user: seller)
+      offered_product = create(:product, user: seller)
+      create(:upsell, selected_products: [product], seller:, product: offered_product, cross_sell: true)
+
+      # A buyer with purchases of many unrelated products. The cross-sell check should
+      # not load these — it should only look at purchases of the offered product.
+      buyer = create(:user)
+      create_list(:product, 5, user: seller).each do |unrelated_product|
+        create(:purchase, link: unrelated_product, purchaser: buyer)
+      end
+
+      instance = described_class.new(logged_in_user: buyer, ip: "127.0.0.1")
+      cart_item = product.cart_item({})
+
+      queries = []
+      callback = lambda { |_name, _start, _finish, _id, payload|
+        queries << payload[:sql] if payload[:sql] && !payload[:name]&.match?(/SCHEMA|TRANSACTION/)
+      }
+
+      cross_sells = nil
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        cross_sells = instance.checkout_product(product, cart_item, {})[:product][:cross_sells]
+      end
+
+      expect(cross_sells).to be_present
+      purchase_queries = queries.select { |sql| sql.match?(/FROM `purchases`/i) }
+      # One query for the offered product's purchases; none should be an unscoped load
+      # of the buyer's full purchase history.
+      expect(purchase_queries).to all(match(/`purchases`\.`link_id`/))
+    end
   end
 
   describe "#subscription_manager_props", :vcr do


### PR DESCRIPTION
## What

Fixes the checkout page 504ing for logged-in buyers with very large purchase histories whenever a cart item has a cross-sell configured.

`CheckoutPresenter` answered "has this buyer already purchased product X / variant Y" (used to filter cross-sell and upsell offers) by loading the buyer's **entire purchase history** with products and variants and building an in-memory lookup set. For buyers with thousands of purchases that single load exceeded the request timeout, so any cart containing a cross-sell-bearing product returned a 504 on every load — the buyer couldn't view, edit, or check out their cart.

This PR replaces the full-history load with a targeted, indexed query per candidate product (`logged_in_user.purchases.where(link_id: product.id)`), memoized per product. A cart only ever checks a handful of cross-sell/upsell candidates, so this is a few cheap `link_id`-indexed queries instead of one unbounded load.

## Why

Tracking issue: antiwork/gumroad-private#1063 (support-originated; verified on the read replica — the full-history load alone timed out at >55s for the affected buyer, while the rest of their cart rendered in about a second).

Both call sites of `already_purchased?` are covered: the cross-sell filter in `checkout_product` and the upsell variant filter for product options.

Behavior is intentionally unchanged apart from performance: the old code counted **all** of the buyer's purchases of a product (not just successful ones), and the new per-product query uses the same `purchases` association so the filtering semantics are identical.

## Test plan

- New spec: hides a cross-sell the buyer has already purchased (behavior preserved).
- New spec: asserts every `purchases` query issued during cross-sell rendering is scoped by `link_id` — i.e. no unscoped full-history load can regress back in.
- Existing "eager loads purchases to avoid N+1 queries" spec still passes (query count for the upsell path stays bounded).
- Ran locally: `bundle exec rspec spec/presenters/checkout_presenter_spec.rb` — 49 examples, 0 failures.
- RuboCop clean on both changed files.

## Before/After

Not applicable — no user-facing rendering change; the page simply loads instead of timing out.
