### PR TITLE
Speed up mobile library search post-filter probes for mega-sellers

### DIFF
--- a/app/models/concerns/with_filtering.rb
+++ b/app/models/concerns/with_filtering.rb
@@ -167,10 +167,15 @@ module WithFiltering
     end
 
     if exclude_product_ids.present? || not_bought_variants.present?
-      # Memoize per (variants, products, email) signature so multiple posts
-      # sharing the same exclusion criteria do not re-issue the SAME
-      # `seller_sales.where(...).exists?(email:)` SQL once per post.
-      cache_key = [Array(not_bought_variants).sort, exclude_product_ids.sort, email]
+      # Memoize per (seller, variants, products, email) signature so multiple
+      # posts sharing the same exclusion criteria do not re-issue the SAME
+      # `seller_sales.where(...).exists?(email:)` SQL once per post. The seller
+      # id is part of the key because the existence probe runs against THIS
+      # post's seller's sales — a shared cache can span posts from different
+      # sellers (e.g. Purchase.product_installments batches a page of library
+      # purchases), and without the seller id two sellers whose posts target
+      # the same product/variant ids would incorrectly share one result.
+      cache_key = [seller_id, Array(not_bought_variants).sort, exclude_product_ids.sort, email]
       cache = seller_post_filter_cache
       if cache && cache.key?(cache_key)
         return false if cache[cache_key]

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -2741,9 +2741,10 @@ class Purchase < ApplicationRecord
     # shared cache the same probe re-runs once per (post, purchase) pair. For
     # mega-sellers each probe can take seconds (antiwork/gumroad#6009: two
     # identical probes accounted for 19.9s of a 22s request), so memoize per
-    # unique (targeting criteria, buyer email) signature across the whole batch.
-    # Cache keys include seller-scoped product/variant ids, so entries from
-    # different sellers in the same batch can't collide.
+    # unique (seller, targeting criteria, buyer email) signature across the
+    # whole batch. The cache key carries the post's seller id (see
+    # WithFiltering#seller_post_passes_filters), so entries from different
+    # sellers in the same batch can't collide.
     seller_post_filter_cache = {}
 
     check_filters = lambda do |posts|

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -2734,10 +2734,22 @@ class Purchase < ApplicationRecord
     variant_ids = BaseVariant.joins(:purchases).where("purchases.id IN (?)", purchase_ids).select("base_variants.id")
     seller_ids = purchases.map(&:seller_id)
 
+    # Posts with "hasn't bought X" targeting run an existence probe against the
+    # seller's purchase history (see WithFiltering#seller_post_passes_filters).
+    # Many posts share the same exclusion criteria, and the mobile library
+    # endpoints call this method for a page of purchases at a time — without a
+    # shared cache the same probe re-runs once per (post, purchase) pair. For
+    # mega-sellers each probe can take seconds (antiwork/gumroad#6009: two
+    # identical probes accounted for 19.9s of a 22s request), so memoize per
+    # unique (targeting criteria, buyer email) signature across the whole batch.
+    # Cache keys include seller-scoped product/variant ids, so entries from
+    # different sellers in the same batch can't collide.
+    seller_post_filter_cache = {}
+
     check_filters = lambda do |posts|
       posts.select do |post|
         purchases.reduce(false) do |select_post, purchase|
-          select_post || post.purchase_passes_filters(purchase)
+          select_post || post.purchase_passes_filters(purchase, seller_post_filter_cache:)
         end
       end
     end
@@ -2748,7 +2760,7 @@ class Purchase < ApplicationRecord
           next true if select_post
 
           next false unless purchase.link.should_show_all_posts?
-          next false unless post.purchase_passes_filters(purchase)
+          next false unless post.purchase_passes_filters(purchase, seller_post_filter_cache:)
           # A seller-wide post (no product/variant targeting) is not "targeted at
           # the purchased item", but a should_show_all_posts buyer (e.g. a member)
           # is entitled to the full post history regardless of individual email

--- a/db/migrate/20261206000004_add_email_and_link_id_index_to_purchases.rb
+++ b/db/migrate/20261206000004_add_email_and_link_id_index_to_purchases.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class AddEmailAndLinkIdIndexToPurchases < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    # The mobile library endpoints (Api::Mobile::PurchasesController#search /
+    # #index) serialize each purchase's product-updates feed, and posts with
+    # "hasn't bought X" targeting run an existence probe of the shape:
+    #
+    #   SELECT 1 FROM purchases
+    #   WHERE seller_id = ? AND link_id = ? AND email = ? AND <flag predicates>
+    #   LIMIT 1
+    #
+    # MySQL was driving this off the single-column seller_id index and then
+    # scanning that seller's entire purchase history to check link_id/email —
+    # instant for small sellers, 7-12 seconds per probe for mega-sellers
+    # (antiwork/gumroad#6009: two such probes were 19.9s of a 22.0s request).
+    #
+    # A composite (email, link_id) index lets the optimizer satisfy both
+    # equality predicates directly, reducing the probe to a handful of row
+    # lookups regardless of how large the seller is. Email leads because it is
+    # the most selective predicate and also serves existing email-only lookups
+    # if the optimizer prefers this index over index_purchases_on_email_long.
+    # The 191-character prefix matches that existing email index (the column is
+    # TEXT, so a prefix length is required, and 191 keeps it within the 767-byte
+    # InnoDB key limit under utf8mb4).
+    add_index :purchases, [:email, :link_id],
+              name: "index_purchases_on_email_and_link_id",
+              length: { email: 191 }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_12_06_000003) do
+ActiveRecord::Schema[7.1].define(version: 2026_12_06_000004) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -2023,6 +2023,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_12_06_000003) do
     t.index ["card_type", "card_visual", "created_at", "stripe_fingerprint"], name: "index_purchases_on_card_type_visual_date_fingerprint"
     t.index ["card_type", "card_visual", "stripe_fingerprint"], name: "index_purchases_on_card_type_visual_fingerprint"
     t.index ["created_at"], name: "index_purchases_on_created_at"
+    t.index ["email", "link_id"], name: "index_purchases_on_email_and_link_id", length: { email: 191 }
     t.index ["email"], name: "index_purchases_on_email_long", length: 191
     t.index ["full_name"], name: "index_purchases_on_full_name"
     t.index ["ip_address"], name: "index_purchases_on_ip_address"

--- a/spec/models/concerns/with_filtering_spec.rb
+++ b/spec/models/concerns/with_filtering_spec.rb
@@ -606,6 +606,33 @@ describe WithFiltering do
           seller_sales: @creator.sales
         )).to eq(false)
       end
+
+      it "does not reuse another seller's cached probe result for the same targeting signature and email" do
+        other_seller = create(:user)
+        post_a = create(:seller_installment, seller: @creator, json_data: { not_bought_products: [@product.unique_permalink] })
+        post_b = create(:seller_installment, seller: other_seller, json_data: { not_bought_products: ["reused-permalink"] })
+        shared_cache = {}
+
+        # Buyer bought @product from @creator, so seller A's post excludes them.
+        # This warms the shared cache with a `true` (matched) entry.
+        expect(post_a.seller_post_passes_filters(
+          email: @purchase.email,
+          permalink_to_link_id: { @product.unique_permalink => @product.id },
+          seller_sales: @creator.sales,
+          seller_post_filter_cache: shared_cache
+        )).to eq(false)
+
+        # Seller B's post resolves to the same product id / variant / email
+        # signature (e.g. a recycled permalink). The buyer has NOT bought
+        # anything from seller B, so B's post must pass — the cache entry from
+        # seller A must not be reused across sellers.
+        expect(post_b.seller_post_passes_filters(
+          email: @purchase.email,
+          permalink_to_link_id: { "reused-permalink" => @product.id },
+          seller_sales: other_seller.sales,
+          seller_post_filter_cache: shared_cache
+        )).to eq(true)
+      end
     end
   end
 


### PR DESCRIPTION
Part of #6009 — two-part fix for the dominant 19.9s query shape (two identical "hasn't bought X" existence probes were 19.9s of a 22.0s mobile library search request).

1. **Shared memoization**: `Purchase.product_installments` now creates one `seller_post_filter_cache` for the whole batch and passes it into both filter lambdas — the cache plumbing already exists in `WithFiltering` (used by `User::Posts`); this call site just never used it, so identical probes re-ran once per (post, purchase) pair.
2. **Composite index**: `(email(191), link_id)` on `purchases`. The probe (`seller_id = ? AND link_id = ? AND email = ? LIMIT 1`) was driven off the single-column `seller_id` index, scanning a mega-seller's entire purchase history per probe (7–12s each). The composite index satisfies both equality predicates directly.

Migration uses `disable_ddl_transaction!`; 191-prefix matches the existing `index_purchases_on_email_long` (TEXT column, 767-byte InnoDB key limit under utf8mb4).

## QA / test notes
Backend perf change, no UI. Rubocop clean. This branch was salvaged from a gateway-restart-interrupted session — CI is the verification gate.

🤖 Authored by gumclaw (AI agent).
