### PR TITLE
Document the per-file Send to Kindle and Read buttons toggle in the help center

### DIFF
--- a/app/views/help_center/articles/contents/_112-mobile-friendly-files.html.erb
+++ b/app/views/help_center/articles/contents/_112-mobile-friendly-files.html.erb
@@ -25,7 +25,7 @@
   </ul>
   <h3>Optimizing a PDF for Mobile:</h3>
   <p>Some customers would rather download ebooks to their devices instead of using the Gumroad app. For an optimized customer service experience, consider uploading multiple ebook formats. A PDF version is a safe default since most devices can display one, but we recommend also uploading an EPUB version: EPUB text reflows to fit any screen, which makes it much nicer to read on phones and e-readers.</p>
-  <p>Gumroad can read both PDF and EPUB files directly in the browser. Customers see a "Read" button next to these files on the download page, and the reader remembers where they left off. EPUB files over 32 MB are download-only. If your product has a PDF but no EPUB, you'll see a reminder on the product's content tab suggesting you add one.</p>
+  <p>Gumroad can read both PDF and EPUB files directly in the browser. Customers see a "Read" button next to these files on the download page, and the reader remembers where they left off. EPUB files over 32 MB are download-only. If your product has a PDF but no EPUB, you'll see a reminder on the product's content tab suggesting you add one. If you prefer, you can hide the "Send to Kindle" and "Read" buttons for a specific file: while editing your product's content, click the file to expand its settings and toggle off <strong>Show "Send to Kindle" and "Read" buttons on the download page</strong>.</p>
   <figure><%= image_tag "help_center/epub-nudge.png" %></figure>
   <h3>PDF Settings</h3>
   <p>Set the page size to 6x9" and use a 12pt font for the body. Regular PDF defaults tend to make them hard to read on mobile because they are generally optimized for print.</p>

--- a/app/views/help_center/articles/contents/_198-your-gumroad-library.html.erb
+++ b/app/views/help_center/articles/contents/_198-your-gumroad-library.html.erb
@@ -12,7 +12,7 @@
   <p>You can easily see your archived products again by clicking “Show archived only” on the left side of your screen, and unarchive them again from the three-dots menu.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/64b7bc79c2f5ed048130c846/file-hnL4nj8I1W.png" %></figure>
   <h3>Reading your purchases in the browser</h3>
-  <p>If a product includes a PDF or EPUB file, you can read it right in your browser without downloading it. Open the product from your Library and click the "Read" button next to the file.</p>
+  <p>If a product includes a PDF or EPUB file, you can read it right in your browser without downloading it. Open the product from your Library and click the "Read" button next to the file. Some creators turn this option off for certain files, in which case you won't see a "Read" button and can download the file instead.</p>
   <figure><%= image_tag "help_center/read-button-download-page.png" %></figure>
   <p>The reader saves your place automatically, so the next time you open the file you will pick up where you left off. You can turn pages with the arrow buttons, your keyboard's arrow keys, or the progress bar at the top.</p>
   <p>For EPUB files, you can also adjust the text size (from 70% to 200%) and choose a light, sepia, or dark background from the reader's settings.</p>

--- a/app/views/help_center/articles/contents/_208-how-do-i-send-my-gumroad-purchase-to-my-kindle.html.erb
+++ b/app/views/help_center/articles/contents/_208-how-do-i-send-my-gumroad-purchase-to-my-kindle.html.erb
@@ -1,6 +1,6 @@
 <div>
   <p>If you've purchased a .mobi or a PDF file, you can send it to your Kindle directly from your Gumroad Library.</p>
-  <p><strong>Note:</strong> ePub files do not work on Kindle for now. If you have mistakenly purchased an ePub file and need a PDF, please <a href="195-theres-an-issue-with-my-purchase" target="_self">contact the creator</a>. Also, Gumroad can only send files 16 MB in size or smaller. If the "Send to Kindle" button is not appearing in your Library, please verify the size of the file you have purchased.</p>
+  <p><strong>Note:</strong> ePub files do not work on Kindle for now. If you have mistakenly purchased an ePub file and need a PDF, please <a href="195-theres-an-issue-with-my-purchase" target="_self">contact the creator</a>. Also, Gumroad can only send files 16 MB in size or smaller. If the "Send to Kindle" button is not appearing in your Library, please verify the size of the file you have purchased. Creators can also turn the "Send to Kindle" button off for individual files, in which case you can download the file and send it as an email attachment instead (see below).</p>
   <h3>Send from your Gumroad Library</h3>
   <ol>
     <li>From your Amazon account, add <a href="mailto:support@gumroad.com">support@gumroad.com</a> to your "Approved sender list". <a href="https://www.amazon.com/gp/help/customer/display.html?nodeId=GX9XLEVV8G4DB28H" target="_blank" rel="noopener noreferrer">Here are the instructions</a> from Amazon.</li>

--- a/app/views/help_center/articles/contents/_247-what-your-customers-see.html.erb
+++ b/app/views/help_center/articles/contents/_247-what-your-customers-see.html.erb
@@ -22,6 +22,7 @@
   <p>If your product includes a PDF or an EPUB file up to 32 MB, your customers will see a "Read" button next to it on the download page. Clicking it opens the file in an in-browser reader, so they can start reading right away without downloading anything. Larger EPUB files remain available for download.</p>
   <figure><%= image_tag "help_center/read-button-download-page.png" %></figure>
   <p>The reader remembers where they left off, so they can pick up their reading later, and for EPUB files it also lets them adjust the text size and switch between light, sepia, and dark backgrounds.</p>
+  <p>If you would rather not offer these options for a particular file, you can turn them off. While editing your product's content, click the file to expand its settings and toggle off <strong>Show "Send to Kindle" and "Read" buttons on the download page</strong>. Customers will then only see the Download button for that file.</p>
   <h3 id="What-is-the-Gumroad-Library-app-x5AtC">What is the Gumroad app?</h3>
   <p>You can also access your Library from our iOS or Android mobile app. <a href="177-the-gumroad-dashboard-app" target="_self">Read this article</a> to know all about downloading and using our app! </p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/654dedfc2d28585006d0164c/file-jcOHcoXhih.png" %></figure>


### PR DESCRIPTION
## What

Updates four help center articles for the new per-file setting that hides the "Send to Kindle" and "Read" buttons on the download page (shipped in #6069).

- `_247-what-your-customers-see` (seller-facing): adds a sentence pointing at the new file-embed switch — 'Show "Send to Kindle" and "Read" buttons on the download page' — and its effect (customers only see the Download button).
- `_112-mobile-friendly-files` (seller-facing): same pointer added to the in-browser reader paragraph.
- `_198-your-gumroad-library` (buyer-facing): notes that some creators turn the Read option off for certain files, so the button may be absent.
- `_208-how-do-i-send-my-gumroad-purchase-to-my-kindle` (buyer-facing): adds the per-file creator toggle as a reason the "Send to Kindle" button might not appear, pointing at the existing email-attachment fallback.

The switch label is quoted verbatim from `ProductEdit/ContentTab/FileEmbed.tsx`, and the "Download button only" behavior matches `UrlRedirectPresenter#map_file` nulling `kindle_data` and `read_url` for flagged files.

## Why

These articles described the Send to Kindle and Read buttons unconditionally. With #6069 merged, sellers can hide them per file, so the seller docs need to mention the control and the buyer docs need to explain why a button may not appear (otherwise buyers file "missing button" tickets).

## Test plan

- Rendered all four partials via `ApplicationController.render` in the test env — all render OK, per-tag open/close counts balanced.
- `bundle exec rspec spec/models/help_center` — 1 example, 0 failures (slug ↔ partial integrity).
- `articles.yml` untouched (body-only prose edits, no title/description changes).

Autoreview skipped (docs copy only, no logic).

---

## AI disclosure

Authored by Claude Fable 5 (Hermes Agent) via the merged-PR → help-center sync automation, triggered by the merge of #6069.
