### PR TITLE
Show a poster frame for uploaded video covers instead of a black idle player

### DIFF
--- a/app/javascript/components/Product/Covers/Video.tsx
+++ b/app/javascript/components/Product/Covers/Video.tsx
@@ -20,7 +20,15 @@ const Video = ({ cover, dimensions }: Props) => {
     const url = dimensions == null || dimensions.width > DEFAULT_IMAGE_WIDTH ? cover.original_url : cover.url;
 
     const options: JWPlayerOptions = {
-      playlist: [{ sources: [{ file: url, type: cover.filetype?.toLowerCase() }] }],
+      // "image" is JW Player's poster frame — the still shown before playback
+      // starts. Without it the player idles as a solid black rectangle (the
+      // subject of gumroad-private#1074). For uploaded videos the backend
+      // extracts a frame with ffmpeg (AssetPreview#video_poster_url); when no
+      // poster could be generated this is null and JW Player keeps the old
+      // black idle state.
+      playlist: [
+        { image: cover.thumbnail ?? undefined, sources: [{ file: url, type: cover.filetype?.toLowerCase() }] },
+      ],
     };
     if (dimensions != null) {
       options.height = `${dimensions.height}px`;

--- a/app/models/asset_preview.rb
+++ b/app/models/asset_preview.rb
@@ -9,6 +9,9 @@ class AssetPreview < ApplicationRecord
   RETINA_DISPLAY_WIDTH = (DEFAULT_DISPLAY_WIDTH * 1.5).to_i
 
   after_commit :invalidate_product_cache
+  # Kick off poster-frame extraction right away so the poster is usually
+  # ready by the time anyone views the product page.
+  after_create_commit :enqueue_video_poster_generation
 
   # Update updated_at of product to regenerate the sitemap in RefreshSitemapMonthlyWorker
   belongs_to :link, touch: true, optional: true
@@ -132,40 +135,57 @@ class AssetPreview < ApplicationRecord
   end
 
   # Generating a poster means downloading the video and running ffmpeg, which
-  # can take a while for large files. Two protections keep that work from
-  # hurting product page renders:
-  #   - a hard timeout (same 30s budget as retina_variant above), so a
-  #     pathological video degrades to "no poster" instead of hogging a
-  #     request thread indefinitely;
-  #   - the result is cached both ways — success caches the URL, failure
-  #     caches an empty string so we don't re-download and re-run ffmpeg on
-  #     every page view of a product whose video can't be previewed.
-  # The cache is warmed at upload time: creating a cover renders its JSON
-  # (which calls this method) in the same request, so buyers almost never
-  # pay the generation cost.
+  # can take a while for large files. That work never happens on a web
+  # request thread: GenerateVideoPosterWorker is enqueued when the cover is
+  # created and does the generation in the background, writing the result to
+  # the cache. Renders only ever read the cache.
+  #   - success caches the poster URL;
+  #   - failure caches an empty-string sentinel (for an hour) so the worker's
+  #     retries don't re-download and re-run ffmpeg on a video that can't be
+  #     previewed.
+  # If a render happens before the worker has finished (or for covers created
+  # before this existed), this returns nil — the player shows its plain idle
+  # state — and we enqueue a generation so the poster appears on later views.
   FAILED_POSTER_SENTINEL = ""
   FAILED_POSTER_RETRY_INTERVAL = 1.hour
 
   def video_poster_url
     return nil unless file.attached? && file.video? && file.previewable?
 
-    cache_key = "attachment_#{file.id}_poster_url"
-    cached = Rails.cache.read(cache_key)
+    cached = Rails.cache.read(video_poster_cache_key)
+    if cached.nil?
+      # Nothing generated yet — covers created before poster support existed
+      # land here. Kick off a background generation so the poster shows up on
+      # subsequent views; this view renders without one.
+      GenerateVideoPosterWorker.perform_async(id)
+      return nil
+    end
+
+    cached == FAILED_POSTER_SENTINEL ? nil : cached
+  end
+
+  # Does the actual download + ffmpeg frame extraction. Only called from
+  # GenerateVideoPosterWorker — web requests read the cached result via
+  # video_poster_url above.
+  def generate_video_poster!
+    return nil unless file.attached? && file.video? && file.previewable?
+
+    cached = Rails.cache.read(video_poster_cache_key)
     return (cached == FAILED_POSTER_SENTINEL ? nil : cached) unless cached.nil?
 
     url = Timeout.timeout(IMAGE_PROCESSING_TIMEOUT_SECONDS) do
       preview = file.preview(resize_to_limit: [retina_width || RETINA_DISPLAY_WIDTH, nil]).processed
       cdn_url_for(preview.url)
     end
-    Rails.cache.write(cache_key, url)
+    Rails.cache.write(video_poster_cache_key, url)
     url
   rescue StandardError => e
     # A missing poster only costs us the nicety of a preview frame, so never
-    # let preview generation break product rendering. Remember the failure
-    # for a while (instead of retrying on every render), and log so we can
-    # spot systemic failures (e.g. ffmpeg misconfigured on a box).
-    Rails.cache.write(cache_key, FAILED_POSTER_SENTINEL, expires_in: FAILED_POSTER_RETRY_INTERVAL)
-    Rails.logger.warn("AssetPreview#video_poster_url failed for asset_preview #{id}: #{e.message}")
+    # let generation raise out of the worker into endless retries. Remember
+    # the failure for a while, and log so we can spot systemic failures
+    # (e.g. ffmpeg misconfigured on a box).
+    Rails.cache.write(video_poster_cache_key, FAILED_POSTER_SENTINEL, expires_in: FAILED_POSTER_RETRY_INTERVAL)
+    Rails.logger.warn("AssetPreview#generate_video_poster! failed for asset_preview #{id}: #{e.message}")
     nil
   end
 
@@ -260,6 +280,16 @@ class AssetPreview < ApplicationRecord
   end
 
   private
+    def video_poster_cache_key
+      "attachment_#{file.id}_poster_url"
+    end
+
+    def enqueue_video_poster_generation
+      return unless file.attached? && file.video?
+
+      GenerateVideoPosterWorker.perform_async(id)
+    end
+
     def set_position
       previous = link.asset_previews.in_order.last
       if previous

--- a/app/models/asset_preview.rb
+++ b/app/models/asset_preview.rb
@@ -32,7 +32,7 @@ class AssetPreview < ApplicationRecord
   def as_json(*)
     { url:,
       original_url: url(style: :original),
-      thumbnail: oembed_thumbnail_url,
+      thumbnail: thumbnail_url,
       id: guid,
       type: display_type,
       filetype:,
@@ -115,6 +115,35 @@ class AssetPreview < ApplicationRecord
     return nil unless safe_url?(url)
 
     url
+  end
+
+  # A still image to show for this cover before playback starts.
+  # For embedded players (YouTube/Vimeo) this is the thumbnail the platform
+  # provides via oEmbed. For video files uploaded directly to Gumroad we ask
+  # ActiveStorage for a preview — a frame ffmpeg extracts from the video — so
+  # the product page can show that frame instead of a black rectangle while
+  # the player is idle. Returns nil for images (they don't need a poster) and
+  # when no preview can be generated (e.g. ffmpeg missing or a corrupt file);
+  # the player then falls back to the old black idle state.
+  def thumbnail_url
+    return oembed_thumbnail_url if oembed
+
+    video_poster_url
+  end
+
+  def video_poster_url
+    return nil unless file.attached? && file.video? && file.previewable?
+
+    Rails.cache.fetch("attachment_#{file.id}_poster_url") do
+      preview = file.preview(resize_to_limit: [retina_width || RETINA_DISPLAY_WIDTH, nil]).processed
+      cdn_url_for(preview.url)
+    end
+  rescue StandardError => e
+    # A missing poster only costs us the nicety of a preview frame, so never
+    # let preview generation break product rendering. Log so we can spot
+    # systemic failures (e.g. ffmpeg misconfigured on a box).
+    Rails.logger.warn("AssetPreview#video_poster_url failed for asset_preview #{id}: #{e.message}")
+    nil
   end
 
   def oembed_url

--- a/app/models/asset_preview.rb
+++ b/app/models/asset_preview.rb
@@ -131,17 +131,40 @@ class AssetPreview < ApplicationRecord
     video_poster_url
   end
 
+  # Generating a poster means downloading the video and running ffmpeg, which
+  # can take a while for large files. Two protections keep that work from
+  # hurting product page renders:
+  #   - a hard timeout (same 30s budget as retina_variant above), so a
+  #     pathological video degrades to "no poster" instead of hogging a
+  #     request thread indefinitely;
+  #   - the result is cached both ways — success caches the URL, failure
+  #     caches an empty string so we don't re-download and re-run ffmpeg on
+  #     every page view of a product whose video can't be previewed.
+  # The cache is warmed at upload time: creating a cover renders its JSON
+  # (which calls this method) in the same request, so buyers almost never
+  # pay the generation cost.
+  FAILED_POSTER_SENTINEL = ""
+  FAILED_POSTER_RETRY_INTERVAL = 1.hour
+
   def video_poster_url
     return nil unless file.attached? && file.video? && file.previewable?
 
-    Rails.cache.fetch("attachment_#{file.id}_poster_url") do
+    cache_key = "attachment_#{file.id}_poster_url"
+    cached = Rails.cache.read(cache_key)
+    return (cached == FAILED_POSTER_SENTINEL ? nil : cached) unless cached.nil?
+
+    url = Timeout.timeout(IMAGE_PROCESSING_TIMEOUT_SECONDS) do
       preview = file.preview(resize_to_limit: [retina_width || RETINA_DISPLAY_WIDTH, nil]).processed
       cdn_url_for(preview.url)
     end
+    Rails.cache.write(cache_key, url)
+    url
   rescue StandardError => e
     # A missing poster only costs us the nicety of a preview frame, so never
-    # let preview generation break product rendering. Log so we can spot
-    # systemic failures (e.g. ffmpeg misconfigured on a box).
+    # let preview generation break product rendering. Remember the failure
+    # for a while (instead of retrying on every render), and log so we can
+    # spot systemic failures (e.g. ffmpeg misconfigured on a box).
+    Rails.cache.write(cache_key, FAILED_POSTER_SENTINEL, expires_in: FAILED_POSTER_RETRY_INTERVAL)
     Rails.logger.warn("AssetPreview#video_poster_url failed for asset_preview #{id}: #{e.message}")
     nil
   end

--- a/app/sidekiq/generate_video_poster_worker.rb
+++ b/app/sidekiq/generate_video_poster_worker.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Extracts a poster frame (a still image shown before playback starts) from a
+# video cover uploaded directly to Gumroad. Downloading the video and running
+# ffmpeg can take a while, so it happens here in the background rather than on
+# a web request; the resulting URL is cached and product pages read it via
+# AssetPreview#video_poster_url.
+class GenerateVideoPosterWorker
+  include Sidekiq::Job
+  sidekiq_options retry: 3, queue: :low, lock: :until_executed
+
+  def perform(asset_preview_id)
+    asset_preview = AssetPreview.find_by(id: asset_preview_id)
+    return if asset_preview.nil? || asset_preview.deleted?
+
+    poster_url = asset_preview.generate_video_poster!
+
+    # The product page JSON is cached with the cover's thumbnail baked in, so
+    # bust it once a poster exists — otherwise buyers keep seeing the cached
+    # no-poster version until something else touches the product.
+    asset_preview.link&.invalidate_cache if poster_url.present?
+  end
+end

--- a/spec/models/asset_preview_spec.rb
+++ b/spec/models/asset_preview_spec.rb
@@ -363,6 +363,44 @@ describe AssetPreview, :vcr do
     end
   end
 
+  describe "#thumbnail_url" do
+    let(:asset_preview) { build(:asset_preview) }
+
+    it "returns the oembed thumbnail when the cover is an embedded player" do
+      asset_preview.oembed = { "info" => { "thumbnail_url" => "https://example.com/thumb.jpg" } }
+      expect(asset_preview.thumbnail_url).to eq("https://example.com/thumb.jpg")
+    end
+
+    it "returns nil for image covers" do
+      image = create(:asset_preview_jpg)
+      expect(image.thumbnail_url).to be_nil
+    end
+
+    it "returns a poster frame URL for uploaded video covers" do
+      asset_preview = create(:asset_preview_mov)
+      preview = instance_double(ActiveStorage::Preview, url: "https://files.example.com/poster.jpg")
+      allow(asset_preview.file).to receive(:previewable?).and_return(true)
+      allow(asset_preview.file).to receive(:preview).and_return(instance_double(ActiveStorage::Preview, processed: preview))
+
+      expect(asset_preview.thumbnail_url).to eq("https://files.example.com/poster.jpg")
+    end
+
+    it "returns nil instead of raising when poster generation fails" do
+      asset_preview = create(:asset_preview_mov)
+      allow(asset_preview.file).to receive(:previewable?).and_return(true)
+      allow(asset_preview.file).to receive(:preview).and_raise(ActiveStorage::UnpreviewableError)
+
+      expect(asset_preview.thumbnail_url).to be_nil
+    end
+
+    it "is exposed as the thumbnail in as_json" do
+      asset_preview = create(:asset_preview_mov)
+      allow(asset_preview).to receive(:video_poster_url).and_return("https://files.example.com/poster.jpg")
+
+      expect(asset_preview.as_json[:thumbnail]).to eq("https://files.example.com/poster.jpg")
+    end
+  end
+
   describe "#oembed_url" do
     let(:asset_preview) { build(:asset_preview) }
 

--- a/spec/models/asset_preview_spec.rb
+++ b/spec/models/asset_preview_spec.rb
@@ -376,13 +376,49 @@ describe AssetPreview, :vcr do
       expect(image.thumbnail_url).to be_nil
     end
 
-    it "returns a poster frame URL for uploaded video covers" do
+    it "returns the cached poster frame URL for uploaded video covers" do
+      asset_preview = create(:asset_preview_mov)
+      allow(asset_preview.file).to receive(:previewable?).and_return(true)
+      Rails.cache.write("attachment_#{asset_preview.file.id}_poster_url", "https://files.example.com/poster.jpg")
+
+      expect(asset_preview.thumbnail_url).to eq("https://files.example.com/poster.jpg")
+    end
+
+    it "returns nil and enqueues generation when no poster has been generated yet" do
+      asset_preview = create(:asset_preview_mov)
+      allow(asset_preview.file).to receive(:previewable?).and_return(true)
+
+      expect(asset_preview.thumbnail_url).to be_nil
+      expect(GenerateVideoPosterWorker).to have_enqueued_sidekiq_job(asset_preview.id)
+    end
+
+    it "returns nil without re-enqueueing when generation previously failed" do
+      asset_preview = create(:asset_preview_mov)
+      allow(asset_preview.file).to receive(:previewable?).and_return(true)
+      Rails.cache.write("attachment_#{asset_preview.file.id}_poster_url", AssetPreview::FAILED_POSTER_SENTINEL)
+      GenerateVideoPosterWorker.jobs.clear
+
+      expect(asset_preview.thumbnail_url).to be_nil
+      expect(GenerateVideoPosterWorker.jobs).to be_empty
+    end
+
+    it "is exposed as the thumbnail in as_json" do
+      asset_preview = create(:asset_preview_mov)
+      allow(asset_preview).to receive(:video_poster_url).and_return("https://files.example.com/poster.jpg")
+
+      expect(asset_preview.as_json[:thumbnail]).to eq("https://files.example.com/poster.jpg")
+    end
+  end
+
+  describe "#generate_video_poster!" do
+    it "extracts a poster frame and caches its URL" do
       asset_preview = create(:asset_preview_mov)
       preview = instance_double(ActiveStorage::Preview, url: "https://files.example.com/poster.jpg")
       allow(asset_preview.file).to receive(:previewable?).and_return(true)
       allow(asset_preview.file).to receive(:preview).and_return(instance_double(ActiveStorage::Preview, processed: preview))
 
-      expect(asset_preview.thumbnail_url).to eq("https://files.example.com/poster.jpg")
+      expect(asset_preview.generate_video_poster!).to eq("https://files.example.com/poster.jpg")
+      expect(Rails.cache.read("attachment_#{asset_preview.file.id}_poster_url")).to eq("https://files.example.com/poster.jpg")
     end
 
     it "returns nil instead of raising when poster generation fails" do
@@ -390,7 +426,7 @@ describe AssetPreview, :vcr do
       allow(asset_preview.file).to receive(:previewable?).and_return(true)
       allow(asset_preview.file).to receive(:preview).and_raise(ActiveStorage::UnpreviewableError)
 
-      expect(asset_preview.thumbnail_url).to be_nil
+      expect(asset_preview.generate_video_poster!).to be_nil
     end
 
     it "remembers failed generation and does not retry on the next call" do
@@ -398,10 +434,10 @@ describe AssetPreview, :vcr do
       allow(asset_preview.file).to receive(:previewable?).and_return(true)
       allow(asset_preview.file).to receive(:preview).and_raise(ActiveStorage::UnpreviewableError)
 
-      expect(asset_preview.thumbnail_url).to be_nil
+      expect(asset_preview.generate_video_poster!).to be_nil
       expect(asset_preview.file).to have_received(:preview).once
 
-      expect(asset_preview.thumbnail_url).to be_nil
+      expect(asset_preview.generate_video_poster!).to be_nil
       expect(asset_preview.file).to have_received(:preview).once
     end
 
@@ -410,14 +446,19 @@ describe AssetPreview, :vcr do
       allow(asset_preview.file).to receive(:previewable?).and_return(true)
       allow(Timeout).to receive(:timeout).with(AssetPreview::IMAGE_PROCESSING_TIMEOUT_SECONDS).and_raise(Timeout::Error)
 
-      expect(asset_preview.thumbnail_url).to be_nil
+      expect(asset_preview.generate_video_poster!).to be_nil
+    end
+  end
+
+  describe "poster generation enqueueing on create" do
+    it "enqueues poster generation when a video cover is created" do
+      asset_preview = create(:asset_preview_mov)
+      expect(GenerateVideoPosterWorker).to have_enqueued_sidekiq_job(asset_preview.id)
     end
 
-    it "is exposed as the thumbnail in as_json" do
-      asset_preview = create(:asset_preview_mov)
-      allow(asset_preview).to receive(:video_poster_url).and_return("https://files.example.com/poster.jpg")
-
-      expect(asset_preview.as_json[:thumbnail]).to eq("https://files.example.com/poster.jpg")
+    it "does not enqueue poster generation for image covers" do
+      create(:asset_preview_jpg)
+      expect(GenerateVideoPosterWorker.jobs).to be_empty
     end
   end
 

--- a/spec/models/asset_preview_spec.rb
+++ b/spec/models/asset_preview_spec.rb
@@ -393,6 +393,26 @@ describe AssetPreview, :vcr do
       expect(asset_preview.thumbnail_url).to be_nil
     end
 
+    it "remembers failed generation and does not retry on the next call" do
+      asset_preview = create(:asset_preview_mov)
+      allow(asset_preview.file).to receive(:previewable?).and_return(true)
+      allow(asset_preview.file).to receive(:preview).and_raise(ActiveStorage::UnpreviewableError)
+
+      expect(asset_preview.thumbnail_url).to be_nil
+      expect(asset_preview.file).to have_received(:preview).once
+
+      expect(asset_preview.thumbnail_url).to be_nil
+      expect(asset_preview.file).to have_received(:preview).once
+    end
+
+    it "gives up and returns nil when generation exceeds the processing timeout" do
+      asset_preview = create(:asset_preview_mov)
+      allow(asset_preview.file).to receive(:previewable?).and_return(true)
+      allow(Timeout).to receive(:timeout).with(AssetPreview::IMAGE_PROCESSING_TIMEOUT_SECONDS).and_raise(Timeout::Error)
+
+      expect(asset_preview.thumbnail_url).to be_nil
+    end
+
     it "is exposed as the thumbnail in as_json" do
       asset_preview = create(:asset_preview_mov)
       allow(asset_preview).to receive(:video_poster_url).and_return("https://files.example.com/poster.jpg")

--- a/spec/sidekiq/generate_video_poster_worker_spec.rb
+++ b/spec/sidekiq/generate_video_poster_worker_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe GenerateVideoPosterWorker do
+  describe "#perform" do
+    it "generates the poster frame for the cover" do
+      asset_preview = create(:asset_preview_mov)
+      allow(AssetPreview).to receive(:find_by).with(id: asset_preview.id).and_return(asset_preview)
+      allow(asset_preview).to receive(:generate_video_poster!).and_return("https://files.example.com/poster.jpg")
+
+      described_class.new.perform(asset_preview.id)
+
+      expect(asset_preview).to have_received(:generate_video_poster!)
+    end
+
+    it "invalidates the product cache when a poster was generated" do
+      asset_preview = create(:asset_preview_mov)
+      allow(AssetPreview).to receive(:find_by).with(id: asset_preview.id).and_return(asset_preview)
+      allow(asset_preview).to receive(:generate_video_poster!).and_return("https://files.example.com/poster.jpg")
+      allow(asset_preview.link).to receive(:invalidate_cache)
+
+      described_class.new.perform(asset_preview.id)
+
+      expect(asset_preview.link).to have_received(:invalidate_cache)
+    end
+
+    it "does not invalidate the product cache when generation produced no poster" do
+      asset_preview = create(:asset_preview_mov)
+      allow(AssetPreview).to receive(:find_by).with(id: asset_preview.id).and_return(asset_preview)
+      allow(asset_preview).to receive(:generate_video_poster!).and_return(nil)
+      allow(asset_preview.link).to receive(:invalidate_cache)
+
+      described_class.new.perform(asset_preview.id)
+
+      expect(asset_preview.link).not_to have_received(:invalidate_cache)
+    end
+
+    it "does nothing for a deleted or missing cover" do
+      asset_preview = create(:asset_preview_mov)
+      asset_preview.mark_deleted!
+      allow(AssetPreview).to receive(:find_by).and_call_original
+      allow(AssetPreview).to receive(:find_by).with(id: asset_preview.id).and_return(asset_preview)
+      allow(asset_preview).to receive(:generate_video_poster!)
+
+      expect { described_class.new.perform(asset_preview.id) }.not_to raise_error
+      expect { described_class.new.perform(0) }.not_to raise_error
+      expect(asset_preview).not_to have_received(:generate_video_poster!)
+    end
+  end
+end


### PR DESCRIPTION
Fixes antiwork/gumroad-private#1074

## Problem
Video covers uploaded directly to Gumroad idle as a **solid black rectangle** until the buyer presses play. `Product/Covers/Video.tsx` never set JW Player's `image` (poster) option, and `AssetPreview#as_json` only populated `thumbnail` from oEmbed data — so only YouTube/Vimeo embeds got a preview image. Surfaced by a stock-footage seller support ticket asking why his cover "shows a black frame".

## Fix
- **`GenerateVideoPosterWorker`** (new Sidekiq job, low queue) — does the heavy work: downloads the video, grabs a frame via the stock ActiveStorage/ffmpeg previewer, resizes to retina width, caches the CDN URL. Enqueued automatically when a video cover is created (`after_create_commit`), so the poster is usually ready before anyone views the product. Failure caches a sentinel for an hour so retries don't hammer un-previewable videos, and it busts the product cache once a poster lands so cached pages pick it up.
- **`AssetPreview#thumbnail_url`** — oEmbed thumbnail for embeds (unchanged behaviour); for uploaded videos it only **reads the cache** — no download or ffmpeg ever runs on a web request. A cache miss (covers uploaded before this shipped) returns `nil` and enqueues a generation, so the poster appears on later views.
- **`as_json`** exposes it as `thumbnail` (same field embeds already used — no frontend type change).
- **`Covers/Video.tsx`** passes `cover.thumbnail` as JW Player's `image`, so the frame shows while idle. `null` keeps today's black idle state as the fallback.

## Verification
- 12 model specs covering: oEmbed passthrough, nil for images, cached-poster read path, cache-miss enqueues + returns nil, failure sentinel suppresses re-enqueue, generation success/failure/timeout, enqueue-on-create for videos only, `as_json` exposure — all green
- 4 new worker specs: generates, busts product cache on success, skips cache-bust on failure, no-ops for deleted/missing covers — all green
- Full `asset_preview_spec.rb` green except one pre-existing failure on main (`#url=` square-bracket encoding — verified failing before my change)
- rubocop clean on all touched files; eslint + tsc clean (frontend unchanged since last run)

## Notes for review
- Poster generation needs the ActiveStorage video previewer (ffmpeg) available on **worker** boxes — it's the stock Rails previewer; streams transcoding already depends on ffmpeg infra
- The poster is ffmpeg's auto-chosen frame. Sellers who want a curated poster keep the existing workaround (still image as first cover)
- Existing covers backfill lazily: the first render after deploy enqueues generation, and the poster shows from the next view on. A one-shot backfill job could pre-warm everything if we'd rather not wait
