### PR TITLE
Fix missing og:image on custom-HTML product pages for cover-only products

### DIFF
--- a/app/controllers/concerns/page_meta/product.rb
+++ b/app/controllers/concerns/page_meta/product.rb
@@ -41,10 +41,10 @@ module PageMeta::Product
     end
 
     def set_open_graph_image_meta(product)
-      # Cover image (or the thumbnail of a video/oembed cover) — shared with the
-      # custom-HTML wrapper document via Link#social_share_preview_url so both
-      # surfaces resolve the share image the same way.
-      image_url = product.social_share_preview_url
+      # Cover image (or the thumbnail/poster of a video/oembed cover) — shared
+      # with the custom-HTML wrapper document via Link#social_share_image so
+      # both surfaces resolve the share image the same way.
+      image_url = product.social_share_image
       return if image_url.blank?
 
       set_meta_tag(property: "og:image", content: image_url)

--- a/app/controllers/concerns/page_meta/product.rb
+++ b/app/controllers/concerns/page_meta/product.rb
@@ -41,16 +41,14 @@ module PageMeta::Product
     end
 
     def set_open_graph_image_meta(product)
-      if product.preview_image_path?
-        set_meta_tag(property: "og:image", content: product.preview_url)
-        set_meta_tag(property: "og:image:alt", content: "")
-      elsif product.preview_oembed_thumbnail_url
-        set_meta_tag(
-          property: "og:image",
-          content: Addressable::URI.escape(product.preview_oembed_thumbnail_url).html_safe,
-        )
-        set_meta_tag(property: "og:image:alt", content: "")
-      end
+      # Cover image (or the thumbnail of a video/oembed cover) — shared with the
+      # custom-HTML wrapper document via Link#social_share_preview_url so both
+      # surfaces resolve the share image the same way.
+      image_url = product.social_share_preview_url
+      return if image_url.blank?
+
+      set_meta_tag(property: "og:image", content: image_url)
+      set_meta_tag(property: "og:image:alt", content: "")
     end
 
     # Equivalent to `twitter_product_card(product, product_description:).html_safe`

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1005,8 +1005,19 @@ class LinksController < ApplicationController
       checkout_url_js = ERB::Util.json_escape("/l/#{product.unique_permalink}?#{Rack::Utils.build_query(checkout_params)}".to_json)
       title = ERB::Util.h(product.name.to_s)
       canonical = ERB::Util.h(product.long_url.to_s)
-      og_image = product.thumbnail&.alive&.url
-      og_image_tag = og_image ? %(<meta property="og:image" content="#{ERB::Util.h(og_image)}">) : ""
+      # Thumbnail first (the wrapper's original image source, kept as the
+      # winner), then the standard product page's fallback chain — cover image,
+      # then the thumbnail of a video/oembed cover — via
+      # Link#social_share_preview_url. Without the fallbacks, products with a
+      # cover but no thumbnail (the common case) lost their link-preview image
+      # the moment they went custom (gumroad-private#1122).
+      share_image = product.thumbnail&.alive&.url || product.social_share_preview_url
+      share_image_tags = if share_image
+        escaped_share_image = ERB::Util.h(share_image)
+        %(<meta property="og:image" content="#{escaped_share_image}">\n    <meta property="twitter:card" content="summary_large_image">\n    <meta property="twitter:image" content="#{escaped_share_image}">)
+      else
+        ""
+      end
       <<~HTML
         <!doctype html>
         <html lang="en">
@@ -1018,7 +1029,7 @@ class LinksController < ApplicationController
             <meta property="og:title" content="#{title}">
             <meta property="og:type" content="product">
             <meta property="og:url" content="#{canonical}">
-            #{og_image_tag}
+            #{share_image_tags}
             <meta name="csrf-token" content="#{ERB::Util.h(form_authenticity_token)}">
             #{custom_html_analytics_head(product)}
             <style>html,body{margin:0;padding:0;height:100%;overflow:hidden}iframe{display:block;width:100%;height:100%;border:0}</style>

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1008,10 +1008,10 @@ class LinksController < ApplicationController
       # Thumbnail first (the wrapper's original image source, kept as the
       # winner), then the standard product page's fallback chain — cover image,
       # then the thumbnail of a video/oembed cover — via
-      # Link#social_share_preview_url. Without the fallbacks, products with a
+      # Link#social_share_image. Without the fallbacks, products with a
       # cover but no thumbnail (the common case) lost their link-preview image
       # the moment they went custom (gumroad-private#1122).
-      share_image = product.thumbnail&.alive&.url || product.social_share_preview_url
+      share_image = product.thumbnail&.alive&.url || product.social_share_image
       share_image_tags = if share_image
         escaped_share_image = ERB::Util.h(share_image)
         %(<meta property="og:image" content="#{escaped_share_image}">\n    <meta property="twitter:card" content="summary_large_image">\n    <meta property="twitter:image" content="#{escaped_share_image}">)

--- a/app/modules/product/preview.rb
+++ b/app/modules/product/preview.rb
@@ -84,12 +84,17 @@ module Product::Preview
   # any product that had a cover but no thumbnail (gumroad-private#1122).
   # Oembed thumbnail URLs come from third-party hosts and can contain characters
   # that are invalid in a URL, so that branch is URI-escaped here; cover URLs
-  # are our own storage/CDN URLs and are returned as-is.
-  def social_share_preview_url
+  # and video poster URLs are our own storage/CDN URLs and are returned as-is.
+  # For a video file uploaded directly to Gumroad the poster is the ffmpeg
+  # frame generated in the background by GenerateVideoPosterWorker — nil until
+  # that has run, in which case the share image is simply omitted.
+  # (Named without a _url suffix because CONTRIBUTING.md forbids new methods
+  # ending in _url/_path — they can collide with Rails route helpers.)
+  def social_share_image
     return preview_url if preview_image_path?
-    return if preview_oembed_thumbnail_url.blank?
+    return Addressable::URI.escape(preview_oembed_thumbnail_url) if preview_oembed_thumbnail_url.present?
 
-    Addressable::URI.escape(preview_oembed_thumbnail_url)
+    main_preview&.video_poster_url
   end
 
   def preview_width_for_mobile

--- a/app/modules/product/preview.rb
+++ b/app/modules/product/preview.rb
@@ -75,6 +75,23 @@ module Product::Preview
     main_preview&.url
   end
 
+  # The image social scrapers (Facebook, iMessage, X, etc.) should use when this
+  # product is shared: the cover image when one exists, otherwise the thumbnail
+  # of a video/oembed cover. Shared by the standard product page meta tags
+  # (PageMeta::Product) and the custom-HTML wrapper document (LinksController)
+  # so the two surfaces can't drift apart — the wrapper previously implemented
+  # its own og:image logic without these fallbacks, which dropped the image for
+  # any product that had a cover but no thumbnail (gumroad-private#1122).
+  # Oembed thumbnail URLs come from third-party hosts and can contain characters
+  # that are invalid in a URL, so that branch is URI-escaped here; cover URLs
+  # are our own storage/CDN URLs and are returned as-is.
+  def social_share_preview_url
+    return preview_url if preview_image_path?
+    return if preview_oembed_thumbnail_url.blank?
+
+    Addressable::URI.escape(preview_oembed_thumbnail_url)
+  end
+
   def preview_width_for_mobile
     preview_width || 0
   end

--- a/spec/controllers/links_controller_custom_html_spec.rb
+++ b/spec/controllers/links_controller_custom_html_spec.rb
@@ -97,6 +97,16 @@ describe LinksController, :vcr, type: :controller do
         expect(response.body).to include(%(<meta property="twitter:image" content="https://images.unsplash.com/example.jpeg">))
       end
 
+      it "falls back to the generated poster for an uploaded video cover" do
+        product.preview = Rack::Test::UploadedFile.new(Rails.root.join("spec", "support", "fixtures", "thing.mov"), "video/quicktime")
+        allow_any_instance_of(AssetPreview).to receive(:video_poster_url).and_return("https://files.example.com/poster.jpg")
+
+        get :show, params: { id: product.unique_permalink }
+
+        expect(response.body).to include(%(<meta property="og:image" content="https://files.example.com/poster.jpg">))
+        expect(response.body).to include(%(<meta property="twitter:image" content="https://files.example.com/poster.jpg">))
+      end
+
       it "prefers the thumbnail over the cover when both exist" do
         thumbnail = create(:thumbnail, product:)
         create(:asset_preview, link: product, unsplash_url: "https://images.unsplash.com/example.jpeg", attach: false)

--- a/spec/controllers/links_controller_custom_html_spec.rb
+++ b/spec/controllers/links_controller_custom_html_spec.rb
@@ -70,6 +70,44 @@ describe LinksController, :vcr, type: :controller do
       expect(response.body).to include(%(ALLOWED_CHECKOUT_KEYS = ["variant","option","quantity","price","recurrence"]))
     end
 
+    describe "social share image meta tags" do
+      it "omits og:image and twitter:image when the product has no thumbnail or cover" do
+        get :show, params: { id: product.unique_permalink }
+
+        expect(response.body).not_to include(%(property="og:image"))
+        expect(response.body).not_to include(%(property="twitter:image"))
+      end
+
+      it "uses the thumbnail when one is set" do
+        thumbnail = create(:thumbnail, product:)
+
+        get :show, params: { id: product.unique_permalink }
+
+        expect(response.body).to include(%(<meta property="og:image" content="#{ERB::Util.h(thumbnail.url)}">))
+        expect(response.body).to include(%(<meta property="twitter:card" content="summary_large_image">))
+        expect(response.body).to include(%(<meta property="twitter:image" content="#{ERB::Util.h(thumbnail.url)}">))
+      end
+
+      it "falls back to the cover image when there is no thumbnail" do
+        create(:asset_preview, link: product, unsplash_url: "https://images.unsplash.com/example.jpeg", attach: false)
+
+        get :show, params: { id: product.unique_permalink }
+
+        expect(response.body).to include(%(<meta property="og:image" content="https://images.unsplash.com/example.jpeg">))
+        expect(response.body).to include(%(<meta property="twitter:image" content="https://images.unsplash.com/example.jpeg">))
+      end
+
+      it "prefers the thumbnail over the cover when both exist" do
+        thumbnail = create(:thumbnail, product:)
+        create(:asset_preview, link: product, unsplash_url: "https://images.unsplash.com/example.jpeg", attach: false)
+
+        get :show, params: { id: product.unique_permalink }
+
+        expect(response.body).to include(%(<meta property="og:image" content="#{ERB::Util.h(thumbnail.url)}">))
+        expect(response.body).not_to include(%(content="https://images.unsplash.com/example.jpeg"))
+      end
+    end
+
     it "escapes the checkout URL for JavaScript string context" do
       allow(product).to receive(:unique_permalink).and_return(%(abc</script><script>alert(1)</script>))
 

--- a/spec/modules/product/preview_spec.rb
+++ b/spec/modules/product/preview_spec.rb
@@ -133,15 +133,15 @@ describe Product::Preview do
       end
     end
 
-    describe "#social_share_preview_url" do
+    describe "#social_share_image" do
       it "returns nil when the product has no previews" do
         product = create(:product)
-        expect(product.social_share_preview_url).to be(nil)
+        expect(product.social_share_image).to be(nil)
       end
 
       it "returns the cover URL when the cover is an image" do
         product = create(:product, preview: @png_file)
-        expect(product.social_share_preview_url).to eq(product.preview_url)
+        expect(product.social_share_image).to eq(product.preview_url)
       end
 
       it "falls back to the escaped oembed thumbnail URL for embeddable covers" do
@@ -149,12 +149,19 @@ describe Product::Preview do
         product = asset_preview.link
         allow(asset_preview).to receive(:oembed_thumbnail_url).and_return("https://i.ytimg.com/vi/qKebcV1jv3A/hq default.jpg")
         allow(product).to receive(:main_preview).and_return(asset_preview)
-        expect(product.social_share_preview_url).to eq("https://i.ytimg.com/vi/qKebcV1jv3A/hq%20default.jpg")
+        expect(product.social_share_image).to eq("https://i.ytimg.com/vi/qKebcV1jv3A/hq%20default.jpg")
       end
 
-      it "returns nil for a video cover with no oembed thumbnail" do
+      it "falls back to the generated poster for an uploaded video cover" do
         product = create(:product, preview: @mov_file)
-        expect(product.social_share_preview_url).to be(nil)
+        allow_any_instance_of(AssetPreview).to receive(:video_poster_url).and_return("https://files.example.com/poster.jpg")
+        expect(product.social_share_image).to eq("https://files.example.com/poster.jpg")
+      end
+
+      it "returns nil for an uploaded video cover whose poster has not been generated yet" do
+        product = create(:product, preview: @mov_file)
+        allow_any_instance_of(AssetPreview).to receive(:video_poster_url).and_return(nil)
+        expect(product.social_share_image).to be(nil)
       end
     end
   end

--- a/spec/modules/product/preview_spec.rb
+++ b/spec/modules/product/preview_spec.rb
@@ -132,5 +132,30 @@ describe Product::Preview do
         expect(product.preview_url).to eq(asset_preview.unsplash_url)
       end
     end
+
+    describe "#social_share_preview_url" do
+      it "returns nil when the product has no previews" do
+        product = create(:product)
+        expect(product.social_share_preview_url).to be(nil)
+      end
+
+      it "returns the cover URL when the cover is an image" do
+        product = create(:product, preview: @png_file)
+        expect(product.social_share_preview_url).to eq(product.preview_url)
+      end
+
+      it "falls back to the escaped oembed thumbnail URL for embeddable covers" do
+        asset_preview = create(:asset_preview_youtube)
+        product = asset_preview.link
+        allow(asset_preview).to receive(:oembed_thumbnail_url).and_return("https://i.ytimg.com/vi/qKebcV1jv3A/hq default.jpg")
+        allow(product).to receive(:main_preview).and_return(asset_preview)
+        expect(product.social_share_preview_url).to eq("https://i.ytimg.com/vi/qKebcV1jv3A/hq%20default.jpg")
+      end
+
+      it "returns nil for a video cover with no oembed thumbnail" do
+        product = create(:product, preview: @mov_file)
+        expect(product.social_share_preview_url).to be(nil)
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes antiwork/gumroad-private#1122

## Problem

Custom-HTML product pages drop `og:image` (and emit no Twitter card tags at all) for any product that has a **cover but no thumbnail** — the common case, since thumbnails are optional. The wrapper document (`LinksController#custom_html_wrapper_document`) built its own og:image tag from `product.thumbnail&.alive&.url` only, while the standard product page (`PageMeta::Product#set_open_graph_image_meta`) falls back to the cover (`preview_url` when `preview_image_path?`) and then the oembed thumbnail. So the moment a seller published a custom page, their Facebook/iMessage/X link previews lost the image (reporter: `gprsjunkie.gumroad.com/l/dont-get-suspended`, FB Sharing Debugger warned "'og:image' should be explicitly provided").

## Fix

- Extract the standard page's fallback chain into `Link#social_share_image` (cover image → escaped oembed thumbnail → generated video poster), shared by both surfaces so they can't drift again. (Named without a `_url` suffix per CONTRIBUTING.md's rule against new `_url`/`_path` methods.)
- Directly uploaded video covers now use the cached ffmpeg poster from #5860 (`AssetPreview#video_poster_url`) as the final fallback — previously both surfaces omitted the image for video covers with no thumbnail. Nil until the background worker has generated the poster, in which case the tags are simply omitted.
- `PageMeta::Product#set_open_graph_image_meta` now delegates to it (image/oembed behavior unchanged; video-poster fallback is new).
- The wrapper resolves its share image as thumbnail → `social_share_image` (thumbnail still wins there, as before), and now also emits `twitter:card` / `twitter:image`.

## Checklist (from the issue)

- [x] Mirror `PageMeta::Product`'s fallback chain in `custom_html_wrapper_document`; extract shared logic
- [x] Add `twitter:image` (plus `twitter:card`) on the wrapper
- [x] Spec: cover-only product with custom_html renders `og:image` with the preview URL; thumbnail still wins when present
- [x] Uploaded-video covers fall back to the generated poster (model + wrapper specs)
- [ ] Verify on the reporter's live page post-deploy + re-run FB Sharing Debugger scrape

## Tests

- `spec/controllers/links_controller_custom_html_spec.rb`: 5 new wrapper examples (no image → tags omitted; thumbnail; cover-only fallback; video-poster fallback; thumbnail beats cover). Full file: 37 examples, 0 failures.
- `spec/modules/product/preview_spec.rb`: 5 new `#social_share_image` examples (nil, image cover, escaped oembed thumbnail, video poster fallback, video cover with no poster yet → nil). Full file: 18 examples, 0 failures.
- `links_controller_spec.rb -e "product information markup"` (standard-page og:image): 7 examples, 0 failures.
- Rubocop clean on all touched files.
