### PR TITLE
Require 7-8 digit Japanese bank account numbers to match Stripe

### DIFF
--- a/app/models/japan_bank_account.rb
+++ b/app/models/japan_bank_account.rb
@@ -11,7 +11,11 @@ class JapanBankAccount < BankAccount
   BRANCH_CODE_FORMAT_REGEX = /\A[0-9]{3}\z/
   private_constant :BRANCH_CODE_FORMAT_REGEX
 
-  ACCOUNT_NUMBER_FORMAT_REGEX = /\A[0-9]{4,8}\z/
+  # Stripe rejects Japanese account numbers shorter than 7 digits at tokenization
+  # ("must be 7-8 digits"), so accepting 4-6 digits here only delays the failure to a
+  # raw Stripe error after submit. Match Stripe's bounds so the seller gets inline
+  # validation instead. Verified by live token probes, 2026-07-20 (gumroad-private#1180).
+  ACCOUNT_NUMBER_FORMAT_REGEX = /\A[0-9]{7,8}\z/
   private_constant :ACCOUNT_NUMBER_FORMAT_REGEX
 
   # Zengin-format account names allow katakana, digits, and the symbols ( ) . - /

--- a/spec/models/japan_bank_account_spec.rb
+++ b/spec/models/japan_bank_account_spec.rb
@@ -62,7 +62,7 @@ describe JapanBankAccount do
   describe "#validate_account_number" do
     it "allows records that match the required account number regex" do
       expect(build(:japan_bank_account, account_number: "0001234")).to be_valid
-      expect(build(:japan_bank_account, account_number: "1234")).to be_valid
+      expect(build(:japan_bank_account, account_number: "1234567")).to be_valid
       expect(build(:japan_bank_account, account_number: "12345678")).to be_valid
 
       jp_bank_account = build(:japan_bank_account, account_number: "ABCDEFG")
@@ -70,6 +70,16 @@ describe JapanBankAccount do
       expect(jp_bank_account.errors.full_messages.to_sentence).to eq("The account number is invalid.")
 
       jp_bank_account = build(:japan_bank_account, account_number: "123456789")
+      expect(jp_bank_account).to_not be_valid
+      expect(jp_bank_account.errors.full_messages.to_sentence).to eq("The account number is invalid.")
+
+      # Stripe requires 7-8 digits for Japan; 4-6 digit numbers used to pass here and
+      # then fail at Stripe tokenization with a raw error.
+      jp_bank_account = build(:japan_bank_account, account_number: "1234")
+      expect(jp_bank_account).to_not be_valid
+      expect(jp_bank_account.errors.full_messages.to_sentence).to eq("The account number is invalid.")
+
+      jp_bank_account = build(:japan_bank_account, account_number: "123456")
       expect(jp_bank_account).to_not be_valid
       expect(jp_bank_account.errors.full_messages.to_sentence).to eq("The account number is invalid.")
 


### PR DESCRIPTION
## Why

Stripe rejects Japanese bank account numbers shorter than 7 digits at tokenization (its own validation error says "must be 7-8 digits"), but our inline validation accepted 4-8 digits. A seller entering a 4-6 digit number passed our form validation and then hit a raw Stripe tokenization error after submit instead of the standard inline "The account number is invalid." message.

Found during the bank-account regex boundary sweep that produced #5928 (Brunei), #5981 (Uruguay), and #5982 (HK/SG/TH/KR) — this is the inverse case: our regex looser than Stripe rather than stricter. Verified by live Stripe token probes on 2026-07-20; details in the internal tracking issue.

Unlike the widening fixes, nothing is silently lost today — the failure is just late and ugly. This aligns the bound so it fails inline.

## What

- `app/models/japan_bank_account.rb`: `ACCOUNT_NUMBER_FORMAT_REGEX` minimum 4 → 7 (`/\A[0-9]{7,8}\z/`), matching Stripe's accepted range
- Spec boundary cases: 7 and 8 digits valid; 4, 6 (new Stripe-mismatch cases), 3, and 9 digits invalid

Existing accounts are unaffected: validation runs on create/update, and any previously saved 4-6 digit account would already be failing at Stripe payout time.

## Demo

![demo](https://i.ibb.co/DDx3XhrP/demo-jp.gif)

Terminal walkthrough: the same boundary probe run against main (4/6-digit numbers `valid? true`) and against this branch (`valid? false` with the standard inline message; 7/8 still valid, 9 still invalid), then the full model spec (21 examples, 0 failures).

## QA steps

Model-validation-only change — no UI diff, no preview app needed. Reviewer path: run `bundle exec rspec spec/models/japan_bank_account_spec.rb`, or in a console `build(:japan_bank_account, account_number: "123456").valid?` → `false` on this branch, `true` on main.

## Test plan

- `bundle exec rspec spec/models/japan_bank_account_spec.rb` — 21 examples, 0 failures (run locally)
- Factory uses a 7-digit number (`0001234`), already within the new bounds; swept the suite for other 4-6 digit Japan fixtures — none

---

AI disclosure: authored by Hermes (Claude fable-5) operating the gumclaw workstation, from the boundary-sweep findings in gumroad-private#1180. Prompt: "Do gp#1180 [Japan optional item] — assign both the issue and PR to me."
