### PR TITLE
Update privacy policy cross-border transfer section (remove invalidated Privacy Shield)

### DIFF
--- a/app/views/home/privacy.html.erb
+++ b/app/views/home/privacy.html.erb
@@ -1,7 +1,7 @@
 <%= render "home/shared/header",
   bg_color: "pink",
   title: "Privacy Policy",
-  description: "Last revised: June 2, 2026" %>
+  description: "Last revised: July 15, 2026" %>
 
 <div class="max-w-6xl px-8 lg:px-[4vw] py-12 md:py-20 mx-auto space-y-16 text-lg">
   <div>
@@ -255,9 +255,11 @@
     <h3 class="text-4xl lg:text-5xl font-medium leading-tight pt-12 pb-6">Cross-Border Data Transfer</h3>
     <p>Whenever we transfer your personal information out of the EEA to countries not deemed by the European Commission to provide an adequate level of personal information protection, the transfer will be based:</p>
     <ul class="list-disc my-6 pl-4 [&>li]:leading-8 space-y-2">
-      <li>Pursuant to the recipient's compliance with standard contractual clauses, EU-US Privacy Shield, or Binding Corporate Rules</li>
-      <li>Pursuant to the consent of the individual to whom the personal information pertains</li>
-      <li>As otherwise permitted by applicable EEA requirements.</li>
+      <li>On standard contractual clauses adopted by the European Commission</li>
+      <li>On an adequacy decision by the European Commission covering the recipient country or framework</li>
+      <li>On the recipient's Binding Corporate Rules</li>
+      <li>On the consent of the individual to whom the personal information pertains</li>
+      <li>On another transfer mechanism permitted under applicable EEA requirements.</li>
     </ul>
     <p class="pt-8">Please contact us if you want further information on the specific mechanism used by us when transferring your personal information out of the EEA.</p>
   </div>

--- a/app/views/home/privacy.html.erb
+++ b/app/views/home/privacy.html.erb
@@ -253,13 +253,13 @@
     <p class="pt-8">You can submit these requests by email to <a href="mailto:support@gumroad.com">support@gumroad.com</a> or our postal address provided above. We may request specific information from you to help us confirm your identity and process your request. Applicable law may require or permit us to decline your request. If we decline your request, we will tell you why, subject to legal restrictions. If you would like to submit a complaint about our use of your personal information or response to your requests regarding your personal information, you may contact us as described above or submit a complaint to the data protection regulator in your jurisdiction. You can find your data protection regulator here.</p>
     <p class="pt-8">To the extent we act as a processor on behalf of a seller, individuals should contact the relevant seller to exercise the rights and choices described in this section.</p>
     <h3 class="text-4xl lg:text-5xl font-medium leading-tight pt-12 pb-6">Cross-Border Data Transfer</h3>
-    <p>Whenever we transfer your personal information out of the EEA to countries not deemed by the European Commission to provide an adequate level of personal information protection, the transfer will be based:</p>
+    <p>Whenever we transfer your personal information out of the EEA, we will make sure the transfer is based on one of the following:</p>
     <ul class="list-disc my-6 pl-4 [&>li]:leading-8 space-y-2">
-      <li>On standard contractual clauses adopted by the European Commission</li>
-      <li>On an adequacy decision by the European Commission covering the recipient country or framework</li>
-      <li>On the recipient's Binding Corporate Rules</li>
-      <li>On the consent of the individual to whom the personal information pertains</li>
-      <li>On another transfer mechanism permitted under applicable EEA requirements.</li>
+      <li>An adequacy decision by the European Commission covering the recipient country or framework</li>
+      <li>Standard contractual clauses adopted by the European Commission</li>
+      <li>The recipient's Binding Corporate Rules</li>
+      <li>The explicit consent of the individual to whom the personal information pertains</li>
+      <li>Another transfer mechanism permitted under applicable EEA requirements.</li>
     </ul>
     <p class="pt-8">Please contact us if you want further information on the specific mechanism used by us when transferring your personal information out of the EEA.</p>
   </div>


### PR DESCRIPTION
## What

Updates the Cross-Border Data Transfer section of the Privacy Policy (`app/views/home/privacy.html.erb`) and bumps the last-revised date. The intro now covers all EEA transfers ("based on one of the following") and the list of transfer bases reads:

- An adequacy decision by the European Commission covering the recipient country or framework
- Standard contractual clauses adopted by the European Commission
- The recipient's Binding Corporate Rules
- The explicit consent of the individual (per GDPR Art. 49(1)(a))
- Another transfer mechanism permitted under applicable EEA requirements

## Why

The section still cited the **EU-US Privacy Shield**, invalidated by the CJEU's Schrems II decision in July 2020. An EU seller drafting her own privacy policy flagged this while asking about Gumroad's Chapter V transfer mechanism — quoting the current text to a compliance-minded seller would cite a dead framework. The replacement wording covers the valid mechanisms (adequacy decisions — the category the current EU-US Data Privacy Framework falls under — SCCs, BCRs, explicit consent) without asserting a specific DPF certification, which is still pending a legal decision.

This is a docs-only slice of the tracking issue; the DPA (Art. 28), definitive transfer-mechanism confirmation, and subprocessor list remain open legal decisions on the issue.

Refs antiwork/gumroad-private#1098

## Test plan

- Static ERB content page, no logic change; tag-balance check passes on all elements (div/ul/li/p/h2/h3/h4/strong/a)
- No specs cover this static page; CI green
- Adversarial (fable-5) pre-merge review run locally; its P1 (intro/adequacy contradiction) and consent-wording nit fixed in the second commit

**Before:**
![before](https://i.ibb.co/DPbSmwH8/privacy-before.png)

**After:**
![after](https://i.ibb.co/nNqKdvFk/privacy-after.png)
