### PR TITLE
Remove the fully-enabled tax_center rollout flag

### DIFF
--- a/app/models/concerns/user/taxation.rb
+++ b/app/models/concerns/user/taxation.rb
@@ -95,6 +95,15 @@ module User::Taxation
     alive_user_compliance_info&.country_code == Compliance::Countries::USA.alpha2
   end
 
+  # The tax center (1099 forms, earnings summaries) only applies to US-based
+  # sellers, because the forms it serves are IRS forms. The `tax_center`
+  # feature flag that used to gate this was fully enabled in production and
+  # removed (see gumroad-private#1208), leaving US residency as the only
+  # remaining condition.
+  def tax_center_enabled?
+    from_us?
+  end
+
   private
     def sales_scope_for(year)
       range = Date.new(year).in_time_zone(timezone).all_year

--- a/app/modules/user/feature_status.rb
+++ b/app/modules/user/feature_status.rb
@@ -90,9 +90,5 @@ class User
       is_today_gumroad_day = Time.now.in_time_zone(timezone_for_gumroad_day).to_date == $redis.get(RedisKey.gumroad_day_date)&.to_date
       is_today_gumroad_day || Feature.active?(:waive_gumroad_fee_on_new_sales, self)
     end
-
-    def tax_center_enabled?
-      Feature.active?(:tax_center, self) && from_us?
-    end
   end
 end

--- a/spec/controllers/api/v2/earnings_controller_spec.rb
+++ b/spec/controllers/api/v2/earnings_controller_spec.rb
@@ -11,7 +11,6 @@ describe Api::V2::EarningsController do
   before do
     travel_to Time.new(2026, 4, 15)
     create(:user_compliance_info, user: seller)
-    Feature.activate_user(:tax_center, seller)
   end
 
   describe "GET 'show'" do
@@ -35,8 +34,9 @@ describe Api::V2::EarningsController do
         expect(response.body.strip).to be_empty
       end
 
-      it "returns 403 when tax_center is not enabled" do
-        Feature.deactivate_user(:tax_center, seller)
+      it "returns 403 when the seller is not US-based (tax center disabled)" do
+        seller.alive_user_compliance_info.mark_deleted!
+        create(:user_compliance_info_singapore, user: seller)
         get :show, params: @params
 
         expect(response.status).to eq(403)

--- a/spec/controllers/api/v2/tax_forms_controller_spec.rb
+++ b/spec/controllers/api/v2/tax_forms_controller_spec.rb
@@ -11,7 +11,6 @@ describe Api::V2::TaxFormsController do
   before do
     travel_to Time.new(2026, 4, 15)
     create(:user_compliance_info, user: seller)
-    Feature.activate_user(:tax_center, seller)
   end
 
   describe "GET 'index'" do
@@ -35,8 +34,9 @@ describe Api::V2::TaxFormsController do
         expect(response.body.strip).to be_empty
       end
 
-      it "returns 403 when tax_center is not enabled for the seller" do
-        Feature.deactivate_user(:tax_center, seller)
+      it "returns 403 when the seller is not US-based (tax center disabled)" do
+        seller.alive_user_compliance_info.mark_deleted!
+        create(:user_compliance_info_singapore, user: seller)
         get :index, params: @params
 
         expect(response.status).to eq(403)
@@ -44,15 +44,6 @@ describe Api::V2::TaxFormsController do
           success: false,
           message: "Tax center is not enabled for this account."
         }.as_json)
-      end
-
-      it "returns 403 when seller is not US-based" do
-        seller.alive_user_compliance_info.mark_deleted!
-        create(:user_compliance_info_singapore, user: seller)
-
-        get :index, params: @params
-
-        expect(response.status).to eq(403)
       end
 
       it "returns an empty list when the seller has no forms" do
@@ -171,8 +162,9 @@ describe Api::V2::TaxFormsController do
         expect(response.body.strip).to be_empty
       end
 
-      it "returns 403 when tax_center is not enabled" do
-        Feature.deactivate_user(:tax_center, seller)
+      it "returns 403 when the seller is not US-based (tax center disabled)" do
+        seller.alive_user_compliance_info.mark_deleted!
+        create(:user_compliance_info_singapore, user: seller)
         get :download, params: @params
 
         expect(response.status).to eq(403)

--- a/spec/controllers/tax_center_controller_spec.rb
+++ b/spec/controllers/tax_center_controller_spec.rb
@@ -10,7 +10,6 @@ describe TaxCenterController, type: :controller, inertia: true do
 
   before do
     create(:user_compliance_info, user: seller)
-    Feature.activate_user(:tax_center, seller)
   end
 
   describe "GET index" do
@@ -40,19 +39,6 @@ describe TaxCenterController, type: :controller, inertia: true do
 
       expect(response).to be_successful
       expect(inertia.props).to include(TaxCenterPresenter.new(seller:, year: 2023).props)
-    end
-
-    context "when tax_center feature is disabled" do
-      before do
-        Feature.deactivate_user(:tax_center, seller)
-      end
-
-      it "redirects to dashboard with alert" do
-        get :index
-
-        expect(response).to redirect_to(dashboard_path)
-        expect(flash[:alert]).to eq("Tax center is not enabled for your account.")
-      end
     end
 
     context "when seller is not from the US" do
@@ -222,9 +208,10 @@ describe TaxCenterController, type: :controller, inertia: true do
       end
     end
 
-    context "when tax_center feature is disabled" do
+    context "when seller is not from the US" do
       before do
-        Feature.deactivate_user(:tax_center, seller)
+        seller.alive_user_compliance_info.mark_deleted!
+        create(:user_compliance_info_singapore, user: seller)
       end
 
       it "redirects to dashboard with alert" do
@@ -315,9 +302,10 @@ describe TaxCenterController, type: :controller, inertia: true do
       end
     end
 
-    context "when tax_center feature is disabled" do
+    context "when seller is not from the US" do
       before do
-        Feature.deactivate_user(:tax_center, seller)
+        seller.alive_user_compliance_info.mark_deleted!
+        create(:user_compliance_info_singapore, user: seller)
       end
 
       it "redirects to dashboard with alert" do

--- a/spec/presenters/creator_home_presenter_spec.rb
+++ b/spec/presenters/creator_home_presenter_spec.rb
@@ -355,9 +355,8 @@ describe CreatorHomePresenter do
         )
       end
 
-      it "returns empty tax forms when tax_center feature flag is enabled for US user" do
+      it "returns empty tax forms for a US user (tax center enabled)" do
         create(:user_compliance_info, user: seller)
-        Feature.activate_user(:tax_center, seller)
 
         create(:user_tax_form, user: seller, tax_year: 2021, tax_form_type: "us_1099_k")
 
@@ -378,9 +377,8 @@ describe CreatorHomePresenter do
         expect(tax_forms.keys.min).to be >= Time.current.year - 3
       end
 
-      it "disables tax center for non-US user even with feature flag enabled" do
+      it "disables tax center for non-US user" do
         create(:user_compliance_info_singapore, user: seller)
-        Feature.activate_user(:tax_center, seller)
 
         props = presenter.creator_home_props
 

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -143,11 +143,7 @@ describe "Dashboard", js: true, type: :system do
       seller.update!(created_at: 1.year.ago)
     end
 
-    context "when tax_center feature is disabled" do
-      before do
-        Feature.deactivate_user(:tax_center, seller)
-      end
-
+    context "when seller is not US-based (tax center disabled)" do
       it "displays a 1099 form ready notice with a link to download if eligible" do
         download_url = "#{AWS_S3_ENDPOINT}/#{S3_BUCKET}/attachments/23b2d41ac63a40b5afa1a99bf38a0982/original/test.pdf"
         allow_any_instance_of(User).to receive(:eligible_for_1099?).and_return(true)
@@ -169,10 +165,9 @@ describe "Dashboard", js: true, type: :system do
       end
     end
 
-    context "when tax_center feature is enabled" do
+    context "when seller is US-based (tax center enabled)" do
       before do
         create(:user_compliance_info, user: seller)
-        Feature.activate_user(:tax_center, seller)
       end
 
       it "displays notice with link to tax center when user has tax form for previous year" do

--- a/spec/requests/tax_center_spec.rb
+++ b/spec/requests/tax_center_spec.rb
@@ -8,7 +8,6 @@ describe "Tax Center", js: true, type: :system do
 
   before do
     create(:user_compliance_info, user: seller)
-    Feature.activate_user(:tax_center, seller)
 
     login_as seller
   end


### PR DESCRIPTION
Part of the Category A rollout-flag audit (antiwork/gumroad-private#1208), following the pattern of #6105 / #6107 / #6114.

The `:tax_center` Flipper flag is 100% enabled in production (state=on, boolean=true; prod-state audit request `20260721T025828Z-d0d55a50`) and the tax-center code has been stable since 2025-12. Removal is behavior-neutral — production behavior already IS the post-removal behavior.

- `User#tax_center_enabled?` reduces to `from_us?` (US residency was always the second condition and is the only real requirement — the tax center serves IRS forms). Moved from `User::FeatureStatus` to `User::Taxation` next to `from_us?`, with a comment explaining the history.
- Specs: dropped `Feature.activate_user(:tax_center)` setups; flag-off contexts converted to non-US-seller contexts (the guard that still exists).

## Test results
- `spec/controllers/tax_center_controller_spec.rb` + `spec/controllers/api/v2/tax_forms_controller_spec.rb`: **43 examples, 0 failures** locally.
- `spec/controllers/api/v2/earnings_controller_spec.rb`: 2 failures locally, but they reproduce identically on unmodified main (purchase factory hitting Stripe — environmental). 0 new regressions.
- Rubocop clean. Repo-wide grep: zero remaining `:tax_center` Feature references.

Post-merge housekeeping (queued): `Flipper.remove(:tax_center)` via the audited prod console after deploy confirmation.

🤖 Authored by gumclaw (AI agent).
