### PR TITLE
Always show license key settings expanded in the product content editor

### DIFF
--- a/app/javascript/components/TiptapExtensions/LicenseKey.tsx
+++ b/app/javascript/components/TiptapExtensions/LicenseKey.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, ChevronUp, Key } from "@boxicons/react";
+import { Key } from "@boxicons/react";
 import { Node as TiptapNode } from "@tiptap/core";
 import { NodeViewProps, NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
 import * as React from "react";
@@ -44,7 +44,6 @@ export const LicenseKey = TiptapNode.create({
 });
 
 const LicenseKeyNodeView = ({ editor, selected }: NodeViewProps) => {
-  const [isDrawerOpen, setIsDrawerOpen] = React.useState(false);
   const { licenseKey, isMultiSeatLicense, seats, onIsMultiSeatLicenseChange, productId } = useLicense();
   const uid = React.useId();
 
@@ -70,17 +69,11 @@ const LicenseKeyNodeView = ({ editor, selected }: NodeViewProps) => {
                 <Button>Copy</Button>
               </CopyToClipboard>
             ) : null}
-            {editor.isEditable ? (
-              <Button
-                size="icon"
-                onClick={() => setIsDrawerOpen(!isDrawerOpen)}
-                aria-label={isDrawerOpen ? "Close drawer" : "Edit"}
-              >
-                {isDrawerOpen ? <ChevronUp className="size-5" /> : <ChevronDown className="size-5" />}
-              </Button>
-            ) : null}
           </RowActions>
-          {editor.isEditable && isDrawerOpen ? (
+          {/* The settings (seat toggle and product ID) are always visible while editing. The product ID is
+              required for the license verification API, and hiding it behind an expand button made it hard
+              for creators to find (see issue #5838). */}
+          {editor.isEditable ? (
             <RowDetails asChild>
               <Drawer>
                 {isMultiSeatLicense !== null ? (


### PR DESCRIPTION
## What

Always shows the license key block's settings expanded in the product content editor, and removes the expand/collapse chevron. The seat-license toggle and the read-only product ID field (with its Copy button) are now visible whenever the block is on the page in edit mode.

## Why

The product ID required by the license verification API only appeared after clicking a small expand button inside the license key block. Creators looking for it couldn't find it — the API docs point them to the edit page, and the only visible ID there is the URL permalink, which doesn't work with the API. Surfacing the drawer permanently makes the product ID discoverable without any interaction.

Refs #5838.

## Before/After

Captured from a local run of the branch (desktop 1280px, mobile 375px).

**Before:**
| Desktop (1280px) | Mobile (375px) |
|---|---|
| ![before-desktop](https://raw.githubusercontent.com/antiwork/gumroad/expand-license-key-block/qa-media/pr-5873-license-key-before-desktop.png) | ![before-mobile](https://raw.githubusercontent.com/antiwork/gumroad/expand-license-key-block/qa-media/pr-5873-license-key-before-mobile.png) |

**After:**
| Desktop (1280px) | Mobile (375px) |
|---|---|
| ![after-desktop](https://raw.githubusercontent.com/antiwork/gumroad/expand-license-key-block/qa-media/pr-5873-license-key-after-desktop.png) | ![after-mobile](https://raw.githubusercontent.com/antiwork/gumroad/expand-license-key-block/qa-media/pr-5873-license-key-after-mobile.png) |

## Test plan

- `prettier` + `eslint` clean on the changed file
- No specs interact with the removed toggle (checked `spec/requests/products/edit/rich_text_editor_spec.rb` and grep for the drawer controls); existing rich-text editor specs cover the block's serialization, which is unchanged
- Verified live on a local boot of the branch: settings render without any click, seat toggle works, product ID copies; buyer-facing (read-only) view unchanged since the drawer only renders when `editor.isEditable`
- CI green
