### PR TITLE
Fix ActiveRecord::RecordNotSaved when recording payment flow on an unsaved purchase

### DIFF
--- a/app/services/purchase/create_service.rb
+++ b/app/services/purchase/create_service.rb
@@ -146,7 +146,12 @@ class Purchase::CreateService < Purchase::BaseService
       purchase.build_purchase_wallet_type(wallet_type: params[:wallet_type]) if params[:wallet_type].present?
 
       payment_flow_attributes = PurchasePaymentFlow.attributes_for_checkout_params(params)
-      if payment_flow_attributes && !purchase.free_purchase?
+      # The purchase may still be unsaved here: `prepare_for_charge!` leaves it
+      # unpersisted when a validation fails (for example, an invalid email).
+      # Creating the dependent analytics row on an unsaved parent raises
+      # ActiveRecord::RecordNotSaved, and a purchase that never saved has no
+      # payment flow worth recording anyway.
+      if payment_flow_attributes && purchase.persisted? && !purchase.free_purchase?
         begin
           purchase.create_purchase_payment_flow(payment_flow_attributes)
         rescue => e

--- a/spec/services/purchase/create_service_spec.rb
+++ b/spec/services/purchase/create_service_spec.rb
@@ -3833,4 +3833,48 @@ describe Purchase::CreateService, :vcr do
       end
     end
   end
+
+  describe "payment flow analytics recording" do
+    let(:payment_flow_params) do
+      # `payment_details_source` + a Stripe payment param make
+      # PurchasePaymentFlow.attributes_for_checkout_params return attributes,
+      # which triggers the analytics-recording branch in the service.
+      # `is_part_of_combined_charge` mirrors how OrdersController#prepare invokes
+      # this service (charging happens later, in Charge::CreateService).
+      params.merge(
+        payment_details_source: "payment_element",
+        stripe_payment_method_id: "pm_123",
+        is_part_of_combined_charge: true,
+      )
+    end
+
+    it "records a payment flow for a successfully built purchase" do
+      purchase, error = Purchase::CreateService.new(product:, params: payment_flow_params).perform
+
+      expect(error).to be_nil
+      expect(purchase.purchase_payment_flow).to be_present
+    end
+
+    context "when the purchase fails validation and is never saved" do
+      before do
+        # An invalid email fails the `must_have_valid_email` validation, so the
+        # save inside `prepare_for_charge!` leaves the purchase unpersisted.
+        payment_flow_params[:purchase][:email] = "not-an-email"
+      end
+
+      it "skips payment flow recording instead of reporting ActiveRecord::RecordNotSaved" do
+        # Attempting to create the dependent row on an unsaved purchase raises
+        # ActiveRecord::RecordNotSaved, which the rescue below reports to Sentry.
+        # Nothing should be reported: a purchase that never saved has no
+        # analytics row to record.
+        expect(ErrorNotifier).not_to receive(:notify)
+
+        purchase, error = Purchase::CreateService.new(product:, params: payment_flow_params).perform
+
+        expect(purchase).not_to be_persisted
+        expect(purchase.purchase_payment_flow).to be_nil
+        expect(error).to be_present
+      end
+    end
+  end
 end

--- a/spec/support/fixtures/vcr_cassettes/Purchase_CreateService/payment_flow_analytics_recording/records_a_payment_flow_for_a_successfully_built_purchase.yml
+++ b/spec/support/fixtures/vcr_cassettes/Purchase_CreateService/payment_flow_analytics_recording/records_a_payment_flow_for_a_successfully_built_purchase.yml
@@ -1,0 +1,281 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa&billing_details[address][postal_code]=<STRONGBOX_GENERAL_PASSWORD>5
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Idempotency-Key:
+      - b1b12048-4cc1-4975-8ad8-06e169d9f818
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 13 Jul 2026 23:57:33 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1132'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=nQ18p_9MB4vorjKEgJwQRk5LHDiXB2zIhx-A3GO1pN1CntU06j6sMZhtKgNbF9fTJ22tH3b2XlkYfIvq;
+        report-to csp
+      Idempotency-Key:
+      - b1b12048-4cc1-4975-8ad8-06e169d9f818
+      Original-Request:
+      - req_PuidhrwDKeuqDj
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=nQ18p_9MB4vorjKEgJwQRk5LHDiXB2zIhx-A3GO1pN1CntU06j6sMZhtKgNbF9fTJ22tH3b2XlkYfIvq&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=nQ18p_9MB4vorjKEgJwQRk5LHDiXB2zIhx-A3GO1pN1CntU06j6sMZhtKgNbF9fTJ22tH3b2XlkYfIvq&t=1"
+      Request-Id:
+      - req_PuidhrwDKeuqDj
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1Tstj7IBOqvOFDrfjTLRYDlA",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": "<STRONGBOX_GENERAL_PASSWORD>5",
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": "unchecked",
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783987053,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Mon, 13 Jul 2026 23:57:34 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1Tstj7IBOqvOFDrfjTLRYDlA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_PuidhrwDKeuqDj","request_duration_ms":321}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 13 Jul 2026 23:57:34 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1132'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=GOLU2fWlJa3wtoiFVdou9tWY0Y1DWSs2bSUS4uLQOuw9O3GI4H0Qg_Ck1DNvUoO5djrW_MsMbIyBtATX;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=GOLU2fWlJa3wtoiFVdou9tWY0Y1DWSs2bSUS4uLQOuw9O3GI4H0Qg_Ck1DNvUoO5djrW_MsMbIyBtATX&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=GOLU2fWlJa3wtoiFVdou9tWY0Y1DWSs2bSUS4uLQOuw9O3GI4H0Qg_Ck1DNvUoO5djrW_MsMbIyBtATX&t=1"
+      Request-Id:
+      - req_FgknHs81yjbG9N
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1Tstj7IBOqvOFDrfjTLRYDlA",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": "<STRONGBOX_GENERAL_PASSWORD>5",
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": "unchecked",
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783987053,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Mon, 13 Jul 2026 23:57:34 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/Purchase_CreateService/payment_flow_analytics_recording/when_the_purchase_fails_validation_and_is_never_saved/skips_payment_flow_recording_instead_of_reporting_ActiveRecord_RecordNotSaved.yml
+++ b/spec/support/fixtures/vcr_cassettes/Purchase_CreateService/payment_flow_analytics_recording/when_the_purchase_fails_validation_and_is_never_saved/skips_payment_flow_recording_instead_of_reporting_ActiveRecord_RecordNotSaved.yml
@@ -1,0 +1,145 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa&billing_details[address][postal_code]=<STRONGBOX_GENERAL_PASSWORD>5
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Idempotency-Key:
+      - bebbe2b4-f63a-4288-9388-85c44fe0f634
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        gumclaw-on-macbook-pro 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:42
+        PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6031 arm64","hostname":"gumclaw-on-macbook-pro"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 13 Jul 2026 23:59:34 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1132'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=LppzajQRpYz1qkEsK6-40QgSKdxqxooZCpv4P4GaTWYBrqJKAINlVcRdFdz_QVP7P8b4Q0AYx61VKHlr;
+        report-to csp
+      Idempotency-Key:
+      - bebbe2b4-f63a-4288-9388-85c44fe0f634
+      Original-Request:
+      - req_Tks8yucaXZyEQo
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=LppzajQRpYz1qkEsK6-40QgSKdxqxooZCpv4P4GaTWYBrqJKAINlVcRdFdz_QVP7P8b4Q0AYx61VKHlr&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=LppzajQRpYz1qkEsK6-40QgSKdxqxooZCpv4P4GaTWYBrqJKAINlVcRdFdz_QVP7P8b4Q0AYx61VKHlr&t=1"
+      Request-Id:
+      - req_Tks8yucaXZyEQo
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1Tstl4IBOqvOFDrfPSt6NSwH",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": "<STRONGBOX_GENERAL_PASSWORD>5",
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": "unchecked",
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 7,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1783987174,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Mon, 13 Jul 2026 23:59:34 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## What

Guards the checkout payment-flow analytics recording in `Purchase::CreateService#perform` so it only runs when the purchase actually persisted. Previously, when `prepare_for_charge!` left the purchase unsaved (a validation failure such as an invalid email), the subsequent `purchase.create_purchase_payment_flow(...)` raised `ActiveRecord::RecordNotSaved`, which the surrounding rescue reported to Sentry on every such failed checkout.

## Why

Sentry issue [GUMROAD-XZ](https://gumroad-to.sentry.io/issues/7609043470/) — `ActiveRecord::RecordNotSaved: You cannot call create unless the parent is saved` in `OrdersController#prepare` → `Purchase::CreateService#perform` (`app/services/purchase/create_service.rb:151`). Rails refuses to create a `has_one` dependent row on an unsaved parent. A purchase that never saved has no analytics row worth recording, so the correct behavior is to skip recording rather than report noise to Sentry. The buyer-facing outcome (validation error returned to the client) is unchanged.

## Test plan

- New specs in `spec/services/purchase/create_service_spec.rb` ("payment flow analytics recording"):
  - a successfully built combined-charge purchase still records its `purchase_payment_flow`
  - an unpersisted purchase (validation failure) skips recording, does not call `ErrorNotifier.notify`, and still returns the validation error
- The failing-validation spec reproduces the exact `ActiveRecord::RecordNotSaved` on `main` (ErrorNotifier receives the exception) and passes with the fix.
- Ran locally: `bundle exec rspec spec/services/purchase/create_service_spec.rb -e "payment flow analytics recording"` → 2 examples, 0 failures; `spec/services/order/create_service_spec.rb -e "recording the payment flow"` → 9 examples, 0 failures; `spec/models/purchase_payment_flow_spec.rb` green. Rubocop clean on changed files.
- After deploy: the Sentry issue should stop receiving events.
