### PR TITLE
Help center: document standalone store pages (First-class Pages)

### DIFF
--- a/app/views/help_center/articles/contents/_124-your-gumroad-profile-page.html.erb
+++ b/app/views/help_center/articles/contents/_124-your-gumroad-profile-page.html.erb
@@ -21,6 +21,7 @@
         <li><a href="#Add-sections-to-product-pages-ABGsI" target="_self">Add sections to product pages</a></li>
       </ul>
     </li>
+    <li><a href="#Standalone-pages-Kw3xR" target="_self">Add standalone pages to your store</a></li>
   </ul>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/6628533d7303ea4a739d367b/file-GLfzOQP5BK.png" %></figure>
   <p>Your profile allows you to have your own website on Gumroad. You can use it to introduce yourself with a profile picture and bio, <a href="170-audience">grow your following</a> by collecting email addresses, and showcase your products across customizable pages and sections.</p>
@@ -36,6 +37,7 @@
   <p>Click on the three-dot menu and select New page to get started. On a given page, click the + icon at the bottom to create a new section to be displayed on your profile.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/660a470bd00a8f46829b75dc/file-LcDS8NDJzg.gif" %></figure>
   <p>You can also rename and reorder your pages and sections from the three-dot menu.</p>
+  <p><i>Note:</i> These profile pages appear as tabs on your profile itself. To publish separate pages at their own URLs, like an about page or FAQ, see <a href="#Standalone-pages-Kw3xR" target="_self">Add standalone pages to your store</a> below.</p>
   <p><i>Note:</i> If you have published products but haven't added any sections yet, your profile automatically shows a section with all of your products, newest first. As soon as you save a section of your own, your layout replaces the automatic one. If you have no products for sale and no sections, your profile shows an email signup form instead.</p>
   <h3 id="Product-sections-WxaV_">Product sections</h3>
   <p>On a given product section, click the three-dot menu on the left to assign a name and select the products you want it to contain. You can choose whether to display the section's name or not, and automatically add any new products to a section (enabled by default on new sections).</p>
@@ -63,6 +65,12 @@
   <h3 id="Add-sections-to-product-pages-ABGsI">Add sections to product pages</h3>
   <p>Like on your profile, you can add sections like products, posts, subscribe, and text blocks on your product pages too!</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/66988bf35908935e84818b2b/file-h0OJRWWXyI.png" %></figure>
+  <h3 id="Standalone-pages-Kw3xR">Add standalone pages to your store</h3>
+  <p>Beyond your profile, you can publish standalone pages on your store, like an about page, an FAQ, or licensing terms. Each page gets its own URL at [username].gumroad.com/[page-slug], and on your custom domain if you have one connected.</p>
+  <p>To manage your pages, click Pages in the Gumroad navigation. The list shows your profile pinned at the top as your home page (it serves at your store's root and can't be deleted), with your other pages below it.</p>
+  <p>Click New page to create one. Give it a title, write the content in the rich text editor, and click Create page. The page's URL is generated from its title, and the pages list shows the link for each page. When editing an existing page, the preview pane on the right shows the page as visitors will see it, refreshing each time you save.</p>
+  <p>To delete a page, click the trash icon next to it in the list. Deleted pages are no longer reachable by visitors, and this can't be undone.</p>
+  <p><i>Note:</i> Pages built by an AI agent as fully custom HTML show a preview instead of the rich text editor, so the agent's design can't be accidentally overwritten. Team members with the marketing or admin role can create and edit pages; support and accountant roles can view them.</p>
 </div>
 <div>
   <h3>Related Articles</h3>


### PR DESCRIPTION
## What

Adds help-center coverage for First-class Pages (#5812) to `_124-your-gumroad-profile-page.html.erb` ("Build a website on Gumroad"):

- New "Add standalone pages to your store" section: what pages are, their URLs (`[username].gumroad.com/[page-slug]`, custom domains), the Pages entry in the nav, the profile pinned as the undeletable home page, create/edit/preview/delete flow, agent-built custom HTML pages showing a preview instead of the editor, and team-role access.
- A disambiguation note under "Create pages and sections": that section's "pages" are profile tabs, distinct from standalone pages — the article previously used the same word for both features.
- Matching TOC entry.

Body-only edit; `articles.yml` untouched (title/description unchanged).

## Why

gumroad#5812 shipped the Pages dashboard with zero help-center coverage of the feature (tracked in antiwork/gumroad-private#1091). Deliberate scoping per the open questions on that issue:

- The `gumroad pages` CLI commands are still follow-ups, so the doc leads with the in-app editor and does not mention CLI commands that don't exist yet. Agent-built pages are described only as far as the shipped UI shows them (preview instead of editor).
- The custom HTML path is Flipper-gated (`custom_html_pages`), so there is no how-to copy for authoring custom HTML — only the read-side behavior every seller sees in the dashboard.
- Internal limits (`Page::MAX_CUSTOM_HTML_LENGTH`, reserved slugs) are omitted; slug generation is described as automatic from the title, which is all a seller needs.

Every claim is verified against code: nav entry and label (`Nav/index.tsx`, gated on `policies.page.index`), pinned undeletable Home row and delete modal (`Pages/Index.tsx`), "New page"/"Create page"/"Save changes" labels and save-refreshed preview pane (`Pages/Edit.tsx`), role access (`PagePolicy` — marketing/admin create+edit, support/accountant view), custom-HTML pages not editable in place (`PagesController#update` backstop), public serving at `/<slug>` on subdomains and custom domains (`UserPagesController` routes).

## Test plan

- Rendered the partial in the real view context (`ApplicationController.render`) — renders clean, new copy present, anchors intact
- Tag-balance check on the full article body — all tags balanced
- ERB syntax check passes
- CI runs the help-center specs (slug/partial integrity)
