### PR TITLE
Fix ActiveModel::RangeError when cart item price exceeds bigint limit

### DIFF
--- a/app/models/cart_product.rb
+++ b/app/models/cart_product.rb
@@ -5,6 +5,10 @@ class CartProduct < ApplicationRecord
   include Deletable
 
   MAX_QUANTITY = 2_147_483_647
+  # `price` is a signed 8-byte (bigint) column. Values beyond this raise
+  # ActiveModel::RangeError at serialization time — after validations — so we must
+  # reject them here to turn a hard crash into a normal validation failure.
+  MAX_PRICE = 9_223_372_036_854_775_807
 
   URL_PARAMETERS_JSON_SCHEMA = { type: "object", additionalProperties: { type: "string" } }.freeze
   ACCEPTED_OFFER_DETAILS_JSON_SCHEMA = {
@@ -26,6 +30,7 @@ class CartProduct < ApplicationRecord
 
   validates :price, :quantity, :referrer, presence: true
   validates :quantity, numericality: { only_integer: true, greater_than: 0, less_than_or_equal_to: MAX_QUANTITY }, allow_nil: true
+  validates :price, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: MAX_PRICE }, allow_nil: true
 
   validate :ensure_url_parameters_conform_to_schema
   validate :ensure_accepted_offer_details_conform_to_schema

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -693,6 +693,28 @@ describe CheckoutController, type: :controller, inertia: true do
         expect(flash[:alert]).to eq("Sorry, something went wrong. Please try again.")
       end
 
+      it "returns an error when an item price exceeds the bigint column limit" do
+        expect do
+          patch :update, params: {
+            cart: {
+              items: [
+                {
+                  product: { id: create(:product).external_id },
+                  price: CartProduct::MAX_PRICE + 1,
+                  quantity: 1,
+                  referrer: "direct"
+                }
+              ],
+              discountCodes: []
+            }
+          }, as: :json
+        end.not_to change(Cart, :count)
+
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to(checkout_path)
+        expect(flash[:alert]).to eq("Sorry, something went wrong. Please try again.")
+      end
+
       it "returns an error when cart contains more than allowed number of cart products" do
         items = (Cart::MAX_ALLOWED_CART_PRODUCTS + 1).times.map { { product: { id: _1 + 1 } }  }
         patch :update, params: { cart: { items: } }, as: :json

--- a/spec/models/cart_product_spec.rb
+++ b/spec/models/cart_product_spec.rb
@@ -57,6 +57,32 @@ describe CartProduct do
       end
     end
 
+    describe "price" do
+      context "when price is within the bigint column range" do
+        it "marks the cart product as valid" do
+          cart_product = build(:cart_product, price: CartProduct::MAX_PRICE)
+          expect(cart_product).to be_valid
+        end
+      end
+
+      context "when price is negative" do
+        it "marks the cart product as invalid" do
+          cart_product = build(:cart_product, price: -1)
+          expect(cart_product).to be_invalid
+          expect(cart_product.errors.full_messages.join).to include("Price must be greater than or equal to 0")
+        end
+      end
+
+      context "when price exceeds the 8-byte integer column limit" do
+        it "marks the cart product as invalid instead of raising a range error on save" do
+          cart_product = build(:cart_product, price: 10_000_000_000_000_000_000_000)
+          expect(cart_product).to be_invalid
+          expect(cart_product.errors.full_messages.join).to include("Price must be less than or equal to #{CartProduct::MAX_PRICE}")
+          expect { cart_product.save! }.to raise_error(ActiveRecord::RecordInvalid)
+        end
+      end
+    end
+
     describe "url parameters" do
       context "when url parameters are empty" do
         it "marks the cart product as valid" do


### PR DESCRIPTION
## What

Adds a numericality validation on `CartProduct#price` capping it at the signed 8-byte integer maximum (`MAX_PRICE = 9_223_372_036_854_775_807`) and rejecting negative values, mirroring the existing `MAX_QUANTITY` guard on `quantity`.

## Why

Sentry issue [GUMROAD-YR](https://gumroad-to.sentry.io/issues/7613867625/): `CheckoutController#update` crashed with an unhandled `ActiveModel::RangeError` when a request supplied an item price of `10^22`. The `price` column is a bigint, and Rails raises `RangeError` at type-serialization time — after validations pass — so the oversized value bypassed the controller's `ActiveRecord::RecordInvalid` rescue and produced a 500 instead of the friendly "Sorry, something went wrong" redirect. 2 events / 1 user so far; trivially reproducible by any client sending a large price.

With the validation in place, the save fails as `RecordInvalid`, which the controller already rescues and turns into a redirect with an error flash.

## Test plan

- New model specs: price at `MAX_PRICE` is valid; negative price invalid; `10^22` invalid and `save!` raises `RecordInvalid` (not `RangeError`). `spec/models/cart_product_spec.rb` — 17 examples, 0 failures locally.
- New controller spec: `PATCH /checkout` with `price: MAX_PRICE + 1` redirects with the error flash and creates no cart. `spec/controllers/checkout_controller_spec.rb` — 36 examples, 0 failures locally.
- Reproduced the crash first on unpatched code (`ActiveModel::RangeError` raised on save with `price = 10**22`), then confirmed the fix converts it to a validation failure.
- CI green.
