### PR TITLE
Null UserComplianceInfo PII columns during GDPR erasure

### DIFF
--- a/app/services/gdpr_data_erasure_service.rb
+++ b/app/services/gdpr_data_erasure_service.rb
@@ -21,6 +21,7 @@ class GdprDataErasureService
     ActiveRecord::Base.transaction do
       @products_deleted = deactivate_account!
       anonymized_email = anonymize_user_pii!
+      anonymize_compliance_info!
       delete_device_records!
       anonymize_carts!(anonymized_email)
       anonymize_credit_cards!(credit_card_ids)
@@ -101,6 +102,35 @@ class GdprDataErasureService
       )
 
       anonymized_email
+    end
+
+    def anonymize_compliance_info!
+      # Compliance (KYC) records hold the person's legal name, date of birth, street
+      # address, and phone number. deactivate_account! only soft-deletes them, which hides
+      # the rows from the app but leaves that data in the table, so erasure must also null
+      # the columns. This intentionally covers every row for the user, not just alive ones:
+      # UserComplianceInfo is Immutable, meaning each edit creates a new row and soft-deletes
+      # the previous one, and those older rows hold the same PII. update_all writes SQL
+      # directly, which also bypasses the Immutable guard — appropriate here because this is
+      # a legally mandated destruction (Article 17), not a normal edit.
+      #
+      # json_data is nulled because it stores PII too: phone numbers, nationality, and the
+      # kana/kanji name and address variants used for Japanese accounts. Country and the
+      # tax ids (encrypted at rest) are retained with the transaction and tax records per
+      # Article 17(3)(b), as are the business-entity columns.
+      @user.user_compliance_infos.update_all(
+        full_name: nil,
+        first_name: nil,
+        last_name: nil,
+        birthday: nil,
+        street_address: nil,
+        city: nil,
+        state: nil,
+        zip_code: nil,
+        telephone_number: nil,
+        json_data: nil,
+        updated_at: Time.current,
+      )
     end
 
     def anonymize_carts!(anonymized_email)
@@ -213,6 +243,7 @@ class GdprDataErasureService
         user_id: @user.id,
         email_anonymized: true,
         profile_anonymized: true,
+        compliance_info_anonymized: true,
         purchases_anonymized: true,
         account_deactivated: true,
         products_deleted: @products_deleted,

--- a/app/services/onetime/scrub_gdpr_erased_user_compliance_info_pii.rb
+++ b/app/services/onetime/scrub_gdpr_erased_user_compliance_info_pii.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Before GdprDataErasureService learned to null the PII columns on compliance (KYC)
+# records, an erasure only soft-deleted them — so users erased before that fix still
+# have their legal name, date of birth, street address, and phone number sitting in
+# plaintext in user_compliance_info rows. This task sweeps those historical erasures.
+#
+# Erased accounts are identifiable by the placeholder email the erasure service
+# assigns ("deleted-<user id>@deleted.gumroad.com"); no other flow writes emails on
+# that domain to the users table. The columns nulled here match the ones the service
+# now nulls during erasure, so re-running this task is safe (it just re-nulls nils).
+#
+# Usage: Onetime::ScrubGdprErasedUserComplianceInfoPii.process
+module Onetime
+  class ScrubGdprErasedUserComplianceInfoPii
+    BATCH_SIZE = 500
+
+    def self.process(batch_size: BATCH_SIZE)
+      new.process(batch_size:)
+    end
+
+    def process(batch_size: BATCH_SIZE)
+      scrubbed_rows = 0
+
+      erased_users.in_batches(of: batch_size) do |batch|
+        ReplicaLagWatcher.watch
+        scrubbed_rows += UserComplianceInfo.where(user_id: batch.ids).update_all(
+          full_name: nil,
+          first_name: nil,
+          last_name: nil,
+          birthday: nil,
+          street_address: nil,
+          city: nil,
+          state: nil,
+          zip_code: nil,
+          telephone_number: nil,
+          json_data: nil,
+          updated_at: Time.current,
+        )
+      end
+
+      puts "Nulled PII columns on #{scrubbed_rows} user_compliance_info rows"
+      scrubbed_rows
+    end
+
+    private
+      def erased_users
+        # Prefix LIKE so index_users_on_email can be used as a range scan.
+        User.where("email LIKE ?", "deleted-%@#{GdprDataErasureService::ANONYMIZED_EMAIL_DOMAIN}")
+      end
+  end
+end

--- a/spec/services/gdpr_data_erasure_service_spec.rb
+++ b/spec/services/gdpr_data_erasure_service_spec.rb
@@ -26,6 +26,35 @@ describe GdprDataErasureService do
       expect(user.deleted_at).to be_present
     end
 
+    it "nulls PII columns on all compliance info rows, including previously replaced ones" do
+      # Compliance edits replace the row (Immutable), so a user accumulates soft-deleted
+      # rows that still carry PII — erasure must scrub those too, not just the alive one.
+      replaced_info = create(:user_compliance_info, user:, full_name: "John Doe", telephone_number: "+1 555 555 0100")
+      replaced_info.mark_deleted!
+      current_info = create(:user_compliance_info, user:, full_name: "John Doe", telephone_number: "+1 555 555 0100")
+
+      described_class.new(user, performed_by: admin).perform!
+
+      [replaced_info, current_info].each do |compliance_info|
+        compliance_info.reload
+        expect(compliance_info.deleted_at).to be_present
+        expect(compliance_info.full_name).to be_nil
+        expect(compliance_info.first_name).to be_nil
+        expect(compliance_info.last_name).to be_nil
+        expect(compliance_info.birthday).to be_nil
+        expect(compliance_info.street_address).to be_nil
+        expect(compliance_info.city).to be_nil
+        expect(compliance_info.state).to be_nil
+        expect(compliance_info.zip_code).to be_nil
+        expect(compliance_info.telephone_number).to be_nil
+        expect(compliance_info.phone).to be_nil
+        # The JsonData concern deserializes a NULL column as an empty hash.
+        expect(compliance_info.json_data).to be_blank
+        # Country stays with the retained transaction/tax records (Article 17(3)(b)).
+        expect(compliance_info.country).to eq("United States")
+      end
+    end
+
     it "anonymizes buyer purchases" do
       purchase = create(
         :free_purchase,

--- a/spec/services/onetime/scrub_gdpr_erased_user_compliance_info_pii_spec.rb
+++ b/spec/services/onetime/scrub_gdpr_erased_user_compliance_info_pii_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Onetime::ScrubGdprErasedUserComplianceInfoPii do
+  def simulate_pre_fix_erasure(user)
+    # Reproduce the state GdprDataErasureService left behind before it learned to null
+    # compliance PII: placeholder email on the user, compliance rows soft-deleted but
+    # with all their PII columns intact.
+    user.user_compliance_infos.alive.each(&:mark_deleted!)
+    user.update_columns(
+      email: "deleted-#{user.id}@#{GdprDataErasureService::ANONYMIZED_EMAIL_DOMAIN}",
+      deleted_at: Time.current,
+    )
+  end
+
+  it "nulls PII columns on compliance rows of erased users and leaves other users untouched" do
+    erased_user = create(:user)
+    replaced_info = create(:user_compliance_info, user: erased_user, full_name: "Jane Roe", telephone_number: "+1 555 555 0100")
+    replaced_info.mark_deleted!
+    current_info = create(:user_compliance_info, user: erased_user, full_name: "Jane Roe", telephone_number: "+1 555 555 0100")
+    simulate_pre_fix_erasure(erased_user)
+
+    active_user = create(:user)
+    active_info = create(:user_compliance_info, user: active_user)
+
+    scrubbed_rows = described_class.process
+
+    expect(scrubbed_rows).to eq(2)
+    [replaced_info, current_info].each do |compliance_info|
+      compliance_info.reload
+      expect(compliance_info.full_name).to be_nil
+      expect(compliance_info.first_name).to be_nil
+      expect(compliance_info.last_name).to be_nil
+      expect(compliance_info.birthday).to be_nil
+      expect(compliance_info.street_address).to be_nil
+      expect(compliance_info.city).to be_nil
+      expect(compliance_info.state).to be_nil
+      expect(compliance_info.zip_code).to be_nil
+      expect(compliance_info.telephone_number).to be_nil
+      # The JsonData concern deserializes a NULL column as an empty hash.
+      expect(compliance_info.json_data).to be_blank
+      expect(compliance_info.country).to eq("United States")
+    end
+
+    active_info.reload
+    expect(active_info.first_name).to eq("Chuck")
+    expect(active_info.street_address).to be_present
+    expect(active_info.json_data).to be_present
+  end
+
+  it "processes erased users across multiple batches" do
+    erased_users = create_list(:user, 2)
+    infos = erased_users.map do |user|
+      info = create(:user_compliance_info, user:)
+      simulate_pre_fix_erasure(user)
+      info
+    end
+
+    scrubbed_rows = described_class.process(batch_size: 1)
+
+    expect(scrubbed_rows).to eq(2)
+    infos.each do |info|
+      expect(info.reload.first_name).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## What

- `GdprDataErasureService` gains an `anonymize_compliance_info!` step inside the erasure transaction: it nulls `full_name`, `first_name`, `last_name`, `birthday`, `street_address`, `city`, `state`, `zip_code`, `telephone_number`, and `json_data` on **every** `user_compliance_info` row belonging to the user (not just alive rows), and the erasure summary now reports `compliance_info_anonymized: true`.
- New `Onetime::ScrubGdprErasedUserComplianceInfoPii` task backfills the same nulling for users erased before this fix, identified by the `deleted-<id>@deleted.gumroad.com` placeholder email that only the erasure service writes (prefix LIKE, so `index_users_on_email` is usable), batched with `ReplicaLagWatcher`.
- Regression specs covering all the PII columns across both an alive and a previously replaced compliance row, plus specs for the onetime task (scoping to erased users only, batching).

## Why

The erasure service treated soft-deletion as erasure for compliance records: `deactivate_account!` calls `mark_deleted!` on them, while the column-nulling step only touches the `users` table. Soft-deletion just sets `deleted_at`, so after a "successful" GDPR/DPDP erasure the data subject's legal name, date of birth, street address, and phone number remained in the table in plaintext (confirmed on a live erasure; see antiwork/gumroad-private#1105).

The root of the confusion is that `UserComplianceInfo` is `Immutable` — rows are never edited in place, each change dups a new row and soft-deletes the old — so "deleted" here has always meant "hidden," never "destroyed," and a user accumulates multiple historical rows each holding a full PII snapshot. That's also why the fix uses `update_all` (bypassing the Immutable guard is correct for a legally mandated destruction) and sweeps all rows rather than only the alive one.

Scope decisions: `json_data` is nulled because it stores phone, nationality, and the Japanese kana/kanji name and address variants. `country` and the tax ids (encrypted at rest with a public key) are retained with the transaction/tax records under Article 17(3)(b), as are the business-entity columns.

## How tested

- `bundle exec rspec spec/services/gdpr_data_erasure_service_spec.rb spec/services/onetime/scrub_gdpr_erased_user_compliance_info_pii_spec.rb` → 16 examples, 0 failures.
- Reverted the service change and re-ran the new regression spec → 1 failure (fails on revert, as required).
- `bundle exec rubocop -a` on all four touched files → no offenses.

## Progress

- [x] Add UserComplianceInfo PII-column anonymization to GdprDataErasureService
- [x] Backfill task for previously erased users (`Onetime::ScrubGdprErasedUserComplianceInfoPii`)
- [x] Regression spec covering the compliance-row columns (fails on revert)
- [ ] Run the onetime backfill in production after merge
- [ ] Un-patch the support-side erasure skill's manual UCI sweep once this ships

---

AI disclosure: Written by Claude Fable 5 (agent account gumclaw), prompted to own antiwork/gumroad-private#1105 end-to-end (root-cause the plaintext PII surviving GDPR erasure in `user_compliance_info`, fix the service, add a backfill for historical erasures, and open a PR with regression specs).

Co-authored-by: Gianfranco <gianfranco@gumroad.com>