### PR TITLE
Fix NoMethodError on 'transfer' in StripeChargeProcessor#get_charge_object for failed destination charges

### DIFF
--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -151,7 +151,11 @@ class StripeChargeProcessor
   end
 
   def get_charge_object(charge)
-    if charge[:transfer_data]
+    # A destination charge (transfer_data present) only carries a `transfer` id once Stripe has
+    # actually created the transfer — i.e. after the charge succeeds. Failed or still-pending
+    # charges (synced via SyncStatusWithChargeProcessorService) have transfer_data but no
+    # `transfer` attribute at all, and Stripe::StripeObject raises NoMethodError on access.
+    if charge[:transfer_data] && charge[:transfer].present?
       destination_transfer = Stripe::Transfer.retrieve(id: charge.transfer)
       stripe_destination_payment = Stripe::Charge.retrieve({ id: destination_transfer.destination_payment, expand: %w[balance_transaction] },
                                                            { stripe_account: destination_transfer.destination })

--- a/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
@@ -269,6 +269,39 @@ describe StripeChargeProcessor, :vcr do
         expect(charge.fee).to be_nil
       end
     end
+    describe "when the charge has transfer_data but no transfer yet" do
+      # A failed (or still-pending) destination charge carries `transfer_data` but Stripe has not
+      # created the transfer, so the `transfer` attribute is absent from the payload entirely.
+      # Accessing `charge.transfer` on such an object raises NoMethodError (seen in production via
+      # SyncStatusWithChargeProcessorService syncing failed purchases — Sentry GUMROAD-YV).
+      it "returns a charge object without attempting to retrieve the destination transfer" do
+        mock_charge = Stripe::Charge.construct_from(
+          id: "ch_test_456",
+          status: "failed",
+          refunded: false,
+          dispute: nil,
+          amount: 100,
+          currency: "usd",
+          destination: nil,
+          transfer_data: { destination: "acct_test_123" },
+          transfer_group: nil,
+          balance_transaction: nil,
+          application_fee: nil,
+          payment_method: "pm_test_456",
+          payment_method_details: nil,
+          outcome: nil
+        )
+
+        allow(Stripe::Charge).to receive(:retrieve).and_return(mock_charge)
+        expect(Stripe::Transfer).not_to receive(:retrieve)
+
+        charge = subject.get_charge("ch_test_456")
+
+        expect(charge).to be_a(BaseProcessorCharge)
+        expect(charge.id).to eq("ch_test_456")
+        expect(charge.status).to eq("failed")
+      end
+    end
   end
 
   describe "#search_charge" do


### PR DESCRIPTION
## What

Guards the destination-transfer lookup in `StripeChargeProcessor#get_charge_object` so it only retrieves the destination transfer when the charge actually carries a `transfer` id. Previously the method assumed any charge with `transfer_data` also had a `transfer` attribute.

## Why

A destination charge only gets a `transfer` once Stripe has created it — i.e. after the charge succeeds. Failed or still-pending destination charges have `transfer_data` but no `transfer` attribute at all, and `Stripe::StripeObject` raises `NoMethodError: undefined method 'transfer'` on access.

This fires in production when `Purchase::SyncStatusWithChargeProcessorService` re-syncs a failed purchase whose charge was created with `transfer_data` (via `ChargeProcessor.get_or_search_charge` → `get_charge_object`).

Sentry: [GUMROAD-YV](https://gumroad-to.sentry.io/issues/7615064249/) — `NoMethodError: undefined method 'transfer' for #<Stripe::Charge>` in `StripeChargeProcessor#get_charge_object` (2 events so far, new issue as of today).

## Test plan

- New spec: charge with `transfer_data` but no `transfer` → `get_charge` returns a `BaseProcessorCharge` without calling `Stripe::Transfer.retrieve`. Confirmed red on `main` (raises `NoMethodError`), green with the fix.
- Full `#get_charge` describe block: 9 examples, 0 failures locally.
- RuboCop clean on both changed files.

## Before/After

Not applicable — backend-only change, no UI impact.
