### PR TITLE
Guard product-editor saves from wiping variants and content without explicit deletion intent

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -408,7 +408,9 @@ class LinksController < ApplicationController
           :call_limitation_info,
           :installment_plan,
           :community_chat_enabled,
-          :default_offer_code_id
+          :default_offer_code_id,
+          :confirmed_removed_variant_ids,
+          :confirmed_removed_rich_content_ids
         ))
         @product.description = SaveContentUpsellsService.new(seller: @product.user, content: product_permitted_params[:description], old_content: @product.description_was).from_html
         @product.skus_enabled = false
@@ -457,7 +459,14 @@ class LinksController < ApplicationController
           rich_content.update!(title: product_rich_content[:title].presence, description: product_rich_content[:description].presence || [], position: index)
           rich_contents_to_keep << rich_content
         end
-        (existing_rich_contents - rich_contents_to_keep).each(&:mark_deleted!)
+        product_rich_contents_to_delete = existing_rich_contents - rich_contents_to_keep
+        Product::RichContentDeletionGuard.ensure_intent!(
+          product: @product,
+          rich_contents_to_delete: product_rich_contents_to_delete,
+          payload_page_ids:,
+          confirmed_removed_ids: confirmed_removed_rich_content_ids
+        )
+        product_rich_contents_to_delete.each(&:mark_deleted!)
 
         Product::SaveIntegrationsService.perform(@product, product_permitted_params[:integrations])
         update_variants
@@ -802,6 +811,9 @@ class LinksController < ApplicationController
               options: variants,
             }
           ],
+          confirmed_removed_variant_ids:,
+          payload_page_ids:,
+          confirmed_removed_rich_content_ids:,
         ).perform
       elsif variant_category.present?
         Product::VariantsUpdaterService.new(
@@ -811,7 +823,42 @@ class LinksController < ApplicationController
               id: variant_category.external_id,
               options: nil,
             }
-          ]).perform
+          ],
+          confirmed_removed_variant_ids:,
+          payload_page_ids:,
+          confirmed_removed_rich_content_ids:,
+        ).perform
+      end
+    end
+
+    # External ids of variants the seller explicitly removed in the editor (via
+    # the "Remove version/tier/duration" confirmation modal). Used to distinguish
+    # an intentional deletion from a stale payload that simply doesn't know about
+    # a variant.
+    def confirmed_removed_variant_ids
+      Array.wrap(product_permitted_params[:confirmed_removed_variant_ids])
+    end
+
+    # External ids of content pages the seller explicitly deleted or replaced in
+    # the editor (delete-page modal, copy-content-from-version, discard-other-
+    # versions'-content).
+    def confirmed_removed_rich_content_ids
+      Array.wrap(product_permitted_params[:confirmed_removed_rich_content_ids])
+    end
+
+    # Every page id present anywhere in the save payload (product-level and
+    # variant-level). A page whose id appears here isn't being deleted — at most
+    # it's moving between the product level and a variant (e.g. toggling "use the
+    # same content for all versions"), so the deletion guards must not block it.
+    def payload_page_ids
+      @_payload_page_ids ||= begin
+        product_pages = product_permitted_params[:rich_content]
+        ids = product_pages.is_a?(Array) ? product_pages.map { _1[:id] } : []
+        (product_permitted_params[:variants] || []).each do |variant|
+          variant_pages = variant[:rich_content]
+          ids.concat(variant_pages.map { _1[:id] }) if variant_pages.is_a?(Array)
+        end
+        ids.compact
       end
     end
 

--- a/app/javascript/components/ProductEdit/ContentTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.tsx
@@ -187,6 +187,17 @@ const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: string | 
         product.rich_content = pages;
       }
     });
+  // Records that the seller explicitly deleted these pages, so the server-side
+  // wipe guard allows removing them even though they may still have content.
+  const confirmPageRemovals = (removedPages: Page[]) => {
+    if (removedPages.length === 0) return;
+    updateProduct((product) => {
+      product.confirmed_removed_rich_content_ids = [
+        ...(product.confirmed_removed_rich_content_ids ?? []),
+        ...removedPages.map(({ id }) => id),
+      ];
+    });
+  };
   const addPage = (description?: object) => {
     const page = {
       id: GuidGenerator.generate(),
@@ -521,6 +532,9 @@ const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: string | 
         updated_at: new Date().toISOString(),
       };
     });
+    // Replacing this variant's pages deletes the current ones — record that the
+    // seller confirmed it (the copy-from-version dialog) for the server-side guard.
+    confirmPageRemovals(pages);
     updatePages(cloned);
     if (cloned[0]) setSelectedPageId(cloned[0].id);
     setCopyFromOpen(false);
@@ -1032,6 +1046,7 @@ const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: string | 
                 color="danger"
                 onClick={() => {
                   if (!editor) return;
+                  confirmPageRemovals([confirmingDeletePage]);
                   updatePages(pages.filter((page) => page !== confirmingDeletePage));
                   setConfirmingDeletePage(null);
                 }}
@@ -1142,6 +1157,20 @@ export const ContentTab = () => {
       updateProduct((product) => {
         product.has_same_rich_content_for_all_variants = true;
         if (!product.rich_content.length) product.rich_content = selectedVariant?.rich_content ?? [];
+        // Emptying the variants' page lists deletes any page that didn't move to
+        // the product level. The seller confirmed this (the "Discard content from
+        // other versions?" dialog) — record the removals so the server-side wipe
+        // guard allows the save.
+        const keptPageIds = new Set(product.rich_content.map(({ id }) => id));
+        const removedPageIds = product.variants
+          .flatMap((variant) => variant.rich_content)
+          .filter(({ id }) => !keptPageIds.has(id))
+          .map(({ id }) => id);
+        if (removedPageIds.length > 0)
+          product.confirmed_removed_rich_content_ids = [
+            ...(product.confirmed_removed_rich_content_ids ?? []),
+            ...removedPageIds,
+          ];
         for (const variant of product.variants) variant.rich_content = [];
       });
     } else {

--- a/app/javascript/components/ProductEdit/ProductTab/DurationsEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/DurationsEditor.tsx
@@ -30,8 +30,19 @@ export const DurationsEditor = ({
     onChange(durations.map((duration) => (duration.id === id ? { ...duration, ...update } : duration)));
   };
 
+  const { updateProduct } = useProductEditContext();
   const [deletionModalDurationId, setDeletionModalDurationId] = React.useState<string | null>(null);
   const deletionModalDuration = durations.find(({ id }) => id === deletionModalDurationId);
+
+  // Records that the seller explicitly confirmed removing this duration, so the
+  // server-side wipe guard allows deleting it even if it still has content.
+  const confirmRemoval = (duration: Duration) => {
+    if (!duration.newlyAdded)
+      updateProduct((product) => {
+        product.confirmed_removed_variant_ids = [...(product.confirmed_removed_variant_ids ?? []), duration.id];
+      });
+    onChange(durations.filter(({ id }) => id !== duration.id));
+  };
 
   const addButton = (
     <Button
@@ -78,10 +89,7 @@ export const DurationsEditor = ({
           footer={
             <>
               <Button onClick={() => setDeletionModalDurationId(null)}>No, cancel</Button>
-              <Button
-                color="accent"
-                onClick={() => onChange(durations.filter(({ id }) => id !== deletionModalDuration.id))}
-              >
+              <Button color="accent" onClick={() => confirmRemoval(deletionModalDuration)}>
                 Yes, remove
               </Button>
             </>

--- a/app/javascript/components/ProductEdit/ProductTab/TiersEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/TiersEditor.tsx
@@ -47,12 +47,23 @@ const areAllEnabledPricesZero = (recurrencePriceValues: Record<string, Recurrenc
 };
 
 export const TiersEditor = ({ tiers, onChange }: { tiers: Tier[]; onChange: (tiers: Tier[]) => void }) => {
+  const { updateProduct } = useProductEditContext();
   const updateVersion = (id: string, update: Partial<Tier>) => {
     onChange(tiers.map((version) => (version.id === id ? { ...version, ...update } : version)));
   };
 
   const [deletionModalVersionId, setDeletionModalVersionId] = React.useState<string | null>(null);
   const deletionModalVersion = tiers.find(({ id }) => id === deletionModalVersionId);
+
+  // Records that the seller explicitly confirmed removing this tier, so the
+  // server-side wipe guard allows deleting it even if it still has content.
+  const confirmRemoval = (tier: Tier) => {
+    if (!tier.newlyAdded)
+      updateProduct((product) => {
+        product.confirmed_removed_variant_ids = [...(product.confirmed_removed_variant_ids ?? []), tier.id];
+      });
+    onChange(tiers.filter(({ id }) => id !== tier.id));
+  };
 
   const addButton = (
     <Button
@@ -104,7 +115,7 @@ export const TiersEditor = ({ tiers, onChange }: { tiers: Tier[]; onChange: (tie
           footer={
             <>
               <Button onClick={() => setDeletionModalVersionId(null)}>No, cancel</Button>
-              <Button color="accent" onClick={() => onChange(tiers.filter(({ id }) => id !== deletionModalVersion.id))}>
+              <Button color="accent" onClick={() => confirmRemoval(deletionModalVersion)}>
                 Yes, remove
               </Button>
             </>

--- a/app/javascript/components/ProductEdit/ProductTab/VersionsEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/VersionsEditor.tsx
@@ -27,12 +27,23 @@ export const VersionsEditor = ({
   versions: Version[];
   onChange: (versions: Version[]) => void;
 }) => {
+  const { updateProduct } = useProductEditContext();
   const updateVersion = (id: string, update: Partial<Version>) => {
     onChange(versions.map((version) => (version.id === id ? { ...version, ...update } : version)));
   };
 
   const [deletionModalVersionId, setDeletionModalVersionId] = React.useState<string | null>(null);
   const deletionModalVersion = versions.find(({ id }) => id === deletionModalVersionId);
+
+  // Records that the seller explicitly confirmed removing this version, so the
+  // server-side wipe guard allows deleting it even if it still has content.
+  const confirmRemoval = (version: Version) => {
+    if (!version.newlyAdded)
+      updateProduct((product) => {
+        product.confirmed_removed_variant_ids = [...(product.confirmed_removed_variant_ids ?? []), version.id];
+      });
+    onChange(versions.filter(({ id }) => id !== version.id));
+  };
 
   const addButton = (
     <Button
@@ -78,10 +89,7 @@ export const VersionsEditor = ({
           footer={
             <>
               <Button onClick={() => setDeletionModalVersionId(null)}>No, cancel</Button>
-              <Button
-                color="accent"
-                onClick={() => onChange(versions.filter(({ id }) => id !== deletionModalVersion.id))}
-              >
+              <Button color="accent" onClick={() => confirmRemoval(deletionModalVersion)}>
                 Yes, remove
               </Button>
             </>

--- a/app/javascript/components/ProductEdit/state.ts
+++ b/app/javascript/components/ProductEdit/state.ts
@@ -157,6 +157,12 @@ export type Product = {
   public_files: PublicFileWithStatus[];
   audio_previews_enabled: boolean;
   community_chat_enabled: boolean | null;
+  // External ids of variants / content pages the seller explicitly deleted in
+  // this editor session (via the respective confirmation modals). Sent with the
+  // save payload so the server can tell an intentional deletion apart from a
+  // stale payload that would otherwise silently wipe content.
+  confirmed_removed_variant_ids?: string[];
+  confirmed_removed_rich_content_ids?: string[];
 } & (
   | { native_type: "call"; variants: Duration[] }
   | { native_type: "membership"; variants: Tier[] }

--- a/app/javascript/components/server-components/ProductEditPage.tsx
+++ b/app/javascript/components/server-components/ProductEditPage.tsx
@@ -13,10 +13,12 @@ import { Taxonomy } from "$app/utils/discover";
 import { ALLOWED_EXTENSIONS } from "$app/utils/file";
 import { assertResponseError, request } from "$app/utils/request";
 
+import { Button } from "$app/components/Button";
+import { Modal } from "$app/components/Modal";
 import { Seller } from "$app/components/Product";
 import { ContentTab } from "$app/components/ProductEdit/ContentTab";
 import { getDownloadUrl } from "$app/components/ProductEdit/ContentTab/FileEmbed";
-import { Page } from "$app/components/ProductEdit/ContentTab/PageTab";
+import { Page, titleWithFallback } from "$app/components/ProductEdit/ContentTab/PageTab";
 import { ProductTab } from "$app/components/ProductEdit/ProductTab";
 import { ReceiptTab } from "$app/components/ProductEdit/ReceiptTab";
 import { RefundPolicy } from "$app/components/ProductEdit/RefundPolicy";
@@ -130,6 +132,64 @@ const createContextValue = (props: Props) => ({
 
 const pagesHaveSameContent = (pages1: Page[], pages2: Page[]): boolean => isEqual(pages1, pages2);
 
+// Client-side mirror of RichContent#has_editor_content?: a page counts as
+// contentful when its tiptap document contains anything a buyer could see.
+// A bare empty paragraph/heading (the editor's blank placeholder) is not content.
+const nodeHasContent = (node: unknown): boolean => {
+  if (typeof node !== "object" || node === null) return false;
+  if ("text" in node && typeof node.text === "string" && node.text.length > 0) return true;
+  if ("content" in node && Array.isArray(node.content)) return node.content.some(nodeHasContent);
+  // Leaf nodes without a content array (fileEmbed, image, etc.) render
+  // something by themselves — except empty structural placeholders.
+  return !("type" in node) || (node.type !== "paragraph" && node.type !== "heading");
+};
+
+const pageHasVisibleContent = (page: Page) => {
+  const description: unknown = page.description;
+  return (
+    typeof description === "object" &&
+    description !== null &&
+    "content" in description &&
+    Array.isArray(description.content) &&
+    description.content.some(nodeHasContent)
+  );
+};
+
+// What the seller is deleting in this editor session — the pieces of the
+// product that existed at the last save but are gone from the current state.
+// Shown in a summary confirmation modal before the save request goes out, so
+// a save that removes real content (especially a lot of it) never happens
+// without one final explicit "yes".
+type PendingDeletions = {
+  variants: { id: string; name: string }[];
+  pages: { id: string; title: string | null }[];
+};
+
+const findPendingDeletions = (product: Product, lastSavedProduct: Product): PendingDeletions => {
+  const currentVariantIds = new Set(product.variants.map(({ id }) => id));
+  const removedVariants = lastSavedProduct.variants.filter(({ id }) => !currentVariantIds.has(id));
+
+  // A page id that still appears anywhere in the current state (product-level
+  // or under any variant) is a MOVE (e.g. toggling "use the same content for
+  // all versions"), not a deletion.
+  const currentPageIds = new Set([
+    ...product.rich_content.map(({ id }) => id),
+    ...product.variants.flatMap((variant) => variant.rich_content.map(({ id }) => id)),
+  ]);
+  const removedPagesById = new Map<string, Page>();
+  for (const page of [
+    ...lastSavedProduct.rich_content,
+    ...lastSavedProduct.variants.flatMap((variant) => variant.rich_content),
+  ]) {
+    if (!currentPageIds.has(page.id) && pageHasVisibleContent(page)) removedPagesById.set(page.id, page);
+  }
+
+  return {
+    variants: removedVariants.map(({ id, name }) => ({ id, name })),
+    pages: [...removedPagesById.values()].map(({ id, title }) => ({ id, title })),
+  };
+};
+
 const findUpdatedContent = (product: Product, lastSavedProduct: Product) => {
   const contentUpdatedVariantIds = product.variants
     .filter((variant) => {
@@ -164,7 +224,13 @@ const ProductEditPage = (props: Props) => {
 
   const [saving, setSaving] = React.useState(false);
   const [imagesUploading, setImagesUploading] = React.useState<Set<File>>(new Set());
-  const save = async () => {
+  // Deletions awaiting the seller's final confirmation in the save-time summary
+  // modal. Non-null while the modal is open; the ref holds the resolver of the
+  // in-flight save() promise so callers awaiting save() (e.g. "Save and
+  // continue") settle once the seller decides.
+  const [pendingDeletions, setPendingDeletions] = React.useState<PendingDeletions | null>(null);
+  const pendingSaveRef = React.useRef<(() => void) | null>(null);
+  const performSave = async () => {
     try {
       setSaving(true);
       const response = await saveProduct(props.unique_permalink, props.id, product, currencyType);
@@ -195,6 +261,39 @@ const ProductEditPage = (props: Props) => {
     }
     setSaving(false);
   };
+  const save = async () => {
+    // A save that deletes existing versions/tiers or content pages gets one
+    // final summary confirmation before the request goes out. Each deletion
+    // already had its own modal when the seller clicked delete, but this is
+    // the last chance to notice an accumulated (possibly large) wipe before
+    // it becomes permanent.
+    const deletions = findPendingDeletions(product, lastSavedProductRef.current);
+    if (deletions.variants.length + deletions.pages.length > 0) {
+      setPendingDeletions(deletions);
+      await new Promise<void>((resolve) => {
+        pendingSaveRef.current = resolve;
+      });
+      return;
+    }
+    await performSave();
+  };
+  const confirmDeletionsAndSave = async () => {
+    setPendingDeletions(null);
+    await performSave();
+    pendingSaveRef.current?.();
+    pendingSaveRef.current = null;
+  };
+  const cancelDeletionConfirmation = () => {
+    setPendingDeletions(null);
+    // Resolve without saving — callers chained on save() (e.g. "Save and
+    // continue") proceed the same way they do when a save request fails.
+    pendingSaveRef.current?.();
+    pendingSaveRef.current = null;
+  };
+  // What the product type calls its variants, matching the per-row deletion
+  // modals ("Remove Tier 1?" etc.) in the Product tab editors.
+  const variantLabel =
+    product.native_type === "membership" ? "tier" : product.native_type === "call" ? "duration" : "version";
 
   const filesById = React.useMemo(() => buildFilesById(props.id, product.files), [product.files, props.id]);
 
@@ -253,6 +352,54 @@ const ProductEditPage = (props: Props) => {
   return (
     <ProductEditContext.Provider value={contextValue}>
       <ImageUploadSettingsContext.Provider value={imageSettings}>
+        {pendingDeletions ? (
+          <Modal
+            open
+            onClose={cancelDeletionConfirmation}
+            title="Save and delete content?"
+            footer={
+              <>
+                <Button onClick={cancelDeletionConfirmation}>No, cancel</Button>
+                <Button color="danger" onClick={() => void confirmDeletionsAndSave()}>
+                  Yes, save and delete
+                </Button>
+              </>
+            }
+          >
+            <div className="flex flex-col gap-4">
+              <p>Saving now will permanently delete the following from this product:</p>
+              {pendingDeletions.variants.length > 0 ? (
+                <div>
+                  <strong>
+                    {pendingDeletions.variants.length === 1
+                      ? `1 ${variantLabel}`
+                      : `${pendingDeletions.variants.length} ${variantLabel}s`}
+                  </strong>
+                  <ul className="list-disc pl-6">
+                    {pendingDeletions.variants.map(({ id, name }) => (
+                      <li key={id}>{name || "Untitled"}</li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+              {pendingDeletions.pages.length > 0 ? (
+                <div>
+                  <strong>
+                    {pendingDeletions.pages.length === 1
+                      ? "1 content page"
+                      : `${pendingDeletions.pages.length} content pages`}
+                  </strong>
+                  <ul className="list-disc pl-6">
+                    {pendingDeletions.pages.map(({ id, title }) => (
+                      <li key={id}>{titleWithFallback(title)}</li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+              <p>Customers who purchased this content will lose access to it.</p>
+            </div>
+          </Modal>
+        ) : null}
         <RouterProvider router={router} />
       </ImageUploadSettingsContext.Provider>
     </ProductEditContext.Provider>

--- a/app/javascript/data/product_edit.ts
+++ b/app/javascript/data/product_edit.ts
@@ -36,6 +36,8 @@ export const saveProduct = async (permalink: string, id: string, product: Produc
       price_currency_type: currencyType,
       covers: product.covers.map(({ id }) => id),
       variants: product.variants.map(({ newlyAdded, ...variant }) => (newlyAdded ? { ...variant, id: null } : variant)),
+      confirmed_removed_variant_ids: product.confirmed_removed_variant_ids ?? [],
+      confirmed_removed_rich_content_ids: product.confirmed_removed_rich_content_ids ?? [],
       availabilities: product.availabilities.map(({ newlyAdded, ...availability }) =>
         newlyAdded ? { ...availability, id: null } : availability,
       ),

--- a/app/models/rich_content.rb
+++ b/app/models/rich_content.rb
@@ -61,6 +61,16 @@ class RichContent < ApplicationRecord
     description.flat_map { select_file_embed_ids(_1) }.compact.uniq
   end
 
+  # True when the page carries anything a buyer could actually see. A page whose
+  # description is only empty structural nodes (e.g. a single bare paragraph —
+  # the shape the editor creates as a blank placeholder) has no content. This
+  # matters for content resolution: an empty product-level placeholder page must
+  # not make the product look like it has product-level content, which would
+  # hide the real variant-level content from buyers.
+  def has_editor_content?
+    description.present? && description.any? { node_has_content?(_1) }
+  end
+
   def owning_product
     entity.is_a?(Link) ? entity : entity.try(:link)
   end
@@ -147,6 +157,25 @@ class RichContent < ApplicationRecord
         end
 
         []
+      end
+    end
+
+    # A node counts as content when it's anything other than an empty container:
+    # text, media/embed nodes (which have no "content" array), or a container
+    # with at least one contentful child. A bare `{"type" => "paragraph"}` — the
+    # editor's blank placeholder — is not content.
+    def node_has_content?(node)
+      return false unless node.is_a?(Hash)
+      return true if node["text"].present?
+
+      children = node["content"]
+      if children.is_a?(Array)
+        children.any? { node_has_content?(_1) }
+      else
+        # Leaf nodes without a content array (fileEmbed, image, licenseKey,
+        # posts, horizontal rule, etc.) render something by themselves —
+        # except structural placeholders like an empty paragraph/heading.
+        !node["type"].in?(%w[paragraph heading])
       end
     end
 end

--- a/app/models/url_redirect.rb
+++ b/app/models/url_redirect.rb
@@ -517,7 +517,12 @@ class UrlRedirect < ApplicationRecord
 
     def product_or_cheapest_variant_as_rich_content_provider(entity)
       product = entity.is_a?(BaseVariant) ? entity.link : entity
-      return product if product.is_physical? || product.has_same_rich_content_for_all_variants? || product.rich_content_json.present? || product.alive_variants.none?
+      # A product-level page that is just an empty placeholder (a blank paragraph
+      # the editor can leave behind) must not count as "the product has its own
+      # content" — that would show buyers a single blank page instead of falling
+      # through to the content-bearing variant.
+      has_product_level_content = product.alive_rich_contents.any?(&:has_editor_content?)
+      return product if product.is_physical? || product.has_same_rich_content_for_all_variants? || has_product_level_content || product.alive_variants.none?
 
       product.alive_variants.order(price_difference_cents: :asc).first
     end

--- a/app/policies/link_policy.rb
+++ b/app/policies/link_policy.rb
@@ -146,6 +146,8 @@ class LinkPolicy < ApplicationPolicy
       section_ids: [],
       tags: [],
       rich_content:,
+      confirmed_removed_variant_ids: [],
+      confirmed_removed_rich_content_ids: [],
       files: [:id, :display_name, :description, :folder_id, :size, :position, :url, :isbn,
               :extension, :stream_only, :pdf_stamp_enabled, :modified, subtitle_files: [:url, :language], thumbnail: [:signed_id]],
       call_limitation_info: [:minimum_notice_in_minutes, :maximum_calls_per_day],

--- a/app/services/product/rich_content_deletion_guard.rb
+++ b/app/services/product/rich_content_deletion_guard.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Blocks a product-editor save from deleting content pages the seller didn't
+# explicitly delete. The editor always submits the FULL list of pages, so a page
+# that exists in the database but is missing from the payload normally means the
+# seller deleted it in the UI. However, a stale browser tab (or a race between
+# two editor sessions) can submit an outdated page list, in which case the save
+# silently soft-deletes every page the payload doesn't know about — wiping the
+# seller's product content in a single ordinary save.
+#
+# A page deletion is considered intentional when either:
+# - the page's id appears elsewhere in the same payload (the page moved between
+#   the product level and a variant, e.g. when toggling "use the same content
+#   for all versions"), or
+# - the seller confirmed the deletion in the editor (delete-page modal, copy
+#   content from another version, discard other versions' content), which the
+#   client reports via confirmed_removed_rich_content_ids.
+#
+# Pages with a blank description are deletable without confirmation — they carry
+# no content, and the editor legitimately drops them in several flows.
+class Product::RichContentDeletionGuard
+  MESSAGE = "This save would remove content pages that weren't explicitly deleted. Your product may have been updated in another tab — please refresh the page and try again."
+
+  def self.ensure_intent!(product:, rich_contents_to_delete:, payload_page_ids:, confirmed_removed_ids:)
+    unconfirmed = rich_contents_to_delete.select do |rich_content|
+      rich_content.description.present? &&
+        !payload_page_ids.include?(rich_content.external_id) &&
+        !confirmed_removed_ids.include?(rich_content.external_id)
+    end
+    return if unconfirmed.empty?
+
+    ErrorNotifier.notify(
+      "Blocked product save that would delete content pages without confirmation",
+      product_id: product.id,
+      rich_content_ids: unconfirmed.map(&:id)
+    )
+    product.errors.add(:base, MESSAGE)
+    raise Link::LinkInvalid, MESSAGE
+  end
+end

--- a/app/services/product/variant_category_updater_service.rb
+++ b/app/services/product/variant_category_updater_service.rb
@@ -3,7 +3,7 @@
 class Product::VariantCategoryUpdaterService
   include CurrencyHelper
 
-  attr_reader :product, :category_params
+  attr_reader :product, :category_params, :confirmed_removed_variant_ids, :payload_page_ids, :confirmed_removed_rich_content_ids
   attr_accessor :variant_category
 
   delegate :price_currency_type,
@@ -27,9 +27,39 @@ class Product::VariantCategoryUpdaterService
     product_files
   ].freeze
 
-  def initialize(product:, category_params:)
+  def initialize(product:, category_params:, confirmed_removed_variant_ids: [], payload_page_ids: [], confirmed_removed_rich_content_ids: [])
     @product = product
     @category_params = category_params
+    @confirmed_removed_variant_ids = Array.wrap(confirmed_removed_variant_ids)
+    @payload_page_ids = Array.wrap(payload_page_ids)
+    @confirmed_removed_rich_content_ids = Array.wrap(confirmed_removed_rich_content_ids)
+  end
+
+  # Blocks deleting variants that still carry seller content (rich content pages
+  # or attached files) unless the seller explicitly confirmed each removal in the
+  # editor. A stale browser tab (or a race between two editor sessions) can
+  # submit an outdated variant list, and without this check the save would treat
+  # every missing variant as "removed" and soft-delete the seller's entire
+  # version tree along with its content. Purchased variants are already
+  # protected separately; this covers content-bearing ones.
+  def self.ensure_deletion_intent!(product:, variants:, confirmed_removed_variant_ids:)
+    unconfirmed = variants.reject do |variant|
+      confirmed_removed_variant_ids.include?(variant.external_id) || !variant_has_content?(variant)
+    end
+    return if unconfirmed.empty?
+
+    ErrorNotifier.notify(
+      "Blocked product save that would delete content-bearing variants without confirmation",
+      product_id: product.id,
+      variant_ids: unconfirmed.map(&:id)
+    )
+    message = "This save would remove versions that still have content. Your product may have been updated in another tab — please refresh the page and try again."
+    product.errors.add(:base, message)
+    raise Link::LinkInvalid, message
+  end
+
+  def self.variant_has_content?(variant)
+    variant.alive_rich_contents.any? { _1.description.present? } || variant.has_files?
   end
 
   def perform
@@ -41,6 +71,7 @@ class Product::VariantCategoryUpdaterService
     end
 
     if category_params[:options].nil?
+      self.class.ensure_deletion_intent!(product:, variants: variant_category.variants.alive.to_a, confirmed_removed_variant_ids:)
       batch_delete_variants(variant_category.variants)
       variant_category.mark_deleted! if variant_category.title.blank?
     else
@@ -77,6 +108,7 @@ class Product::VariantCategoryUpdaterService
       end
 
       variants_to_delete = existing_variants - keep_variants
+      self.class.ensure_deletion_intent!(product:, variants: variants_to_delete.select(&:alive?), confirmed_removed_variant_ids:)
       batch_delete_variants(variants_to_delete)
     end
 
@@ -162,7 +194,14 @@ class Product::VariantCategoryUpdaterService
         rich_content.update!(title: variant_rich_content[:title].presence, description: variant_rich_content[:description].presence || [], position: index)
         rich_contents_to_keep << rich_content
       end
-      (existing_rich_contents - rich_contents_to_keep).map(&:mark_deleted!)
+      rich_contents_to_delete = existing_rich_contents - rich_contents_to_keep
+      Product::RichContentDeletionGuard.ensure_intent!(
+        product:,
+        rich_contents_to_delete:,
+        payload_page_ids:,
+        confirmed_removed_ids: confirmed_removed_rich_content_ids
+      )
+      rich_contents_to_delete.map(&:mark_deleted!)
     end
 
     # For tiered memberships that have per-tier pricing, validates that:

--- a/app/services/product/variants_updater_service.rb
+++ b/app/services/product/variants_updater_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Product::VariantsUpdaterService
-  attr_reader :product, :skus_params
+  attr_reader :product, :skus_params, :confirmed_removed_variant_ids, :payload_page_ids, :confirmed_removed_rich_content_ids
   attr_accessor :variants_params
 
   delegate :price_currency_type,
@@ -9,10 +9,21 @@ class Product::VariantsUpdaterService
            :variant_categories_alive,
            :skus, to: :product
 
-  def initialize(product:, variants_params:, skus_params: {})
+  # confirmed_removed_variant_ids: external ids of variants the seller explicitly
+  # deleted in the editor (via the "Remove version" confirmation). Deleting a
+  # variant that still has content (rich content pages or files) is only allowed
+  # when its id is in this list — this protects sellers from a stale editor
+  # session submitting an outdated variant list and silently wiping their whole
+  # version tree (it happened three times in one week on a single product).
+  # payload_page_ids / confirmed_removed_rich_content_ids feed the analogous
+  # guard for page deletions (Product::RichContentDeletionGuard).
+  def initialize(product:, variants_params:, skus_params: {}, confirmed_removed_variant_ids: [], payload_page_ids: [], confirmed_removed_rich_content_ids: [])
     @product = product
     @variants_params = variants_params
     @skus_params = skus_params.values
+    @confirmed_removed_variant_ids = Array.wrap(confirmed_removed_variant_ids)
+    @payload_page_ids = Array.wrap(payload_page_ids)
+    @confirmed_removed_rich_content_ids = Array.wrap(confirmed_removed_rich_content_ids)
   end
 
   def perform
@@ -24,7 +35,10 @@ class Product::VariantsUpdaterService
     variants_params.each do |category|
       variant_category_updater = Product::VariantCategoryUpdaterService.new(
         product:,
-        category_params: category
+        category_params: category,
+        confirmed_removed_variant_ids:,
+        payload_page_ids:,
+        confirmed_removed_rich_content_ids:
       )
       variant_category = variant_category_updater.perform
       keep_categories << variant_category if category[:id].present?
@@ -32,7 +46,14 @@ class Product::VariantsUpdaterService
 
     categories_to_delete = existing_categories - keep_categories
     categories_to_delete.each do |variant_category|
-      variant_category.mark_deleted! unless variant_category.has_alive_grouping_variants_with_purchases?
+      next if variant_category.has_alive_grouping_variants_with_purchases?
+
+      Product::VariantCategoryUpdaterService.ensure_deletion_intent!(
+        product:,
+        variants: variant_category.alive_variants.to_a,
+        confirmed_removed_variant_ids:
+      )
+      variant_category.mark_deleted!
     end
 
     begin

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -115,10 +115,10 @@ ActiveRecord::Schema[7.1].define(version: 2026_12_06_000003) do
     t.integer "affiliate_id"
     t.bigint "fee_cents", default: 0, null: false
     t.index ["affiliate_credit_chargeback_balance_id"], name: "idx_affiliate_credits_on_affiliate_credit_chargeback_balance_id"
-    t.index ["affiliate_user_id", "affiliate_credit_refund_balance_id", "affiliate_credit_chargeback_balance_id", "affiliate_credit_success_balance_id", "amount_cents"], name: "idx_affiliate_credits_on_user_and_balances_and_amount"
     t.index ["affiliate_credit_refund_balance_id"], name: "index_affiliate_credits_on_affiliate_credit_refund_balance_id"
     t.index ["affiliate_credit_success_balance_id"], name: "index_affiliate_credits_on_affiliate_credit_success_balance_id"
     t.index ["affiliate_id"], name: "index_affiliate_credits_on_affiliate_id"
+    t.index ["affiliate_user_id", "affiliate_credit_refund_balance_id", "affiliate_credit_chargeback_balance_id", "affiliate_credit_success_balance_id", "amount_cents"], name: "idx_affiliate_credits_on_user_and_balances_and_amount"
     t.index ["affiliate_user_id"], name: "index_affiliate_credits_on_affiliate_user_id"
     t.index ["link_id"], name: "index_affiliate_credits_on_link_id"
     t.index ["oauth_application_id"], name: "index_affiliate_credits_on_oauth_application_id"

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -565,6 +565,133 @@ describe LinksController, :vcr, inertia: true do
         end
       end
 
+      describe "content deletion guards (stale-payload wipe protection)" do
+        # Reproduces gumroad-private#1230: a stale editor session (or a race
+        # between two tabs) submits a save payload that doesn't know about the
+        # product's variants/pages, and without the guards the save silently
+        # soft-deletes the seller's entire version tree and content.
+        let(:content_description) { [{ "type" => "paragraph", "content" => [{ "type" => "text", "text" => "Course content" }] }] }
+
+        before do
+          @category = create(:variant_category, link: @product, title: "Versions")
+          @version1 = create(:variant, variant_category: @category, name: "Summer Sale")
+          @version1_page = create(:rich_content, entity: @version1, description: content_description)
+        end
+
+        it "blocks a save whose payload omits a content-bearing variant" do
+          # The stale payload only knows about a different, new variant — the
+          # server would previously treat version1 as removed and wipe it.
+          post :update, params: @params.merge({
+                                                variants: [{ id: nil, name: "Brand new version" }]
+                                              }), format: :json
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.parsed_body["error_message"]).to include("refresh the page")
+          expect(@version1.reload).to be_alive
+          expect(@version1_page.reload).to be_alive
+        end
+
+        it "blocks a save with an empty variants list that would delete the whole category" do
+          post :update, params: @params.merge({ variants: [] }), format: :json
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(@version1.reload).to be_alive
+          expect(@version1_page.reload).to be_alive
+          expect(@category.reload).to be_alive
+        end
+
+        it "allows removing a content-bearing variant when the seller confirmed the removal" do
+          post :update, params: @params.merge({
+                                                variants: [{ id: nil, name: "Brand new version" }],
+                                                confirmed_removed_variant_ids: [@version1.external_id]
+                                              }), format: :json
+
+          expect(response).to be_successful
+          expect(@version1.reload).to be_deleted
+        end
+
+        it "allows removing a variant that has no content without confirmation" do
+          empty_version = create(:variant, variant_category: @category, name: "Empty version")
+
+          post :update, params: @params.merge({
+                                                variants: [{ id: @version1.external_id, name: @version1.name, rich_content: [{ id: @version1_page.external_id, title: "Page", description: { type: "doc", content: content_description } }] }]
+                                              }), format: :json
+
+          expect(response).to be_successful
+          expect(empty_version.reload).to be_deleted
+          expect(@version1.reload).to be_alive
+        end
+
+        it "blocks a save whose payload omits a content-bearing page" do
+          page2 = create(:rich_content, entity: @version1, description: [{ "type" => "paragraph", "content" => [{ "type" => "text", "text" => "Page 2" }] }])
+
+          # Payload keeps the variant but only knows about one of its two pages.
+          post :update, params: @params.merge({
+                                                variants: [{ id: @version1.external_id, name: @version1.name, rich_content: [{ id: @version1_page.external_id, title: "Page 1", description: { type: "doc", content: content_description } }] }]
+                                              }), format: :json
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(page2.reload).to be_alive
+          expect(@version1_page.reload).to be_alive
+        end
+
+        it "allows deleting a page when the seller confirmed the deletion" do
+          page2 = create(:rich_content, entity: @version1, description: [{ "type" => "paragraph", "content" => [{ "type" => "text", "text" => "Page 2" }] }])
+
+          post :update, params: @params.merge({
+                                                variants: [{ id: @version1.external_id, name: @version1.name, rich_content: [{ id: @version1_page.external_id, title: "Page 1", description: { type: "doc", content: content_description } }] }],
+                                                confirmed_removed_rich_content_ids: [page2.external_id]
+                                              }), format: :json
+
+          expect(response).to be_successful
+          expect(page2.reload).to be_deleted
+        end
+
+        it "allows deleting a page with no content without confirmation" do
+          blank_page = create(:rich_content, entity: @version1, description: [])
+
+          post :update, params: @params.merge({
+                                                variants: [{ id: @version1.external_id, name: @version1.name, rich_content: [{ id: @version1_page.external_id, title: "Page 1", description: { type: "doc", content: content_description } }] }]
+                                              }), format: :json
+
+          expect(response).to be_successful
+          expect(blank_page.reload).to be_deleted
+        end
+
+        it "allows a page to move between the product level and a variant without confirmation" do
+          # Toggling "use the same content for all versions" legitimately moves
+          # pages from the variant to the product level — the page id appears
+          # elsewhere in the payload, so it isn't a deletion.
+          post :update, params: @params.merge({
+                                                rich_content: [{ id: @version1_page.external_id, title: "Moved page", description: { type: "doc", content: content_description } }],
+                                                variants: [{ id: @version1.external_id, name: @version1.name, rich_content: [] }]
+                                              }), format: :json
+
+          expect(response).to be_successful
+        end
+
+        it "blocks deleting a product-level content page missing from a stale payload" do
+          product_page = create(:product_rich_content, entity: @product, description: content_description)
+
+          post :update, params: @params.merge({
+                                                rich_content: [{ id: nil, title: "Other page", description: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "Other" }] }] } }],
+                                                variants: [{ id: @version1.external_id, name: @version1.name, rich_content: [{ id: @version1_page.external_id, title: "Page 1", description: { type: "doc", content: content_description } }] }]
+                                              }), format: :json
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(product_page.reload).to be_alive
+        end
+
+        it "reports blocked wipes to the error notifier" do
+          expect(ErrorNotifier).to receive(:notify).with(
+            "Blocked product save that would delete content-bearing variants without confirmation",
+            hash_including(product_id: @product.id)
+          )
+
+          post :update, params: @params.merge({ variants: [] }), format: :json
+        end
+      end
+
       describe "coffee products" do
         it "sets suggested_price_cents to the maximum price_difference_cents of variants" do
           coffee_product = create(:coffee_product)
@@ -2084,9 +2211,22 @@ describe LinksController, :vcr, inertia: true do
           expect(new_rich_content.description).to eq(new_rich_content_description)
           expect(product.alive_rich_contents.sort_by(&:position).pluck(:title, :position)).to eq([["Intro", 0], ["Page 1", 1], ["Page 2", 2], ["Page 3", 3]])
 
-          # Deletes all existing rich content pages if no rich content is passed
+          # A save with no rich content and no confirmed removals would wipe
+          # content-bearing pages — the deletion guard now blocks it (see
+          # "content deletion guards" above).
           expect do
             post :update, params: { id: product.unique_permalink, rich_content: [] }, format: :json
+          end.not_to change { product.reload.alive_rich_contents.count }
+          expect(response).to have_http_status(:unprocessable_entity)
+
+          # Deletes all existing rich content pages when the seller confirmed
+          # removing them (empty pages need no confirmation).
+          expect do
+            post :update, params: {
+              id: product.unique_permalink,
+              rich_content: [],
+              confirmed_removed_rich_content_ids: product.alive_rich_contents.map(&:external_id),
+            }, format: :json
           end.to change { product.reload.alive_rich_contents.count }.from(4).to(0)
           .and change { product.rich_contents.count }.by(0)
         end
@@ -2147,6 +2287,10 @@ describe LinksController, :vcr, inertia: true do
                   name: "Version 1",
                   rich_content: [
                     {
+                      # The page moves from the product level to the variant,
+                      # keeping its id — mirroring what the editor sends when
+                      # un-toggling "use the same content for all versions".
+                      id: @product.alive_rich_contents.find_by(position: 0).external_id,
                       title: "Version 1 - Page 1",
                       description: { type: "doc", content: description, }
                     }
@@ -2186,7 +2330,10 @@ describe LinksController, :vcr, inertia: true do
             post :update, params: {
               id: @product.unique_permalink,
               has_same_rich_content_for_all_variants: true,
-              rich_content: [{ id: nil, title: "Version 1 - Page 1", description: { type: "doc", content: version1_rich_content_description } }],
+              # The page keeps its id as it moves from the variant to the
+              # product level — mirroring what the editor sends when toggling
+              # "use the same content for all versions".
+              rich_content: [{ id: version1.reload.alive_rich_contents.first.external_id, title: "Version 1 - Page 1", description: { type: "doc", content: version1_rich_content_description } }],
               files: [{ id: file1.external_id, url: file1.url }, { id: file2.external_id, url: file2.url }],
               variants: [{ id: version1.external_id, name: version1.name }]
             }, format: :json
@@ -2256,7 +2403,9 @@ describe LinksController, :vcr, inertia: true do
             post :update, params: {
               id: @product.unique_permalink,
               name: "New product name",
-              rich_content: [{ id: nil, title: "New page title", description: { type: "doc", content: [folder1] } }],
+              # Reuse the existing page's id — the editor renames a page in
+              # place rather than replacing it with a brand-new one.
+              rich_content: [{ id: @product.alive_rich_contents.first.external_id, title: "New page title", description: { type: "doc", content: [folder1] } }],
               files: [{ id: file1.external_id, url: file1.url }, { id: file2.external_id, url: file2.url }],
             }, format: :json
           end.to_not change { @product.product_files_archives.folder_archives.alive.count }

--- a/spec/models/rich_content_spec.rb
+++ b/spec/models/rich_content_spec.rb
@@ -280,4 +280,37 @@ describe RichContent do
       )
     end
   end
+
+  describe "#has_editor_content?" do
+    let(:product) { create(:product) }
+
+    it "returns false for an empty description" do
+      expect(create(:rich_content, entity: product, description: []).has_editor_content?).to be(false)
+    end
+
+    it "returns false for the editor's blank placeholder (a single bare paragraph)" do
+      rich_content = create(:rich_content, entity: product, description: [{ "type" => "paragraph" }])
+      expect(rich_content.has_editor_content?).to be(false)
+    end
+
+    it "returns false for empty paragraphs and headings" do
+      rich_content = create(:rich_content, entity: product, description: [{ "type" => "paragraph", "content" => [] }, { "type" => "heading" }])
+      expect(rich_content.has_editor_content?).to be(false)
+    end
+
+    it "returns true when a node has text" do
+      rich_content = create(:rich_content, entity: product, description: [{ "type" => "paragraph", "content" => [{ "type" => "text", "text" => "Hello" }] }])
+      expect(rich_content.has_editor_content?).to be(true)
+    end
+
+    it "returns true for content-bearing leaf nodes like file embeds" do
+      rich_content = create(:rich_content, entity: product, description: [{ "type" => "fileEmbed", "attrs" => { "id" => "abc", "uid" => "def" } }])
+      expect(rich_content.has_editor_content?).to be(true)
+    end
+
+    it "returns true when content is nested inside containers" do
+      rich_content = create(:rich_content, entity: product, description: [{ "type" => "orderedList", "content" => [{ "type" => "listItem", "content" => [{ "type" => "paragraph", "content" => [{ "type" => "text", "text" => "Item" }] }] }] }])
+      expect(rich_content.has_editor_content?).to be(true)
+    end
+  end
 end

--- a/spec/models/url_redirect_spec.rb
+++ b/spec/models/url_redirect_spec.rb
@@ -747,6 +747,20 @@ describe UrlRedirect do
         product_level_rich_content = @product.alive_rich_contents.first
         expect(UrlRedirect.find(@url_redirect.id).rich_content_json).to eq([{ id: product_level_rich_content.external_id, page_id: product_level_rich_content.external_id, variant_id: nil, title: "Product-level page", description: { type: "doc", content: product_level_rich_content.description }, updated_at: product_level_rich_content.updated_at }])
       end
+
+      it "ignores an empty product-level placeholder page and returns the variant's rich content for a variant-less purchase" do
+        # Regression for gumroad-private#1230: an editor bug left an alive but
+        # empty product-level page (a single blank paragraph). For purchases
+        # without variant_attributes, that placeholder made the product look
+        # content-bearing, so buyers saw one blank page instead of the real
+        # variant content.
+        @product.alive_rich_contents.find_each(&:mark_deleted!)
+        create(:product_rich_content, entity: @product, description: [{ "type" => "paragraph" }])
+        variant_rich_content = @variant.alive_rich_contents.first
+        @purchase.variant_attributes = []
+
+        expect(UrlRedirect.find(@url_redirect.id).rich_content_json).to eq([{ id: variant_rich_content.external_id, page_id: variant_rich_content.external_id, variant_id: @variant.external_id, title: "Variant-level page", description: { type: "doc", content: variant_rich_content.description }, updated_at: variant_rich_content.updated_at }])
+      end
     end
 
     context "when associated with a product" do

--- a/spec/requests/products/edit/digital_versions_spec.rb
+++ b/spec/requests/products/edit/digital_versions_spec.rb
@@ -147,6 +147,52 @@ describe("Product Edit Digital Versions", type: :system, js: true) do
         expect(@variant_option.reload).to be_deleted
       end
 
+      it "shows a save-time summary confirmation and keeps the version when cancelled" do
+        visit edit_link_path(product.unique_permalink)
+
+        within version_rows[0] do
+          within version_option_rows[0] do
+            click_on "Remove version"
+          end
+        end
+
+        within_modal "Remove First Product Files Grouping?" do
+          click_on "Yes, remove"
+        end
+
+        # The save itself re-confirms the accumulated deletions in one summary
+        # modal. Cancelling aborts the save entirely — nothing is deleted.
+        click_on "Save changes"
+        within_modal "Save and delete content?" do
+          expect(page).to have_text("Saving now will permanently delete the following from this product:")
+          expect(page).to have_text("1 version")
+          expect(page).to have_text("First Product Files Grouping")
+          click_on "No, cancel"
+        end
+
+        refresh
+        expect(@variant_option.reload).to be_present
+
+        within version_rows[0] do
+          within version_option_rows[0] do
+            click_on "Remove version"
+          end
+        end
+
+        within_modal "Remove First Product Files Grouping?" do
+          click_on "Yes, remove"
+        end
+
+        click_on "Save changes"
+        within_modal "Save and delete content?" do
+          click_on "Yes, save and delete"
+        end
+        wait_for_ajax
+        expect(page).to have_alert(text: "Changes saved!")
+
+        expect(@variant_option.reload).to be_deleted
+      end
+
       it "deletes a variant option with only test purchases" do
         create(:purchase, link: product, variant_attributes: [@variant_option], purchaser: seller, purchase_state: "test_successful")
         visit edit_link_path(product.unique_permalink)

--- a/spec/services/product/variant_category_updater_service_spec.rb
+++ b/spec/services/product/variant_category_updater_service_spec.rb
@@ -160,11 +160,25 @@ describe Product::VariantCategoryUpdaterService do
               Product::VariantCategoryUpdaterService.new(
                 product: @product,
                 category_params: { id: @variant.variant_category.external_id, title: "" },
+                # The variant carries files, so the wipe guard requires explicit
+                # deletion intent (the seller confirming the removal in the editor).
+                confirmed_removed_variant_ids: [@variant.external_id],
                 ).perform
             end.to change { @variant.reload.deleted_at }.from(nil).to(Time.current)
 
             expect(DeleteProductRichContentWorker).to have_enqueued_sidekiq_job(@product.id, @variant.id)
           end
+        end
+
+        it "refuses to delete a content-bearing version without explicit confirmation" do
+          expect do
+            Product::VariantCategoryUpdaterService.new(
+              product: @product,
+              category_params: { id: @variant.variant_category.external_id, title: "" },
+              ).perform
+          end.to raise_error(Link::LinkInvalid, /updated in another tab/)
+
+          expect(@variant.reload.deleted_at).to be_nil
         end
       end
     end

--- a/spec/support/product_edit_page_helpers.rb
+++ b/spec/support/product_edit_page_helpers.rb
@@ -3,6 +3,17 @@
 module ProductEditPageHelpers
   def save_change(expect_alert: true, expect_message: "Changes saved!")
     click_on "Save changes"
+
+    # A save that removes existing versions/tiers/durations or content pages
+    # first shows a summary confirmation modal (rendered synchronously by the
+    # editor, before any request goes out). Confirm it so specs exercising
+    # deletions proceed; saves that don't delete anything never show it.
+    if page.has_text?("Save and delete content?", wait: 1)
+      within_modal "Save and delete content?" do
+        click_on "Yes, save and delete"
+      end
+    end
+
     wait_for_ajax
 
     if expect_alert


### PR DESCRIPTION
## Summary

A seller's product lost its entire version tree (VariantCategory, BaseVariants, all RichContent pages, ProductFiles — soft-deleted in the same second) from a single ordinary edit-page save, **three times in eight days** — the third time triggered by nothing more than clicking the version dropdown, with confirmed buyer impact (customers saw empty download pages mid-sale).

**Root cause:** the editor always submits the FULL variants + pages list on every save, and the server treats anything missing from the payload as removed. A stale tab or a race between two editor sessions submits an outdated list, and the save silently wipes everything. There was no deletion-intent signal server-side (purchased variants were protected; content-bearing-but-unpurchased variants and ALL pages were not).

## Changes

**Server-side guards (the fix that holds regardless of client bugs):**
- `Product::VariantCategoryUpdaterService.ensure_deletion_intent!` — blocks deleting any variant that still has content (rich-content pages or files) unless the seller explicitly confirmed the removal. Wired into both variant-deletion paths and whole-category deletion in `VariantsUpdaterService`.
- New `Product::RichContentDeletionGuard` — the page analogue, for both product-level (controller) and variant-level (updater service) page deletion. A page whose id appears elsewhere in the payload is a *move* (the "same content for all versions" toggle), not a deletion, and is allowed. Blank pages delete freely.
- Blocked saves roll back the transaction, return a "product may have been updated in another tab — refresh and try again" 422, and `ErrorNotifier.notify` so blocked wipes surface in Sentry (each one is a stale-payload incident we want to see).

**Client-side deletion intent:**
- New `confirmed_removed_variant_ids` / `confirmed_removed_rich_content_ids` sent with every save; recorded by the Remove version/tier/duration confirmation modals, the delete-page modal, copy-content-from-version, and the "use same content for all versions" discard flow.

**Buyer-facing fix from the same incident:**
- The wipe also left behind an alive-but-empty product-level page (single bare paragraph), which made `UrlRedirect#product_or_cheapest_variant_as_rich_content_provider` treat the product as content-bearing — variant-less buyers got ONE BLANK PAGE instead of the real variant content, *even after the variants were restored*. New `RichContent#has_editor_content?` (recursive node check) replaces the `rich_content_json.present?` test in the resolver.

## Tests

- 10 new controller specs reproducing the incident: stale payload omitting a content-bearing variant/page is **blocked** (verified RED on the pre-fix code); confirmed removals, empty-variant/page cleanup, and page moves between product/variant level all still work; ErrorNotifier assertion.
- 6 new `has_editor_content?` model specs; 1 url_redirect regression spec (empty placeholder no longer hijacks content resolution for variant-less purchases); updater-service spec for the unconfirmed-deletion raise.
- 4 existing specs updated where they relied on unconfirmed content wipes (each now uses confirmed ids or page-move semantics, with comments).
- Full runs: links_controller_spec 347 ✓, url_redirect_spec / rich_content_spec / both updater-service specs ✓ (2 pre-existing `enqueue_job_to_regenerate_deleted_transcoded_videos` failures reproduce on clean main without this diff). Rubocop, tsc, eslint, prettier clean.

## QA steps

1. Open a product with versions+content in TWO tabs; delete a version in tab A and save; save tab B (stale) → save is rejected with the refresh message, content intact.
2. Remove a version via the confirmation modal → save succeeds, version deleted.
3. Delete a page via the delete-page modal → succeeds. Toggle "use same content for all versions" both ways → succeeds.
4. For a variant-less purchase of a product whose only real content is variant-level, with an empty product-level placeholder page present → download page shows the variant content.

<!-- tracker is in the private repo -->

🤖 Generated with assistance from Claude

**AI disclosure:** authored by gumclaw (agent). @gianfrancopiana will validate locally before this leaves draft.
