### PR TITLE
Backfill legacy custom receipt text into custom_receipt_text json_data

### DIFF
--- a/app/services/onetime/backfill_custom_receipt_text.rb
+++ b/app/services/onetime/backfill_custom_receipt_text.rb
@@ -17,7 +17,9 @@
 #   * Deleted products are included: buyers can still request receipt resends for purchases of
 #     deleted products, and those receipts render from the product record.
 #   * Products where the new field is already set are skipped — the seller (or an earlier manual
-#     restore) has already chosen the new-format text, and this task must never overwrite it.
+#     restore) has already chosen the new-format text, and this task must never overwrite it. The
+#     check is re-done under a row lock right before the write, so a seller saving receipt text
+#     while the task is running can't be overwritten by a stale copy of the row.
 #   * Legacy text longer than the new field's validation limit
 #     (Product::Validations::MAX_CUSTOM_RECEIPT_TEXT_LENGTH) is skipped and counted rather than
 #     truncated or written as-is. Writing an over-limit value would make every subsequent save of
@@ -73,12 +75,24 @@ module Onetime
 
         return tick(:would_backfill) if @dry_run
 
-        # Copy into json_data without callbacks/validations (see class comment). The json_data
-        # reader instantiates and mutates the in-memory hash, so write the merged hash back
-        # through update_column, which serializes it via the model's JSON coder.
-        link.set_json_data_for_attr("custom_receipt_text", legacy_text)
-        link.update_column(:json_data, link.json_data)
-        tick(:backfilled)
+        # Re-check the no-overwrite guard under a row lock before writing. The write below replaces
+        # the whole json_data hash, so if a seller saved new receipt text between this row being
+        # loaded and this write, an unguarded write would restore the stale hash and erase their
+        # text. with_lock reloads the row with FOR UPDATE, so the seller's concurrent save either
+        # lands before the re-check (and we skip) or waits until this transaction commits.
+        outcome = link.with_lock do
+          if link.custom_receipt_text.present?
+            :skipped_already_set
+          else
+            # Copy into json_data without callbacks/validations (see class comment). The json_data
+            # reader instantiates and mutates the in-memory hash, so write the merged hash back
+            # through update_column, which serializes it via the model's JSON coder.
+            link.set_json_data_for_attr("custom_receipt_text", legacy_text)
+            link.update_column(:json_data, link.json_data)
+            :backfilled
+          end
+        end
+        tick(outcome)
       end
 
       def tick(key)

--- a/app/services/onetime/backfill_custom_receipt_text.rb
+++ b/app/services/onetime/backfill_custom_receipt_text.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+# Restores custom receipt text that silently disappeared from buyer receipts for products last
+# edited before the customizable-receipts feature shipped (December 2025, #2180).
+#
+# Before that change, the receipt email read the seller's custom text from the legacy
+# `links.custom_receipt` column. The feature moved the read to a new `custom_receipt_text`
+# attribute stored in `links.json_data`, but shipped without copying the old column into the new
+# field. Products whose sellers wrote receipt text before the change — and haven't re-saved it in
+# the new Receipt tab since — send receipts without that text, even though the legacy column still
+# holds it.
+#
+# This copies non-blank `links.custom_receipt` into `json_data.custom_receipt_text` wherever the
+# new field is still blank, restoring the seller's original wording on future receipts and resends.
+#
+# Notes on scope and safety:
+#   * Deleted products are included: buyers can still request receipt resends for purchases of
+#     deleted products, and those receipts render from the product record.
+#   * Products where the new field is already set are skipped — the seller (or an earlier manual
+#     restore) has already chosen the new-format text, and this task must never overwrite it.
+#   * Legacy text longer than the new field's validation limit
+#     (Product::Validations::MAX_CUSTOM_RECEIPT_TEXT_LENGTH) is skipped and counted rather than
+#     truncated or written as-is. Writing an over-limit value would make every subsequent save of
+#     that product fail validation, breaking the seller's product editor; truncating would silently
+#     rewrite wording the seller chose carefully. Those products are reported in the stats for a
+#     human decision.
+#   * Writes use update_column so the restore doesn't trigger the product's save callbacks
+#     (search reindexing, cache busting, etc.) for a receipt-text-only data fix, and doesn't
+#     require the rest of the (possibly old, otherwise-invalid) record to pass validation.
+#
+# Idempotent and dry-run by default:
+#
+#   Onetime::BackfillCustomReceiptText.process                 # dry run, logs what it would do
+#   Onetime::BackfillCustomReceiptText.process(dry_run: false) # writes
+module Onetime
+  class BackfillCustomReceiptText
+    BATCH_SIZE = 1_000
+
+    def self.process(dry_run: true, batch_size: BATCH_SIZE)
+      new(dry_run:, batch_size:).process
+    end
+
+    def initialize(dry_run: true, batch_size: BATCH_SIZE)
+      @dry_run = dry_run
+      @batch_size = batch_size
+      @stats = Hash.new(0)
+    end
+
+    def process
+      Link.where.not(custom_receipt: [nil, ""]).find_each(batch_size: @batch_size) do |link|
+        ReplicaLagWatcher.watch
+        backfill(link)
+      rescue => e
+        @stats[:errors] += 1
+        Rails.logger.error("[BackfillCustomReceiptText] link=#{link.id} error=#{e.class}: #{e.message}")
+      end
+
+      @stats[:dry_run] = @dry_run
+      Rails.logger.info("[BackfillCustomReceiptText] #{@stats.to_h}")
+      @stats
+    end
+
+    private
+      def backfill(link)
+        legacy_text = link.custom_receipt
+        return tick(:skipped_blank_legacy) if legacy_text.blank?
+        return tick(:skipped_already_set) if link.custom_receipt_text.present?
+
+        if legacy_text.length > Product::Validations::MAX_CUSTOM_RECEIPT_TEXT_LENGTH
+          Rails.logger.warn("[BackfillCustomReceiptText] link=#{link.id} legacy text is #{legacy_text.length} chars (limit #{Product::Validations::MAX_CUSTOM_RECEIPT_TEXT_LENGTH}), skipping — needs a human decision")
+          return tick(:skipped_too_long)
+        end
+
+        return tick(:would_backfill) if @dry_run
+
+        # Copy into json_data without callbacks/validations (see class comment). The json_data
+        # reader instantiates and mutates the in-memory hash, so write the merged hash back
+        # through update_column, which serializes it via the model's JSON coder.
+        link.set_json_data_for_attr("custom_receipt_text", legacy_text)
+        link.update_column(:json_data, link.json_data)
+        tick(:backfilled)
+      end
+
+      def tick(key)
+        @stats[key] += 1
+      end
+  end
+end

--- a/app/services/onetime/backfill_custom_receipt_text.rb
+++ b/app/services/onetime/backfill_custom_receipt_text.rb
@@ -19,7 +19,11 @@
 #   * Products where the new field is already set are skipped — the seller (or an earlier manual
 #     restore) has already chosen the new-format text, and this task must never overwrite it. The
 #     check is re-done under a row lock right before the write, so a seller saving receipt text
-#     while the task is running can't be overwritten by a stale copy of the row.
+#     while the task is running can't be overwritten by a stale copy of the row. One known
+#     trade-off: a seller who set text in the new Receipt tab and later cleared it (leaving an
+#     empty string in json_data) is indistinguishable from never-migrated, so their legacy wording
+#     is restored. A key-presence check would be wrong the other way — the product editor
+#     round-trips the field on every save — so value-presence is the deliberate choice.
 #   * Legacy text longer than the new field's validation limit
 #     (Product::Validations::MAX_CUSTOM_RECEIPT_TEXT_LENGTH) is skipped and counted rather than
 #     truncated or written as-is. Writing an over-limit value would make every subsequent save of
@@ -29,6 +33,9 @@
 #   * Writes use update_column so the restore doesn't trigger the product's save callbacks
 #     (search reindexing, cache busting, etc.) for a receipt-text-only data fix, and doesn't
 #     require the rest of the (possibly old, otherwise-invalid) record to pass validation.
+#   * This restores existing data only. The public API v2 still accepts writes to the legacy
+#     `custom_receipt` param (which nothing reads anymore) — pointing that at the new field is
+#     tracked separately on the regression issue and deliberately out of scope here.
 #
 # Idempotent and dry-run by default:
 #

--- a/spec/services/onetime/backfill_custom_receipt_text_spec.rb
+++ b/spec/services/onetime/backfill_custom_receipt_text_spec.rb
@@ -60,6 +60,25 @@ describe Onetime::BackfillCustomReceiptText do
       expect(stats[:skipped_too_long]).to eq(1)
     end
 
+    it "backfills text exactly at the validation limit" do
+      at_limit = "a" * Product::Validations::MAX_CUSTOM_RECEIPT_TEXT_LENGTH
+      product = product_with_legacy_receipt(at_limit)
+
+      stats = described_class.process(dry_run: false)
+
+      expect(product.reload.custom_receipt_text).to eq(at_limit)
+      expect(stats[:backfilled]).to eq(1)
+    end
+
+    it "skips whitespace-only legacy text" do
+      product = product_with_legacy_receipt("   \n  ")
+
+      stats = described_class.process(dry_run: false)
+
+      expect(product.reload.custom_receipt_text).to be_nil
+      expect(stats[:backfilled]).to be_nil.or eq(0)
+    end
+
     it "does not write anything in dry-run mode (the default)" do
       product = product_with_legacy_receipt("Dry run text")
 
@@ -114,6 +133,17 @@ describe Onetime::BackfillCustomReceiptText do
 
       expect(stats[:errors]).to eq(1)
       expect(good.reload.custom_receipt_text).to eq("Will succeed")
+    end
+
+    it "counts a row with corrupt non-Hash json_data as an error and continues" do
+      bad = product_with_legacy_receipt("Corrupt json_data row")
+      bad.update_column(:json_data, [].to_json)
+      good = product_with_legacy_receipt("Healthy row")
+
+      stats = described_class.process(dry_run: false)
+
+      expect(stats[:errors]).to eq(1)
+      expect(good.reload.custom_receipt_text).to eq("Healthy row")
     end
   end
 end

--- a/spec/services/onetime/backfill_custom_receipt_text_spec.rb
+++ b/spec/services/onetime/backfill_custom_receipt_text_spec.rb
@@ -30,6 +30,18 @@ describe Onetime::BackfillCustomReceiptText do
       expect(stats[:backfilled]).to be_nil.or eq(0)
     end
 
+    it "re-checks under the row lock and does not overwrite text saved after the row was loaded" do
+      product = product_with_legacy_receipt("Old legacy text")
+      stale_copy = Link.find(product.id)
+      # Simulate a seller saving new receipt text between the batch load and the write.
+      Link.find(product.id).update!(custom_receipt_text: "Saved concurrently by the seller")
+
+      service = described_class.new(dry_run: false)
+      service.send(:backfill, stale_copy)
+
+      expect(product.reload.custom_receipt_text).to eq("Saved concurrently by the seller")
+    end
+
     it "backfills deleted products so receipt resends still render the text" do
       product = product_with_legacy_receipt("Text on a deleted product", deleted_at: 1.month.ago)
 

--- a/spec/services/onetime/backfill_custom_receipt_text_spec.rb
+++ b/spec/services/onetime/backfill_custom_receipt_text_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Onetime::BackfillCustomReceiptText do
+  describe ".process" do
+    def product_with_legacy_receipt(text, **attrs)
+      create(:product, **attrs).tap do |product|
+        product.update_column(:custom_receipt, text)
+      end
+    end
+
+    it "copies legacy custom_receipt into json_data custom_receipt_text when the new field is blank" do
+      product = product_with_legacy_receipt("Carefully worded access instructions.")
+
+      stats = described_class.process(dry_run: false)
+
+      expect(product.reload.custom_receipt_text).to eq("Carefully worded access instructions.")
+      expect(stats[:backfilled]).to eq(1)
+    end
+
+    it "does not overwrite a custom_receipt_text the seller already set" do
+      product = product_with_legacy_receipt("Old legacy text")
+      product.update!(custom_receipt_text: "New text saved via the Receipt tab")
+
+      stats = described_class.process(dry_run: false)
+
+      expect(product.reload.custom_receipt_text).to eq("New text saved via the Receipt tab")
+      expect(stats[:skipped_already_set]).to eq(1)
+      expect(stats[:backfilled]).to be_nil.or eq(0)
+    end
+
+    it "backfills deleted products so receipt resends still render the text" do
+      product = product_with_legacy_receipt("Text on a deleted product", deleted_at: 1.month.ago)
+
+      described_class.process(dry_run: false)
+
+      expect(product.reload.custom_receipt_text).to eq("Text on a deleted product")
+    end
+
+    it "skips legacy text longer than the new field's validation limit instead of truncating" do
+      too_long = "a" * (Product::Validations::MAX_CUSTOM_RECEIPT_TEXT_LENGTH + 1)
+      product = product_with_legacy_receipt(too_long)
+
+      stats = described_class.process(dry_run: false)
+
+      expect(product.reload.custom_receipt_text).to be_nil
+      expect(stats[:skipped_too_long]).to eq(1)
+    end
+
+    it "does not write anything in dry-run mode (the default)" do
+      product = product_with_legacy_receipt("Dry run text")
+
+      stats = described_class.process
+
+      expect(product.reload.custom_receipt_text).to be_nil
+      expect(stats[:would_backfill]).to eq(1)
+      expect(stats[:dry_run]).to eq(true)
+    end
+
+    it "is idempotent across runs" do
+      product = product_with_legacy_receipt("Run twice")
+
+      described_class.process(dry_run: false)
+      stats = described_class.process(dry_run: false)
+
+      expect(product.reload.custom_receipt_text).to eq("Run twice")
+      expect(stats[:skipped_already_set]).to eq(1)
+      expect(stats[:backfilled]).to be_nil.or eq(0)
+    end
+
+    it "preserves other json_data attributes when writing" do
+      product = product_with_legacy_receipt("Keep my neighbors")
+      product.update!(custom_view_content_button_text: "Open course")
+
+      described_class.process(dry_run: false)
+
+      product.reload
+      expect(product.custom_receipt_text).to eq("Keep my neighbors")
+      expect(product.custom_view_content_button_text).to eq("Open course")
+    end
+
+    it "does not run save callbacks or validations on the product" do
+      product = product_with_legacy_receipt("No callbacks please")
+      expect_any_instance_of(Link).not_to receive(:save)
+      expect_any_instance_of(Link).not_to receive(:save!)
+
+      described_class.process(dry_run: false)
+
+      expect(product.reload.custom_receipt_text).to eq("No callbacks please")
+    end
+
+    it "continues past a bad row and counts the error" do
+      bad = product_with_legacy_receipt("Will raise")
+      good = product_with_legacy_receipt("Will succeed")
+      allow_any_instance_of(Link).to receive(:custom_receipt_text).and_wrap_original do |m, *args|
+        raise "boom" if m.receiver.id == bad.id
+        m.call(*args)
+      end
+
+      stats = described_class.process(dry_run: false)
+
+      expect(stats[:errors]).to eq(1)
+      expect(good.reload.custom_receipt_text).to eq("Will succeed")
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds `Onetime::BackfillCustomReceiptText`, a one-time task that copies non-blank legacy `links.custom_receipt` into `json_data.custom_receipt_text` wherever the new field is still blank.

## Why

The customizable-receipts feature (#2180, shipped 2025-12-31) moved the receipt email's custom-text read from the legacy `links.custom_receipt` column to the new `custom_receipt_text` json_data attribute (`ReceiptPresenter::ItemInfo#custom_receipt_note`), with no backfill. Every product whose custom receipt text was written before that change — and not re-saved in the new Receipt tab since — sends receipts without the seller's text, even though the legacy column still holds it.

The legacy data is intact, so this is fully recoverable by copying it forward.

Tracking issue: antiwork/gumroad-private#1120

Design decisions:
- **Skips products where `custom_receipt_text` is already set** — never overwrites text a seller saved via the new Receipt tab (or an earlier manual restore).
- **Includes deleted products** — buyers can still get receipt resends for purchases of deleted products.
- **Legacy text over the new 500-char validation limit is skipped and counted**, not truncated — truncating would silently rewrite wording sellers chose carefully, and writing it as-is would make every subsequent product save fail validation. The `skipped_too_long` count in the run stats flags those for a human decision.
- **Writes via `update_column`** — no save callbacks (search reindex, cache busting) and no full-record validation for a receipt-text-only data fix.
- Dry-run by default, idempotent, batched with `ReplicaLagWatcher`, per-row error isolation.

## Test plan

- `bundle exec rspec spec/services/onetime/backfill_custom_receipt_text_spec.rb` — 13 examples, 0 failures (run locally on this branch). Covers: happy-path backfill, no-overwrite guard, the row-lock re-check against a concurrent seller save, deleted products, over-limit skip, exactly-at-limit boundary, whitespace-only skip, dry-run default, idempotency, json_data neighbor preservation, no save callbacks, per-row error isolation, and corrupt non-Hash json_data rows.
- After merge + deploy, run on production:
  1. `Onetime::BackfillCustomReceiptText.process` (dry run) — review stats, especially `skipped_too_long`.
  2. `Onetime::BackfillCustomReceiptText.process(dry_run: false)`.
  3. Verify a known-affected pre-2026 product renders its custom receipt text in a receipt resend.

- Fable-5 adversarial pre-merge review completed; P1 (stale-snapshot json_data clobber) fixed with a row-locked re-check, P2 spec gaps closed — see the triage comment on this PR.
