### PR TITLE
Add e2e system spec for admin purchase page presentment amounts

### DIFF
--- a/spec/requests/admin/purchases_spec.rb
+++ b/spec/requests/admin/purchases_spec.rb
@@ -139,6 +139,41 @@ describe "Admin::PurchasesController Scenario", type: :system, js: true do
     end
   end
 
+  describe "presentment amounts display" do
+    # Purchases charged in the buyer's own currency ("presentment" purchases) show the
+    # buyer-currency amount in parentheses next to the canonical USD figure, both for the
+    # transaction total and for each refund that carries a presentment snapshot. These
+    # specs drive the real page so a regression in the TSX rendering (not just the
+    # presenter props) turns the suite red.
+    let(:product) { create(:product, price_cents: 1000) }
+    let(:presentment_purchase) { create(:purchase, link: product) }
+
+    it "renders the paired USD and buyer-currency amounts for a presentment purchase" do
+      create(:purchase_presentment, purchase: presentment_purchase, presentment_currency: Currency::CAD, presentment_total_cents: 13_50)
+      refund = create(:refund, purchase: presentment_purchase, total_transaction_cents: 10_00)
+      refund.update!(presentment_currency: Currency::CAD, presentment_amount_cents: 14_30)
+
+      usd_total = MoneyFormatter.format(presentment_purchase.total_transaction_cents, :usd, no_cents_if_whole: true, symbol: true)
+
+      visit admin_purchase_path(presentment_purchase.id)
+
+      expect(page).to have_text("Transaction Total #{usd_total} (CAD$13.50)", normalize_ws: true)
+      expect(page).to have_text("$10 (CAD$14.30)", normalize_ws: true)
+    end
+
+    it "renders no parenthesized second currency for a non-presentment purchase" do
+      purchase = create(:purchase, link: product)
+      create(:refund, purchase:)
+
+      visit admin_purchase_path(purchase.id)
+
+      expect(page).to have_text("Transaction Total #{purchase.formatted_total_transaction_amount}", normalize_ws: true)
+      # No amount on the page should be wrapped in parentheses — that formatting is
+      # reserved for the buyer-currency pairing.
+      expect(page.text).not_to match(/\([^)]*[$€£]/)
+    end
+  end
+
   describe "discount display" do
     it "displays discount code when offer_code has a code" do
       product = create(:product, price_cents: 1000)


### PR DESCRIPTION
## What

Adds a browser-driven system spec (`type: :system, js: true`) covering the presentment amounts on the admin purchase page, in `spec/requests/admin/purchases_spec.rb`:

- A buyer-currency purchase renders the paired `$X (CAD$Y)` Transaction Total and the per-refund `Amount: $X (CAD$Y)` line on the real rendered page.
- A non-presentment purchase renders only the display-currency total, and no amount anywhere on the page is wrapped in parentheses.

## Why

Follow-up to #5935, which added vitest component tests for this rendering. End-to-end coverage matters more here: the component tests exercise the TSX in isolation with hand-built props, while this spec drives the real page through the presenter, Inertia props, and browser rendering, so a regression at any layer turns the suite red. The component tests stay — they're the fast layer of the same pyramid.

Tracking issue: #5922

## Test plan

- `bundle exec rspec spec/requests/admin/purchases_spec.rb -e "presentment amounts display"` — 2 examples, 0 failures
- Mutation check: reverting the Transaction Total pairing in `app/javascript/components/Admin/Purchases/index.tsx` to its pre-#5846 form makes the presentment spec fail (`1 example, 1 failure`); restoring it goes green
- `rubocop -a` on the spec file — no offenses

## Before/After

Not applicable — test-only change, no UI or behavior change.


---

AI disclosure: written with Claude Opus 4.8 (via Hermes Agent). Prompt: as a follow-up to #5935 (tracking issue #5922), add a browser-driven RSpec system spec covering presentment amounts on the admin purchase page — paired `$X (CAD$Y)` totals and per-refund amounts for buyer-currency purchases, no parenthesized amounts for non-presentment purchases — and prove it fails under a mutation revert of the #5846 pairing.
