### PR TITLE
Scope seat-change proration copy to memberships in customer dashboard article

### DIFF
--- a/app/views/help_center/articles/contents/_268-customer-dashboard.html.erb
+++ b/app/views/help_center/articles/contents/_268-customer-dashboard.html.erb
@@ -48,7 +48,8 @@
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/62171f7a1c416e446e804223/file-n9069uPZRk.png" %></figure>
   <h3 id="Manage-license-keys-5AuIs">Manage license keys</h3>
   <p>You can disable a <a href="76-license-keys">license key</a> or change the number of seats for a multi-seat license key.</p>
-  <p>Customers will immediately be charged a prorated amount if the number of seats is increased. However, for a decrease in the number of seats, their membership will get updated at the end of the current billing cycle, and they will be charged the reduced amount for subsequent renewals.</p>
+  <p>For memberships, customers will immediately be charged a prorated amount if the number of seats is increased. However, for a decrease in the number of seats, their membership will get updated at the end of the current billing cycle, and they will be charged the reduced amount for subsequent renewals.</p>
+  <p>For one-time products, changing the number of seats here updates the seat count on the license key without charging or refunding the customer.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/639b0a1c2e586565571c20eb/file-4oW74KD2yB.gif" %></figure>
   <h3 id="Ratings-HLwRM">Ratings</h3>
   <p>You can see how a customer has rated your product. If you're unhappy with your ratings, you can hide all of <a href="222-product-ratings-on-gumroad">them</a> from being visible or refund the customer to automatically delete their rating.  You cannot hide a single rating only.</p>


### PR DESCRIPTION
## What

Updates the "Manage license keys" section of the customer dashboard help article (`_268-customer-dashboard`) so the seat-change proration copy is scoped to memberships, and adds one sentence covering seat edits on one-time products.

## Why

#5931 extended multi-seat licensing from tiered memberships to every licensed product type (except calls). That PR updated the license-keys article (`_76-license-keys`) with the same "For memberships, ..." scoping, but the customer dashboard article still states unconditionally that increasing seats charges a prorated amount and decreasing seats updates at the end of the billing cycle. That is only true for memberships. For one-time products, the seat edit in the customer drawer updates `Purchase#quantity` directly with no charge or refund (`PurchasesController#update` sets `quantity` and saves; there is no billing path for non-subscription purchases).

## Changes

- `_268-customer-dashboard.html.erb`: prefix the proration paragraph with "For memberships," (mirroring the wording #5931 shipped in `_76-license-keys`) and add: "For one-time products, changing the number of seats here updates the seat count on the license key without charging or refunding the customer."

`articles.yml` untouched (body-only edit, no title/description change). Anchor IDs preserved.

## Test Results

- Rendered the partial via `ApplicationController.render` in the test env: render OK, new copy present.
- ERB syntax check and tag-balance check pass (all tags balanced).
- Body-only edit; CI runs the help-center specs.

## QA steps

Docs-only — diff is the reviewable artifact. To verify on the live site after deploy: open help.gumroad.com/help/article/268-customer-dashboard, scroll to "Manage license keys", and confirm the proration paragraph now begins "For memberships," followed by the new one-time-products sentence.

## Before / After

Docs-only copy change — no media; the diff is the reviewable artifact.

---

AI disclosure: Authored by Claude Fable 5 (Hermes Agent) via the merged-PR → help-center sync automation, triggered by the merge of #5931. Instructions: check merged gumroad PRs for help-center impact and update affected articles.
