### PR TITLE
Document refund status on regenerated invoices in the invoice help article

### DIFF
--- a/app/views/help_center/articles/contents/_194-i-need-an-invoice.html.erb
+++ b/app/views/help_center/articles/contents/_194-i-need-an-invoice.html.erb
@@ -3,6 +3,7 @@
   <ul>
     <li><a href="#How-to-generate-your-invoice-from-the-receipt-wpmBD" target="_self">How to generate your invoice from the receipt</a></li>
     <li><a href="#VAT-ID-Erp7a" target="_self">VAT ID</a></li>
+    <li><a href="#Refunded-purchases-mQx4T" target="_self">Refunded purchases</a></li>
     <li><a href="#Dont-have-your-receipt-Kger0" target="_self">Don't have your receipt?</a></li>
     <li><a href="#Older-purchases-II5BZ" target="_self">Older purchases</a></li>
     <li><a href="#No-W9-KSAkH" target="_self">No W9?</a></li>
@@ -16,6 +17,8 @@
   <h3 id="VAT-ID-Erp7a">VAT ID</h3>
   <p>If you paid VAT and you're a business in the EU, you can also enter your VAT registration number and automatically process a refund for the VAT you paid. The VAT refund will take 2-3 days to arrive at your credit card or PayPal account. The invoice will display without VAT.</p>
   <p>Please note that everything you need on your invoice should be written in the custom text box called "Additional notes" when you generate your invoice. Gumroad Support doesn't have the capability to change or adjust invoices, so be sure to add anything your tax office might need.</p>
+  <h3 id="Refunded-purchases-mQx4T">Refunded purchases</h3>
+  <p>If your purchase has been refunded, the invoice you generate reflects that. The payment total shows the amount you actually paid after refunds (so a fully refunded purchase shows a zero total), and a "Refund status" line appears under the payment total reading "Fully refunded" or "Partially refunded", along with the date of the most recent refund. This lets you use the regenerated invoice as documentation of the refund for your books.</p>
   <h3 id="Dont-have-your-receipt-Kger0">Don't have your receipt?</h3>
   <p>Please see <a href="212-i-never-received-a-receipt" target="_self">this article</a> if you are unable to find your receipt.</p>
   <h3 id="Older-purchases-II5BZ">Older purchases</h3>


### PR DESCRIPTION
## What

Adds a "Refunded purchases" section to the "I need an invoice" help article (`_194-i-need-an-invoice.html.erb`), documenting that a regenerated invoice now reflects refunds: the payment total shows the post-refund amount (zero for a full refund), and a "Refund status" line appears under the payment total reading "Fully refunded" or "Partially refunded" with the date of the most recent refund. Adds the matching TOC entry. Body-only edit; `articles.yml` untouched.

## Why

antiwork/gumroad#5857 (merged) made the regenerated invoice's Payment Total subtract the full refunded amount, and antiwork/gumroad#5858 (merged) added the "Refund status" line to the invoice. The help center's invoice article said nothing about how refunds appear on a regenerated invoice, so buyers who need refund documentation for their books (a common EU business-buyer request) had no doc telling them the regenerated invoice serves as that evidence. This keeps help.gumroad.com in sync with the shipped behavior.

Wording is cross-checked against the shipped code: `InvoicePresenter::OrderInfo#refund_status_attribute` renders `"Fully refunded"` / `"Partially refunded"` plus `" on <date>"` from the most recent refund's `created_at`, placed directly after the payment total attribute on both the PDF and the invoice form.

## Test plan

- Rendered the article partial in the real view context locally: render OK, new copy present, per-tag open/close counts balanced.
- `bundle exec rspec spec/models/help_center` passes locally (1 example, 0 failures — guards slug/partial integrity).
- Docs copy only, no logic; help-center specs run in CI.
