### PR TITLE
Remove au_backtaxes feature flag (fully enabled in prod, campaign complete)

### DIFF
--- a/app/presenters/settings_presenter.rb
+++ b/app/presenters/settings_presenter.rb
@@ -541,8 +541,7 @@ class SettingsPresenter
 
     def aus_backtax_details(user_compliance_info)
       {
-        show_au_backtax_prompt: Feature.active?(:au_backtaxes, seller) &&
-          seller.au_backtax_owed_cents >= User::MIN_AU_BACKTAX_OWED_CENTS_FOR_CONTACT &&
+        show_au_backtax_prompt: seller.au_backtax_owed_cents >= User::MIN_AU_BACKTAX_OWED_CENTS_FOR_CONTACT &&
           AustraliaBacktaxEmailInfo.where(user_id: seller.id).exists?,
         total_amount_to_au: Money.new(seller.au_backtax_sales_cents).format(no_cents_if_whole: false, symbol: true),
         au_backtax_amount: Money.new(seller.au_backtax_owed_cents).format(no_cents_if_whole: false, symbol: true),

--- a/spec/presenters/settings_presenter_spec.rb
+++ b/spec/presenters/settings_presenter_spec.rb
@@ -670,8 +670,7 @@ describe SettingsPresenter do
       expect(countries).to have_key("US")
     end
 
-    it "shows the AU backtax prompt when the feature is on and the creator owes more than $100 and the creator has received an email" do
-      Feature.activate_user(:au_backtaxes, seller)
+    it "shows the AU backtax prompt when the creator owes more than $100 and the creator has received an email" do
       seller.update!(au_backtax_owed_cents: 100_01)
       create(:australia_backtax_email_info, user: seller)
 
@@ -684,7 +683,6 @@ describe SettingsPresenter do
     end
 
     it "does not show the AU backtax prompt when the creator owes less than $100" do
-      Feature.activate_user(:au_backtaxes, seller)
       seller.update!(au_backtax_owed_cents: 99_00)
       create(:australia_backtax_email_info, user: seller)
 

--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -6376,67 +6376,53 @@ describe("Payments Settings Scenario", type: :system, js: true) do
       login_as @creator
     end
 
-    describe "when the feature flag is not active" do
-      it "displays the taxes collection section" do
-        visit settings_payments_path
+    it "does not display the backtaxes collection section if creator has not received an email" do
+      visit settings_payments_path
 
-        expect(page).not_to have_text("Backtaxes collection")
-      end
+      expect(page).not_to have_text("Backtaxes collection")
     end
 
-    describe "when the feature flag is active" do
+    describe "when the creator has received an email" do
       before do
-        Feature.activate(:au_backtaxes)
+        create(:australia_backtax_email_info, user: @creator)
       end
 
-      it "does not display the backtaxes collection section if creator has not received an email" do
+      it "displays the taxes collection section and allows the creator to opt in" do
         visit settings_payments_path
 
-        expect(page).not_to have_text("Backtaxes collection")
+        expect(page).to have_text("Backtaxes collection")
+
+        click_on "Opt-in to backtaxes collection"
+        fill_in "Type your full name to opt-in", with: "Chuck Bartowski"
+        click_on "Save and opt-in"
+
+        expect(page).to have_text("You've opted in to backtaxes collection.")
+        expect(@creator.backtax_agreements.count).to eq(1)
+        expect(@creator.backtax_agreements.first.signature).to eq("Chuck Bartowski")
       end
 
-      describe "when the creator has received an email" do
-        before do
-          create(:australia_backtax_email_info, user: @creator)
-        end
+      it "renders an error message when the creator provides an invalid name for a signature" do
+        visit settings_payments_path
 
-        it "displays the taxes collection section and allows the creator to opt in" do
-          visit settings_payments_path
+        expect(page).to have_text("Backtaxes collection")
 
-          expect(page).to have_text("Backtaxes collection")
+        click_on "Opt-in to backtaxes collection"
+        fill_in "Type your full name to opt-in", with: "Chuck"
+        click_on "Save and opt-in"
 
-          click_on "Opt-in to backtaxes collection"
-          fill_in "Type your full name to opt-in", with: "Chuck Bartowski"
-          click_on "Save and opt-in"
+        expect(page).to have_text("Please enter your exact name.")
+        expect(@creator.backtax_agreements.count).to eq(0)
+      end
 
-          expect(page).to have_text("You've opted in to backtaxes collection.")
-          expect(@creator.backtax_agreements.count).to eq(1)
-          expect(@creator.backtax_agreements.first.signature).to eq("Chuck Bartowski")
-        end
+      it "allows the creator to open the opt-in modal even if their legal entity name is missing" do
+        @creator.fetch_or_build_user_compliance_info
+        allow_any_instance_of(UserComplianceInfo).to receive(:legal_entity_name).and_return(nil)
 
-        it "renders an error message when the creator provides an invalid name for a signature" do
-          visit settings_payments_path
+        visit settings_payments_path
 
-          expect(page).to have_text("Backtaxes collection")
+        click_on "Opt-in to backtaxes collection"
 
-          click_on "Opt-in to backtaxes collection"
-          fill_in "Type your full name to opt-in", with: "Chuck"
-          click_on "Save and opt-in"
-
-          expect(page).to have_text("Please enter your exact name.")
-          expect(@creator.backtax_agreements.count).to eq(0)
-        end
-
-        it "allows the creator to open the opt-in modal even if their legal entity name is missing" do
-          @creator.fetch_or_build_user_compliance_info
-          allow_any_instance_of(UserComplianceInfo).to receive(:legal_entity_name).and_return(nil)
-
-          visit settings_payments_path
-
-          click_on "Opt-in to backtaxes collection"
-
-          expect(page).to have_field("Type your full name to opt-in")
-        end
+        expect(page).to have_field("Type your full name to opt-in")
       end
     end
   end


### PR DESCRIPTION
Part of the Category A rollout-flag audit (antiwork/gumroad-private#1208), following the pattern of #6105 / #6107 / #6114 / #6125.

## What

Removes the `:au_backtaxes` Flipper flag check from `SettingsPresenter#aus_backtax_details` and the corresponding `Feature.activate` setups / flag-off contexts in the presenter and request specs.

## Why

The `:au_backtaxes` flag is 100% enabled in production (state=on, boolean=true; prod-state audit request `20260721T025828Z-d0d55a50`) and the AU backtax collection campaign is confirmed complete (sign-off on gumroad-private#1208). The flag only gated the settings-page backtax prompt, which is additionally guarded by two real conditions that remain in place:

- the seller owes at least `User::MIN_AU_BACKTAX_OWED_CENTS_FOR_CONTACT`, and
- an `AustraliaBacktaxEmailInfo` record exists for the seller (they received the campaign email).

Sellers who never received a campaign email continue to see nothing, so removal is behavior-neutral — production behavior already IS the post-removal behavior. No UI pixels change for any seller state.

## Test results

- `spec/presenters/settings_presenter_spec.rb -e "AU backtax"`: **2 examples, 0 failures** locally.
- `spec/requests/settings/payments_spec.rb -e "Taxes collection"`: 4 failures locally, but the same section fails identically on unmodified main in this worktree (Capybara `#app` hydration timeout — vite-asset/browser environmental, screenshots show a blank app shell on both). **0 new regressions**; CI will verify.
- Rubocop clean on all three touched files. Repo-wide grep: zero remaining `:au_backtaxes` Feature references (remaining `au_backtaxes*` hits are unrelated prop names for paid-status display).

Post-merge housekeeping (queued): `Flipper.remove(:au_backtaxes)` via the audited prod console after deploy confirmation.

---

🤖 AI disclosure: authored by gumclaw (Claude Fable 5) as part of the automated rollout-flag audit; flag removal, spec restructuring, and local spec runs done by the agent.
