### PR TITLE
Attribute VAT report refunds to the refund date, not the purchase date

### DIFF
--- a/app/sidekiq/create_vat_report_job.rb
+++ b/app/sidekiq/create_vat_report_job.rb
@@ -54,10 +54,20 @@ class CreateVatReportJob
                                                                .where("flags & :bit = :bit", bit: Purchase.flag_mapping["flags"][:chargeback_reversed])
                                                                .where(created_at: date.beginning_of_day..date.end_of_day)
 
+          # Refunds are subtracted in the period the refund happened, not the period of the
+          # original purchase. A refund is an event of its own period (matching how OSS/MOSS
+          # corrections are reported in the current return), and a purchase from a past quarter
+          # refunded this quarter must still reduce this quarter's VAT due. The purchase-side
+          # filters mirror the two queries above so we only ever subtract VAT that was (or would
+          # have been) reported in the first place: settled purchases that are either not charged
+          # back or had their chargeback reversed. A purchase that was charged back outright never
+          # contributes VAT to the report, so its refunds must not be subtracted either.
           vat_refunds_on_date = zip_tax_rate.purchases
                                               .where("purchase_state != 'failed'")
+                                              .where("stripe_transaction_id IS NOT NULL")
+                                              .not_chargedback_or_chargedback_reversed
                                               .joins(:refunds)
-                                              .where(created_at: date.beginning_of_day..date.end_of_day)
+                                              .where(refunds: { created_at: date.beginning_of_day..date.end_of_day })
 
           total_purchase_excluding_vat_amount_cents = vat_purchases_on_date.sum(:price_cents)
           total_purchase_vat_cents = vat_purchases_on_date.sum(:gumroad_tax_cents)

--- a/spec/sidekiq/create_vat_report_job_spec.rb
+++ b/spec/sidekiq/create_vat_report_job_spec.rb
@@ -160,4 +160,92 @@ describe CreateVatReportJob do
       temp_file.close(true)
     end
   end
+
+  describe "refund period attribution" do
+    let(:s3_bucket_double) do
+      s3_bucket_double = double
+      allow(Aws::S3::Resource).to receive_message_chain(:new, :bucket).and_return(s3_bucket_double)
+      s3_bucket_double
+    end
+
+    before :context do
+      @s3_object = Aws::S3::Resource.new.bucket("gumroad-specs").object("specs/vat-reporting-refund-attribution-spec-#{SecureRandom.hex(18)}.csv")
+    end
+
+    before do
+      zip_tax_rate = create(:zip_tax_rate, country: "AT", state: nil, zip_code: nil, combined_rate: 0.20, flags: 0)
+
+      travel_to(Time.zone.local(2023, 11, 15)) do
+        # Sold in Q4 2023, refunded in Q1 2024. The refund must reduce the Q1 2024
+        # report (the period the refund happened in), and re-generating the Q4 2023
+        # report must NOT be changed by the later refund.
+        @cross_quarter_purchase = create(:purchase, zip_tax_rate:, price_cents: 100_00, gumroad_tax_cents: 20_00,
+                                                    country: "Austria", ip_country: "Austria")
+      end
+
+      travel_to(Time.zone.local(2024, 1, 10)) do
+        create(:refund, purchase: @cross_quarter_purchase, amount_cents: 50_00, gumroad_tax_cents: 10_00)
+
+        # An ordinary same-quarter sale, so the Q1 2024 totals are non-zero and the
+        # refund subtraction is visible against them.
+        create(:purchase, zip_tax_rate:, price_cents: 100_00, gumroad_tax_cents: 20_00,
+                          country: "Austria", ip_country: "Austria")
+
+        # A purchase that was charged back outright never contributes VAT to the report,
+        # so a refund against it must not be subtracted either — otherwise the same VAT
+        # would be relieved twice (once by the chargeback exclusion, once by the refund).
+        chargedback_purchase = create(:purchase, zip_tax_rate:, price_cents: 100_00, gumroad_tax_cents: 20_00,
+                                                 country: "Austria", ip_country: "Austria")
+        chargedback_purchase.update!(chargeback_date: Time.current)
+        create(:refund, purchase: chargedback_purchase, amount_cents: 100_00, gumroad_tax_cents: 20_00)
+
+        # A purchase with no settled charge is never counted on the sales side, so its
+        # refund must not be subtracted from VAT we never reported. Paid purchases can't
+        # be built without transaction info, so null the column directly.
+        unsettled_purchase = create(:purchase, zip_tax_rate:, price_cents: 100_00, gumroad_tax_cents: 20_00,
+                                               country: "Austria", ip_country: "Austria")
+        unsettled_purchase.update_column(:stripe_transaction_id, nil)
+        create(:refund, purchase: unsettled_purchase, amount_cents: 100_00, gumroad_tax_cents: 20_00)
+      end
+    end
+
+    it "subtracts a refund in the quarter the refund happened, not the purchase's quarter" do
+      expect(s3_bucket_double).to receive(:object).and_return(@s3_object)
+      allow_any_instance_of(described_class).to receive(:gbp_to_usd_rate_for_date).and_return(2.0)
+
+      described_class.new.perform(1, 2024)
+
+      actual_payload = read_report_csv
+
+      # Q1 2024 sales: one 100.00 purchase with 20.00 VAT (the charged-back and
+      # unsettled purchases are excluded). Subtractions: only the cross-quarter
+      # refund of 50.00 with 10.00 VAT. Supplies 100.00 - 50.00 = 50.00, VAT due
+      # 20.00 - 10.00 = 10.00, estimated supplies 10.00 / 0.20 = 50.00. GBP columns
+      # are the USD amounts at the stubbed rate of 2.0.
+      expect(actual_payload[1]).to eq(["Austria", "Standard", "20.0", "50.00", "50.00", "10.00", "25.00", "25.00", "5.00"])
+    end
+
+    it "does not change a past quarter's report when a refund happens after that quarter closed" do
+      expect(s3_bucket_double).to receive(:object).and_return(@s3_object)
+      allow_any_instance_of(described_class).to receive(:gbp_to_usd_rate_for_date).and_return(2.0)
+
+      described_class.new.perform(4, 2023)
+
+      actual_payload = read_report_csv
+
+      # Q4 2023 contains only the original 100.00 sale with 20.00 VAT. The refund
+      # issued in January 2024 belongs to Q1 2024 and must not leak backwards into a
+      # re-generated Q4 2023 report (whose return may already be filed).
+      expect(actual_payload[1]).to eq(["Austria", "Standard", "20.0", "100.00", "100.00", "20.00", "50.00", "50.00", "10.00"])
+    end
+
+    def read_report_csv
+      temp_file = Tempfile.new("actual-file", encoding: "ascii-8bit")
+      @s3_object.get(response_target: temp_file)
+      temp_file.rewind
+      CSV.read(temp_file)
+    ensure
+      temp_file.close(true)
+    end
+  end
 end


### PR DESCRIPTION
## What

`CreateVatReportJob` now subtracts refunds in the period the **refund** happened, not the period of the original purchase. The unqualified `where(created_at: ...)` on the refund query bound to `purchases.created_at`, so a refund only counted if the original purchase was created inside the report quarter.

The refund query also now mirrors the purchase-side filters:

- `stripe_transaction_id IS NOT NULL` — refunds against purchases that never had a settled charge (never counted on the sales side) are no longer subtracted.
- `not_chargedback_or_chargedback_reversed` — a purchase that was charged back outright never contributes VAT to the report, so its refunds no longer double-relieve the same VAT.

## Why

A refund issued this quarter for a purchase from an earlier quarter was never subtracted from any report generated after that earlier quarter's filing — roughly 22% of refund VAT in a typical quarter (~$6.7k/quarter measured on Q2 2026 production data) was attributed to the wrong period and overpaid. Conversely, re-generating a past quarter's report retroactively pulled in later refunds, changing a period whose return was already filed.

Refund-date attribution is the correct period cut-off treatment for the VAT payable liability and matches the EU OSS mechanism, where corrections to prior periods are reported in the current return rather than by amending the filed one. After this change, re-running a historical quarter is deterministic with respect to refunds.

Out of scope, tracked on the issue: the chargeback legs have the same event-date attribution problem (`not_chargedback` / `chargeback_reversed` read current purchase state against the purchase-date window) and should get the same treatment in a follow-up; historical filed quarters are left as-filed, with the cumulative under-claimed refund VAT recoverable as a correction in the next OSS return.

Refs: https://github.com/antiwork/gumroad-private/issues/1093 (fable-5 GAAP review of the finding and fix direction is on the issue). Builds on the `effective_refunds` narrowing in #5779, which is orthogonal and should land regardless.

## Test plan

- New specs cover: a cross-quarter refund reducing the quarter it was issued in; re-generation determinism (a later refund must not change a closed quarter's report); refunds on charged-back purchases excluded; refunds on unsettled purchases excluded.
- Ran locally: `rspec spec/sidekiq/create_vat_report_job_spec.rb` — 5 examples, 0 failures (the pre-existing happy-case spec passes unchanged, confirming same-quarter behavior is untouched).
- `rubocop` clean on both changed files.
