### PR TITLE
Document the content_moderation flag as a deliberate kill switch

### DIFF
--- a/app/services/content_moderation/moderate_record_service.rb
+++ b/app/services/content_moderation/moderate_record_service.rb
@@ -107,6 +107,11 @@ class ContentModeration::ModerateRecordService
     attr_reader :record, :entity_type
 
     def moderation_enabled?
+      # The :content_moderation flag is fully enabled in production and is kept ONLY as an
+      # operational kill switch (disable it to turn off automated moderation globally, e.g. if the
+      # classifier misbehaves). It was deliberately excluded from the rollout-flag cleanup in
+      # gumroad-private#1208 and should be removed once we're confident we never need to disable
+      # moderation globally. Do not treat it as a rollout gate.
       Feature.active?(:content_moderation)
     end
 

--- a/app/services/create_public_media_service.rb
+++ b/app/services/create_public_media_service.rb
@@ -256,6 +256,9 @@ class CreatePublicMediaService
     # by the caller's ensure-style cleanup, so it never gets a stable, discoverable public_id.
     # Mirrors ModerateRecordService: feature-flagged, verified sellers exempt, blocklist first.
     def moderation_error_for(blob, content_type)
+      # :content_moderation is fully enabled in production; the flag survives only as a global
+      # kill switch for automated moderation (see ModerateRecordService#moderation_enabled? and
+      # gumroad-private#1208). Remove this check once the kill switch is retired.
       return nil unless Feature.active?(:content_moderation)
       return nil if seller&.verified?
 


### PR DESCRIPTION
## What

Adds explanatory comments at both `Feature.active?(:content_moderation)` call sites (`ContentModeration::ModerateRecordService#moderation_enabled?` and `CreatePublicMediaService#moderation_error_for`) documenting that the flag is deliberately kept as a global kill switch for automated moderation, not a stale rollout gate.

## Why

The rollout-flag audit ([gumroad-private#1208](https://github.com/antiwork/gumroad-private/issues/1208)) is removing flags that are 100% enabled and stable in production. `content_moderation` matches that profile but is intentionally excluded — it acts as an operational kill switch (disable it globally if the classifier misbehaves). Without a comment, the next cleanup pass would flag it for removal again. The comments also mark themselves for deletion together with the flag once the kill switch is retired.

Comment-only change — no behavior change, no UI surface.

## QA steps

Docs-only — the diff is the reviewable artifact (Ruby comment lines only, zero executable changes). Both files pass RuboCop.

## Test results

- `rubocop app/services/content_moderation/moderate_record_service.rb app/services/create_public_media_service.rb` — 2 files inspected, no offenses detected.
- No spec run needed: zero executable lines changed.

Part of gumroad-private#1208.

---

## AI disclosure

Authored with AI assistance (Claude Fable 5 via Hermes Agent), acting on the direction to keep `content_moderation` as a kill switch and document that decision in code.
