### PR TITLE
Document 50 MB cover image limit and automatic resizing in help center

### DIFF
--- a/app/views/help_center/articles/contents/_60-adding-a-cover-image.html.erb
+++ b/app/views/help_center/articles/contents/_60-adding-a-cover-image.html.erb
@@ -24,6 +24,7 @@
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/65f2840354e485464f3dcae1/file-JjBHQhY6pB.png" %></figure>
   <h3 id="The-best-shapes-for-cover-images-in-pixels-eTSks">Recommended specifications</h3>
   <p>As a rule of thumb, if you are going to upload an image as a cover image, it should be 1280 pixels wide x 720 pixels tall <em>at least </em>72 DPI (dots per inch).</p>
+  <p>Image covers must be smaller than 50 MB. If an image you upload is larger than 4096 pixels on its longest side, we automatically resize it down to that size shortly after upload. Covers display at a much smaller size, so this does not change how your product page looks. GIFs are not resized, so their animation is preserved.</p>
   <p><b>Note: </b>We auto-adjust the height of covers on a product to match the height of the first cover. If you are uploading multiple covers, we highly recommend making them of equal height for the best look!</p>
   <h3 id="Embed-videos-lA3TZ">Embed videos</h3>
   <p>Hit 'Upload from an external website' and paste your share link. </p>
@@ -49,6 +50,7 @@
   <ul>
     <li>If the filename of the image/video file contains one of these characters: #, $, _, +, &amp;, ;, :, %, please rename your cover image to something simple like "hello.png" and try uploading it again.</li>
     <li>You cannot upload a PDF as a cover image.</li>
+    <li>If you see "Cover images must be smaller than 50 MB. Please resize or compress the image and try again." the image file is over our 50 MB limit for image covers. Reduce the file size (for example by exporting it as a JPEG or compressing the PNG) and upload it again.</li>
     <li>You can use free image-editing software like <a href="https://www.canva.com/">Canva</a> or <a href="https://www.gimp.org/">Gimp</a> to generate thumbnails &amp; covers in the correct sizes.</li>
     <li><b>Old Cover Image Showing in Preview on X (formerly Twitter)</b><br>When you share your Gumroad product link on X, that platform caches the link preview, including your cover image. Because X no longer offers a tool to refresh link previews, your updated cover image might not appear immediately.<br>The only reliable solution is to wait — X will automatically update the preview over time when it re-scrapes your link.</li>
   </ul>


### PR DESCRIPTION
## What

Updates the "Adding a cover image" help center article (`_60-adding-a-cover-image.html.erb`) to document the new cover upload limits shipped in #6109:

- Adds a paragraph to the **Recommended specifications** section: image covers must be smaller than 50 MB, images larger than 4096 pixels on their longest side are automatically resized down after upload, and GIFs are excluded from resizing to preserve animation.
- Adds a **Known issues** entry quoting the exact rejection message ("Cover images must be smaller than 50 MB. Please resize or compress the image and try again.") so help center search matches what a seller pastes, with guidance to compress and retry.

Body-only edit; `articles.yml` untouched (no title/description change).

## Why

#6109 introduced a 50 MB cap on image cover uploads (client- and server-side) plus background auto-resizing of covers over 4096px on their longest side. The article previously described cover uploads with no size limits, so sellers hitting the new rejection message had no documented explanation.

All numbers verified against the merged code: `AssetPreview::MAX_IMAGE_FILE_SIZE = 50.megabytes`, `AssetPreview::MAX_IMAGE_DIMENSION = 4096`, GIF exclusion via `should_post_process?` in `AssetPreview#oversized_image?`. The rejection message is quoted verbatim from `CoverEditor.tsx` / `AssetPreview#image_file_size_within_limit` (identical strings).

## QA steps

1. Visit https://help.gumroad.com/help/article/60-adding-a-cover-image
2. Confirm the "Recommended specifications" section mentions the 50 MB limit and 4096px auto-resize.
3. Confirm the "Known issues" list includes the entry quoting the rejection message.

## Test results

- `bundle exec rspec spec/models/help_center` — 1 example, 0 failures (guards slug ↔ partial integrity).
- Partial rendered via `ApplicationController.render` in test env — render OK, new copy present.
- ERB syntax check + HTML tag-balance check — all tags balanced.

Autoreview skipped (docs copy only, no logic).

---

## AI disclosure

Authored by Claude Fable 5 (Gumclaw), triggered automatically by the merge of #6109 via the merged-PR → help-center doc sync pipeline. Instructions: check whether the merged PR changes externally documented behavior and update the affected help center article(s) to match.
