### PR TITLE
Remove the "Price cents" prefix from the price-changed checkout error

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -4211,7 +4211,10 @@ class Purchase < ApplicationRecord
       return if customizable_price_that_has_not_changed?
 
       self.error_code = PurchaseErrorCode::PERCEIVED_PRICE_CENTS_NOT_MATCHING
-      errors.add(:price_cents, "The price just changed! Refresh the page for the updated price.")
+      # This message is shown to buyers verbatim (checkout surfaces errors via
+      # errors.full_messages), so it must live on :base — attaching it to an attribute
+      # would prepend "Price cents" to the buyer-facing alert.
+      errors.add(:base, "The price just changed! Refresh the page for the updated price.")
       true
     end
 

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -541,10 +541,13 @@ describe Purchase, :vcr do
       let(:product) { create(:product, price_cents: 10_00) }
       let(:purchase) { build(:purchase, link: product, perceived_price_cents: 5_00) }
 
-      it "returns false if the perceived price is different from the link price" do
+      it "adds a buyer-facing error without an attribute-name prefix if the perceived price is different from the product price" do
         purchase.save
 
-        expect(purchase.errors.full_messages).to include "Price cents The price just changed! Refresh the page for the updated price."
+        # Checkout shows errors.full_messages to buyers verbatim, so the message must not
+        # carry a humanized attribute prefix like "Price cents".
+        expect(purchase.errors.full_messages).to include "The price just changed! Refresh the page for the updated price."
+        expect(purchase.error_code).to eq PurchaseErrorCode::PERCEIVED_PRICE_CENTS_NOT_MATCHING
       end
 
       it "returns true if the purchase is_upgrade_purchase" do

--- a/spec/services/purchase/create_service_spec.rb
+++ b/spec/services/purchase/create_service_spec.rb
@@ -3515,7 +3515,9 @@ describe Purchase::CreateService, :vcr do
 
       purchase, error = Purchase::CreateService.new(product:, params:).perform
 
-      expect(error).to include("The price just changed!")
+      # This error string is returned to the checkout page as-is, so assert the exact
+      # buyer-facing message (no "Price cents" attribute prefix from full_messages).
+      expect(error).to eq("The price just changed! Refresh the page for the updated price.")
       expect(purchase).to have_attributes(
         purchase_state: "failed",
         is_installment_payment: false,


### PR DESCRIPTION
## What

Buyers who checked out after a price change saw the alert "Price cents The price just changed! Refresh the page for the updated price." This PR moves the error from the `:price_cents` attribute to `:base` in `Purchase`, so the alert now reads "The price just changed! Refresh the page for the updated price." Specs assert the exact buyer-facing string at the model layer and at the checkout service that returns it to the client.

## Why

Checkout surfaces purchase errors through `errors.full_messages`, which prepends the humanized attribute name to any error keyed to an attribute. This error was the only buyer-facing error in `Purchase` attached to an attribute; every other one already uses `:base`. Fixing it at the source also cleans up every flow that reads `full_messages` from a failed purchase (combined charges, preorders, membership plan changes). The wording itself is unchanged, and `Subscription::UpdaterService` raises this wording as a plain string, so it was already correct.

## Before/After

**Before: "Price cents The price just changed! Refresh the page for the updated price." (visible in the partial-failure screenshots of #5880)**
<img width="1999" height="1249" src="https://github.com/user-attachments/assets/9227b206-5d83-4235-9cfc-938e88683595" />

**After: "The price just changed! Refresh the page for the updated price."**
<img width="1999" height="1249" src="https://github.com/user-attachments/assets/808e6b6d-eee0-4058-8e56-72e923cd40cd" />

---

This PR was implemented with AI assistance using Claude Fable 5.