### PR TITLE
Update teams-and-roles help article: admins can manage payout settings

### DIFF
--- a/app/views/help_center/articles/contents/_326-teams-and-roles.html.erb
+++ b/app/views/help_center/articles/contents/_326-teams-and-roles.html.erb
@@ -109,7 +109,7 @@
       <tr>
         <td>Settings / Payout</td>
         <td>Full access</td>
-        <td>View only</td>
+        <td>Full access</td>
         <td>No access</td>
         <td>No access</td>
         <td>View only</td>
@@ -164,6 +164,7 @@
       </tr>
     </tbody>
   </table>
+  <p><i>Note:</i> Team members with the Admin role can update payout settings, but identity verification is owner-only. Only the account owner can submit their identity documents on the Payments settings page.</p>
   <h3 id="invite">Invite team members</h3>
   <p>You can invite members to co-admin your account or remove them from <a href="https://gumroad.com/settings/team">your Team settings</a>.</p>
   <p>You can have unlimited team members.</p>


### PR DESCRIPTION
## What

Updates the "Teams and roles" help center article (`_326-teams-and-roles.html.erb`) to reflect that team members with the Admin role can now manage the seller's payout settings:

- The **Settings / Payout** row's Admin cell changes from "View only" to "Full access".
- Adds a note under the roles table that identity verification remains owner-only: only the account owner can submit their identity documents on the Payments settings page.

## Why

Merged PR #6067 changed `Settings::Payments::UserPolicy#update?` (and the delegated payout actions: country, PayPal/Stripe connect, saved debit card, remediation, AU backtax opt-in) from `role_owner_for?` to `role_admin_for?`. The article's roles table still described the old owner-only behavior for admins. `verify_document?` / `verify_identity?` stayed owner-only in the code (KYC documents belong to the owner), which the new note documents so admins aren't surprised by the one control that stays disabled.

⚠️ **Payout-policy wording** — reviewer attention: this changes documented payout-settings permissions. Verified against `app/policies/settings/payments/user_policy.rb` at current main (`update?` = `role_admin_for?(seller) && record == seller`; `owner_only_update?` for `verify_document?`/`verify_identity?`).

## Test plan

- Rendered the partial via `ApplicationController.render` in the test env: render OK, new note present, Settings / Payout row shows Full access for Admin.
- HTML tag-balance check on the article body: all tags balanced.
- `articles.yml` untouched (body-only edit; title/description unchanged).
- Diff scope: 1 file, +2/-1 lines.

## QA steps

1. Open help.gumroad.com/help/article/326-teams-and-roles (after deploy).
2. In the roles table, confirm the "Settings / Payout" row shows "Full access" under Admin.
3. Confirm the note under the table about owner-only identity verification renders.

---

AI disclosure: authored by Claude Fable 5 (Hermes agent) as an automated help-center sync triggered by the merge of #6067. Instructions: check merged gumroad PRs for help-center impact and update affected articles to match shipped behavior.
