### PR TITLE
Add monthly Stripe balance summary email reports for all Antiwork entities

### DIFF
--- a/app/business/payments/reports/stripe_balance_summaries_report.rb
+++ b/app/business/payments/reports/stripe_balance_summaries_report.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+# Builds the month-end Stripe balance summary packet for every Antiwork Stripe account
+# (Gumroad, Flexile, Helper, Iffy). For each account it pulls three Stripe Reporting API
+# reports for the given month — balance summary, balance change from activity, and
+# payouts — and merges them into a single CSV that mirrors the Stripe dashboard's
+# Balance page layout. The CSVs are emailed to finance by
+# SendStripeBalanceSummariesReportJob as inputs to the monthly close.
+#
+# Gumroad settles in dozens of currencies, so its reports are pulled with a USD filter —
+# an unfiltered pull adds a starting/ending balance line for every settlement currency,
+# which doesn't match the dashboard's USD view that finance reconciles against. The
+# other accounts settle in USD only and need no filter.
+module StripeBalanceSummariesReport
+  # Each entry names an Antiwork Stripe account and where its restricted (reporting +
+  # files read) API key lives. Gumroad reuses the platform key already configured for
+  # the app; the other entities' keys are separate credentials. An entity whose key is
+  # not configured is skipped and reported as such in the email rather than failing the
+  # whole run.
+  ENTITIES = [
+    { name: "Gumroad", api_key: -> { STRIPE_SECRET }, usd_only: true },
+    { name: "Flexile", api_key: -> { GlobalConfig.get("STRIPE_API_KEY_FLEXILE") }, usd_only: false },
+    { name: "Helper",  api_key: -> { GlobalConfig.get("STRIPE_API_KEY_HELPER") }, usd_only: false },
+    { name: "Iffy",    api_key: -> { GlobalConfig.get("STRIPE_API_KEY_IFFY") }, usd_only: false },
+  ].freeze
+
+  REPORT_TYPES = %w[balance.summary.1 balance_change_from_activity.summary.1 payouts.summary.1].freeze
+
+  POLL_INTERVAL = 5.seconds
+  # Stripe report runs usually finish in under 30 seconds but can take a few minutes
+  # under load; give each one plenty of headroom before treating it as failed.
+  MAX_WAIT_PER_REPORT = 10.minutes
+
+  # Human-readable labels for the activity report's reporting_category values, matching
+  # how the Stripe dashboard displays them.
+  ACTIVITY_LABELS = {
+    "charge" => "Charges",
+    "refund" => "Refunds",
+    "refund_failure" => "Refund failures",
+    "dispute" => "Disputes",
+    "dispute_reversal" => "Dispute reversals",
+    "transfer" => "Transfers",
+    "transfer_reversal" => "Transfer reversals",
+    "platform_earning" => "Platform earnings",
+    "platform_earning_refund" => "Platform earning refunds",
+    "connect_collection_transfer" => "Connect collection transfers",
+    "fee" => "Additional Stripe fees",
+    "network_cost" => "Network costs",
+    "payout_minimum_balance_hold" => "Payout minimum balance hold",
+    "payout_minimum_balance_release" => "Payout minimum balance release",
+    "revenue_share" => "Revenue share",
+    "total" => "Net balance change from activity",
+  }.freeze
+
+  # Returns { csvs: { "Gumroad" => <csv string>, ... }, skipped: ["Flexile", ...] }.
+  # `skipped` lists entities whose API key is not configured; a configured entity whose
+  # reports fail raises instead, so Sidekiq retries (and the exhaustion alert) kick in.
+  def self.generate(month, year)
+    interval_start = Time.utc(year, month).to_i
+    interval_end = Time.utc(year, month).next_month.to_i
+
+    csvs = {}
+    skipped = []
+    ENTITIES.each do |entity|
+      api_key = entity[:api_key].call
+      if api_key.blank?
+        skipped << entity[:name]
+        next
+      end
+
+      raw_reports = REPORT_TYPES.index_with do |report_type|
+        run_report(api_key:, report_type:, interval_start:, interval_end:, usd_only: entity[:usd_only])
+      end
+      csvs[entity[:name]] = build_combined_csv(raw_reports)
+    end
+
+    { csvs:, skipped: }
+  end
+
+  def self.run_report(api_key:, report_type:, interval_start:, interval_end:, usd_only:)
+    parameters = { interval_start:, interval_end:, timezone: "Etc/UTC" }
+    parameters[:currency] = "usd" if usd_only
+
+    run = Stripe::Reporting::ReportRun.create({ report_type:, parameters: }, { api_key: })
+
+    deadline = Time.current + MAX_WAIT_PER_REPORT
+    while run.status == "pending"
+      raise "Stripe report run #{run.id} (#{report_type}) timed out after #{MAX_WAIT_PER_REPORT.inspect}" if Time.current > deadline
+      sleep(POLL_INTERVAL)
+      run = Stripe::Reporting::ReportRun.retrieve(run.id, { api_key: })
+    end
+    raise "Stripe report run #{run.id} (#{report_type}) failed: #{run.error}" unless run.status == "succeeded"
+
+    download_result(api_key, run.result.url)
+  end
+
+  # Report result files live on files.stripe.com and are fetched with the same API key
+  # via basic auth. The stripe gem has no download helper for them, hence Net::HTTP.
+  def self.download_result(api_key, url)
+    uri = URI.parse(url)
+    request = Net::HTTP::Get.new(uri)
+    request.basic_auth(api_key, "")
+    response = Net::HTTP.start(uri.host, uri.port, use_ssl: true) { _1.request(request) }
+    raise "Downloading Stripe report result failed with HTTP #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+
+    response.body
+  end
+
+  # Merges the three raw report CSVs into one CSV shaped like the Stripe dashboard's
+  # Balance page: a Balance Summary section, a Balance Change from Activity section
+  # (where a category with a non-zero fee shows the gross amount plus an indented fee
+  # sub-line, as the dashboard does), and a Payouts section.
+  def self.build_combined_csv(raw_reports)
+    balance_rows = CSV.parse(raw_reports["balance.summary.1"], headers: true)
+    activity_rows = CSV.parse(raw_reports["balance_change_from_activity.summary.1"], headers: true)
+    payout_rows = CSV.parse(raw_reports["payouts.summary.1"], headers: true)
+
+    CsvSafe.generate do |csv|
+      csv << %w[Section Description Count Amount Currency]
+
+      balance_rows.each do |row|
+        csv << ["Balance Summary", row["description"], nil, row["net_amount"], row["currency"]]
+      end
+
+      activity_rows.each do |row|
+        category = row["reporting_category"]
+        label = ACTIVITY_LABELS.fetch(category) { category.to_s.tr("_", " ").capitalize }
+        if category != "total" && row["fee"].to_f.nonzero?
+          csv << ["Balance Change from Activity", label, row["count"], row["gross"], row["currency"]]
+          csv << ["Balance Change from Activity", "  Fees (#{label})", nil, row["fee"], row["currency"]]
+        else
+          csv << ["Balance Change from Activity", label, row["count"], row["net"], row["currency"]]
+        end
+      end
+
+      payout_rows.each do |row|
+        label = row["reporting_category"] == "total" ? "Total paid out" : "Payouts"
+        csv << ["Payouts", label, row["count"], row["net"], row["currency"]]
+      end
+    end
+  end
+end

--- a/app/business/payments/reports/stripe_currency_balances_report.rb
+++ b/app/business/payments/reports/stripe_currency_balances_report.rb
@@ -1,25 +1,59 @@
 # frozen_string_literal: true
 
+# Snapshots the Gumroad platform Stripe account's balance, broken out per currency, for
+# the monthly close email (AccountingMailer.stripe_currency_balances_report).
+#
+# A currency's cash position is the sum of three Stripe balance buckets: available (ready
+# to pay out), pending (settling), and connect_reserved (held by Gumroad as the platform
+# against connected-account obligations — still Gumroad's cash). The CSV keeps the
+# per-bucket split visible so finance can see the composition, and adds a USD-converted
+# column (from the app's hourly-cached exchange rates) so non-USD residuals can be
+# reconciled without a separate FX lookup.
 module StripeCurrencyBalancesReport
   extend CurrencyHelper
 
+  BUCKETS = %i[available pending connect_reserved].freeze
+
   def self.stripe_currency_balances_report
-    currency_balances = {}
+    # to_hash gives plain nested hashes (symbol keys) and, unlike calling the accessor,
+    # tolerates a bucket being entirely absent from the API response.
+    stripe_balance = Stripe::Balance.retrieve.to_hash
 
-    stripe_balance = Stripe::Balance.retrieve
-    stripe_balance.available.sort_by { _1["currency"]  }.each do |balance|
-      currency_balances[balance["currency"]] = balance["amount"]
-    end
-
-    stripe_balance.connect_reserved.sort_by { _1["currency"]  }.each do |balance|
-      currency_balances[balance["currency"]] += balance["amount"] if currency_balances[balance["currency"]].abs != balance["amount"].abs
+    currency_balances = Hash.new { |hash, currency| hash[currency] = BUCKETS.index_with { 0 } }
+    BUCKETS.each do |bucket|
+      Array(stripe_balance[bucket]).each do |balance|
+        currency_balances[balance[:currency]][bucket] += balance[:amount]
+      end
     end
 
     CsvSafe.generate do |csv|
-      csv << %w(Currency Balance)
-      currency_balances.each do |currency, balance|
-        csv << [currency, is_currency_type_single_unit?(currency) ? balance : (balance / 100.0).round(2)]
+      csv << ["Currency", "Available", "Pending", "Connect reserved", "Total", "USD equivalent"]
+      currency_balances.sort.each do |currency, buckets|
+        total = buckets.values.sum
+        csv << [
+          currency,
+          *buckets.values.map { in_major_units(currency, _1) },
+          in_major_units(currency, total),
+          usd_equivalent(currency, total),
+        ]
       end
     end
+  end
+
+  # Stripe reports amounts in the currency's minor unit; single-unit currencies (JPY,
+  # KRW, ...) have no minor unit, so their amounts are already whole.
+  def self.in_major_units(currency, amount)
+    is_currency_type_single_unit?(currency) ? amount : (amount / 100.0).round(2)
+  end
+
+  # Converts a minor-unit amount to whole US dollars using the hourly-cached rate (safe
+  # to read here — no inline rate fetch). Left blank when no rate is cached for the
+  # currency so a missing rate is visible rather than silently reported as zero.
+  def self.usd_equivalent(currency, amount)
+    rate = cached_usd_rate(currency)
+    return nil if rate.nil?
+
+    major_units = is_currency_type_single_unit?(currency) ? amount : amount / 100.0
+    (major_units / rate).round(2)
   end
 end

--- a/app/mailers/accounting_mailer.rb
+++ b/app/mailers/accounting_mailer.rb
@@ -46,6 +46,23 @@ class AccountingMailer < ApplicationMailer
          cc: %w[gumclaw@gumroad.com]
   end
 
+  # One Stripe dashboard-style balance summary CSV per Antiwork Stripe account (Gumroad,
+  # Flexile, Helper, Iffy) for the given month — the month-end close inputs that were
+  # previously pulled by hand. `skipped_entities` names accounts whose API key isn't
+  # configured, so a silently missing attachment is called out in the email body instead.
+  def stripe_balance_summaries_report(csvs_by_entity, skipped_entities, month, year)
+    @month = month
+    @year = year
+    @skipped_entities = skipped_entities
+
+    csvs_by_entity.each do |entity, csv|
+      attachments["stripe-balance-#{entity.downcase}-#{month}-#{year}.csv"] = { data: csv }
+    end
+    mail subject: "#{SUBJECT_PREFIX}Stripe Balance Summaries Report – #{month}/#{year}",
+         to: FINANCE_EMAIL,
+         cc: %w[gumclaw@gumroad.com]
+  end
+
   def stripe_currency_balances_report(balances_csv)
     last_month = Time.current.last_month
     month = last_month.month

--- a/app/sidekiq/send_stripe_balance_summaries_report_job.rb
+++ b/app/sidekiq/send_stripe_balance_summaries_report_job.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class SendStripeBalanceSummariesReportJob
+  include Sidekiq::Job
+  include FinanceReportFailureAlert
+  sidekiq_options retry: 5, queue: :default, lock: :until_executed, on_conflict: :replace
+
+  # The scheduler fires with no args; pin the resolved period in the exhaustion alert so a
+  # late re-run reports the month the failed run was for (not whatever "last month" is then).
+  def self.default_alert_args(reference_time = Time.current)
+    last_month = reference_time.last_month
+    [last_month.month, last_month.year]
+  end
+
+  # month/year default to the previous month for the scheduled run. Pass them explicitly to
+  # re-run a specific month — re-running is safe (read-only pulls from Stripe's Reporting API).
+  #
+  # Scheduled on the 2nd of the month (not the 1st): Stripe's balance reports only cover
+  # up to roughly 24 hours ago, so asking for a full month too soon after it ends gets
+  # rejected by Stripe's API.
+  def perform(month = nil, year = nil)
+    return unless Rails.env.production?
+
+    if month.nil? || year.nil?
+      last_month = Time.current.last_month
+      month ||= last_month.month
+      year ||= last_month.year
+    end
+    raise ArgumentError, "Invalid month" unless month.in?(1..12)
+    raise ArgumentError, "Invalid year" unless year.in?(2014..3200)
+
+    report = StripeBalanceSummariesReport.generate(month, year)
+
+    AccountingMailer.stripe_balance_summaries_report(report[:csvs], report[:skipped], month, year).deliver_now
+  end
+end

--- a/app/sidekiq/verify_finance_reports_delivery_job.rb
+++ b/app/sidekiq/verify_finance_reports_delivery_job.rb
@@ -36,6 +36,7 @@ class VerifyFinanceReportsDeliveryJob
     "SendDeferredRefundsReportWorker" => ->(fire_time) { SendDeferredRefundsReportWorker.default_alert_args(fire_time) },
     "SendDailyFinanceLedgerReportJob" => ->(fire_time) { SendDailyFinanceLedgerReportJob.default_alert_args(fire_time) },
     "SendStripeCurrencyBalancesReportJob" => ->(_fire_time) { [] },
+    "SendStripeBalanceSummariesReportJob" => ->(fire_time) { SendStripeBalanceSummariesReportJob.default_alert_args(fire_time) },
     "EmailOutstandingBalancesCsvWorker" => ->(_fire_time) { [] },
     "CreateIndiaSalesReportJob" => ->(fire_time) { CreateIndiaSalesReportJob.default_alert_args(fire_time) },
     "GenerateFinancialReportsForPreviousMonthJob" => ->(fire_time) { GenerateFinancialReportsForPreviousMonthJob.default_alert_args(fire_time) },

--- a/app/views/accounting_mailer/stripe_balance_summaries_report.html.erb
+++ b/app/views/accounting_mailer/stripe_balance_summaries_report.html.erb
@@ -1,0 +1,13 @@
+<%= header_section("Stripe Balance Summaries Report") %>
+<div>
+  <p>
+    Attached are the Stripe balance summary reports for <%= "#{@month}/#{@year}" %> — one CSV per
+    Stripe account, each combining the balance summary, balance change from activity, and payouts
+    reports for the month.
+  </p>
+  <% if @skipped_entities.present? %>
+    <p>
+      Not included (no Stripe API key configured): <%= @skipped_entities.join(", ") %>.
+    </p>
+  <% end %>
+</div>

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -358,9 +358,13 @@ daily_finance_ledger_report:
   class: SendDailyFinanceLedgerReportJob
   description: Daily event-ledger finance report (funds received, refunds, disputes) for the previous UTC day
 stripe_currency_balances_report:
-  cron: "0 11 1 * *" # UTC 11:00 on 1st of every month
+  cron: "5 0 1 * *" # UTC 00:05 on 1st of every month — the balance is read live (point-in-time), so run as close to month-end as possible
   class: SendStripeCurrencyBalancesReportJob
   description: Email with Stripe currency balances report
+stripe_balance_summaries_report:
+  cron: "0 11 2 * *" # UTC 11:00 on 2nd of every month — Stripe's balance reports lag ~24h, so the full previous month isn't queryable on the 1st
+  class: SendStripeBalanceSummariesReportJob
+  description: Email with Stripe balance summary reports (all Antiwork Stripe accounts) for the previous month
 reset_admin_action_call_counts:
   cron: "0 11 1 * *" # UTC 11:00 on 1st of every month
   class: ResetAdminActionCallCountsJob

--- a/lib/mailer_previews/accounting_mailer_preview.rb
+++ b/lib/mailer_previews/accounting_mailer_preview.rb
@@ -10,6 +10,15 @@ class AccountingMailerPreview < ActionMailer::Preview
     AccountingMailer.funds_received_report(last_month.month, last_month.year)
   end
 
+  def stripe_balance_summaries_report
+    last_month = Time.current.last_month
+    csvs = {
+      "Gumroad" => "Section,Description,Count,Amount,Currency\nBalance Summary,Starting balance (2026-06-01),,1000000.00,usd\n",
+      "Flexile" => "Section,Description,Count,Amount,Currency\nBalance Summary,Starting balance (2026-06-01),,50000.00,usd\n",
+    }
+    AccountingMailer.stripe_balance_summaries_report(csvs, ["Helper", "Iffy"], last_month.month, last_month.year)
+  end
+
   def deferred_refunds_report
     last_month = Time.current.last_month
     AccountingMailer.deferred_refunds_report(last_month.month, last_month.year)

--- a/spec/business/payments/reports/stripe_balance_summaries_report_spec.rb
+++ b/spec/business/payments/reports/stripe_balance_summaries_report_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+describe StripeBalanceSummariesReport do
+  let(:balance_csv) do
+    <<~CSV
+      category,description,net_amount,currency
+      starting_balance,Starting balance (2026-06-01),100000.00,usd
+      ending_balance,Ending balance (2026-07-01),120000.00,usd
+    CSV
+  end
+
+  let(:activity_csv) do
+    <<~CSV
+      reporting_category,currency,count,gross,fee,net
+      charge,usd,10,5000.00,0.00,5000.00
+      refund,usd,2,-300.00,-10.00,-310.00
+      total,usd,12,4700.00,-10.00,4690.00
+    CSV
+  end
+
+  let(:payouts_csv) do
+    <<~CSV
+      reporting_category,currency,count,gross,fee,net
+      payout,usd,4,-2000.00,0.00,-2000.00
+      total,usd,4,-2000.00,0.00,-2000.00
+    CSV
+  end
+
+  describe ".generate" do
+    before do
+      allow(GlobalConfig).to receive(:get).and_call_original
+      allow(GlobalConfig).to receive(:get).with("STRIPE_API_KEY_FLEXILE").and_return("rk_live_flexile")
+      allow(GlobalConfig).to receive(:get).with("STRIPE_API_KEY_HELPER").and_return(nil)
+      allow(GlobalConfig).to receive(:get).with("STRIPE_API_KEY_IFFY").and_return(nil)
+
+      allow(described_class).to receive(:run_report) do |api_key:, report_type:, **|
+        case report_type
+        when "balance.summary.1" then balance_csv
+        when "balance_change_from_activity.summary.1" then activity_csv
+        when "payouts.summary.1" then payouts_csv
+        end
+      end
+    end
+
+    it "builds one combined CSV per configured entity and lists unconfigured entities as skipped" do
+      result = described_class.generate(6, 2026)
+
+      expect(result[:csvs].keys).to eq(["Gumroad", "Flexile"])
+      expect(result[:skipped]).to eq(["Helper", "Iffy"])
+
+      rows = CSV.parse(result[:csvs]["Gumroad"])
+      expect(rows.first).to eq(%w[Section Description Count Amount Currency])
+      expect(rows).to include(["Balance Summary", "Starting balance (2026-06-01)", nil, "100000.00", "usd"])
+      expect(rows).to include(["Balance Change from Activity", "Charges", "10", "5000.00", "usd"])
+      expect(rows).to include(["Payouts", "Total paid out", "4", "-2000.00", "usd"])
+    end
+
+    it "requests the month's UTC boundaries, filtering Gumroad to USD and leaving the others unfiltered" do
+      described_class.generate(6, 2026)
+
+      expect(described_class).to have_received(:run_report)
+        .with(api_key: STRIPE_SECRET, report_type: "balance.summary.1",
+              interval_start: Time.utc(2026, 6, 1).to_i, interval_end: Time.utc(2026, 7, 1).to_i, usd_only: true)
+      expect(described_class).to have_received(:run_report)
+        .with(api_key: "rk_live_flexile", report_type: "balance.summary.1",
+              interval_start: Time.utc(2026, 6, 1).to_i, interval_end: Time.utc(2026, 7, 1).to_i, usd_only: false)
+    end
+  end
+
+  describe ".build_combined_csv" do
+    it "splits activity categories with fees into a gross line plus an indented fee sub-line" do
+      csv = described_class.build_combined_csv(
+        "balance.summary.1" => balance_csv,
+        "balance_change_from_activity.summary.1" => activity_csv,
+        "payouts.summary.1" => payouts_csv,
+      )
+
+      rows = CSV.parse(csv)
+      refund_index = rows.index { |row| row[1] == "Refunds" }
+      expect(rows[refund_index]).to eq(["Balance Change from Activity", "Refunds", "2", "-300.00", "usd"])
+      expect(rows[refund_index + 1]).to eq(["Balance Change from Activity", "  Fees (Refunds)", nil, "-10.00", "usd"])
+    end
+
+    it "keeps the activity total as a single net line even though it carries the summed fees" do
+      csv = described_class.build_combined_csv(
+        "balance.summary.1" => balance_csv,
+        "balance_change_from_activity.summary.1" => activity_csv,
+        "payouts.summary.1" => payouts_csv,
+      )
+
+      rows = CSV.parse(csv)
+      expect(rows).to include(["Balance Change from Activity", "Net balance change from activity", "12", "4690.00", "usd"])
+      expect(rows.none? { |row| row[1] == "  Fees (Net balance change from activity)" }).to eq(true)
+    end
+  end
+
+  describe ".run_report" do
+    it "creates the report run, polls until it succeeds, and downloads the result" do
+      pending_run = double("run", id: "frr_123", status: "pending")
+      succeeded_run = double("run", id: "frr_123", status: "succeeded", result: double("file", url: "https://files.stripe.com/v1/files/file_123/contents"))
+
+      expect(Stripe::Reporting::ReportRun).to receive(:create)
+        .with({ report_type: "balance.summary.1",
+                parameters: { interval_start: 1, interval_end: 2, timezone: "Etc/UTC", currency: "usd" } },
+              { api_key: "rk_live_test" })
+        .and_return(pending_run)
+      expect(Stripe::Reporting::ReportRun).to receive(:retrieve).with("frr_123", { api_key: "rk_live_test" }).and_return(succeeded_run)
+      allow(described_class).to receive(:sleep)
+      expect(described_class).to receive(:download_result).with("rk_live_test", "https://files.stripe.com/v1/files/file_123/contents").and_return("csv")
+
+      expect(described_class.run_report(api_key: "rk_live_test", report_type: "balance.summary.1", interval_start: 1, interval_end: 2, usd_only: true)).to eq("csv")
+    end
+
+    it "raises when the report run fails" do
+      failed_run = double("run", id: "frr_123", status: "failed", error: "boom")
+      expect(Stripe::Reporting::ReportRun).to receive(:create).and_return(failed_run)
+
+      expect do
+        described_class.run_report(api_key: "rk_live_test", report_type: "balance.summary.1", interval_start: 1, interval_end: 2, usd_only: false)
+      end.to raise_error(/failed: boom/)
+    end
+  end
+end

--- a/spec/business/payments/reports/stripe_currency_balances_report_spec.rb
+++ b/spec/business/payments/reports/stripe_currency_balances_report_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+describe StripeCurrencyBalancesReport do
+  describe ".stripe_currency_balances_report" do
+    before do
+      balance = {
+        available: [
+          { currency: "usd", amount: 617_402_08 },
+          { currency: "gbp", amount: -50_000_00 },
+          { currency: "jpy", amount: 12_345 },
+        ],
+        pending: [
+          { currency: "usd", amount: 10_000_00 },
+          { currency: "gbp", amount: -1_000_00 },
+        ],
+        connect_reserved: [
+          { currency: "usd", amount: 5_000_00 },
+        ],
+      }
+      allow(Stripe::Balance).to receive(:retrieve).and_return(double("balance", to_hash: balance))
+
+      allow(described_class).to receive(:cached_usd_rate).and_return(nil)
+      allow(described_class).to receive(:cached_usd_rate).with("usd").and_return(BigDecimal("1"))
+      allow(described_class).to receive(:cached_usd_rate).with("gbp").and_return(BigDecimal("0.8"))
+    end
+
+    it "sums available, pending, and connect_reserved per currency and converts totals to USD" do
+      rows = CSV.parse(described_class.stripe_currency_balances_report)
+
+      expect(rows.first).to eq(["Currency", "Available", "Pending", "Connect reserved", "Total", "USD equivalent"])
+      expect(rows).to include(["usd", "617402.08", "10000.0", "5000.0", "632402.08", "632402.08"])
+      expect(rows).to include(["gbp", "-50000.0", "-1000.0", "0.0", "-51000.0", "-63750.0"])
+    end
+
+    it "reports single-unit currencies without dividing by 100 and leaves the USD column blank when no rate is cached" do
+      rows = CSV.parse(described_class.stripe_currency_balances_report)
+
+      jpy_row = rows.find { |row| row.first == "jpy" }
+      expect(jpy_row).to eq(["jpy", "12345", "0", "0", "12345", nil])
+    end
+
+    it "sorts rows by currency code" do
+      rows = CSV.parse(described_class.stripe_currency_balances_report)
+
+      expect(rows.drop(1).map(&:first)).to eq(%w[gbp jpy usd])
+    end
+  end
+end

--- a/spec/mailers/accounting_mailer_spec.rb
+++ b/spec/mailers/accounting_mailer_spec.rb
@@ -96,6 +96,30 @@ describe AccountingMailer, :vcr do
     end
   end
 
+  describe "#stripe_balance_summaries_report" do
+    it "attaches one CSV per entity and names entities skipped for missing keys" do
+      csvs = {
+        "Gumroad" => "Section,Description,Count,Amount,Currency\nBalance Summary,Starting balance,,100.00,usd\n",
+        "Flexile" => "Section,Description,Count,Amount,Currency\nBalance Summary,Starting balance,,50.00,usd\n",
+      }
+      email = AccountingMailer.stripe_balance_summaries_report(csvs, ["Helper", "Iffy"], 6, 2026)
+
+      expect(email.to).to eq([ApplicationMailer::FINANCE_EMAIL])
+      expect(email.subject).to include("Stripe Balance Summaries Report – 6/2026")
+      expect(email.attachments.map(&:filename)).to match_array(["stripe-balance-gumroad-6-2026.csv", "stripe-balance-flexile-6-2026.csv"])
+      html_body = email.body.parts.find { |part| part.content_type.include?("html") }.body
+      expect(html_body).to include("Helper, Iffy")
+    end
+
+    it "omits the missing-key note when every entity was reported" do
+      csvs = { "Gumroad" => "Section,Description,Count,Amount,Currency\n" }
+      email = AccountingMailer.stripe_balance_summaries_report(csvs, [], 6, 2026)
+
+      html_body = email.body.parts.find { |part| part.content_type.include?("html") }.body
+      expect(html_body).not_to include("no Stripe API key configured")
+    end
+  end
+
   describe "#stripe_currency_balances_report" do
     it "sends an email with balances report attached as csv" do
       last_month = Time.current.last_month

--- a/spec/sidekiq/send_stripe_balance_summaries_report_job_spec.rb
+++ b/spec/sidekiq/send_stripe_balance_summaries_report_job_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+describe SendStripeBalanceSummariesReportJob do
+  describe "perform" do
+    let(:mailer_double) { double("mailer", deliver_now: nil) }
+    let(:report) { { csvs: { "Gumroad" => "csv" }, skipped: ["Iffy"] } }
+
+    before do
+      allow(Rails.env).to receive(:production?).and_return(true)
+      allow(StripeBalanceSummariesReport).to receive(:generate).and_return(report)
+      allow(AccountingMailer).to receive(:stripe_balance_summaries_report).and_return(mailer_double)
+    end
+
+    it "emails the balance summaries for the given month" do
+      described_class.new.perform(6, 2026)
+
+      expect(StripeBalanceSummariesReport).to have_received(:generate).with(6, 2026)
+      expect(AccountingMailer).to have_received(:stripe_balance_summaries_report).with({ "Gumroad" => "csv" }, ["Iffy"], 6, 2026)
+      expect(mailer_double).to have_received(:deliver_now)
+    end
+
+    it "defaults to the previous month for the scheduled no-arg run" do
+      travel_to(Time.utc(2026, 8, 2, 11)) do
+        described_class.new.perform
+      end
+
+      expect(StripeBalanceSummariesReport).to have_received(:generate).with(7, 2026)
+    end
+
+    it "rejects invalid months and years" do
+      expect { described_class.new.perform(13, 2026) }.to raise_error(ArgumentError, "Invalid month")
+      expect { described_class.new.perform(6, 2013) }.to raise_error(ArgumentError, "Invalid year")
+    end
+
+    it "does nothing outside production" do
+      allow(Rails.env).to receive(:production?).and_return(false)
+
+      described_class.new.perform(6, 2026)
+
+      expect(StripeBalanceSummariesReport).not_to have_received(:generate)
+    end
+  end
+
+  describe ".default_alert_args" do
+    it "pins the previous month relative to the reference time" do
+      expect(described_class.default_alert_args(Time.utc(2026, 8, 2, 11))).to eq([7, 2026])
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds a monthly `SendStripeBalanceSummariesReportJob` that pulls the Stripe Reporting API's three balance reports (`balance.summary.1`, `balance_change_from_activity.summary.1`, `payouts.summary.1`) for every Antiwork Stripe account — Gumroad, Flexile, Helper, Iffy — for the previous month, merges them into one dashboard-style CSV per account, and emails them to finance with gumclaw cc'd (same recipients as the funds-received report).

Also enriches the existing Stripe currency balances report: the CSV now shows the available / pending / connect_reserved split per currency, a total, and a USD-equivalent column (from the app's hourly-cached exchange rates), and its schedule moves from 11:00 to 00:05 UTC on the 1st so the point-in-time balance snapshot lands as close to month-end as possible.

## Why

The month-end close consumes Stripe balance summary reports for all four entities plus the Gumroad currency-balance snapshot. Today those are pulled outside the codebase by hand each month. Moving them into the codebase as scheduled email reports (following the funds-received report's mailer/cron conventions) makes them deterministic, retried on failure, and covered by the finance-report delivery backstop.

Refs antiwork/gumroad-private#1089.

Notes:
- The new job is scheduled on the **2nd** of the month, not the 1st: Stripe's balance reports only cover through ~24 hours ago, so a full previous month isn't queryable on the 1st.
- Gumroad's reports are pulled with `currency=usd` — it settles in 60+ currencies and an unfiltered pull adds a balance line per currency, which doesn't match the dashboard's USD view finance reconciles against. The other three accounts settle in USD only.
- Flexile/Helper/Iffy keys are read from `STRIPE_API_KEY_FLEXILE` / `STRIPE_API_KEY_HELPER` / `STRIPE_API_KEY_IFFY` (GlobalConfig: env or credentials). An entity with no key configured is skipped and named in the email body rather than failing the run — so this ships safely before the keys are added, and the email shows exactly what's missing. Restricted keys with Reporting + Files read access are sufficient.
- Both jobs register with `FinanceReportFailureAlert` (retry-exhaustion email with a pinned re-run command) and `VerifyFinanceReportsDeliveryJob` (daily backstop for vanished runs).

## Test plan

- New specs: `spec/business/payments/reports/stripe_balance_summaries_report_spec.rb` (CSV assembly, USD filter, month boundaries, report-run polling/failure), `spec/business/payments/reports/stripe_currency_balances_report_spec.rb` (bucket sums, single-unit currencies, missing-rate handling), `spec/sidekiq/send_stripe_balance_summaries_report_job_spec.rb`, plus mailer specs.
- Ran locally: 32 examples, 0 failures (new/touched specs + `verify_finance_reports_delivery_job_spec`). Two pre-existing `email_outstanding_balances_csv` failures in `accounting_mailer_spec.rb` are factory-seed issues unrelated to this diff.
- Mailer preview added: `/rails/mailers/accounting_mailer/stripe_balance_summaries_report`.
- After deploy: the currency balances report fires 00:05 UTC Aug 1, the balance summaries report 11:00 UTC Aug 2 — verify both land in the finance inbox before the August close.

## Before/After

Not applicable — no user-facing UI change; output is internal finance emails (see mailer preview).
