### PR TITLE
Document the seller Data Processing Addendum in the GDPR data requests help article

### DIFF
--- a/app/views/help_center/articles/contents/_349-gdpr-data-requests.html.erb
+++ b/app/views/help_center/articles/contents/_349-gdpr-data-requests.html.erb
@@ -2,6 +2,7 @@
   <p>In this article:</p>
   <ul>
     <li><a href="#your-rights">Your data privacy rights</a></li>
+    <li><a href="#seller-dpa">Data Processing Addendum for sellers</a></li>
     <li><a href="#request-deletion">How to request data deletion</a></li>
     <li><a href="#request-access">How to request your data</a></li>
     <li><a href="#what-we-retain">What data we retain and why</a></li>
@@ -16,6 +17,10 @@
     <li><strong>Request correction</strong> of inaccurate personal data</li>
     <li><strong>Opt out</strong> of certain data processing activities</li>
   </ul>
+
+  <h3 id="seller-dpa">Data Processing Addendum for sellers</h3>
+  <p>If you sell on Gumroad, you are the controller of the buyer data you collect through Gumroad (like your audience email lists and customer information), and Gumroad processes that data on your behalf. Our <a href="https://gumroad.com/dpa">Data Processing Addendum</a> covers this processing under Article 28 of the GDPR, including security measures, breach notification, subprocessors, and international transfers under the standard contractual clauses.</p>
+  <p>The DPA is incorporated into our <a href="https://gumroad.com/terms">Terms of Service</a> by reference and applies automatically, so no signature is needed. If you need a countersigned copy for your records, email <a href="mailto:support@gumroad.com">support@gumroad.com</a>. The subprocessors we use are listed in <a href="/help/article/110-gumroads-subprocessors">Gumroad's subprocessors</a>, and we update that list at least 30 days before adding or replacing a subprocessor.</p>
 
   <h3 id="request-deletion">How to request data deletion</h3>
   <p>You can delete your Gumroad account yourself from your <a href="https://app.gumroad.com/settings/advanced">Advanced Settings</a> page. This is the fastest way to close your account.</p>


### PR DESCRIPTION
## What

Adds a "Data Processing Addendum for sellers" section to the GDPR data requests help article (`_349-gdpr-data-requests.html.erb`), linking the new DPA at gumroad.com/dpa. The section explains that sellers are controllers of the buyer data they collect through Gumroad, that the DPA covers this processing under Article 28 GDPR, that it applies automatically through the Terms of Service (with a countersigned copy available on request), and that subprocessors are listed in the "Gumroad's subprocessors" article with 30 days' advance notice before changes.

## Why

Merged PR antiwork/gumroad#5904 published a seller-facing Data Processing Addendum at `/dpa`. The help center's GDPR article covered data subject rights (deletion, access, retention) but said nothing about the processor terms sellers need for their own GDPR compliance — the exact question multiple EU sellers have asked. Every claim in the new section mirrors the published DPA text: automatic incorporation into the Terms of Service, no signature required, countersign on request via support@gumroad.com, and the 30-day subprocessor notice period (DPA section 6 / `_110-gumroads-subprocessors` update policy).

Body-only edit; `articles.yml` untouched (no title/description change). Anchor IDs preserved; new section added to the in-article TOC.

## Test plan

- Rendered the partial via `ApplicationController.render` in the test env — renders cleanly with the new copy present
- ERB syntax check and HTML tag-balance check pass
- CI runs the help-center specs (slug/partial integrity)

Autoreview skipped (docs copy only, no logic).
