### PR TITLE
Update bundles help article: buyers can now review the bundle itself

### DIFF
--- a/app/views/help_center/articles/contents/_339-product-bundles.html.erb
+++ b/app/views/help_center/articles/contents/_339-product-bundles.html.erb
@@ -48,7 +48,7 @@
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/6589a7df25778b0d0faef350/file-Qrs0qewLCn.png" %></figure>
   <h3 id="Checkout-DUhSH">Checkout</h3>
   <p>Customers who purchase your bundle will see a list of the individual products included within. On the product page, the price will show the cumulative value of every product in the bundle crossed out with the new price shown next to it.</p>
-  <p><i>Note:</i> Customers can only <a href="222-product-ratings-on-gumroad">rate and review</a> the individual products inside a bundle, not the bundle itself. The bundle's product page automatically shows a rating aggregated from the reviews of the products it contains. Products with ratings hidden are not included in this aggregate.</p>
+  <p><i>Note:</i> Customers can <a href="222-product-ratings-on-gumroad">rate and review</a> the bundle itself as well as the individual products inside it. The bundle's product page shows one combined rating summary: the bundle's own reviews plus the reviews of the products it contains. Products with ratings hidden are not included in this combined summary.</p>
   <p>On the checkout page, customers will once again find a list of everything they will receive inside the bundle.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/6589a58bdcdba22513abb141/file-jsLiTIsQef.png" %></figure>
   <h3 id="Customer-drawer-Lijr-">Customer drawer</h3>


### PR DESCRIPTION
## What

Updates the "Product bundles" help-center article (`_339-product-bundles.html.erb`). The Checkout section's note said customers "can only rate and review the individual products inside a bundle, not the bundle itself" — that statement is now wrong. Rewrote it to say buyers can review the bundle itself as well as the products inside it, and that the bundle page shows one combined rating summary (bundle's own reviews + bundled products' reviews, with hidden-ratings products still excluded).

## Why

Triggered by merged PR #6078 (gumroad-private#1213, Option A): bundle purchases now allow reviews on the bundle itself, and `Product::ReviewStat#bundle_rating_stats` merges the bundle's own reviews into the aggregate from the bundled products. The article described the pre-#6078 exclusion.

Facts verified against the merged code:
- Bundle reviews allowed: `not_is_bundle_purchase` removed from both `allowing_reviews_to_be_counted` and `allows_reviews` in `app/modules/purchase/reviews.rb`.
- Combined summary: `bundle_rating_stats` sums the bundle's own `rating_counts` with each alive bundled product's counts, skipping products where `display_product_reviews?` is false — so the "hidden ratings excluded" sentence stays true.

No `articles.yml` change (body-only edit; title/description untouched). No article removals. No pricing/payout/tax wording touched.

Docs-only — the diff is the reviewable artifact (one sentence rewritten in a help-center article body; no UI surface, no code).

## Test plan

- ERB syntax check on the edited partial: OK.
- Tag-balance check across all tags in the file: all balanced.
- Rendered the partial in the real view context (`ApplicationController.render`, test env): render OK, new copy present, stale "not the bundle itself" copy gone.
- CI runs the help-center specs (slug ↔ partial integrity).

## QA steps

1. Open help.gumroad.com/help/article/339-product-bundles.
2. Scroll to the Checkout section.
3. Confirm the note now says customers can review the bundle itself and describes the combined rating summary.

---

AI disclosure: Authored by Claude Fable 5 (Hermes Agent, gumclaw), triggered automatically by the merge of #6078 via the merged-PR → help-center doc-sync pipeline. Instructions: verify the merged behavior against the code and update any help-center article that now describes it wrong.
