### PR TITLE
docs: note aggregated bundled-product ratings on bundle pages

### DIFF
--- a/app/views/help_center/articles/contents/_339-product-bundles.html.erb
+++ b/app/views/help_center/articles/contents/_339-product-bundles.html.erb
@@ -48,6 +48,7 @@
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/6589a7df25778b0d0faef350/file-Qrs0qewLCn.png" %></figure>
   <h3 id="Checkout-DUhSH">Checkout</h3>
   <p>Customers who purchase your bundle will see a list of the individual products included within. On the product page, the price will show the cumulative value of every product in the bundle crossed out with the new price shown next to it.</p>
+  <p><i>Note:</i> Customers can only <a href="222-product-ratings-on-gumroad">rate and review</a> the individual products inside a bundle, not the bundle itself. The bundle's product page automatically shows a rating aggregated from the reviews of the products it contains. Products with ratings hidden are not included in this aggregate.</p>
   <p>On the checkout page, customers will once again find a list of everything they will receive inside the bundle.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/6589a58bdcdba22513abb141/file-jsLiTIsQef.png" %></figure>
   <h3 id="Customer-drawer-Lijr-">Customer drawer</h3>


### PR DESCRIPTION
## What

Adds a note to the "Product bundles" help-center article (`_339-product-bundles.html.erb`, Checkout section) explaining that buyers rate the individual products inside a bundle — not the bundle itself — and that the bundle's product page shows a rating aggregated from the bundled products' reviews, excluding products with ratings hidden.

## Why

Triggered by merged PR #6074, which made bundle product pages show a ratings summary aggregated from the bundled products' review stats. The bundles article said nothing about ratings, so it now under-describes visible behavior. One additive sentence keeps it accurate; `articles.yml` untouched (body-only edit).

Claims verified against the shipped code (`Product::ReviewStat#bundle_rating_stats`):
- aggregation covers alive bundled products only
- children with reviews hidden are skipped (`display_product_reviews?` guard)
- bundle wrapper purchases are excluded from reviews by design (`Purchase::Reviews` — `not_is_bundle_purchase`), so "customers can only rate the individual products" is exact

## Before / After

Docs-only — diff is the reviewable artifact (single additive sentence in one help-center article body).

## Test plan

- Rendered the partial via `ApplicationController.render` in the test env — new copy present, 6085 bytes, all tag pairs balanced (div/p/ul/li/ol/h3/figure/a).
- CI runs the help-center specs (slug ↔ partial integrity unaffected — body-only change).

## QA steps

1. Open help.gumroad.com/help/article/339-product-bundles
2. Scroll to the "Checkout" section — the note about aggregated bundled-product ratings appears after the price paragraph, linking to the product-ratings article.

---

AI disclosure: authored by Claude Fable 5 (Hermes agent) as part of the automated merged-PR → help-center doc sync, triggered by the merge of #6074.
