### PR TITLE
Batch failed-refund escalation notifications into a digest above a threshold

### DIFF
--- a/app/sidekiq/dispatch_pending_failed_refund_exceptions_job.rb
+++ b/app/sidekiq/dispatch_pending_failed_refund_exceptions_job.rb
@@ -30,6 +30,11 @@ class DispatchPendingFailedRefundExceptionsJob
   # a run behaves exactly as before; above it, the run sends a single digest.
   ESCALATION_DIGEST_THRESHOLD = 5
 
+  # A row collected for escalation, its trigger kind (:delivery_exhausted or
+  # :overdue), and the human-readable reason recorded on the row.
+  Escalation = Struct.new(:row, :kind, :reason)
+  private_constant :Escalation
+
   def perform
     FailedRefundException.notification_deliverable.find_each do |failed_refund_exception|
       NotifyFailedRefundExceptionJob.perform_async(failed_refund_exception.id)
@@ -69,8 +74,6 @@ class DispatchPendingFailedRefundExceptionsJob
   end
 
   private
-    Escalation = Struct.new(:row, :kind, :reason)
-
     def escalate(failed_refund_exception, reason:)
       message = "Failed-refund exception ##{failed_refund_exception.id} escalated. #{reason} " \
         "Refund #{failed_refund_exception.refund_id}, owner #{failed_refund_exception.owner}."
@@ -106,7 +109,11 @@ class DispatchPendingFailedRefundExceptionsJob
     def escalate_with_digest(escalations)
       rows = escalations.map(&:row)
       ids = rows.map(&:id)
-      due_ats = rows.map(&:due_at)
+      # due_at is presence-validated, but a validation-bypassing backfill could
+      # leave it nil on delivery-exhausted rows; skip nils so one bad row cannot
+      # crash the whole dispatcher run.
+      due_ats = rows.filter_map(&:due_at)
+      due_window = due_ats.any? ? "due between #{due_ats.min.iso8601} and #{due_ats.max.iso8601}, " : ""
       owners = rows.map(&:owner).tally
       exhausted_count = escalations.count { |escalation| escalation.kind == :delivery_exhausted }
       overdue_count = escalations.size - exhausted_count
@@ -116,8 +123,8 @@ class DispatchPendingFailedRefundExceptionsJob
 
       message = "#{rows.size} failed-refund exceptions escalated in one dispatcher run " \
         "(#{exhausted_count} with notification delivery exhausted, #{overdue_count} past their response SLA). " \
-        "IDs #{ids.min}–#{ids.max}, owners: #{owners.map { |owner, count| "#{owner} (#{count})" }.join(", ")}, " \
-        "due between #{due_ats.min.iso8601} and #{due_ats.max.iso8601}, " \
+        "ID range #{ids.min}–#{ids.max}, owners: #{owners.map { |owner, count| "#{owner} (#{count})" }.join(", ")}, " \
+        "#{due_window}" \
         "refund amounts totaling #{total_refund_amount_cents} cents. " \
         "Per-row notifications were replaced by this digest to avoid flooding; " \
         "each exception row records its own escalation reason."

--- a/app/sidekiq/dispatch_pending_failed_refund_exceptions_job.rb
+++ b/app/sidekiq/dispatch_pending_failed_refund_exceptions_job.rb
@@ -10,32 +10,67 @@
 #    that reports the problem; Sentry is used instead.
 # 3. Escalates exceptions still pending past their response deadline (due_at), so
 #    the SLA recorded on the row is enforced rather than being a promise in an email.
+#
+# Escalation notifications are flood-proofed: when many rows cross their deadline in
+# the same run (for example a backfill creating hundreds of rows with the same
+# due_at), one digest email and one Sentry event summarize all of them instead of
+# one per row. Each row still transitions individually with its real reason, so the
+# durable audit trail is identical either way — only the notification is batched.
 class DispatchPendingFailedRefundExceptionsJob
   include Sidekiq::Job
 
   sidekiq_options retry: 5, queue: :default, lock: :until_executed
+
+  # How many escalations a single run may notify about individually before
+  # switching to one digest notification. The per-row email is the right level of
+  # detail for the normal trickle (an escalation or two per day), but any bulk
+  # event — like the 2026-07-19 backfill where ~2,000 historical rows crossed
+  # their 24-hour deadline within the same hour — would otherwise send one email
+  # and one Sentry event per row and flood both channels. At or below this count
+  # a run behaves exactly as before; above it, the run sends a single digest.
+  ESCALATION_DIGEST_THRESHOLD = 5
 
   def perform
     FailedRefundException.notification_deliverable.find_each do |failed_refund_exception|
       NotifyFailedRefundExceptionJob.perform_async(failed_refund_exception.id)
     end
 
+    # Collect every row that needs escalating before notifying, so the run knows
+    # the total count and can pick per-row versus digest notification. A row can
+    # match both scopes (delivery exhausted AND past its deadline); it is
+    # escalated once, with the delivery-exhausted reason taking precedence
+    # because a broken mailer is the more actionable problem.
+    escalations = []
+    seen_ids = Set.new
+
     FailedRefundException.delivery_exhausted.find_each do |failed_refund_exception|
-      escalate(
+      next unless seen_ids.add?(failed_refund_exception.id)
+      escalations << Escalation.new(
         failed_refund_exception,
-        reason: "Notification delivery failed #{failed_refund_exception.notification_failures} times; the internal mailer needs attention."
+        :delivery_exhausted,
+        "Notification delivery failed #{failed_refund_exception.notification_failures} times; the internal mailer needs attention."
       )
     end
 
     FailedRefundException.overdue.find_each do |failed_refund_exception|
-      escalate(
+      next unless seen_ids.add?(failed_refund_exception.id)
+      escalations << Escalation.new(
         failed_refund_exception,
-        reason: "Response SLA breached: due by #{failed_refund_exception.due_at.iso8601} and still pending."
+        :overdue,
+        "Response SLA breached: due by #{failed_refund_exception.due_at.iso8601} and still pending."
       )
+    end
+
+    if escalations.size <= ESCALATION_DIGEST_THRESHOLD
+      escalations.each { |escalation| escalate(escalation.row, reason: escalation.reason) }
+    else
+      escalate_with_digest(escalations)
     end
   end
 
   private
+    Escalation = Struct.new(:row, :kind, :reason)
+
     def escalate(failed_refund_exception, reason:)
       message = "Failed-refund exception ##{failed_refund_exception.id} escalated. #{reason} " \
         "Refund #{failed_refund_exception.refund_id}, owner #{failed_refund_exception.owner}."
@@ -55,17 +90,77 @@ class DispatchPendingFailedRefundExceptionsJob
         }
       )
 
-      begin
-        InternalNotificationMailer.notify(
-          room_name: failed_refund_exception.notification_room,
-          sender: "Failed Refund Exception",
-          message_text: message
-        ).deliver_now
-      rescue => e
-        # Expected when escalating because delivery is broken; Sentry already fired.
-        Rails.logger.error("DispatchPendingFailedRefundExceptionsJob: escalation email failed for exception #{failed_refund_exception.id}: #{e.message}")
-      end
+      deliver_escalation_email(
+        room_name: failed_refund_exception.notification_room,
+        message_text: message,
+        log_label: "exception #{failed_refund_exception.id}"
+      )
 
       failed_refund_exception.escalate!(resolution: reason)
+    end
+
+    # Bulk path: one Sentry event and one digest email per notification room
+    # (normally a single room) summarizing every escalation in this run. Rows are
+    # still escalated one by one with their individual reasons afterwards, so
+    # nothing about the durable per-row state differs from the per-row path.
+    def escalate_with_digest(escalations)
+      rows = escalations.map(&:row)
+      ids = rows.map(&:id)
+      due_ats = rows.map(&:due_at)
+      owners = rows.map(&:owner).tally
+      exhausted_count = escalations.count { |escalation| escalation.kind == :delivery_exhausted }
+      overdue_count = escalations.size - exhausted_count
+      # Sum through a query instead of loading every associated refund into memory;
+      # a digest can cover thousands of rows.
+      total_refund_amount_cents = FailedRefundException.where(id: ids).joins(:refund).sum("refunds.amount_cents")
+
+      message = "#{rows.size} failed-refund exceptions escalated in one dispatcher run " \
+        "(#{exhausted_count} with notification delivery exhausted, #{overdue_count} past their response SLA). " \
+        "IDs #{ids.min}–#{ids.max}, owners: #{owners.map { |owner, count| "#{owner} (#{count})" }.join(", ")}, " \
+        "due between #{due_ats.min.iso8601} and #{due_ats.max.iso8601}, " \
+        "refund amounts totaling #{total_refund_amount_cents} cents. " \
+        "Per-row notifications were replaced by this digest to avoid flooding; " \
+        "each exception row records its own escalation reason."
+
+      # Same ordering rationale as the per-row path: Sentry first and unrescued,
+      # email second and rescued, state transitions last.
+      ErrorNotifier.notify(
+        message,
+        context: {
+          escalated_count: rows.size,
+          delivery_exhausted_count: exhausted_count,
+          overdue_count: overdue_count,
+          failed_refund_exception_id_min: ids.min,
+          failed_refund_exception_id_max: ids.max,
+          owners: owners,
+          oldest_due_at: due_ats.min,
+          newest_due_at: due_ats.max,
+          total_refund_amount_cents: total_refund_amount_cents,
+        }
+      )
+
+      # Rows can be assigned to different notification rooms; each room gets the
+      # digest once so no owning team misses the alert. In practice all rows share
+      # the default room and this sends exactly one email.
+      rows.map(&:notification_room).uniq.each do |room_name|
+        deliver_escalation_email(
+          room_name: room_name,
+          message_text: message,
+          log_label: "digest of #{rows.size} exceptions"
+        )
+      end
+
+      escalations.each { |escalation| escalation.row.escalate!(resolution: escalation.reason) }
+    end
+
+    def deliver_escalation_email(room_name:, message_text:, log_label:)
+      InternalNotificationMailer.notify(
+        room_name: room_name,
+        sender: "Failed Refund Exception",
+        message_text: message_text
+      ).deliver_now
+    rescue => e
+      # Expected when escalating because delivery is broken; Sentry already fired.
+      Rails.logger.error("DispatchPendingFailedRefundExceptionsJob: escalation email failed for #{log_label}: #{e.message}")
     end
 end

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -94,10 +94,6 @@ expire_rental_purchases: # Duration: 45sec
   cron: "0 12 * * *" # UTC 12:00
   class: ExpireRentalPurchasesWorker
   description: update rental purchases that have expired in the last one day
-daily_flagged_and_suspended_users: # Duration: 5sec
-  cron: "0 15 * * *" # UTC 15:00
-  class: DailyRefundQueueNotifyWorker
-  description: Suspended users to refund
 delete_old_versions_records_worker: # Duration: 5min
   cron: "30 9 * * *" # UTC 09:30
   class: DeleteOldVersionsRecordsWorker

--- a/spec/sidekiq/dispatch_pending_failed_refund_exceptions_job_spec.rb
+++ b/spec/sidekiq/dispatch_pending_failed_refund_exceptions_job_spec.rb
@@ -84,5 +84,119 @@ describe DispatchPendingFailedRefundExceptionsJob do
       described_class.new.perform
       described_class.new.perform
     end
+
+    describe "digest flood protection" do
+      it "keeps per-row emails and Sentry events at the digest threshold" do
+        exceptions = create_list(
+          :failed_refund_exception,
+          DispatchPendingFailedRefundExceptionsJob::ESCALATION_DIGEST_THRESHOLD,
+          due_at: 1.hour.ago,
+          notification_sent_at: 25.hours.ago
+        )
+
+        expect(ErrorNotifier).to receive(:notify)
+          .exactly(exceptions.size).times
+          .with(a_string_including("Response SLA breached"), context: anything)
+        expect do
+          described_class.new.perform
+        end.to change { ActionMailer::Base.deliveries.size }.by(exceptions.size)
+
+        exceptions.each do |exception|
+          expect(exception.reload).to have_attributes(
+            state: "escalated",
+            resolution: a_string_including("Response SLA breached")
+          )
+        end
+      end
+
+      it "sends one digest email and one Sentry event when more than the threshold escalate in one run" do
+        exceptions = create_list(
+          :failed_refund_exception,
+          DispatchPendingFailedRefundExceptionsJob::ESCALATION_DIGEST_THRESHOLD + 1,
+          due_at: 2.hours.ago,
+          notification_sent_at: 25.hours.ago
+        )
+        total_amount_cents = exceptions.sum { |exception| exception.refund.amount_cents }
+
+        expect(ErrorNotifier).to receive(:notify).once.with(
+          a_string_including("#{exceptions.size} failed-refund exceptions escalated"),
+          context: hash_including(
+            escalated_count: exceptions.size,
+            overdue_count: exceptions.size,
+            delivery_exhausted_count: 0,
+            failed_refund_exception_id_min: exceptions.map(&:id).min,
+            failed_refund_exception_id_max: exceptions.map(&:id).max,
+            total_refund_amount_cents: total_amount_cents
+          )
+        )
+
+        expect do
+          described_class.new.perform
+        end.to change { ActionMailer::Base.deliveries.size }.by(1)
+
+        digest_body = ActionMailer::Base.deliveries.last.body.encoded
+        expect(digest_body).to include("#{exceptions.size} failed-refund exceptions escalated")
+
+        exceptions.each do |exception|
+          expect(exception.reload).to have_attributes(
+            state: "escalated",
+            resolution: a_string_including("Response SLA breached")
+          )
+        end
+      end
+
+      it "digests a mixed run of delivery-exhausted and overdue exceptions with per-kind resolutions" do
+        exhausted = create_list(
+          :failed_refund_exception,
+          3,
+          notification_failures: FailedRefundException::MAX_NOTIFICATION_FAILURES
+        )
+        overdue = create_list(
+          :failed_refund_exception,
+          3,
+          due_at: 1.hour.ago,
+          notification_sent_at: 25.hours.ago
+        )
+
+        expect(ErrorNotifier).to receive(:notify).once.with(
+          a_string_including("6 failed-refund exceptions escalated"),
+          context: hash_including(
+            escalated_count: 6,
+            delivery_exhausted_count: 3,
+            overdue_count: 3
+          )
+        )
+
+        expect do
+          described_class.new.perform
+        end.to change { ActionMailer::Base.deliveries.size }.by(1)
+
+        exhausted.each do |exception|
+          expect(exception.reload.resolution).to include("Notification delivery failed")
+        end
+        overdue.each do |exception|
+          expect(exception.reload.resolution).to include("Response SLA breached")
+        end
+      end
+
+      it "escalates every row even when the digest email cannot be delivered" do
+        exceptions = create_list(
+          :failed_refund_exception,
+          DispatchPendingFailedRefundExceptionsJob::ESCALATION_DIGEST_THRESHOLD + 1,
+          due_at: 1.hour.ago,
+          notification_sent_at: 25.hours.ago
+        )
+        expect(ErrorNotifier).to receive(:notify).once
+        mailer = double("mailer")
+        expect(InternalNotificationMailer).to receive(:notify).and_return(mailer)
+        expect(mailer).to receive(:deliver_now).and_raise("mail unavailable")
+
+        expect { described_class.new.perform }.not_to raise_error
+
+        exceptions.each do |exception|
+          expect(exception.reload.state).to eq("escalated")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Flood-proofs `FailedRefundException` escalation notifications. During the 2026-07-19 incident, the 2026-07-18 backfill created 1,975 historical exception rows that all crossed their 24-hour `due_at` within the same hour, and `DispatchPendingFailedRefundExceptionsJob` sent one email to finance@ plus one Sentry event **per row** — ~2,000 emails in ~1.5 hours. The per-row design is right for the live trickle (1–2/day) but melts down on any bulk crossing.

## Progress

- [x] Add `ESCALATION_DIGEST_THRESHOLD` (5) with a plain-language comment: runs escalating ≤5 rows behave exactly as today (per-row email + Sentry event); >5 rows switch to one digest email + one Sentry event
- [x] Digest summarizes count, split by kind (delivery-exhausted vs overdue), id range, owners with counts, oldest/newest `due_at`, and summed refund amounts (SQL sum, not per-row loads)
- [x] Rows still transition individually via `escalate!(resolution:)` with their real reason — durable per-row audit state unchanged; only the notification channel is batched
- [x] Preserve channel-ordering invariants in the digest path: Sentry first and unrescued, email rescued, state transitions last
- [x] Dedupe rows matching both scopes (exhausted AND overdue) — escalated once, delivery-exhausted reason wins (matches the old sequential-loop behavior)
- [x] Remove lingering `sidekiq_schedule.yml` entry for `DailyRefundQueueNotifyWorker` (class deleted in an earlier refactor; its 21 leftover scheduled/retrying jobs were purged today)
- [x] Specs: >threshold overdue → exactly 1 mailer + 1 Sentry call, all rows escalated with correct resolutions; ≤threshold → per-row behavior preserved; mixed exhausted+overdue digest with per-kind resolutions; digest-email failure still escalates every row
- [x] Rubocop clean; all touched specs green locally

No re-enqueue-loop digest is needed: `NotifyFailedRefundExceptionJob` already has the uniqueness lock and `notification_sent_at` guard.

## Before / after

- **Before:** 1,975 rows crossing `due_at` in one hour → ~1,975 emails + ~1,975 Sentry events.
- **After:** the same event → **1** digest email + **1** Sentry event per run, while all 1,975 rows still escalate individually with their real reasons. A normal day (1–2 escalations) is byte-for-byte identical to today.

## test-results

Backend-only change — rspec output is the reviewable evidence:

```
$ bundle exec rspec spec/sidekiq/dispatch_pending_failed_refund_exceptions_job_spec.rb \
    spec/sidekiq/notify_failed_refund_exception_job_spec.rb \
    spec/models/failed_refund_exception_spec.rb
23 examples, 0 failures

$ bundle exec rspec spec/sidekiq/verify_finance_reports_delivery_job_spec.rb   # reads sidekiq_schedule.yml
15 examples, 0 failures

$ bundle exec rubocop app/sidekiq/dispatch_pending_failed_refund_exceptions_job.rb \
    spec/sidekiq/dispatch_pending_failed_refund_exceptions_job_spec.rb
2 files inspected, no offenses detected
```

## QA steps

Backend-only Sidekiq job change (no UI surface) — the diff is the reviewable artifact and the spec output above is the evidence. To reproduce locally: create >5 `FailedRefundException` rows past `due_at`, run `DispatchPendingFailedRefundExceptionsJob.new.perform`, and observe one digest email in `ActionMailer::Base.deliveries` plus one `ErrorNotifier` call, with every row individually `escalated` carrying its real reason. With ≤5 rows the run is identical to today's per-row behavior.

## qa-media

Backend-only — spec output above is the reviewable artifact (no UI surface).

---

AI disclosure: authored by Hermes Agent running claude-fable-5 (Anthropic), prompted to flood-proof FailedRefundException escalation notifications after the 2026-07-19 email-flood incident (one digest email + one Sentry event above a threshold, per-row audit state unchanged) and to remove the lingering DailyRefundQueueNotifyWorker schedule entry.
