### PR TITLE
Add hourly interval to sales analytics and the v2 sales summary API

### DIFF
--- a/app/controllers/api/v2/sales_controller.rb
+++ b/app/controllers/api/v2/sales_controller.rb
@@ -224,6 +224,10 @@ class Api::V2::SalesController < Api::V2::BaseController
 
       return error_400("'from' must be on or before 'to'.") if from > to
       return error_400("Date range cannot exceed #{AnalyticsController::MAX_DATE_RANGE_DAYS} days.") if (to - from).to_i > AnalyticsController::MAX_DATE_RANGE_DAYS
+      # Hourly grouping produces 24 buckets per day, so it only allows short ranges.
+      if group_by == "hour" && (to - from).to_i > CreatorAnalytics::Sales::MAX_HOURLY_DATE_RANGE_DAYS
+        return error_400("Date range cannot exceed #{CreatorAnalytics::Sales::MAX_HOURLY_DATE_RANGE_DAYS} days when grouping by hour.")
+      end
 
       { from:, to:, group_by: }
     end

--- a/app/services/api/v2/sales_summary.rb
+++ b/app/services/api/v2/sales_summary.rb
@@ -4,6 +4,12 @@ class Api::V2::SalesSummary
   VALID_GROUPS = %w[product day week month hour].freeze
 
   def initialize(seller:, from:, to:, group_by: nil)
+    # The controller returns a friendly 400 for this case; the guard here protects
+    # any future caller from requesting an unbounded number of hourly buckets.
+    if group_by == "hour" && (to - from).to_i > CreatorAnalytics::Sales::MAX_HOURLY_DATE_RANGE_DAYS
+      raise ArgumentError, "date range cannot exceed #{CreatorAnalytics::Sales::MAX_HOURLY_DATE_RANGE_DAYS} days when grouping by hour"
+    end
+
     @seller = seller
     @from = from
     @to = to
@@ -33,7 +39,25 @@ class Api::V2::SalesSummary
       items = buckets.map { breakdown_item(_1) }
       return items.sort_by { [-_1[:gross_cents], _1[:label].to_s] } if @group_by == "product"
 
+      items = merge_items_sharing_a_key(items) if @group_by == "hour"
       items.sort_by { _1[:key] }
+    end
+
+    # At a DST fall-back the same local hour occurs twice, so two Elasticsearch
+    # buckets can map onto the same wall-clock key. Merge them into a single item
+    # for that hour so consumers never see duplicate keys.
+    def merge_items_sharing_a_key(items)
+      items.group_by { _1[:key] }.map do |_key, group|
+        group.reduce do |merged, item|
+          merged.merge(
+            gross_cents: merged[:gross_cents] + item[:gross_cents],
+            net_cents: merged[:net_cents] + item[:net_cents],
+            units: merged[:units] + item[:units],
+            refunded_cents: merged[:refunded_cents] + item[:refunded_cents],
+            refunded_units: merged[:refunded_units] + item[:refunded_units],
+          )
+        end
+      end
     end
 
     def paginated_breakdown_buckets
@@ -90,17 +114,28 @@ class Api::V2::SalesSummary
       when "product"
         [{ product_id: { terms: { field: "product_id" } } }]
       when "day", "week", "month", "hour"
-        [{ date: { date_histogram: { time_zone: @seller.timezone_id, field: "created_at", calendar_interval: @group_by, format: date_format } } }]
+        histogram = { time_zone: @seller.timezone_id, field: "created_at", calendar_interval: @group_by }
+        # Hourly buckets are keyed by epoch milliseconds and formatted in Ruby (see
+        # bucket_date_key). An offset-less hour string is ambiguous at a DST fall-back,
+        # and Elasticsearch rejects the query when the formatted composite after_key no
+        # longer parses back to the same instant.
+        histogram[:format] = date_format unless @group_by == "hour"
+        [{ date: { date_histogram: histogram } }]
       end
     end
 
     def date_format
-      case @group_by
-      when "month" then "yyyy-MM"
-      # Hourly keys carry the time of day in the seller's timezone, e.g. "2026-07-16T13:00".
-      when "hour" then "yyyy-MM-dd'T'HH:mm"
-      else "yyyy-MM-dd"
-      end
+      @group_by == "month" ? "yyyy-MM" : "yyyy-MM-dd"
+    end
+
+    def bucket_date_key(bucket)
+      value = bucket["key"]["date"]
+      return value unless @group_by == "hour"
+
+      # Convert the bucket's epoch timestamp to a wall-clock hour in the seller's
+      # timezone, e.g. "2026-07-16T13:00". The two instants of a DST fall-back hour
+      # map onto the same key; merge_items_sharing_a_key combines them.
+      Time.at(value.to_i / 1000).in_time_zone(@seller.timezone).strftime("%Y-%m-%dT%H:%M")
     end
 
     def breakdown_item(bucket)
@@ -109,7 +144,8 @@ class Api::V2::SalesSummary
         product = products_by_id[bucket["key"]["product_id"].to_i]
         item.merge(key: product&.external_id || bucket["key"]["product_id"].to_s, label: product&.name)
       else
-        item.merge(key: bucket["key"]["date"], label: bucket["key"]["date"])
+        date_key = bucket_date_key(bucket)
+        item.merge(key: date_key, label: date_key)
       end
     end
 

--- a/app/services/api/v2/sales_summary.rb
+++ b/app/services/api/v2/sales_summary.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V2::SalesSummary
-  VALID_GROUPS = %w[product day week month].freeze
+  VALID_GROUPS = %w[product day week month hour].freeze
 
   def initialize(seller:, from:, to:, group_by: nil)
     @seller = seller
@@ -89,13 +89,18 @@ class Api::V2::SalesSummary
       case @group_by
       when "product"
         [{ product_id: { terms: { field: "product_id" } } }]
-      when "day", "week", "month"
+      when "day", "week", "month", "hour"
         [{ date: { date_histogram: { time_zone: @seller.timezone_id, field: "created_at", calendar_interval: @group_by, format: date_format } } }]
       end
     end
 
     def date_format
-      @group_by == "month" ? "yyyy-MM" : "yyyy-MM-dd"
+      case @group_by
+      when "month" then "yyyy-MM"
+      # Hourly keys carry the time of day in the seller's timezone, e.g. "2026-07-16T13:00".
+      when "hour" then "yyyy-MM-dd'T'HH:mm"
+      else "yyyy-MM-dd"
+      end
     end
 
     def breakdown_item(bucket)

--- a/app/services/creator_analytics/sales.rb
+++ b/app/services/creator_analytics/sales.rb
@@ -34,9 +34,9 @@ class CreatorAnalytics::Sales
     paginate(sources:).each_with_object({}) do |bucket, result|
       key = [
         bucket["key"]["product_id"],
-        bucket["key"]["date"]
+        bucket_date_key(bucket)
       ]
-      result[key] = { count: bucket["doc_count"], total: bucket["total"]["value"].to_i }
+      result[key] = merge_date_bucket(result[key], bucket)
     end
   end
 
@@ -63,25 +63,46 @@ class CreatorAnalytics::Sales
       date_histogram_source
     ]
 
-    paginate(sources:).each_with_object(Hash.new(0)) do |bucket, hash|
+    paginate(sources:).each_with_object({}) do |bucket, hash|
       key = [
         bucket["key"]["product_id"],
         bucket["key"]["referrer_domain"],
-        bucket["key"]["date"],
+        bucket_date_key(bucket),
       ]
-      hash[key] = { count: bucket["doc_count"], total: bucket["total"]["value"].to_i }
+      hash[key] = merge_date_bucket(hash[key], bucket)
     end
   end
 
   private
-    def date_histogram_source
-      { date: { date_histogram: { time_zone: @user.timezone_id, field: "created_at", calendar_interval: @interval, format: date_key_format } } }
+    # At a DST fall-back the same local hour occurs twice, so two Elasticsearch
+    # buckets can map onto the same wall-clock key. Combine them into one bucket
+    # for that hour instead of letting the second silently overwrite the first.
+    def merge_date_bucket(existing, bucket)
+      count = bucket["doc_count"]
+      total = bucket["total"]["value"].to_i
+      return { count:, total: } if existing.nil?
+
+      { count: existing[:count] + count, total: existing[:total] + total }
     end
 
-    def date_key_format
-      # Hourly bucket keys carry the time of day in the seller's timezone
-      # ("2026-07-16T13:00"); daily keys keep the existing "2026-07-16" shape.
-      @interval == "hour" ? "yyyy-MM-dd'T'HH:mm" : "yyyy-MM-dd"
+    def date_histogram_source
+      histogram = { time_zone: @user.timezone_id, field: "created_at", calendar_interval: @interval }
+      # Hourly buckets are keyed by epoch milliseconds and formatted in Ruby (see
+      # bucket_date_key). An offset-less hour string is ambiguous at a DST fall-back,
+      # and Elasticsearch rejects the query when the formatted composite after_key no
+      # longer parses back to the same instant.
+      histogram[:format] = "yyyy-MM-dd" unless @interval == "hour"
+      { date: { date_histogram: histogram } }
+    end
+
+    def bucket_date_key(bucket)
+      value = bucket["key"]["date"]
+      return value unless @interval == "hour"
+
+      # Convert the bucket's epoch timestamp to a wall-clock hour in the seller's
+      # timezone, e.g. "2026-07-16T13:00". The two instants of a DST fall-back hour
+      # map onto the same key; merge_date_bucket combines them.
+      Time.at(value.to_i / 1000).in_time_zone(@user.timezone).strftime("%Y-%m-%dT%H:%M")
     end
 
     def paginate(sources:)

--- a/app/services/creator_analytics/sales.rb
+++ b/app/services/creator_analytics/sales.rb
@@ -6,10 +6,21 @@ class CreatorAnalytics::Sales
     exclude_unreversed_chargedback: false,
   )
 
-  def initialize(user:, products:, dates:)
+  VALID_INTERVALS = %w[day hour].freeze
+  # Hourly buckets multiply fast (24 per day per product), so hourly analytics are
+  # limited to short date ranges to keep Elasticsearch bucket counts sane.
+  MAX_HOURLY_DATE_RANGE_DAYS = 7
+
+  def initialize(user:, products:, dates:, interval: "day")
+    raise ArgumentError, "interval must be one of: #{VALID_INTERVALS.join(", ")}" unless VALID_INTERVALS.include?(interval)
+    if interval == "hour" && (dates.last - dates.first).to_i > MAX_HOURLY_DATE_RANGE_DAYS
+      raise ArgumentError, "date range cannot exceed #{MAX_HOURLY_DATE_RANGE_DAYS} days for the hour interval"
+    end
+
     @user = user
     @products = products
     @dates = dates
+    @interval = interval
     @query = PurchaseSearchService.new(SEARCH_OPTIONS).body[:query]
     @query[:bool][:filter] << { terms: { product_id: @products.map(&:id) } }
     @query[:bool][:must] << CreatorAnalytics::DateQuery.day_range(field: :created_at, start_date: @dates.first, end_date: @dates.last, timezone: @user.timezone)
@@ -18,7 +29,7 @@ class CreatorAnalytics::Sales
   def by_product_and_date
     sources = [
       { product_id: { terms: { field: "product_id" } } },
-      { date: { date_histogram: { time_zone: @user.timezone_id, field: "created_at", calendar_interval: "day", format: "yyyy-MM-dd" } } }
+      date_histogram_source
     ]
     paginate(sources:).each_with_object({}) do |bucket, result|
       key = [
@@ -49,7 +60,7 @@ class CreatorAnalytics::Sales
     sources = [
       { product_id: { terms: { field: "product_id" } } },
       { referrer_domain: { terms: { field: "referrer_domain" } } },
-      { date: { date_histogram: { time_zone: @user.timezone_id, field: "created_at", calendar_interval: "day", format: "yyyy-MM-dd" } } }
+      date_histogram_source
     ]
 
     paginate(sources:).each_with_object(Hash.new(0)) do |bucket, hash|
@@ -63,6 +74,16 @@ class CreatorAnalytics::Sales
   end
 
   private
+    def date_histogram_source
+      { date: { date_histogram: { time_zone: @user.timezone_id, field: "created_at", calendar_interval: @interval, format: date_key_format } } }
+    end
+
+    def date_key_format
+      # Hourly bucket keys carry the time of day in the seller's timezone
+      # ("2026-07-16T13:00"); daily keys keep the existing "2026-07-16" shape.
+      @interval == "hour" ? "yyyy-MM-dd'T'HH:mm" : "yyyy-MM-dd"
+    end
+
     def paginate(sources:)
       after_key = nil
       body = build_body(sources)

--- a/spec/controllers/api/v2/sales_controller_spec.rb
+++ b/spec/controllers/api/v2/sales_controller_spec.rb
@@ -614,7 +614,41 @@ describe Api::V2::SalesController do
         expect(response.code).to eq "400"
         expect(response.parsed_body).to eq({
           status: 400,
-          error: "Invalid group_by. Valid values are: product, day, week, month."
+          error: "Invalid group_by. Valid values are: product, day, week, month, hour."
+        }.as_json)
+        expect(Api::V2::SalesSummary).not_to have_received(:new)
+      end
+
+      it "returns a sales summary grouped by hour for a short date range" do
+        get :summary, params: @params.merge(from: "2026-05-15", to: "2026-05-21", group_by: "hour")
+
+        expect(response.parsed_body).to eq({ success: true }.merge(@summary).as_json)
+        expect(Api::V2::SalesSummary).to have_received(:new).with(
+          seller: @seller,
+          from: Date.new(2026, 5, 15),
+          to: Date.new(2026, 5, 21),
+          group_by: "hour"
+        )
+      end
+
+      it "returns a 400 error if date range is too wide for hourly grouping" do
+        get :summary, params: @params.merge(from: "2026-05-13", to: "2026-05-21", group_by: "hour")
+
+        expect(response.code).to eq "400"
+        expect(response.parsed_body).to eq({
+          status: 400,
+          error: "Date range cannot exceed 7 days when grouping by hour."
+        }.as_json)
+        expect(Api::V2::SalesSummary).not_to have_received(:new)
+      end
+
+      it "returns a 400 error when grouping by hour with the default 30-day range" do
+        get :summary, params: @params.merge(group_by: "hour")
+
+        expect(response.code).to eq "400"
+        expect(response.parsed_body).to eq({
+          status: 400,
+          error: "Date range cannot exceed 7 days when grouping by hour."
         }.as_json)
         expect(Api::V2::SalesSummary).not_to have_received(:new)
       end

--- a/spec/controllers/api/v2/sales_controller_spec.rb
+++ b/spec/controllers/api/v2/sales_controller_spec.rb
@@ -619,13 +619,13 @@ describe Api::V2::SalesController do
         expect(Api::V2::SalesSummary).not_to have_received(:new)
       end
 
-      it "returns a sales summary grouped by hour for a short date range" do
-        get :summary, params: @params.merge(from: "2026-05-15", to: "2026-05-21", group_by: "hour")
+      it "returns a sales summary grouped by hour for a date range at the allowed maximum" do
+        get :summary, params: @params.merge(from: "2026-05-14", to: "2026-05-21", group_by: "hour")
 
         expect(response.parsed_body).to eq({ success: true }.merge(@summary).as_json)
         expect(Api::V2::SalesSummary).to have_received(:new).with(
           seller: @seller,
-          from: Date.new(2026, 5, 15),
+          from: Date.new(2026, 5, 14),
           to: Date.new(2026, 5, 21),
           group_by: "hour"
         )

--- a/spec/services/api/v2/sales_summary_spec.rb
+++ b/spec/services/api/v2/sales_summary_spec.rb
@@ -147,6 +147,39 @@ describe Api::V2::SalesSummary do
                                        ])
     end
 
+    it "merges the repeated local hour at a DST fall-back into a single hourly item" do
+      seller = create(:user, timezone: "Pacific Time (US & Canada)")
+      product = create(:product, user: seller, price_cents: 10_00)
+      # On Nov 1, 2026 Pacific clocks fall back at 2:00 AM, so 08:30 UTC (01:30 PDT)
+      # and 09:30 UTC (01:30 PST) are distinct Elasticsearch buckets that format to
+      # the same "2026-11-01T01:00" key.
+      create(:purchase, link: product, price_cents: 10_00, created_at: Time.utc(2026, 11, 1, 8, 30))
+      create(:purchase, link: product, price_cents: 20_00, created_at: Time.utc(2026, 11, 1, 9, 30))
+      index_model_records(Purchase)
+
+      result = described_class.new(seller:, from: Date.new(2026, 11, 1), to: Date.new(2026, 11, 1), group_by: "hour").as_json
+
+      expect(result[:breakdown]).to eq([
+                                         {
+                                           key: "2026-11-01T01:00",
+                                           label: "2026-11-01T01:00",
+                                           gross_cents: 30_00,
+                                           net_cents: 30_00,
+                                           units: 2,
+                                           refunded_cents: 0,
+                                           refunded_units: 0,
+                                         }
+                                       ])
+    end
+
+    it "raises an error when grouping by hour over more than the allowed range" do
+      seller = create(:user, timezone: "UTC")
+
+      expect do
+        described_class.new(seller:, from: Date.new(2026, 5, 13), to: Date.new(2026, 5, 21), group_by: "hour")
+      end.to raise_error(ArgumentError, "date range cannot exceed 7 days when grouping by hour")
+    end
+
     it "groups monthly breakdowns" do
       seller = create(:user, timezone: "UTC")
       product = create(:product, user: seller, price_cents: 10_00)

--- a/spec/services/api/v2/sales_summary_spec.rb
+++ b/spec/services/api/v2/sales_summary_spec.rb
@@ -113,6 +113,40 @@ describe Api::V2::SalesSummary do
                                        ])
     end
 
+    it "groups hourly breakdowns in the seller's timezone" do
+      seller = create(:user, timezone: "Pacific Time (US & Canada)")
+      product = create(:product, user: seller, price_cents: 10_00)
+      # 06:30 UTC on May 21 is 23:30 on May 20 in Pacific time; the two purchases
+      # around 08:00 UTC both fall inside the 01:00 hour on May 21 Pacific time.
+      create(:purchase, link: product, price_cents: 10_00, created_at: Time.utc(2026, 5, 21, 6, 30))
+      create(:purchase, link: product, price_cents: 20_00, created_at: Time.utc(2026, 5, 21, 8, 0))
+      create(:purchase, link: product, price_cents: 30_00, created_at: Time.utc(2026, 5, 21, 8, 45))
+      index_model_records(Purchase)
+
+      result = described_class.new(seller:, from: Date.new(2026, 5, 20), to: Date.new(2026, 5, 21), group_by: "hour").as_json
+
+      expect(result[:breakdown]).to eq([
+                                         {
+                                           key: "2026-05-20T23:00",
+                                           label: "2026-05-20T23:00",
+                                           gross_cents: 10_00,
+                                           net_cents: 10_00,
+                                           units: 1,
+                                           refunded_cents: 0,
+                                           refunded_units: 0,
+                                         },
+                                         {
+                                           key: "2026-05-21T01:00",
+                                           label: "2026-05-21T01:00",
+                                           gross_cents: 50_00,
+                                           net_cents: 50_00,
+                                           units: 2,
+                                           refunded_cents: 0,
+                                           refunded_units: 0,
+                                         }
+                                       ])
+    end
+
     it "groups monthly breakdowns" do
       seller = create(:user, timezone: "UTC")
       product = create(:product, user: seller, price_cents: 10_00)

--- a/spec/services/creator_analytics/sales_spec.rb
+++ b/spec/services/creator_analytics/sales_spec.rb
@@ -229,6 +229,31 @@ describe CreatorAnalytics::Sales do
   end
 end
 
+describe CreatorAnalytics::Sales, "hourly interval across a DST fall-back" do
+  it "merges the two Elasticsearch buckets for the repeated local hour" do
+    user = create(:user, timezone: "Pacific Time (US & Canada)")
+    product = create(:product, user: user)
+    # On Nov 1, 2026 Pacific clocks fall back at 2:00 AM, so the 1:00 AM local hour
+    # occurs twice: 08:00-09:00 UTC (PDT) and 09:00-10:00 UTC (PST). Both buckets
+    # format to the same "2026-11-01T01:00" key and must combine, not overwrite.
+    create(:purchase, link: product, created_at: Time.utc(2026, 11, 1, 7, 30), referrer: "https://google.com")
+    create(:purchase, link: product, created_at: Time.utc(2026, 11, 1, 8, 30), referrer: "https://google.com")
+    create(:purchase, link: product, created_at: Time.utc(2026, 11, 1, 9, 30), referrer: "https://google.com")
+    index_model_records(Purchase)
+
+    service = described_class.new(user:, products: [product], dates: [Date.new(2026, 11, 1)], interval: "hour")
+
+    expect(service.by_product_and_date).to eq(
+      [product.id, "2026-11-01T00:00"] => { count: 1, total: 100 },
+      [product.id, "2026-11-01T01:00"] => { count: 2, total: 200 },
+    )
+    expect(service.by_product_and_referrer_and_date).to eq(
+      [product.id, "google.com", "2026-11-01T00:00"] => { count: 1, total: 100 },
+      [product.id, "google.com", "2026-11-01T01:00"] => { count: 2, total: 200 },
+    )
+  end
+end
+
 describe CreatorAnalytics::Sales, "timezone with DST gap at midnight" do
   context "when user timezone has a DST transition at midnight (e.g. Tehran)" do
     it "filters and buckets sales consistently on March 22, 2026" do

--- a/spec/services/creator_analytics/sales_spec.rb
+++ b/spec/services/creator_analytics/sales_spec.rb
@@ -165,6 +165,68 @@ describe CreatorAnalytics::Sales do
       end
     end
   end
+
+  describe "hourly interval" do
+    let(:hourly_service) do
+      described_class.new(
+        user: @user,
+        products: @products,
+        dates: [Date.new(2021, 1, 1)],
+        interval: "hour"
+      )
+    end
+
+    it "buckets sales by hour in #by_product_and_date" do
+      expect(hourly_service.by_product_and_date).to eq(
+        [@products[0].id, "2021-01-01T00:00"] => { count: 1, total: 100 },
+        [@products[0].id, "2021-01-01T01:00"] => { count: 1, total: 100 },
+        [@products[1].id, "2021-01-01T02:00"] => { count: 1, total: 100 },
+      )
+    end
+
+    it "buckets sales by hour in #by_product_and_referrer_and_date" do
+      expect(hourly_service.by_product_and_referrer_and_date).to eq(
+        [@products[0].id, "google.com", "2021-01-01T00:00"] => { count: 1, total: 100 },
+        [@products[0].id, "google.com", "2021-01-01T01:00"] => { count: 1, total: 100 },
+        [@products[1].id, "direct", "2021-01-01T02:00"] => { count: 1, total: 100 },
+      )
+    end
+
+    context "when user time zone is Central European Time" do
+      let(:user_timezone) { "Paris" }
+
+      it "buckets hours in the seller's timezone" do
+        # The Jan 1 purchases at 00:00/01:00/02:00 UTC land at 01:00/02:00/03:00 in Paris.
+        expect(hourly_service.by_product_and_date).to eq(
+          [@products[0].id, "2021-01-01T01:00"] => { count: 1, total: 100 },
+          [@products[0].id, "2021-01-01T02:00"] => { count: 1, total: 100 },
+          [@products[1].id, "2021-01-01T03:00"] => { count: 1, total: 100 },
+        )
+      end
+    end
+
+    it "raises an error for an unsupported interval" do
+      expect do
+        described_class.new(user: @user, products: @products, dates: [Date.new(2021, 1, 1)], interval: "minute")
+      end.to raise_error(ArgumentError, "interval must be one of: day, hour")
+    end
+
+    it "raises an error when the hourly date range is longer than the allowed maximum" do
+      dates = (Date.new(2021, 1, 1) .. Date.new(2021, 1, 9)).to_a
+
+      expect do
+        described_class.new(user: @user, products: @products, dates:, interval: "hour")
+      end.to raise_error(ArgumentError, "date range cannot exceed 7 days for the hour interval")
+    end
+
+    it "allows an hourly range of exactly the allowed maximum" do
+      dates = (Date.new(2021, 1, 1) .. Date.new(2021, 1, 8)).to_a
+
+      expect do
+        described_class.new(user: @user, products: @products, dates:, interval: "hour")
+      end.not_to raise_error
+    end
+  end
 end
 
 describe CreatorAnalytics::Sales, "timezone with DST gap at midnight" do


### PR DESCRIPTION
## What

Adds an hourly interval to sales analytics, as the backend foundation for an hourly sales graph on the analytics dashboard:

- `CreatorAnalytics::Sales` accepts an `interval:` keyword (`"day"`, the default, or `"hour"`) instead of hardcoding `calendar_interval: "day"` in its two `date_histogram` aggregations. Unknown intervals raise, and hourly requests spanning more than 7 days raise, so every caller gets the bucket-count bound.
- The v2 sales API summary endpoint (`GET /v2/sales/summary`) accepts `group_by=hour`, returning breakdown buckets with ISO-8601 hour keys (for example `2026-07-16T13:00`) in the seller's timezone, consistent with the existing day/month keys. Requests grouping by hour over a range wider than 7 days get a 400, mirroring the existing 366-day bound, and `Api::V2::SalesSummary` itself carries the same guard so future callers can't request an unbounded hourly range.
- DST is handled explicitly: hourly buckets come back from Elasticsearch keyed by epoch milliseconds and are formatted to seller-local wall-clock time in Ruby. Formatting inside ES with an offset-less hour pattern actually made ES 7.17 reject any query covering a DST fall-back (the formatted composite `after_key` no longer parses back to the same instant), and the repeated 01:00 hour would otherwise produce two identical keys where one bucket silently overwrites the other. Both services merge the fall-back hour's two buckets into one wall-clock hour instead.

## Why

Sellers have asked for an hourly view of sales for a single-day range — around a launch, the daily graph hides how a release performs hour by hour (internal ref: antiwork/gumroad-private#1129).

The sales data already lives in Elasticsearch with full `created_at` timestamps and a seller-timezone-aware `date_histogram`, so nothing structural blocked hourly bucketing: only the hardcoded interval and the API validation list did. Parameterizing the existing aggregation is the smallest change that unlocks it; a separate hourly query path would duplicate the aggregation logic for no benefit. The 7-day bound keeps hourly responses to at most ~192 buckets per product, in line with how the existing 366-day bound protects the daily path.

The dashboard toggle ships as a follow-up PR: the chart is fed through `CreatorAnalytics::Web` and a day-keyed cache (`CreatorAnalytics::CachingProxy`), so the UI needs its own plumbing and this split keeps both PRs reviewable.

## How tested

- `bundle exec rspec spec/services/creator_analytics/sales_spec.rb spec/services/api/v2/sales_summary_spec.rb spec/controllers/api/v2/sales_controller_spec.rb` — 98 examples, 0 failures. New coverage: hourly bucketing for `by_product_and_date` and `by_product_and_referrer_and_date`, seller-timezone hourly bucketing (Paris and Pacific), a DST fall-back regression spec against real Elasticsearch proving the repeated local hour merges into one bucket instead of erroring or dropping sales, `ArgumentError` on unsupported intervals and on hourly ranges over 7 days (service and API layers), `group_by=hour` accepted at exactly the 7-day bound, 400 above it (including the default 30-day range), and the updated valid-groups error message.
- `spec/services/creator_analytics/web_spec.rb` (the only production caller of `CreatorAnalytics::Sales`) passes unchanged.
- Verified the new specs fail with the application change reverted (`unknown keyword: :interval`), so they are valid regression specs.
- `bundle exec rubocop` clean on all six touched files.

No video: this PR has no UI surface — it's a service parameter and a public API option, and the specs above exercise the full behavior. The follow-up dashboard PR will include before/after media for the visible change.

## Progress

- [x] Parameterize `calendar_interval` in `CreatorAnalytics::Sales`, bounded to 7 days for hourly
- [x] `group_by=hour` in the v2 sales summary API with range validation and hour key format
- [x] DST fall-back handling (epoch keys formatted in Ruby, repeated hour merged)
- [x] Regression specs (service interval, API validation including the range bound, ES `date_histogram` interval, DST fall-back)
- [ ] Dashboard hourly toggle (follow-up PR)
- [ ] Verified in production

---

AI disclosure: written by Claude Fable 5 (Anthropic), operating as an autonomous engineering agent. Prompt: implement hourly sales analytics per the plan in antiwork/gumroad-private#1129 (parameterize the sales analytics interval, add a bounded `group_by=hour` to the v2 sales summary API, dashboard toggle as follow-up); an adversarial self-review pass then drove the DST fall-back fix.

Co-authored-by: Gianfranco <gianfranco@gumroad.com>
