### PR TITLE
Lift the test-mode gate on the buyer-currency card presentment path

### DIFF
--- a/app/presenters/checkout/stripe_payment_presenter.rb
+++ b/app/presenters/checkout/stripe_payment_presenter.rb
@@ -255,9 +255,10 @@ class Checkout::StripePaymentPresenter
         #   2. The buyer-currency card shape (single USD-priced one-time item — the same cart
         #      shape the eligibility service's card mode accepts), which mounts the
         #      server-confirm Payment Element in the buyer's quote currency (see props).
-        # Live mode and non-flagged sellers never produce a candidate
-        # (buyer_presentment_candidate? checks both), so neither branch changes production
-        # behavior.
+        # Non-flagged sellers never produce a candidate (buyer_presentment_candidate? checks
+        # the seller flags), so neither branch changes behavior for unflagged checkouts. The
+        # card shape (2) runs in live mode since the production rollout; the method-forced
+        # shape (1) is still test-mode only (method_forced_qa_shape? checks the Stripe key).
         supported = (method_forced_qa_shape?(items) && client_confirm_eligible?) ||
           buyer_currency_presentment_element_shape?(items)
         return "buyer_currency_presentment_unsupported" unless supported
@@ -269,7 +270,7 @@ class Checkout::StripePaymentPresenter
     # The cart shape whose buyer-currency presentment the CARD charge path supports, mirroring
     # the gates of Checkout::BuyerCurrencyEligibility#decision that are knowable at render time:
     # a single one-time, USD-priced, non-commission item from a presentment-candidate seller
-    # (candidate? already covers test mode, the seller's flags, and an active buyer-local
+    # (candidate? already covers the seller's flags and an active buyer-local
     # display). Products that offer installments stay on CardElement even when the buyer chooses
     # a one-time purchase because quote creation cannot see that choice and rejects the product.
     # Charge-time-only gates (merchant account model, wallet params, GeoIP re-check, quote

--- a/app/services/checkout/buyer_currency_eligibility.rb
+++ b/app/services/checkout/buyer_currency_eligibility.rb
@@ -53,8 +53,7 @@ class Checkout::BuyerCurrencyEligibility
   end
 
   def self.buyer_presentment_candidate?(seller:, buyer_currency_display:)
-    stripe_test_mode? &&
-      seller_enabled?(seller) &&
+    seller_enabled?(seller) &&
       buyer_presentment_display?(buyer_currency_display)
   end
 
@@ -83,7 +82,6 @@ class Checkout::BuyerCurrencyEligibility
 
   def decision
     return fallback(:feature_disabled) unless self.class.seller_enabled?(seller)
-    return fallback(:live_mode) unless stripe_test_mode?
     return fallback(:unsupported_processor) unless merchant_account&.stripe_charge_processor?
     return fallback(:unsupported_charge_model) unless supported_charge_model?
     return fallback(:unsupported_settlement_currency) unless usd_settling_merchant_account?

--- a/app/services/checkout/buyer_currency_quote.rb
+++ b/app/services/checkout/buyer_currency_quote.rb
@@ -71,7 +71,6 @@ class Checkout::BuyerCurrencyQuote
     product = products.first
     seller = product.user
     return unless Checkout::BuyerCurrencyEligibility.seller_enabled?(seller)
-    return unless Checkout::BuyerCurrencyEligibility.stripe_test_mode?
     return unless product.price_currency_type.to_s.downcase == Currency::USD
     return if product.is_in_preorder_state? || product.is_recurring_billing? || product.free_trial_enabled?
     # Commissions charge only a deposit now and installment plans charge only the first

--- a/spec/presenters/checkout/stripe_payment_presenter_spec.rb
+++ b/spec/presenters/checkout/stripe_payment_presenter_spec.rb
@@ -246,7 +246,7 @@ describe Checkout::StripePaymentPresenter do
     Feature.deactivate_user(Checkout::BuyerCurrencyEligibility::FEATURE_NAME, seller) if seller
   end
 
-  it "keeps the existing Payment Element and wallet path in live mode" do
+  it "selects the buyer-currency presentment Payment Element in live mode now that the gate is lifted" do
     seller = create(:user, disable_buyer_local_currency: false)
     product = create(:product, user: seller, price_cents: 1234)
     allow(Stripe).to receive(:api_key).and_return("sk_live_currency")
@@ -263,7 +263,9 @@ describe Checkout::StripePaymentPresenter do
       )
     ]
 
-    expect(stripe_payment_props(add_products:)).to eq(payment_element_props)
+    expect(stripe_payment_props(add_products:)).to eq(
+      payment_element_props(buyer_currency_presentment: true, disable_wallets: true)
+    )
   ensure
     Feature.deactivate_user(:buyer_local_currency, seller) if seller
     Feature.deactivate_user(Checkout::BuyerCurrencyEligibility::FEATURE_NAME, seller) if seller

--- a/spec/presenters/checkout/stripe_payment_presenter_spec.rb
+++ b/spec/presenters/checkout/stripe_payment_presenter_spec.rb
@@ -271,6 +271,47 @@ describe Checkout::StripePaymentPresenter do
     Feature.deactivate_user(Checkout::BuyerCurrencyEligibility::FEATURE_NAME, seller) if seller
   end
 
+  it "falls back to CardElement for a flag-on seller's unsupported presentment shape in live mode" do
+    # Lifting the test-mode gate makes every buyer-local-display cart from a double-flagged
+    # seller a presentment candidate in live, not just the supported card shape. Unsupported
+    # shapes (here: a recurring membership) get the safety posture — CardElement with wallets
+    # disabled — instead of the full Payment Element, because a wallet or multi-method charge
+    # would collect canonical USD while the cart displays buyer-currency totals. This example
+    # pins that live-mode downgrade so the flag ramp is done knowing a seller's whole catalog
+    # changes checkout surface, not only their USD one-time products.
+    seller = create(:user, disable_buyer_local_currency: false)
+    product = create(:membership_product, user: seller, price_cents: 1234)
+    allow(Stripe).to receive(:api_key).and_return("sk_live_currency")
+    Feature.activate_user(described_class::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, seller)
+    Feature.activate_user(:buyer_local_currency, seller)
+    Feature.activate_user(Checkout::BuyerCurrencyEligibility::FEATURE_NAME, seller)
+    add_products = [
+      checkout_product_for(
+        product,
+        # Membership products keep their price on tiers, so the checkout item's price must be
+        # passed explicitly or the cart totals zero and trips the earlier not_charged fallback
+        # before reaching the presentment gate this example is about.
+        price: 1234,
+        recurrence: "monthly",
+        buyer_currency_display: {
+          display_mode: "buyer_local",
+          buyer_currency_shown: Currency::CAD,
+        }
+      )
+    ]
+
+    expect(stripe_payment_props(add_products:)).to eq(
+      integration: described_class::STRIPE_CARD_ELEMENT_INTEGRATION,
+      fallback_reason: "buyer_currency_presentment_unsupported",
+      disable_wallets: true,
+      request_apple_pay_merchant_tokens: false,
+      elements_options: nil,
+    )
+  ensure
+    Feature.deactivate_user(:buyer_local_currency, seller) if seller
+    Feature.deactivate_user(Checkout::BuyerCurrencyEligibility::FEATURE_NAME, seller) if seller
+  end
+
   it "selects Stripe Payment Element for a multi-seller cart when every seller is flagged" do
     cart = create(:cart, :guest)
     products = [

--- a/spec/services/checkout/buyer_currency_eligibility_spec.rb
+++ b/spec/services/checkout/buyer_currency_eligibility_spec.rb
@@ -76,11 +76,12 @@ describe Checkout::BuyerCurrencyEligibility do
     expect(decision.fallback_reason).to eq(:feature_disabled)
   end
 
-  it "falls back in live mode" do
+  it "stays eligible in live mode now that the card presentment path has shipped its safety gates" do
     allow(Stripe).to receive(:api_key).and_return("sk_live_currency")
 
-    expect(decision).not_to be_eligible
-    expect(decision.fallback_reason).to eq(:live_mode)
+    expect(decision).to be_eligible
+    expect(decision.currency).to eq(Currency::CAD)
+    expect(decision.fallback_reason).to be_nil
   end
 
   it "falls back for commission deposit purchases even when a quote token is present" do

--- a/spec/services/checkout/buyer_currency_quote_spec.rb
+++ b/spec/services/checkout/buyer_currency_quote_spec.rb
@@ -50,6 +50,14 @@ describe Checkout::BuyerCurrencyQuote do
       expect(result).to be_nil
     end
 
+    it "creates a signed quote in live mode now that the card presentment path has shipped its safety gates" do
+      allow(Stripe).to receive(:api_key).and_return("sk_live_presentment")
+
+      result = described_class.create(products: [product], canonical_total_cents: 10_00, ip: "24.48.0.1")
+
+      expect(result).to have_attributes(currency: Currency::CAD, presentment_total_cents: 12_50)
+    end
+
     it "returns nil for multi-product checkouts" do
       expect(StripeFxQuote).not_to receive(:create)
 


### PR DESCRIPTION
## What

Removes the Stripe test-mode gate from the buyer-currency **card** presentment path so it can run in production: `Checkout::BuyerCurrencyEligibility#decision` no longer falls back with `:live_mode`, `buyer_presentment_candidate?` no longer requires test mode, and `Checkout::BuyerCurrencyQuote.create` mints FX quotes on live keys. The method-forced iDEAL/Bancontact surface keeps its test-mode gate — local payment methods are a separate launch that queues behind this one.

Everything stays flag-gated per seller: the eligibility service requires both `buyer_currency_charging` and `buyer_local_currency` on the seller (plus no `disable_buyer_local_currency` opt-out). Verified live state before opening this PR: `buyer_currency_charging` is unregistered/off with zero actors, so merging + deploying this PR changes no production behavior until the flag ramp begins.

## Why

The test-mode gate was the PR 1 hard safety boundary from antiwork/gumroad#5419: live-mode presentment charges were disabled until refund, dispute, and balance handling could safely process money that moved in a non-USD presentment currency. Those gates have all shipped:

- Quote re-lock on cart-total changes — on main as 13f707c5c
- Per-method refund/dispute matrix + FX-lock validation — #5779
- Presentment amounts in refund emails and admin views — #5846
- Presentment refund path fails closed when a presentment refund amount cannot be computed (`Purchase::PresentmentRefund` in `app/modules/purchase/refundable.rb`)

The production rollout was approved by the human owner on the private tracking issue (2026-07-17). This PR is the deploy prerequisite for the ramp: enabling the Flipper flag before this ships would be a silent no-op because the eligibility service falls back with `:live_mode` on production keys.

Rollout plan after deploy: staged `percentage_of_actors` ramp on `buyer_currency_charging` (cohort → percentage steps), with the daily migration digest and per-surface success-rate monitoring already in place. Instant rollback lever: disable the `buyer_currency_charging` gate — every checkout falls back to the canonical USD path by construction.

## Test plan

- `spec/services/checkout/buyer_currency_eligibility_spec.rb` — live-mode example now asserts eligibility (31 examples; the 1 pre-existing failure on the platform-account example also fails on unmodified main in this worktree — shared test-DB residue, not this change)
- `spec/services/checkout/buyer_currency_quote_spec.rb` — new example proves a signed quote is minted on a live key (12 examples, all passing)
- `spec/presenters/checkout/stripe_payment_presenter_spec.rb` + `spec/services/checkout/payment_method_resolver_spec.rb` — 105 examples, 0 failures; the live-mode presenter example now asserts the presentment Payment Element mounts, and the resolver specs confirm iDEAL/Bancontact stay withheld in live mode
- `spec/services/order/prepare_payment_intent_service_spec.rb` + `spec/services/charge/` — 75 examples, 1 pre-existing failure (also red on unmodified main)
- rubocop clean on all six touched files
- Post-deploy: verify the flag-off fallback with a live checkout before the first flag enable (expect `fallback_reason: :feature_disabled` in the charge log line)

## Before/After

Not a UI change at flag-off (no seller has `buyer_currency_charging`; checkout is byte-identical until the ramp). The flag-on presentment UI shipped and was QA'd in #5781/#5788 with preview-app evidence.


---

AI disclosure: written with Claude Opus 4.8 (via Hermes Agent). Prompt: with all buyer-currency safety gates shipped (#5779, #5846, quote re-lock) and the production rollout approved on the private tracking issue, lift the Stripe test-mode gate on the buyer-currency card presentment path only — keep the iDEAL/Bancontact gate in place — verify the change is a no-op while the `buyer_currency_charging` flag is off, and update the affected specs.
