### PR TITLE
Give products index a replica and raise ES client timeout

### DIFF
--- a/app/modules/product/searchable.rb
+++ b/app/modules/product/searchable.rb
@@ -65,7 +65,10 @@ module Product::Searchable
 
     index_name "products"
 
-    settings number_of_shards: 1, number_of_replicas: 0, analysis: {
+    # One replica so product search can be served by a second node when the node
+    # holding the primary shard is unavailable or paused in garbage collection.
+    # With zero replicas, a single node's GC pause fails every product search.
+    settings number_of_shards: 1, number_of_replicas: 1, analysis: {
       filter: {
         edge_ngram_filter: {
           type: "edge_ngram",

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -3,7 +3,11 @@
 EsClient = Elasticsearch::Model.client = Elasticsearch::Client.new(
   host: ENV.fetch("ELASTICSEARCH_HOST"),
   retry_on_failure: 5,
-  transport_options: { request: { timeout: 5 } },
+  # The Elasticsearch cluster can pause for several seconds during garbage
+  # collection. A 5 second timeout expired inside those pauses, and each retry
+  # hit the same paused cluster and failed again. 15 seconds lets a request
+  # ride out a pause instead of failing.
+  transport_options: { request: { timeout: 15 } },
   log: true
 )
 


### PR DESCRIPTION
## What

Two app-side changes for the production search cluster's GC-pause incident:

- `app/modules/product/searchable.rb`: set `number_of_replicas: 1` on the `products` index settings, so any future index create/reindex from the app keeps the replica instead of silently recreating the index with zero replicas.
- `config/initializers/elasticsearch.rb`: raise the Elasticsearch client's transport timeout from 5s to 15s.

## Why

Refs antiwork/gumroad-private#1059.

The production search domain is heap-bound and hitting 3–7s stop-the-world GC pauses. Because the `products` index runs 1 shard / 0 replicas, a single node's pause fails every product search (`all shards failed` on `products_v3`). The client's 5s timeout expires inside those pauses, and its `retry_on_failure: 5` retries re-hit the same paused cluster and fail again — so raising the timeout is the meaningful app-side lever.

The live index's replica count is changed via the settings API on the domain (after the instance-type bump adds heap headroom — a replica roughly doubles the products data footprint); this change just prevents the app from regressing it on the next reindex. Other searchable concerns (purchases, installments, audience members, balances) are left at 0 replicas deliberately — they weren't implicated and each replica costs heap/disk on a cluster that's already tight.

## Test plan

- `rubocop` clean on both files.
- CI test suite (existing product search specs exercise the index settings via local single-node ES; a 1-replica index on a single node reports yellow but serves reads/writes normally — nothing in the suite waits for green cluster status, verified by grep).
- After deploy + domain-side replica change: `GET products_v3/_settings` shows `number_of_replicas: 1`, and product search stays available through a GC-overhead window.

## Before/After

Not applicable — no user-facing UI change; search infrastructure configuration only.
