### PR TITLE
Fix NoMethodError when products param is not an array in CustomerSurchargeController

### DIFF
--- a/app/controllers/customer_surcharge_controller.rb
+++ b/app/controllers/customer_surcharge_controller.rb
@@ -5,6 +5,13 @@ class CustomerSurchargeController < ApplicationController
 
   def calculate_all
     products = params.require(:products)
+    # Malformed requests can send `products` as a raw string (or an array containing
+    # strings) instead of an array of product hashes. Reject those with a 400 instead
+    # of letting `products.each` / `item[:permalink]` raise a NoMethodError.
+    unless products.is_a?(Array) && products.all? { |item| item.is_a?(ActionController::Parameters) || item.is_a?(Hash) }
+      return head :bad_request
+    end
+
     vat_id_valid = false
     has_vat_id_input = false
     shipping_rate = 0

--- a/spec/controllers/customer_surcharge_controller_spec.rb
+++ b/spec/controllers/customer_surcharge_controller_spec.rb
@@ -26,6 +26,16 @@ describe CustomerSurchargeController, :vcr do
     @zip_tax_rate = create(:zip_tax_rate, combined_rate: 0.1, zip_code: nil, state: "CA")
   end
 
+  it "responds with 400 when products is a string instead of an array" do
+    post "calculate_all", params: { products: "not-an-array" }, as: :json
+    expect(response).to have_http_status(:bad_request)
+  end
+
+  it "responds with 400 when products is an array of strings instead of product hashes" do
+    post "calculate_all", params: { products: [@product.unique_permalink] }, as: :json
+    expect(response).to have_http_status(:bad_request)
+  end
+
   it "returns 0 if price input is invalid" do
     post "calculate_all", params: { products: [{ permalink: @physical_product.unique_permalink, price: "invalid", quantity: 1 }] }, as: :json
     expect(response.parsed_body).to eq(expected_surcharge_response)


### PR DESCRIPTION
## What

Adds an input-shape guard to `CustomerSurchargeController#calculate_all`: if the `products` param is not an array of product hashes (e.g. a raw string, or an array of strings), the endpoint now returns `400 Bad Request` instead of crashing.

## Why

Sentry issue [GUMROAD-YJ](https://gumroad-to.sentry.io/issues/7613213105/) — unhandled `NoMethodError: undefined method 'each' for an instance of String` at `customer_surcharge_controller.rb` when a malformed request sends `products` as a string. `params.require(:products)` only checks presence, not type, so `products.each` blows up on non-array payloads (and `item[:permalink]` would blow up on string array members). 2 events / 1 user so far; this is a public checkout endpoint, so malformed payloads are expected noise and should be a clean 4xx, not a 500 + Sentry alert.

## Test plan

- New controller specs assert `400` for `products: "not-an-array"` and `products: ["<permalink>"]`. Both fail with the original `NoMethodError` before the fix and pass after.
- Ran `bundle exec rspec spec/controllers/customer_surcharge_controller_spec.rb` locally: the 2 new specs pass; 5 subscription-context specs fail identically on unmodified `main` (pre-existing local-env failures, not introduced here). CI will confirm.
- `rubocop -a` clean on both files.

## Before/After

Not applicable — API behavior change only (500 → 400 on malformed input), no UI.
