### PR TITLE
Add failed_refund_exceptions table and credits.failed_refund_id (schema for #5779)

### DIFF
--- a/db/migrate/20261205000004_create_failed_refund_exceptions.rb
+++ b/db/migrate/20261205000004_create_failed_refund_exceptions.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class CreateFailedRefundExceptions < ActiveRecord::Migration[7.1]
+  def change
+    create_table :failed_refund_exceptions do |t|
+      t.bigint :refund_id, null: false
+      t.string :owner, null: false
+      t.string :notification_room, null: false
+      t.string :state, null: false, default: "pending"
+      t.datetime :due_at, null: false
+      t.boolean :balance_reversed, null: false, default: false
+      t.integer :notification_failures, null: false, default: 0
+      t.datetime :notification_sent_at
+      t.datetime :resolved_at
+      t.text :resolution
+
+      t.timestamps
+      t.index :refund_id, unique: true
+      t.index [:state, :notification_sent_at],
+              name: "idx_failed_refund_exceptions_pending_notification"
+      t.index [:state, :due_at],
+              name: "idx_failed_refund_exceptions_on_state_due_at"
+    end
+  end
+end

--- a/db/migrate/20261205000005_add_failed_refund_id_to_credits.rb
+++ b/db/migrate/20261205000005_add_failed_refund_id_to_credits.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddFailedRefundIdToCredits < ActiveRecord::Migration[7.1]
+  def change
+    # Links a credit that gives back a previously retained refund fee to the refund
+    # that FAILED after acceptance. A dedicated column (instead of a json_data flag)
+    # lets payout exports and finance reports find and label these give-backs with a
+    # plain indexed query, so they aren't presented as generic unexplained credits.
+    change_table :credits, bulk: true do |t|
+      t.bigint :failed_refund_id
+      t.index :failed_refund_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -766,8 +766,10 @@ ActiveRecord::Schema[7.1].define(version: 2026_12_06_000000) do
     t.bigint "backtax_agreement_id"
     t.text "json_data"
     t.text "reason"
+    t.bigint "failed_refund_id"
     t.index ["balance_id"], name: "index_credits_on_balance_id"
     t.index ["dispute_id"], name: "index_credits_on_dispute_id"
+    t.index ["failed_refund_id"], name: "index_credits_on_failed_refund_id"
     t.index ["user_id", "created_at", "id"], name: "index_credits_on_user_id_and_created_at_and_id"
   end
 
@@ -987,6 +989,24 @@ ActiveRecord::Schema[7.1].define(version: 2026_12_06_000000) do
     t.index ["service_charge_id"], name: "index_events_on_service_charge_id"
     t.index ["user_id"], name: "index_events_on_user_id"
     t.index ["visit_id"], name: "index_events_on_visit_id"
+  end
+
+  create_table "failed_refund_exceptions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "refund_id", null: false
+    t.string "owner", null: false
+    t.string "notification_room", null: false
+    t.string "state", default: "pending", null: false
+    t.datetime "due_at", null: false
+    t.boolean "balance_reversed", default: false, null: false
+    t.integer "notification_failures", default: 0, null: false
+    t.datetime "notification_sent_at"
+    t.datetime "resolved_at"
+    t.text "resolution"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["refund_id"], name: "index_failed_refund_exceptions_on_refund_id", unique: true
+    t.index ["state", "due_at"], name: "idx_failed_refund_exceptions_on_state_due_at"
+    t.index ["state", "notification_sent_at"], name: "idx_failed_refund_exceptions_pending_notification"
   end
 
   create_table "followers", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
## What

Adds the two additive schema changes needed by the failed bank-transfer refund handling in #5779:

- **`failed_refund_exceptions` table** — durable exception queue recording every failed-refund case that needs human follow-up (owner, notification room, state, due date, whether the balance was auto-reversed, notification/resolution tracking). Unique on `refund_id`; indexed on `(state, notification_sent_at)` and `(state, due_at)` for the pending-notification and overdue scans.
- **`credits.failed_refund_id` column + index** — links a credit that gives back a previously retained refund fee to the refund that failed after acceptance, so payout exports and finance reports can find and label these give-backs with a plain indexed query instead of presenting them as generic unexplained credits.

No application code reads or writes these yet — that stays in #5779.

## Why

Splitting the schema out so it deploys and verifies first. With the schema already live, the application code in #5779 can be rolled back without touching the database: a rollback stops new failed-refund handling but leaves the additive table/column in place (a rollback cannot undo completed reversals anyway). Both changes are purely additive — no existing reads or writes are affected.

## Test plan

- CI green (schema loads, no app code depends on the new table/column yet).
- After deploy, verify in production: `failed_refund_exceptions` table exists with its three indexes, `credits.failed_refund_id` column and index exist, app health normal, no replica lag spike from the `credits` ALTER.
- #5779 then merges main and drops its copy of these migrations (its diff becomes app-code only).

## Production ALTER safety (`AddFailedRefundIdToCredits`)

Verified against production directly (audited console read `20260715T035303Z-66aada40`, 2026-07-15): `credits` is **656,419 rows / 41.6 MB data / 46.6 MB index**, InnoDB on MySQL **8.0.42**.

- The nullable `bigint` column add is **`ALGORITHM=INSTANT`** on MySQL 8.0 — metadata-only, no table rebuild.
- The secondary index on `failed_refund_id` builds **online INPLACE** (DML not blocked). With `bulk: true` the combined ALTER runs as a single INPLACE statement — seconds of background work at this table size.
- No pt-osc / gh-ost or maintenance window needed; expected replica lag negligible.

`failed_refund_exceptions` is a brand-new table — no ALTER risk by definition.
