### PR TITLE
Document the account ownership transfer process in the help center

### DIFF
--- a/app/views/help_center/articles/contents/_252-multiple-accounts.html.erb
+++ b/app/views/help_center/articles/contents/_252-multiple-accounts.html.erb
@@ -35,13 +35,16 @@
     <li>Name of the product</li>
     <li>Date of purchase</li>
     <li>Payment method: Card brand + last 4 digits (Eg. VISA *1111) or your PayPal ID</li>
-  </ol>
+  </ul>
   <p>We will transfer your purchases after verifying the above information.</p>
   <h3 id="Transferring-ownership-of-account-fk2W3">Transferring ownership of account</h3>
-  <p>To transfer ownership of your Gumroad account:</p>
+  <p>You can transfer your Gumroad account to a new owner, for example when you sell your business. Under our <a href="https://gumroad.com/terms">Terms of Service</a>, transferring an account to someone else requires Gumroad's prior written consent, so contact us before making any changes.</p>
+  <p>Here is how it works:</p>
   <ul>
-    <li>The current owner will need to change the account’s email address to the new owner's email address from the <a href="https://gumroad.com/settings">settings</a>.</li>
-    <li>The new owner will need to update the <a href="https://gumroad.com/settings/payments">payments settings</a> to their own. This includes updating the compliance and PayPal or bank account information. Changing the account’s country may require you to forfeit your existing balance.</li>
-  </ol>
-  <p>Please remember that all the products, followers, and sales data will remain intact during this process.</p>
+    <li>Click the "Contact Us" button below from the email address on the account, and tell us you want to transfer ownership. Include the new owner's legal name, country, and email address.</li>
+    <li>We will review the request and confirm the approved handover in writing. Do not change the account's email, password, or payout details before you hear back from us, as unannounced changes like these can flag the account for review.</li>
+    <li>Once approved, the current owner changes the account's email address to the new owner's email address from the <a href="https://gumroad.com/settings">settings</a>. The new owner then updates the password and two-factor authentication.</li>
+    <li>Finally, the new owner updates the <a href="https://gumroad.com/settings/payments">payments settings</a> to their own. This includes updating the compliance and PayPal or bank account information. The new owner will need to complete identity verification, and payouts may pause for a few business days while that happens. Changing the account's country may require you to forfeit your existing balance.</li>
+  </ul>
+  <p>All the products, reviews, followers, and sales data will remain intact during this process. The account's obligations carry over too: the new owner takes on the Terms of Service, along with any refund and chargeback responsibilities for past sales.</p>
 </div>

--- a/app/views/help_center/articles/contents/_252-multiple-accounts.html.erb
+++ b/app/views/help_center/articles/contents/_252-multiple-accounts.html.erb
@@ -42,7 +42,7 @@
   <p>Here is how it works:</p>
   <ul>
     <li>Click the "Contact Us" button below from the email address on the account, and tell us you want to transfer ownership. Include the new owner's legal name, country, and email address.</li>
-    <li>We will review the request and confirm the approved handover in writing. Do not change the account's email, password, or payout details before you hear back from us, as unannounced changes like these can flag the account for review.</li>
+    <li>We will review the request and, if approved, confirm the handover in writing. Do not change the account's email, password, or payout details before you hear back from us, as unannounced changes like these can flag the account for review.</li>
     <li>Once approved, the current owner changes the account's email address to the new owner's email address from the <a href="https://gumroad.com/settings">settings</a>. The new owner then updates the password and two-factor authentication.</li>
     <li>Finally, the new owner updates the <a href="https://gumroad.com/settings/payments">payments settings</a> to their own. This includes updating the compliance and PayPal or bank account information. The new owner will need to complete identity verification, and payouts may pause for a few business days while that happens. Changing the account's country may require you to forfeit your existing balance.</li>
   </ul>


### PR DESCRIPTION
## What

Updates the "Transferring ownership of account" section of the [multiple accounts article](https://help.gumroad.com/help/article/252-multiple-accounts) to document the full account ownership transfer process, and fixes two stray `</ol>` closing tags that should have been `</ul>`.

## Why

The section only listed the mechanical steps (change the email, update payout settings). It left out everything a seller actually needs when selling their business:

- Transfers require Gumroad's prior written consent under the [Terms of Service](https://gumroad.com/terms) (§27.1) — the old copy read as if a seller could just hand off credentials, which is prohibited conduct without consent.
- How to request consent (contact support with the new owner's legal name, country, and email).
- Not to change email/password/payout details before approval, since unannounced changes flag the account for review.
- The recommended handover order (email → password/2FA → payout details).
- That the new owner completes identity verification, with a possible short payout pause.
- That products, reviews, followers, and sales data carry over, along with refund/chargeback obligations.

This matches the process support now follows for consented transfers (recent business-sale request tracked in antiwork/gumroad-private#1068).

## Test plan

- `spec/models/help_center` green locally (guards slug ↔ partial integrity).
- Rendered the partial in the real view context locally: `ApplicationController.render(partial: "help_center/articles/contents/252-multiple-accounts")` — renders OK, new copy present, old copy gone.
- ERB syntax check + HTML tag-balance check pass (the fix removes the only two unbalanced tags in the file).

Autoreview not applicable (docs copy only, no logic). Policy wording flag for the reviewer: this section commits in writing to the consent requirement, verification pause, and obligation carry-over — please sanity-check the wording since sellers will keep this on file during sale transactions.
