### PR TITLE
Snapshot blast audiences in Redis so retries resume instead of reloading

### DIFF
--- a/app/models/audience_member.rb
+++ b/app/models/audience_member.rb
@@ -35,15 +35,24 @@ class AudienceMember < ApplicationRecord
     params
   end
 
-  def self.filter(seller_id:, params: {}, with_ids: false)
+  # Filters a seller's audience by the given params (see FILTER_PARAM_KEYS).
+  #
+  # ids: optionally restricts the filter to a known set of audience_members ids. Every
+  # subquery the filter builds becomes primary-key-bound, so re-checking a previously
+  # resolved member list against the CURRENT filter criteria is cheap even when running
+  # the unrestricted filter over the whole audience would be slow. Used by blast retries
+  # to revalidate their snapshotted recipient lists.
+  def self.filter(seller_id:, params: {}, with_ids: false, ids: nil)
     params = normalize_filter_params(params)
+    base_scope = where(seller_id:)
+    base_scope = base_scope.where(id: ids) if ids
 
     if params[:type]
-      types_sql = where(:seller_id => seller_id, params[:type] => true).to_sql
+      types_sql = base_scope.where(params[:type] => true).to_sql
     end
 
     if params[:bought_product_ids]
-      products_relation = where(seller_id:)
+      products_relation = base_scope
       json_contains = "JSON_CONTAINS(details->'$.purchases[*].product_id', ?)"
       products_where_sql = ([json_contains] * params[:bought_product_ids].size).join(" OR ")
       products_relation = products_relation.where(products_where_sql, *params[:bought_product_ids])
@@ -51,7 +60,7 @@ class AudienceMember < ApplicationRecord
     end
 
     if params[:bought_variant_ids]
-      variants_relation = where(seller_id:)
+      variants_relation = base_scope
       json_contains = "JSON_CONTAINS(details->'$.purchases[*].variant_ids[*]', ?)"
       variants_where_sql = ([json_contains] * params[:bought_variant_ids].size).join(" OR ")
       variants_relation = variants_relation.where(variants_where_sql, *params[:bought_variant_ids])
@@ -61,7 +70,7 @@ class AudienceMember < ApplicationRecord
     bought_products_union_variants_sql = [products_sql, variants_sql].compact.join(" UNION ").presence
 
     if params[:not_bought_product_ids]
-      products_relation = where(seller_id:)
+      products_relation = base_scope
       json_contains = "JSON_CONTAINS(details->'$.purchases[*].product_id', ?)"
       products_where_sql = (["(#{json_contains} IS NULL OR #{json_contains} = 0)"] * params[:not_bought_product_ids].size).join(" AND ")
       products_relation = products_relation.where(products_where_sql, *(params[:not_bought_product_ids].zip(params[:not_bought_product_ids]).flatten))
@@ -69,7 +78,7 @@ class AudienceMember < ApplicationRecord
     end
 
     if params[:not_bought_variant_ids]
-      variants_relation = where(seller_id:)
+      variants_relation = base_scope
       json_contains = "JSON_CONTAINS(details->'$.purchases[*].variant_ids[*]', ?)"
       variants_where_sql = (["(#{json_contains} IS NULL OR #{json_contains} = 0)"] * params[:not_bought_variant_ids].size).join(" AND ")
       variants_relation = variants_relation.where(variants_where_sql, *(params[:not_bought_variant_ids].zip(params[:not_bought_variant_ids]).flatten))
@@ -77,14 +86,14 @@ class AudienceMember < ApplicationRecord
     end
 
     if params[:paid_more_than_cents] || params[:paid_less_than_cents]
-      prices_relation = where(seller_id:)
+      prices_relation = base_scope
       prices_relation = prices_relation.where("max_paid_cents > ?", params[:paid_more_than_cents]) if params[:paid_more_than_cents]
       prices_relation = prices_relation.where("min_paid_cents < ?", params[:paid_less_than_cents]) if params[:paid_less_than_cents]
       prices_sql = prices_relation.to_sql
     end
 
     if params[:created_after] || params[:created_before]
-      created_at_relation = where(seller_id:)
+      created_at_relation = base_scope
       min_created_at_column, max_created_at_column = \
         case params[:type]
         when "customer" then [:min_purchase_created_at, :max_purchase_created_at]
@@ -98,12 +107,12 @@ class AudienceMember < ApplicationRecord
     end
 
     if params[:bought_from]
-      country_relation = where(seller_id:).where("JSON_CONTAINS(details->'$.purchases[*].country', ?)", %("#{params[:bought_from]}"))
+      country_relation = base_scope.where("JSON_CONTAINS(details->'$.purchases[*].country', ?)", %("#{params[:bought_from]}"))
       country_sql = country_relation.to_sql
     end
 
     if params[:affiliate_product_ids]
-      affiliates_relation = where(seller_id:)
+      affiliates_relation = base_scope
       json_contains = "JSON_CONTAINS(details->'$.affiliates[*].product_id', ?)"
       affiliates_where_sql = ([json_contains] * params[:affiliate_product_ids].size).join(" OR ")
       affiliates_relation = affiliates_relation.where(affiliates_where_sql, *params[:affiliate_product_ids])
@@ -126,7 +135,7 @@ class AudienceMember < ApplicationRecord
     filter_purchases_when ||= (params[:created_after] && params[:created_before])
     filter_purchases_when ||= params[:active_customers_only] || params[:minimum_license_uses]
     if filter_purchases_when || with_ids
-      json_filter = where(seller_id:)
+      json_filter = base_scope
       json_table = <<~SQL.squish
         JSON_TABLE(details, '$' COLUMNS (
           NESTED PATH '$.follower' COLUMNS (
@@ -222,7 +231,7 @@ class AudienceMember < ApplicationRecord
       affiliates_sql,
       json_filter_sql,
     ].compact
-    return where(seller_id:) if subqueries.empty?
+    return base_scope if subqueries.empty?
 
 
     relation = from("(#{subqueries.first}) AS audience_members")

--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -31,7 +31,7 @@ class RedisKey
     def recommended_products_associated_product_ids_limit = "recommended_products_associated_product_ids_limit"
     def blast_recipients_slice_size = "blast:recipients_slice_size"
     def blast_sent_emails(blast_id) = "blast:#{blast_id}:sent_emails"
-    def blast_audience_member_ids(blast_id) = "blast:#{blast_id}:audience_member_ids"
+    def blast_audience_snapshot(blast_id) = "blast:#{blast_id}:audience_snapshot"
     def audience_member_load_max_execution_time_seconds = "audience_member_load:max_execution_time_seconds"
     def impersonated_user(admin_user_id) = "impersonated_user_by_admin_#{admin_user_id}"
     def gumroad_day_date = "gumroad_day_date"

--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -31,6 +31,7 @@ class RedisKey
     def recommended_products_associated_product_ids_limit = "recommended_products_associated_product_ids_limit"
     def blast_recipients_slice_size = "blast:recipients_slice_size"
     def blast_sent_emails(blast_id) = "blast:#{blast_id}:sent_emails"
+    def blast_audience_member_ids(blast_id) = "blast:#{blast_id}:audience_member_ids"
     def audience_member_load_max_execution_time_seconds = "audience_member_load:max_execution_time_seconds"
     def impersonated_user(admin_user_id) = "impersonated_user_by_admin_#{admin_user_id}"
     def gumroad_day_date = "gumroad_day_date"

--- a/app/sidekiq/send_post_blast_emails_job.rb
+++ b/app/sidekiq/send_post_blast_emails_job.rb
@@ -16,13 +16,7 @@ class SendPostBlastEmailsJob
     @filters = @post.audience_members_filter_params
     # The filter query can be expensive to run, it's better to run it on the replica DB.
     Makara::Context.release_all
-    # For sellers with very large audiences (hundreds of thousands of members) the filter
-    # query can take longer than the database's default 5-minute statement cap, which made
-    # big blasts fail with a StatementTimeout on every attempt and never send anything.
-    # Raise the cap for this one query, the same way the sales report jobs do.
-    @members = WithMaxExecutionTime.timeout_queries(seconds: audience_load_timeout_seconds) do
-      AudienceMember.filter(seller_id: @post.seller_id, params: @filters, with_ids: true).select(:id, :email, :purchase_id, :follower_id, :affiliate_id).to_a
-    end
+    @members = load_audience_members
 
     if @blast.to_non_openers?
       keep_emails = @post.unopened_recipient_emails.to_set
@@ -60,6 +54,58 @@ class SendPostBlastEmailsJob
   end
 
   private
+    # How long the audience snapshot survives in Redis. Long enough to cover the full
+    # Sidekiq retry schedule of this job (10 retries spans roughly a day), short enough
+    # that an abandoned blast doesn't hold hundreds of thousands of entries forever.
+    AUDIENCE_SNAPSHOT_TTL = 3.days
+
+    # A snapshotted recipient. Quacks like the AudienceMember rows the filter query
+    # returns (the send loop only uses these five attributes). purchase_id / follower_id /
+    # affiliate_id are DERIVED by the filter's JSON_TABLE subquery — they are not columns
+    # on audience_members — which is why the snapshot must store full tuples instead of
+    # bare ids.
+    SnapshotMember = Struct.new(:id, :email, :purchase_id, :follower_id, :affiliate_id)
+
+    # Loads the recipient list for the blast. For sellers with very large audiences
+    # (hundreds of thousands of members) the filter query is the slowest, most fragile
+    # part of the job: it can exceed the database's default 5-minute statement cap, and a
+    # deploy or worker restart mid-run loses all its progress. Two protections here:
+    #
+    # 1. The query runs under a raised statement-time cap (Redis-tunable), the same way
+    #    the sales report jobs handle long queries.
+    # 2. The resolved members are snapshotted in Redis keyed by blast id. When a retry of
+    #    the SAME blast runs after a mid-run kill (deploys will only get more frequent),
+    #    it skips the expensive filter entirely and rehydrates from the snapshot, so each
+    #    retry resumes sending within seconds instead of repaying the minutes-long load
+    #    and re-racing the next deploy.
+    #
+    # Rehydrated members are re-checked against audience_members, so anyone who left the
+    # audience after the snapshot was taken (unsubscribed, erased) is dropped from the
+    # retry rather than emailed from stale data. Members ADDED after the first attempt
+    # won't be picked up by a retry — acceptable for a send already mid-flight.
+    def load_audience_members
+      snapshot_key = RedisKey.blast_audience_member_ids(@blast.id)
+      snapshot = $redis.lrange(snapshot_key, 0, -1)
+
+      if snapshot.empty?
+        members = WithMaxExecutionTime.timeout_queries(seconds: audience_load_timeout_seconds) do
+          AudienceMember.filter(seller_id: @post.seller_id, params: @filters, with_ids: true).select(:id, :email, :purchase_id, :follower_id, :affiliate_id).to_a
+        end
+        if members.any?
+          members.each_slice(10_000) do |slice|
+            $redis.rpush(snapshot_key, slice.map { |m| [m.id, m.email, m.purchase_id, m.follower_id, m.affiliate_id].to_json })
+          end
+          $redis.expire(snapshot_key, AUDIENCE_SNAPSHOT_TTL.to_i)
+        end
+        members
+      else
+        Rails.logger.info("[#{self.class.name}] blast_id=#{@blast.id} resuming from audience snapshot (#{snapshot.size} members)")
+        members = snapshot.map { SnapshotMember.new(*JSON.parse(_1)) }
+        still_present = AudienceMember.where(id: members.map(&:id)).pluck(:id).to_set
+        members.select { still_present.include?(_1.id) }
+      end
+    end
+
     def prepare_recipients(members)
       members_with_specifics = members.index_with { { email: _1.email } }
       enrich_with_gathered_records(members_with_specifics)
@@ -170,6 +216,8 @@ class SendPostBlastEmailsJob
 
     def mark_blast_as_completed
       @blast.update!(completed_at: Time.current)
+      # The blast is done, so the retry-resume snapshot has served its purpose.
+      $redis.del(RedisKey.blast_audience_member_ids(@blast.id))
     end
 
     # Stores email addresses in SentPostEmail, just before sending the emails.

--- a/app/sidekiq/send_post_blast_emails_job.rb
+++ b/app/sidekiq/send_post_blast_emails_job.rb
@@ -79,31 +79,53 @@ class SendPostBlastEmailsJob
     #    retry resumes sending within seconds instead of repaying the minutes-long load
     #    and re-racing the next deploy.
     #
-    # Rehydrated members are re-checked against audience_members, so anyone who left the
-    # audience after the snapshot was taken (unsubscribed, erased) is dropped from the
-    # retry rather than emailed from stale data. Members ADDED after the first attempt
-    # won't be picked up by a retry — acceptable for a send already mid-flight.
+    # Rehydrated members are re-verified against audience_members before sending: the row
+    # must still exist AND (when the blast targets a specific role) still hold that role.
+    # The role check matters because a person with multiple relationships to the seller
+    # (e.g. a customer who also follows) KEEPS their audience_members row when they
+    # unsubscribe from just one role — the row's `customer`/`follower`/`affiliate` boolean
+    # flips instead. Checking existence alone would let a retry email someone who opted
+    # out between attempts. Members ADDED after the first attempt won't be picked up by a
+    # retry — acceptable for a send already mid-flight.
     def load_audience_members
-      snapshot_key = RedisKey.blast_audience_member_ids(@blast.id)
+      snapshot_key = RedisKey.blast_audience_snapshot(@blast.id)
       snapshot = $redis.lrange(snapshot_key, 0, -1)
 
       if snapshot.empty?
         members = WithMaxExecutionTime.timeout_queries(seconds: audience_load_timeout_seconds) do
           AudienceMember.filter(seller_id: @post.seller_id, params: @filters, with_ids: true).select(:id, :email, :purchase_id, :follower_id, :affiliate_id).to_a
         end
-        if members.any?
-          members.each_slice(10_000) do |slice|
-            $redis.rpush(snapshot_key, slice.map { |m| [m.id, m.email, m.purchase_id, m.follower_id, m.affiliate_id].to_json })
-          end
-          $redis.expire(snapshot_key, AUDIENCE_SNAPSHOT_TTL.to_i)
-        end
+        write_audience_snapshot(snapshot_key, members)
         members
       else
         Rails.logger.info("[#{self.class.name}] blast_id=#{@blast.id} resuming from audience snapshot (#{snapshot.size} members)")
         members = snapshot.map { SnapshotMember.new(*JSON.parse(_1)) }
-        still_present = AudienceMember.where(id: members.map(&:id)).pluck(:id).to_set
-        members.select { still_present.include?(_1.id) }
+        still_eligible_ids = members.map(&:id).each_slice(10_000).flat_map do |ids_slice|
+          scope = AudienceMember.where(id: ids_slice)
+          # `customer`/`follower`/`affiliate` are real, indexed boolean columns.
+          scope = scope.where(@filters[:type] => true) if @filters[:type]
+          scope.pluck(:id)
+        end.to_set
+        members.select { still_eligible_ids.include?(_1.id) }
       end
+    end
+
+    # Writes the snapshot to a temporary key first, then atomically renames it into
+    # place. The retry path treats ANY non-empty list at the real key as the complete
+    # audience, so a worker killed partway through the slice-by-slice write must never
+    # leave a partial list there — that would make a retry send to a fraction of the
+    # audience and mark the blast completed. With the rename, the real key either
+    # doesn't exist (retry re-runs the filter) or is complete with its TTL already set.
+    def write_audience_snapshot(snapshot_key, members)
+      return if members.empty?
+
+      tmp_key = "#{snapshot_key}:tmp"
+      $redis.del(tmp_key)
+      members.each_slice(10_000) do |slice|
+        $redis.rpush(tmp_key, slice.map { |m| [m.id, m.email, m.purchase_id, m.follower_id, m.affiliate_id].to_json })
+      end
+      $redis.expire(tmp_key, AUDIENCE_SNAPSHOT_TTL.to_i)
+      $redis.rename(tmp_key, snapshot_key)
     end
 
     def prepare_recipients(members)
@@ -216,8 +238,11 @@ class SendPostBlastEmailsJob
 
     def mark_blast_as_completed
       @blast.update!(completed_at: Time.current)
-      # The blast is done, so the retry-resume snapshot has served its purpose.
-      $redis.del(RedisKey.blast_audience_member_ids(@blast.id))
+      # The blast is done, so the retry-resume snapshot has served its purpose. Also
+      # remove the temporary write-in-progress key in case a previous attempt died
+      # mid-write (it carries a TTL, but no reason to keep it around).
+      snapshot_key = RedisKey.blast_audience_snapshot(@blast.id)
+      $redis.del(snapshot_key, "#{snapshot_key}:tmp")
     end
 
     # Stores email addresses in SentPostEmail, just before sending the emails.

--- a/app/sidekiq/send_post_blast_emails_job.rb
+++ b/app/sidekiq/send_post_blast_emails_job.rb
@@ -59,13 +59,6 @@ class SendPostBlastEmailsJob
     # that an abandoned blast doesn't hold hundreds of thousands of entries forever.
     AUDIENCE_SNAPSHOT_TTL = 3.days
 
-    # A snapshotted recipient. Quacks like the AudienceMember rows the filter query
-    # returns (the send loop only uses these five attributes). purchase_id / follower_id /
-    # affiliate_id are DERIVED by the filter's JSON_TABLE subquery — they are not columns
-    # on audience_members — which is why the snapshot must store full tuples instead of
-    # bare ids.
-    SnapshotMember = Struct.new(:id, :email, :purchase_id, :follower_id, :affiliate_id)
-
     # Loads the recipient list for the blast. For sellers with very large audiences
     # (hundreds of thousands of members) the filter query is the slowest, most fragile
     # part of the job: it can exceed the database's default 5-minute statement cap, and a
@@ -73,41 +66,58 @@ class SendPostBlastEmailsJob
     #
     # 1. The query runs under a raised statement-time cap (Redis-tunable), the same way
     #    the sales report jobs handle long queries.
-    # 2. The resolved members are snapshotted in Redis keyed by blast id. When a retry of
-    #    the SAME blast runs after a mid-run kill (deploys will only get more frequent),
-    #    it skips the expensive filter entirely and rehydrates from the snapshot, so each
-    #    retry resumes sending within seconds instead of repaying the minutes-long load
-    #    and re-racing the next deploy.
+    # 2. The resolved member ids are snapshotted in Redis keyed by blast id. When a retry
+    #    of the SAME blast runs after a mid-run kill (deploys will only get more
+    #    frequent), it re-runs the filter restricted to just those ids — cheap,
+    #    primary-key-bound — instead of the unrestricted filter over the whole audience,
+    #    so each retry resumes sending within seconds instead of repaying the
+    #    minutes-long load and re-racing the next deploy.
     #
-    # Rehydrated members are re-verified against audience_members before sending: the row
-    # must still exist AND (when the blast targets a specific role) still hold that role.
-    # The role check matters because a person with multiple relationships to the seller
-    # (e.g. a customer who also follows) KEEPS their audience_members row when they
-    # unsubscribe from just one role — the row's `customer`/`follower`/`affiliate` boolean
-    # flips instead. Checking existence alone would let a retry email someone who opted
-    # out between attempts. Members ADDED after the first attempt won't be picked up by a
-    # retry — acceptable for a send already mid-flight.
+    # Because the retry re-applies the ORIGINAL filter criteria to the snapshotted ids,
+    # anyone whose eligibility changed after the snapshot was taken (unsubscribed,
+    # erased, refunded the qualifying purchase, removed as an affiliate) is dropped from
+    # the retry rather than emailed from stale data. Members ADDED after the first
+    # attempt won't be picked up by a retry — acceptable for a send already mid-flight.
     def load_audience_members
       snapshot_key = RedisKey.blast_audience_snapshot(@blast.id)
-      snapshot = $redis.lrange(snapshot_key, 0, -1)
+      snapshotted_ids = $redis.lrange(snapshot_key, 0, -1)
 
-      if snapshot.empty?
+      if snapshotted_ids.empty?
         members = WithMaxExecutionTime.timeout_queries(seconds: audience_load_timeout_seconds) do
           AudienceMember.filter(seller_id: @post.seller_id, params: @filters, with_ids: true).select(:id, :email, :purchase_id, :follower_id, :affiliate_id).to_a
         end
         write_audience_snapshot(snapshot_key, members)
         members
       else
-        Rails.logger.info("[#{self.class.name}] blast_id=#{@blast.id} resuming from audience snapshot (#{snapshot.size} members)")
-        members = snapshot.map { SnapshotMember.new(*JSON.parse(_1)) }
-        still_eligible_ids = members.map(&:id).each_slice(10_000).flat_map do |ids_slice|
-          scope = AudienceMember.where(id: ids_slice)
-          # `customer`/`follower`/`affiliate` are real, indexed boolean columns.
-          scope = scope.where(@filters[:type] => true) if @filters[:type]
-          scope.pluck(:id)
-        end.to_set
-        members.select { still_eligible_ids.include?(_1.id) }
+        Rails.logger.info("[#{self.class.name}] blast_id=#{@blast.id} resuming from audience snapshot (#{snapshotted_ids.size} members)")
+        revalidate_snapshotted_members(snapshotted_ids.map(&:to_i))
       end
+    end
+
+    # A snapshot can be up to a day old by the time the last retry runs, and audience
+    # membership changes in that window: buyers refund, followers unsubscribe, affiliates
+    # get removed. Simply checking that the audience_members row still exists is not
+    # enough — a person with multiple relationships to the seller (e.g. a customer who
+    # also follows) KEEPS their row when they leave just one role, so a follower who
+    # unsubscribed (but also bought something) would still be emailed by a follower
+    # blast from the stale snapshot.
+    #
+    # So the retry re-runs the SAME audience filter the first attempt used, restricted
+    # to the snapshotted ids. Primary-key-bounding every subquery (the `ids:` option)
+    # makes this cheap even for huge audiences — unlike the unrestricted filter the
+    # snapshot exists to avoid — while re-checking every original criterion (role,
+    # bought products, price/date bounds). The filter also returns FRESH rows, so the
+    # send uses current emails and current purchase/follower/affiliate ids rather than
+    # anything stale from the first attempt.
+    def revalidate_snapshotted_members(snapshotted_ids)
+      members = snapshotted_ids.each_slice(10_000).flat_map do |ids_slice|
+        AudienceMember.filter(seller_id: @post.seller_id, params: @filters, with_ids: true, ids: ids_slice)
+          .select(:id, :email, :purchase_id, :follower_id, :affiliate_id).to_a
+      end
+
+      dropped = snapshotted_ids.size - members.size
+      Rails.logger.info("[#{self.class.name}] blast_id=#{@blast.id} dropped #{dropped} snapshotted members no longer in the audience") if dropped > 0
+      members
     end
 
     # Writes the snapshot to a temporary key first, then atomically renames it into
@@ -122,7 +132,7 @@ class SendPostBlastEmailsJob
       tmp_key = "#{snapshot_key}:tmp"
       $redis.del(tmp_key)
       members.each_slice(10_000) do |slice|
-        $redis.rpush(tmp_key, slice.map { |m| [m.id, m.email, m.purchase_id, m.follower_id, m.affiliate_id].to_json })
+        $redis.rpush(tmp_key, slice.map(&:id))
       end
       $redis.expire(tmp_key, AUDIENCE_SNAPSHOT_TTL.to_i)
       $redis.rename(tmp_key, snapshot_key)

--- a/spec/sidekiq/send_post_blast_emails_job_spec.rb
+++ b/spec/sidekiq/send_post_blast_emails_job_spec.rb
@@ -397,11 +397,7 @@ describe SendPostBlastEmailsJob, :freeze_time do
   end
 
   describe "audience snapshot for retry resume" do
-    def snapshot_entry(member)
-      [member.id, member.email, member.purchase_id, member.follower_id, member.affiliate_id].to_json
-    end
-
-    it "snapshots the audience members in Redis and clears the snapshot on completion" do
+    it "snapshots the audience member ids in Redis and clears the snapshot on completion" do
       post = basic_post_with_audience
       blast = create(:blast, :just_requested, post:)
       snapshot_key = RedisKey.blast_audience_snapshot(blast.id)
@@ -414,19 +410,21 @@ describe SendPostBlastEmailsJob, :freeze_time do
       described_class.new.perform(blast.id)
 
       expected_ids = AudienceMember.where(seller_id: post.seller_id).pluck(:id)
-      expect(snapshot_during_run.map { JSON.parse(_1).first }).to match_array(expected_ids)
+      expect(snapshot_during_run.map(&:to_i)).to match_array(expected_ids)
       expect($redis.exists?(snapshot_key)).to eq(false)
       expect(blast.reload.completed_at).to be_present
     end
 
-    it "resumes from the snapshot on retry without re-running the audience filter" do
+    it "resumes from the snapshot on retry using only an id-restricted filter" do
       post = basic_post_with_audience
       blast = create(:blast, :just_requested, post:)
       snapshot_key = RedisKey.blast_audience_snapshot(blast.id)
-      members = AudienceMember.filter(seller_id: post.seller_id, params: post.audience_members_filter_params, with_ids: true).select(:id, :email, :purchase_id, :follower_id, :affiliate_id).to_a
-      $redis.rpush(snapshot_key, members.map { snapshot_entry(_1) })
+      snapshotted_ids = AudienceMember.where(seller_id: post.seller_id).pluck(:id)
+      $redis.rpush(snapshot_key, snapshotted_ids)
 
-      expect(AudienceMember).not_to receive(:filter)
+      # The retry must never run the unrestricted filter (that's the expensive query the
+      # snapshot exists to avoid) — every call must be bounded to the snapshotted ids.
+      expect(AudienceMember).to receive(:filter).with(hash_including(ids: snapshotted_ids)).and_call_original
       described_class.new.perform(blast.id)
 
       expect_sent_count 1
@@ -440,14 +438,13 @@ describe SendPostBlastEmailsJob, :freeze_time do
       post = basic_post_with_audience
       blast = create(:blast, :just_requested, post:)
       snapshot_key = RedisKey.blast_audience_snapshot(blast.id)
-      members = AudienceMember.filter(seller_id: post.seller_id, params: post.audience_members_filter_params, with_ids: true).select(:id, :email, :purchase_id, :follower_id, :affiliate_id).to_a
-      departed = SendPostBlastEmailsJob::SnapshotMember.new(members.map(&:id).max + 1_000, "departed@example.com", nil, nil, nil)
-      $redis.rpush(snapshot_key, (members + [departed]).map { snapshot_entry(_1) })
+      snapshotted_ids = AudienceMember.where(seller_id: post.seller_id).pluck(:id)
+      departed_id = snapshotted_ids.max + 1_000
+      $redis.rpush(snapshot_key, snapshotted_ids + [departed_id])
 
       described_class.new.perform(blast.id)
 
       expect_sent_count 1
-      expect(PostSendgridApi.mails["departed@example.com"]).to be_blank
       expect(blast.reload.completed_at).to be_present
     ensure
       $redis.del(snapshot_key)
@@ -455,19 +452,24 @@ describe SendPostBlastEmailsJob, :freeze_time do
 
     it "drops snapshotted members who lost the targeted role but kept their audience row" do
       # A follower who is ALSO a customer keeps their audience_members row when they
-      # unsubscribe from follower updates — only the row's `follower` flag flips. A
-      # follower-targeted retry must not email them from the stale snapshot.
+      # unsubscribe from follower updates — only the follower entry leaves the row's
+      # details. A follower-targeted retry must not email them from the stale snapshot.
       post = create(:follower_post, :published, seller: @seller)
       follower = create(:active_follower, user: @seller)
+      # Give the follower a purchase too, so their audience_members row SURVIVES the
+      # follower opt-out below — the mixed-role case this test is about.
+      create(:free_purchase, link: create(:product, user: @seller), seller: @seller, email: follower.email)
       blast = create(:blast, :just_requested, post:)
       snapshot_key = RedisKey.blast_audience_snapshot(blast.id)
-      members = AudienceMember.filter(seller_id: post.seller_id, params: post.audience_members_filter_params, with_ids: true).select(:id, :email, :purchase_id, :follower_id, :affiliate_id).to_a
-      expect(members.map(&:email)).to include(follower.email)
-      $redis.rpush(snapshot_key, members.map { snapshot_entry(_1) })
+      snapshotted_ids = AudienceMember.filter(seller_id: post.seller_id, params: post.audience_members_filter_params).pluck(:id)
+      expect(snapshotted_ids).not_to be_empty
+      $redis.rpush(snapshot_key, snapshotted_ids)
 
-      # Simulate the mixed-role opt-out between attempts: the row survives with the
-      # follower flag off (as it would for a follower who is also a customer).
-      AudienceMember.where(seller_id: post.seller_id, email: follower.email).update_all(follower: false)
+      # Simulate the mixed-role opt-out between attempts: unsubscribing removes the
+      # follower entry from the member's details, but the row survives because they're
+      # still a customer.
+      follower.mark_deleted!
+      expect(AudienceMember.find_by(email: follower.email, seller: @seller)).to be_present
 
       described_class.new.perform(blast.id)
 
@@ -478,6 +480,32 @@ describe SendPostBlastEmailsJob, :freeze_time do
       $redis.del(snapshot_key)
     end
 
+    it "drops snapshotted members whose qualifying purchase left the audience even though their row survives" do
+      # A buyer who is ALSO a follower: refunding the purchase removes it from the
+      # member's details but keeps the audience_members row (they're still a follower).
+      # A retried product blast must not email them from the stale snapshot.
+      product = create(:product, user: @seller)
+      purchase = create(:free_purchase, link: product, seller: @seller)
+      create(:active_follower, user: @seller, email: purchase.email)
+      post = create(:product_post, :published, seller: @seller, link: product, bought_products: [product.unique_permalink])
+      blast = create(:blast, :just_requested, post:)
+      snapshot_key = RedisKey.blast_audience_snapshot(blast.id)
+      snapshotted_ids = AudienceMember.filter(seller_id: post.seller_id, params: post.audience_members_filter_params).pluck(:id)
+      expect(snapshotted_ids).not_to be_empty
+      $redis.rpush(snapshot_key, snapshotted_ids)
+
+      # Simulate the purchase leaving the audience (refund) between snapshot and retry.
+      purchase.remove_from_audience_member_details
+      expect(AudienceMember.find_by(email: purchase.email, seller: @seller)).to be_present
+
+      described_class.new.perform(blast.id)
+
+      expect(PostSendgridApi.mails[purchase.email]).to be_blank
+      expect(blast.reload.completed_at).to be_present
+    ensure
+      $redis.del(snapshot_key) if snapshot_key
+    end
+
     it "ignores a leftover partial write at the temporary key and re-runs the filter" do
       # If a worker dies partway through writing the snapshot, the half-written list
       # lives only at the :tmp key — the real key must stay absent so a retry re-runs
@@ -485,14 +513,12 @@ describe SendPostBlastEmailsJob, :freeze_time do
       post = basic_post_with_audience
       blast = create(:blast, :just_requested, post:)
       snapshot_key = RedisKey.blast_audience_snapshot(blast.id)
-      partial = SendPostBlastEmailsJob::SnapshotMember.new(1, "partial@example.com", nil, nil, nil)
-      $redis.rpush("#{snapshot_key}:tmp", snapshot_entry(partial))
+      $redis.rpush("#{snapshot_key}:tmp", 1)
 
       expect(AudienceMember).to receive(:filter).and_call_original
       described_class.new.perform(blast.id)
 
       expect_sent_count 1
-      expect(PostSendgridApi.mails["partial@example.com"]).to be_blank
       expect($redis.exists?("#{snapshot_key}:tmp")).to eq(false)
       expect(blast.reload.completed_at).to be_present
     ensure

--- a/spec/sidekiq/send_post_blast_emails_job_spec.rb
+++ b/spec/sidekiq/send_post_blast_emails_job_spec.rb
@@ -396,6 +396,79 @@ describe SendPostBlastEmailsJob, :freeze_time do
     end
   end
 
+  describe "audience snapshot for retry resume" do
+    def snapshot_entry(member)
+      [member.id, member.email, member.purchase_id, member.follower_id, member.affiliate_id].to_json
+    end
+
+    it "snapshots the audience members in Redis and clears the snapshot on completion" do
+      post = basic_post_with_audience
+      blast = create(:blast, :just_requested, post:)
+      snapshot_key = RedisKey.blast_audience_member_ids(blast.id)
+
+      snapshot_during_run = nil
+      allow(PostEmailApi).to receive(:process) do |**_kwargs|
+        snapshot_during_run = $redis.lrange(snapshot_key, 0, -1)
+      end
+
+      described_class.new.perform(blast.id)
+
+      expected_ids = AudienceMember.where(seller_id: post.seller_id).pluck(:id)
+      expect(snapshot_during_run.map { JSON.parse(_1).first }).to match_array(expected_ids)
+      expect($redis.exists?(snapshot_key)).to eq(false)
+      expect(blast.reload.completed_at).to be_present
+    end
+
+    it "resumes from the snapshot on retry without re-running the audience filter" do
+      post = basic_post_with_audience
+      blast = create(:blast, :just_requested, post:)
+      snapshot_key = RedisKey.blast_audience_member_ids(blast.id)
+      members = AudienceMember.filter(seller_id: post.seller_id, params: post.audience_members_filter_params, with_ids: true).select(:id, :email, :purchase_id, :follower_id, :affiliate_id).to_a
+      $redis.rpush(snapshot_key, members.map { snapshot_entry(_1) })
+
+      expect(AudienceMember).not_to receive(:filter)
+      described_class.new.perform(blast.id)
+
+      expect_sent_count 1
+      expect(blast.reload.completed_at).to be_present
+      expect($redis.exists?(snapshot_key)).to eq(false)
+    ensure
+      $redis.del(snapshot_key)
+    end
+
+    it "drops snapshotted members who have since left the audience" do
+      post = basic_post_with_audience
+      blast = create(:blast, :just_requested, post:)
+      snapshot_key = RedisKey.blast_audience_member_ids(blast.id)
+      members = AudienceMember.filter(seller_id: post.seller_id, params: post.audience_members_filter_params, with_ids: true).select(:id, :email, :purchase_id, :follower_id, :affiliate_id).to_a
+      departed = SendPostBlastEmailsJob::SnapshotMember.new(members.map(&:id).max + 1_000, "departed@example.com", nil, nil, nil)
+      $redis.rpush(snapshot_key, (members + [departed]).map { snapshot_entry(_1) })
+
+      described_class.new.perform(blast.id)
+
+      expect_sent_count 1
+      expect(PostSendgridApi.mails["departed@example.com"]).to be_blank
+      expect(blast.reload.completed_at).to be_present
+    ensure
+      $redis.del(snapshot_key)
+    end
+
+    it "keeps the snapshot when the send fails so the retry can reuse it" do
+      post = basic_post_with_audience
+      blast = create(:blast, :just_requested, post:)
+      snapshot_key = RedisKey.blast_audience_member_ids(blast.id)
+
+      expect(PostEmailApi).to receive(:process).and_raise(StandardError.new("API failure"))
+      expect do
+        described_class.new.perform(blast.id)
+      end.to raise_error(StandardError, "API failure")
+
+      expect($redis.exists?(snapshot_key)).to eq(true)
+    ensure
+      $redis.del(snapshot_key)
+    end
+  end
+
   describe "error handling" do
     it "deletes sent_post_emails records if PostEmailApi.process raises an error" do
       # Setup post and blast

--- a/spec/sidekiq/send_post_blast_emails_job_spec.rb
+++ b/spec/sidekiq/send_post_blast_emails_job_spec.rb
@@ -404,7 +404,7 @@ describe SendPostBlastEmailsJob, :freeze_time do
     it "snapshots the audience members in Redis and clears the snapshot on completion" do
       post = basic_post_with_audience
       blast = create(:blast, :just_requested, post:)
-      snapshot_key = RedisKey.blast_audience_member_ids(blast.id)
+      snapshot_key = RedisKey.blast_audience_snapshot(blast.id)
 
       snapshot_during_run = nil
       allow(PostEmailApi).to receive(:process) do |**_kwargs|
@@ -422,7 +422,7 @@ describe SendPostBlastEmailsJob, :freeze_time do
     it "resumes from the snapshot on retry without re-running the audience filter" do
       post = basic_post_with_audience
       blast = create(:blast, :just_requested, post:)
-      snapshot_key = RedisKey.blast_audience_member_ids(blast.id)
+      snapshot_key = RedisKey.blast_audience_snapshot(blast.id)
       members = AudienceMember.filter(seller_id: post.seller_id, params: post.audience_members_filter_params, with_ids: true).select(:id, :email, :purchase_id, :follower_id, :affiliate_id).to_a
       $redis.rpush(snapshot_key, members.map { snapshot_entry(_1) })
 
@@ -439,7 +439,7 @@ describe SendPostBlastEmailsJob, :freeze_time do
     it "drops snapshotted members who have since left the audience" do
       post = basic_post_with_audience
       blast = create(:blast, :just_requested, post:)
-      snapshot_key = RedisKey.blast_audience_member_ids(blast.id)
+      snapshot_key = RedisKey.blast_audience_snapshot(blast.id)
       members = AudienceMember.filter(seller_id: post.seller_id, params: post.audience_members_filter_params, with_ids: true).select(:id, :email, :purchase_id, :follower_id, :affiliate_id).to_a
       departed = SendPostBlastEmailsJob::SnapshotMember.new(members.map(&:id).max + 1_000, "departed@example.com", nil, nil, nil)
       $redis.rpush(snapshot_key, (members + [departed]).map { snapshot_entry(_1) })
@@ -453,10 +453,56 @@ describe SendPostBlastEmailsJob, :freeze_time do
       $redis.del(snapshot_key)
     end
 
+    it "drops snapshotted members who lost the targeted role but kept their audience row" do
+      # A follower who is ALSO a customer keeps their audience_members row when they
+      # unsubscribe from follower updates — only the row's `follower` flag flips. A
+      # follower-targeted retry must not email them from the stale snapshot.
+      post = create(:follower_post, :published, seller: @seller)
+      follower = create(:active_follower, user: @seller)
+      blast = create(:blast, :just_requested, post:)
+      snapshot_key = RedisKey.blast_audience_snapshot(blast.id)
+      members = AudienceMember.filter(seller_id: post.seller_id, params: post.audience_members_filter_params, with_ids: true).select(:id, :email, :purchase_id, :follower_id, :affiliate_id).to_a
+      expect(members.map(&:email)).to include(follower.email)
+      $redis.rpush(snapshot_key, members.map { snapshot_entry(_1) })
+
+      # Simulate the mixed-role opt-out between attempts: the row survives with the
+      # follower flag off (as it would for a follower who is also a customer).
+      AudienceMember.where(seller_id: post.seller_id, email: follower.email).update_all(follower: false)
+
+      described_class.new.perform(blast.id)
+
+      expect(PostSendgridApi.mails[follower.email]).to be_blank
+      expect_sent_count 0
+      expect(blast.reload.completed_at).to be_present
+    ensure
+      $redis.del(snapshot_key)
+    end
+
+    it "ignores a leftover partial write at the temporary key and re-runs the filter" do
+      # If a worker dies partway through writing the snapshot, the half-written list
+      # lives only at the :tmp key — the real key must stay absent so a retry re-runs
+      # the full audience filter instead of sending to a fraction of the audience.
+      post = basic_post_with_audience
+      blast = create(:blast, :just_requested, post:)
+      snapshot_key = RedisKey.blast_audience_snapshot(blast.id)
+      partial = SendPostBlastEmailsJob::SnapshotMember.new(1, "partial@example.com", nil, nil, nil)
+      $redis.rpush("#{snapshot_key}:tmp", snapshot_entry(partial))
+
+      expect(AudienceMember).to receive(:filter).and_call_original
+      described_class.new.perform(blast.id)
+
+      expect_sent_count 1
+      expect(PostSendgridApi.mails["partial@example.com"]).to be_blank
+      expect($redis.exists?("#{snapshot_key}:tmp")).to eq(false)
+      expect(blast.reload.completed_at).to be_present
+    ensure
+      $redis.del(snapshot_key, "#{snapshot_key}:tmp")
+    end
+
     it "keeps the snapshot when the send fails so the retry can reuse it" do
       post = basic_post_with_audience
       blast = create(:blast, :just_requested, post:)
-      snapshot_key = RedisKey.blast_audience_member_ids(blast.id)
+      snapshot_key = RedisKey.blast_audience_snapshot(blast.id)
 
       expect(PostEmailApi).to receive(:process).and_raise(StandardError.new("API failure"))
       expect do


### PR DESCRIPTION
Follow-up to #5862 / antiwork/gumroad-private#1076, requested by @slavingia: "Open PR for this as deploys will become more frequent over time."

## What

Snapshots the resolved audience-member ids in Redis (keyed by blast id) the first time `SendPostBlastEmailsJob` loads an audience. If the worker is killed mid-send (deploy recycle, OOM) and Sidekiq retries the blast, the retry re-runs the audience filter **restricted to just the snapshotted ids** — a cheap, primary-key-bound query — instead of the unrestricted filter over the whole audience. The snapshot is deleted when the blast completes, and expires after 3 days as a backstop.

## Why

#5862 fixed yesterday's incident (blast 443766, ~350k recipients, every attempt dying at the DB's 5-minute statement cap) by raising the cap for the audience-load query. But the load still takes minutes for the largest audiences, and it restarts **from zero** on every retry. That leaves a window where each retry re-races the next deploy: worker killed mid-load → retry → repeat. As deploy frequency increases, the probability that a big blast never gets past the load phase increases with it. Same failure family as the Friday payout batch (#5797) — all-or-nothing cohort walk + silent worker kill.

With the snapshot, only the FIRST attempt pays the minutes-long unrestricted query. Every subsequent retry starts sending within seconds, so a mid-send kill costs one slice of progress, not the whole load. `SentPostEmail` dedupe (and the Redis set for non-opener re-blasts) already makes re-sending safe — this makes it *fast*.

## Design notes

- **Snapshot stores bare member ids** (no emails or PII in Redis). The retry re-runs `AudienceMember.filter` with a new `ids:` option that primary-key-bounds every subquery, so the re-run is cheap even for ~475k members while re-checking **every original filter criterion** (role, bought products, price/date bounds) against current data — and returning fresh rows, so the send uses current emails and current purchase/follower/affiliate ids. Re-runs are batched in 10k-id slices to avoid a 475k-id `IN` clause.
- **Why full re-filtering instead of an existence check**: a person with multiple relationships to the seller (customer-who-also-follows) KEEPS their `audience_members` row when leaving just one role, so an existence check alone would email opted-out people on retry. Re-applying the original filter to the snapshotted ids also catches refunds, purchase-specific criteria changes, and role opt-outs, not just row deletion. (This addressed both a fable-5 P1 and Greptile's T-Rex-verified P1 on the first two drafts.)
- **Atomic snapshot write**: the list is built at a `:tmp` key and `RENAME`d into place. A worker killed mid-write (the exact scenario this PR defends against) can never leave a partial list at the real key — which a retry would otherwise treat as the complete audience and silently under-send.
- Snapshot (and any leftover `:tmp` key) cleared in `mark_blast_as_completed` (both the sent-everyone path and the empty-audience path go through it); the 3-day TTL covers abandoned blasts and exceeds the job's full 10-retry backoff span.
- Kept the failure path untouched: if `PostEmailApi.process` raises, the snapshot survives for the retry (spec-covered).
- `SendWorkflowPostEmailsJob` is intentionally NOT changed: it fans out to per-member jobs immediately after the load (no long send phase to resume into), and its `earliest_valid_time` filter makes a stale snapshot semantically wrong for workflows.

## Test plan

- 7 new specs: snapshot ids written during send + cleared on completion; retry resumes via the id-restricted filter only (asserted with `hash_including(ids:)`); row-deleted members skipped; **mixed-role follower opt-out** (row survives, follower entry gone) not emailed on retry; **refunded qualifying purchase** (row survives via follower role) not emailed by a product-blast retry; **leftover partial `:tmp` write** ignored and filter re-run; snapshot survives a send failure for the next retry.
- Full `spec/sidekiq/send_post_blast_emails_job_spec.rb` + `spec/models/audience_member_spec.rb` run locally; all snapshot/filter specs green; remaining failures are pre-existing local-worktree environment failures (`create(:purchase)` card-validation without VCR), identical on the base commit, verified by stash-diff.

# AI Disclosure

Written by Claude (claude-fable-5) running as the Gumclaw agent, at Sahil's direction on gumroad-private#1076. The agent wrote the code and specs and ran the test suite and rubocop locally.


> Post-review note: an adversarial fable-5 pass flagged two P1s in the first draft (existence-only re-verification, non-atomic snapshot writes), and Greptile's T-Rex run flagged a remaining P1 in the second draft (role-flag check still missed refunded/changed qualifying purchases). All fixed with spec coverage; the design converged on "snapshot ids, re-run the original filter id-restricted" described above.
