### PR TITLE
Document seller gifting opt-out in help center

### DIFF
--- a/app/views/help_center/articles/contents/_213-how-do-i-give-a-product-as-a-gift.html.erb
+++ b/app/views/help_center/articles/contents/_213-how-do-i-give-a-product-as-a-gift.html.erb
@@ -10,5 +10,7 @@
   <h3>Restrictions</h3>
   <ul>
     <li>You cannot gift more than one product in the cart at a time</li>
+    <li>Some creators turn gifting off for their products. If the creator has disabled gifting, the “Give as a gift” option will not appear at checkout for any of their products.</li>
   </ul>
+  <p><i>Note for creators:</i> you can turn gifting on or off for all of your products from your Checkout form settings. Go to Checkout > Form and use the “Allow customers to purchase your products as gifts” switch in the Gifting section.</p>
 </div>

--- a/app/views/help_center/articles/contents/_343-wishlists.html.erb
+++ b/app/views/help_center/articles/contents/_343-wishlists.html.erb
@@ -30,7 +30,7 @@
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/66668abf1f3fa9421e287be3/file-WAxUDJItSv.png" %></figure>
   <h3>How Gifting from wishlists works:</h3>
   <ul>
-    <li>It must be a "giftable product," which means the product is available to purchase and not a subscription or preorder (we don't support gifting those at this time)</li>
+    <li>It must be a "giftable product," which means the product is available to purchase, is not a subscription or preorder (we don't support gifting those at this time), and the creator has not disabled gifting for their products</li>
     <li>Clicking the gift icon button will take them directly to checkout and:
       <ul>
         <li>Clear their existing cart</li>


### PR DESCRIPTION
## What

Updates two help-center articles for the seller gifting opt-out shipped in #6068 (`User#gifting_disabled`, bit 56, surfaced as the "Allow customers to purchase your products as gifts" switch in the new **Gifting** section on Checkout > Form):

- `_213-how-do-i-give-a-product-as-a-gift.html.erb` — adds a restriction bullet ("Give as a gift" won't appear when the creator has disabled gifting) and a creator-facing note pointing at the Checkout > Form Gifting switch, quoting the UI label verbatim from `CheckoutDashboard/FormPage.tsx`.
- `_343-wishlists.html.erb` — folds the new condition into the "giftable product" definition, since `Link#can_gift?` now returns false when the seller has disabled gifting and the wishlist gift button keys off giftability.

`articles.yml` untouched (body-only edits, no title/description change).

## Why

Both articles described gifting as unconditionally available at checkout and on wishlists. After #6068, sellers can turn it off account-wide; without these notes, buyers would file tickets about a "missing" gift toggle and creators wouldn't know where the setting lives.

Dual-audience sweep per the opt-out-toggle pattern: buyer-facing expectation set in both articles, seller-facing pointer added in the gifting article. The opt-out is ACCOUNT-wide (a `User` flag), and the wording says "their products" collectively rather than implying per-product control. `Purchase::CreateService`'s distinct error ("The creator has disabled gifting for their products.") only fires on stale checkout state, so it's not documented as a normal path.

## Test plan

- Rendered both partials in the real view context (`ApplicationController.render`) — both render OK, new copy present, tag-balance check clean (div/p/ul/li/h3/figure all matched).
- Body-only edit: help-center model specs unaffected (`articles.yml` unchanged); CI runs the full suite.
- Verified UI label and section header verbatim against the #6068 diff (`label="Allow customers to purchase your products as gifts"`, `<h2>Gifting</h2>`), and the account-wide scope against `Link#can_gift?` (`!user.gifting_disabled?`).

## QA steps

1. Open help.gumroad.com/help/article/213-how-do-i-give-a-product-as-a-gift — Restrictions now lists the creator opt-out, followed by the creator note pointing at Checkout > Form.
2. Open help.gumroad.com/help/article/343-wishlists — "How Gifting from wishlists works" giftable-product bullet includes the creator opt-out condition.

---

AI disclosure: authored by Claude Fable 5 via the merged-PR → help-center sync automation. Instructions: triggering event was the merge of #6068; mapped the change to affected articles per the gumroad-help-center-editing skill (dual-audience opt-out verdict) and shipped the additive edits.
