### PR TITLE
Recover the store agent chat from silently stalled SSE streams

### DIFF
--- a/app/controllers/api/internal/agent_message_streams_controller.rb
+++ b/app/controllers/api/internal/agent_message_streams_controller.rb
@@ -23,6 +23,17 @@ class Api::Internal::AgentMessageStreamsController < Api::Internal::BaseControll
   AGENT_REQUESTS_PERIOD_WINDOW = 1.hour
   private_constant :AGENT_REQUESTS_PER_PERIOD, :AGENT_REQUESTS_PERIOD_WINDOW
 
+  # How often to write an SSE keepalive comment while the turn is being generated. Real events can
+  # be minutes apart: tool-use iterations (up to Ai::StoreAgentService::MAX_TOOL_ITERATIONS of
+  # them) write nothing to the stream — the model's tool JSON and the tool execution all happen
+  # server-side — and the model client tolerates up to 120 seconds of silence between chunks. Each
+  # heartbeat does two jobs: the comment bytes tell the client the connection is alive (its stall
+  # detector treats a long-silent stream as a dead connection and gives up on it), and the
+  # in-progress marker refresh keeps a recovering client told the truth. 15s leaves a wide margin
+  # against both the client's stall threshold and the marker's TTL.
+  STREAM_HEARTBEAT_INTERVAL = 15.seconds
+  private_constant :STREAM_HEARTBEAT_INTERVAL
+
   # POST /internal/agent/messages/stream
   # params: { messages: [{ role:, content: }, ...], conversation_id: <optional external id>,
   #           client_turn_id: <optional client-generated id for this turn> }
@@ -46,12 +57,23 @@ class Api::Internal::AgentMessageStreamsController < Api::Internal::BaseControll
     response.headers["X-Accel-Buffering"] = "no"
     sse = ActionController::Live::SSE.new(response.stream)
     client_turn_id = agent_client_turn_id
+    # The heartbeat thread below writes to the stream alongside this request thread, and SSE
+    # frames must never interleave mid-frame — every stream write goes through this lock.
+    write_lock = Mutex.new
+    write_event = ->(payload, event) { write_lock.synchronize { sse.write(payload, event:) } }
+    # Commit the response headers right away with an SSE comment (":"-prefixed lines are ignored
+    # by SSE parsers). ActionController::Live holds headers back until the first stream write, and
+    # on a turn that opens with silent tool work the first real event can be minutes away — until
+    # the client sees the response begin it can't tell a working turn from a dead connection.
+    write_lock.synchronize { response.stream.write(": connected\n\n") }
+    heartbeat = nil
+    stop_heartbeat = Thread::Queue.new
 
     begin
       messages = sanitize_messages(params[:messages])
       if messages.empty?
         mark_agent_turn_failed!(client_turn_id)
-        sse.write({ message: "A message is required." }, event: "error")
+        write_event.call({ message: "A message is required." }, "error")
         return
       end
 
@@ -61,15 +83,47 @@ class Api::Internal::AgentMessageStreamsController < Api::Internal::BaseControll
         conversation = find_agent_conversation!
       rescue ActiveRecord::RecordNotFound
         mark_agent_turn_failed!(client_turn_id)
-        sse.write({ message: "That conversation could not be found." }, event: "error")
+        write_event.call({ message: "That conversation could not be found." }, "error")
         return
       end
 
       # From here the turn is genuinely in flight. Arm the liveness marker so a client whose
       # connection breaks can distinguish "still generating — keep waiting" from "gone". It's
-      # re-armed on every stream write below, keeping it alive across the model's silent stretches
-      # (the model client tolerates up to 120s between chunks, well under the marker's TTL).
+      # re-armed on every stream write below and by the heartbeat, keeping it alive across the
+      # turn's silent stretches (tool-use iterations write nothing to the stream, and the model
+      # client tolerates up to 120s between chunks).
       mark_agent_turn_in_progress!(client_turn_id)
+
+      # Keepalive writer for the silent stretches. Queue#pop with a timeout doubles as an
+      # interruptible sleep: it returns nil each interval until the ensure below pushes the stop
+      # signal, so shutdown is immediate rather than waiting out a sleep.
+      heartbeat = Thread.new do
+        socket_alive = true
+        until stop_heartbeat.pop(timeout: STREAM_HEARTBEAT_INTERVAL.to_f)
+          # The marker refresh must outlive the socket: the request thread keeps generating after
+          # a client disconnect (silent tool iterations write nothing, so nothing raises) and can
+          # legitimately persist the turn minutes later — and a recovering client is told
+          # "in_progress" only while this marker lives. So refresh unconditionally, and only skip
+          # the socket write once the client is known to be gone. A Redis blip must not kill the
+          # heartbeat either — the socket comment below is what keeps the client's stall detector
+          # fed — so refresh failures are logged and retried on the next tick.
+          begin
+            refresh_agent_turn_in_progress!(client_turn_id)
+          rescue => e
+            Rails.logger.error("Store agent heartbeat marker refresh failed: #{e.message}")
+          end
+          next unless socket_alive
+
+          begin
+            write_lock.synchronize { response.stream.write(": heartbeat\n\n") }
+          rescue IOError, ActionController::Live::ClientDisconnected
+            # The client is gone — stop writing to the dead socket, but keep the marker refreshes
+            # going. The request thread's own next write surfaces the disconnect through its
+            # existing handling.
+            socket_alive = false
+          end
+        end
+      end
 
       # The last user entry in the posted history is this turn's new message; when resuming, the
       # earlier entries are replaced by the stored transcript so a stale client can't rewrite
@@ -111,7 +165,7 @@ class Api::Internal::AgentMessageStreamsController < Api::Internal::BaseControll
         # Each write proves the turn is still alive — refresh the marker so long multi-tool turns
         # never read as dead to a recovering client.
         mark_agent_turn_in_progress!(client_turn_id)
-        sse.write(payload, event:)
+        write_event.call(payload, event)
       end
       # conversation_id is omitted entirely (not null) when creating the conversation itself
       # failed above — the client validates this frame against a schema where conversation_id
@@ -125,10 +179,10 @@ class Api::Internal::AgentMessageStreamsController < Api::Internal::BaseControll
         suggestions: result[:suggestions] || [],
       }
       done_payload[:conversation_id] = conversation.external_id if conversation
-      sse.write(done_payload, event: "done")
+      write_event.call(done_payload, "done")
     rescue ::Ai::StoreAgentService::Error => e
       mark_agent_turn_failed!(client_turn_id) unless turn_persisted
-      sse.write({ message: e.message }, event: "error")
+      write_event.call({ message: e.message }, "error")
     rescue ActionController::Live::ClientDisconnected
       # The seller navigated away or closed the tab mid-stream. Nothing to surface on the dead
       # socket. If this raised before the turn persisted (a token write failed mid-generation, so
@@ -140,8 +194,16 @@ class Api::Internal::AgentMessageStreamsController < Api::Internal::BaseControll
       mark_agent_turn_failed!(client_turn_id) unless turn_persisted
       Rails.logger.error("Store agent stream failed: #{e.full_message}")
       ErrorNotifier.notify(e)
-      sse.write({ message: "Something went wrong. Please try again." }, event: "error")
+      write_event.call({ message: "Something went wrong. Please try again." }, "error")
     ensure
+      # Stop the heartbeat before closing the stream so it can't write to (or refresh the marker
+      # for) a turn that has already ended. The failure paths above run first, so a "failed"
+      # marker is in place before the heartbeat's last value check — and its refresh only extends
+      # markers still reading "in_progress", never a recorded outcome.
+      if heartbeat
+        stop_heartbeat << true
+        heartbeat.join
+      end
       sse.close
     end
   end

--- a/app/controllers/api/internal/agent_message_streams_controller.rb
+++ b/app/controllers/api/internal/agent_message_streams_controller.rb
@@ -116,10 +116,12 @@ class Api::Internal::AgentMessageStreamsController < Api::Internal::BaseControll
 
           begin
             write_lock.synchronize { response.stream.write(": heartbeat\n\n") }
-          rescue IOError, ActionController::Live::ClientDisconnected
+          rescue IOError, SystemCallError, ActionController::Live::ClientDisconnected
             # The client is gone — stop writing to the dead socket, but keep the marker refreshes
             # going. The request thread's own next write surfaces the disconnect through its
-            # existing handling.
+            # existing handling. SystemCallError is included because a dead socket can surface as
+            # Errno::EPIPE / Errno::ECONNRESET rather than the wrapped ClientDisconnected, and an
+            # uncaught error here would kill the whole heartbeat thread, refreshes included.
             socket_alive = false
           end
         end

--- a/app/controllers/concerns/agent_conversation_persistence.rb
+++ b/app/controllers/concerns/agent_conversation_persistence.rb
@@ -26,11 +26,12 @@ module AgentConversationPersistence
   # validated so arbitrary client strings don't end up in Redis keys or stored metadata.
   CLIENT_TURN_ID_FORMAT = /\A[0-9a-fA-F-]{1,64}\z/
   # TTL of the Redis "this turn is being generated right now" marker. The marker is re-armed on
-  # every stream write, and the model client tolerates up to 120 seconds of silence between chunks
-  # (Ai::StoreAgentService::REQUEST_TIMEOUT_IN_SECONDS) — so the TTL must comfortably outlast that
-  # silence plus the trailing persistence + follow-up-suggestions work. If the marker expires it
-  # means the server stopped working on the turn without recording an outcome (the process died),
-  # and a recovering client should stop waiting.
+  # every stream write and by the streaming controller's periodic heartbeat (which covers the long
+  # silent stretches: tool-use iterations write nothing to the stream, and the model client
+  # tolerates up to 120 seconds of silence between chunks —
+  # Ai::StoreAgentService::REQUEST_TIMEOUT_IN_SECONDS). The TTL must comfortably outlast the
+  # heartbeat interval. If the marker expires it means the server stopped working on the turn
+  # without recording an outcome (the process died), and a recovering client should stop waiting.
   AGENT_TURN_IN_PROGRESS_TTL = 180.seconds
   # TTL of the Redis "this turn failed / will never persist" marker. Only needs to outlive a
   # recovering client's polling window; it exists so the client can stop waiting immediately
@@ -149,6 +150,29 @@ module AgentConversationPersistence
       return if client_turn_id.blank?
 
       $redis.set(RedisKey.agent_turn_status(current_seller.id, client_turn_id), "failed", ex: AGENT_TURN_FAILED_TTL.to_i)
+    end
+
+    # Re-arm the in-progress marker's TTL without changing what it says. Used by the streaming
+    # controller's heartbeat, which fires on a timer and can race the failure paths — a plain SET
+    # there could resurrect "in_progress" moments after the turn was marked failed, leaving a
+    # recovering client polling a verdict the server already reached. Only an existing
+    # "in_progress" marker is extended; a "failed" marker (or an already-expired one) is left
+    # untouched. The check and the extend run as one Lua script because they race the request
+    # thread: done separately, a "failed" written between them would get the (much shorter)
+    # in-progress TTL applied to it, cutting the failure marker's lifetime.
+    AGENT_TURN_REFRESH_IF_IN_PROGRESS_SCRIPT = <<~LUA.squish
+      if redis.call("get", KEYS[1]) == ARGV[1] then
+        return redis.call("expire", KEYS[1], ARGV[2])
+      else
+        return 0
+      end
+    LUA
+
+    def refresh_agent_turn_in_progress!(client_turn_id)
+      return if client_turn_id.blank?
+
+      key = RedisKey.agent_turn_status(current_seller.id, client_turn_id)
+      $redis.eval(AGENT_TURN_REFRESH_IF_IN_PROGRESS_SCRIPT, keys: [key], argv: ["in_progress", AGENT_TURN_IN_PROGRESS_TTL.to_i])
     end
 
     def agent_turn_marker(client_turn_id)

--- a/app/javascript/components/Agent/AgentChat.test.tsx
+++ b/app/javascript/components/Agent/AgentChat.test.tsx
@@ -43,6 +43,13 @@ const sentClientTurnId = () => {
   return call?.[3];
 };
 
+// The abort signal streamAgentMessage was called with. Aborting it is how the chat releases a
+// connection the stream's stall timeout abandoned — allowed only once the turn's fate is known.
+const sentAbortSignal = () => {
+  const call = streamAgentMessage.mock.calls[streamAgentMessage.mock.calls.length - 1];
+  return call?.[4];
+};
+
 const interruptedStream = () =>
   streamAgentMessage.mockImplementation(async (_messages, handlers = {}) => {
     handlers.onToken?.("Your bio currently has thr");
@@ -107,6 +114,7 @@ describe("AgentChat streamed reply reconciliation", () => {
         expect.anything(),
         "conv1",
         expect.any(String),
+        expect.any(AbortSignal),
       ),
     );
   });
@@ -135,6 +143,8 @@ describe("AgentChat streamed reply reconciliation", () => {
     // the "stale proposal from a previous session" dismissed state hydration uses.
     expect(screen.getByText("Confirm")).toBeTruthy();
     expect(screen.getByText("Dismiss")).toBeTruthy();
+    // The turn is recovered — terminal — so the abandoned connection is released.
+    expect(sentAbortSignal()?.aborted).toBe(true);
   });
 
   it("keeps polling while the server reports the turn in progress, then recovers it", async () => {
@@ -181,6 +191,8 @@ describe("AgentChat streamed reply reconciliation", () => {
     expect(fetchAgentTurnStatus).toHaveBeenCalledTimes(1);
     // The partial text that did stream is kept, exactly as before.
     expect(screen.getByText("Your bio currently has thr")).toBeTruthy();
+    // "failed" is a server verdict, so any connection the stall timeout abandoned is released.
+    expect(sentAbortSignal()?.aborted).toBe(true);
   });
 
   it("gives up after consecutive unknown statuses when the turn was never persisted", async () => {
@@ -200,6 +212,31 @@ describe("AgentChat streamed reply reconciliation", () => {
 
       expect(showAlert).toHaveBeenCalled();
       expect(fetchAgentTurnStatus).toHaveBeenCalledTimes(2);
+      expect(screen.getByText("Your bio currently has thr")).toBeTruthy();
+      // "unknown" is a give-up, not a server verdict — the turn may still be generating, so the
+      // abandoned connection must NOT be aborted yet (that could kill a turn that would yet
+      // persist).
+      expect(sentAbortSignal()?.aborted).toBe(false);
+
+      // The background watch takes over the cleanup, but "unknown" is still not a verdict — after
+      // its first slow poll the connection must remain untouched.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(15_000);
+      });
+      expect(sentAbortSignal()?.aborted).toBe(false);
+
+      // Once the server records a verdict (the turn persisted after all), the watch releases the
+      // connection — without adopting the late turn into the chat, which has moved on.
+      fetchAgentTurnStatus.mockResolvedValue({
+        status: "persisted",
+        conversation_id: "conv1",
+        message: { role: "assistant", content: PERSISTED_REPLY },
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(15_000);
+      });
+      expect(sentAbortSignal()?.aborted).toBe(true);
+      expect(screen.queryByText(PERSISTED_REPLY)).toBeNull();
       expect(screen.getByText("Your bio currently has thr")).toBeTruthy();
     } finally {
       vi.useRealTimers();

--- a/app/javascript/components/Agent/AgentChat.tsx
+++ b/app/javascript/components/Agent/AgentChat.tsx
@@ -33,7 +33,7 @@ const STICK_TO_BOTTOM_THRESHOLD_PX = 200;
 // After a stream breaks, how often to ask the server what became of the turn (identified by the
 // client-generated turn id sent with the stream request), and how long to keep asking. The server
 // tracks the turn's liveness while generating (its model client tolerates up to 120 seconds of
-// silence between chunks, across up to 5 tool iterations), so recovery keeps polling as long as
+// silence between chunks, across up to 25 tool iterations), so recovery keeps polling as long as
 // the server says "in_progress" — a fixed short deadline would abandon turns the server goes on
 // to finish. The hard cap only guards against a marker that never resolves.
 const TURN_RECOVERY_POLL_INTERVAL_MS = 3000;
@@ -45,6 +45,54 @@ const TURN_RECOVERY_MAX_CONSECUTIVE_UNKNOWNS = 2;
 // Consecutive failed status fetches tolerated before giving up — the same flaky network that
 // broke the stream may still be down, so this is more generous than the unknown allowance.
 const TURN_RECOVERY_MAX_CONSECUTIVE_FETCH_FAILURES = 10;
+// When recovery gives up without a server verdict ("inconclusive"), the stream's connection is
+// deliberately left open — the turn may still be generating, and aborting would kill it. These
+// pace the background watch that keeps checking the turn's fate (more slowly than recovery)
+// purely to release that connection once a verdict makes dropping it safe, so abandoned
+// connections don't accumulate for the life of the page.
+const ABANDONED_TURN_WATCH_INTERVAL_MS = 15_000;
+const ABANDONED_TURN_WATCH_MAX_POLLS = 60;
+const ABANDONED_TURN_WATCH_MAX_CONSECUTIVE_UNKNOWNS = 2;
+
+// Cleanup-only watcher for a turn whose recovery ended inconclusively. It never touches the chat
+// — adopting a turn this late would race whatever the seller did next — its only job is to abort
+// the abandoned stream connection once the server records a verdict ("persisted"/"failed"),
+// which is the only evidence that makes the abort safe. When the watch stops WITHOUT a verdict
+// (persistent unknowns, or the poll cap with the turn still in progress) it deliberately does
+// not abort: "unknown" almost always means the server died — and then its end of the socket is
+// already closed, so the browser reclaims the connection without our help — but a server build
+// without heartbeat refreshes can look identical while still generating, and an abort would kill
+// that turn. The remaining truly-held connection (a turn alive past the cap) is bounded by the
+// page's lifetime.
+const watchAbandonedTurn = async (clientTurnId: string, streamAbort: AbortController): Promise<void> => {
+  let consecutiveUnknowns = 0;
+  for (let poll = 0; poll < ABANDONED_TURN_WATCH_MAX_POLLS; poll++) {
+    await new Promise((resolve) => setTimeout(resolve, ABANDONED_TURN_WATCH_INTERVAL_MS));
+    let turn: AgentTurnStatus;
+    try {
+      turn = await fetchAgentTurnStatus(clientTurnId);
+    } catch {
+      // The network may still be down — keep watching until the cap.
+      continue;
+    }
+    switch (turn.status) {
+      case "persisted":
+      case "failed":
+        // Terminal: the turn's outcome is recorded, so dropping the connection can't hurt it.
+        streamAbort.abort();
+        return;
+      case "in_progress":
+        consecutiveUnknowns = 0;
+        continue;
+      case "unknown":
+        // No record, no liveness marker: nothing left to wait for — but not a verdict either,
+        // so stop watching without aborting (see the comment above).
+        consecutiveUnknowns += 1;
+        if (consecutiveUnknowns >= ABANDONED_TURN_WATCH_MAX_CONSECUTIVE_UNKNOWNS) return;
+        continue;
+    }
+  }
+};
 
 // A UUID v4 for tagging a streamed turn. `crypto.randomUUID` only exists in secure contexts
 // (HTTPS or localhost), and the app also runs on plain-HTTP origins (system tests, local dev on
@@ -445,9 +493,18 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
   // as the server reports the turn in progress: the server allows long silent stretches between
   // model chunks, so a completed reply can persist well after the stream broke. When the turn is
   // recovered, replaces the partially-rendered assistant message with the persisted one (including
-  // its proposed-action card and object cards) and adopts the conversation id. Returns whether the
-  // turn was recovered; when it wasn't, the caller falls back to the normal error handling.
-  const recoverInterruptedTurn = async (clientTurnId: string, assistantIndex: number): Promise<boolean> => {
+  // its proposed-action card and object cards) and adopts the conversation id.
+  //
+  // The outcome distinguishes how sure we are, because the caller acts on it twice over:
+  //   recovered    -> the persisted turn was adopted; nothing to surface
+  //   failed       -> the server's own verdict: this turn will never persist
+  //   inconclusive -> recovery gave up (unknowns, fetch failures, poll cap) without a server
+  //                   verdict — the turn MAY still be generating
+  // For anything but "recovered" the caller falls back to the normal error handling; but only a
+  // terminal outcome ("recovered"/"failed") makes it safe to tear down the abandoned stream
+  // connection — after "inconclusive", an abort could kill a turn that is still being generated.
+  type RecoveryOutcome = "recovered" | "failed" | "inconclusive";
+  const recoverInterruptedTurn = async (clientTurnId: string, assistantIndex: number): Promise<RecoveryOutcome> => {
     const adopt = (turn: Extract<AgentTurnStatus, { status: "persisted" }>) => {
       setMessages((prev) => {
         const next = [...prev];
@@ -473,31 +530,32 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
         // The same flaky network that broke the stream may fail this fetch too — keep trying for
         // a while before concluding anything.
         consecutiveFetchFailures += 1;
-        if (consecutiveFetchFailures >= TURN_RECOVERY_MAX_CONSECUTIVE_FETCH_FAILURES) return false;
+        if (consecutiveFetchFailures >= TURN_RECOVERY_MAX_CONSECUTIVE_FETCH_FAILURES) return "inconclusive";
         continue;
       }
       consecutiveFetchFailures = 0;
       switch (turn.status) {
         case "persisted":
           adopt(turn);
-          return true;
+          return "recovered";
         case "failed":
           // The server's verdict: this turn errored and will never persist. Stop immediately.
-          return false;
+          return "failed";
         case "in_progress":
           // The server is still generating — keep waiting, however long it takes; its own
           // liveness marker (not a client-side deadline) decides when the turn is dead.
           consecutiveUnknowns = 0;
           continue;
         case "unknown":
-          // No stored turn and no liveness marker. Conclusive unless it's a transient blip, so
-          // allow a couple of confirming looks before giving up.
+          // No stored turn and no liveness marker. Normally conclusive, but a Redis blip (or a
+          // server build without heartbeat refreshes) can produce it spuriously — so give up on
+          // waiting, but don't report it as a server verdict.
           consecutiveUnknowns += 1;
-          if (consecutiveUnknowns >= TURN_RECOVERY_MAX_CONSECUTIVE_UNKNOWNS) return false;
+          if (consecutiveUnknowns >= TURN_RECOVERY_MAX_CONSECUTIVE_UNKNOWNS) return "inconclusive";
           continue;
       }
     }
-    return false;
+    return "inconclusive";
   };
 
   const send = async (text: string) => {
@@ -553,6 +611,16 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
         return next;
       });
 
+    // Handle for tearing down the stream's connection once the turn's fate is known. It matters
+    // for the stalled-connection case: the stream's inactivity timeout abandons (rather than
+    // cancels) a read that will never resolve, leaving the connection held open — abandoning is
+    // deliberate, since cancelling a connection the server is still writing to would abort and
+    // fail a healthy turn. The abort below fires only on a terminal outcome (the stream resolved
+    // or errored, or recovery reached a server verdict); after an inconclusive recovery the
+    // connection is left alone, because the server may still be generating on it.
+    const streamAbort = new AbortController();
+    let turnSettled = false;
+
     const handlers: AgentStreamHandlers = {
       onToken: (chunk) => {
         setIsStreaming(true);
@@ -571,7 +639,14 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
     };
 
     try {
-      const result = await streamAgentMessage(history, handlers, conversationIdRef.current, clientTurnId);
+      const result = await streamAgentMessage(
+        history,
+        handlers,
+        conversationIdRef.current,
+        clientTurnId,
+        streamAbort.signal,
+      );
+      turnSettled = true;
       if (result.conversationId) setConversationId(result.conversationId);
       // Reconcile with the final assembled turn. Upsert (not map) so a turn that produced no token —
       // e.g. the model staged a write and returned an empty reply — still lands its card/objects.
@@ -594,9 +669,20 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
       // without noticing the client stopped receiving — so the truncated text on screen
       // misrepresents a reply that exists (or will exist) in full server-side. Recover this exact
       // turn by its id before treating this as a failure. Server-reported errors (`error` events)
-      // skip this: those turns were never saved.
-      const recovered =
-        e instanceof AgentStreamInterruptedError && (await recoverInterruptedTurn(clientTurnId, assistantIndex));
+      // skip this: those turns were never saved, and the server already closed the stream, so the
+      // turn counts as settled.
+      let recovered = false;
+      if (e instanceof AgentStreamInterruptedError) {
+        const outcome = await recoverInterruptedTurn(clientTurnId, assistantIndex);
+        recovered = outcome === "recovered";
+        turnSettled = outcome !== "inconclusive";
+        // Recovery couldn't tell what became of the turn, so the `finally` below leaves its
+        // connection open (aborting could kill a turn still being generated). Hand the cleanup to
+        // the background watch, which releases the connection once the turn's fate is known.
+        if (!turnSettled) void watchAbandonedTurn(clientTurnId, streamAbort);
+      } else {
+        turnSettled = true;
+      }
       if (!recovered) {
         showAlert(e instanceof Error && e.message ? e.message : "Something went wrong. Please try again.", "error");
         setMessages((prev) => {
@@ -609,6 +695,13 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
         });
       }
     } finally {
+      // Tear down whatever the stall timeout abandoned only when the turn's fate is known —
+      // completed, recovered, or a server "failed" verdict. On a cleanly finished stream this is
+      // a no-op; on a stalled one it releases the held connection. After an inconclusive recovery
+      // the connection is deliberately left open: the server may still be generating on it, and
+      // an abort would raise ClientDisconnected there and kill a turn that could yet persist —
+      // the background watch started above releases it later instead.
+      if (turnSettled) streamAbort.abort();
       setIsSending(false);
       setIsStreaming(false);
     }

--- a/app/javascript/data/agent.test.ts
+++ b/app/javascript/data/agent.test.ts
@@ -33,13 +33,37 @@ const sseResponse = (chunks: string[], { fail = false } = {}) => {
   return new Response(body, { headers: { "content-type": "text/event-stream" } });
 };
 
+// A Response whose body stays open under manual control: chunks are pushed (and the stream closed)
+// via the returned controller. Models a connection that goes silent or never delivers its EOF.
+const openSseResponse = () => {
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  const body = new ReadableStream<Uint8Array>({
+    start(c) {
+      controller = c;
+    },
+  });
+  const encoder = new TextEncoder();
+  return {
+    response: new Response(body, { headers: { "content-type": "text/event-stream" } }),
+    push: (chunk: string) => controller.enqueue(encoder.encode(chunk)),
+    close: () => controller.close(),
+    // Rejects any pending read, the way aborting the underlying fetch does.
+    error: (reason: unknown) => controller.error(reason),
+  };
+};
+
 const frame = (event: string, data: object) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
 
 const MESSAGES = [{ role: "user" as const, content: "hello" }];
 
+// Mirrors STREAM_INACTIVITY_TIMEOUT_MS in $app/data/agent — how long the stream may stay silent
+// before the client treats the connection as dead.
+const INACTIVITY_TIMEOUT_MS = 130_000;
+
 describe("streamAgentMessage", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   it("yields tokens as they arrive and resolves with the done frame's assembled turn", async () => {
@@ -90,6 +114,108 @@ describe("streamAgentMessage", () => {
 
     const result = await streamAgentMessage(MESSAGES);
     expect(result.reply).toBe("Want me to pull up?");
+  });
+
+  it("throws AgentStreamInterruptedError when the stream goes silent without a done frame", async () => {
+    // The bug this guards against: the server finishes the turn (200 OK logged), but the client
+    // never receives the trailing frames OR the connection close — reader.read() just stays
+    // pending. The inactivity timeout must surface that as an interruption so the caller enters
+    // turn-status recovery instead of hanging with the composer locked.
+    vi.useFakeTimers();
+    const stream = openSseResponse();
+    request.mockResolvedValue(stream.response);
+    const onToken = vi.fn<(text: string) => void>();
+
+    const promise = streamAgentMessage(MESSAGES, { onToken });
+    const expectation = expect(promise).rejects.toBeInstanceOf(AgentStreamInterruptedError);
+    stream.push(frame("token", { text: "Want me to " }));
+    await vi.advanceTimersByTimeAsync(INACTIVITY_TIMEOUT_MS);
+    await expectation;
+    expect(onToken).toHaveBeenCalledWith("Want me to ");
+  });
+
+  it("throws AgentStreamInterruptedError when the connection stalls before response headers arrive", async () => {
+    // The server holds response headers until its first stream write, so a connection that dies
+    // before that leaves the fetch itself pending forever — the inactivity clock must cover the
+    // pre-header phase too, not just body reads.
+    vi.useFakeTimers();
+    request.mockReturnValue(new Promise<never>(() => {}));
+
+    const promise = streamAgentMessage(MESSAGES);
+    const expectation = expect(promise).rejects.toBeInstanceOf(AgentStreamInterruptedError);
+    await vi.advanceTimersByTimeAsync(INACTIVITY_TIMEOUT_MS);
+    await expectation;
+  });
+
+  it("treats server keepalive comments as activity and never surfaces them as events", async () => {
+    // Tool-heavy turns can go minutes between real events; the server fills those stretches with
+    // SSE comment frames. Each one must reset the inactivity clock (four quiet stretches here,
+    // together well past the timeout) without producing tokens or other handler calls.
+    vi.useFakeTimers();
+    const stream = openSseResponse();
+    request.mockResolvedValue(stream.response);
+    const onToken = vi.fn<(text: string) => void>();
+
+    const promise = streamAgentMessage(MESSAGES, { onToken });
+    const expectation = expect(promise).resolves.toMatchObject({ reply: "All done." });
+    for (let i = 0; i < 4; i++) {
+      await vi.advanceTimersByTimeAsync(INACTIVITY_TIMEOUT_MS - 1000);
+      stream.push(": heartbeat\n\n");
+    }
+    stream.push(frame("done", { reply: "All done.", proposed_action: null }));
+    stream.close();
+    await expectation;
+    expect(onToken).not.toHaveBeenCalled();
+  });
+
+  it("does not treat a slow but active stream as stalled — each frame resets the inactivity clock", async () => {
+    vi.useFakeTimers();
+    const stream = openSseResponse();
+    request.mockResolvedValue(stream.response);
+
+    const promise = streamAgentMessage(MESSAGES);
+    const expectation = expect(promise).resolves.toMatchObject({ reply: "Want me to pull up?" });
+    // Two quiet stretches whose total exceeds the timeout, but with a frame between them — the
+    // clock must restart on every chunk, so neither stretch alone trips it.
+    await vi.advanceTimersByTimeAsync(INACTIVITY_TIMEOUT_MS - 1000);
+    stream.push(frame("token", { text: "Want me to " }));
+    await vi.advanceTimersByTimeAsync(INACTIVITY_TIMEOUT_MS - 1000);
+    stream.push(frame("done", { reply: "Want me to pull up?", proposed_action: null }));
+    stream.close();
+    await expectation;
+  });
+
+  it("passes the abort signal through and swallows the abandoned read's late rejection", async () => {
+    vi.useFakeTimers();
+    const stream = openSseResponse();
+    request.mockResolvedValue(stream.response);
+    const controller = new AbortController();
+
+    const promise = streamAgentMessage(MESSAGES, {}, null, null, controller.signal);
+    const expectation = expect(promise).rejects.toBeInstanceOf(AgentStreamInterruptedError);
+    await vi.advanceTimersByTimeAsync(INACTIVITY_TIMEOUT_MS);
+    await expectation;
+
+    expect(request).toHaveBeenLastCalledWith(expect.objectContaining({ abortSignal: controller.signal }));
+
+    // The caller aborts the connection once the turn settles, which rejects the read the timeout
+    // abandoned. Nothing awaits that read anymore — its rejection must be swallowed internally,
+    // or it surfaces as an unhandled rejection (which vitest reports as a run-level error).
+    controller.abort();
+    stream.error(new DOMException("The operation was aborted.", "AbortError"));
+    await vi.advanceTimersByTimeAsync(0);
+  });
+
+  it("resolves the turn on the done frame even when the connection never closes", async () => {
+    const stream = openSseResponse();
+    request.mockResolvedValue(stream.response);
+
+    const promise = streamAgentMessage(MESSAGES);
+    stream.push(frame("done", { reply: "Want me to pull up?", proposed_action: null, conversation_id: "conv1" }));
+    // No close(): the stream stays open, but `done` is terminal so the turn must resolve anyway.
+    const result = await promise;
+    expect(result.reply).toBe("Want me to pull up?");
+    expect(result.conversationId).toBe("conv1");
   });
 
   it("throws AgentStreamInterruptedError when a frame arrives mangled", async () => {

--- a/app/javascript/data/agent.ts
+++ b/app/javascript/data/agent.ts
@@ -226,8 +226,20 @@ type DoneData = {
   conversation_id?: string;
 };
 
-// Thrown when the stream dies before its terminal `done` frame — the connection dropped or a
-// frame arrived mangled — as opposed to the server explicitly reporting a failure via an `error`
+// How long to wait for the next stream bytes before treating the connection as dead. The server
+// commits the response immediately and writes a keepalive comment every 15 seconds for as long as
+// the turn is being generated (real events can be minutes apart on tool-heavy turns), so a
+// healthy connection is never silent anywhere near this long. The value also stays above the
+// 120 seconds of model silence the server itself tolerates between chunks, which keeps the
+// timeout safe even against a server build that predates the heartbeats (deploy skew). Erring
+// high is cheap anyway: a timeout that fires on a turn the server is in fact still generating
+// lands in the same turn-status recovery, which keeps waiting while the server reports it in
+// progress.
+const STREAM_INACTIVITY_TIMEOUT_MS = 130_000;
+
+// Thrown when the stream dies before its terminal `done` frame — the connection dropped, a
+// frame arrived mangled, or the connection went silent past the inactivity timeout — as opposed
+// to the server explicitly reporting a failure via an `error`
 // event. The distinction matters to the caller: when the transport breaks, the server usually
 // never notices and finishes the turn anyway (its remaining writes land in dead socket buffers),
 // so the complete reply exists in the stored conversation and the caller can recover it from
@@ -241,22 +253,64 @@ export class AgentStreamInterruptedError extends ResponseError {}
 // `clientTurnId` (a caller-generated UUID) tags the turn server-side so that, after an
 // interruption, the caller can recover this exact turn via fetchAgentTurnStatus instead of
 // guessing from the seller's latest conversation.
+// `abortSignal` lets the caller tear down the underlying connection once the turn has settled.
+// It exists for the stalled-connection case: the inactivity timeout below abandons (rather than
+// cancels) a pending read, so without an abort the connection would be held open indefinitely.
+// The caller should abort only AFTER the turn reaches a terminal state — the stream resolved,
+// errored, or turn-status recovery finished — never while the server may still be generating
+// (aborting then raises ClientDisconnected server-side, which aborts and fails the turn).
 export const streamAgentMessage = async (
   messages: ChatMessage[],
   handlers: AgentStreamHandlers = {},
   conversationId?: string | null,
   clientTurnId?: string | null,
+  abortSignal?: AbortSignal,
 ): Promise<StreamResult> => {
-  const response = await request({
-    method: "POST",
-    accept: "json",
-    url: Routes.internal_agent_messages_stream_path(),
-    data: {
-      messages,
-      ...(conversationId ? { conversation_id: conversationId } : {}),
-      ...(clientTurnId ? { client_turn_id: clientTurnId } : {}),
-    },
-  });
+  // Guards every await on the connection — the initial fetch below and each body read later.
+  // Neither resolves on its own when the connection silently dies: a fetch awaiting response
+  // headers (the server holds them until its first stream write) and a read awaiting more bytes
+  // can both sit pending forever (observed locally: the server logs the request complete, the
+  // trailing frames never surface, and nothing settles — leaving the composer locked with no
+  // error to recover from). The race turns that silence into an interruption, which sends the
+  // caller into turn-status recovery instead of hanging.
+  //
+  // When the clock wins, the pending promise is abandoned rather than cancelled — deliberately.
+  // Cancelling tears the connection down, and if the server is in fact still generating, its next
+  // write raises ClientDisconnected, aborting the turn and marking it failed — a slow-but-healthy
+  // turn would be lost for good. Abandoned, a healthy server finishes and persists the turn, and
+  // recovery adopts it. Releasing the connection is then the caller's job, via `abortSignal`,
+  // once the turn has settled (see the function comment above).
+  const withInactivityTimeout = async <T>(promise: Promise<T>): Promise<T> => {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => reject(new AgentStreamInterruptedError()), STREAM_INACTIVITY_TIMEOUT_MS);
+    });
+    try {
+      return await Promise.race([promise, timeout]);
+    } catch (e) {
+      // An abandoned promise can still settle later — typically rejecting when the caller aborts
+      // the connection after recovery. Nothing is waiting on it anymore, so swallow that rejection
+      // rather than letting it surface as an unhandled promise rejection.
+      promise.catch(() => {});
+      throw e;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  };
+
+  const response = await withInactivityTimeout(
+    request({
+      method: "POST",
+      accept: "json",
+      url: Routes.internal_agent_messages_stream_path(),
+      abortSignal,
+      data: {
+        messages,
+        ...(conversationId ? { conversation_id: conversationId } : {}),
+        ...(clientTurnId ? { client_turn_id: clientTurnId } : {}),
+      },
+    }),
+  );
 
   // request() only rejects 5xx/429, so a 4xx or an HTML response from auth/CSRF/authorization
   // middleware arrives here as a non-stream body. Treat anything that isn't an event-stream as an
@@ -338,7 +392,7 @@ export const streamAgentMessage = async (
 
   try {
     for (;;) {
-      const { value, done: streamDone } = await reader.read();
+      const { value, done: streamDone } = await withInactivityTimeout(reader.read());
       if (streamDone) break;
       buffer += decoder.decode(value, { stream: true });
       // Frames are separated by a blank line. Process every complete frame, keep the remainder.
@@ -349,6 +403,10 @@ export const streamAgentMessage = async (
         if (frame.trim().length > 0) done = handleFrame(frame) ?? done;
         separator = buffer.indexOf("\n\n");
       }
+      // `done` is the terminal frame — the server writes nothing meaningful after it. Return the
+      // assembled turn now rather than draining to EOF, so a connection whose close never reaches
+      // the client can't hold a finished turn hostage until the inactivity timeout.
+      if (done) return done;
     }
     if (buffer.trim().length > 0) done = handleFrame(buffer) ?? done;
   } catch (e) {

--- a/spec/controllers/api/internal/agent_message_streams_controller_spec.rb
+++ b/spec/controllers/api/internal/agent_message_streams_controller_spec.rb
@@ -47,6 +47,37 @@ describe Api::Internal::AgentMessageStreamsController do
     end
 
     context "when authenticated and authorized" do
+      it "commits the stream with a keepalive comment before any event" do
+        # ActionController::Live holds response headers until the first write, and a turn that
+        # opens with silent tool work can go minutes before its first real event — the client
+        # can't start its stall detection until it sees the response begin. The comment must be
+        # the very first thing on the stream.
+        stub_streaming_service(reply: "Hi.", proposed_action: nil, objects: [])
+
+        post :create, params: valid_params, format: :json
+
+        expect(response.body).to start_with(": connected\n\n")
+      end
+
+      it "writes keepalive heartbeats while the turn generates without emitting events" do
+        # Tool-use iterations write nothing to the stream, so without heartbeats a healthy
+        # multi-tool turn looks identical to a dead connection from the client's side.
+        stub_const("Api::Internal::AgentMessageStreamsController::STREAM_HEARTBEAT_INTERVAL", 0.02.seconds)
+        service_double = instance_double(Ai::StoreAgentService)
+        allow(Ai::StoreAgentService).to receive(:new).and_return(service_double)
+        allow(service_double).to receive(:respond_streaming) do |messages:, on_reply_complete: nil, &_blk|
+          sleep 0.15
+          turn = { reply: "Done.", proposed_action: nil, objects: [] }
+          on_reply_complete&.call(turn)
+          turn.merge(suggestions: [])
+        end
+
+        post :create, params: valid_params, format: :json
+
+        expect(response.body).to include(": heartbeat\n\n")
+        expect(response.body).to include("event: done")
+      end
+
       it "persists the turn to a new conversation and emits its id on the done event" do
         stub_streaming_service(reply: "You have 3 products.", proposed_action: nil, objects: [])
 


### PR DESCRIPTION
## What

The agent chat composer could stay disabled forever after a turn the server had already completed. The stream reader sat waiting on a connection that delivered neither the terminal `done` frame nor an end-of-stream, so the client never resolved the turn and never started recovery. Reloading the page was the only way out.

Client changes:

- Every wait on the stream (the initial fetch and each read) now races a 130s inactivity clock. When it fires, the client enters the existing turn-status recovery flow, which restores the persisted reply and unlocks the composer.
- The turn resolves as soon as the `done` frame arrives, so a connection that never closes can still finish cleanly.
- The connection is torn down only once the server records a verdict for the turn. When recovery ends without one, a background watch keeps polling and releases the connection when the verdict appears. This keeps the timeout from ever killing a turn that is still generating.

Server changes:

- The SSE response commits immediately and writes a keepalive comment every 15s. Tool-use iterations stream nothing, so long silent stretches previously looked identical to a dead connection.
- Each heartbeat also refreshes the turn's liveness marker (atomically, via a Lua check-and-expire) and keeps refreshing it after a client disconnect, since the server can still finish and persist the turn minutes later.

## Why

The stall reproduced locally on a turn the server logged as `200 OK`: the reply rendered, then the composer stayed locked with zero recovery polls and no console errors. The read loop had no time bound, so a lost final frame meant an infinite hang. The existing recovery flow already handles broken streams well; this change makes sure a silent stall reaches it, and the heartbeats make client-side silence a trustworthy signal on both ends.

---

This PR was implemented with AI assistance using Claude Fable 5.