### PR TITLE
Name retired-account balances in the payout drift-guard error

### DIFF
--- a/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
+++ b/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
@@ -299,9 +299,42 @@ class StripePayoutProcessor
     "Destination Stripe balance mismatch on #{merchant_account.charge_processor_merchant_id}: " \
       "expected #{expected_destination_cents} #{destination_currency} cents, " \
       "Stripe has #{available_cents} cents available + #{pending_cents} cents pending (gap: #{gap_cents} cents). " \
-      "Reconcile destination balance before retry."
+      "Reconcile destination balance before retry." \
+      "#{retired_account_balances_hint(merchant_account)}"
   end
   private_class_method :destination_balance_drift_error
+
+  # Every drift-guard case investigated so far had the same root cause: the seller changed
+  # country (or otherwise got a new Stripe account), and a returned payout or leftover funds
+  # stayed on the retired account. Finding that used to take a manual Stripe trace per case,
+  # so when the guard trips, look up the seller's retired Gumroad-managed accounts and name
+  # any that still hold money — the diagnosis then ships inside the error message itself.
+  def self.retired_account_balances_hint(merchant_account)
+    retired_accounts = merchant_account.user.merchant_accounts.stripe.deleted
+      .where.not(id: merchant_account.id)
+      .select(&:is_a_gumroad_managed_stripe_account?)
+
+    balances_found = retired_accounts.filter_map do |retired_account|
+      stripe_balance = Stripe::Balance.retrieve({}, { stripe_account: retired_account.charge_processor_merchant_id })
+      residual_cents = (stripe_balance.available + stripe_balance.pending).sum { |b| [b.amount, 0].max }
+      next if residual_cents <= 0
+
+      amounts = (stripe_balance.available + stripe_balance.pending)
+        .filter_map { |b| "#{b.amount} #{b.currency} cents" if b.amount > 0 }
+        .join(" + ")
+      "#{retired_account.charge_processor_merchant_id} holds #{amounts}"
+    rescue Stripe::StripeError
+      # The retired account may be gone at Stripe entirely; the hint is best-effort and the
+      # drift error itself must still get through, so skip accounts we can't read.
+      nil
+    end
+    return "" if balances_found.empty?
+
+    " Possible cause: the seller has retired Stripe account(s) still holding funds — " \
+      "#{balances_found.join("; ")}. A returned payout may have re-credited a retired account " \
+      "after a country change; move those funds to the active account."
+  end
+  private_class_method :retired_account_balances_hint
 
   def self.enqueue_payments(user_ids, date_string, payout_type: Payouts::PAYOUT_TYPE_STANDARD)
     user_ids.each do |user_id|

--- a/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
@@ -315,6 +315,75 @@ describe StripePayoutProcessor, :vcr do
         expect(payment.errors.full_messages.first).to include("Destination Stripe balance mismatch")
         expect(payment.errors.full_messages.first).to include("gap: 25969 cents")
       end
+
+      context "when the seller has a retired Gumroad-managed account still holding funds" do
+        let!(:retired_account) do
+          create(:merchant_account, user:, charge_processor_merchant_id: "acct_retired_with_funds",
+                                    currency: Currency::EUR, country: "ES", deleted_at: Time.current)
+        end
+
+        before do
+          allow(Stripe::Balance).to receive(:retrieve)
+            .with({}, { stripe_account: "acct_retired_with_funds" })
+            .and_return(
+              Stripe::Balance.construct_from(object: "balance",
+                                             available: [{ amount: 25_969, currency: "eur" }],
+                                             pending: [{ amount: 0, currency: "eur" }])
+            )
+        end
+
+        it "names the retired account and its residual balance in the error message" do
+          errors = described_class.prepare_payment_and_set_amount(payment, [eur_balance])
+
+          expect(errors.first).to include("Destination Stripe balance mismatch")
+          expect(errors.first).to include("acct_retired_with_funds holds 25969 eur cents")
+          expect(errors.first).to include("retired Stripe account(s) still holding funds")
+        end
+      end
+
+      context "when the seller has a retired account but it holds nothing" do
+        let!(:retired_account) do
+          create(:merchant_account, user:, charge_processor_merchant_id: "acct_retired_empty",
+                                    currency: Currency::EUR, country: "ES", deleted_at: Time.current)
+        end
+
+        before do
+          allow(Stripe::Balance).to receive(:retrieve)
+            .with({}, { stripe_account: "acct_retired_empty" })
+            .and_return(
+              Stripe::Balance.construct_from(object: "balance",
+                                             available: [{ amount: 0, currency: "eur" }],
+                                             pending: [{ amount: 0, currency: "eur" }])
+            )
+        end
+
+        it "keeps the plain drift message without a retired-account hint" do
+          errors = described_class.prepare_payment_and_set_amount(payment, [eur_balance])
+
+          expect(errors.first).to include("Destination Stripe balance mismatch")
+          expect(errors.first).not_to include("retired Stripe account(s)")
+        end
+      end
+
+      context "when reading the retired account's balance fails at Stripe" do
+        let!(:retired_account) do
+          create(:merchant_account, user:, charge_processor_merchant_id: "acct_retired_gone",
+                                    currency: Currency::EUR, country: "ES", deleted_at: Time.current)
+        end
+
+        before do
+          allow(Stripe::Balance).to receive(:retrieve)
+            .with({}, { stripe_account: "acct_retired_gone" })
+            .and_raise(Stripe::PermissionError.new("account does not exist"))
+        end
+
+        it "still returns the drift error without the hint" do
+          errors = described_class.prepare_payment_and_set_amount(payment, [eur_balance])
+
+          expect(errors.first).to include("Destination Stripe balance mismatch")
+          expect(errors.first).not_to include("retired Stripe account(s)")
+        end
+      end
     end
 
     context "when Stripe's pending balance covers the gap (funds settling, no true drift)" do


### PR DESCRIPTION
## What

When the payout destination-balance drift guard trips, the error message now also checks the seller's retired Gumroad-managed Stripe accounts and names any that still hold funds, with the exact residual amounts. Example suffix: "Possible cause: the seller has retired Stripe account(s) still holding funds — acct_… holds 12345 eur cents. A returned payout may have re-credited a retired account after a country change; move those funds to the active account."

## Why

The drift guard says how big the gap is but not where the money went. Every investigated drift case so far had the same root cause: the seller changed country (retiring their Stripe account), and a returned payout or leftover funds stayed on the retired account. Confirming that took a manual per-account Stripe trace each time. Putting the retired-account balances directly in the error turns an hours-long investigation into a one-line read.

The lookup is best-effort: it only runs when the guard has already tripped (no extra Stripe calls on the happy path), and if a retired account can't be read at Stripe, the original drift error still goes through unchanged.

Companion PRs: blocking country changes while a payout is in flight (prevention), and alerting when a returned payout lands on a retired account (day-of detection).

## Test plan

- `spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb` — new examples under `destination_balance_drift_error`: retired account with funds is named with its amounts; empty retired account adds no hint; Stripe read failure on the retired account degrades gracefully to the plain drift error. Full drift-guard context: 14 examples, 0 failures locally.
- No UI change.
