### PR TITLE
Alert when a returned payout re-credits a retired Stripe account

### DIFF
--- a/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
+++ b/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
@@ -522,6 +522,8 @@ class StripePayoutProcessor
       payment.processor_reversing_payout_id = reversing_payout_id
       payment.save!
     end
+
+    alert_if_payout_credited_retired_account(payment)
   end
 
   def self.handle_stripe_event_payout_reversal_failed(payment, reversing_payout_id)
@@ -579,6 +581,32 @@ class StripePayoutProcessor
       payment.save!
       payment.send_payout_failure_email
     end
+
+    alert_if_payout_credited_retired_account(payment)
+  end
+
+  # When a bank payout fails or is returned, Stripe re-credits the money to the Connect account
+  # the payout was made from. If the seller has since changed country (which deletes that account
+  # and creates a fresh one), the re-credited funds sit on the retired account where nothing looks
+  # at them: the seller's ledger balance says they are owed money, but future payouts draw from
+  # the NEW account, whose Stripe balance is short by exactly the returned amount — so the payout
+  # drift guard refuses every payout from then on. Raise the alarm the day it happens instead of
+  # letting the seller discover it weeks later through blocked payouts.
+  def self.alert_if_payout_credited_retired_account(payment)
+    merchant_account = MerchantAccount.find_by(charge_processor_merchant_id: payment.stripe_connect_account_id)
+    return if merchant_account.nil?
+    return unless merchant_account.is_a_gumroad_managed_stripe_account?
+
+    active_account = payment.user.stripe_account
+    return if active_account.present? && active_account.id == merchant_account.id
+
+    message = "Returned/failed payout #{payment.id} (#{payment.stripe_transfer_id}) re-credited " \
+      "retired Stripe account #{payment.stripe_connect_account_id}, which is no longer the user's " \
+      "active merchant account#{active_account ? " (now #{active_account.charge_processor_merchant_id})" : ""}. " \
+      "The funds are stranded there and future payouts will fail the destination balance check " \
+      "until they are moved to the active account."
+    payment.user.add_payout_note(content: "[PAYOUT][DRIFT] #{message}")
+    ErrorNotifier.notify(message, payment_id: payment.id, user_id: payment.user_id)
   end
 
   def self.reverse_internal_transfer!(payment)

--- a/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
@@ -489,6 +489,85 @@ describe StripePayoutProcessor, :vcr do
     end
   end
 
+  describe "alert_if_payout_credited_retired_account" do
+    let(:user) { create(:user) }
+    let(:retired_account) do
+      create(:merchant_account, user:, charge_processor_merchant_id: "acct_retired",
+                                charge_processor_alive_at: nil, deleted_at: Time.current)
+    end
+    let(:payment) do
+      create(:payment, user:, processor: PayoutProcessorType::STRIPE,
+                       stripe_connect_account_id: retired_account.charge_processor_merchant_id,
+                       stripe_transfer_id: "po_test_returned")
+    end
+
+    context "when the payout's account is no longer the user's active merchant account" do
+      let!(:active_account) do
+        create(:merchant_account, user:, charge_processor_merchant_id: "acct_active")
+      end
+
+      it "adds a payout note and notifies the error tracker" do
+        expect(ErrorNotifier).to receive(:notify).with(
+          a_string_including("retired Stripe account acct_retired"),
+          payment_id: payment.id,
+          user_id: user.id
+        )
+
+        described_class.alert_if_payout_credited_retired_account(payment)
+
+        note = user.reload.comments.with_type_payout_note.last
+        expect(note.content).to include("[PAYOUT][DRIFT]")
+        expect(note.content).to include("acct_retired")
+        expect(note.content).to include("acct_active")
+      end
+    end
+
+    context "when the user has no active merchant account at all" do
+      it "still adds a payout note and notifies the error tracker" do
+        expect(ErrorNotifier).to receive(:notify)
+
+        described_class.alert_if_payout_credited_retired_account(payment)
+
+        note = user.reload.comments.with_type_payout_note.last
+        expect(note.content).to include("[PAYOUT][DRIFT]")
+      end
+    end
+
+    context "when the payout's account is still the user's active merchant account" do
+      let(:active_account) { create(:merchant_account, user:, charge_processor_merchant_id: "acct_live") }
+      let(:payment) do
+        create(:payment, user:, processor: PayoutProcessorType::STRIPE,
+                         stripe_connect_account_id: active_account.charge_processor_merchant_id,
+                         stripe_transfer_id: "po_test_returned")
+      end
+
+      it "does nothing" do
+        expect(ErrorNotifier).not_to receive(:notify)
+
+        expect do
+          described_class.alert_if_payout_credited_retired_account(payment)
+        end.not_to change { user.comments.count }
+      end
+    end
+
+    context "when the payout went to a user-connected Stripe Standard account" do
+      let(:connect_account) { create(:merchant_account_stripe_connect, user:) }
+      let(:payment) do
+        create(:payment, user:, processor: PayoutProcessorType::STRIPE,
+                         stripe_connect_account_id: connect_account.charge_processor_merchant_id,
+                         stripe_transfer_id: "po_test_returned")
+      end
+
+      it "does nothing because Gumroad does not manage that account's balance" do
+        expect(ErrorNotifier).not_to receive(:notify)
+
+        expect do
+          described_class.alert_if_payout_credited_retired_account(payment)
+        end.not_to change { user.comments.count }
+      end
+    end
+  end
+
   describe "prepare_payment_and_set_amount when balance_transaction is nil" do
     let(:user) { create(:user) }
     let(:merchant_account) { create(:merchant_account, user:, charge_processor_id: StripeChargeProcessor.charge_processor_id) }


### PR DESCRIPTION
## What

When a Stripe bank payout fails or is returned and the webhook re-credits the funds to the Connect account the payout came from, check whether that account is still the seller's active merchant account. If it isn't (typically because a country change replaced it), add a `[PAYOUT][DRIFT]` payout note on the seller's account naming both the retired and the active account, and notify Sentry.

## Why

Stripe always returns failed/returned payout funds to the account the payout was made from. If the seller changed country in the meantime, that account has been deleted and replaced — the returned money sits on the retired account where nothing looks at it. The seller's ledger balance says they're owed money, future payouts draw from the new account whose Stripe balance is short by exactly the returned amount, and the destination-balance drift guard then refuses every payout. Today this strands silently and only surfaces weeks later as repeated payout failures and an auto-pause; this alert catches it the day the webhook arrives.

The check runs in both `handle_stripe_event_payout_failed` and `handle_stripe_event_payout_reversed`, only for Gumroad-managed Stripe accounts, and is a no-op when the payout's account is still the active one.

Companion PRs: blocking country changes while a payout is in flight (prevention), and a self-diagnosing drift-guard error (detection at payout time).

## Test plan

- `spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb` — new `alert_if_payout_credited_retired_account` examples: notes + notifies when the account is retired (with and without an active replacement); no-op when the account is still active; no-op for user-connected Stripe Standard accounts. 4 examples, 0 failures locally.
- Existing `handle_stripe_event` suite (41 examples) and `handle_payout_reversed_worker_spec.rb` (3 examples) still green locally.
- No UI change.
