### PR TITLE
Key the preview asset cache on the config/ subset the compile reads

### DIFF
--- a/.buildkite/scripts/preview_asset_cache.sh
+++ b/.buildkite/scripts/preview_asset_cache.sh
@@ -39,18 +39,46 @@ preview_asset_cache_logger() {
 }
 
 # Everything that can change the output of `docker/web/compile_assets.sh`.
-# Kept deliberately broad (all of config/, vendored assets, tracked public
-# files, the base-image definition that pins the Node version, the Makefile
-# recipe the cache-hit path mirrors, and these two buildkite scripts
-# themselves — the cache-hit image bakes in env vars defined in
+# Kept deliberately broad (vendored assets, tracked public files, the
+# base-image definition that pins the Node version, the Makefile recipe the
+# cache-hit path mirrors, and these two buildkite scripts themselves — the
+# cache-hit image bakes in env vars defined in
 # .buildkite/scripts/compile_assets.sh, so changing them must invalidate
 # existing entries): a false miss costs one full compile; a false hit serves
 # stale assets on a preview app.
+#
+# config/ is keyed on the subset the compile actually reads, not the whole
+# directory — hashing all of config/ made every runtime-only initializer
+# toggle (QA spoofs, feature constants, rate limits) a false miss that cost a
+# 13-minute compile. The compile touches config/ through exactly three
+# channels:
+#   1. `rails js:export` (lib/tasks/js_export.rake) boots Rails and serializes
+#      the routes via JsRoutes — the output depends on the routes files, the
+#      constants they reference (all defined in config/domain.rb), the
+#      JsRoutes initializer, and the boot plumbing that loads them.
+#   2. Vite reads config/vite.json plus the plugins under config/vite/.
+#   3. app/javascript imports config/currencies.json directly.
+# Nothing else under config/ can reach the compiled artifacts: the other
+# initializers, locales, and service configs (database/redis/mongo/puma/
+# sidekiq/certs) only affect runtime behavior. If you add a new compile-time
+# read of config/ — a JS `import` from config/, a new file consumed by
+# js:export or the Vite configs, or a routes-file reference to a constant
+# defined outside config/domain.rb — add its path here.
 preview_asset_cache_inputs() {
   git ls-tree -r HEAD -- \
     app/assets \
     app/javascript \
-    config \
+    config/routes.rb \
+    config/routes \
+    config/domain.rb \
+    config/application.rb \
+    config/boot.rb \
+    config/environment.rb \
+    config/environments \
+    config/initializers/js-routes.rb \
+    config/vite.json \
+    config/vite \
+    config/currencies.json \
     lib/json_schemas \
     lib/tasks \
     Rakefile \

--- a/.buildkite/scripts/preview_asset_cache.sh
+++ b/.buildkite/scripts/preview_asset_cache.sh
@@ -55,11 +55,15 @@ preview_asset_cache_logger() {
 #   1. `rails js:export` (lib/tasks/js_export.rake) boots Rails and serializes
 #      the routes via JsRoutes — the output depends on the routes files, the
 #      constants they reference (all defined in config/domain.rb), the
-#      JsRoutes initializer, and the boot plumbing that loads them.
+#      JsRoutes initializer, and the boot plumbing that loads them. "Boot
+#      plumbing" includes every file config/application.rb require_relatives
+#      directly (config/redis.rb, lib/catch_bad_request_errors.rb,
+#      lib/utilities/global_config.rb) — they run at boot before js:export, so
+#      they're keyed even though today's versions don't shape the output.
 #   2. Vite reads config/vite.json plus the plugins under config/vite/.
 #   3. app/javascript imports config/currencies.json directly.
 # Nothing else under config/ can reach the compiled artifacts: the other
-# initializers, locales, and service configs (database/redis/mongo/puma/
+# initializers, locales, and service configs (database/mongo/puma/
 # sidekiq/certs) only affect runtime behavior. If you add a new compile-time
 # read of config/ — a JS `import` from config/, a new file consumed by
 # js:export or the Vite configs, or a routes-file reference to a constant
@@ -75,6 +79,9 @@ preview_asset_cache_inputs() {
     config/boot.rb \
     config/environment.rb \
     config/environments \
+    config/redis.rb \
+    lib/catch_bad_request_errors.rb \
+    lib/utilities/global_config.rb \
     config/initializers/js-routes.rb \
     config/vite.json \
     config/vite \


### PR DESCRIPTION
## What

Narrows the preview asset cache key (#5834) from all of `config/` to the subset of `config/` that the asset compile actually reads: the routes files, `config/domain.rb` and the Rails boot plumbing that `js:export` depends on, the JsRoutes initializer, the Vite configs (`config/vite.json`, `config/vite/`), and `config/currencies.json` (imported directly by `app/javascript/utils/currency.ts`). Everything else in the key is unchanged.

## Why

The per-deploy instrumentation on #5802 showed the cache mechanically working but false-missing on runtime-only config changes: two of the first seven redeploys after #5834 merged were misses caused solely by toggling a QA initializer under `config/initializers/` — a file the compile never reads — each costing the full 13-minute compile instead of the ~2-minute cache-hit path (builds 14102/14132 showed hits land at 4m58s–6m10s wall vs the 17m13s baseline).

The compile reaches `config/` through exactly three channels, each still covered by the new key:

1. `rails js:export` (`lib/tasks/js_export.rake`) boots Rails and serializes routes via JsRoutes → covered by `config/routes.rb`, `config/routes/`, `config/domain.rb` (defines every constant the routes files reference: `DOMAIN`, `SHORT_DOMAIN`, `THIRD_PARTY_ANALYTICS_DOMAIN`), `config/initializers/js-routes.rb`, and the boot files (`application.rb`, `boot.rb`, `environment.rb`, `environments/`, plus the files `application.rb` itself `require_relative`s before js:export runs: `config/redis.rb`, `lib/catch_bad_request_errors.rb`, `lib/utilities/global_config.rb`).
2. Vite reads `config/vite.json` and the plugin under `config/vite/`.
3. `app/javascript/utils/currency.ts` imports `config/currencies.json`.

Runtime-only initializers, locales, and service configs (database/redis/mongo/puma/sidekiq) can't affect the compiled artifacts. A comment in the key function documents the three channels and when a new path must be added. The version constant is untouched — narrowing inputs changes every tag anyway, so existing entries are naturally invalidated once and repopulate on the next compile.

Refs #5802 (item 1 of the remaining work: raise the cache hit rate).

## Test plan

- `bash -n` on the edited script passes.
- Sourced the script and verified tag behavior against real commits in a worktree:
  - runtime-only initializer commit (`config/initializers/rack_attack.rb`) → tag **unchanged** (previously a false miss)
  - `config/routes.rb`, `config/domain.rb`, `config/currencies.json`, `app/javascript/**` commits → tag **changed** (correct misses)
  - tag stable across repeated computation on the same tree
- After merge: PHASE annotations on the next preview redeploys following a `config/initializers/` toggle should show `cache HIT` instead of a full compile; will post hit-rate before/after on #5802.

