### PR TITLE
Fix test-ping no-sales detection: HTTParty::Response#nil? lies for empty bodies

### DIFF
--- a/app/controllers/test_pings_controller.rb
+++ b/app/controllers/test_pings_controller.rb
@@ -11,7 +11,11 @@ class TestPingsController < Sellers::BaseController
 
     response = current_seller.send_test_ping params[:url]
 
-    if response.nil?
+    # send_test_ping returns the :no_sales sentinel (never nil) when there's nothing
+    # to ping with. Do NOT test the response with nil?/truthiness: HTTParty::Response
+    # overrides #nil? to return true for empty-bodied responses, which would misroute
+    # a real 200-or-403-with-empty-body here.
+    if response == :no_sales
       render json: { success: true, message: "There are no sales on your account to test with. Please make a test purchase and try again." }
     elsif response.success?
       render json: { success: true, message: "Your last sale's data has been sent to your Ping URL. Your endpoint responded with HTTP #{response.code}." }

--- a/app/modules/user/ping_notification.rb
+++ b/app/modules/user/ping_notification.rb
@@ -3,7 +3,10 @@
 module User::PingNotification
   def send_test_ping(url)
     latest_sale = sales.last
-    return nil if latest_sale.blank?
+    # Distinct sentinel rather than nil: HTTParty::Response overrides #nil? to
+    # return true for empty-bodied responses, so callers must never use nil/truthiness
+    # checks to distinguish "no sales" from a real response (see TestPingsController).
+    return :no_sales if latest_sale.blank?
 
     URI.parse(url) # TestPingsController.create catches URI::InvalidURIError
 

--- a/spec/controllers/test_pings_controller_spec.rb
+++ b/spec/controllers/test_pings_controller_spec.rb
@@ -32,8 +32,32 @@ describe TestPingsController do
                                               headers: { "Content-Type" => last_purchase.seller.notification_content_type })
                                         .and_return(http_double)
       post :create, params: { url: ping_url }
-      expect(response.body).to include "Your last sale's data has been sent to your Ping URL."
-      expect(response.body).to include "200"
+      parsed = response.parsed_body
+      expect(parsed["success"]).to eq(true)
+      expect(parsed["message"]).to eq "Your last sale's data has been sent to your Ping URL. Your endpoint responded with HTTP 200."
+    end
+
+    it "treats an empty-bodied 200 as success (HTTParty::Response#nil? returns true for empty bodies)" do
+      create(:purchase, link: product)
+      # HTTParty::Response overrides #nil? to be true when the body is empty, so this
+      # double mimics a real `head :ok` style endpoint. It must NOT be routed to the
+      # "no sales" branch.
+      http_double = double(success?: true, code: 200, nil?: true)
+      expect(HTTParty).to receive(:post).and_return(http_double)
+      post :create, params: { url: seller.notification_endpoint }
+      parsed = response.parsed_body
+      expect(parsed["success"]).to eq(true)
+      expect(parsed["message"]).to include "responded with HTTP 200"
+    end
+
+    it "surfaces a rejection even when the endpoint's error response has an empty body" do
+      create(:purchase, link: product)
+      http_double = double(success?: false, code: 403, nil?: true)
+      expect(HTTParty).to receive(:post).and_return(http_double)
+      post :create, params: { url: seller.notification_endpoint }
+      parsed = response.parsed_body
+      expect(parsed["success"]).to eq(false)
+      expect(parsed["error_message"]).to include "403"
     end
 
     it "reports failure with the HTTP status when the endpoint rejects the ping" do


### PR DESCRIPTION
## Follow-up to #5849 — fixes the P1 its fable review caught

#5849 merged at its first commit, before the adversarial-review fix landed on the branch — so main currently carries the P1.

**The bug (empirically proven on the locked httparty 0.22.0):** `HTTParty::Response` overrides `#nil?` to return `true` whenever the response **body** is empty. The merged controller checks `response.nil?` to detect the "no sales" case, so:

- an endpoint replying **200 with an empty body** (any `head :ok` endpoint) is told "There are no sales on your account to test with" — a regression vs pre-#5849 main, which used plain truthiness;
- a **Cloudflare 403 with an empty body** hides the status code entirely — defeating #5849's purpose on a plausible variant of the original ticket (gumroad-private#1066);
- every test ping logs HTTParty's `#nil?` deprecation warning.

The #5849 specs passed because plain RSpec doubles have an honest `nil?`, masking the override.

## Fix

`send_test_ping` returns a `:no_sales` sentinel instead of nil; the controller compares against the sentinel and never calls `nil?`/truthiness on the response object. Comments in both files document the trap.

## Testing

- Two new regression specs with `nil?: true` doubles (empty-body 200 → success + code surfaced; empty-body 403 → error + code surfaced) — these fail against current main.
- Tightened the weak `include "200"` assertion from #5849 to assert the exact message (fable P3).
- 15 examples, 0 failures across both spec files; rubocop clean.
