### PR TITLE
Withdraw ACH Direct Debit from checkout platform-wide

### DIFF
--- a/app/services/checkout/payment_method_resolver.rb
+++ b/app/services/checkout/payment_method_resolver.rb
@@ -10,8 +10,7 @@
 #     policy). This is the logged decision and what later units intersect with per-method launch/PPP gates.
 #   - payment_method_types: what Stripe actually receives on the client-confirmed path today. Card and
 #     Link are always launched (Link is inline and auto-enables with the Payment Element itself); the
-#     US-locked first-launch methods (Cash App Pay, ACH Direct Debit) join for US buyers via the GeoIP
-#     gate below.
+#     US-locked first-launch method (Cash App Pay) joins for US buyers via the GeoIP gate below.
 #
 # Handshake note: the deferred PaymentIntent's payment_method_types must equal the Payment Element's or
 # Stripe rejects the ConfirmationToken (which is payment_method_types-scoped, so it also can't be
@@ -32,11 +31,13 @@ class Checkout::PaymentMethodResolver
   # Launched on the client-confirmed path: card everywhere; Link everywhere (inline — it rides
   # card's two-step confirm machinery with no return-page/webhook dependency, launched under the
   # element flags themselves since Stripe's dashboard payment-method settings are the emergency
-  # kill switch, per-seller Flipper adds no useful lever); plus the US-locked first-launch methods
-  # (region-gated below) — Cash App Pay (redirect; confirms via the #5664 return page) and ACH Direct
-  # Debit (delayed-notification; settles via the PaymentIntent webhook lifecycle). The EUR methods
-  # (iDEAL/Bancontact/SEPA) stay gated until buyer-currency FX lands.
-  LAUNCHED_PAYMENT_METHOD_TYPES = %w[card link cashapp us_bank_account].freeze
+  # kill switch, per-seller Flipper adds no useful lever); plus Cash App Pay (US-locked, region-gated
+  # below; redirect — confirms via the #5664 return page). The EUR methods (iDEAL/Bancontact/SEPA)
+  # stay gated until buyer-currency FX lands. ACH Direct Debit (us_bank_account) was launched and
+  # then withdrawn platform-wide: it settles in ~4 business days and content only delivers on
+  # settlement, which doesn't fit digital products (gumroad-private#1143). Its webhook settlement
+  # lifecycle stays wired so in-flight ACH purchases still complete.
+  LAUNCHED_PAYMENT_METHOD_TYPES = %w[card link cashapp].freeze
   LINK_PAYMENT_METHOD_TYPE = "link"
   # Methods that only work for US buyers on USD PaymentIntents. ACH Direct Debit debits a US bank
   # account; Cash App Pay is US-locked. These are dropped from the launched set unless GeoIP ∈ {US}.

--- a/spec/presenters/checkout/stripe_payment_presenter_spec.rb
+++ b/spec/presenters/checkout/stripe_payment_presenter_spec.rb
@@ -492,11 +492,11 @@ describe Checkout::StripePaymentPresenter do
         .to eq(payment_element_client_confirm_props)
     end
 
-    it "launches Cash App Pay and ACH Direct Debit alongside card for a US buyer" do
+    it "launches Cash App Pay alongside card for a US buyer — ACH Direct Debit stays withdrawn platform-wide" do
       stub_geoip_country("104.28.0.1", "United States")
 
       expect(stripe_payment_props(add_products: [confirm_flagged_seller_product], ip: "104.28.0.1"))
-        .to eq(payment_element_client_confirm_props(payment_method_types: %w[card link cashapp us_bank_account]))
+        .to eq(payment_element_client_confirm_props(payment_method_types: %w[card link cashapp]))
     end
 
     it "offers card and Link only for a non-US buyer (Cash App/ACH are US-locked)" do
@@ -520,7 +520,7 @@ describe Checkout::StripePaymentPresenter do
         stub_geoip_country("104.28.0.1", "United States")
 
         expect(stripe_payment_props(add_products: [confirm_flagged_seller_product(ppp_details:)], ip: "104.28.0.1"))
-          .to eq(payment_element_client_confirm_props(payment_method_types: %w[card cashapp us_bank_account], stripe_link_enabled: false))
+          .to eq(payment_element_client_confirm_props(payment_method_types: %w[card cashapp], stripe_link_enabled: false))
       end
 
       it "gates Link out on a PPP checkout — its funding country is not verifiable pre-charge" do
@@ -528,7 +528,7 @@ describe Checkout::StripePaymentPresenter do
 
         props = stripe_payment_props(add_products: [confirm_flagged_seller_product(ppp_details:)], ip: "104.28.0.1")
 
-        expect(props[:elements_options][:payment_method_types]).to eq(%w[card cashapp us_bank_account])
+        expect(props[:elements_options][:payment_method_types]).to eq(%w[card cashapp])
         expect(props[:elements_options][:stripe_link_enabled]).to eq(false)
       end
 
@@ -540,14 +540,14 @@ describe Checkout::StripePaymentPresenter do
 
         props = stripe_payment_props(add_products: [item], ip: "104.28.0.1")
 
-        expect(props[:elements_options][:payment_method_types]).to eq(%w[card link cashapp us_bank_account])
+        expect(props[:elements_options][:payment_method_types]).to eq(%w[card link cashapp])
       end
 
       it "leaves a non-PPP checkout's method set untouched" do
         stub_geoip_country("104.28.0.1", "United States")
 
         expect(stripe_payment_props(add_products: [confirm_flagged_seller_product], ip: "104.28.0.1"))
-          .to eq(payment_element_client_confirm_props(payment_method_types: %w[card link cashapp us_bank_account]))
+          .to eq(payment_element_client_confirm_props(payment_method_types: %w[card link cashapp]))
       end
     end
 

--- a/spec/services/checkout/payment_method_resolver_spec.rb
+++ b/spec/services/checkout/payment_method_resolver_spec.rb
@@ -30,9 +30,13 @@ describe Checkout::PaymentMethodResolver do
       it "enables the launched methods on Stripe for a US buyer, gating the rest behind later units" do
         resolution = resolve(buyer_country: "US")
 
-        expect(resolution.payment_method_types).to eq(%w[card link cashapp us_bank_account])
+        expect(resolution.payment_method_types).to eq(%w[card link cashapp])
         # The launched set is always a subset of the eligible policy set.
         expect(resolution.eligible_payment_method_types).to include(*resolution.payment_method_types)
+      end
+
+      it "keeps ACH Direct Debit launch-gated out even for a US buyer — withdrawn platform-wide because its ~4-business-day settlement delays content delivery (gumroad-private#1143)" do
+        expect(resolve(buyer_country: "US").payment_method_types).not_to include("us_bank_account")
       end
 
       it "drops US-locked methods (Cash App/ACH) for a non-US buyer, keeping card and Link" do
@@ -95,7 +99,7 @@ describe Checkout::PaymentMethodResolver do
 
       context "with a PPP-discounted checkout (U13 method matrix)" do
         it "keeps card and the US-locked methods for a US buyer — verifiable + region-matched" do
-          expect(resolve(ppp_discounted: true).payment_method_types).to eq(%w[card cashapp us_bank_account])
+          expect(resolve(ppp_discounted: true).payment_method_types).to eq(%w[card cashapp])
         end
 
         it "resolves card-only for a non-US PPP buyer (region-locked methods already dropped)" do
@@ -103,8 +107,8 @@ describe Checkout::PaymentMethodResolver do
         end
 
         it "gates Link out — no Stripe-owned funding country to verify pre-charge" do
-          expect(resolve(ppp_discounted: true).payment_method_types).to eq(%w[card cashapp us_bank_account])
-          expect(resolve(ppp_discounted: false).payment_method_types).to eq(%w[card link cashapp us_bank_account])
+          expect(resolve(ppp_discounted: true).payment_method_types).to eq(%w[card cashapp])
+          expect(resolve(ppp_discounted: false).payment_method_types).to eq(%w[card link cashapp])
         end
 
         it "logs the PPP gate input" do
@@ -192,7 +196,7 @@ describe Checkout::PaymentMethodResolver do
         it "still uses the stale snapshot (checkout never blocks) but enqueues a background re-fetch — the self-heal for webhooks dropped by the worker's until_executed lock" do
           expect(RefreshMerchantAccountPaymentMethodAvailabilityWorker).to receive(:perform_async).with(connect_account.id)
 
-          expect(resolve(buyer_country: "US").payment_method_types).to eq(%w[card link cashapp us_bank_account])
+          expect(resolve(buyer_country: "US").payment_method_types).to eq(%w[card link cashapp])
         end
       end
 
@@ -204,10 +208,10 @@ describe Checkout::PaymentMethodResolver do
                                   })
         end
 
-        it "offers them to a US buyer without enqueueing a refresh" do
+        it "offers Cash App Pay to a US buyer without enqueueing a refresh — an active ACH capability does not re-add the launch-gated method" do
           expect(RefreshMerchantAccountPaymentMethodAvailabilityWorker).not_to receive(:perform_async)
 
-          expect(resolve(buyer_country: "US").payment_method_types).to eq(%w[card link cashapp us_bank_account])
+          expect(resolve(buyer_country: "US").payment_method_types).to eq(%w[card link cashapp])
         end
 
         it "still drops them for a non-US buyer — our region policy applies regardless of the account's capabilities" do
@@ -293,7 +297,7 @@ describe Checkout::PaymentMethodResolver do
 
         expect(resolution.client_confirm_eligible?).to be(true)
         expect(resolution.stripe_connect_account_id).to be_nil
-        expect(resolution.payment_method_types).to eq(%w[card link cashapp us_bank_account])
+        expect(resolution.payment_method_types).to eq(%w[card link cashapp])
       end
     end
 
@@ -333,7 +337,7 @@ describe Checkout::PaymentMethodResolver do
       resolver.resolve
 
       expect(Rails.logger).to have_received(:info).with(
-        a_string_matching(/buyer_country="US".*enabled=\["card", "link", "cashapp", "us_bank_account"\]/)
+        a_string_matching(/buyer_country="US".*enabled=\["card", "link", "cashapp"\]/)
       )
     end
 

--- a/spec/services/order/prepare_payment_intent_service_spec.rb
+++ b/spec/services/order/prepare_payment_intent_service_spec.rb
@@ -189,14 +189,14 @@ describe Order::PreparePaymentIntentService, :vcr do
         order, params = build_order
         order.purchases.each { _1.update!(ip_country: "United States") }
 
-        expect(create_args_for(order, params)[:payment_method_types]).to eq(%w[card cashapp us_bank_account])
+        expect(create_args_for(order, params)[:payment_method_types]).to eq(%w[card cashapp])
       end
 
       it "gates Link out of the intent on a PPP checkout" do
         order, params = build_order
         order.purchases.each { _1.update!(ip_country: "United States") }
 
-        expect(create_args_for(order, params)[:payment_method_types]).to eq(%w[card cashapp us_bank_account])
+        expect(create_args_for(order, params)[:payment_method_types]).to eq(%w[card cashapp])
       end
 
       it "does not gate the intent when the seller disabled PPP payment verification" do
@@ -204,7 +204,7 @@ describe Order::PreparePaymentIntentService, :vcr do
         order, params = build_order
         order.purchases.each { _1.update!(ip_country: "United States") }
 
-        expect(create_args_for(order, params)[:payment_method_types]).to eq(%w[card link cashapp us_bank_account])
+        expect(create_args_for(order, params)[:payment_method_types]).to eq(%w[card link cashapp])
       end
     end
 
@@ -491,7 +491,7 @@ describe Order::PreparePaymentIntentService, :vcr do
 
         described_class.new(order:, params:, confirmation_token: "ctoken_us").perform
 
-        expect(create_args[:payment_method_types]).to eq(%w[card link cashapp us_bank_account])
+        expect(create_args[:payment_method_types]).to eq(%w[card link cashapp])
       end
 
       # The presenter derives the Element's Link config from the same resolver output, so the


### PR DESCRIPTION
## What

Withdraws ACH Direct Debit (`us_bank_account`) from checkout platform-wide by removing it from `Checkout::PaymentMethodResolver::LAUNCHED_PAYMENT_METHOD_TYPES`. The Payment Element and the deferred PaymentIntent both derive their method list from this resolver, so both sides drop ACH together — no handshake divergence. Cash App Pay, card, and Link are unchanged.

Kept intact:
- The eligibility policy set and `US_LOCKED_PAYMENT_METHOD_TYPES` (the resolver's decision logging still records ACH as launch-gated-out).
- The `payment_intent.processing` → `payment_intent.succeeded` webhook settlement lifecycle, so ACH purchases already in flight settle and deliver normally.
- The connected-account capability plumbing (`StripeConnectPaymentMethodAvailabilityService`), unchanged — an active ACH capability no longer re-adds the method, covered by spec.

## Why

ACH is a delayed-notification method: it settles in ~4 business days and content only delivers on settlement. For digital products that delay surprises both buyer and seller, and sellers have no way to opt out. Decision is to disable it for all creators rather than build a per-seller toggle.

Tracking issue: antiwork/gumroad-private#1143

## Test plan

- `spec/services/checkout/payment_method_resolver_spec.rb` — 42 examples, 0 failures locally, including a new example pinning ACH launch-gated-out for US buyers and one proving an active `us_bank_account_ach_payments` capability doesn't re-add it.
- `spec/services/order/prepare_payment_intent_service_spec.rb` + `spec/presenters/checkout/stripe_payment_presenter_spec.rb` — 106 examples, 0 failures locally (intent method lists and Payment Element props both drop ACH).
- Rubocop clean on all changed files.
- After deploy: US-buyer checkout Payment Element shows card / Link / Cash App Pay only; resolver logs show `launch_gated_out` including `us_bank_account`.

## Before/After

Before: US buyers on eligible carts see a "US bank account" tab in the Stripe Payment Element. After: the tab is gone (card / Link / Cash App Pay remain). Payment Element screenshots to follow from the preview app.
