### PR TITLE
Revert products index replica to 0 in the non-production settings block

### DIFF
--- a/app/modules/product/searchable.rb
+++ b/app/modules/product/searchable.rb
@@ -65,10 +65,15 @@ module Product::Searchable
 
     index_name "products"
 
-    # One replica so product search can be served by a second node when the node
-    # holding the primary shard is unavailable or paused in garbage collection.
-    # With zero replicas, a single node's GC pause fails every product search.
-    settings number_of_shards: 1, number_of_replicas: 1, analysis: {
+    # These settings only apply outside production: local dev, CI, branch apps,
+    # and staging, which create the index from this block (see
+    # DevTools.delete_all_indices_and_reindex_all and the branch-app initializer).
+    # In production the app is blocked from recreating indices, so the live
+    # `products` index (`products_v3`) is created operationally with 5 shards and
+    # 1 replica; this block never touches it. On the single-node clusters the
+    # non-production environments use, 1 shard / 0 replicas is correct — a replica
+    # has no second node to land on and would just leave the index yellow.
+    settings number_of_shards: 1, number_of_replicas: 0, analysis: {
       filter: {
         edge_ngram_filter: {
           type: "edge_ngram",


### PR DESCRIPTION
## What

Set `number_of_replicas` back to `0` on the `products` Elasticsearch index settings in `app/modules/product/searchable.rb`, and add a comment explaining which environments this settings block actually governs. Follow-up to #5861.

## Why

#5861 changed this block to `number_of_replicas: 1` so that a future app-side reindex wouldn't recreate the index without a replica. That rationale doesn't hold in practice:

- The app **cannot** recreate the index in production. `DevTools.delete_all_indices_and_reindex_all` raises in production, and it's the only path that recreates an index from this settings block. Production's `products` index is created and maintained operationally, so this block never applies to it.
- The block only takes effect in **local dev, CI, branch apps, and staging**, all of which run single-node Elasticsearch. On a single node a replica has no second node to be allocated to, so `number_of_replicas: 1` just leaves the index in the **yellow** state with no benefit — reads and writes still work, which is why it went unnoticed.

Reverting to `0` restores green cluster status in those environments, and the added comment records that production's topology differs and is managed operationally — so this block isn't mistaken for production's configuration.

The 15s client timeout added in #5861 (`config/initializers/elasticsearch.rb`) is unrelated to this and stays as-is.

## Before/After

Not applicable — no user-facing surface. The only effect is on Elasticsearch index creation in non-production single-node environments (yellow → green cluster status); there's no runtime UI to capture.

## Test Results

No specs assert these index settings (verified across `spec/`), and #5861 added none, so there's no test to update. The change is a single settings value plus an explanatory comment.

---

AI disclosure: drafted with Claude Opus 4.8.
