### PR TITLE
Update review article: star ratings save immediately

### DIFF
--- a/app/views/help_center/articles/contents/_344-rate-and-review-your-purchase.html.erb
+++ b/app/views/help_center/articles/contents/_344-rate-and-review-your-purchase.html.erb
@@ -9,6 +9,8 @@
     <li>The product page </li>
   </ul>
   <br>
+  <p>Your star rating is saved as soon as you select it, so a rating on its own counts as a review even if you don't add anything else. To share more, write your feedback in the text box and click "Post review".</p>
+  <br>
   <p>If you haven't left a review in the first 5 days after a purchase (90 days for physical products), we will send you a reminder email. You can unsubscribe from these reminders using the link at the bottom of the email. Some creators turn review reminders off, in which case you won't receive one.</p>
   <br>
   <h3>Restrictions</h3>


### PR DESCRIPTION
## What

Adds one sentence to the "Rate and review your purchase" help article (`_344-rate-and-review-your-purchase.html.erb`): the star rating is saved as soon as it's selected, a rating alone counts as a review, and a written review is posted with the "Post review" button.

## Why

PR #6040 changed the review form so tapping a star autosaves the rating immediately (previously nothing was saved until the buyer clicked "Post review"). The article described leaving a review without mentioning that the rating is captured at selection time, which is now the behavior a buyer sees (a "Rating saved!" toast fires on the star tap). The "Post review" button label is quoted verbatim from `app/javascript/components/ReviewForm.tsx`.

Triggered by merged PR #6040. Article changed: `344-rate-and-review-your-purchase` (body only; `articles.yml` untouched — no title/description change). No removals, no policy/pricing/tax/payout wording.

## Test plan

- Rendered the partial via `ApplicationController.render` locally — renders OK with the new copy present.
- ERB syntax check + HTML tag-balance check pass.
- `bundle exec rspec spec/models/help_center` — 1 example, 0 failures (guards slug↔partial integrity).
- CI runs the full help-center spec set.

## Before / After media

docs-only — diff is the reviewable artifact (single-sentence help-article copy addition, no UI surface).

## QA steps

1. Open https://help.gumroad.com/help/article/344-rate-and-review-your-purchase after deploy.
2. Confirm the "Leaving a review" section includes the sentence about the rating saving as soon as it's selected.

---

AI disclosure: authored by Claude Fable 5 (Hermes agent) as part of the automated merged-PR → help-center sync. Instruction: keep help articles accurate when product behavior changes; triggered by the merge of #6040.
