### PR TITLE
Document the hourly analytics view in the help center

### DIFF
--- a/app/views/help_center/articles/contents/_74-the-analytics-dashboard.html.erb
+++ b/app/views/help_center/articles/contents/_74-the-analytics-dashboard.html.erb
@@ -34,11 +34,11 @@
   <p>By default, analytics shows data from the past month; however, it's often necessary to view sales data over a more extended period. From the date picker in the top right, you can access any range of data you'd like to view, going back to your first sale.</p>
   <p>The data in the sales chart, referrer list, and location will be updated to reflect the period you choose.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/64bf9636a9d61472afe09529/file-5EEqngjHHA.png" %></figure>
-  <p>You can also toggle between daily and monthly views to get the best of both analytic worlds: the close-up and the big picture.</p>
+  <p>You can also toggle between daily and monthly views to get the best of both analytic worlds: the close-up and the big picture. When your selected date range is 7 days or less, an hourly view is available too, so you can follow how a launch performs hour by hour. If you widen the range past 7 days while in the hourly view, the chart switches back to daily automatically.</p>
   <h3>Sales chart</h3>
-  <p>Sales data for the period you've selected is shown as a combined graph. Each bar represents a single day. The light grey section of the bar represents the number of views.</p>
+  <p>Sales data for the period you've selected is shown as a combined graph. Each bar represents a single day (or a single hour or month, depending on the view you've chosen). The light grey section of the bar represents the number of views.</p>
   <p>A line graph of sales volume is overlaid on top to give you a sense of sales volume relative to your views.</p>
-  <p>Hover on any day to see more information about the sales, views, and absolute sales value in dollars.</p>
+  <p>Hover on any bar to see more information about the sales, views, and absolute sales value in dollars.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/6246932342ba434a7afe2278/file-V5ESJfaXNp.png" %></figure>
   <h3 id="churn">Churn</h3>
   <p>If you sell <a href="82-membership-products">membership or subscription products</a>, the Churn tab helps you understand how many subscribers cancel over time. Go to <%= link_to "Analytics → Churn", churn_dashboard_path %> to access it.</p>


### PR DESCRIPTION
## What

Updates the help-center article "The sales analytics dashboard" (`_74-the-analytics-dashboard.html.erb`) to document the new hourly view on the sales chart:

- The "Selecting the date range" section now mentions the hourly view, its 7-day range limit, and the automatic fallback to daily when the range is widened past 7 days.
- The "Sales chart" section no longer claims each bar is always a single day.
- "Hover on any day" became "Hover on any bar" so it holds for all three views.

## Why

antiwork/gumroad#5927 (merged) added an "Hourly" option to the analytics dashboard's aggregate-by select, available when the picked range spans at most 7 days. The article previously described the chart as daily/monthly only, which is now stale. Claims verified against the merged code: `MAX_HOURLY_DATE_RANGE_DAYS = 7` (`CreatorAnalytics::Sales`, mirrored in `Analytics/index.tsx`), and the frontend's `useEffect` fallback that resets `aggregateBy` to `daily` when the range exceeds the limit.

Body-only edit; `articles.yml` untouched (title/description unchanged).

## Test plan

- ERB syntax check passes; tag-balance check clean.
- Rendered the partial via `ApplicationController.render` in the test env: render OK, new copy present.
- Autoreview skipped (docs copy only, no logic); help-center specs run in CI.

---

AI disclosure: written by Claude Fable 5 (Anthropic), operating as an autonomous docs-sync agent. Prompt: merged-PR → help-center sync automation triggered by the merge of antiwork/gumroad#5927; update the affected help-center article(s) to match the shipped behavior.

## Media note

Docs-only — the diff is the reviewable artifact (single help-center ERB article edit; CONTRIBUTING.md exempts documentation-only PRs from the video requirement).