### PR TITLE
Document the already-subscribed checkout error in the payment-failure help article

### DIFF
--- a/app/views/help_center/articles/contents/_203-why-did-my-payment-fail.html.erb
+++ b/app/views/help_center/articles/contents/_203-why-did-my-payment-fail.html.erb
@@ -43,9 +43,9 @@
   <p>There is nothing you need to do. We will email you a receipt as soon as the payment completes, and you will get access to your purchase then.</p>
   <p>Paying by bank account is only offered by some creators, and only to customers in the United States, so you may not see it on every checkout.</p>
   <h3 id="Email-already-has-an-active-subscription-tR7vN">Email already has an active subscription</h3>
-  <p>If you see the message "This email address already has an active subscription to this membership. We've emailed it a link to manage the subscription — check your inbox," the email address you entered at checkout already has an active subscription to that membership. To prevent duplicate charges, we block the second purchase and send an email to that address instead.</p>
+  <p>You may see this message at checkout: "This email address already has an active subscription to this membership. We've emailed it a link to manage the subscription — check your inbox." It means the email address you entered already has an active subscription to that membership. To prevent duplicate charges, we block the second purchase and send an email to that address instead.</p>
   <p>If the existing subscription is yours, you don't need to buy again. Your membership is still active, and you can manage or cancel it from your membership receipt or from your <a href="https://app.gumroad.com/library">Gumroad Library</a>. See <a href="192-how-do-i-cancel-my-membership">How do I cancel my membership?</a> for the steps.</p>
-  <p>If you are logged in to Gumroad, the message reads "You already have an active subscription to this membership. Visit your Library to manage it" instead.</p>
+  <p>If you are logged in to Gumroad, the message instead reads "You already have an active subscription to this membership. Visit your Library to manage it."</p>
   <h3 id="Blocked-by-Gumroads-risk-system-Slrvd">Blocked by Gumroad’s risk system</h3>
   <p>Our risk detectors may have accidentally blocked you from purchasing. Please use "incognito" or "private" mode on your browser, and try the purchase using a different email address.</p>
   <h3 id="Chargeback-against-Gumroad-IvRQH">Chargeback against Gumroad</h3>

--- a/app/views/help_center/articles/contents/_203-why-did-my-payment-fail.html.erb
+++ b/app/views/help_center/articles/contents/_203-why-did-my-payment-fail.html.erb
@@ -44,7 +44,7 @@
   <p>Paying by bank account is only offered by some creators, and only to customers in the United States, so you may not see it on every checkout.</p>
   <h3 id="Email-already-has-an-active-subscription-tR7vN">Email already has an active subscription</h3>
   <p>If you see the message "This email address already has an active subscription to this membership. We've emailed it a link to manage the subscription — check your inbox," the email address you entered at checkout already has an active subscription to that membership. To prevent duplicate charges, we block the second purchase and send an email to that address instead.</p>
-  <p>If the existing subscription is yours, you don't need to buy again — your membership is still active. You can manage or cancel it from your membership receipt or from your <a href="https://app.gumroad.com/library">Gumroad Library</a>. See <a href="192-how-do-i-cancel-my-membership">How do I cancel my membership?</a> for the steps.</p>
+  <p>If the existing subscription is yours, you don't need to buy again. Your membership is still active, and you can manage or cancel it from your membership receipt or from your <a href="https://app.gumroad.com/library">Gumroad Library</a>. See <a href="192-how-do-i-cancel-my-membership">How do I cancel my membership?</a> for the steps.</p>
   <p>If you are logged in to Gumroad, the message reads "You already have an active subscription to this membership. Visit your Library to manage it" instead.</p>
   <h3 id="Blocked-by-Gumroads-risk-system-Slrvd">Blocked by Gumroad’s risk system</h3>
   <p>Our risk detectors may have accidentally blocked you from purchasing. Please use "incognito" or "private" mode on your browser, and try the purchase using a different email address.</p>

--- a/app/views/help_center/articles/contents/_203-why-did-my-payment-fail.html.erb
+++ b/app/views/help_center/articles/contents/_203-why-did-my-payment-fail.html.erb
@@ -8,6 +8,7 @@
     <li><a href="#Proxy-server-issues-5J9hZ">Proxy server issues</a></li>
     <li><a href="#Browser-error-_SZW5">Browser error</a></li>
     <li><a href="#Previous-payment-still-processing-kQ2pF">Previous payment still processing</a></li>
+    <li><a href="#Email-already-has-an-active-subscription-tR7vN">Email already has an active subscription</a></li>
     <li><a href="#Blocked-by-Gumroads-risk-system-Slrvd">Blocked by Gumroad’s risk system</a></li>
     <li><a href="#Chargeback-against-Gumroad-IvRQH">Chargeback against Gumroad</a></li>
   </ul>
@@ -41,6 +42,10 @@
   <p>If you see the message "Your previous payment for this product is still processing. We will email you a receipt as soon as it completes — please do not pay again," your earlier purchase went through and is on its way. Some payment methods, like bank debits, can take several business days to complete. To prevent you from being charged twice, we block repeat purchases of the same product while a confirmed payment is settling.</p>
   <p>There is nothing you need to do. We will email you a receipt as soon as the payment completes, and you will get access to your purchase then.</p>
   <p>Paying by bank account is only offered by some creators, and only to customers in the United States, so you may not see it on every checkout.</p>
+  <h3 id="Email-already-has-an-active-subscription-tR7vN">Email already has an active subscription</h3>
+  <p>If you see the message "This email address already has an active subscription to this membership. We've emailed it a link to manage the subscription — check your inbox," the email address you entered at checkout already has an active subscription to that membership. To prevent duplicate charges, we block the second purchase and send an email to that address instead.</p>
+  <p>If the existing subscription is yours, you don't need to buy again — your membership is still active. You can manage or cancel it from your membership receipt or from your <a href="https://app.gumroad.com/library">Gumroad Library</a>. See <a href="192-how-do-i-cancel-my-membership">How do I cancel my membership?</a> for the steps.</p>
+  <p>If you are logged in to Gumroad, the message reads "You already have an active subscription to this membership. Visit your Library to manage it" instead.</p>
   <h3 id="Blocked-by-Gumroads-risk-system-Slrvd">Blocked by Gumroad’s risk system</h3>
   <p>Our risk detectors may have accidentally blocked you from purchasing. Please use "incognito" or "private" mode on your browser, and try the purchase using a different email address.</p>
   <h3 id="Chargeback-against-Gumroad-IvRQH">Chargeback against Gumroad</h3>


### PR DESCRIPTION
## What

Adds a section to the "Why did my payment fail?" help-center article (`_203-why-did-my-payment-fail.html.erb`) documenting the checkout error a logged-out buyer sees when the email they enter already has an active subscription to the membership. The section quotes the new in-app message verbatim ("This email address already has an active subscription to this membership. We've emailed it a link to manage the subscription — check your inbox."), explains why the purchase is blocked (duplicate-charge prevention), points at the reminder email and the Library, links the cancellation guide, and notes the logged-in variant of the message.

## Why

PR #6006 replaced the generic "Sorry, something went wrong…" error on this path with the explicit already-subscribed message. The new message is a brand-new user-facing error string with zero help-center coverage — a buyer pasting it into help search found nothing. `_203` is the article that catalogs checkout failure messages (it already documents the "previous payment still processing" block the same way), so this is an additive section + TOC entry there.

Copy verified against code:
- Message strings: `Purchase::CreateService#handle_existing_subscription` (both logged-out and logged-in variants quoted verbatim).
- Reminder email: `CustomerLowPriorityMailer#already_subscribed_checkout_attempt` — sent to the subscription's email, confirms the existing membership is still active.

Triggered by merged PR #6006.

## Before / After

Not applicable — additive docs section; no product UI change. New section renders with the article's existing structure (h3 + TOC anchor, matching sibling anchor style).

## QA steps

1. Open help.gumroad.com/help/article/203-why-did-my-payment-fail on this branch.
2. Confirm the TOC lists "Email already has an active subscription" and the anchor link jumps to the new section.
3. Confirm the quoted message matches the checkout error shipped in #6006.

## Test Results

- `ApplicationController.render` of the article partial: renders OK, new copy present, all tag counts balanced (div/p/ul/li/h3/a).
- `bundle exec rspec spec/models/help_center`: 1 example, 0 failures (slug↔partial integrity).
- Body-only edit; `articles.yml` untouched (no title/description change).

---

**AI disclosure:** Authored by Claude Fable 5 (Hermes agent) from the automated merged-PR → help-center sync pipeline. Instructions: check merged gumroad PRs for help-center impact and update the affected article(s); this run mapped #6006's new checkout error message to the payment-failure article and added the documenting section.
