### PR TITLE
Fix time-window flake in two-factor authentication mailer spec

### DIFF
--- a/spec/mailers/two_factor_authentication_mailer_spec.rb
+++ b/spec/mailers/two_factor_authentication_mailer_spec.rb
@@ -5,7 +5,11 @@ require "spec_helper"
 describe TwoFactorAuthenticationMailer do
   let(:user) { create :user }
 
-  describe "#authentication_token" do
+  # The OTP code is time-based (TOTP), so it changes every 30 seconds. Freezing
+  # time ensures the code baked into the email matches the one the assertions
+  # recompute — without this the spec fails whenever the mail is built in one
+  # 30-second window and the expectation runs in the next.
+  describe "#authentication_token", :freeze_time do
     before do
       @mail = TwoFactorAuthenticationMailer.authentication_token(user.id)
     end


### PR DESCRIPTION
## What

Freezes time (`:freeze_time`) around the `TwoFactorAuthenticationMailer#authentication_token` specs so the OTP code stays stable for the whole example.

## Why

The spec builds the authentication email, then asserts the subject and body contain `user.otp_code`. The OTP code is time-based (TOTP) and rolls over every 30 seconds, so when the mail render and the assertion land in different 30-second windows the codes differ and the spec fails. Seen on CI (Test Fast 6, run 29359943093): `expected "Your authentication token is 881313" to include "Your authentication token is 140355"`. The repo already provides a `:freeze_time` metadata tag for exactly this; applying it removes the race deterministically.

## Test plan

- `bundle exec rspec spec/mailers/two_factor_authentication_mailer_spec.rb` — 3 examples, 0 failures locally
- `rubocop` clean on the changed file
- CI green
