### PR TITLE
Follow dark mode in the rich text editor toolbar

### DIFF
--- a/app/javascript/components/RichTextEditor.tsx
+++ b/app/javascript/components/RichTextEditor.tsx
@@ -457,16 +457,21 @@ export const RichTextEditorToolbar = ({
         role="toolbar"
         className={classNames(
           "sticky top-0 z-1 flex flex-wrap gap-1 px-2 py-1 text-foreground",
-          color === "ghost" ? "bg-background" : "bg-primary text-primary-foreground",
+          // In light mode the toolbar is an inverted (black) bar. Inverting in dark mode would
+          // make it near-white — a glaring light strip on a dark page — so there it uses the
+          // page background instead, which sits slightly lighter than the black text field
+          // beneath it and reads as the same toolbar without breaking the dark theme.
+          color === "ghost" ? "bg-background" : "bg-primary text-primary-foreground dark:bg-body dark:text-foreground",
           className,
         )}
         style={
           color === "primary"
             ? {
-                // Fix muted to work with the inverted background. This is necessary because muted is currently semitransparent,
-                // but when we're fully in Tailwind we can remove the --gray-3 definition, make muted a solid color, and remove this.
-                "--color-muted":
-                  "color-mix(in srgb, var(--color-primary-foreground) calc(var(--gray-3) * 100%), transparent)",
+                // Fix muted to work with the toolbar's own background. This is necessary because muted is
+                // currently semitransparent, but when we're fully in Tailwind we can remove the --gray-3
+                // definition, make muted a solid color, and remove this. currentColor tracks the toolbar's
+                // text color in both schemes (inverted in light mode, regular foreground in dark mode).
+                "--color-muted": "color-mix(in srgb, currentColor calc(var(--gray-3) * 100%), transparent)",
               }
             : {}
         }


### PR DESCRIPTION
## What

The rich text editor toolbar now follows dark mode. The toolbar uses an inverted `bg-primary` bar, which is black in light mode but flips to near-white in dark mode — a bright strip across an otherwise dark editor. In dark mode it now uses the page background (`bg-body`, `#242423`), which sits slightly lighter than the black text field beneath it, with regular foreground text. Light mode is unchanged. The `--color-muted` override for toolbar icons now derives from `currentColor` so muted icons stay legible on both bars.

Re-opened from #5992 after review: the preview-palette portion of that PR was dropped (`#ffffff` is the seller's actual storefront background, so making the preview inherit dark mode would stop it matching what buyers see; scheme-aware default pages need a proper theme model first). This PR is the surviving toolbar-only fix on a clean branch.

## Why

Sahil flagged the toolbar on #5888 after merge: the description toolbar stayed light in dark mode ("Fix the tool bar too — should be dark bg too or just slightly lighter than the text field bg").

## Before / After

**Before (dark mode):** light toolbar strip across the dark editor — visible in the top area of ![before-dark](https://raw.githubusercontent.com/antiwork/gumroad/main/qa-media/pr-5888-after-bundle-edit-dark.png)

**After:** capturing from the preview app once the deploy is up; PR stays draft until attached.

## QA steps

1. Set the OS/browser to dark mode.
2. Open a product or bundle editor — the description toolbar should render dark, slightly lighter than the text field beneath it, with legible icons.
3. Switch to light mode — the toolbar is unchanged from before (inverted black bar).

## Test plan

- TSX-only change to `RichTextEditor.tsx`; no Ruby touched.
- Prettier + ESLint clean on the changed file.
- CI on this PR builds fresh assets and runs the full suite.

---

## AI disclosure

Authored by Claude Fable 5 (Hermes agent) from Sahil's review comment on #5888. Carried over from #5992 with the preview-palette change removed per gianfrancopiana's review.
