### PR TITLE
Document why Japan bank account number minimum stays at 4 digits

### DIFF
--- a/app/models/japan_bank_account.rb
+++ b/app/models/japan_bank_account.rb
@@ -11,6 +11,16 @@ class JapanBankAccount < BankAccount
   BRANCH_CODE_FORMAT_REGEX = /\A[0-9]{3}\z/
   private_constant :BRANCH_CODE_FORMAT_REGEX
 
+  # The 4-digit minimum is intentionally looser than Stripe's documented
+  # "must be 7-8 digits" tokenization error. Real Japanese (Zengin) account
+  # numbers can be shorter than 7 digits, and Stripe accepts them in practice:
+  # a July 2026 production audit found 55 live accounts with sub-7-digit
+  # numbers, all successfully verified by Stripe and several with recent
+  # completed payouts. Tightening the minimum to 7 was tried and reverted
+  # (gumroad#5990 → reverted in gumroad#5993) because it would have broken
+  # re-validation for those working sellers. Do not "fix" this to match the
+  # Stripe docs without first auditing how many stored accounts the stricter
+  # rule would reject. See antiwork/gumroad-private#1180 for the full history.
   ACCOUNT_NUMBER_FORMAT_REGEX = /\A[0-9]{4,8}\z/
   private_constant :ACCOUNT_NUMBER_FORMAT_REGEX
 


### PR DESCRIPTION
## What

Adds an explanatory comment above `ACCOUNT_NUMBER_FORMAT_REGEX` in `app/models/japan_bank_account.rb` documenting why the 4-digit minimum intentionally differs from Stripe's documented "must be 7-8 digits" tokenization error. No behavior change — comment only.

## Why

Tightening the minimum to 7 digits was attempted in #5990 and reverted in #5993: a production audit found 55 live Japanese bank accounts with sub-7-digit (Zengin zero-padded) numbers, all Stripe-verified, several with recent completed payouts. Stripe accepts these in practice despite what its tokenization error message says. Without an in-code note, a future sweep comparing our regexes against Stripe's documented bounds would flag this as a bug and re-introduce the regression. Full history: antiwork/gumroad-private#1180.

## Before / After

Docs-only — diff is the reviewable artifact. Comment-only change to a backend model; no UI or behavior surface. The adjacent validation behavior is unchanged by construction (regex untouched), confirmed by the full model spec passing below.

## QA steps

1. Open `app/models/japan_bank_account.rb` and confirm the comment sits directly above `ACCOUNT_NUMBER_FORMAT_REGEX`.
2. Confirm the regex itself (`/\A[0-9]{4,8}\z/`) is unchanged from main.

## Test Results

```
$ bundle exec rspec spec/models/japan_bank_account_spec.rb
21 examples, 0 failures

$ bundle exec rubocop app/models/japan_bank_account.rb
1 file inspected, no offenses detected
```

---

## AI disclosure

Written by Claude Fable 5 (Hermes agent). Instruction: add a code comment for the Japan bank account number regex explaining the intentional difference from Stripe's documented expectations so it isn't accidentally changed again.
