### PR TITLE
Add a pull/source endpoint for storefront pages

### DIFF
--- a/app/controllers/api/v2/pages_controller.rb
+++ b/app/controllers/api/v2/pages_controller.rb
@@ -139,7 +139,7 @@ class Api::V2::PagesController < Api::V2::BaseController
       }
     end
 
-    # The eject path: a faithful standalone-HTML render of the page as it
+    # The pull path: a faithful standalone-HTML render of the page as it
     # serves publicly today. When an agent takes over a rich text page with
     # custom HTML, it starts from this instead of reverse-engineering the
     # public layout from raw rich text. Custom HTML pages return the stored

--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -29,9 +29,18 @@ class Api::V2::UsersController < Api::V2::BaseController
 
   # GET the seller's own profile landing page HTML. has_landing_page lets the
   # agent decide whether it's editing an existing page or authoring a new one.
+  #
+  # rendered_html is the pull path for going custom: a faithful standalone-HTML
+  # render of the profile as it serves today. When no custom HTML is published
+  # yet, that's a render of the default storefront (creator header, product
+  # grid, posts) — so an agent taking over the home page starts from what the
+  # profile already looks like instead of a blank file. Once custom HTML is
+  # live, the stored HTML already IS the document, so it's returned as-is.
+  # Slugged pages have the same field on GET /v2/pages/:slug.
   def custom_html
     user = current_resource_owner
-    render_response(true, custom_html: user.custom_html, has_landing_page: user.has_custom_landing_page?, profile_url: profile_url_for(user))
+    rendered_html = user.custom_html.presence || Pages::DefaultProfileDocument.render(user)
+    render_response(true, custom_html: user.custom_html, rendered_html:, has_landing_page: user.has_custom_landing_page?, profile_url: profile_url_for(user))
   end
 
   # PUT the profile landing page. Mirrors the product custom_html surface but is

--- a/app/controllers/user_pages_controller.rb
+++ b/app/controllers/user_pages_controller.rb
@@ -91,7 +91,7 @@ class UserPagesController < ApplicationController
 
     # Sanitized rich text renders directly — it can't carry scripts, so it
     # doesn't need the sandboxed-iframe pipeline. The document itself comes
-    # from Pages::RichTextDocument, shared with the API's eject render.
+    # from Pages::RichTextDocument, shared with the API's pull render.
     def rich_text_page_document
       profile_href = @is_user_custom_domain ? "/" : @user.profile_url
       Pages::RichTextDocument.render(page: @page, seller_name: @user.name_or_username, profile_href:, head_extra: page_meta_head)

--- a/app/javascript/components/ApiDocumentation/Endpoints/User.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/User.tsx
@@ -139,6 +139,7 @@ export const GetUserCustomHtml = () => (
       {`{
   "success": true,
   "custom_html": "<main><h1>Moonwalk Records</h1></main>",
+  "rendered_html": "<main><h1>Moonwalk Records</h1></main>",
   "has_landing_page": true,
   "profile_url": "https://sailorjohn.gumroad.com"
 }`}

--- a/app/javascript/components/ApiDocumentation/Endpoints/User.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/User.tsx
@@ -50,8 +50,9 @@ const ProfileCustomHtmlDocumentation = () => (
     </p>
     <ul>
       <li>
-        <code>GET /v2/user/custom_html</code> returns the current <code>custom_html</code>, a{" "}
-        <code>has_landing_page</code> flag, and your public <code>profile_url</code>.
+        <code>GET /v2/user/custom_html</code> returns the current <code>custom_html</code>, a <code>rendered_html</code>{" "}
+        starting point (the published HTML, or a render of the default storefront when none is set — pull it, edit,
+        preview, and push back), a <code>has_landing_page</code> flag, and your public <code>profile_url</code>.
       </li>
       <li>
         <code>PUT /v2/user/custom_html</code> sets it; send <code>null</code> or an empty string to clear it and fall
@@ -118,6 +119,12 @@ export const GetUserCustomHtml = () => (
       {renderFields([
         { name: "success", type: "boolean", description: "Whether the request succeeded" },
         { name: "custom_html", type: "string", description: "The published profile HTML, or null if none is set" },
+        {
+          name: "rendered_html",
+          type: "string",
+          description:
+            "A standalone HTML render of the profile as it serves today — the published custom HTML, or a faithful render of the default storefront when none is set. Pull this as the starting point for going custom.",
+        },
         { name: "has_landing_page", type: "boolean", description: "Whether a custom profile page is currently set" },
         { name: "profile_url", type: "string", description: "Your public profile URL" },
       ])}

--- a/app/services/pages/default_profile_document.rb
+++ b/app/services/pages/default_profile_document.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+# Renders the seller's DEFAULT storefront (the profile home page as it looks
+# before any custom HTML takeover) into a single standalone HTML document.
+#
+# This is the "pull" starting point for going custom on the profile: instead of
+# starting an agent from a blank file, `GET /v2/user/custom_html` returns this
+# render (as `rendered_html`) so the agent begins from a faithful snapshot of
+# what the profile already shows — creator header, product grid, recent posts,
+# links to the seller's other pages — then edits and pushes the result back.
+# Slugged pages get the same treatment from Pages::RichTextDocument; this
+# service is the profile-root counterpart.
+#
+# It deliberately reuses Pages::ProfileData (the same cached snapshot injected
+# into published custom pages as `gumroad-data`), so the pulled document and
+# the data an agent later reads at runtime agree with each other. All URLs are
+# absolute (products use Link#long_url on the seller's subdomain) because the
+# document is destined to be served inside the sandboxed custom-HTML iframe,
+# where relative links wouldn't reach the seller's store.
+class Pages::DefaultProfileDocument
+  def self.render(seller)
+    profile = SellerProfile.find_by(seller_id: seller.id)
+    background = ERB::Util.h(profile&.background_color.presence || "#ffffff")
+    highlight = ERB::Util.h(profile&.highlight_color.presence || "#ff90e8")
+    name = ERB::Util.h(seller.name_or_username.to_s)
+    bio = ERB::Util.h(seller.bio.to_s)
+    avatar = ERB::Util.h(seller.avatar_url.to_s)
+    data = Pages::ProfileData.build(seller)
+
+    <<~HTML
+      <!doctype html>
+      <html lang="en">
+        <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+          <title>#{name}</title>
+          <style>
+            :root { --background: #{background}; --accent: #{highlight}; }
+            * { box-sizing: border-box; }
+            body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; background: var(--background); color: #000; line-height: 1.5; }
+            main { max-width: 64rem; margin: 0 auto; padding: 3rem 1.5rem; }
+            header.creator { display: flex; align-items: center; gap: 1rem; margin-bottom: 1rem; }
+            header.creator img { width: 4rem; height: 4rem; border-radius: 50%; border: 1px solid #000; }
+            header.creator h1 { margin: 0; font-size: 2rem; line-height: 1.2; }
+            p.bio { margin: 0 0 2rem; max-width: 42rem; }
+            nav.pages { display: flex; flex-wrap: wrap; gap: 0.75rem; margin-bottom: 2.5rem; }
+            nav.pages a { color: inherit; font-size: 0.875rem; }
+            section h2 { font-size: 1.25rem; margin: 2.5rem 0 1rem; }
+            .products { display: grid; grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr)); gap: 1rem; padding: 0; margin: 0; list-style: none; }
+            .products a { display: block; height: 100%; color: inherit; text-decoration: none; border: 1px solid #000; border-radius: 8px; overflow: hidden; background: #fff; }
+            .products a:hover { box-shadow: 4px 4px 0 var(--accent); }
+            .products img { display: block; width: 100%; aspect-ratio: 1; object-fit: cover; border-bottom: 1px solid #000; }
+            .products .details { padding: 0.75rem 1rem; }
+            .products h3 { margin: 0 0 0.5rem; font-size: 1rem; }
+            .products .price { display: inline-block; padding: 0.125rem 0.5rem; border: 1px solid #000; border-radius: 4px; background: var(--accent); font-size: 0.875rem; }
+            .posts { padding: 0; margin: 0; list-style: none; }
+            .posts li { border-top: 1px solid rgba(0, 0, 0, 0.2); }
+            .posts a { display: block; padding: 0.75rem 0; color: inherit; }
+          </style>
+        </head>
+        <body>
+          <main>
+            <header class="creator">
+              #{avatar.present? ? %(<img src="#{avatar}" alt="#{name}">) : ""}
+              <h1>#{name}</h1>
+            </header>
+            #{bio.present? ? %(<p class="bio">#{bio}</p>) : ""}
+            #{pages_nav(seller)}
+            #{products_section(data[:products])}
+            #{posts_section(data[:posts])}
+          </main>
+        </body>
+      </html>
+    HTML
+  end
+
+  # Links to the seller's other (slugged) pages, so the pulled home page keeps
+  # the store navigable the way the seller's pages list is today.
+  def self.pages_nav(seller)
+    links = seller.pages.filter_map do |page|
+      next if page.slug.blank?
+      %(<a href="#{ERB::Util.h("#{seller.subdomain_with_protocol}/#{page.slug}")}">#{ERB::Util.h(page.title.to_s)}</a>)
+    end
+    return "" if links.empty?
+
+    %(<nav class="pages">#{links.join("\n")}</nav>)
+  end
+
+  def self.products_section(products)
+    return "" if products.blank?
+
+    items = products.map do |product|
+      thumbnail = product[:thumbnail_url].present? ? %(<img src="#{ERB::Util.h(product[:thumbnail_url])}" alt="">) : ""
+      <<~ITEM
+        <li>
+          <a href="#{ERB::Util.h(product[:url])}">
+            #{thumbnail}
+            <div class="details">
+              <h3>#{ERB::Util.h(product[:name])}</h3>
+              <span class="price">#{ERB::Util.h(product[:price])}</span>
+            </div>
+          </a>
+        </li>
+      ITEM
+    end
+    %(<section><h2>Products</h2><ul class="products">#{items.join("\n")}</ul></section>)
+  end
+
+  def self.posts_section(posts)
+    return "" if posts.blank?
+
+    items = posts.map do |post|
+      %(<li><a href="#{ERB::Util.h(post[:url])}">#{ERB::Util.h(post[:name])}</a></li>)
+    end
+    %(<section><h2>Posts</h2><ul class="posts">#{items.join("\n")}</ul></section>)
+  end
+end

--- a/app/services/pages/default_profile_document.rb
+++ b/app/services/pages/default_profile_document.rb
@@ -27,8 +27,14 @@
 class Pages::DefaultProfileDocument
   def self.render(seller)
     profile = SellerProfile.find_by(seller_id: seller.id)
-    background = ERB::Util.h(profile&.background_color.presence || "#ffffff")
-    highlight = ERB::Util.h(profile&.highlight_color.presence || "#ff90e8")
+    # The colors land inside a <style> block, where HTML-escaping isn't the
+    # right defense (it leaves CSS metacharacters like ; { } intact). The model
+    # validates these as hex colors, but its regex uses line anchors (^ $),
+    # which a multiline value can slip past — so re-check the whole string here
+    # (\A \z) and fall back to the defaults for anything that isn't exactly a
+    # hex color. Nothing seller-controlled can then reach the <style> block.
+    background = css_hex_color(profile&.background_color, default: "#ffffff")
+    highlight = css_hex_color(profile&.highlight_color, default: "#ff90e8")
     name = ERB::Util.h(seller.name_or_username.to_s)
     bio = ERB::Util.h(seller.bio.to_s)
     avatar = ERB::Util.h(seller.avatar_url.to_s)
@@ -105,5 +111,11 @@ class Pages::DefaultProfileDocument
       %(<li><a href="#{ERB::Util.h(post[:url])}">#{ERB::Util.h(post[:name])}</a></li>)
     end
     %(<section><h2>Posts</h2><ul class="posts">#{items.join("\n")}</ul></section>)
+  end
+
+  # Strict whole-string hex color check (#rrggbb) for values interpolated into
+  # the <style> block. Anything else falls back to the given default.
+  def self.css_hex_color(value, default:)
+    value.to_s.match?(/\A#[0-9a-f]{6}\z/i) ? value : default
   end
 end

--- a/app/services/pages/default_profile_document.rb
+++ b/app/services/pages/default_profile_document.rb
@@ -6,10 +6,17 @@
 # This is the "pull" starting point for going custom on the profile: instead of
 # starting an agent from a blank file, `GET /v2/user/custom_html` returns this
 # render (as `rendered_html`) so the agent begins from a faithful snapshot of
-# what the profile already shows — creator header, product grid, recent posts,
-# links to the seller's other pages — then edits and pushes the result back.
+# what the profile already shows — creator header, product grid, recent posts —
+# then edits and pushes the result back.
 # Slugged pages get the same treatment from Pages::RichTextDocument; this
 # service is the profile-root counterpart.
+#
+# Deliberately NOT included: links to the seller's slugged pages. The default
+# storefront doesn't render those links anywhere, and a seller may rely on a
+# page being unlinked (a hidden discount page, a draft shared privately). Adding
+# them here would mean a pull-then-push publishes navigation the current
+# storefront never showed. Agents that want a pages nav can list pages via the
+# API and add links intentionally.
 #
 # It deliberately reuses Pages::ProfileData (the same cached snapshot injected
 # into published custom pages as `gumroad-data`), so the pulled document and
@@ -43,8 +50,6 @@ class Pages::DefaultProfileDocument
             header.creator img { width: 4rem; height: 4rem; border-radius: 50%; border: 1px solid #000; }
             header.creator h1 { margin: 0; font-size: 2rem; line-height: 1.2; }
             p.bio { margin: 0 0 2rem; max-width: 42rem; }
-            nav.pages { display: flex; flex-wrap: wrap; gap: 0.75rem; margin-bottom: 2.5rem; }
-            nav.pages a { color: inherit; font-size: 0.875rem; }
             section h2 { font-size: 1.25rem; margin: 2.5rem 0 1rem; }
             .products { display: grid; grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr)); gap: 1rem; padding: 0; margin: 0; list-style: none; }
             .products a { display: block; height: 100%; color: inherit; text-decoration: none; border: 1px solid #000; border-radius: 8px; overflow: hidden; background: #fff; }
@@ -65,25 +70,12 @@ class Pages::DefaultProfileDocument
               <h1>#{name}</h1>
             </header>
             #{bio.present? ? %(<p class="bio">#{bio}</p>) : ""}
-            #{pages_nav(seller)}
             #{products_section(data[:products])}
             #{posts_section(data[:posts])}
           </main>
         </body>
       </html>
     HTML
-  end
-
-  # Links to the seller's other (slugged) pages, so the pulled home page keeps
-  # the store navigable the way the seller's pages list is today.
-  def self.pages_nav(seller)
-    links = seller.pages.filter_map do |page|
-      next if page.slug.blank?
-      %(<a href="#{ERB::Util.h("#{seller.subdomain_with_protocol}/#{page.slug}")}">#{ERB::Util.h(page.title.to_s)}</a>)
-    end
-    return "" if links.empty?
-
-    %(<nav class="pages">#{links.join("\n")}</nav>)
   end
 
   def self.products_section(products)

--- a/app/services/pages/rich_text_document.rb
+++ b/app/services/pages/rich_text_document.rb
@@ -4,7 +4,7 @@
 # the public page serves. Shared by:
 #
 # - UserPagesController#show — the actual public render at /<slug>
-# - Api::V2::PagesController#show (`rendered_html`) — the eject path: when an
+# - Api::V2::PagesController#show (`rendered_html`) — the pull path: when an
 #   agent takes over a rich text page with custom HTML, it starts from this
 #   faithful render of the current page instead of reverse-engineering the
 #   layout from raw rich text.

--- a/spec/controllers/api/v2/users_controller_custom_html_spec.rb
+++ b/spec/controllers/api/v2/users_controller_custom_html_spec.rb
@@ -23,6 +23,27 @@ describe Api::V2::UsersController do
       expect(body["profile_url"]).to eq(@user.profile_url)
     end
 
+    it "returns the published custom HTML verbatim as the pull render" do
+      @user.update!(custom_html: "<section>Published HTML</section>")
+
+      get :custom_html, params: { format: :json, access_token: @token.token }
+
+      expect(response.parsed_body["rendered_html"]).to eq("<section>Published HTML</section>")
+    end
+
+    it "returns a default storefront render as the pull starting point when no custom HTML is published" do
+      product = create(:product, user: @user, name: "Design Course")
+
+      get :custom_html, params: { format: :json, access_token: @token.token }
+
+      body = response.parsed_body
+      expect(body["custom_html"]).to be_nil
+      expect(body["rendered_html"]).to include("<!doctype html>")
+      expect(body["rendered_html"]).to include("<h1>Jane Doe</h1>")
+      expect(body["rendered_html"]).to include("Design Course")
+      expect(body["rendered_html"]).to include(product.long_url)
+    end
+
     it "reports no landing page when none is published" do
       get :custom_html, params: { format: :json, access_token: @token.token }
 

--- a/spec/services/pages/default_profile_document_spec.rb
+++ b/spec/services/pages/default_profile_document_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Pages::DefaultProfileDocument do
+  describe ".render" do
+    let(:seller) { create(:user, name: "Jane Doe", bio: "Maker of things", username: "janedoe") }
+
+    it "renders a standalone document with the creator header and bio" do
+      html = described_class.render(seller)
+
+      expect(html).to include("<!doctype html>")
+      expect(html).to include("<title>Jane Doe</title>")
+      expect(html).to include("<h1>Jane Doe</h1>")
+      expect(html).to include(%(<p class="bio">Maker of things</p>))
+    end
+
+    it "lists the seller's live products with absolute store URLs" do
+      product = create(:product, user: seller, name: "Design Course")
+      draft = create(:product, user: seller, name: "Unfinished Draft", draft: true)
+
+      html = described_class.render(seller)
+
+      expect(html).to include("Design Course")
+      expect(html).to include(product.long_url)
+      expect(html).not_to include(draft.name)
+    end
+
+    it "links the seller's slugged pages so the pulled home page stays navigable" do
+      create(:user_page, pageable: seller, slug: "about", title: "About me")
+
+      html = described_class.render(seller)
+
+      expect(html).to include(%(href="#{seller.subdomain_with_protocol}/about"))
+      expect(html).to include("About me")
+    end
+
+    it "uses the seller's saved profile colors" do
+      seller.seller_profile.update!(background_color: "#123456", highlight_color: "#abcdef")
+
+      html = described_class.render(seller)
+
+      expect(html).to include("--background: #123456")
+      expect(html).to include("--accent: #abcdef")
+    end
+
+    it "escapes seller-controlled text so it cannot break out of the document" do
+      seller.update!(name: %(<script>alert("x")</script>))
+
+      html = described_class.render(seller)
+
+      expect(html).not_to include("<script>alert")
+      expect(html).to include("&lt;script&gt;")
+    end
+
+    it "omits the products, posts, and pages sections when the seller has none" do
+      html = described_class.render(seller)
+
+      expect(html).not_to include("<h2>Products</h2>")
+      expect(html).not_to include("<h2>Posts</h2>")
+      expect(html).not_to include(%(<nav class="pages">))
+    end
+  end
+end

--- a/spec/services/pages/default_profile_document_spec.rb
+++ b/spec/services/pages/default_profile_document_spec.rb
@@ -26,13 +26,17 @@ describe Pages::DefaultProfileDocument do
       expect(html).not_to include(draft.name)
     end
 
-    it "links the seller's slugged pages so the pulled home page stays navigable" do
+    it "does not link slugged pages, since the default storefront never shows those links" do
+      # A pulled document must only contain what the current storefront renders:
+      # a seller may rely on a slugged page being unlinked (a hidden discount
+      # page, a draft shared privately), and pushing the pull back must not
+      # publish navigation the storefront never had.
       create(:user_page, pageable: seller, slug: "about", title: "About me")
 
       html = described_class.render(seller)
 
-      expect(html).to include(%(href="#{seller.subdomain_with_protocol}/about"))
-      expect(html).to include("About me")
+      expect(html).not_to include("/about")
+      expect(html).not_to include("About me")
     end
 
     it "uses the seller's saved profile colors" do
@@ -53,12 +57,11 @@ describe Pages::DefaultProfileDocument do
       expect(html).to include("&lt;script&gt;")
     end
 
-    it "omits the products, posts, and pages sections when the seller has none" do
+    it "omits the products and posts sections when the seller has none" do
       html = described_class.render(seller)
 
       expect(html).not_to include("<h2>Products</h2>")
       expect(html).not_to include("<h2>Posts</h2>")
-      expect(html).not_to include(%(<nav class="pages">))
     end
   end
 end

--- a/spec/services/pages/default_profile_document_spec.rb
+++ b/spec/services/pages/default_profile_document_spec.rb
@@ -57,6 +57,19 @@ describe Pages::DefaultProfileDocument do
       expect(html).to include("&lt;script&gt;")
     end
 
+    it "falls back to the default colors when a saved color is not exactly a hex color" do
+      # The colors are interpolated into the <style> block, so anything that
+      # isn't a plain #rrggbb value must be dropped, not escaped.
+      profile = seller.seller_profile.tap(&:save!)
+      profile.update_columns(background_color: "#123456; } body { display: none } /*", highlight_color: "#abcdef\n}")
+
+      html = described_class.render(seller)
+
+      expect(html).to include("--background: #ffffff")
+      expect(html).to include("--accent: #ff90e8")
+      expect(html).not_to include("display: none")
+    end
+
     it "omits the products and posts sections when the seller has none" do
       html = described_class.render(seller)
 


### PR DESCRIPTION
## What

Adds the **pull** half of the go-custom loop for storefront Pages: pull the current page as faithful standalone HTML → edit with your agent → preview → push back. Going custom no longer starts from a blank file for any page kind:

| Page kind | Endpoint | `rendered_html` returns |
|---|---|---|
| Profile home (root) | `GET /v2/user/custom_html` | Published custom HTML verbatim, or **a standalone render of the default storefront** (creator header + bio, product grid with live prices/thumbnails, recent posts) when none is set — **new in this PR** |
| Rich text page | `GET /v2/pages/:slug` | The sanitized rich text wrapped in the same standalone document the public page serves (shipped in #5812 via `Pages::RichTextDocument`; concept renamed here) |
| Custom HTML page | `GET /v2/pages/:slug` | The stored custom HTML verbatim (shipped in #5812) |

New service `Pages::DefaultProfileDocument` renders the default-storefront snapshot. It reuses `Pages::ProfileData` (the same cached snapshot injected into published custom pages as `gumroad-data`) so the pulled document and the runtime data an agent later reads agree, uses the seller's saved profile colors, escapes all seller-controlled text, and emits absolute store URLs (the document is destined for the sandboxed custom-HTML iframe, where relative links wouldn't reach the store).

Also renames the concept from "eject" to "pull" in code comments (it's not a one-way door — it's symmetric with `gumroad pages push`) and documents `rendered_html` on the `/v2/user/custom_html` API docs page.

## Why

gumroad-private#1047 V1 remainder: the go-custom flow should start from a faithful HTML render of the current page. Slugged pages got their render in #5812; the profile home — the page most sellers will take over first — still started blank.

## API shape

```
GET /v2/user/custom_html   (edit_profile / view_profile scope — unchanged)
{
  "success": true,
  "custom_html": null,
  "rendered_html": "<!doctype html>\n<html lang=\"en\">…<h1>Jane Doe</h1>…Design Course…</html>",
  "has_landing_page": false,
  "profile_url": "https://janedoe.gumroad.com"
}

GET /v2/pages/faq   (unchanged response shape, comment-level rename only)
{
  "success": true,
  "page": { "slug": "faq", "title": "FAQ", "content": "<p>Q &amp; A</p>", "custom_html": null, … },
  "rendered_html": "<!doctype html>…<h1 class=\"page-title\">FAQ</h1>…"
}
```

No new routes, no scope changes, no schema changes.

## Test plan

- `bundle exec rspec spec/services/pages/default_profile_document_spec.rb spec/controllers/api/v2/users_controller_custom_html_spec.rb spec/controllers/api/v2/pages_controller_spec.rb` → **53 examples, 0 failures**
  - default storefront render: header/bio, live products only (drafts excluded), no links to slugged pages (the storefront doesn't show them, so a pull-then-push can't publish them), profile colors, escaping, empty-state sections
  - `GET /v2/user/custom_html`: `rendered_html` = published HTML verbatim when set; default render (with product `long_url`) when not; existing scope/feature-flag gating unchanged
  - `GET /v2/pages/:slug`: existing rich-text + custom-HTML render specs still green; other users' pages still invisible
- `bundle exec rubocop` on all touched Ruby files → no offenses

## Progress

- [x] `Pages::DefaultProfileDocument` — default storefront → standalone HTML
- [x] `rendered_html` on `GET /v2/user/custom_html`
- [x] eject → pull rename in comments (no user-facing strings used the old name)
- [x] API docs (`User.tsx`) mention `rendered_html`
- [x] Specs + rubocop green
- [ ] Follow-up (separate PR, antiwork/gumroad-cli): `gumroad pages pull <slug>` / `gumroad pages pull profile`

Ref gumroad-private#1047

