### PR TITLE
Raise the statement execution cap when loading email audiences

### DIFF
--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -31,6 +31,7 @@ class RedisKey
     def recommended_products_associated_product_ids_limit = "recommended_products_associated_product_ids_limit"
     def blast_recipients_slice_size = "blast:recipients_slice_size"
     def blast_sent_emails(blast_id) = "blast:#{blast_id}:sent_emails"
+    def audience_member_load_max_execution_time_seconds = "audience_member_load:max_execution_time_seconds"
     def impersonated_user(admin_user_id) = "impersonated_user_by_admin_#{admin_user_id}"
     def gumroad_day_date = "gumroad_day_date"
     def update_cached_srpis_job_delay_hours = "update_cached_srpis_job_delay_hours"

--- a/app/sidekiq/send_post_blast_emails_job.rb
+++ b/app/sidekiq/send_post_blast_emails_job.rb
@@ -16,7 +16,13 @@ class SendPostBlastEmailsJob
     @filters = @post.audience_members_filter_params
     # The filter query can be expensive to run, it's better to run it on the replica DB.
     Makara::Context.release_all
-    @members = AudienceMember.filter(seller_id: @post.seller_id, params: @filters, with_ids: true).select(:id, :email, :purchase_id, :follower_id, :affiliate_id).to_a
+    # For sellers with very large audiences (hundreds of thousands of members) the filter
+    # query can take longer than the database's default 5-minute statement cap, which made
+    # big blasts fail with a StatementTimeout on every attempt and never send anything.
+    # Raise the cap for this one query, the same way the sales report jobs do.
+    @members = WithMaxExecutionTime.timeout_queries(seconds: audience_load_timeout_seconds) do
+      AudienceMember.filter(seller_id: @post.seller_id, params: @filters, with_ids: true).select(:id, :email, :purchase_id, :follower_id, :affiliate_id).to_a
+    end
 
     if @blast.to_non_openers?
       keep_emails = @post.unopened_recipient_emails.to_set
@@ -192,5 +198,10 @@ class SendPostBlastEmailsJob
       @recipients_slice_size ||= begin
         $redis.get(RedisKey.blast_recipients_slice_size) || PostEmailApi.max_recipients
       end.to_i.clamp(1..PostEmailApi.max_recipients)
+    end
+
+    # Tunable via Redis so a stuck blast can be unblocked without a deploy.
+    def audience_load_timeout_seconds
+      ($redis.get(RedisKey.audience_member_load_max_execution_time_seconds) || 1.hour).to_i
     end
 end

--- a/app/sidekiq/send_workflow_post_emails_job.rb
+++ b/app/sidekiq/send_workflow_post_emails_job.rb
@@ -15,8 +15,13 @@ class SendWorkflowPostEmailsJob
     @filters = @post.audience_members_filter_params
     @filters[:created_after] = Time.zone.parse(earliest_valid_time) if earliest_valid_time
     Makara::Context.release_all
-    @members = AudienceMember.filter(seller_id: @post.seller_id, params: @filters, with_ids: true).
-      select(:id, :email, :details, :purchase_id, :follower_id, :affiliate_id).to_a
+    # Same protection as SendPostBlastEmailsJob: for sellers with very large audiences the
+    # filter query can exceed the database's default 5-minute statement cap, so raise it for
+    # this one query.
+    @members = WithMaxExecutionTime.timeout_queries(seconds: audience_load_timeout_seconds) do
+      AudienceMember.filter(seller_id: @post.seller_id, params: @filters, with_ids: true).
+        select(:id, :email, :details, :purchase_id, :follower_id, :affiliate_id).to_a
+    end
 
     @members.each do |member|
       if @post.seller_or_product_or_variant_type?
@@ -49,5 +54,10 @@ class SendWorkflowPostEmailsJob
         created_at = Time.zone.parse(member.details["affiliates"].find { _1["id"] == id }["created_at"])
         SendWorkflowInstallmentWorker.perform_at(created_at + @rule_delay, @post.id, @rule_version, nil, nil, id)
       end
+    end
+
+    # Tunable via Redis so a stuck job can be unblocked without a deploy.
+    def audience_load_timeout_seconds
+      ($redis.get(RedisKey.audience_member_load_max_execution_time_seconds) || 1.hour).to_i
     end
 end

--- a/spec/sidekiq/send_post_blast_emails_job_spec.rb
+++ b/spec/sidekiq/send_post_blast_emails_job_spec.rb
@@ -372,6 +372,30 @@ describe SendPostBlastEmailsJob, :freeze_time do
     end
   end
 
+  describe "audience load statement timeout" do
+    it "loads the audience with a raised statement execution cap of one hour by default" do
+      blast = create(:blast, :just_requested, post: basic_post_with_audience)
+
+      expect(WithMaxExecutionTime).to receive(:timeout_queries).with(seconds: 1.hour.to_i).and_call_original
+      described_class.new.perform(blast.id)
+
+      expect_sent_count 1
+      expect(blast.reload.completed_at).to be_present
+    end
+
+    it "honors the Redis override for the statement execution cap" do
+      $redis.set(RedisKey.audience_member_load_max_execution_time_seconds, 2.hours.to_i)
+      blast = create(:blast, :just_requested, post: basic_post_with_audience)
+
+      expect(WithMaxExecutionTime).to receive(:timeout_queries).with(seconds: 2.hours.to_i).and_call_original
+      described_class.new.perform(blast.id)
+
+      expect_sent_count 1
+    ensure
+      $redis.del(RedisKey.audience_member_load_max_execution_time_seconds)
+    end
+  end
+
   describe "error handling" do
     it "deletes sent_post_emails records if PostEmailApi.process raises an error" do
       # Setup post and blast

--- a/spec/sidekiq/send_workflow_post_emails_job_spec.rb
+++ b/spec/sidekiq/send_workflow_post_emails_job_spec.rb
@@ -152,6 +152,13 @@ describe SendWorkflowPostEmailsJob, :freeze_time do
         expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(@post.id, @post_rule.version, @sales[4].id, nil, nil).immediately
         expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(@post.id, @post_rule.version, @sales[5].id, nil, nil).at(18.hours.from_now)
       end
+
+      it "loads the audience with a raised statement execution cap" do
+        expect(WithMaxExecutionTime).to receive(:timeout_queries).with(seconds: 1.hour.to_i).and_call_original
+        described_class.new.perform(@post.id)
+
+        expect(SendWorkflowInstallmentWorker.jobs.size).to eq(7)
+      end
     end
   end
 end


### PR DESCRIPTION
## What

Wraps the audience-member load in `SendPostBlastEmailsJob` and `SendWorkflowPostEmailsJob` in `WithMaxExecutionTime.timeout_queries` with a 1-hour cap, tunable via Redis (`audience_member_load:max_execution_time_seconds`) without a deploy.

## Why

A blast to a ~350k-recipient audience was stuck at zero sends while smaller blasts completed normally (antiwork/gumroad-private#1076). Production logs show every attempt failing the same way:

```
16:43:24 elapsed=300.119 INFO: fail
16:43:24 WARN: ActiveRecord::StatementTimeout: Mysql2::Error: Query execution was interrupted, maximum statement execution time exceeded
16:43:24 app/sidekiq/send_post_blast_emails_job.rb:19:in 'SendPostBlastEmailsJob#perform'
```

The `AudienceMember.filter(..., with_ids: true)` query for a very large audience runs longer than the database's default 5-minute `max_execution_time` (set globally in `config/database.yml`). Because the failure happens while loading recipients — before any `SentPostEmail` rows are written or any email is sent — each of the job's 10 retries dies at exactly 300 seconds at line 19, and the blast never makes progress. Sidekiq's start/fail log pairs for the affected blast show retries at 16:38, 16:43, 16:48, 16:54, 17:01, 17:11, 17:23 UTC, each one ~300s of query followed by the same StatementTimeout.

The `with_ids: true` path forces the JSON_TABLE join plus a `GROUP BY` over every audience row, which is much heavier than the count query the composer UI runs — the Elasticsearch migration that fixed slow audience counts (antiwork/gumroad#5361) did not change this send path, which still runs the SQL filter.

The sales report jobs already handle the same problem by raising the cap around their long queries via `WithMaxExecutionTime` with a Redis-tunable timeout; this applies the identical pattern to the two audience-loading jobs. `SendWorkflowPostEmailsJob` shares the same filter query and would fail identically for large audiences.

If the raised cap is still exceeded, `WithMaxExecutionTime` re-raises as `QueryTimeoutError`, so the job still retries and the existing failure visibility is unchanged.

## Test plan

- New specs assert both jobs load the audience under the raised cap (1 hour default) and that the Redis override is honored; the blast job specs verify emails still send and the blast completes.
- `bundle exec rspec spec/sidekiq/send_post_blast_emails_job_spec.rb` — 24 examples, 0 failures (locally).
- `bundle exec rspec spec/sidekiq/send_workflow_post_emails_job_spec.rb` — 11 examples, 0 failures (locally).
- After deploy: the stuck blast's next retry should get past the member load; watch `SentPostEmail` rows for the affected post start accumulating and the blast reach `completed_at`. `SentPostEmail` dedupe makes the retry safe against double-sends.

Refs antiwork/gumroad-private#1076
