### PR TITLE
Stop EasyPost slowness from freezing physical-product checkout for 30+ seconds

### DIFF
--- a/app/controllers/shipments_controller.rb
+++ b/app/controllers/shipments_controller.rb
@@ -13,8 +13,20 @@ class ShipmentsController < ApplicationController
     "country" => "country"
   }.freeze
 
+  # How long we're willing to wait for EasyPost when verifying a buyer's shipping address.
+  # The gem's defaults are 30 seconds to connect and 60 seconds to read — when EasyPost is
+  # slow or unreachable, the buyer sits on a frozen "Processing..." checkout for that whole
+  # time before we fail open. Address verification is a nice-to-have (we already accept the
+  # address as entered when EasyPost errors), so give it a few seconds and then move on.
+  EASYPOST_OPEN_TIMEOUT_SECONDS = 5
+  EASYPOST_READ_TIMEOUT_SECONDS = 10
+
   def verify_shipping_address
-    easy_post = EasyPost::Client.new(api_key: GlobalConfig.get("EASYPOST_API_KEY"))
+    easy_post = EasyPost::Client.new(
+      api_key: GlobalConfig.get("EASYPOST_API_KEY"),
+      open_timeout: EASYPOST_OPEN_TIMEOUT_SECONDS,
+      read_timeout: EASYPOST_READ_TIMEOUT_SECONDS
+    )
     address = easy_post.address.create(
       verify: ["delivery"],
       street1: params.require(:street_address),

--- a/spec/controllers/shipments_controller_spec.rb
+++ b/spec/controllers/shipments_controller_spec.rb
@@ -167,6 +167,35 @@ describe ShipmentsController, :vcr  do
         expect(response.parsed_body["success"]).to be(false)
         expect(response.parsed_body["error_message"]).to eq "We are unable to verify your shipping address. Is your address correct?"
       end
+
+      it "accepts the buyer's address as entered when the request to EasyPost times out" do
+        expect_any_instance_of(EasyPost::Services::Address).to receive(:create)
+          .and_raise(EasyPost::Errors::TimeoutError.new("Net::ReadTimeout"))
+        expect(ErrorNotifier).to receive(:notify).with(
+          an_instance_of(EasyPost::Errors::TimeoutError),
+          context: { action: "verify_shipping_address" }
+        )
+
+        post :verify_shipping_address, params: @params
+
+        expect(response.parsed_body["success"]).to be(true)
+        expect(response.parsed_body["street_address"]).to eq "1640 17th St"
+      end
+
+      it "gives EasyPost a short connect and read deadline instead of the gem's defaults" do
+        expect(EasyPost::Client).to receive(:new).with(
+          api_key: anything,
+          open_timeout: ShipmentsController::EASYPOST_OPEN_TIMEOUT_SECONDS,
+          read_timeout: ShipmentsController::EASYPOST_READ_TIMEOUT_SECONDS
+        ).and_call_original
+        expect_any_instance_of(EasyPost::Services::Address).to receive(:create)
+          .and_raise(EasyPost::Errors::TimeoutError.new("Net::OpenTimeout"))
+        allow(ErrorNotifier).to receive(:notify)
+
+        post :verify_shipping_address, params: @params
+
+        expect(response.parsed_body["success"]).to be(true)
+      end
     end
   end
 


### PR DESCRIPTION
## What

Caps how long checkout waits on EasyPost when verifying a buyer's shipping address. The EasyPost client now uses a 5-second connect / 10-second read deadline instead of the gem's defaults (30s connect / 60s read). Adds specs for the timeout fail-open path and the client configuration.

## Why

CI has been failing repo-wide since 18:38 UTC today — every `Tests` run on main and on every PR branch fails the same three shipping-address system specs (`taxes_spec.rb:140`, `non_tiered_membership_spec.rb:418`, `tiered_membership_fixed_length_spec.rb:33`), while the last green main run was 18:08 UTC ([failing main runs: 29275529239, 29275925423, 29283468058, 29284309141](https://github.com/antiwork/gumroad/actions/runs/29283468058)).

The test logs show the mechanism: `POST /shipments/verify_shipping_address` completes in **30,007 ms** — exactly the EasyPost gem's default 30-second connect timeout. The specs hit real EasyPost (no VCR cassette for that call), EasyPost has been slow/unreachable from CI since this afternoon, and the buyer-side "Processing..." state outlasts the specs' wait windows, so they fail deterministically. The failure screenshot shows checkout frozen at "Processing..." mid-purchase.

This is also a production-facing problem, not just a CI one: any EasyPost slowness makes every physical-product checkout hang for up to 30–90 seconds before the existing fail-open path (rescue `EasyPost::Errors::EasyPostError` → accept the address as entered) takes over. The gem wraps `Net::OpenTimeout`/`Net::ReadTimeout` in `EasyPost::Errors::TimeoutError`, so the shorter deadlines flow into the fail-open branch that already exists — verification degrades gracefully in seconds instead of appearing broken for half a minute.

## Test plan

- `spec/controllers/shipments_controller_spec.rb`: 20 examples, 0 failures locally, including two new ones — the timeout fail-open (accepts the address, notifies) and the client deadline configuration.
- CI: the three failing shipping specs should recover on this branch once EasyPost either responds within 15s or times out fast enough for the fail-open dialog flow the specs already handle (`confirm_shipping_address_if_prompted`).
- After deploy: `verify_shipping_address` p99 latency should cap near 15s, and `ErrorNotifier` will report `EasyPost::Errors::TimeoutError` whenever EasyPost is degraded.

Not a UI change — no pixels rendered differently; the fix only shortens a network deadline.
