### PR TITLE
Fix Ai::AnthropicClient::Error when a stream drops mid-tool-call (retry instead of failing the turn)

### DIFF
--- a/app/services/ai/anthropic_client.rb
+++ b/app/services/ai/anthropic_client.rb
@@ -405,10 +405,15 @@ class Ai::AnthropicClient
 
     # Turn the accumulated streamed blocks into the same tool_use shape #parse_message returns. A
     # tool_use block with no input fragments is a no-arg call; malformed non-empty input must fail the
-    # turn instead of dispatching a lossy {} tool call — EXCEPT when the model was cut off by
-    # max_tokens. A turn truncated mid-tool-call always ends with half-written (unparseable) JSON;
-    # that isn't the model misbehaving, it's the token cap. Dropping the cut-off block and letting
-    # the caller see stop_reason == "max_tokens" lets it respond honestly instead of erroring out.
+    # turn instead of dispatching a lossy {} tool call — with two exceptions where half-written JSON
+    # is expected rather than the model misbehaving:
+    #   - stop_reason == "max_tokens": the token cap cut the call off mid-arguments. Drop the block
+    #     and let the caller see the stop_reason so it can respond honestly instead of erroring out.
+    #   - stop_reason is nil: a complete Anthropic stream always delivers a stop_reason (via
+    #     message_delta) before it ends, so its absence means the connection dropped mid-stream and
+    #     the tool call's JSON was cut off by the disconnect. That is a network failure, not a bad
+    #     tool call, so raise TransientError — the retry loop in #stream_messages re-requests the
+    #     turn when nothing has reached the caller yet, exactly as it does for other dropped streams.
     def assemble_tool_uses(blocks, stop_reason: nil)
       truncated = stop_reason == "max_tokens"
       blocks.keys.sort.filter_map do |index|
@@ -418,9 +423,10 @@ class Ai::AnthropicClient
         input = begin
           parse_tool_use_input(block)
         rescue Error
-          # Only swallow the parse failure for a truncated turn; otherwise it is a real error.
-          raise unless truncated
-          next
+          next if truncated
+          raise TransientError, "Anthropic stream ended mid-tool-call for #{block[:name].presence || "unknown tool"}." if stop_reason.nil?
+          # A completed turn produced unparseable tool arguments: a real error.
+          raise
         end
         { id: block[:id], name: block[:name], input: }
       end

--- a/spec/services/ai/anthropic_client_spec.rb
+++ b/spec/services/ai/anthropic_client_spec.rb
@@ -405,16 +405,43 @@ describe Ai::AnthropicClient do
       expect(result.stop_reason).to eq("tool_use")
     end
 
-    it "raises an error for malformed streamed tool_use input" do
+    it "raises an error for malformed streamed tool_use input on a completed turn" do
       stream = sse(
         ["content_block_start", { index: 0, content_block: { type: "tool_use", id: "toolu_x", name: "api_read" } }],
         ["content_block_delta", { index: 0, delta: { type: "input_json_delta", partial_json: "{not json" } }],
         ["content_block_stop", { index: 0 }],
+        ["message_delta", { delta: { stop_reason: "tool_use" } }],
       )
       stub_request(:post, url).to_return(status: 200, body: stream, headers: { "Content-Type" => "text/event-stream" })
 
       expect { client.stream_messages(system: "s", messages: [{ role: "user", content: "x" }]) }
         .to raise_error(described_class::Error, /unreadable tool call/i)
+    end
+
+    it "retries when the stream drops mid-tool-call, leaving cut-off JSON and no stop_reason" do
+      # A complete Anthropic stream always sends a stop_reason before ending. When the connection
+      # drops mid-tool-call, the accumulated JSON is cut off at the disconnect and no stop_reason
+      # ever arrives — that's a network failure, so the client should retry the request (nothing
+      # reached the caller yet) instead of failing the turn as an unreadable tool call.
+      allow(client).to receive(:sleep)
+      dropped = sse(
+        ["content_block_start", { index: 0, content_block: { type: "tool_use", id: "toolu_x", name: "api_write" } }],
+        ["content_block_delta", { index: 0, delta: { type: "input_json_delta", partial_json: '{"endpoint":"update_product","params":{"description":"cut off here' } }],
+      )
+      complete = sse(
+        ["content_block_start", { index: 0, content_block: { type: "tool_use", id: "toolu_x", name: "api_write" } }],
+        ["content_block_delta", { index: 0, delta: { type: "input_json_delta", partial_json: '{"endpoint":"update_product"}' } }],
+        ["content_block_stop", { index: 0 }],
+        ["message_delta", { delta: { stop_reason: "tool_use" } }],
+      )
+      stub_request(:post, url)
+        .to_return({ status: 200, body: dropped, headers: { "Content-Type" => "text/event-stream" } },
+                   { status: 200, body: complete, headers: { "Content-Type" => "text/event-stream" } })
+
+      result = client.stream_messages(system: "s", messages: [{ role: "user", content: "update my description" }])
+
+      expect(result.tool_uses).to eq([{ id: "toolu_x", name: "api_write", input: { "endpoint" => "update_product" } }])
+      expect(client).to have_received(:sleep).once
     end
 
     it "drops a tool call whose JSON was cut off by max_tokens instead of raising" do


### PR DESCRIPTION
## What

Treats a streamed Anthropic tool call whose JSON is cut off by a mid-stream disconnect as a retryable network failure instead of a hard `Ai::AnthropicClient::Error`. `assemble_tool_uses` now distinguishes three cases when a tool block's input fails to parse:

- `stop_reason == "max_tokens"` → drop the block (unchanged — the token cap cut it off)
- `stop_reason` is nil → the stream never delivered a `message_delta`/stop_reason, meaning the connection dropped mid-tool-call. Raise `TransientError` so the existing retry loop in `#stream_messages` re-requests the turn (which it only does while nothing has been streamed to the caller).
- completed turn with unparseable input → still a real `Error` (unchanged)

## Why

Sentry GUMROAD-Y4 (https://gumroad-to.sentry.io/issues/7609201485/): production raised `Ai::AnthropicClient::Error: Anthropic produced an unreadable tool call for api_write.` from `parse_tool_use_input`, with the underlying cause `JSON::ParserError: expected ',' or '}' after object value, got: EOF at line 1 column 1488` — the classic shape of a stream that died mid-arguments. A complete Anthropic stream always sends a stop_reason before ending, so accumulated-but-unparseable tool JSON with no stop_reason is a dropped connection, not the model misbehaving. Today that surfaces to the seller as a failed agent turn even though a retry (safe here — no output was yielded) would have succeeded.

## Test plan

- New spec: a stream that ends mid-tool-call with no stop_reason is retried and the second attempt's tool call is returned (`sleep` observed once). Verified load-bearing: fails with `unreadable tool call` when the fix is stashed.
- Updated spec: malformed tool input on a *completed* turn (stop_reason present) still raises `Error`.
- Existing max_tokens-truncation spec unchanged and green.
- Local run: `spec/services/ai/anthropic_client_spec.rb` 31 examples, 0 failures; `spec/services/ai/store_agent_service_spec.rb` 31 examples, 0 failures. `rubocop -a` clean on both files.
