### PR TITLE
Provision preview apps in parallel with the asset compile

### DIFF
--- a/.buildkite/preview.yml
+++ b/.buildkite/preview.yml
@@ -46,11 +46,29 @@ steps:
           username: gumroad
           password-env: QUAY_PASSWORD
 
+  # Provisioning (spin up the EC2 instance, create the app's databases/redis,
+  # run first-deploy migrations) needs only the Ruby code in the web image, not
+  # compiled assets — so it depends on the web image alone and runs in parallel
+  # with the ~13-min Compile Assets step instead of serially after it. On a
+  # first deploy the instance boots and the environment is ready by the time
+  # the assets are compiled, leaving only the app boot to happen afterwards.
+  # See deploy.sh in the deployment repo for the provision/release split.
+  - label: ":package: Provision Preview Environment"
+    key: preview-provision
+    depends_on: preview-build-web-image
+    command: ".buildkite/scripts/provision_preview.sh"
+    timeout_in_minutes: 30
+    plugins:
+      - docker-login#v3.0.0:
+          username: "gumroadteam"
+          password-env: DOCKERHUB_PASSWORD
+
   - label: ":rocket: Deploy Preview App"
     key: build-and-deploy-preview
     depends_on:
       - preview-compile-assets
       - preview-build-nginx-image
+      - preview-provision
     command: ".buildkite/scripts/deploy_branch.sh"
     timeout_in_minutes: 45
     plugins:

--- a/.buildkite/scripts/deploy_branch.sh
+++ b/.buildkite/scripts/deploy_branch.sh
@@ -46,11 +46,15 @@ sudo mkdir -p nomad/staging/certs
 sudo mkdir -p nomad/certs
 sudo chown -R buildkite-agent:buildkite-agent nomad/
 
-# Deploy preview app
+# Deploy preview app. The provision phase (instance scale-up, environment
+# setup, first-deploy migrations) already ran in parallel with the asset
+# compile via the "Provision Preview Environment" step, so here we run only the
+# "release" phase: nginx + Puma boot (Puma needs the compiled assets), plus
+# redeploy migrations. See deploy.sh for the phase split.
 cd nomad/staging/deploy_branch
 BRANCH=$BRANCH \
   DEPLOY_TAG=$DEPLOY_TAG \
-  ./deploy.sh
+  ./deploy.sh release
 
 set_github_deployment_status "$DEPLOYMENT_ID" "success" "$PREVIEW_URL" || true
 logger "Preview app available at ${PREVIEW_URL}"

--- a/.buildkite/scripts/provision_preview.sh
+++ b/.buildkite/scripts/provision_preview.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -e
+
+GREEN="\033[0;32m"
+NC="\033[0m"
+logger() {
+  echo -e "${GREEN}$(date "+%Y/%m/%d %H:%M:%S") provision_preview.sh: $1${NC}"
+}
+
+# Runs the asset-independent half of a preview deploy — spin up the EC2
+# instance, create the app's databases/redis, and run first-deploy migrations —
+# in parallel with the "Compile Assets" step (both depend only on the web
+# image). The app boot itself, which needs the compiled assets, happens later in
+# the "Deploy Preview App" step (deploy_branch.sh, which runs the "release"
+# phase). See nomad/staging/deploy_branch/deploy.sh for the phase split.
+#
+# On a redeploy the environment already exists, so the provision phase is a
+# no-op; this step then just confirms nothing is needed and exits quickly.
+
+REVISION=${BUILDKITE_COMMIT}
+WEB_TAG=$(echo $REVISION | cut -c1-12)
+
+logger "Starting preview app provisioning"
+
+# Install Nomad
+source .buildkite/scripts/install_nomad.sh
+install_nomad
+
+# Copy secrets from credentials repo (also brings in the nomad/ deploy tree)
+source .buildkite/scripts/copy_secrets.sh
+copy_secrets
+
+BRANCH=${BUILDKITE_BRANCH}
+DEPLOY_TAG="staging-${WEB_TAG}"
+
+logger "Provisioning preview environment for ${BRANCH} with tag ${DEPLOY_TAG}"
+
+# Ensure necessary directories exist with proper permissions (mirrors
+# deploy_branch.sh; the nomad jobs write rendered specs and certs under nomad/).
+logger "Creating required directories"
+sudo mkdir -p nomad/staging/certs
+sudo mkdir -p nomad/certs
+sudo chown -R buildkite-agent:buildkite-agent nomad/
+
+cd nomad/staging/deploy_branch
+BRANCH=$BRANCH \
+  DEPLOY_TAG=$DEPLOY_TAG \
+  ./deploy.sh provision
+
+logger "Preview environment provisioned for ${BRANCH}"


### PR DESCRIPTION
## What

Adds a **Provision Preview Environment** Buildkite step to the preview pipeline that spins up the preview app's instance, creates its databases/redis, and runs first-deploy migrations **in parallel with** the ~13-minute `Compile Assets` step, instead of serially after it. The existing deploy step now depends on the new step and runs only the app boot (nginx + Puma).

- `.buildkite/preview.yml` — new `preview-provision` step, gated only on `preview-build-web-image` (the same gate as `preview-compile-assets`), so the two run concurrently. `build-and-deploy-preview` now also depends on `preview-provision`.
- `.buildkite/scripts/provision_preview.sh` (new) — bootstraps Nomad + secrets and runs `deploy.sh provision`.
- `.buildkite/scripts/deploy_branch.sh` — now runs `deploy.sh release`.

Pairs with **antiwork/gumroad-deployment#41**, which splits `deploy.sh` into `provision`/`release` phases and points the migration + env-setup jobs at the pre-compile `web-<sha>` image.

## Why

Provisioning needs only the Ruby code in the web image (built before the compile), not the compiled assets. Only Puma needs the compiled assets, because staging serves digested assets from the manifest baked into the `staging-<sha>` image. So everything except the Puma boot can move off the critical path and overlap the compile. On a **first deploy** — the worst case, where a reviewer is waiting on a brand-new preview — the EC2 instance boots and the environment is migrated during the compile window, leaving only the fast Puma boot afterwards.

This targets the first-deploy path specifically. **Redeploys are unchanged** — they already skip provisioning (the environment exists), and their migration stays immediately before boot to keep the schema-change window tight (migrations are ~0–2s per the phase timings in #5802).

Alternative considered (see [#5802](https://github.com/antiwork/gumroad/issues/5802)): a true two-phase "boot early on the previous asset bundle, redeploy when fresh assets land" deploy. Rejected because staging can't render a page without the baked-in asset manifest (it 500s, not "slow"), and stale JS against new Ruby is riskiest for exactly the UI PRs previews exist for. This change gets the first-deploy speedup with no wrong-assets risk.

## Before / After

This is a CI/deploy-pipeline change with no user-facing surface, and the pipeline can't be run locally (it needs Buildkite + Nomad + the staging AWS account), so there's no UI video. The observable effect is the per-phase `PHASE` annotations already emitted on every preview deploy (from antiwork/gumroad-deployment#39): on a first deploy after this lands, `scale_up` / `env_setup` / `migrations` move out of the post-compile critical path and overlap `Compile Assets`. Before/after first-deploy wall-clock numbers will be posted to #5802.

## Test Results

No unit tests cover the CI YAML / shell / ERB, so verification was local and structural:

- `bash -n` on all changed/added scripts — clean
- YAML parse + dependency-graph check of `preview.yml` — confirms `preview-provision` and `preview-compile-assets` share the same single dependency (`preview-build-web-image`), so they run concurrently
- ERB render of the two re-pointed Nomad jobs — resolve to `web:web-<sha>`; mongo image unchanged
- Control-flow test of the phased `deploy.sh` — each Nomad job runs exactly once, in the original order, across all (phase × first-deploy/redeploy) combinations

## Rollout note

At CI time the `nomad/` deploy tree is copied from the private credentials repo, so the paired `antiwork/gumroad-deployment` change must be mirrored there before this takes effect — same as antiwork/gumroad-deployment#38 / #39.

---

Generated with Claude Opus 4.8 (1M context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
