### PR TITLE
Surface the endpoint's HTTP status in test ping results

### DIFF
--- a/app/controllers/test_pings_controller.rb
+++ b/app/controllers/test_pings_controller.rb
@@ -9,14 +9,22 @@ class TestPingsController < Sellers::BaseController
       return
     end
 
-    message = if current_seller.send_test_ping params[:url]
-      "Your last sale's data has been sent to your Ping URL."
+    response = current_seller.send_test_ping params[:url]
+
+    if response.nil?
+      render json: { success: true, message: "There are no sales on your account to test with. Please make a test purchase and try again." }
+    elsif response.success?
+      render json: { success: true, message: "Your last sale's data has been sent to your Ping URL. Your endpoint responded with HTTP #{response.code}." }
     else
-      "There are no sales on your account to test with. Please make a test purchase and try again."
+      # The ping was delivered but the endpoint rejected it (4xx/5xx). Surface the
+      # status code so sellers can self-diagnose (e.g. a firewall or Cloudflare rule
+      # returning 403) instead of concluding Gumroad never sent anything.
+      render json: { success: false, error_message: "Your endpoint responded with HTTP #{response.code} instead of a success code. Check your endpoint's logs and any firewall or bot-protection rules (e.g. Cloudflare) that may be blocking Gumroad's requests." }
     end
-    render json: { success: true, message: }
   rescue *INTERNET_EXCEPTIONS
-    render json: { success: false, error_message: "That URL seems to be invalid." }
+    # Connection-level failure: DNS, refused connection, timeout, SSL, etc.
+    # The request never completed, so there is no HTTP status to report.
+    render json: { success: false, error_message: "We couldn't reach your Ping URL — the connection failed or timed out. Check that the URL is correct and that your server is reachable from the internet." }
   rescue Exception
     render json: { success: false, error_message: "Sorry, something went wrong. Please try again." }
   end

--- a/spec/controllers/test_pings_controller_spec.rb
+++ b/spec/controllers/test_pings_controller_spec.rb
@@ -19,13 +19,13 @@ describe TestPingsController do
   end
 
   describe "POST create" do
-    it "posts a test ping containing latest sale details to the specified endpoint" do
+    it "posts a test ping containing latest sale details to the specified endpoint and reports the endpoint's status" do
       create(:purchase, link: product, created_at: 2.days.ago)
       create(:purchase, link: product)
       last_purchase = create(:purchase, link: product, created_at: 2.hours.from_now)
       ping_url = last_purchase.seller.notification_endpoint
       ping_params = last_purchase.payload_for_ping_notification
-      http_double = double
+      http_double = double(success?: true, code: 200)
       expect(HTTParty).to receive(:post).with(ping_url,
                                               timeout: 5,
                                               body: ping_params.merge(test: true).deep_stringify_keys,
@@ -33,6 +33,27 @@ describe TestPingsController do
                                         .and_return(http_double)
       post :create, params: { url: ping_url }
       expect(response.body).to include "Your last sale's data has been sent to your Ping URL."
+      expect(response.body).to include "200"
+    end
+
+    it "reports failure with the HTTP status when the endpoint rejects the ping" do
+      create(:purchase, link: product)
+      ping_url = seller.notification_endpoint
+      http_double = double(success?: false, code: 403)
+      expect(HTTParty).to receive(:post).and_return(http_double)
+      post :create, params: { url: ping_url }
+      parsed = response.parsed_body
+      expect(parsed["success"]).to eq(false)
+      expect(parsed["error_message"]).to include "403"
+    end
+
+    it "reports failure when the endpoint is unreachable" do
+      create(:purchase, link: product)
+      expect(HTTParty).to receive(:post).and_raise(Errno::ECONNREFUSED)
+      post :create, params: { url: seller.notification_endpoint }
+      parsed = response.parsed_body
+      expect(parsed["success"]).to eq(false)
+      expect(parsed["error_message"]).to include "couldn't reach your Ping URL"
     end
 
     it "fails and displays error if no sale present for the user" do


### PR DESCRIPTION
## Fixes antiwork/gumroad-private#1066

## Problem

`TestPingsController#create` rendered the success message for **any** HTTParty response — it never looked at the response object. A seller whose Cloudflare returned 403 to our pings clicked "Send test ping", saw "Your last sale's data has been sent to your Ping URL", reasonably concluded Gumroad was broken, and filed a revenue-critical ticket. The test-ping feature was actively misleading for exactly the sellers who need it.

Bonus confusion: connection-level failures (DNS, refused, timeout, SSL) rendered "That URL seems to be invalid" — wrong message for a valid-but-unreachable URL.

## Fix

The controller now branches on the actual response:

| Outcome | Seller sees |
|---|---|
| 2xx | "…sent to your Ping URL. Your endpoint responded with HTTP 200." |
| 4xx/5xx | Error with the status code + hint to check firewall/bot-protection (Cloudflare) rules |
| Connection failure | "We couldn't reach your Ping URL — the connection failed or timed out…" |
| No sales | unchanged |
| Invalid URL format | unchanged ("That URL seems to be invalid.") |

No changes needed in the frontend — `NotificationEndpointSection.tsx` already renders `success: false` responses as error alerts with `error_message`.

`send_test_ping` already returned the HTTParty response object (or nil for no sales); the controller was just ignoring it. No change to the module.

## Notes / decision points

- **Real sale pings (`PostToIndividualPingEndpointWorker`) are NOT changed.** That worker already checks `.success?` and logs failures — the gap was only in the test-ping path.
- Deliberately did NOT retry or follow redirects differently — this is a diagnostics-surface change only, zero behavior change to what gets sent.
- The 403-from-Cloudflare class of issue is now self-diagnosable, which should shed the "pings are broken" ticket category at the source.

## Testing

- `rspec spec/controllers/test_pings_controller_spec.rb` — 7 examples, 0 failures (3 new: 200 success with code surfaced, 403 rejection surfaced, connection-refused message)
- `rspec spec/modules/user/ping_notification_spec.rb` — 6 examples, 0 failures
- rubocop clean
