### PR TITLE
Scope the deferred refunds report's sums to the reported month's refunds

### DIFF
--- a/app/business/payments/reports/deferred_refunds_reports.rb
+++ b/app/business/payments/reports/deferred_refunds_reports.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 module DeferredRefundsReports
+  # Monthly accounting email listing the refunds and disputes from the given month that were
+  # issued against purchases from an EARLIER month ("deferred" — the sale's revenue period
+  # already closed when the money went back out).
   def self.deferred_refunds_report(month, year)
     json = { "Purchases" => [] }
     range = DateTime.new(year, month)...DateTime.new(year, month).end_of_month
@@ -21,14 +24,22 @@ module DeferredRefundsReports
       refunded_purchases = charges.first
       disputed_purchases = charges.second
 
+      # Sum only the refunds created inside the reported month. The purchases were selected
+      # because they have at least one refund in the month, but a purchase refunded across
+      # several months (e.g. two partial refunds in different months) has refund rows outside
+      # the range too — an unscoped join would count those in this month's totals as well,
+      # so each refund of a multi-month purchase would be reported in every month that
+      # purchase appears in.
+      month_refunds = refunded_purchases.joins(:refunds).where(refunds: { created_at: range })
+
       json["Purchases"] << {
         "Processor" => name,
         "Sales" => {
           total_transaction_count: refunded_purchases.count + disputed_purchases.count,
-          total_transaction_cents: refunded_purchases.joins(:refunds).sum("refunds.total_transaction_cents") + disputed_purchases.sum(:total_transaction_cents),
-          gumroad_tax_cents: refunded_purchases.joins(:refunds).sum("refunds.gumroad_tax_cents") + disputed_purchases.sum(:gumroad_tax_cents),
-          affiliate_credit_cents: refunded_purchases.joins(:refunds).sum("TRUNCATE(purchases.affiliate_credit_cents * (refunds.amount_cents / purchases.price_cents), 0)") + disputed_purchases.sum(:affiliate_credit_cents),
-          fee_cents: refunded_purchases.joins(:refunds).sum("refunds.fee_cents") + disputed_purchases.sum(:fee_cents)
+          total_transaction_cents: month_refunds.sum("refunds.total_transaction_cents") + disputed_purchases.sum(:total_transaction_cents),
+          gumroad_tax_cents: month_refunds.sum("refunds.gumroad_tax_cents") + disputed_purchases.sum(:gumroad_tax_cents),
+          affiliate_credit_cents: month_refunds.sum("TRUNCATE(purchases.affiliate_credit_cents * (refunds.amount_cents / purchases.price_cents), 0)") + disputed_purchases.sum(:affiliate_credit_cents),
+          fee_cents: month_refunds.sum("refunds.fee_cents") + disputed_purchases.sum(:fee_cents)
         }
       }
     end

--- a/app/business/payments/reports/deferred_refunds_reports.rb
+++ b/app/business/payments/reports/deferred_refunds_reports.rb
@@ -6,7 +6,11 @@ module DeferredRefundsReports
   # already closed when the money went back out).
   def self.deferred_refunds_report(month, year)
     json = { "Purchases" => [] }
-    range = DateTime.new(year, month)...DateTime.new(year, month).end_of_month
+    # Exclusive upper bound at the FIRST INSTANT of the next month. Using end_of_month here
+    # would drop the month's final second entirely (refunds.created_at has second precision,
+    # and `...23:59:59` excludes 23:59:59 itself), so a refund created in that second would
+    # appear in no month's report, ever.
+    range = DateTime.new(year, month)...DateTime.new(year, month).next_month
 
     refunded_purchase_ids = Refund.where(created_at: range).pluck(:purchase_id)
     deferred_refund_purchases = Purchase.successful.where(id: refunded_purchase_ids).where("succeeded_at < ?", range.first)
@@ -35,6 +39,9 @@ module DeferredRefundsReports
       json["Purchases"] << {
         "Processor" => name,
         "Sales" => {
+          # Counts are purchase-grain (purchases affected this month), while the cents sums
+          # below are refund-grain (only this month's refund rows) — a purchase partially
+          # refunded twice in one month counts once but sums both refunds.
           total_transaction_count: refunded_purchases.count + disputed_purchases.count,
           total_transaction_cents: month_refunds.sum("refunds.total_transaction_cents") + disputed_purchases.sum(:total_transaction_cents),
           gumroad_tax_cents: month_refunds.sum("refunds.gumroad_tax_cents") + disputed_purchases.sum(:gumroad_tax_cents),

--- a/spec/business/payments/reports/deferred_refunds_reports_spec.rb
+++ b/spec/business/payments/reports/deferred_refunds_reports_spec.rb
@@ -35,6 +35,27 @@ describe DeferredRefundsReports do
       expect(july_stripe[:fee_cents]).to eq(4_00)
     end
 
+    it "includes a refund created in the month's final second" do
+      # Guards the range's upper bound: refunds.created_at has second precision, so an
+      # end_of_month exclusive bound (`...23:59:59`) would drop the final second and the
+      # refund would appear in no month's report at all.
+      purchase = nil
+      travel_to(Time.utc(2026, 5, 10)) do
+        purchase = create(:purchase, price_cents: 100_00, total_transaction_cents: 100_00)
+      end
+
+      travel_to(Time.utc(2026, 6, 30, 23, 59, 59)) do
+        create(:refund, purchase:, amount_cents: 25_00, total_transaction_cents: 25_00)
+      end
+
+      june = described_class.deferred_refunds_report(6, 2026)["Purchases"].find { |entry| entry["Processor"] == "Stripe" }["Sales"]
+      expect(june[:total_transaction_count]).to eq(1)
+      expect(june[:total_transaction_cents]).to eq(25_00)
+
+      july = described_class.deferred_refunds_report(7, 2026)["Purchases"].find { |entry| entry["Processor"] == "Stripe" }["Sales"]
+      expect(july[:total_transaction_count]).to eq(0)
+    end
+
     it "does not include a purchase refunded in the same month it succeeded" do
       travel_to(Time.utc(2026, 6, 10)) do
         purchase = create(:purchase, price_cents: 100_00, total_transaction_cents: 100_00)

--- a/spec/business/payments/reports/deferred_refunds_reports_spec.rb
+++ b/spec/business/payments/reports/deferred_refunds_reports_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe DeferredRefundsReports do
+  describe ".deferred_refunds_report" do
+    it "sums only the refunds created inside the reported month" do
+      # A purchase from May that is refunded twice: a partial refund in June and another in
+      # July. The June report must count only the June refund and the July report only the
+      # July refund — before the refunds join was scoped by date, every month a purchase
+      # appeared in counted ALL of its refunds, double-counting multi-month refunds.
+      purchase = nil
+      travel_to(Time.utc(2026, 5, 10)) do
+        purchase = create(:purchase, price_cents: 100_00, total_transaction_cents: 100_00)
+      end
+
+      travel_to(Time.utc(2026, 6, 15)) do
+        create(:refund, purchase:, amount_cents: 30_00, total_transaction_cents: 30_00, gumroad_tax_cents: 0, fee_cents: 3_00)
+      end
+
+      travel_to(Time.utc(2026, 7, 20)) do
+        create(:refund, purchase:, amount_cents: 40_00, total_transaction_cents: 40_00, gumroad_tax_cents: 0, fee_cents: 4_00)
+      end
+
+      june_report = described_class.deferred_refunds_report(6, 2026)
+      june_stripe = june_report["Purchases"].find { |entry| entry["Processor"] == "Stripe" }["Sales"]
+      expect(june_stripe[:total_transaction_count]).to eq(1)
+      expect(june_stripe[:total_transaction_cents]).to eq(30_00)
+      expect(june_stripe[:fee_cents]).to eq(3_00)
+
+      july_report = described_class.deferred_refunds_report(7, 2026)
+      july_stripe = july_report["Purchases"].find { |entry| entry["Processor"] == "Stripe" }["Sales"]
+      expect(july_stripe[:total_transaction_count]).to eq(1)
+      expect(july_stripe[:total_transaction_cents]).to eq(40_00)
+      expect(july_stripe[:fee_cents]).to eq(4_00)
+    end
+
+    it "does not include a purchase refunded in the same month it succeeded" do
+      travel_to(Time.utc(2026, 6, 10)) do
+        purchase = create(:purchase, price_cents: 100_00, total_transaction_cents: 100_00)
+        create(:refund, purchase:, amount_cents: 100_00, total_transaction_cents: 100_00)
+      end
+
+      report = described_class.deferred_refunds_report(6, 2026)
+      stripe = report["Purchases"].find { |entry| entry["Processor"] == "Stripe" }["Sales"]
+      expect(stripe[:total_transaction_count]).to eq(0)
+      expect(stripe[:total_transaction_cents]).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
## What

Scopes the deferred refunds report's refund sums to refunds created inside the reported month, and fixes the range's upper bound: the report now runs to the first instant of the next month instead of `end_of_month`, whose exclusive bound silently dropped the month's final second. Also documents that `total_transaction_count` is purchase-grain while the cents sums are refund-grain.

## Why

Two period bugs in the accounting email that feeds the monthly close JEs:

1. The report selected purchases by "has a refund created in the month" but then summed **all** refunds on those purchases via an unscoped `joins(:refunds)`. A purchase partially refunded in June and again in July had both refunds counted in July's report (and the June refund counted in June's too) — multi-month refunds were double-reported.
2. `DateTime.new(year, month)...end_of_month` excludes 23:59:59 on the last day (`refunds.created_at` has second precision), so a refund created in the month's final second appeared in **no** month's report, ever.

This is a sibling of the refund period-attribution fixes in #5890 (VAT) and #5891 (TaxJar): a refund belongs to the period it was created in.

**Conflict note for the resolver:** open PR #5779 rewrites the same sum lines (`joins(:refunds)` → `joins(:effective_refunds)`) and the selection (`Refund.effective`). Whichever merges second must compose both changes — the month scope here AND the effective scope there are each load-bearing, and each PR's specs fail if its scope is dropped in resolution.

Refs: antiwork/gumroad-private#1093

## Test plan

- New `spec/business/payments/reports/deferred_refunds_reports_spec.rb`: a May purchase refunded partially in June and again in July is reported with only the June refund in June's report and only the July refund in July's (fails with the fix reverted); a refund created at 23:59:59 on the month's last day lands in that month and no other; a same-month purchase+refund stays excluded.
- Ran locally: 3 examples, 0 failures (plus the existing worker/mailer deferred-report specs). Rubocop clean.

## Before/After

Not applicable — accounting report data change, no UI.
