### PR TITLE
Serve the custom-page Tailwind build as a fingerprinted asset

### DIFF
--- a/.buildkite/scripts/compile_assets.sh
+++ b/.buildkite/scripts/compile_assets.sh
@@ -120,6 +120,13 @@ if [[ ${BUILDKITE_PARALLEL_JOB:-0} = 0 && $BUILDKITE_BRANCH != "main" ]]; then
     # the expensive part (the docker commit above) already succeeded, so a
     # transient S3 failure here is logged but never discards the committed
     # image or triggers the full recompile.
+    #
+    # This best-effort failure mode can't leave pages linking to a missing
+    # stylesheet: a cache entry only exists after a full compile whose S3
+    # upload succeeded (the push runs as a fatal step inside `make
+    # build_staging`), so the fingerprinted pages Tailwind CSS named by the
+    # image's manifest is already in the bucket before any image carrying
+    # that manifest can be built from cache.
     logger "Syncing cached assets to S3"
     local container_id
     if container_id=$(docker run -d --entrypoint="bash" --volume /app $WEB_REPO:staging-$WEB_TAG); then

--- a/.buildkite/scripts/preview_asset_cache.sh
+++ b/.buildkite/scripts/preview_asset_cache.sh
@@ -9,7 +9,7 @@
 # preview branch" refreshes.
 #
 # This helper caches the compiled artifacts (node_modules, public/vite,
-# public/js, public/pages-tailwind.css) in S3, keyed on a hash of every input
+# public/js, the pages Tailwind build and its manifest) in S3, keyed on a hash of every input
 # that feeds the compile. On a hit, compile_assets.sh restores the artifacts
 # into a fresh web-image container and commits that as the staging image,
 # skipping npm install / js:export / Vite entirely. On a miss it builds
@@ -195,7 +195,7 @@ preview_asset_cache_save() {
   # gzip -1: node_modules dominates the tarball and compresses slowly at the
   # default level; speed matters more than a few percent of S3 storage.
   if ! docker run --rm --entrypoint="" "$image" \
-    bash -c 'set -o pipefail; cd /app && paths=""; for p in node_modules public/vite public/js public/pages-tailwind.css; do [ -e "$p" ] && paths="$paths $p"; done; tar -cf - $paths | gzip -1' \
+    bash -c 'set -o pipefail; cd /app && paths=""; for p in node_modules public/vite public/js public/pages-tailwind.css public/pages public/pages-tailwind-manifest.json; do [ -e "$p" ] && paths="$paths $p"; done; tar -cf - $paths | gzip -1' \
     > "$PREVIEW_ASSET_CACHE_TARBALL"; then
     preview_asset_cache_logger "Failed to extract assets from $image; skipping cache save"
     rm -f "$PREVIEW_ASSET_CACHE_TARBALL"

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@
 /public/packs
 /public/packs-test
 /public/pages-tailwind.css
+/public/pages-tailwind-manifest.json
+/public/pages/
 /public/vite
 /public/vite-dev
 /public/vite-test

--- a/app/controllers/concerns/renders_custom_html_pages.rb
+++ b/app/controllers/concerns/renders_custom_html_pages.rb
@@ -4,12 +4,20 @@
 # sandboxed, strictly-CSP'd document. Both product landing pages
 # (LinksController) and profile landing pages (UsersController) render the
 # same opaque-origin iframe content, so the CSP, the storage-shim script, and
-# the inlined Tailwind build all live here to stay in lockstep — a drift
+# the shared Tailwind stylesheet all live here to stay in lockstep — a drift
 # between the two surfaces would be a security regression, not a cosmetic one.
 module RendersCustomHtmlPages
   extend ActiveSupport::Concern
 
   PAGE_ASSET_HOSTS = [CDN_S3_PROXY_HOST, PUBLIC_STORAGE_CDN_S3_PROXY_HOST].compact.uniq.join(" ")
+
+  # The kitchen-sink Tailwind build these pages rely on is ~4.9 MB, so it's
+  # served as a fingerprinted file from the shared asset host (the same S3 +
+  # CDN that serves the app's compiled JS/CSS) instead of being inlined into
+  # every response. The host must be allowed in style-src explicitly: this
+  # document's CSP has no 'self' anywhere, so without this entry the
+  # stylesheet <link> would be blocked.
+  PAGES_TAILWIND_ASSET_HOST = "#{PROTOCOL}://#{ASSET_DOMAIN}"
 
   CUSTOM_HTML_CSP = [
     # Sandbox the response itself, not just the wrapper's iframe attribute.
@@ -20,7 +28,7 @@ module RendersCustomHtmlPages
     "sandbox allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox",
     "default-src 'none'",
     "script-src 'unsafe-inline' https://cdn.tailwindcss.com https://cdn.jsdelivr.net https://unpkg.com",
-    "style-src 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com https://fonts.bunny.net",
+    "style-src 'unsafe-inline' #{PAGES_TAILWIND_ASSET_HOST} https://cdn.tailwindcss.com https://fonts.googleapis.com https://fonts.bunny.net",
     "frame-src https://www.youtube-nocookie.com https://www.youtube.com https://player.vimeo.com",
     "img-src data: blob: #{PAGE_ASSET_HOSTS}",
     # Mirror img-src so the <audio>/<video>/<source> tags the sanitizer
@@ -202,7 +210,7 @@ module RendersCustomHtmlPages
             return;
           }
         }
-        // After load so the inlined stylesheet and any seller scripts have laid the page out —
+        // After load so the Tailwind stylesheet and any seller scripts have laid the page out —
         // scrolling earlier would center on coordinates that then shift.
         window.addEventListener("load", function () { requestAnimationFrame(scrollToChange); });
       })();
@@ -224,14 +232,51 @@ module RendersCustomHtmlPages
   HTML
 
   module ClassMethods
-    # Memoized per process — the file ships with the deployed artifact and
-    # only changes on deploy, which restarts the process.
-    def pages_tailwind_inline
-      path = Rails.root.join("public/pages-tailwind.css")
-      return "" unless File.exist?(path)
+    # The <head> markup that loads the shared Tailwind build for custom pages.
+    # Preferred form is a <link> to the fingerprinted copy on the asset host:
+    # the build is ~4.9 MB, and inlining it (the old behavior) made every
+    # custom page, product landing, and agent preview response carry the full
+    # stylesheet on every view. As an immutable fingerprinted asset it
+    # downloads once per browser and that one cached copy serves every
+    # seller's pages.
+    #
+    # Falls back to inlining public/pages-tailwind.css when the manifest is
+    # missing (a checkout that hasn't rerun `npm run build:pages-tailwind`
+    # since fingerprinting was introduced), and renders nothing when no build
+    # exists at all. Memoized per process — both files ship with the deployed
+    # artifact and only change on deploy, which restarts the process.
+    def pages_tailwind_head
+      return @pages_tailwind_head if @pages_tailwind_head
 
-      @pages_tailwind_inline ||= "<style>#{File.read(path)}</style>"
+      if (asset_path = pages_tailwind_asset_path)
+        @pages_tailwind_head = %(<link rel="stylesheet" href="#{PAGES_TAILWIND_ASSET_HOST}/#{asset_path}">)
+      else
+        css_path = Rails.root.join("public/pages-tailwind.css")
+        return "" unless File.exist?(css_path)
+
+        @pages_tailwind_head = "<style>#{File.read(css_path)}</style>"
+      end
     end
+
+    private
+      # The manifest maps the logical stylesheet name to its current
+      # fingerprinted path (e.g. "pages/pages-tailwind-<sha>.css"). Both are
+      # written by scripts/build_pages_tailwind.mjs. The path is only trusted
+      # if it looks like a build output and the file is actually present on
+      # disk — the same tree that gets synced to the asset host — so we never
+      # emit a <link> to a stylesheet that wasn't built.
+      def pages_tailwind_asset_path
+        manifest_path = Rails.root.join("public/pages-tailwind-manifest.json")
+        return nil unless File.exist?(manifest_path)
+
+        asset_path = JSON.parse(File.read(manifest_path))["pages-tailwind.css"]
+        return nil unless asset_path.is_a?(String) && asset_path.match?(%r{\Apages/pages-tailwind-\h+\.css\z})
+        return nil unless File.exist?(Rails.root.join("public", asset_path))
+
+        asset_path
+      rescue JSON::ParserError
+        nil
+      end
   end
 
   private
@@ -378,7 +423,7 @@ module RendersCustomHtmlPages
             <meta name="viewport" content="width=device-width, initial-scale=1">
             #{meta_csp ? %(<meta http-equiv="Content-Security-Policy" content="#{ERB::Util.h(CUSTOM_HTML_META_CSP)}">) : ""}
             #{SANDBOX_COMPAT_SCRIPT}
-            #{self.class.pages_tailwind_inline}
+            #{self.class.pages_tailwind_head}
           </head>
           <body>
             <script id="gumroad-data" type="application/json">#{data_json}</script>

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -978,7 +978,7 @@ class LinksController < ApplicationController
             <meta charset="utf-8">
             <meta name="viewport" content="width=device-width, initial-scale=1">
             #{SANDBOX_COMPAT_SCRIPT}
-            #{self.class.pages_tailwind_inline}
+            #{self.class.pages_tailwind_head}
           </head>
           <body>
             #{custom_html}

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -156,7 +156,7 @@ class PagesController < Sellers::BaseController
           <meta charset="utf-8">
           <meta name="viewport" content="width=device-width, initial-scale=1">
           #{SANDBOX_COMPAT_SCRIPT}
-          #{self.class.pages_tailwind_inline}
+          #{self.class.pages_tailwind_head}
         </head>
         <body>
           #{interpolated}

--- a/app/controllers/user_pages_controller.rb
+++ b/app/controllers/user_pages_controller.rb
@@ -41,7 +41,7 @@ class UserPagesController < ApplicationController
           <meta charset="utf-8">
           <meta name="viewport" content="width=device-width, initial-scale=1">
           #{SANDBOX_COMPAT_SCRIPT}
-          #{self.class.pages_tailwind_inline}
+          #{self.class.pages_tailwind_head}
         </head>
         <body>
           #{interpolated}

--- a/docker/web/push_assets_to_s3.sh
+++ b/docker/web/push_assets_to_s3.sh
@@ -20,6 +20,13 @@ logger "Uploading public/images to S3"
 aws s3 sync /app/public/images s3://${ASSETS_S3_BUCKET}/images --acl public-read --cache-control max-age=300,public
 logger "Done uploading public/images to S3"
 
+# Fingerprinted Tailwind build for custom HTML pages (see
+# scripts/build_pages_tailwind.mjs). Filenames carry a content hash, so they
+# can be cached forever; sync never deletes, so hashes referenced by the
+# previous deploy keep resolving during a rolling deploy.
+logger "Uploading public/pages to S3"
+aws s3 sync /app/public/pages s3://${ASSETS_S3_BUCKET}/pages --acl public-read --cache-control max-age=31536000,immutable
+
 logger "Uploading public/fonts to S3"
 aws s3 sync /app/public/fonts s3://${ASSETS_S3_BUCKET}/fonts --acl public-read --cache-control max-age=31536000,public
 logger "Done uploading public/fonts to S3"

--- a/scripts/build_pages_tailwind.mjs
+++ b/scripts/build_pages_tailwind.mjs
@@ -1,5 +1,6 @@
 import { spawnSync } from "node:child_process";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { copyFileSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -299,3 +300,25 @@ const result = spawnSync(tailwindBin, ["-i", inputPath, "-o", outputPath, "--min
 });
 
 if (result.status !== 0) process.exit(result.status ?? 1);
+
+// The build is ~4.9 MB, so pages link to it as an external stylesheet instead
+// of inlining it into every response. For that link to be cacheable forever
+// (and safe across deploys), publish a copy whose filename carries a content
+// hash, plus a manifest the Rails side reads to know the current filename.
+// public/pages/ is synced to the asset CDN with immutable cache headers at
+// deploy time; public/pages-tailwind.css stays as the un-fingerprinted
+// fallback for checkouts that predate the manifest.
+const css = readFileSync(outputPath);
+const digest = createHash("sha256").update(css).digest("hex").slice(0, 12);
+const fingerprintedDir = resolve(root, "public/pages");
+const fingerprintedName = `pages-tailwind-${digest}.css`;
+// Drop stale hashes locally so the directory only ever holds the current
+// build. The CDN sync doesn't delete, so previously deployed hashes keep
+// resolving for pages served by not-yet-restarted processes during a deploy.
+rmSync(fingerprintedDir, { recursive: true, force: true });
+mkdirSync(fingerprintedDir, { recursive: true });
+copyFileSync(outputPath, resolve(fingerprintedDir, fingerprintedName));
+writeFileSync(
+  resolve(root, "public/pages-tailwind-manifest.json"),
+  `${JSON.stringify({ "pages-tailwind.css": `pages/${fingerprintedName}` })}\n`,
+);

--- a/spec/controllers/links_controller_custom_html_spec.rb
+++ b/spec/controllers/links_controller_custom_html_spec.rb
@@ -181,6 +181,9 @@ describe LinksController, :vcr, type: :controller do
       expect(response.headers["Content-Security-Policy"]).to eq(CUSTOM_HTML_CSP)
       expect(response.headers["Content-Security-Policy"]).to include("sandbox allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox")
       expect(response.headers["Content-Security-Policy"]).to include("frame-src https://www.youtube-nocookie.com https://www.youtube.com https://player.vimeo.com")
+      # The shared Tailwind build loads from the asset host as an external
+      # stylesheet, so style-src must allow it.
+      expect(response.headers["Content-Security-Policy"]).to include("style-src 'unsafe-inline' #{RendersCustomHtmlPages::PAGES_TAILWIND_ASSET_HOST}")
       expect(response.headers["Content-Security-Policy"]).not_to include("allow-same-origin")
       expect(response.headers["Content-Security-Policy"]).not_to include("allow-top-navigation")
       expect(response.headers["X-Frame-Options"]).to eq("SAMEORIGIN")
@@ -247,24 +250,65 @@ describe LinksController, :vcr, type: :controller do
     end
   end
 
-  describe ".pages_tailwind_inline" do
+  describe ".pages_tailwind_head" do
+    let(:manifest_path) { Rails.root.join("public/pages-tailwind-manifest.json") }
+    let(:css_path) { Rails.root.join("public/pages-tailwind.css") }
+    let(:fingerprinted_path) { Rails.root.join("public", "pages/pages-tailwind-0123456789ab.css") }
+
     before do
-      described_class.remove_instance_variable(:@pages_tailwind_inline) if described_class.instance_variable_defined?(:@pages_tailwind_inline)
+      described_class.remove_instance_variable(:@pages_tailwind_head) if described_class.instance_variable_defined?(:@pages_tailwind_head)
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:read).and_call_original
     end
 
     after do
-      described_class.remove_instance_variable(:@pages_tailwind_inline) if described_class.instance_variable_defined?(:@pages_tailwind_inline)
+      described_class.remove_instance_variable(:@pages_tailwind_head) if described_class.instance_variable_defined?(:@pages_tailwind_head)
+    end
+
+    it "links to the fingerprinted stylesheet on the asset host when the manifest and file exist" do
+      allow(File).to receive(:exist?).with(manifest_path).and_return(true)
+      allow(File).to receive(:read).with(manifest_path).and_return({ "pages-tailwind.css" => "pages/pages-tailwind-0123456789ab.css" }.to_json)
+      allow(File).to receive(:exist?).with(fingerprinted_path).and_return(true)
+
+      expect(described_class.pages_tailwind_head).to eq(
+        %(<link rel="stylesheet" href="#{RendersCustomHtmlPages::PAGES_TAILWIND_ASSET_HOST}/pages/pages-tailwind-0123456789ab.css">)
+      )
+    end
+
+    it "falls back to inlining the un-fingerprinted build when the manifest is missing" do
+      allow(File).to receive(:exist?).with(manifest_path).and_return(false)
+      allow(File).to receive(:exist?).with(css_path).and_return(true)
+      allow(File).to receive(:read).with(css_path).and_return(".hero{display:block}")
+
+      expect(described_class.pages_tailwind_head).to eq("<style>.hero{display:block}</style>")
+    end
+
+    it "falls back to inlining when the manifest points at a file that is not on disk" do
+      allow(File).to receive(:exist?).with(manifest_path).and_return(true)
+      allow(File).to receive(:read).with(manifest_path).and_return({ "pages-tailwind.css" => "pages/pages-tailwind-0123456789ab.css" }.to_json)
+      allow(File).to receive(:exist?).with(fingerprinted_path).and_return(false)
+      allow(File).to receive(:exist?).with(css_path).and_return(true)
+      allow(File).to receive(:read).with(css_path).and_return(".hero{display:block}")
+
+      expect(described_class.pages_tailwind_head).to eq("<style>.hero{display:block}</style>")
+    end
+
+    it "ignores a manifest entry that does not look like a build output" do
+      allow(File).to receive(:exist?).with(manifest_path).and_return(true)
+      allow(File).to receive(:read).with(manifest_path).and_return({ "pages-tailwind.css" => "../../etc/passwd" }.to_json)
+      allow(File).to receive(:exist?).with(css_path).and_return(true)
+      allow(File).to receive(:read).with(css_path).and_return(".hero{display:block}")
+
+      expect(described_class.pages_tailwind_head).to eq("<style>.hero{display:block}</style>")
     end
 
     it "does not memoize a missing Tailwind build artifact" do
-      path = Rails.root.join("public/pages-tailwind.css")
-      allow(File).to receive(:exist?).and_call_original
-      allow(File).to receive(:read).and_call_original
-      allow(File).to receive(:exist?).with(path).and_return(false, true)
-      allow(File).to receive(:read).with(path).and_return(".hero{display:block}")
+      allow(File).to receive(:exist?).with(manifest_path).and_return(false)
+      allow(File).to receive(:exist?).with(css_path).and_return(false, true)
+      allow(File).to receive(:read).with(css_path).and_return(".hero{display:block}")
 
-      expect(described_class.pages_tailwind_inline).to eq("")
-      expect(described_class.pages_tailwind_inline).to eq("<style>.hero{display:block}</style>")
+      expect(described_class.pages_tailwind_head).to eq("")
+      expect(described_class.pages_tailwind_head).to eq("<style>.hero{display:block}</style>")
     end
   end
 


### PR DESCRIPTION
## What

Every custom HTML page and preview response inlined the shared Tailwind build (~4.9 MB) into its document head, so each page view shipped a ~4.9 MB HTML document that browsers could never cache.

The build script now writes `public/pages/pages-tailwind-<hash>.css` plus a manifest, the deploy syncs that directory to the assets bucket with immutable cache headers, and the document head links to it (allowed by the page CSP). The HTML drops to a few KB and one cached copy of the stylesheet serves every seller's pages. When the manifest is absent, the inline behavior remains as a fallback.

## Why

The stylesheet only changes on deploy, so inlining it paid its full cost on every view: ~257 KB compressed per page view, 4.9 MB origin egress per request, and a 4.9 MB response string built in Ruby each time. A content-hashed file on the existing assets CDN downloads once per browser. Purging or trimming the build was rejected because pages are arbitrary seller/AI-authored HTML — a purge can't know which classes future pages will use, and trimming risks breaking published pages.

---

This PR was implemented with AI assistance using Claude Fable 5.

Prompts used:

- Verify that custom HTML pages and agent previews inline the ~4.9 MB pages-tailwind build, measure the real payload against production, and propose a fix (external cacheable asset or purged build)
- "run /autoreview and push the branch"