### PR TITLE
Accept 14-digit Brunei (BIBD) bank account numbers

### DIFF
--- a/app/models/brunei_bank_account.rb
+++ b/app/models/brunei_bank_account.rb
@@ -6,7 +6,9 @@ class BruneiBankAccount < BankAccount
   BANK_CODE_FORMAT_REGEX = /^[0-9a-zA-Z]{8,11}$/
   private_constant :BANK_CODE_FORMAT_REGEX
 
-  ACCOUNT_NUMBER_FORMAT_REGEX = /^[0-9]{1,13}$/
+  # Stripe accepts Brunei account numbers of up to 14 digits, which matches the
+  # standard length of BIBD (Bank Islam Brunei Darussalam) account numbers.
+  ACCOUNT_NUMBER_FORMAT_REGEX = /^[0-9]{1,14}$/
   private_constant :ACCOUNT_NUMBER_FORMAT_REGEX
 
   alias_attribute :bank_code, :bank_number

--- a/spec/models/brunei_bank_account_spec.rb
+++ b/spec/models/brunei_bank_account_spec.rb
@@ -39,6 +39,7 @@ describe BruneiBankAccount do
       expect(build(:brunei_bank_account, account_number: "000012345")).to be_valid
       expect(build(:brunei_bank_account, account_number: "1")).to be_valid
       expect(build(:brunei_bank_account, account_number: "000012345678")).to be_valid
+      expect(build(:brunei_bank_account, account_number: "00001234567891")).to be_valid
 
       bn_bank_account = build(:brunei_bank_account, account_number: "000012345678910")
       expect(bn_bank_account).to_not be_valid


### PR DESCRIPTION
## What

Raises the Brunei (`BN`) bank-account number validation limit from 13 to 14 digits in `app/models/brunei_bank_account.rb`, so sellers with BIBD (Bank Islam Brunei Darussalam) accounts can save their payout details.

## Why / root cause

BIBD issues **14-digit** account numbers, but `ACCOUNT_NUMBER_FORMAT_REGEX` was `/^[0-9]{1,13}$/`, so every valid BIBD account was rejected at the model layer with "The account number is invalid." before ever reaching Stripe. The frontend renders the generic account-number input for BN with no maxLength, so this regex was the only gate.

Live Stripe token probes (2026-07-16, from the audited production console) confirmed Stripe's actual BN limit is 14 digits:

- 13-digit synthetic account → tokenizes OK (bank resolves "BANK ISLAM BRUNEI DARUSSALAM BERHAD" for `BIBDBNBB`)
- **14-digit synthetic account → tokenizes OK**
- 15, 16, 17, 20 digits → all rejected by Stripe ("Invalid account number")

So our validation was stricter than Stripe by exactly one digit — the digit BIBD uses.

## Fix

- `ACCOUNT_NUMBER_FORMAT_REGEX` → `/^[0-9]{1,14}$/`, with a comment explaining the Stripe/BIBD 14-digit limit.
- Spec: added a valid 14-digit case (`"00001234567891"`); the existing 15-digit case (`"000012345678910"`) remains invalid, so we stay aligned with Stripe's upper bound.

## Test plan / verification

- `bundle exec rspec spec/models/brunei_bank_account_spec.rb` → **6 examples, 0 failures** locally.
- Regression check: with the model change reverted (spec kept), `rspec spec/models/brunei_bank_account_spec.rb:37` → **1 example, 1 failure** (RED→GREEN).
- `bundle exec rubocop` on both touched files → no offenses.

## Progress

- [x] Root cause verified against current `main` and posted on the internal issue
- [x] Regex fix + regression spec (fails on revert)
- [x] Targeted specs + rubocop green locally
- [ ] Review + merge
- [ ] After deploy: reply on the Helper tickets ([1041dc5132…](https://help.gumroad.com/all?id=1041dc5132500b1ff32647496fb28907), [4f7f2706…](https://help.gumroad.com/all?id=4f7f27063348ba372c046bf5762a51d2)) so the seller re-enters their 14-digit account number at gumroad.com/settings/payments

## Tracking

Resolves the payout block reported internally in antiwork/gumroad-private#1137 (duplicate antiwork/gumroad-private#1138 consolidated into it). Same "our regex is stricter than Stripe" family as the Niger (#5626), Côte d'Ivoire (#5417), and Angola (#5266) fixes.

Co-authored-by: Gianfranco <gianfranco@gumroad.com>

---

Opened as a **draft** for engineer review/merge. Filed by Gumclaw.

**AI disclosure:** Authored by Claude Fable 5 (autonomous agent `gumclaw`), dispatched from the internal issue with the prompt to verify the root cause against current main, apply the 14-digit regex fix with a revert-failing regression spec, and open this PR.