### PR TITLE
Fix NoMethodError in installment plan receipts when expected completion time is nil

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -675,6 +675,12 @@ class Subscription < ApplicationRecord
   def expected_completion_time
     return nil unless has_fixed_length?
 
+    # end_time_of_last_paid_period is nil when the subscription has no
+    # successful, non-refunded/non-chargedback charge and no free trial (for
+    # example, when the only installment charge was refunded or charged back).
+    # In that case there is no anchor date to project the final charge from.
+    return nil if end_time_of_last_paid_period.nil?
+
     end_time_of_last_paid_period + period * remaining_charges_count
   end
 

--- a/app/presenters/receipt_presenter/item_info.rb
+++ b/app/presenters/receipt_presenter/item_info.rb
@@ -277,11 +277,21 @@ class ReceiptPresenter::ItemInfo
     def manage_installment_plan_note
       timezone = subscription.user&.timezone
       started_at = subscription.created_at.in_time_zone(timezone)
-      expected_ends_at = subscription.expected_completion_time.in_time_zone(timezone)
+      expected_completion_time = subscription.expected_completion_time
+
+      # The expected completion time is nil when the subscription has no
+      # successful, non-refunded charge to anchor the projection on (for
+      # example, when the only installment charge was refunded). Skip the
+      # final-charge sentence rather than crashing the receipt.
+      final_charge_sentence =
+        if expected_completion_time.present?
+          expected_ends_at = expected_completion_time.in_time_zone(timezone)
+          "Your final charge will be on #{expected_ends_at.to_fs(:formatted_date_abbrev_month)}."
+        end
 
       <<~HTML.squish.html_safe
         Installment plan initiated on #{started_at.to_fs(:formatted_date_abbrev_month)}.
-        Your final charge will be on #{expected_ends_at.to_fs(:formatted_date_abbrev_month)}.
+        #{final_charge_sentence}
         You can manage your payment settings #{link_to("here", manage_subscription_href, target: "_blank")}.
       HTML
     end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -3440,6 +3440,21 @@ describe Subscription, :vcr do
         expect(subscription.charges_completed?).to eq(true)
         expect(subscription.expected_completion_time).to eq(subscription.end_time_of_last_paid_period)
       end
+
+      it "returns nil when there is no paid period to anchor on" do
+        travel_to(t0)
+
+        purchase = create(:membership_purchase, succeeded_at: t0)
+        subscription = purchase.subscription
+        subscription.update!(charge_occurrence_count: 3)
+
+        # Fully refunding the only successful charge leaves the subscription
+        # with no end_time_of_last_paid_period and no free trial.
+        purchase.update!(stripe_refunded: true)
+
+        expect(subscription.end_time_of_last_paid_period).to be_nil
+        expect(subscription.expected_completion_time).to be_nil
+      end
     end
   end
 

--- a/spec/presenters/receipt_presenter/item_info_spec.rb
+++ b/spec/presenters/receipt_presenter/item_info_spec.rb
@@ -768,6 +768,34 @@ describe ReceiptPresenter::ItemInfo do
             "You can manage your payment settings <a target=\"_blank\" href=\"#{url}\">here</a>."
           )
         end
+
+        it "omits the final charge date when the expected completion time is unknown" do
+          travel_to(Time.zone.parse("2025-03-14"))
+
+          product_installment_plan = create(
+            :product_installment_plan,
+            number_of_installments: 5,
+            recurrence: "monthly",
+          )
+          purchase = create(:installment_plan_purchase, link: product_installment_plan.link)
+          subscription = purchase.subscription
+
+          # Fully refunding the only successful charge leaves the subscription
+          # without a paid period to project the final charge date from.
+          purchase.update!(stripe_refunded: true)
+          expect(subscription.expected_completion_time).to be_nil
+
+          props = described_class.new(purchase).props
+
+          url = Rails.application.routes.url_helpers.manage_subscription_url(
+            subscription.external_id,
+            host: UrlService.domain_with_protocol,
+          )
+          expect(props[:manage_subscription_note]).to eq(
+            "Installment plan initiated on Mar 14, 2025. " \
+            "You can manage your payment settings <a target=\"_blank\" href=\"#{url}\">here</a>."
+          )
+        end
       end
     end
 


### PR DESCRIPTION
## What

Fixes a `NoMethodError: undefined method '+' for nil` crash in `Subscription#expected_completion_time` that raised `ActionView::Template::Error` while rendering grouped receipt emails for installment-plan purchases ([GUMROAD-YC](https://gumroad-to.sentry.io/issues/7611223884/)).

- `Subscription#expected_completion_time` now returns `nil` when `end_time_of_last_paid_period` is `nil` — i.e. when a fixed-length subscription has no successful, non-refunded/non-chargedback charge and no free trial (for example, the only installment charge was refunded or charged back).
- `ReceiptPresenter::ItemInfo#manage_installment_plan_note` omits the "Your final charge will be on …" sentence when the completion time is unknown, instead of crashing the receipt render.

## Why

`end_time_of_last_paid_period` falls back to `free_trial_ends_at` when there is no anchoring charge; installment plans have no free trial, so it can be `nil`. `expected_completion_time` then attempted `nil + period * remaining_charges_count`, and the receipt presenter called `.in_time_zone` on the crash path unguarded. This blew up the `ActionMailer::MailDeliveryJob` sending the grouped receipt (Sentry GUMROAD-YC, production, first seen 2026-07-14).

## Test plan

- New model spec: `Subscription#expected_completion_time` returns `nil` when the only successful charge is fully refunded (previously raised `NoMethodError`).
- New presenter spec: installment-plan receipt note omits the final-charge sentence when the completion time is unknown (previously raised).
- Both new specs verified RED against main (fail with the exact production exception) and GREEN with the fix; full `expected_completion_time` + `manage_subscription_note` groups pass (12 examples, 0 failures). Rubocop clean on all changed files.

## Before/After

Before: the receipt email for this state failed to send entirely (job crashed).

After — receipt for an installment plan whose only charge was refunded (final-charge sentence omitted):

![receipt-after](https://i.ibb.co/WvFKMrVG/receipt-after.png)

Unaffected normal installment-plan receipt (final-charge date still shown):

![receipt-normal](https://i.ibb.co/Fbgbd8WG/receipt-normal.png)
