### PR TITLE
Fix stale refund-fee wording in help center articles (47, 66)

### DIFF
--- a/app/views/help_center/articles/contents/_47-how-to-refund-a-customer.html.erb
+++ b/app/views/help_center/articles/contents/_47-how-to-refund-a-customer.html.erb
@@ -28,7 +28,8 @@
   <p>In the case of a full refund, customers will no longer be able to access the content or receive the respective product’s updates.</p>
   <p>Refunding a customer fully will also delete any <a href="222-product-ratings-on-gumroad">product rating</a> they've given.</p>
   <h3 id="Refund-fees-hk-4p">Refund fees</h3>
-  <p>We don't refund any <a href="https://gumroad.com/help/article/66-gumroads-fees">fees</a> when processing refunds.</p>
+  <p>When a sale is refunded (fully or partially), your customer receives the full refunded amount, and Gumroad's own <a href="https://gumroad.com/help/article/66-gumroads-fees">fee</a> on the refunded portion is returned to you. The underlying payment-processing portion of the fee is retained, because payment processors do not return it to Gumroad on a refund.</p>
+  <p>Sales processed through your own connected payment account work differently: for <a href="330-stripe-connect">Stripe Connect</a> and <a href="275-paypal-connect">PayPal Connect</a> purchases, the processor keeps its fees on the sale, and you are responsible for Gumroad's and the processor's fees on the refund.</p>
 </div>
 <div>
   <h3>Related Articles</h3>

--- a/app/views/help_center/articles/contents/_66-gumroads-fees.html.erb
+++ b/app/views/help_center/articles/contents/_66-gumroads-fees.html.erb
@@ -12,7 +12,7 @@
   <h3 id="Affiliates-sW9pK">Affiliates</h3>
   <p>For <a href="333-affiliates-on-gumroad">affiliates</a>, fees on affiliate purchases are split between the affiliate and the creator proportional to the affiliate's commission. For example, if an affiliate's commission is 30%, they'll be responsible for 30% of the fees on the purchase.</p>
   <h3 id="Refunds-aSEwt">Refunds</h3>
-  <p>We don't refund any fees when processing refunds. Learn more about refunds <a href="https://gumroad.com/help/article/47-how-to-refund-a-customer">here</a>.</p>
+  <p>When a sale is refunded, Gumroad's own fee on the refunded portion is returned to you; only the underlying payment-processing portion of the fee is retained, because payment processors do not return it on a refund. Sales through your own connected payment account (Stripe Connect or PayPal Connect) work differently. Learn more about refunds <a href="https://gumroad.com/help/article/47-how-to-refund-a-customer">here</a>.</p>
 </div>
 <div>
   <h3>Related Articles</h3>


### PR DESCRIPTION
## What

Corrects the "Refund fees" wording in two help-center articles:

- `_47-how-to-refund-a-customer.html.erb` — replaced "We don't refund any fees when processing refunds." with the actual behavior for standard sales + a scoped Connect-account exception.
- `_66-gumroads-fees.html.erb` — same correction in the Refunds section.

## Why

A seller (EU GDPR/consumer-law thread, Helper ticket) flagged that the article contradicts the verified behavior we confirmed to them in writing. The code is unambiguous for standard (Gumroad merchant-of-record) sales:

- `Credit.create_for_refund_fee_retention!` retains only the payment-processor portion of the fee (`purchase.processor_fee_cents` when present, else `Purchase::PROCESSOR_FEE_PER_THOUSAND = 29` + `PROCESSOR_FIXED_FEE_CENTS = 30` prorated).
- `Purchase#decrement_balance_for_refund_or_chargeback!` reduces the seller's balance only by their net earnings on the refunded portion — Gumroad's own fee comes back to the seller.
- The old blanket "no fees refunded" sentence is accurate only for connected-account sales (Stripe Connect / PayPal Connect), where the processor keeps its fees — article 47's existing PayPal Connect paragraph already says this.

The fraudulent-purchases article ("We have refunded the fees that we took from the sale") already matched the code; these two were the outliers.

## Checklist
- [x] Both articles updated, ERB syntax verified
- [x] `articles.yml` untouched (description snippet doesn't quote the stale sentence)
- [x] No anchor IDs changed

⚠️ Refund/fee policy wording — flagged per help-center guardrails for reviewer attention on exact wording.

Autoreview skipped (docs copy only, no logic).