### PR TITLE
Speed up the asset_preview factory by stubbing image/video analysis

### DIFF
--- a/spec/models/asset_preview_spec.rb
+++ b/spec/models/asset_preview_spec.rb
@@ -92,6 +92,57 @@ describe AssetPreview, :vcr do
     end
   end
 
+  # Canary for the fast factory. `create(:asset_preview*)` injects hardcoded
+  # metadata instead of shelling out to the image/video analyzer on every call
+  # (see AssetPreviewAnalysisStub) — a big speedup, but on its own it would mean
+  # nothing in the suite still proves the analyzer actually extracts those
+  # dimensions from the real files. These few tests attach the same fixtures and
+  # run the real analyzer, so we keep that coverage and catch drift: if a fixture
+  # file or the analyzer changes, the values here stop matching KNOWN_METADATA
+  # and this block fails, flagging that the stub needs regenerating.
+  describe "real analyzer (fast-factory canary)" do
+    def analyze_fixture(filename, content_type)
+      blob = ActiveStorage::Blob.create_and_upload!(
+        io: File.open(Rails.root.join("spec", "support", "fixtures", filename)),
+        filename:, content_type:)
+      blob.analyze # real analyzer, bypassing the factory stub
+      asset_preview = AssetPreview.new(link: create(:product))
+      asset_preview.file.attach(blob)
+      asset_preview.save!
+      asset_preview
+    end
+
+    it "extracts PNG dimensions matching the stubbed metadata" do
+      asset_preview = analyze_fixture("kFDzu.png", "image/png")
+      expected = AssetPreviewAnalysisStub::KNOWN_METADATA["kFDzu.png"]
+      expect(asset_preview.width).to eq(expected["width"])
+      expect(asset_preview.height).to eq(expected["height"])
+    end
+
+    it "extracts JPG dimensions matching the stubbed metadata" do
+      asset_preview = analyze_fixture("test-small.jpg", "image/jpeg")
+      expected = AssetPreviewAnalysisStub::KNOWN_METADATA["test-small.jpg"]
+      expect(asset_preview.width).to eq(expected["width"])
+      expect(asset_preview.height).to eq(expected["height"])
+    end
+
+    it "extracts GIF dimensions matching the stubbed metadata" do
+      asset_preview = analyze_fixture("sample.gif", "image/gif")
+      expected = AssetPreviewAnalysisStub::KNOWN_METADATA["sample.gif"]
+      expect(asset_preview.width).to eq(expected["width"])
+      expect(asset_preview.height).to eq(expected["height"])
+    end
+
+    it "extracts MOV dimensions and duration matching the stubbed metadata" do
+      asset_preview = analyze_fixture("thing.mov", "video/quicktime")
+      expected = AssetPreviewAnalysisStub::KNOWN_METADATA["thing.mov"]
+      metadata = asset_preview.file.blob.metadata
+      expect(metadata[:width]).to eq(expected["width"])
+      expect(metadata[:height]).to eq(expected["height"])
+      expect(metadata[:duration]).to be_within(0.01).of(expected["duration"])
+    end
+  end
+
   describe "Embeddable link" do
     it "succeeds with a video URL" do
       asset_preview = create(:asset_preview, url: "https://www.youtube.com/watch?v=huKYieB4evw")

--- a/spec/support/asset_preview_analysis_stub.rb
+++ b/spec/support/asset_preview_analysis_stub.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Speeds up the asset_preview factories by injecting the metadata that
+# ActiveStorage's image/video analyzer would produce for the known-good
+# fixture files, instead of shelling out to ImageMagick/ffprobe on every
+# `create(:asset_preview*)`.
+#
+# The shell-out is cheap locally (~0.1s/call) but balloons to ~1.8s/call on CI,
+# where many parallel workers each spawn the analyzer binaries and thrash the
+# box. asset_preview was the single heaviest factory in the suite-profiling
+# pass (#5801): ~96% of its spec file's wall time was factory setup.
+#
+# Only the specific fixture files the factories attach are pre-analyzed. Any
+# other file (e.g. the corrupt/disguised uploads the spec attaches to check
+# that the real analyzer rejects them) falls through to a genuine `analyze`, so
+# those negative-path tests are unaffected.
+#
+# To regenerate a row after changing a fixture file: attach it to a blob, call
+# `blob.analyze`, and copy `blob.reload.metadata`.
+module AssetPreviewAnalysisStub
+  KNOWN_METADATA = {
+    "kFDzu.png" => { "identified" => true, "width" => 1633, "height" => 512, "analyzed" => true },
+    "test-small.jpg" => { "identified" => true, "width" => 25, "height" => 25, "analyzed" => true },
+    "sample.gif" => { "identified" => true, "width" => 670, "height" => 500, "analyzed" => true },
+    "thing.mov" => { "identified" => true, "width" => 1396.0, "height" => 958.0, "duration" => 2.003167,
+                     "display_aspect_ratio" => [698, 479], "audio" => false, "video" => true, "analyzed" => true },
+  }.freeze
+
+  # Mirrors the factory's old `preview.file.analyze if attached?`, but takes the
+  # fast path for known fixture files.
+  def self.analyze(attachment)
+    return unless attachment.attached?
+
+    metadata = KNOWN_METADATA[attachment.filename.to_s]
+    if metadata
+      attachment.blob.update!(metadata: attachment.blob.metadata.merge(metadata))
+    else
+      attachment.analyze
+    end
+  end
+end

--- a/spec/support/factories/asset_previews.rb
+++ b/spec/support/factories/asset_previews.rb
@@ -47,7 +47,9 @@ FactoryBot.define do
     end
 
     after(:create) do |preview|
-      preview.file.analyze if preview.file.attached?
+      # Inject known metadata for the fixture files instead of shelling out to
+      # the image/video analyzer on every create; see AssetPreviewAnalysisStub.
+      AssetPreviewAnalysisStub.analyze(preview.file)
     end
   end
 end


### PR DESCRIPTION
## What

Speeds up the `asset_preview` factory — the single heaviest factory in the suite-profiling pass ([#5801](https://github.com/antiwork/gumroad/issues/5801)), where ~96% of `asset_preview_spec`'s wall time was factory setup at ~1.8–2.4s per create.

- `spec/support/asset_preview_analysis_stub.rb` (new) — injects the exact metadata the ActiveStorage analyzer produces for the known-good fixture files (`kFDzu.png`, `test-small.jpg`, `sample.gif`, `thing.mov`).
- `spec/support/factories/asset_previews.rb` — the factory's `after(:create)` calls the stub instead of `preview.file.analyze`.
- `spec/models/asset_preview_spec.rb` — adds a small "real analyzer (fast-factory canary)" block.

## Why

The per-create cost is the analyzer shelling out to ImageMagick/ffprobe. It's cheap locally (~0.1s) but brutal on CI, where parallel workers each spawn the binaries and thrash the box — that's where the ~1.8–2.4s/call came from. Injecting the metadata skips the shell-out entirely.

This is the fix [#5801](https://github.com/antiwork/gumroad/issues/5801) explicitly calls for — "Fix the 5 pathologically slow factories … **stub the file/image processing, cut cost factors**" — and `asset_preview` is one of the five named. It's scoped to a spec that stays in RSpec (it's `:vcr`, not a fixtures-migration candidate).

**Why a scoped stub rather than a global analyze stub:** the spec's negative-path tests rely on the *real* analyzer rejecting corrupt / disguised / unsupported / unanalyzable files. Those tests build their own blobs and call `analyze` directly, and the stub only fast-paths the known fixture filenames — everything else falls through to a genuine `analyze`. So that coverage is untouched, and because the injected values are byte-identical to real analyzer output, every downstream read (`width`/`height`/`duration`/`analyzed?`) is unchanged.

**What the stub gives up, and how the canary buys it back:** on its own, the stub means nothing in the suite still proves the analyzer actually extracts those dimensions from the real files, and `KNOWN_METADATA` could silently drift if a fixture file changed. The canary block attaches each fixture, runs the *real* analyzer, and asserts the output matches `KNOWN_METADATA` — restoring the analyzer-extraction coverage and failing loudly on drift. Four real analyzes instead of forty-three.

## Before/After

Non-user-facing (spec-only; `spec/**` and a support module, no app code), so there's nothing to capture on video — the reviewable artifact is the timing and the passing suite below. Local `test-prof` (`EVENT_PROF=factory.create`) on `asset_preview_spec`:

| | factory.create time | file wall time |
|---|---|---|
| Before (real `analyze`) | 7.50s | 9.24s |
| After (metadata injection + canaries) | 3.11s | 4.57s |

Locally `analyze` is ~0.1s/call, so this reflects ~43 shell-outs removed; on the profiling machine each `analyze` was ~1.8s, so the CI win is far larger (this file's ~1:17 of factory-create time).

## Test Results

```
spec/models/asset_preview_spec.rb — 58 examples, 0 failures
```

Spot-checked the shared factory's blast radius (identical metadata + `analyzed? == true` preserved):

```
product_duplicator_service_spec + generate_video_poster_worker_spec + product_presenter_spec — 59 examples, 0 failures
```

Rubocop clean on all changed files.

---

AI disclosure: drafted with Claude Opus 4.8 (1M context) via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
