### PR TITLE
Don't 422 buyer pages when UTM tracking hits a disabled duplicate link

### DIFF
--- a/app/controllers/concerns/utm_link_tracking.rb
+++ b/app/controllers/concerns/utm_link_tracking.rb
@@ -32,7 +32,17 @@ module UtmLinkTracking
       utm_params = required_params.merge(optional_params).transform_values { _1.to_s.strip.downcase.gsub(/[^a-z0-9\-_]/u, "-").first(UtmLink::MAX_UTM_PARAM_LENGTH).presence }
 
       ActiveRecord::Base.transaction do
-        utm_link = UtmLink.active.find_or_initialize_by(utm_params.merge(target_resource_type:, target_resource_id:))
+        # Look up existing links with the "alive" scope (not "active") so we see links the
+        # seller has disabled. The model's uniqueness validation also checks against "alive"
+        # links, so if we only searched "active" links here we could miss a disabled duplicate,
+        # try to create a new link, and have the save fail — which used to surface as a 422
+        # error on the buyer-facing page.
+        utm_link = UtmLink.alive.find_or_initialize_by(utm_params.merge(target_resource_type:, target_resource_id:))
+
+        # A disabled link means the seller intentionally paused tracking for these UTM
+        # parameters — respect that and don't record the visit.
+        return if utm_link.persisted? && !utm_link.enabled?
+
         auto_create_utm_link(utm_link, seller) if utm_link.new_record?
         return unless utm_link.persisted?
         return unless Feature.active?(:utm_links, utm_link.seller)
@@ -52,6 +62,11 @@ module UtmLinkTracking
 
         UpdateUtmLinkStatsJob.perform_async(utm_link.id)
       end
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique => e
+      # Analytics tracking must never break the buyer-facing page. A validation failure or a
+      # race between two simultaneous first visits (both trying to auto-create the same link,
+      # colliding on the database's unique index) should be reported and swallowed, not raised.
+      ErrorNotifier.notify(e, utm_params: params.permit(:utm_source, :utm_medium, :utm_campaign, :utm_term, :utm_content).to_h)
     end
 
     def auto_create_utm_link(utm_link, seller)

--- a/spec/controllers/concerns/utm_link_tracking_spec.rb
+++ b/spec/controllers/concerns/utm_link_tracking_spec.rb
@@ -86,6 +86,108 @@ describe UtmLinkTracking, type: :controller do
     end
   end
 
+  context "when a matching UTM link exists but the seller has disabled it" do
+    let(:product) { create(:product, user: seller) }
+    let!(:utm_link) do
+      create(:utm_link, seller:, target_resource_type: "product_page", target_resource_id: product.id, disabled_at: 1.day.ago)
+    end
+    let(:utm_params) do
+      {
+        utm_source: utm_link.utm_source,
+        utm_medium: utm_link.utm_medium,
+        utm_campaign: utm_link.utm_campaign,
+        utm_content: utm_link.utm_content,
+        utm_term: utm_link.utm_term
+      }
+    end
+
+    before do
+      allow(controller).to receive(:short_link_path).and_return("/l/#{product.unique_permalink}")
+      request.host = "#{seller.subdomain}"
+      request.path = "/l/#{product.unique_permalink}"
+    end
+
+    it "renders the page successfully without creating a duplicate link or tracking a visit" do
+      expect do
+        expect do
+          get :action, params: utm_params.merge(id: product.unique_permalink)
+        end.not_to change(UtmLink, :count)
+      end.not_to change(UtmLinkVisit, :count)
+
+      expect(response).to be_successful
+      expect(UpdateUtmLinkStatsJob).not_to have_enqueued_sidekiq_job(utm_link.id)
+    end
+  end
+
+  context "when a matching UTM link exists but is soft-deleted" do
+    let(:product) { create(:product, user: seller) }
+    let!(:utm_link) do
+      create(:utm_link, seller:, target_resource_type: "product_page", target_resource_id: product.id, deleted_at: 1.day.ago)
+    end
+    let(:utm_params) do
+      {
+        utm_source: utm_link.utm_source,
+        utm_medium: utm_link.utm_medium,
+        utm_campaign: utm_link.utm_campaign,
+        utm_content: utm_link.utm_content,
+        utm_term: utm_link.utm_term
+      }
+    end
+
+    before do
+      allow(controller).to receive(:short_link_path).and_return("/l/#{product.unique_permalink}")
+      request.host = "#{seller.subdomain}"
+      request.path = "/l/#{product.unique_permalink}"
+    end
+
+    it "auto-creates a fresh UTM link and records the visit" do
+      expect do
+        expect do
+          get :action, params: utm_params.merge(id: product.unique_permalink)
+        end.to change(UtmLink.alive, :count).by(1)
+      end.to change(UtmLinkVisit, :count).by(1)
+
+      expect(response).to be_successful
+      expect(UtmLink.alive.last.id).not_to eq(utm_link.id)
+    end
+  end
+
+  context "when tracking raises unexpectedly" do
+    let!(:utm_link) { create(:utm_link, seller:) }
+    let(:utm_params) do
+      {
+        utm_source: utm_link.utm_source,
+        utm_medium: utm_link.utm_medium,
+        utm_campaign: utm_link.utm_campaign,
+        utm_content: utm_link.utm_content,
+        utm_term: utm_link.utm_term
+      }
+    end
+
+    before do
+      request.host = "#{seller.subdomain}"
+      request.path = "/"
+    end
+
+    it "reports the error and still renders the page when a record is invalid" do
+      allow_any_instance_of(UtmLink).to receive(:save!).and_raise(ActiveRecord::RecordInvalid)
+      expect(ErrorNotifier).to receive(:notify).with(instance_of(ActiveRecord::RecordInvalid), anything)
+
+      get :action, params: utm_params
+
+      expect(response).to be_successful
+    end
+
+    it "reports the error and still renders the page when the database uniqueness index is hit" do
+      allow_any_instance_of(UtmLink).to receive(:save!).and_raise(ActiveRecord::RecordNotUnique)
+      expect(ErrorNotifier).to receive(:notify).with(instance_of(ActiveRecord::RecordNotUnique), anything)
+
+      get :action, params: utm_params
+
+      expect(response).to be_successful
+    end
+  end
+
   context "when a matching UTM link is not found" do
     let(:product) { create(:product, user: seller) }
     let(:post) { create(:published_installment, seller:, shown_on_profile: true) }


### PR DESCRIPTION
## What

Fixes a live production incident: campaign links (UTM-parameterized URLs) to product pages return **HTTP 422** while the plain product URL works. Sentry recorded **86 errors across 55 visitors** in a few hours on at least one product ("Starter Stack").

## Why

Root cause is a scope mismatch in `UtmLinkTracking#track_utm_link_visit` (runs as a `before_action` on every buyer-facing GET):

- The lookup used `UtmLink.active.find_or_initialize_by(...)` — `active` = alive **and enabled**.
- The model's uniqueness validation (`utm_fields_are_unique_per_target_resource`) checks against `alive` only, which **includes disabled links**.
- So when a seller disables a UTM link and a buyer later visits with those same UTM params: the `active`-scoped lookup misses the disabled row → initializes a duplicate → `save!` raises `ActiveRecord::RecordInvalid` → bubbles up as a 422 on the buyer's product page. An analytics write was taking down the storefront.

## How

Two layers:

1. **Correct lookup semantics**: look up with the same `alive` scope the validation checks, so the existing disabled row is found. If the link is disabled, the seller intentionally paused tracking — we return silently without recording the visit or creating a duplicate. Soft-deleted links don't collide with the validation, so a fresh link is auto-created as before.
2. **Fail-safe**: the tracking body now rescues `ActiveRecord::RecordInvalid` and `ActiveRecord::RecordNotUnique` (the latter covers a race between two concurrent first visits colliding on the DB's unique index `index_utm_links_on_utm_fields_and_target_resource`), reports via `ErrorNotifier`, and returns. Analytics can never 422 a buyer page again.

## Test plan

- New spec reproducing the incident: disabled UTM link + buyer GET with matching params → previously `ActiveRecord::RecordInvalid` (the 422), now 200 with no duplicate link and no visit tracked.
- New spec: soft-deleted duplicate → fresh link auto-created and visit recorded (unchanged behavior).
- New specs: `save!` raising `RecordInvalid` / `RecordNotUnique` → error reported to `ErrorNotifier`, page still renders 200.
- `bundle exec rspec spec/controllers/concerns/utm_link_tracking_spec.rb` → 15 examples, 0 failures.
- `bundle exec rubocop` on both touched files → no offenses.

## Progress

- [x] Failing spec reproducing the 422 (disabled duplicate link)
- [x] Lookup scope fixed (`active` → `alive`, disabled links respected silently)
- [x] Fail-safe rescue + ErrorNotifier around the tracking write
- [x] Full spec file green (15 examples)
- [x] Rubocop clean
