### PR TITLE
Document that country changes wait for in-flight payouts

### DIFF
--- a/app/views/help_center/articles/contents/_13-getting-paid.html.erb
+++ b/app/views/help_center/articles/contents/_13-getting-paid.html.erb
@@ -21,7 +21,7 @@
   <p>To get paid for your sales, start by filling out your <a href="https://gumroad.com/settings/payments">Payments Settings</a>.</p>
   <h3 id="bank-account">Get paid to your bank account</h3>
   <div class="callout-yellow">
-    <p><b>Note: </b>Due to restrictions from our payment partners, you may have to forfeit your balance if you want to change your country in the future. Choose carefully!</p>
+    <p><b>Note: </b>Due to restrictions from our payment partners, you may have to forfeit your balance if you want to change your country in the future. Choose carefully! Also, if you have a payout in progress, you will need to wait until it has been processed before you can change your country.</p>
   </div>
   <p>We currently support bank payouts in the following countries:</p>
   <div class="table-responsive">


### PR DESCRIPTION
## What

Adds one sentence to the country-change note in the "Getting paid" help article (`_13-getting-paid.html.erb`): if you have a payout in progress, you need to wait until it has been processed before you can change your country. Body-only edit; `articles.yml` untouched.

## Why

#5852 (merged) blocks country changes in payout settings while the seller has a payout in flight, with the inline error "You have a payout in progress. You can change your country once it has been processed." The help center's country-change note only mentioned the balance forfeit, so a seller hitting the new error had no documented explanation. The doc sentence mirrors the in-app error wording.

## Test plan

- ERB syntax check on the edited partial: OK.
- Rendered the partial via `ApplicationController.render` in the test env; new copy present, render OK.
- `bundle exec rspec spec/models/help_center`: 1 example, 0 failures (guards slug/partial integrity).
- Autoreview skipped (docs copy only, no logic).
