### PR TITLE
Serve the agent's custom-HTML proposal preview by URL so its scripts run

### DIFF
--- a/app/controllers/api/internal/agent_custom_html_previews_controller.rb
+++ b/app/controllers/api/internal/agent_custom_html_previews_controller.rb
@@ -4,8 +4,17 @@
 # hasn't confirmed yet. The confirmation card for edit_user_custom_html / update_user_custom_html
 # proposals otherwise shows only the raw find/replace markup — which sellers read as the agent
 # glitching rather than as a staged page edit. This endpoint computes the page as it WOULD look
-# after the change and returns the same sandboxed document the live /landing/embed endpoint
-# serves, so the card can render a real preview inside an opaque-origin iframe.
+# after the change — the same sandboxed document the live /landing/embed endpoint serves — so the
+# card can render a real preview inside an opaque-origin iframe.
+#
+# The computed document is staged in Redis and served back by URL (GET #show) rather than
+# returned inline for the card to render via iframe srcdoc: srcdoc documents inherit the
+# dashboard's CSP, whose script-src has no 'unsafe-inline', so every inline script in the
+# previewed page — including the seller's own scripts and our sandbox shim — would be silently
+# blocked. A page that renders itself client-side (say, a product grid built from the injected
+# gumroad-data JSON) would preview as broken while being perfectly correct. Only a real network
+# response can carry the custom-page CSP header that allows those scripts, exactly like the live
+# embed endpoint does.
 #
 # Nothing is written here: the edit is spliced into an in-memory copy of the current page under
 # the same exactly-once find-match rule the real edit endpoint enforces
@@ -18,10 +27,40 @@ class Api::Internal::AgentCustomHtmlPreviewsController < Api::Internal::BaseCont
   before_action :authorize_store_agent
   after_action :verify_authorized
 
+  # How long a staged preview document stays retrievable. Generous on purpose: the confirmation
+  # card keeps its preview URL so "Review" on an already-acted-on card can re-show what the
+  # seller evaluated, and an applied edit can't be recomputed (its find-snippet no longer matches
+  # the page). After expiry that Review shows the "preview expired" notice below.
+  PREVIEW_DOCUMENT_TTL = 24.hours
+
+  # How many staged documents one seller can have outstanding at once. Documents run up to
+  # ~500 KB (Page::MAX_CUSTOM_HTML_LENGTH), so without a cap a seller scripting this endpoint
+  # could grow the shared Redis without bound. Staging past the cap evicts the seller's oldest
+  # staged documents — in real use a conversation has a handful of proposal cards, so the only
+  # previews old enough to be evicted belong to long-acted-on cards whose "Review" then shows
+  # the expired notice, same as after the TTL.
+  MAX_STAGED_PREVIEWS_PER_SELLER = 20
+
+  # What #show serves when the token is unknown or expired. A human-readable page rather than a
+  # JSON error because the requester is the preview iframe itself.
+  EXPIRED_PREVIEW_DOCUMENT = <<~HTML
+    <!doctype html>
+    <html>
+      <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+      </head>
+      <body style="display: flex; align-items: center; justify-content: center; min-height: 100vh; margin: 0; font-family: system-ui, sans-serif; color: #666;">
+        <p>This preview has expired.</p>
+      </body>
+    </html>
+  HTML
+
   # POST /internal/agent/custom_html_preview
   # params: { endpoint: "edit_user_custom_html" | "update_user_custom_html",
   #           find:, replace:   (edit)  —or—  custom_html: (update) }
-  # Renders { success: true, html: <full sandboxed document> } or { success: false, error: }.
+  # Renders { success: true, preview_url: <GET #show URL for the staged document> } or
+  # { success: false, error: }.
   # Errors render as 200s with success: false — a proposal whose preview can't be computed (say,
   # the page changed under it) is an expected state the card shows inline, not a request failure.
   def create
@@ -43,15 +82,55 @@ class Api::Internal::AgentCustomHtmlPreviewsController < Api::Internal::BaseCont
     document = profile_custom_html_document(
       Pages::Interpolator.interpolate_profile(display_html, profile: current_seller),
       data_json: ERB::Util.json_escape(Pages::ProfileData.build(current_seller).to_json),
-      meta_csp: true,
       scroll_to_change:,
     )
-    render json: { success: true, html: document }
+    render json: { success: true, preview_url: stage_preview_document(document) }
+  end
+
+  # GET /internal/agent/custom_html_previews/:token
+  # Serves a document staged by #create, carrying the same CSP response header as the live
+  # /landing/embed endpoint so the previewed page's scripts actually run. The Redis key is scoped
+  # to the signed-in seller, so a token can never fetch another seller's staged preview.
+  def show
+    document = $redis.get(RedisKey.agent_custom_html_preview(current_seller.id, params[:token]))
+    apply_custom_html_response_headers
+    # The document is derived from a not-yet-applied proposal on the seller's account — never
+    # cacheable by shared proxies, and pointless to cache locally.
+    response.set_header("Cache-Control", "private, no-store")
+    if document
+      render html: document.html_safe, layout: false
+    else
+      render html: EXPIRED_PREVIEW_DOCUMENT.html_safe, layout: false, status: :not_found
+    end
   end
 
   private
     def authorize_store_agent
       authorize current_seller, :use_store_agent?
+    end
+
+    # Stores the computed document under an unguessable, seller-scoped token and returns the URL
+    # #show serves it from. Redis rather than Rails.cache because the latter is a :null_store in
+    # default development setups and its production namespace changes every deploy — both would
+    # break open preview cards for no reason.
+    #
+    # A per-seller list of staged tokens (newest first) enforces MAX_STAGED_PREVIEWS_PER_SELLER:
+    # every stage pushes its token and evicts the documents that fall off the end of the list.
+    # Best-effort on purpose — two concurrent stages can briefly overshoot the cap by one, which
+    # is fine; the cap is a storage bound, not an exact quota.
+    def stage_preview_document(document)
+      token = SecureRandom.urlsafe_base64(24)
+      index_key = RedisKey.agent_custom_html_preview_index(current_seller.id)
+      $redis.set(RedisKey.agent_custom_html_preview(current_seller.id, token), document, ex: PREVIEW_DOCUMENT_TTL.to_i)
+      $redis.lpush(index_key, token)
+      # The index only needs to outlive the documents it tracks; refresh alongside every stage.
+      $redis.expire(index_key, PREVIEW_DOCUMENT_TTL.to_i)
+      evicted = $redis.lrange(index_key, MAX_STAGED_PREVIEWS_PER_SELLER, -1)
+      if evicted.any?
+        $redis.ltrim(index_key, 0, MAX_STAGED_PREVIEWS_PER_SELLER - 1)
+        $redis.del(*evicted.map { |evicted_token| RedisKey.agent_custom_html_preview(current_seller.id, evicted_token) })
+      end
+      internal_agent_custom_html_preview_document_path(token)
     end
 
     # The preview for a proposal that unpublishes the custom page (a blank update, or an edit
@@ -60,7 +139,7 @@ class Api::Internal::AgentCustomHtmlPreviewsController < Api::Internal::BaseCont
     # agents as a starting point — instead of treating a valid "remove the page" proposal as
     # an unpreviewable error (which would leave its Confirm button permanently disabled).
     def render_cleared_page_preview
-      render json: { success: true, html: Pages::DefaultProfileDocument.render(current_seller) }
+      render json: { success: true, preview_url: stage_preview_document(Pages::DefaultProfileDocument.render(current_seller)) }
     end
 
     # [resulting_html, marked_html, error]: the page as it would read after the proposed change

--- a/app/controllers/api/internal/agent_custom_html_previews_controller.rb
+++ b/app/controllers/api/internal/agent_custom_html_previews_controller.rb
@@ -116,8 +116,6 @@ class Api::Internal::AgentCustomHtmlPreviewsController < Api::Internal::BaseCont
     #
     # A per-seller list of staged tokens (newest first) enforces MAX_STAGED_PREVIEWS_PER_SELLER:
     # every stage pushes its token and evicts the documents that fall off the end of the list.
-    # Best-effort on purpose — two concurrent stages can briefly overshoot the cap by one, which
-    # is fine; the cap is a storage bound, not an exact quota.
     def stage_preview_document(document)
       token = SecureRandom.urlsafe_base64(24)
       index_key = RedisKey.agent_custom_html_preview_index(current_seller.id)
@@ -125,9 +123,15 @@ class Api::Internal::AgentCustomHtmlPreviewsController < Api::Internal::BaseCont
       $redis.lpush(index_key, token)
       # The index only needs to outlive the documents it tracks; refresh alongside every stage.
       $redis.expire(index_key, PREVIEW_DOCUMENT_TTL.to_i)
-      evicted = $redis.lrange(index_key, MAX_STAGED_PREVIEWS_PER_SELLER, -1)
+      # Read-what-you-trim atomically (MULTI): if the read and the trim were separate commands, a
+      # concurrent stage's lpush could land between them, shifting the list so the trim drops a
+      # token the read never saw — that document would stay in Redis untracked until its TTL,
+      # quietly weakening the storage cap.
+      evicted, _trimmed = $redis.multi do |transaction|
+        transaction.lrange(index_key, MAX_STAGED_PREVIEWS_PER_SELLER, -1)
+        transaction.ltrim(index_key, 0, MAX_STAGED_PREVIEWS_PER_SELLER - 1)
+      end
       if evicted.any?
-        $redis.ltrim(index_key, 0, MAX_STAGED_PREVIEWS_PER_SELLER - 1)
         $redis.del(*evicted.map { |evicted_token| RedisKey.agent_custom_html_preview(current_seller.id, evicted_token) })
       end
       internal_agent_custom_html_preview_document_path(token)

--- a/app/controllers/concerns/renders_custom_html_pages.rb
+++ b/app/controllers/concerns/renders_custom_html_pages.rb
@@ -39,14 +39,6 @@ module RendersCustomHtmlPages
     "form-action 'self'",
   ].join("; ") + ";"
 
-  # CUSTOM_HTML_CSP for documents delivered without response headers — e.g. the agent's
-  # proposed-change preview, which reaches the browser as an iframe srcdoc. A meta CSP tag can't
-  # carry the `sandbox` directive (browsers ignore it there), so it's stripped; the embedding
-  # iframe's sandbox attribute supplies the sandboxing instead. Everything else applies unchanged,
-  # so a previewed page blocks exactly the resources (external images, fetches, ...) the live page
-  # would block.
-  CUSTOM_HTML_META_CSP = CUSTOM_HTML_CSP.split("; ").reject { |directive| directive.start_with?("sandbox ") }.join("; ")
-
   # Loaded in <head> so it runs before any seller script (without becoming the
   # body's first child). On the opaque origin (allow-scripts, no
   # allow-same-origin) localStorage/sessionStorage/document.cookie throw, so a
@@ -410,18 +402,18 @@ module RendersCustomHtmlPages
     # The full sandboxed document for a profile custom-HTML page. Shared by the live
     # /landing/embed endpoint (UsersController) and the agent's proposed-change preview
     # (Api::Internal::AgentCustomHtmlPreviewsController) so a preview can never drift from what
-    # actually ships. `meta_csp` embeds CUSTOM_HTML_META_CSP for delivery paths that have no
-    # response headers to carry the real CSP (iframe srcdoc). `scroll_to_change` adds the
-    # preview-only script that jumps to the PREVIEW_CHANGED_MARKER comment, so an edit further
-    # down the page opens in view instead of hiding below the fold.
-    def profile_custom_html_document(custom_html, data_json: "{}", live_fields: false, navigation_bridge: "", follow_bridge: "", meta_csp: false, scroll_to_change: false)
+    # actually ships. Both serve it over HTTP with CUSTOM_HTML_CSP as a response header — never
+    # as an iframe srcdoc, which would inherit the embedding dashboard's CSP and block every
+    # inline script in the page (a meta CSP tag can't undo that: policies only intersect).
+    # `scroll_to_change` adds the preview-only script that jumps to the PREVIEW_CHANGED_MARKER
+    # comment, so an edit further down the page opens in view instead of hiding below the fold.
+    def profile_custom_html_document(custom_html, data_json: "{}", live_fields: false, navigation_bridge: "", follow_bridge: "", scroll_to_change: false)
       <<~HTML
         <!doctype html>
         <html>
           <head>
             <meta charset="utf-8">
             <meta name="viewport" content="width=device-width, initial-scale=1">
-            #{meta_csp ? %(<meta http-equiv="Content-Security-Policy" content="#{ERB::Util.h(CUSTOM_HTML_META_CSP)}">) : ""}
             #{SANDBOX_COMPAT_SCRIPT}
             #{self.class.pages_tailwind_head}
           </head>

--- a/app/javascript/components/Agent/AgentChat.test.tsx
+++ b/app/javascript/components/Agent/AgentChat.test.tsx
@@ -304,13 +304,17 @@ describe("AgentChat custom-html proposal cards", () => {
 
   it("renders a page preview instead of raw HTML fields", async () => {
     streamTurnWithAction(customHtmlAction);
-    fetchCustomHtmlProposalPreview.mockResolvedValue("<!doctype html><html><body><h1>New headline</h1></body></html>");
+    fetchCustomHtmlProposalPreview.mockResolvedValue("/internal/agent/custom_html_previews/token123");
 
     render(<AgentChat greeting="Hi" suggestions={[]} />);
     await sendMessage("change my headline");
 
     const iframe = await screen.findByTitle<HTMLIFrameElement>("Preview of your page after this change");
-    expect(iframe.getAttribute("srcdoc")).toContain("<h1>New headline</h1>");
+    // Loaded by URL (never srcdoc) so the staged document's response carries the custom-page CSP
+    // header — inlined via srcdoc it would inherit the dashboard's CSP, which blocks the page's
+    // inline scripts.
+    expect(iframe.getAttribute("src")).toBe("/internal/agent/custom_html_previews/token123");
+    expect(iframe.hasAttribute("srcdoc")).toBe(false);
     // The document renders on an opaque origin, exactly like the live page embed.
     expect(iframe.getAttribute("sandbox")).toBe("allow-scripts allow-forms allow-popups");
     // The raw find/replace rows are gone — the rendered preview is the review surface.
@@ -359,7 +363,7 @@ describe("AgentChat custom-html proposal cards", () => {
 
   it("collapses an applied proposal into a compact card with the details behind Review", async () => {
     streamTurnWithAction(customHtmlAction);
-    fetchCustomHtmlProposalPreview.mockResolvedValue("<!doctype html><html><body><h1>New headline</h1></body></html>");
+    fetchCustomHtmlProposalPreview.mockResolvedValue("/internal/agent/custom_html_previews/token123");
     executeAgentAction.mockResolvedValue({ message: "Done.", object: null });
 
     render(<AgentChat greeting="Hi" suggestions={[]} />);
@@ -400,7 +404,7 @@ describe("AgentChat custom-html proposal cards", () => {
         },
       ],
     });
-    fetchCustomHtmlProposalPreview.mockResolvedValue("<!doctype html><html><body><h1>New headline</h1></body></html>");
+    fetchCustomHtmlProposalPreview.mockResolvedValue("/internal/agent/custom_html_previews/token123");
 
     render(<AgentChat greeting="Hi" suggestions={[]} />);
 

--- a/app/javascript/components/Agent/AgentChat.tsx
+++ b/app/javascript/components/Agent/AgentChat.tsx
@@ -158,17 +158,17 @@ const ObjectList = ({ objects }: { objects: DisplayObject[] }) =>
   ) : null;
 
 // The rendered "what your page will look like" preview state for a custom-HTML proposal card. The
-// server computes the resulting page exactly the way confirming would apply it and returns the
-// same sandboxed document /landing/embed serves. `enabled: false` (a non-page proposal, or a card
-// already acted on) skips the fetch entirely. The state lives here rather than in the preview
-// element because the card gates its Confirm button on it: a proposal whose preview hasn't
-// rendered — still loading, or invalid (say the page changed under it) — shouldn't be
-// confirmable, since the seller would be applying a change they haven't seen (and an invalid one
-// would fail anyway).
+// server computes the resulting page exactly the way confirming would apply it, stages the same
+// sandboxed document /landing/embed serves, and returns a URL the preview iframe loads it from.
+// `enabled: false` (a non-page proposal, or a card already acted on) skips the fetch entirely.
+// The state lives here rather than in the preview element because the card gates its Confirm
+// button on it: a proposal whose preview hasn't rendered — still loading, or invalid (say the
+// page changed under it) — shouldn't be confirmable, since the seller would be applying a change
+// they haven't seen (and an invalid one would fail anyway).
 type CustomHtmlPreviewState =
   | { status: "disabled" }
   | { status: "loading" }
-  | { status: "loaded"; html: string }
+  | { status: "loaded"; url: string }
   | { status: "error"; message: string };
 
 const useCustomHtmlProposalPreview = (action: ProposedAction, enabled: boolean): CustomHtmlPreviewState => {
@@ -189,10 +189,11 @@ const useCustomHtmlProposalPreview = (action: ProposedAction, enabled: boolean):
     const wasEnabled = wasEnabledRef.current;
     wasEnabledRef.current = enabled;
     if (!enabled) {
-      // Keep an already-rendered preview around rather than discarding it: once the seller acts on
-      // the card the hook is disabled, but "Review" on the collapsed card should show the exact
+      // Keep an already-loaded preview URL around rather than discarding it: once the seller acts
+      // on the card the hook is disabled, but "Review" on the collapsed card should show the exact
       // preview they evaluated. Refetching wouldn't work — an applied edit's find-snippet no
-      // longer matches the page — so the loaded snapshot is the only faithful record.
+      // longer matches the page — so the staged document behind this URL is the only faithful
+      // record (the server keeps it for a day; after that Review shows an expired notice).
       setState((current) => (current.status === "loaded" ? current : { status: "disabled" }));
       return;
     }
@@ -203,8 +204,8 @@ const useCustomHtmlProposalPreview = (action: ProposedAction, enabled: boolean):
     let cancelled = false;
     setState({ status: "loading" });
     fetchCustomHtmlProposalPreview(actionRef.current)
-      .then((html) => {
-        if (!cancelled) setState({ status: "loaded", html });
+      .then((url) => {
+        if (!cancelled) setState({ status: "loaded", url });
       })
       .catch((e: unknown) => {
         if (!cancelled)
@@ -221,13 +222,17 @@ const useCustomHtmlProposalPreview = (action: ProposedAction, enabled: boolean):
   return state;
 };
 
-// Renders the preview state produced by useCustomHtmlProposalPreview. The document renders on an
-// opaque origin (no allow-same-origin), just like the live page embed, so the proposed HTML can't
-// reach cookies or the dashboard DOM. Unlike the live page's iframe, the sandbox below
-// deliberately omits allow-popups-to-escape-sandbox (matching ProfileLandingPagePreview): this
-// HTML is a not-yet-confirmed agent proposal shown inside the seller's dashboard, so any popup it
-// opens stays sandboxed rather than getting a full unsandboxed window. Popup escape only changes
-// popup behavior, not how the page itself renders, so preview fidelity is unaffected.
+// Renders the preview state produced by useCustomHtmlProposalPreview. The document is loaded by
+// URL (src, never srcDoc) so its response carries the same CSP header as the live page embed —
+// a srcDoc document would inherit the dashboard's CSP, which blocks the page's inline scripts
+// and shows script-rendered pages (say, a product grid built from the gumroad-data JSON) as
+// broken. It renders on an opaque origin (no allow-same-origin), just like the live page embed,
+// so the proposed HTML can't reach cookies or the dashboard DOM. Unlike the live page's iframe,
+// the sandbox below deliberately omits allow-popups-to-escape-sandbox (matching
+// ProfileLandingPagePreview): this HTML is a not-yet-confirmed agent proposal shown inside the
+// seller's dashboard, so any popup it opens stays sandboxed rather than getting a full
+// unsandboxed window. Popup escape only changes popup behavior, not how the page itself renders,
+// so preview fidelity is unaffected.
 const CustomHtmlProposalPreview = ({ state }: { state: CustomHtmlPreviewState }) => {
   if (state.status === "disabled") return null;
   if (state.status === "loading")
@@ -240,7 +245,7 @@ const CustomHtmlProposalPreview = ({ state }: { state: CustomHtmlPreviewState })
   return (
     <iframe
       title="Preview of your page after this change"
-      srcDoc={state.html}
+      src={state.url}
       sandbox="allow-scripts allow-forms allow-popups"
       referrerPolicy="no-referrer"
       className="h-96 w-full rounded border border-border bg-white"

--- a/app/javascript/data/agent.ts
+++ b/app/javascript/data/agent.ts
@@ -131,6 +131,9 @@ export const fetchCustomHtmlProposalPreview = async (action: ProposedAction): Pr
   // miss (say, the staged document expired or was evicted). Probe the URL before reporting the
   // preview loaded — the card enables Confirm on that signal, and it must never enable it while
   // the iframe is about to render the "preview expired" notice instead of the proposed page.
+  // The probe-then-load window itself is not worth guarding: the token was staged moments ago,
+  // so it sits a full TTL away from expiry and newest in the seller's eviction order — losing it
+  // mid-window would take a burst of further stagings by the same seller within milliseconds.
   const probe = await request({ method: "HEAD", accept: "html", url: json.preview_url });
   if (!probe.ok) throw new ResponseError("The preview couldn't be loaded.");
   return json.preview_url;

--- a/app/javascript/data/agent.ts
+++ b/app/javascript/data/agent.ts
@@ -106,11 +106,14 @@ export const isCustomHtmlProposal = (action: ProposedAction): boolean => {
   return endpoint !== null && CUSTOM_HTML_PROPOSAL_ENDPOINTS.includes(endpoint);
 };
 
-type CustomHtmlPreviewResponse = { success: true; html: string } | { success: false; error: string };
+type CustomHtmlPreviewResponse = { success: true; preview_url: string } | { success: false; error: string };
 
-// Fetch the sandboxed document showing the seller's page as it would look after the proposed
-// custom-HTML change, for the confirmation card's preview iframe. The server computes the change
-// the same way confirming would apply it, so the preview and the eventual result can't disagree.
+// Fetch the URL of a staged document showing the seller's page as it would look after the
+// proposed custom-HTML change, for the confirmation card's preview iframe. The server computes
+// the change the same way confirming would apply it, so the preview and the eventual result
+// can't disagree. The document is served by URL (not returned inline for srcdoc) so its response
+// can carry the custom-page CSP header — a srcdoc document inherits the dashboard's CSP, which
+// blocks the page's inline scripts and would show script-rendered pages as broken.
 export const fetchCustomHtmlProposalPreview = async (action: ProposedAction): Promise<string> => {
   const body = action.params.params;
   const response = await request({
@@ -124,7 +127,13 @@ export const fetchCustomHtmlProposalPreview = async (action: ProposedAction): Pr
   });
   const json = typia.assert<CustomHtmlPreviewResponse>(await response.json());
   if (!json.success) throw new ResponseError(json.error);
-  return json.html;
+  // The POST staged the document, but the iframe's own GET is a separate request that can still
+  // miss (say, the staged document expired or was evicted). Probe the URL before reporting the
+  // preview loaded — the card enables Confirm on that signal, and it must never enable it while
+  // the iframe is about to render the "preview expired" notice instead of the proposed page.
+  const probe = await request({ method: "HEAD", accept: "html", url: json.preview_url });
+  if (!probe.ok) throw new ResponseError("The preview couldn't be loaded.");
+  return json.preview_url;
 };
 
 // One persisted message of a stored conversation, as returned by the conversations endpoint. The

--- a/app/javascript/utils/request.ts
+++ b/app/javascript/utils/request.ts
@@ -3,7 +3,10 @@ export type RequestSettings = {
   url: string;
   abortSignal?: AbortSignal | undefined;
   headers?: Record<string, string> | undefined;
-} & ({ method: "GET" } | { method: "POST" | "PUT" | "PATCH" | "DELETE"; data?: Record<string, unknown> | FormData });
+} & (
+  | { method: "GET" | "HEAD" }
+  | { method: "POST" | "PUT" | "PATCH" | "DELETE"; data?: Record<string, unknown> | FormData }
+);
 
 export class AbortError extends Error {
   constructor() {
@@ -38,7 +41,7 @@ export const defaults: RequestInit = {};
 export const request = async (settings: RequestSettings): Promise<Response> => {
   ++globalThis.__activeRequests;
   const data =
-    settings.method === "GET"
+    settings.method === "GET" || settings.method === "HEAD"
       ? null
       : settings.data instanceof FormData
         ? settings.data

--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -27,6 +27,8 @@ class RedisKey
     def ai_request_throttle(user_id) = "ai_request_throttle:#{user_id}"
     def agent_request_throttle(user_id) = "agent_request_throttle:#{user_id}"
     def agent_turn_status(user_id, client_turn_id) = "agent_turn_status:#{user_id}:#{client_turn_id}"
+    def agent_custom_html_preview(user_id, token) = "agent_custom_html_preview:#{user_id}:#{token}"
+    def agent_custom_html_preview_index(user_id) = "agent_custom_html_preview_index:#{user_id}"
     def fraudulent_free_purchases_block_hours = "fraudulent_free_purchases_block_hours"
     def recaptcha_score_threshold(surface) = "recaptcha_score_threshold:#{surface}"
     def sales_related_products_internal_limit = "sales_related_products_internal_limit"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1159,6 +1159,10 @@ Rails.application.routes.draw do
         get "/agent/conversations/latest", to: "agent_conversations#latest", as: :agent_conversations_latest
         get "/agent/turns/:client_turn_id", to: "agent_conversations#turn_status", as: :agent_turn_status
         post "/agent/custom_html_preview", to: "agent_custom_html_previews#create", as: :agent_custom_html_preview
+        # Serves a staged preview document by token. This must be a real URL (not JSON consumed
+        # into an iframe srcdoc) so the response can carry the custom-page CSP header — srcdoc
+        # documents inherit the dashboard's CSP, which blocks the page's inline scripts.
+        get "/agent/custom_html_previews/:token", to: "agent_custom_html_previews#show", as: :agent_custom_html_preview_document, defaults: { format: :html }
       end
     end
 

--- a/spec/controllers/api/internal/agent_custom_html_previews_controller_spec.rb
+++ b/spec/controllers/api/internal/agent_custom_html_previews_controller_spec.rb
@@ -11,6 +11,16 @@ describe Api::Internal::AgentCustomHtmlPreviewsController do
 
   before { Feature.activate_user(:custom_html_pages, seller) }
 
+  # POST create stages the computed document in Redis and returns a URL; fetch it through GET show
+  # the way the preview iframe does, so these specs exercise the exact path the card uses.
+  def staged_preview_document
+    preview_url = response.parsed_body["preview_url"]
+    expect(preview_url).to be_present
+    get :show, params: { token: preview_url.split("/").last }
+    expect(response).to have_http_status(:ok)
+    response.body
+  end
+
   describe "POST create" do
     let(:valid_params) { { endpoint: "update_user_custom_html", custom_html: "<section><h1>New page</h1></section>" } }
 
@@ -34,30 +44,30 @@ describe Api::Internal::AgentCustomHtmlPreviewsController do
     end
 
     context "for update_user_custom_html" do
-      it "returns the proposed page wrapped in the sandboxed landing document" do
+      it "stages the proposed page wrapped in the sandboxed landing document and returns its URL" do
         post :create, params: valid_params, format: :json
 
         body = response.parsed_body
         expect(body["success"]).to be(true)
-        expect(body["html"]).to include("<h1>New page</h1>")
-        expect(body["html"]).to include("<!doctype html>")
+        expect(body["preview_url"]).to match(%r{/agent/custom_html_previews/[A-Za-z0-9_-]+\z})
+
+        html = staged_preview_document
+        expect(html).to include("<h1>New page</h1>")
+        expect(html).to include("<!doctype html>")
         # The same sandbox-compat shim the live /landing/embed document carries.
-        expect(body["html"]).to include("data-gumroad-sandbox-shim")
+        expect(html).to include("data-gumroad-sandbox-shim")
       end
 
-      it "carries the custom-HTML CSP in a meta tag, minus the header-only sandbox directive" do
+      it "does not embed a meta CSP — the real policy arrives as GET show's response header" do
         post :create, params: valid_params, format: :json
 
-        html = response.parsed_body["html"]
-        expect(html).to include(%(http-equiv="Content-Security-Policy"))
-        expect(html).to include("img-src data: blob:")
-        expect(html).not_to include("sandbox allow-scripts")
+        expect(staged_preview_document).not_to include(%(http-equiv="Content-Security-Policy"))
       end
 
       it "does not carry the scroll-to-change script — a whole-page update has no single changed area" do
         post :create, params: valid_params, format: :json
 
-        html = response.parsed_body["html"]
+        html = staged_preview_document
         expect(html).not_to include("data-gumroad-preview-scroll")
         expect(html).not_to include(RendersCustomHtmlPages::PREVIEW_CHANGED_MARKER)
       end
@@ -65,20 +75,19 @@ describe Api::Internal::AgentCustomHtmlPreviewsController do
       it "sanitizes the proposed HTML the same way applying it would" do
         post :create, params: { endpoint: "update_user_custom_html", custom_html: %(<section><script src="https://evil.com/x.js"></script><h1>Hi</h1></section>) }, format: :json
 
-        body = response.parsed_body
-        expect(body["success"]).to be(true)
-        expect(body["html"]).to include("<h1>Hi</h1>")
-        expect(body["html"]).not_to include("evil.com")
+        expect(response.parsed_body["success"]).to be(true)
+        html = staged_preview_document
+        expect(html).to include("<h1>Hi</h1>")
+        expect(html).not_to include("evil.com")
       end
 
       it "previews the default storefront for a proposal that clears the page" do
         post :create, params: { endpoint: "update_user_custom_html", custom_html: "" }, format: :json
 
-        body = response.parsed_body
-        expect(body["success"]).to be(true)
+        expect(response.parsed_body["success"]).to be(true)
         # Clearing unpublishes the custom page, so the profile falls back to the default
         # storefront — the preview shows that render rather than erroring out.
-        expect(body["html"]).to eq(Pages::DefaultProfileDocument.render(seller))
+        expect(staged_preview_document).to eq(Pages::DefaultProfileDocument.render(seller))
       end
 
       it "previews the default storefront when the proposed page sanitizes down to nothing" do
@@ -86,9 +95,8 @@ describe Api::Internal::AgentCustomHtmlPreviewsController do
         # unpublishes — the preview mirrors that outcome.
         post :create, params: { endpoint: "update_user_custom_html", custom_html: %(<script src="https://evil.com/x.js"></script>) }, format: :json
 
-        body = response.parsed_body
-        expect(body["success"]).to be(true)
-        expect(body["html"]).to eq(Pages::DefaultProfileDocument.render(seller))
+        expect(response.parsed_body["success"]).to be(true)
+        expect(staged_preview_document).to eq(Pages::DefaultProfileDocument.render(seller))
       end
 
       it "renders an error when the custom_html key is missing, mirroring the apply endpoint" do
@@ -112,20 +120,20 @@ describe Api::Internal::AgentCustomHtmlPreviewsController do
         seller.save!
       end
 
-      it "returns the current page with the proposed edit spliced in" do
+      it "stages the current page with the proposed edit spliced in" do
         post :create, params: { endpoint: "edit_user_custom_html", find: "<h1>Old headline</h1>", replace: "<h1>New headline</h1>" }, format: :json
 
-        body = response.parsed_body
-        expect(body["success"]).to be(true)
-        expect(body["html"]).to include("<h1>New headline</h1>")
-        expect(body["html"]).to include("<p>Keep me</p>")
-        expect(body["html"]).not_to include("Old headline")
+        expect(response.parsed_body["success"]).to be(true)
+        html = staged_preview_document
+        expect(html).to include("<h1>New headline</h1>")
+        expect(html).to include("<p>Keep me</p>")
+        expect(html).not_to include("Old headline")
       end
 
       it "marks the changed area and ships the scroll-to-change script so the preview opens on the edit" do
         post :create, params: { endpoint: "edit_user_custom_html", find: "<h1>Old headline</h1>", replace: "<h1>New headline</h1>" }, format: :json
 
-        html = response.parsed_body["html"]
+        html = staged_preview_document
         expect(html).to include("#{RendersCustomHtmlPages::PREVIEW_CHANGED_MARKER}<h1>New headline</h1>")
         expect(html).to include("data-gumroad-preview-scroll")
       end
@@ -138,11 +146,11 @@ describe Api::Internal::AgentCustomHtmlPreviewsController do
 
         post :create, params: { endpoint: "edit_user_custom_html", find: "headline-old", replace: "headline-new" }, format: :json
 
-        body = response.parsed_body
-        expect(body["success"]).to be(true)
-        expect(body["html"]).to include(%(class="headline-new"))
-        expect(body["html"]).not_to include(RendersCustomHtmlPages::PREVIEW_CHANGED_MARKER)
-        expect(body["html"]).not_to include("data-gumroad-preview-scroll")
+        expect(response.parsed_body["success"]).to be(true)
+        html = staged_preview_document
+        expect(html).to include(%(class="headline-new"))
+        expect(html).not_to include(RendersCustomHtmlPages::PREVIEW_CHANGED_MARKER)
+        expect(html).not_to include("data-gumroad-preview-scroll")
       end
 
       it "renders an error when the snippet no longer matches the current page" do
@@ -192,7 +200,7 @@ describe Api::Internal::AgentCustomHtmlPreviewsController do
         body = response.parsed_body
         expect(body["error"]).to be_nil
         expect(body["success"]).to be(true)
-        expect(body["html"]).to eq(Pages::DefaultProfileDocument.render(seller))
+        expect(staged_preview_document).to eq(Pages::DefaultProfileDocument.render(seller))
       end
 
       it "inserts replacements containing backslashes literally" do
@@ -201,9 +209,8 @@ describe Api::Internal::AgentCustomHtmlPreviewsController do
 
         post :create, params: { endpoint: "edit_user_custom_html", find: "<p>Old</p>", replace: "<p>Path C:\\new</p>" }, format: :json
 
-        body = response.parsed_body
-        expect(body["success"]).to be(true)
-        expect(body["html"]).to include("C:\\new")
+        expect(response.parsed_body["success"]).to be(true)
+        expect(staged_preview_document).to include("C:\\new")
       end
     end
 
@@ -211,6 +218,86 @@ describe Api::Internal::AgentCustomHtmlPreviewsController do
       post :create, params: { endpoint: "update_product", custom_html: "<p>hi</p>" }, format: :json
 
       expect(response.parsed_body).to eq("success" => false, "error" => "This change doesn't have a page preview.")
+    end
+  end
+
+  describe "GET show" do
+    def stage_preview
+      post :create, params: { endpoint: "update_user_custom_html", custom_html: "<section><h1>New page</h1></section>" }, format: :json
+      response.parsed_body["preview_url"].split("/").last
+    end
+
+    it_behaves_like "authentication required for action", :get, :show do
+      let(:request_params) { { token: "sometoken" } }
+    end
+
+    it_behaves_like "authorize called for action", :get, :show do
+      let(:record) { seller }
+      let(:policy_method) { :use_store_agent? }
+      let(:request_params) { { token: "sometoken" } }
+    end
+
+    it "serves the staged document with the same CSP response header as the live embed endpoint" do
+      # The whole reason the preview is served by URL instead of iframe srcdoc: only a response
+      # header can carry a CSP that permits the page's inline scripts (srcdoc inherits the
+      # dashboard's policy, which blocks them). This header must never drift from the live page's.
+      token = stage_preview
+
+      get :show, params: { token: }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("<h1>New page</h1>")
+      expect(response.headers["Content-Security-Policy"]).to eq(RendersCustomHtmlPages::CUSTOM_HTML_CSP)
+      expect(response.headers["Content-Security-Policy"]).to include("script-src 'unsafe-inline'")
+      expect(response.headers["Cache-Control"]).to include("no-store")
+    end
+
+    it "renders the expired notice for an unknown or expired token" do
+      get :show, params: { token: "unknown-token" }
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to include("This preview has expired.")
+    end
+
+    it "does not serve a document staged for another seller" do
+      # Tokens are namespaced by seller id in Redis, so even a leaked token is useless to any
+      # other account.
+      other_seller = create(:user)
+      other_token = SecureRandom.urlsafe_base64(24)
+      $redis.set(RedisKey.agent_custom_html_preview(other_seller.id, other_token), "<!doctype html><p>secret</p>", ex: 60)
+
+      get :show, params: { token: other_token }
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).not_to include("secret")
+    end
+
+    it "stages documents with an expiry so abandoned previews clean themselves up" do
+      token = stage_preview
+
+      ttl = $redis.ttl(RedisKey.agent_custom_html_preview(seller.id, token))
+      expect(ttl).to be > 0
+      expect(ttl).to be <= described_class::PREVIEW_DOCUMENT_TTL.to_i
+    end
+
+    it "evicts a seller's oldest staged documents beyond the per-seller cap" do
+      # Documents run up to ~500 KB each, so an uncapped seller could grow the shared Redis
+      # without bound by scripting the stage endpoint.
+      stub_const("#{described_class}::MAX_STAGED_PREVIEWS_PER_SELLER", 2)
+
+      oldest_token = stage_preview
+      kept_tokens = [stage_preview, stage_preview]
+
+      expect($redis.exists?(RedisKey.agent_custom_html_preview(seller.id, oldest_token))).to eq(false)
+      kept_tokens.each do |token|
+        expect($redis.exists?(RedisKey.agent_custom_html_preview(seller.id, token))).to eq(true)
+      end
+
+      get :show, params: { token: oldest_token }
+      expect(response).to have_http_status(:not_found)
+
+      get :show, params: { token: kept_tokens.last }
+      expect(response).to have_http_status(:ok)
     end
   end
 end


### PR DESCRIPTION
## What

The agent's confirmation card for custom-page proposals now loads its preview from a real endpoint. The preview endpoint stages the computed document in Redis under an unguessable, seller-scoped token that expires after a day, and a new GET endpoint serves it with the same CSP header and sandbox as the live `/landing/embed` page. The card's iframe points at that URL.

Two safeguards round it out: each seller can hold a bounded number of staged documents (oldest are evicted), and the client verifies the URL is retrievable before enabling Confirm.

## Why

The card previously inlined the preview document via iframe `srcdoc`. A `srcdoc` document inherits the dashboard's CSP, which blocks inline scripts — so pages that render content client-side (like a product grid built from the injected `gumroad-data` JSON) previewed as an empty page while being perfectly correct. Creators dismissed good changes or escalated (see antiwork/gumroad-private#984). A meta CSP inside the document can't fix this, because policies only tighten. Serving the document over HTTP is the one way to carry the CSP that the published page already runs under, so the preview and the live page now behave identically.

---

This PR was implemented with AI assistance using Claude Fable 5.