### PR TITLE
Block country changes while a payout is in flight

### DIFF
--- a/app/controllers/settings/payments_controller.rb
+++ b/app/controllers/settings/payments_controller.rb
@@ -42,6 +42,8 @@ class Settings::PaymentsController < Settings::BaseController
         UpdateUserCountry.new(new_country_code: updated_country_code, user: current_seller).process
         flash[:notice] = "Your country has been updated!"
         return redirect_to settings_payments_path, status: :see_other
+      rescue UpdateUserCountry::PayoutInProcessingError
+        return redirect_with_error("You have a payout in progress. You can change your country once it has been processed.")
       rescue => e
         ErrorNotifier.notify("Update country failed for user #{current_seller.id} (from #{compliance_info.country_code} to #{updated_country_code}): #{e}")
         return redirect_with_error("Country update failed")

--- a/app/services/update_user_country.rb
+++ b/app/services/update_user_country.rb
@@ -2,10 +2,19 @@
 
 class UpdateUserCountry
   # Raised when the user has a payout that is still in flight. Changing country deletes the
-  # user's current Stripe account, so if a payout that is still processing later fails or is
+  # user's current Stripe account, so if a payout that is still in flight later fails or is
   # returned by the bank, the money is re-credited to an account nobody watches anymore and
   # the funds strand there. Callers should ask the user to wait until the payout settles.
   class PayoutInProcessingError < StandardError; end
+
+  # Payout states that mean money is still moving: the payout has been created or sent but has
+  # not reached a settled outcome yet. "unclaimed" is PayPal-specific (the recipient hasn't
+  # accepted the money), and "creating" is the brief window before the payout is submitted.
+  # Completed payouts are not included: a completed Stripe payout can still be returned by the
+  # bank later, but Gumroad pays out weekly, so blocking on recent completions would lock
+  # nearly every active seller out of country changes. That residual case is handled by
+  # alerting when a returned payout lands on a retired account.
+  PAYOUT_IN_FLIGHT_STATES = %w[creating processing unclaimed]
 
   attr_reader :new_country_code, :user
 
@@ -16,7 +25,7 @@ class UpdateUserCountry
   end
 
   def process
-    raise PayoutInProcessingError if @user.payments.processing.exists?
+    raise PayoutInProcessingError if @user.payments.where(state: PAYOUT_IN_FLIGHT_STATES).exists?
 
     keep_payment_address = !@user.native_payouts_supported? && !@user.native_payouts_supported?(country_code: @new_country_code)
     @user.update!(payment_address: "") unless keep_payment_address

--- a/app/services/update_user_country.rb
+++ b/app/services/update_user_country.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class UpdateUserCountry
+  # Raised when the user has a payout that is still in flight. Changing country deletes the
+  # user's current Stripe account, so if a payout that is still processing later fails or is
+  # returned by the bank, the money is re-credited to an account nobody watches anymore and
+  # the funds strand there. Callers should ask the user to wait until the payout settles.
+  class PayoutInProcessingError < StandardError; end
+
   attr_reader :new_country_code, :user
 
   def initialize(new_country_code:, user:)
@@ -10,6 +16,8 @@ class UpdateUserCountry
   end
 
   def process
+    raise PayoutInProcessingError if @user.payments.processing.exists?
+
     keep_payment_address = !@user.native_payouts_supported? && !@user.native_payouts_supported?(country_code: @new_country_code)
     @user.update!(payment_address: "") unless keep_payment_address
 

--- a/spec/controllers/settings/payments_controller_spec.rb
+++ b/spec/controllers/settings/payments_controller_spec.rb
@@ -1670,6 +1670,16 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
         expect(response).to have_http_status :found
         expect(session[:inertia_errors][:base]).to include("Country update failed")
       end
+
+      it "rejects the change with a clear message when a payout is still processing" do
+        create(:payment, user:, state: "processing")
+
+        put :update, params: { user: { updated_country_code: "GB" } }
+
+        expect(response).to redirect_to(settings_payments_path)
+        expect(session[:inertia_errors][:base]).to include("You have a payout in progress. You can change your country once it has been processed.")
+        expect(user.reload.alive_user_compliance_info.legal_entity_country_code).not_to eq("GB")
+      end
     end
   end
 

--- a/spec/services/update_user_country_spec.rb
+++ b/spec/services/update_user_country_spec.rb
@@ -12,6 +12,39 @@ describe UpdateUserCountry do
   end
 
   describe "#process" do
+    context "when the user has a payout still processing" do
+      before do
+        create(:payment, user: @user, state: "processing")
+      end
+
+      it "raises PayoutInProcessingError and changes nothing" do
+        old_compliance_info = @user.alive_user_compliance_info
+        old_stripe_account = @user.stripe_account
+        old_bank_account = @user.active_bank_account
+
+        expect do
+          UpdateUserCountry.new(new_country_code: "GB", user: @user).process
+        end.to raise_error(UpdateUserCountry::PayoutInProcessingError)
+
+        expect(old_compliance_info.reload.deleted?).to eq(false)
+        expect(old_stripe_account.reload.deleted?).to eq(false)
+        expect(old_bank_account.reload.deleted?).to eq(false)
+      end
+    end
+
+    context "when the user's payouts have all settled" do
+      before do
+        create(:payment_completed, user: @user)
+        create(:payment_failed, user: @user)
+      end
+
+      it "allows the country change" do
+        UpdateUserCountry.new(new_country_code: "GB", user: @user).process
+
+        expect(@user.alive_user_compliance_info.legal_entity_country_code).to eq("GB")
+      end
+    end
+
     it "deletes the old compliance info and creates a new one" do
       old_compliance_info = @user.alive_user_compliance_info
       UpdateUserCountry.new(new_country_code: "GB", user: @user).process

--- a/spec/services/update_user_country_spec.rb
+++ b/spec/services/update_user_country_spec.rb
@@ -12,23 +12,25 @@ describe UpdateUserCountry do
   end
 
   describe "#process" do
-    context "when the user has a payout still processing" do
-      before do
-        create(:payment, user: @user, state: "processing")
-      end
+    UpdateUserCountry::PAYOUT_IN_FLIGHT_STATES.each do |in_flight_state|
+      context "when the user has a payout still in the #{in_flight_state} state" do
+        before do
+          create(:payment, user: @user, state: in_flight_state)
+        end
 
-      it "raises PayoutInProcessingError and changes nothing" do
-        old_compliance_info = @user.alive_user_compliance_info
-        old_stripe_account = @user.stripe_account
-        old_bank_account = @user.active_bank_account
+        it "raises PayoutInProcessingError and changes nothing" do
+          old_compliance_info = @user.alive_user_compliance_info
+          old_stripe_account = @user.stripe_account
+          old_bank_account = @user.active_bank_account
 
-        expect do
-          UpdateUserCountry.new(new_country_code: "GB", user: @user).process
-        end.to raise_error(UpdateUserCountry::PayoutInProcessingError)
+          expect do
+            UpdateUserCountry.new(new_country_code: "GB", user: @user).process
+          end.to raise_error(UpdateUserCountry::PayoutInProcessingError)
 
-        expect(old_compliance_info.reload.deleted?).to eq(false)
-        expect(old_stripe_account.reload.deleted?).to eq(false)
-        expect(old_bank_account.reload.deleted?).to eq(false)
+          expect(old_compliance_info.reload.deleted?).to eq(false)
+          expect(old_stripe_account.reload.deleted?).to eq(false)
+          expect(old_bank_account.reload.deleted?).to eq(false)
+        end
       end
     end
 


### PR DESCRIPTION
## What

Refuses a country change in payout settings while the seller has a payout still in flight. `UpdateUserCountry#process` now raises `PayoutInProcessingError` when the seller has any payout in an in-flight state (`creating`, `processing`, or `unclaimed` — everything between payout creation and a settled outcome), and the settings controller turns that into a clear inline error: "You have a payout in progress. You can change your country once it has been processed."

Completed payouts are deliberately not blocked: a completed Stripe payout can still be returned by the bank later, but Gumroad pays out weekly, so blocking on recent completions would lock nearly every active seller out of country changes. That residual window is covered by the companion alerting work below.

## Why

Changing country deletes the seller's Stripe Connect account and bank account and creates fresh ones. If a payout that is still in flight later fails or is returned by the bank, Stripe re-credits the money to the account the payout came from — which by then is the deleted one. The funds strand there silently: the seller's ledger says they're owed money, but the payout pipeline draws from the new account, whose Stripe balance is short by exactly the returned amount, so the destination-balance drift guard refuses every subsequent payout. Recovering requires a manual Stripe reconciliation. Blocking the country change until in-flight payouts settle closes the front door on this whole failure class.

Companion PRs: an alert when a returned payout does land on a retired account, and a self-diagnosing drift-guard error that names retired accounts still holding funds.

## Test plan

- `spec/services/update_user_country_spec.rb` — new examples: raises `PayoutInProcessingError` and leaves compliance info / Stripe account / bank account untouched for each in-flight state (`creating`, `processing`, `unclaimed`); allows the change when all payouts have settled (completed/failed). 13 examples, 0 failures locally.
- `spec/controllers/settings/payments_controller_spec.rb` — new example: the update renders the inline error and the country stays unchanged. 3 examples in the country context, 0 failures locally.
- Not a UI change beyond a new inline error string rendered through the existing settings error mechanism.
