### PR TITLE
Revert "Require 7-8 digit Japanese bank account numbers to match Stripe" (#5990)

### DIFF
--- a/app/models/japan_bank_account.rb
+++ b/app/models/japan_bank_account.rb
@@ -11,11 +11,7 @@ class JapanBankAccount < BankAccount
   BRANCH_CODE_FORMAT_REGEX = /\A[0-9]{3}\z/
   private_constant :BRANCH_CODE_FORMAT_REGEX
 
-  # Stripe rejects Japanese account numbers shorter than 7 digits at tokenization
-  # ("must be 7-8 digits"), so accepting 4-6 digits here only delays the failure to a
-  # raw Stripe error after submit. Match Stripe's bounds so the seller gets inline
-  # validation instead. Verified by live token probes, 2026-07-20 (gumroad-private#1180).
-  ACCOUNT_NUMBER_FORMAT_REGEX = /\A[0-9]{7,8}\z/
+  ACCOUNT_NUMBER_FORMAT_REGEX = /\A[0-9]{4,8}\z/
   private_constant :ACCOUNT_NUMBER_FORMAT_REGEX
 
   # Zengin-format account names allow katakana, digits, and the symbols ( ) . - /

--- a/spec/models/japan_bank_account_spec.rb
+++ b/spec/models/japan_bank_account_spec.rb
@@ -62,7 +62,7 @@ describe JapanBankAccount do
   describe "#validate_account_number" do
     it "allows records that match the required account number regex" do
       expect(build(:japan_bank_account, account_number: "0001234")).to be_valid
-      expect(build(:japan_bank_account, account_number: "1234567")).to be_valid
+      expect(build(:japan_bank_account, account_number: "1234")).to be_valid
       expect(build(:japan_bank_account, account_number: "12345678")).to be_valid
 
       jp_bank_account = build(:japan_bank_account, account_number: "ABCDEFG")
@@ -70,16 +70,6 @@ describe JapanBankAccount do
       expect(jp_bank_account.errors.full_messages.to_sentence).to eq("The account number is invalid.")
 
       jp_bank_account = build(:japan_bank_account, account_number: "123456789")
-      expect(jp_bank_account).to_not be_valid
-      expect(jp_bank_account.errors.full_messages.to_sentence).to eq("The account number is invalid.")
-
-      # Stripe requires 7-8 digits for Japan; 4-6 digit numbers used to pass here and
-      # then fail at Stripe tokenization with a raw error.
-      jp_bank_account = build(:japan_bank_account, account_number: "1234")
-      expect(jp_bank_account).to_not be_valid
-      expect(jp_bank_account.errors.full_messages.to_sentence).to eq("The account number is invalid.")
-
-      jp_bank_account = build(:japan_bank_account, account_number: "123456")
       expect(jp_bank_account).to_not be_valid
       expect(jp_bank_account.errors.full_messages.to_sentence).to eq("The account number is invalid.")
 


### PR DESCRIPTION
## Why

Reverts #5990 (merged ~05:01 UTC today as `d19be022a`). Minutes after the merge, an audited prod impact check — prompted by @nyomanjyotisa asking whether any stored Japanese accounts have fewer than 7 digits — showed the PR's premise was wrong about the real population:

- 5,627 alive `JapanBankAccount`s; **55 have sub-7-digit account numbers** (1×4, 3×5, 51×6)
- **All 55 hold `stripe_bank_account_id`s** — they tokenized at Stripe successfully
- **7 of those sellers completed payouts within the last 6 months** (one has 17 payouts)
- Several such accounts were created within the last two weeks, so short numbers still tokenize today

Japanese (zengin) account numbers are conventionally zero-padded to 7 digits; Stripe evidently accepts or pads shorter input in practice, so the boundary probe's "must be 7-8 digits" error does not describe the behavior real accounts hit. With #5990 on main, those 55 sellers fail model validation the next time their bank account record is validated (e.g. editing payout settings), breaking working payout configurations to fix a UX papercut that may not exist.

Evidence trail: prod queries logged in the S3 console-audit trail under linked_ref `gumroad#5990`; summary posted on #5990 immediately after the check (comment 5018954271 — the merge and the check crossed in flight).

## What

Clean `git revert` of the squash commit — restores `{4,8}` bounds and the original spec cases. No other changes.

## QA steps

Model-validation-only revert; no UI. Reviewer path: `bundle exec rspec spec/models/japan_bank_account_spec.rb` on this branch (21 examples green, restored expectations), or console: `build(:japan_bank_account, account_number: "123456").valid?` → `true` again, matching the 51 six-digit accounts in prod.

docs-only note: n/a — this is a code revert; the diff is the reviewable artifact (2 files, −16/+2, pure inversion of #5990).

## Test plan

- `bundle exec rspec spec/models/japan_bank_account_spec.rb` — green locally on the revert
- Prod impact of the revert: returns the validator to the state all 5,627 alive JP accounts were created under

---

AI disclosure: authored by Hermes (Claude fable-5) on the gumclaw workstation. Prompt lineage: user asked "Is there anyone with less than 7 digit Japanese bank account on database but verified on Stripe?" → audited prod check → premise falsified → revert.
