### PR TITLE
Serve profile avatars at 400px so they're sharp on Retina screens

### DIFF
--- a/app/javascript/components/Profile/Settings/LogoInput.tsx
+++ b/app/javascript/components/Profile/Settings/LogoInput.tsx
@@ -28,7 +28,7 @@ export const LogoInput = ({
       </FieldsetTitle>
       <ImageUploader
         id={id}
-        helpText="Your avatar will be visible next to your name in your Gumroad profile and product pages. Your image must be at least 200x200px and must be in JPG or PNG format."
+        helpText="Your avatar will be visible next to your name in your Gumroad profile and product pages. Your image must be at least 200x200px (400x400px or larger is recommended so it stays sharp on high-resolution screens) and must be in JPG or PNG format."
         allowedExtensions={ALLOWED_EXTENSIONS}
         imageUrl={changing || !logoUrl ? null : logoUrl}
         onRemove={() => {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -445,7 +445,12 @@ class User < ApplicationRecord
   def avatar_url
     return ActionController::Base.helpers.image_url("gumroad-default-avatar-5.png") unless avatar.attached?
 
-    cached_variant_url = Rails.cache.fetch("attachment_#{avatar.id}_variant_url") { avatar_variant.url }
+    # The "_v2" suffix versions the cache key: we previously served 128x128
+    # variants, and the old (unversioned) key still holds those URLs. Using a
+    # new key makes every user's avatar URL regenerate lazily on next read,
+    # so existing uploads get the sharper 400x400 variant without any manual
+    # backfill. Old keys are simply left behind and evicted by memcached.
+    cached_variant_url = Rails.cache.fetch("attachment_#{avatar.id}_variant_url_v2") { avatar_variant.url }
     cdn_url_for(cached_variant_url)
   rescue => e
     Rails.logger.warn("User#avatar_url error (#{id}): #{e.class} => #{e.message}")
@@ -455,7 +460,9 @@ class User < ApplicationRecord
   def avatar_variant
     return unless avatar.attached?
 
-    avatar.variant(resize_to_limit: [128, 128]).processed
+    # 400x400 so avatars stay sharp on Retina/high-DPI screens: the profile
+    # settings preview box is 200 CSS px, which is 400 device px at 2x.
+    avatar.variant(resize_to_limit: [400, 400]).processed
   end
 
   def username

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -280,6 +280,30 @@ describe User, :vcr do
       it "returns CDN URL" do
         expect(@user.avatar_url).to match("https://public-files.gumroad.com/#{@user.avatar_variant.key}")
       end
+
+      it "caches the variant URL under a versioned key so previously cached 128px URLs are not reused" do
+        # The old, unversioned cache key holds URLs for the smaller 128x128
+        # variants we used to serve. A stale value there must not leak into
+        # what we serve now — only the "_v2" key should be read.
+        Rails.cache.write("attachment_#{@user.avatar.id}_variant_url", "https://example.com/stale-128px-url")
+
+        expect(@user.avatar_url).not_to include("stale-128px-url")
+        expect(Rails.cache.read("attachment_#{@user.avatar.id}_variant_url_v2")).to eq(@user.avatar_variant.url)
+      end
+    end
+
+    describe "#avatar_variant" do
+      it "resizes the avatar to at most 400x400 so it stays sharp on Retina screens" do
+        user = create(:user, :with_avatar)
+
+        expect(user.avatar).to receive(:variant).with(resize_to_limit: [400, 400]).and_call_original
+        variant = user.avatar_variant
+        expect(variant.variation.transformations[:resize_to_limit]).to eq([400, 400])
+      end
+
+      it "returns nil when no avatar is attached" do
+        expect(create(:user).avatar_variant).to be_nil
+      end
     end
 
     describe "#financial_annual_report_url_for" do


### PR DESCRIPTION
## What

Serves profile avatars at a Retina-safe **400x400** instead of 128x128, and versions the cached variant-URL key so **existing uploads sharpen automatically** on next read — no manual backfill, no per-user action.

Fixes antiwork/gumroad-private#1104 (support-ticket driven).

## Why

Every avatar surface goes through `User#avatar_url`, which served a variant capped at `resize_to_limit: [128, 128]`. The profile settings preview box alone is 200 CSS px — 400 device px on a 2x Retina screen — so a 128px source is upscaled ~3x and looks soft/blurry. The seller who reported it uploaded a perfectly sharp image; the blur is entirely our resize.

## How

- `User#avatar_variant` → `resize_to_limit: [400, 400]`.
- **Cache versioning (the promise):** `avatar_url` caches the variant URL in `Rails.cache` under `attachment_#{avatar.id}_variant_url`, with no version in the key — so without this change, existing users would keep getting their cached 128px URL indefinitely. The key is now `..._variant_url_v2`, so every user's URL regenerates lazily on next read and produces the new 400px variant. The seller was told her existing upload will sharpen automatically once this ships; this is what keeps that promise. Old keys are simply orphaned and LRU-evicted by memcached. (Note: production's memcache namespace is keyed on `ENV["REVISION"]`, so the cache would also rotate on deploy — the versioned key makes the intent explicit and is robust if that ever changes.)
- Help text in the profile settings uploader now recommends **400x400px or larger**; the enforced 200px minimum (`MINIMUM_AVATAR_DIMENSION`) is deliberately unchanged so no existing upload flow breaks. A 200px upload served at 400 is mildly upscaled but no worse than today.

## Per-surface caller notes

- `avatar_variant` has no callers besides `avatar_url` (verified by grep) — one variant size change covers everything.
- All avatar surfaces (nav, comments, chat messages, reviews, profile, og:image, favicon) consume `avatar_url`. Small avatars (≤48 CSS px, e.g. comments) will now fetch the 400px file; a 400px JPEG/PNG avatar is tens of KB and CDN-cached, so I did not introduce per-surface sizes — `resized_avatar_url(size:)` already exists if a hot surface ever needs it (`users_controller.rb` uses `size: 240` today).
- Variant processing is on-demand, per-avatar, idempotent in ActiveStorage — first read per avatar after deploy does one resize; no stampede risk beyond the existing shape. S3 growth: one extra small variant per avatar, negligible.

## Test plan

- New specs: `#avatar_variant` asserts the 400x400 transformation; `#avatar_url` asserts the versioned cache key is read/populated and a stale value under the old key is ignored.
- `bundle exec rspec spec/models/user_spec.rb -e "#avatar_url" -e "#avatar_variant" -e "#resized_avatar_url"` → 10 examples, 0 failures. Existing avatar validation/fallback specs also pass.
- Rubocop + Prettier clean on touched files.
- Visual before/after verification is pending a preview deploy (no dev server was trivially available); the settings preview box at 12.5rem on a Retina display is the surface to check.

## Progress

- [x] Bump served variant to 400x400
- [x] Version cached variant-URL key so existing uploads sharpen automatically
- [x] Caller sweep (`avatar_variant` / `avatar_url` / `resized_avatar_url`)
- [x] Update help-text guidance (recommend 400x400+, keep 200 minimum)
- [x] Specs + rubocop
- [ ] Visual Retina verification on preview app
