### PR TITLE
Fix ActiveRecord::SubclassNotFound by restoring ZenginAccount STI model

### DIFF
--- a/app/models/zengin_account.rb
+++ b/app/models/zengin_account.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Zengin was the bank transfer system we used for native Japan payouts before
+# moving them to Stripe. The payout rail itself is retired (see
+# PayoutProcessorType::ZENGIN), but legacy bank_accounts rows with
+# type = "ZenginAccount" still exist in the database. This class must stay so
+# ActiveRecord's single-table inheritance can instantiate those rows — deleting
+# it raises ActiveRecord::SubclassNotFound whenever such a record is loaded.
+class ZenginAccount < BankAccount
+  BANK_ACCOUNT_TYPE = "ZENGIN"
+
+  def bank_account_type
+    BANK_ACCOUNT_TYPE
+  end
+end

--- a/spec/models/zengin_account_spec.rb
+++ b/spec/models/zengin_account_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ZenginAccount do
+  it "loads legacy rows with type ZenginAccount via single-table inheritance" do
+    # Zengin payouts are retired, but old bank_accounts rows still carry this
+    # STI type. Simulate one and make sure ActiveRecord can instantiate it
+    # (this raised ActiveRecord::SubclassNotFound when the class was removed).
+    account = create(:ach_account)
+    account.update_column(:type, "ZenginAccount")
+
+    record = BankAccount.find(account.id)
+    expect(record).to be_a(ZenginAccount)
+    expect(record.bank_account_type).to eq("ZENGIN")
+  end
+end


### PR DESCRIPTION
## What

Restores `app/models/ZenginAccount` (STI subclass of `BankAccount`) that was deleted in #399, with a comment explaining why the class must remain, and adds a regression spec that loads a legacy `bank_accounts` row typed `ZenginAccount` through `BankAccount.find`.

## Why

Sentry issue [GUMROAD-Z2](https://gumroad-to.sentry.io/issues/7616501830/) — `ActiveRecord::SubclassNotFound: The single-table inheritance mechanism failed to locate the subclass: 'ZenginAccount'` (unhandled, 2 events since 2026-07-17 04:03 UTC).

The Zengin payout rail (native Japan payouts) is retired, but legacy `bank_accounts` rows with `type = "ZenginAccount"` still exist in production. #399 removed the model as "unused code", so any query that instantiates one of those rows now raises. This mirrors why `PayoutProcessorType::ZENGIN` is kept: the code path is dead, the data isn't.

## Test plan

- New spec `spec/models/zengin_account_spec.rb` reproduces the failure: with the model removed it raises `uninitialized constant ZenginAccount`; with the model restored it passes (`1 example, 0 failures`, run locally).
- Rubocop clean on both files.
- CI green.

## Before/After

Not applicable — no UI change; restores a model class only.
