### PR TITLE
Wire VCR into the Minitest suite (#5801)

### DIFF
--- a/test/lib/vcr_bridge_test.rb
+++ b/test/lib/vcr_bridge_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Proves the VCR ↔ Minitest wiring (test/support/vcr.rb): an existing cassette
+# recorded by the RSpec suite replays under the Minitest harness with no network
+# access, and an unrecorded request fails loudly rather than reaching out. If the
+# VCR config is removed, the first test can't find/replay the cassette and fails.
+class VcrBridgeTest < ActiveSupport::TestCase
+  test "replays a cassette recorded by the RSpec suite, with no network access" do
+    # Reuses spec/support/fixtures/vcr_cassettes/AssetPreview/Embeddable_link/
+    # succeeds_with_a_video_URL.yml verbatim — the same name RSpec metadata derived.
+    result = VCR.use_cassette("AssetPreview/Embeddable_link/succeeds_with_a_video_URL", record: :none) do
+      OEmbedFinder.embeddable_from_url("https://www.youtube.com/watch?v=huKYieB4evw")
+    end
+
+    assert result, "expected the recorded YouTube oembed response to replay"
+    assert_includes result[:html], "youtube.com/embed/huKYieB4evw"
+    assert_equal "https://i.ytimg.com/vi/huKYieB4evw/hqdefault.jpg", result[:info]["thumbnail_url"]
+  end
+
+  test "a request absent from the cassette raises instead of hitting the network" do
+    assert_raises(VCR::Errors::UnhandledHTTPRequestError) do
+      VCR.use_cassette("vcr_bridge/unrecorded", record: :none) do
+        Net::HTTP.get_response(URI("https://example.com/not-recorded"))
+      end
+    end
+  end
+end

--- a/test/support/vcr.rb
+++ b/test/support/vcr.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "vcr"
+
+# VCR wiring for the Minitest suite.
+#
+# This mirrors spec/spec_helper.rb#configure_vcr, minus the RSpec-only
+# `configure_rspec_metadata!` — the auto-naming that derives a cassette path from
+# each example's describe/context/it chain. VCR itself is framework-agnostic, so
+# the only thing the Minitest suite needs is the same configuration pointed at
+# the same cassette directory. Existing recordings are reused byte-for-byte.
+#
+# Porting a cassette-backed spec: wrap the HTTP section of the test in
+#   VCR.use_cassette("<the original RSpec description path>") { ... }
+# using the name the RSpec metadata would have derived (e.g.
+# "AssetPreview/Embeddable_link/succeeds_with_a_video_URL"). On CI the record
+# mode is :none, so a wrong or missing cassette name errors loudly instead of
+# silently reaching the network — the port is machine-checkable.
+#
+# Keep the ignore-hosts and sensitive-data lists in sync with spec_helper.
+VCR.configure do |config|
+  config.cassette_library_dir = Rails.root.join("spec", "support", "fixtures", "vcr_cassettes").to_s
+  config.hook_into :webmock
+  config.ignore_hosts "gumroad-specs.s3.amazonaws.com", "s3.amazonaws.com", "codeclimate.com", "mongo", "redis", "elasticsearch", "minio"
+  config.ignore_hosts "api.knapsackpro.com", "googlechromelabs.github.io", "storage.googleapis.com"
+  config.ignore_localhost = true
+  config.debug_logger = $stdout if ENV["VCR_DEBUG"]
+  # Same policy as the RSpec suite: replay-only on CI (a missing cassette fails
+  # the build), record-once locally so a new cassette-backed test can capture.
+  config.default_cassette_options[:record] = ENV["CI"].nil? ? :once : :none
+
+  # Scrub the same secrets from any freshly-recorded cassette as spec_helper does.
+  # (No-op on CI where nothing records; matters when recording locally.)
+  %w[
+    AWS_ACCOUNT_ID AWS_ACCESS_KEY_ID STRIPE_PLATFORM_ACCOUNT_ID STRIPE_API_KEY STRIPE_CONNECT_CLIENT_ID
+    PAYPAL_USERNAME PAYPAL_PASSWORD PAYPAL_SIGNATURE STRONGBOX_GENERAL_PASSWORD DROPBOX_API_KEY
+    SENDGRID_GUMROAD_TRANSACTIONS_API_KEY SENDGRID_GR_CREATORS_API_KEY SENDGRID_GR_CUSTOMERS_LEVEL_2_API_KEY
+    SENDGRID_GUMROAD_FOLLOWER_CONFIRMATION_API_KEY BRAINTREE_API_PRIVATE_KEY BRAINTREE_MERCHANT_ID
+    BRAINTREE_PUBLIC_KEY BRAINTREE_MERCHANT_ACCOUNT_ID_FOR_SUPPLIERS PAYPAL_CLIENT_ID PAYPAL_CLIENT_SECRET
+    PAYPAL_MERCHANT_EMAIL PAYPAL_PARTNER_CLIENT_ID PAYPAL_PARTNER_MERCHANT_ID PAYPAL_PARTNER_MERCHANT_EMAIL
+    PAYPAL_BN_CODE VATSTACK_API_KEY IRAS_API_ID IRAS_API_SECRET TAXJAR_API_KEY TAX_ID_PRO_API_KEY
+    CIRCLE_API_KEY OPEN_EXCHANGE_RATES_APP_ID UNSPLASH_CLIENT_ID DISCORD_BOT_TOKEN DISCORD_CLIENT_ID
+    ZOOM_CLIENT_ID GCAL_CLIENT_ID OPENAI_ACCESS_TOKEN IOS_CONSUMER_APP_APPLE_LOGIN_IDENTIFIER
+    IOS_CREATOR_APP_APPLE_LOGIN_TEAM_ID IOS_CREATOR_APP_APPLE_LOGIN_IDENTIFIER GOOGLE_CLIENT_ID
+    RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID CLOUDFRONT_KEYPAIR_ID
+  ].each { |key| config.filter_sensitive_data("<#{key}>") { GlobalConfig.get(key) } }
+end


### PR DESCRIPTION
## What

Wires VCR into the Minitest + fixtures suite so cassettes recorded by the RSpec suite replay under Minitest, unchanged. Part of #5801.

- `test/support/vcr.rb` — a Minitest equivalent of `spec/spec_helper.rb#configure_vcr`: same `cassette_library_dir` (so the existing recordings are reused byte-for-byte), same `hook_into :webmock`, same `ignore_hosts`, the same sensitive-data filters, and the same record policy (`:none` on CI, `:once` locally).
- It deliberately omits `configure_rspec_metadata!` — the RSpec-only bit that auto-derives a cassette path from the describe/context/it chain. Under Minitest a ported test names its cassette explicitly: `VCR.use_cassette("<the path RSpec metadata would have derived>") { … }`. On CI (`record: :none`) a wrong or missing name fails the build, so each port is machine-checkable.
- `VcrBridgeTest` proves it end-to-end: an existing YouTube-oembed cassette recorded by the RSpec suite replays with no network access, and a request absent from its cassette raises `VCR::Errors::UnhandledHTTPRequestError` instead of reaching out.

## Why

This is the prerequisite that unblocks the HTTP-dependent files in the ranking. `asset_preview_spec` (#1) turned out not to be purely factory-bound — it makes real oembed lookups — and the two heaviest files, `subscription_spec` (#2) and `purchase_spec` (#3), are whole-file `:vcr` against Stripe/PayPal. Reusing the existing cassettes (rather than re-recording) means no live payment-sandbox credentials and no risk of silently changing what the tests assert against. Doing the wiring on its own keeps it small and reviewable, and lets the file ports land on top of a known-good base.

Coordinated with the plan gumclaw posted on #5801 (07-16); this implements step 1 of it.

## Before / After

Non-user-facing (test infra). Walkthrough: `VcrBridgeTest` replaying a recorded cassette with net-connect disabled.

## Test Results

`CI=true bin/rails test test/lib/vcr_bridge_test.rb` → 2 runs, 5 assertions, 0 failures (replay-only mode).
Full `bin/rails test` → 546 runs, 0 failures, 0 errors, 5 skips — green in both `record: :none` and `:once`, confirming VCR coexists with the existing WebMock stubs.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AI disclosure: drafted with Claude Opus 4.8.
