### PR TITLE
Fix duplicate alive UTM links breaking visit tracking permanently

### DIFF
--- a/app/controllers/concerns/utm_link_tracking.rb
+++ b/app/controllers/concerns/utm_link_tracking.rb
@@ -42,7 +42,17 @@ module UtmLinkTracking
         # links, so if we only searched "active" links here we could miss a disabled duplicate,
         # try to create a new link, and have the save fail — which used to surface as a 422
         # error on the buyer-facing page.
-        utm_link = UtmLink.alive.find_or_initialize_by(utm_params.merge(target_resource_type:, target_resource_id:))
+        #
+        # Order by id so the lookup is deterministic when duplicate alive links exist.
+        # Duplicates happen when two simultaneous first visits both insert the same link:
+        # MySQL's unique index can't stop that when a nullable column (utm_term, utm_content,
+        # target_resource_id) is NULL, because NULLs never conflict in unique indexes. Without
+        # an explicit order, alternating visits could split between the duplicate rows;
+        # always picking the oldest row keeps all stats accumulating on one link.
+        utm_link = UtmLink.alive
+          .where(utm_params.merge(target_resource_type:, target_resource_id:))
+          .order(:id)
+          .first_or_initialize
 
         # A disabled link means the seller intentionally paused tracking for these UTM
         # parameters — respect that and don't record the visit.
@@ -80,13 +90,13 @@ module UtmLinkTracking
       #     validation sees the winner's row and fails with "A link with similar UTM parameters
       #     already exists".
       #
-      # There is a third outcome this rescue cannot recover: MySQL unique indexes treat NULL
-      # values as non-conflicting, and this index includes nullable columns (utm_term,
-      # utm_content, target_resource_id), so two racers can BOTH insert successfully and leave
-      # duplicate alive rows. After that, every visit fails the uniqueness validation on the
-      # persisted link's save below — new_record? is false, so we correctly don't retry
-      # (retrying would fail identically) and just report. Cleaning up such duplicates needs a
-      # separate dedup pass; see https://github.com/antiwork/gumroad/issues/5989.
+      # There is a third outcome: MySQL unique indexes treat NULL values as non-conflicting,
+      # and this index includes nullable columns (utm_term, utm_content, target_resource_id),
+      # so two racers can BOTH insert successfully and leave duplicate alive rows. Visits keep
+      # working for such links — the lookup above deterministically picks the oldest duplicate,
+      # and the model only re-validates uniqueness when identifying fields change (not on
+      # click-timestamp updates). Merging the duplicate rows themselves is handled by the
+      # Onetime::DedupUtmLinks task; see https://github.com/antiwork/gumroad/issues/5989.
       #
       # In both recoverable cases the winning request has committed the link by the time we get here, so
       # retrying once lets this request find that link and still record the visit. For

--- a/app/models/utm_link.rb
+++ b/app/models/utm_link.rb
@@ -5,6 +5,13 @@ class UtmLink < ApplicationRecord
 
   MAX_UTM_PARAM_LENGTH = 200
 
+  # The set of columns that must be unique together across a seller's alive links. The
+  # database's unique index on these columns cannot fully enforce this because several of
+  # them are nullable and MySQL treats NULLs in unique indexes as non-conflicting — so the
+  # model validation below is the real guard, and it only runs when one of these fields (or
+  # the record's alive-ness) changes. See #utm_fields_are_unique_per_target_resource.
+  UTM_UNIQUENESS_ATTRIBUTES = %w[seller_id utm_source utm_medium utm_campaign utm_term utm_content target_resource_type target_resource_id].freeze
+
   has_paper_trail
 
   belongs_to :seller, class_name: "User"
@@ -37,7 +44,14 @@ class UtmLink < ApplicationRecord
   validates :utm_term, length: { maximum: MAX_UTM_PARAM_LENGTH }
   validates :utm_content, length: { maximum: MAX_UTM_PARAM_LENGTH }
   validate :last_click_at_is_same_or_after_first_click_at
-  validate :utm_fields_are_unique_per_target_resource
+  # Only validate uniqueness when the identifying fields change (or the record is new /
+  # being restored). Duplicate alive rows can already exist in the database: the unique
+  # index can't catch two simultaneous first visits when a nullable column (utm_term,
+  # utm_content, target_resource_id) is NULL, because MySQL treats NULLs as non-conflicting.
+  # Before this condition, any save on such a duplicate (even just updating click
+  # timestamps) failed this validation forever, dropping every visit for that link.
+  # See https://github.com/antiwork/gumroad/issues/5989.
+  validate :utm_fields_are_unique_per_target_resource, if: :utm_uniqueness_fields_changing?
 
   scope :enabled, -> { where(disabled_at: nil) }
   scope :active, -> { alive.enabled }
@@ -153,5 +167,14 @@ class UtmLink < ApplicationRecord
       ).where.not(id:).none?
 
       errors.add(:target_resource_id, "A link with similar UTM parameters already exists for this destination!")
+    end
+
+    def utm_uniqueness_fields_changing?
+      return true if new_record?
+      # A soft-deleted link being restored re-enters the alive set, so it must re-check
+      # uniqueness even though none of its UTM fields changed.
+      return true if will_save_change_to_deleted_at? && deleted_at.nil?
+
+      UTM_UNIQUENESS_ATTRIBUTES.any? { will_save_change_to_attribute?(_1) }
     end
 end

--- a/app/services/onetime/dedup_duplicate_utm_links.rb
+++ b/app/services/onetime/dedup_duplicate_utm_links.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+# One-off cleanup for duplicate alive UTM links left behind by a race in UTM link
+# auto-creation. Two simultaneous first visits with the same UTM parameters could both
+# insert a link: the database's unique index on the UTM fields can't stop this when a
+# nullable column (utm_term, utm_content, target_resource_id) is NULL, because MySQL
+# treats NULLs in unique indexes as non-conflicting. Once duplicates existed, every
+# subsequent visit to that link failed the model's uniqueness validation and was
+# dropped. See https://github.com/antiwork/gumroad/issues/5989.
+#
+# For each group of alive duplicates this task keeps the oldest link (lowest id — the
+# same row the tracking lookup now deterministically picks), repoints the other rows'
+# visits and driven sales to it, merges click timestamps, soft-deletes the extra rows,
+# and refreshes the keeper's click counters.
+#
+# Usage (dry run by default):
+#   Onetime::DedupDuplicateUtmLinks.process
+#   Onetime::DedupDuplicateUtmLinks.process(dry_run: false)
+module Onetime
+  class DedupDuplicateUtmLinks
+    UNIQUENESS_COLUMNS = UtmLink::UTM_UNIQUENESS_ATTRIBUTES
+
+    def self.process(dry_run: true)
+      new.process(dry_run:)
+    end
+
+    def process(dry_run: true)
+      groups = duplicate_groups
+      puts "Found #{groups.size} duplicate group(s) (#{groups.sum { _1.size - 1 }} extra row(s))"
+
+      groups.each do |links|
+        keeper, *extras = links
+        puts "Keeping UtmLink #{keeper.id}; merging #{extras.map(&:id).join(', ')}"
+        next if dry_run
+
+        merge_into_keeper(keeper, extras)
+      end
+
+      puts dry_run ? "Dry run — no changes made. Re-run with dry_run: false to apply." : "Done."
+    end
+
+    private
+      # Returns arrays of alive UtmLink records sharing the same uniqueness key,
+      # each sorted oldest-first (the oldest is the keeper).
+      def duplicate_groups
+        duplicate_keys = UtmLink.alive
+          .group(*UNIQUENESS_COLUMNS)
+          .having("COUNT(*) > 1")
+          .pluck(*UNIQUENESS_COLUMNS)
+
+        duplicate_keys.map do |key_values|
+          conditions = UNIQUENESS_COLUMNS.zip(key_values).to_h
+          UtmLink.alive.where(conditions).order(:id).to_a
+        end
+      end
+
+      def merge_into_keeper(keeper, extras)
+        ActiveRecord::Base.transaction do
+          extra_ids = extras.map(&:id)
+
+          UtmLinkVisit.where(utm_link_id: extra_ids).update_all(utm_link_id: keeper.id)
+          UtmLinkDrivenSale.where(utm_link_id: extra_ids).update_all(utm_link_id: keeper.id)
+
+          first_clicks = ([keeper.first_click_at] + extras.map(&:first_click_at)).compact
+          last_clicks = ([keeper.last_click_at] + extras.map(&:last_click_at)).compact
+          keeper.first_click_at = first_clicks.min
+          keeper.last_click_at = last_clicks.max
+          keeper.total_clicks = keeper.utm_link_visits.count
+          keeper.unique_clicks = keeper.utm_link_visits.distinct.count(:browser_guid)
+          keeper.save!
+
+          # Soft-delete (not destroy) so paper_trail history and the rows themselves are
+          # preserved; their visits/sales have already been repointed to the keeper.
+          extras.each { _1.mark_deleted! }
+        end
+      end
+  end
+end

--- a/app/services/onetime/dedup_duplicate_utm_links.rb
+++ b/app/services/onetime/dedup_duplicate_utm_links.rb
@@ -13,12 +13,25 @@
 # visits and driven sales to it, merges click timestamps, soft-deletes the extra rows,
 # and refreshes the keeper's click counters.
 #
+# A tracking request that loaded one of the duplicate rows just before the merge
+# transaction committed can still insert its visit afterward, stranding tracked data on
+# a soft-deleted row. Once the row is soft-deleted no NEW request can pick it up (the
+# tracking lookup only reads alive links), so that window is bounded by the lifetime of
+# requests already in flight. After processing every group, the task waits out that
+# window and runs a straggler sweep that repoints any late-arriving visits/sales and
+# refreshes the keeper's counters again.
+#
 # Usage (dry run by default):
 #   Onetime::DedupDuplicateUtmLinks.process
 #   Onetime::DedupDuplicateUtmLinks.process(dry_run: false)
 module Onetime
   class DedupDuplicateUtmLinks
     UNIQUENESS_COLUMNS = UtmLink::UTM_UNIQUENESS_ATTRIBUTES
+
+    # How long to wait after the last merge before sweeping for straggler visits.
+    # Generously longer than any web request lives, so every request that had already
+    # loaded a duplicate row has either committed its visit or died by the time we sweep.
+    STRAGGLER_GRACE_PERIOD = 60.seconds
 
     def self.process(dry_run: true)
       new.process(dry_run:)
@@ -28,13 +41,17 @@ module Onetime
       groups = duplicate_groups
       puts "Found #{groups.size} duplicate group(s) (#{groups.sum { _1.size - 1 }} extra row(s))"
 
+      merged = []
       groups.each do |links|
         keeper, *extras = links
         puts "Keeping UtmLink #{keeper.id}; merging #{extras.map(&:id).join(', ')}"
         next if dry_run
 
         merge_into_keeper(keeper, extras)
+        merged << [keeper, extras.map(&:id)]
       end
+
+      sweep_stragglers(merged) if merged.any?
 
       puts dry_run ? "Dry run — no changes made. Re-run with dry_run: false to apply." : "Done."
     end
@@ -58,21 +75,57 @@ module Onetime
         ActiveRecord::Base.transaction do
           extra_ids = extras.map(&:id)
 
-          UtmLinkVisit.where(utm_link_id: extra_ids).update_all(utm_link_id: keeper.id)
-          UtmLinkDrivenSale.where(utm_link_id: extra_ids).update_all(utm_link_id: keeper.id)
+          repoint_tracked_rows(extra_ids, keeper)
 
           first_clicks = ([keeper.first_click_at] + extras.map(&:first_click_at)).compact
           last_clicks = ([keeper.last_click_at] + extras.map(&:last_click_at)).compact
           keeper.first_click_at = first_clicks.min
           keeper.last_click_at = last_clicks.max
-          keeper.total_clicks = keeper.utm_link_visits.count
-          keeper.unique_clicks = keeper.utm_link_visits.distinct.count(:browser_guid)
-          keeper.save!
+          refresh_keeper_counters(keeper)
 
           # Soft-delete (not destroy) so paper_trail history and the rows themselves are
           # preserved; their visits/sales have already been repointed to the keeper.
           extras.each { _1.mark_deleted! }
         end
+      end
+
+      # Catches visits/sales created by requests that were already in flight (holding a
+      # reference to a duplicate row) when the merge transactions committed. See the
+      # class comment for why waiting out the request lifetime makes this sweep complete.
+      def sweep_stragglers(merged)
+        puts "Waiting #{STRAGGLER_GRACE_PERIOD.to_i}s for in-flight tracking requests before the straggler sweep..."
+        sleep(STRAGGLER_GRACE_PERIOD)
+
+        merged.each do |keeper, extra_ids|
+          stragglers = UtmLinkVisit.where(utm_link_id: extra_ids).exists? ||
+            UtmLinkDrivenSale.where(utm_link_id: extra_ids).exists?
+          next unless stragglers
+
+          puts "Repointing straggler visits/sales from #{extra_ids.join(', ')} to UtmLink #{keeper.id}"
+          ActiveRecord::Base.transaction do
+            repoint_tracked_rows(extra_ids, keeper)
+
+            keeper.reload
+            # A straggler visit's created_at is when the click happened, so widen the
+            # keeper's click window to cover it.
+            visit_times = keeper.utm_link_visits.pluck(Arel.sql("MIN(created_at)"), Arel.sql("MAX(created_at)")).first
+            earliest_visit_at, latest_visit_at = visit_times
+            keeper.first_click_at = [keeper.first_click_at, earliest_visit_at].compact.min
+            keeper.last_click_at = [keeper.last_click_at, latest_visit_at].compact.max
+            refresh_keeper_counters(keeper)
+          end
+        end
+      end
+
+      def repoint_tracked_rows(extra_ids, keeper)
+        UtmLinkVisit.where(utm_link_id: extra_ids).update_all(utm_link_id: keeper.id)
+        UtmLinkDrivenSale.where(utm_link_id: extra_ids).update_all(utm_link_id: keeper.id)
+      end
+
+      def refresh_keeper_counters(keeper)
+        keeper.total_clicks = keeper.utm_link_visits.count
+        keeper.unique_clicks = keeper.utm_link_visits.distinct.count(:browser_guid)
+        keeper.save!
       end
   end
 end

--- a/spec/controllers/concerns/utm_link_tracking_spec.rb
+++ b/spec/controllers/concerns/utm_link_tracking_spec.rb
@@ -287,6 +287,45 @@ describe UtmLinkTracking, type: :controller do
     end
   end
 
+  context "when duplicate alive UTM links already exist for the same UTM parameters" do
+    # The auto-create race can leave two alive rows with identical UTM fields when a
+    # nullable column is NULL (MySQL unique indexes never conflict on NULL). Visits to
+    # such links must keep working: the lookup picks the oldest row deterministically and
+    # updating its click timestamps must not fail the uniqueness validation (issue #5989).
+    let!(:older_link) do
+      create(:utm_link, seller:, target_resource_type: "profile_page", target_resource_id: nil,
+                        utm_source: "facebook", utm_medium: "social", utm_campaign: "summer_sale",
+                        utm_term: nil, utm_content: nil)
+    end
+    let!(:newer_duplicate) do
+      build(:utm_link, seller:, target_resource_type: "profile_page", target_resource_id: nil,
+                       utm_source: "facebook", utm_medium: "social", utm_campaign: "summer_sale",
+                       utm_term: nil, utm_content: nil,
+                       permalink: UtmLink.generate_permalink).tap { _1.save!(validate: false) }
+    end
+
+    before do
+      allow(controller).to receive(:root_path).and_return("/")
+      request.host = "#{seller.subdomain}"
+      request.path = "/"
+    end
+
+    it "records the visit on the oldest duplicate without reporting an error", :sidekiq_inline do
+      expect(ErrorNotifier).not_to receive(:notify)
+
+      expect do
+        expect do
+          get :action, params: { utm_source: "facebook", utm_medium: "social", utm_campaign: "summer_sale" }
+        end.to change { older_link.reload.utm_link_visits.count }.by(1)
+      end.not_to change(UtmLink, :count)
+
+      expect(response).to be_successful
+      expect(newer_duplicate.reload.utm_link_visits.count).to eq(0)
+      expect(older_link.reload.total_clicks).to eq(1)
+      expect(older_link.last_click_at).to be_present
+    end
+  end
+
   context "when a matching UTM link is not found" do
     let(:product) { create(:product, user: seller) }
     let(:post) { create(:published_installment, seller:, shown_on_profile: true) }

--- a/spec/models/utm_link_spec.rb
+++ b/spec/models/utm_link_spec.rb
@@ -265,6 +265,60 @@ describe UtmLink do
         expect(utm_link).to be_valid
         expect(utm_link.save).to be(true)
       end
+
+      context "when duplicate alive links already exist in the database" do
+        # MySQL's unique index can't prevent duplicates when a nullable column (utm_term,
+        # utm_content, target_resource_id) is NULL, so a race in auto-creation can leave two
+        # alive rows with the same UTM fields. Existing duplicates must not make every
+        # subsequent save on those rows fail — see issue #5989.
+        let!(:original) do
+          create(:utm_link, seller:, target_resource_type: "profile_page", target_resource_id: nil,
+                            utm_source: "facebook", utm_medium: "social", utm_campaign: "spring",
+                            utm_term: nil, utm_content: nil)
+        end
+        let!(:duplicate) do
+          # save!(validate: false) skips before_validation callbacks too, so the permalink
+          # (normally auto-generated there) must be set explicitly.
+          build(:utm_link, seller:, target_resource_type: "profile_page", target_resource_id: nil,
+                           utm_source: "facebook", utm_medium: "social", utm_campaign: "spring",
+                           utm_term: nil, utm_content: nil,
+                           permalink: UtmLink.generate_permalink).tap { _1.save!(validate: false) }
+        end
+
+        it "still allows saving non-identifying changes (e.g. click timestamps) on a duplicate" do
+          duplicate.first_click_at = Time.current
+          duplicate.last_click_at = Time.current
+          duplicate.title = "Renamed"
+
+          expect(duplicate).to be_valid
+          expect(duplicate.save).to be(true)
+        end
+
+        it "still allows soft-deleting a duplicate" do
+          expect { duplicate.mark_deleted! }.not_to raise_error
+          expect(duplicate.reload).to be_deleted
+        end
+
+        it "re-validates uniqueness when an identifying field changes" do
+          other = create(:utm_link, seller:, target_resource_type: "subscribe_page", target_resource_id: nil,
+                                    utm_source: "twitter", utm_medium: "social", utm_campaign: "spring",
+                                    utm_term: nil, utm_content: nil)
+
+          other.utm_source = "facebook"
+          other.target_resource_type = "profile_page"
+
+          expect(other).not_to be_valid
+          expect(other.errors[:target_resource_id]).to include("A link with similar UTM parameters already exists for this destination!")
+        end
+
+        it "re-validates uniqueness when restoring a soft-deleted link" do
+          duplicate.mark_deleted!
+
+          duplicate.deleted_at = nil
+          expect(duplicate).not_to be_valid
+          expect(duplicate.errors[:target_resource_id]).to include("A link with similar UTM parameters already exists for this destination!")
+        end
+      end
     end
   end
 

--- a/spec/services/onetime/dedup_duplicate_utm_links_spec.rb
+++ b/spec/services/onetime/dedup_duplicate_utm_links_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Onetime::DedupDuplicateUtmLinks do
+  let(:seller) { create(:user) }
+
+  # The race that created these duplicates bypassed the model validation, so the spec
+  # does the same: build the duplicate and save it without validation.
+  def create_duplicate_of(link)
+    build(:utm_link,
+          seller: link.seller,
+          target_resource_type: link.target_resource_type,
+          target_resource_id: link.target_resource_id,
+          utm_source: link.utm_source,
+          utm_medium: link.utm_medium,
+          utm_campaign: link.utm_campaign,
+          utm_term: link.utm_term,
+          utm_content: link.utm_content,
+          permalink: UtmLink.generate_permalink).tap { _1.save!(validate: false) }
+  end
+
+  describe ".process" do
+    let!(:keeper) do
+      create(:utm_link, seller:, target_resource_type: "profile_page", target_resource_id: nil,
+                        utm_source: "facebook", utm_medium: "social", utm_campaign: "spring",
+                        utm_term: nil, utm_content: nil,
+                        first_click_at: 3.days.ago, last_click_at: 2.days.ago)
+    end
+    let!(:duplicate) { create_duplicate_of(keeper) }
+    let!(:unrelated_link) { create(:utm_link, seller:) }
+
+    let!(:keeper_visit) { create(:utm_link_visit, utm_link: keeper, browser_guid: "guid-a") }
+    let!(:duplicate_visit) { create(:utm_link_visit, utm_link: duplicate, browser_guid: "guid-b") }
+    let!(:duplicate_driven_sale) do
+      create(:utm_link_driven_sale, utm_link: duplicate, utm_link_visit: duplicate_visit)
+    end
+
+    before do
+      duplicate.update_columns(first_click_at: 4.days.ago, last_click_at: 1.day.ago)
+    end
+
+    it "does not change anything on a dry run" do
+      expect do
+        described_class.process
+      end.to not_change { duplicate.reload.deleted_at }
+        .and not_change { duplicate_visit.reload.utm_link_id }
+        .and not_change { keeper.reload.total_clicks }
+    end
+
+    it "repoints visits and driven sales to the oldest link, merges click data, and soft-deletes the duplicate" do
+      described_class.process(dry_run: false)
+
+      expect(duplicate.reload).to be_deleted
+      expect(keeper.reload).to be_alive
+
+      expect(duplicate_visit.reload.utm_link_id).to eq(keeper.id)
+      expect(duplicate_driven_sale.reload.utm_link_id).to eq(keeper.id)
+
+      expect(keeper.total_clicks).to eq(2)
+      expect(keeper.unique_clicks).to eq(2)
+      expect(keeper.first_click_at).to be_within(1.second).of(4.days.ago)
+      expect(keeper.last_click_at).to be_within(1.second).of(1.day.ago)
+    end
+
+    it "leaves non-duplicated links untouched" do
+      described_class.process(dry_run: false)
+
+      expect(unrelated_link.reload).to be_alive
+    end
+
+    it "merges all extra rows when a group has more than two duplicates" do
+      second_duplicate = create_duplicate_of(keeper)
+
+      described_class.process(dry_run: false)
+
+      expect(duplicate.reload).to be_deleted
+      expect(second_duplicate.reload).to be_deleted
+      expect(keeper.reload).to be_alive
+    end
+  end
+end

--- a/spec/services/onetime/dedup_duplicate_utm_links_spec.rb
+++ b/spec/services/onetime/dedup_duplicate_utm_links_spec.rb
@@ -33,11 +33,14 @@ describe Onetime::DedupDuplicateUtmLinks do
     let!(:keeper_visit) { create(:utm_link_visit, utm_link: keeper, browser_guid: "guid-a") }
     let!(:duplicate_visit) { create(:utm_link_visit, utm_link: duplicate, browser_guid: "guid-b") }
     let!(:duplicate_driven_sale) do
-      create(:utm_link_driven_sale, utm_link: duplicate, utm_link_visit: duplicate_visit)
+      purchase = create(:free_purchase, seller:, link: create(:product, user: seller, price_cents: 0))
+      create(:utm_link_driven_sale, utm_link: duplicate, utm_link_visit: duplicate_visit, purchase:)
     end
 
     before do
       duplicate.update_columns(first_click_at: 4.days.ago, last_click_at: 1.day.ago)
+      # Don't actually wait out the straggler grace period in specs.
+      allow_any_instance_of(described_class).to receive(:sleep)
     end
 
     it "does not change anything on a dry run" do
@@ -46,6 +49,24 @@ describe Onetime::DedupDuplicateUtmLinks do
       end.to not_change { duplicate.reload.deleted_at }
         .and not_change { duplicate_visit.reload.utm_link_id }
         .and not_change { keeper.reload.total_clicks }
+    end
+
+    it "sweeps up visits committed by requests that raced the merge and recounts the keeper" do
+      # Simulate a request that loaded the duplicate while it was still alive and
+      # committed its visit only after the merge transaction ran: inject the late visit
+      # during the grace-period wait, right before the straggler sweep.
+      late_visit = nil
+      allow_any_instance_of(described_class).to receive(:sleep) do
+        late_visit ||= create(:utm_link_visit, browser_guid: "guid-late").tap do
+          _1.update_column(:utm_link_id, duplicate.id)
+        end
+      end
+
+      described_class.process(dry_run: false)
+
+      expect(late_visit.reload.utm_link_id).to eq(keeper.id)
+      expect(keeper.reload.total_clicks).to eq(3)
+      expect(keeper.unique_clicks).to eq(3)
     end
 
     it "repoints visits and driven sales to the oldest link, merges click data, and soft-deletes the duplicate" do


### PR DESCRIPTION
Fixes #5989.

Duplicate alive UTM links (born from a NULL-column insert race — MySQL unique indexes treat NULLs as non-conflicting) made every subsequent visit fail the uniqueness validation, permanently dropping tracking for those links. Three-part fix:

- **Deterministic lookup**: `UtmLinkTracking` now orders the alive-link lookup by `id`, so all visits accumulate on the oldest duplicate instead of alternating.
- **Scoped validation**: `UtmLink#utm_fields_are_unique_per_target_resource` only runs when an identifying field (or alive-ness) changes — click-timestamp updates on an already-duplicated link no longer fail validation.
- **Cleanup task**: `Onetime::DedupDuplicateUtmLinks` (dry-run by default) merges duplicate groups — keeps the oldest row, repoints visits/driven sales, merges click timestamps, soft-deletes extras, refreshes counters. After all groups are merged it waits out the in-flight request window and runs a straggler sweep that repoints any visits committed by requests that raced the merge, then recounts the keeper.

## QA steps
- Specs added for the race outcome: duplicate alive rows still record visits (concern spec), validation skip on timestamp-only saves (model spec), and full merge behavior of the onetime task, including a straggler-sweep spec that injects a late visit during the grace-period wait and verifies it is repointed and recounted.
- `spec/services/onetime/dedup_duplicate_utm_links_spec.rb` run locally: 5 examples, 0 failures.

🤖 Authored by gumclaw (AI agent).

