### PR TITLE
Filter profile-only seller posts on slim rows in mobile library search

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -2847,13 +2847,7 @@ class Purchase < ApplicationRecord
     # filters between the two queries, deciding from the slim snapshot could
     # hand a now-restricted post to a buyer who no longer passes its filters.
     # The reloaded set is small (only posts the buyer could see), so the
-    # second pass is cheap. The opposite race — a post becoming visible to the
-    # buyer between the two queries — is deliberately not recovered: its ID was
-    # dropped by the slim pass and stays dropped. That is fail-closed on
-    # purpose. Omitting a post for one request is benign and self-corrects on
-    # the next request (the pre-optimization single-query version had the same
-    # window), while recovering it would require re-running the unbounded
-    # full-row query this change exists to avoid.
+    # second pass is cheap.
     #
     # The reverse race — a post the slim pass rejected whose filters change
     # to allow the buyer before the reload — is deliberately left alone: the

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -2832,15 +2832,23 @@ class Purchase < ApplicationRecord
     # full rows for the few posts the buyer can actually see.
     slim_seller_profile_posts = Installment.profile_only_for_sellers(seller_ids)
                                            .select(:id, :seller_id, :installment_type, :link_id, :base_variant_id, :flags, :published_at, :json_data)
-    visible_seller_profile_post_ids = check_filters.call(slim_seller_profile_posts).map(&:id)
+    candidate_seller_profile_post_ids = check_filters.call(slim_seller_profile_posts).map(&:id)
     # Reload through the same scope so a post mutated between the two queries
     # (unpublished, flipped to send_emails) is dropped rather than reaching the
     # sort below with a nil published_at. index_by + filter_map keeps the
     # scope's row order — the final sort_by is stable only relative to its
     # input order, so reordering here would change tie-breaking among posts
     # with equal timestamps.
-    full_seller_profile_posts_by_id = visible_seller_profile_post_ids.any? ? Installment.profile_only_for_sellers(seller_ids).where(id: visible_seller_profile_post_ids).index_by(&:id) : {}
-    seller_profile_posts = visible_seller_profile_post_ids.filter_map { |id| full_seller_profile_posts_by_id[id] }
+    full_seller_profile_posts_by_id = candidate_seller_profile_post_ids.any? ? Installment.profile_only_for_sellers(seller_ids).where(id: candidate_seller_profile_post_ids).index_by(&:id) : {}
+    reloaded_seller_profile_posts = candidate_seller_profile_post_ids.filter_map { |id| full_seller_profile_posts_by_id[id] }
+    # Re-run the buyer-filter pass on the reloaded rows so the visibility
+    # decision is made against the data we actually return. The slim pass
+    # above is only a candidate pre-filter: if a seller edits a post's buyer
+    # filters between the two queries, deciding from the slim snapshot could
+    # hand a now-restricted post to a buyer who no longer passes its filters.
+    # The reloaded set is small (only posts the buyer could see), so the
+    # second pass is cheap.
+    seller_profile_posts = check_filters.call(reloaded_seller_profile_posts)
     seller_posts = check_filters.call(emailed_seller_posts) + seller_profile_posts
 
     profile_seller_sent_email_posts = installments_with_sent_emails + profile_only_product_posts + profile_only_variant_posts + seller_posts

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -2825,17 +2825,21 @@ class Purchase < ApplicationRecord
     # rows, and `installments.*` drags in each post's LONGTEXT `message` body
     # just so the Ruby-side buyer filters can look at `json_data`
     # (antiwork/gumroad#6009: this single fetch was 1.27s of a 2.06s mobile
-    # library search request). Run the filter pass on slim rows carrying only
-    # the columns `purchase_passes_filters` reads (`json_data` for the filter
-    # criteria, `seller_id` for the "hasn't bought X" sales probe), then load
+    # library search request). Run the filter pass on slim rows carrying just
+    # the columns the pass needs (`json_data` for the filter criteria,
+    # `seller_id` for the "hasn't bought X" sales probe, plus the scope's own
+    # type/flag/timestamp columns), then load
     # full rows for the few posts the buyer can actually see.
     slim_seller_profile_posts = Installment.profile_only_for_sellers(seller_ids)
                                            .select(:id, :seller_id, :installment_type, :link_id, :base_variant_id, :flags, :published_at, :json_data)
     visible_seller_profile_post_ids = check_filters.call(slim_seller_profile_posts).map(&:id)
-    # index_by + map keeps the scope's row order — the final sort_by below is
-    # stable only relative to its input order, so reordering here would change
-    # tie-breaking among posts with equal timestamps.
-    full_seller_profile_posts_by_id = visible_seller_profile_post_ids.any? ? Installment.where(id: visible_seller_profile_post_ids).index_by(&:id) : {}
+    # Reload through the same scope so a post mutated between the two queries
+    # (unpublished, flipped to send_emails) is dropped rather than reaching the
+    # sort below with a nil published_at. index_by + filter_map keeps the
+    # scope's row order — the final sort_by is stable only relative to its
+    # input order, so reordering here would change tie-breaking among posts
+    # with equal timestamps.
+    full_seller_profile_posts_by_id = visible_seller_profile_post_ids.any? ? Installment.profile_only_for_sellers(seller_ids).where(id: visible_seller_profile_post_ids).index_by(&:id) : {}
     seller_profile_posts = visible_seller_profile_post_ids.filter_map { |id| full_seller_profile_posts_by_id[id] }
     seller_posts = check_filters.call(emailed_seller_posts) + seller_profile_posts
 

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -2820,8 +2820,24 @@ class Purchase < ApplicationRecord
                                            .pluck(:id)
     emailed_seller_posts = Installment.seller_with_sent_emails_for_purchases(purchase_ids + purchase_ids_with_same_email)
                                       .select("installments.*, email_infos.sent_at, email_infos.delivered_at, email_infos.opened_at")
-    seller_profile_posts = Installment.profile_only_for_sellers(seller_ids)
-    seller_posts = check_filters.call(emailed_seller_posts + seller_profile_posts)
+    # `profile_only_for_sellers` matches every profile-only seller post the
+    # seller has ever published — for prolific sellers that's thousands of
+    # rows, and `installments.*` drags in each post's LONGTEXT `message` body
+    # just so the Ruby-side buyer filters can look at `json_data`
+    # (antiwork/gumroad#6009: this single fetch was 1.27s of a 2.06s mobile
+    # library search request). Run the filter pass on slim rows carrying only
+    # the columns `purchase_passes_filters` reads (`json_data` for the filter
+    # criteria, `seller_id` for the "hasn't bought X" sales probe), then load
+    # full rows for the few posts the buyer can actually see.
+    slim_seller_profile_posts = Installment.profile_only_for_sellers(seller_ids)
+                                           .select(:id, :seller_id, :installment_type, :link_id, :base_variant_id, :flags, :published_at, :json_data)
+    visible_seller_profile_post_ids = check_filters.call(slim_seller_profile_posts).map(&:id)
+    # index_by + map keeps the scope's row order — the final sort_by below is
+    # stable only relative to its input order, so reordering here would change
+    # tie-breaking among posts with equal timestamps.
+    full_seller_profile_posts_by_id = visible_seller_profile_post_ids.any? ? Installment.where(id: visible_seller_profile_post_ids).index_by(&:id) : {}
+    seller_profile_posts = visible_seller_profile_post_ids.filter_map { |id| full_seller_profile_posts_by_id[id] }
+    seller_posts = check_filters.call(emailed_seller_posts) + seller_profile_posts
 
     profile_seller_sent_email_posts = installments_with_sent_emails + profile_only_product_posts + profile_only_variant_posts + seller_posts
     should_show_all_posts = purchases.map(&:link).any? { |product| product.should_show_all_posts? }

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -2847,7 +2847,21 @@ class Purchase < ApplicationRecord
     # filters between the two queries, deciding from the slim snapshot could
     # hand a now-restricted post to a buyer who no longer passes its filters.
     # The reloaded set is small (only posts the buyer could see), so the
-    # second pass is cheap.
+    # second pass is cheap. The opposite race — a post becoming visible to the
+    # buyer between the two queries — is deliberately not recovered: its ID was
+    # dropped by the slim pass and stays dropped. That is fail-closed on
+    # purpose. Omitting a post for one request is benign and self-corrects on
+    # the next request (the pre-optimization single-query version had the same
+    # window), while recovering it would require re-running the unbounded
+    # full-row query this change exists to avoid.
+    #
+    # The reverse race — a post the slim pass rejected whose filters change
+    # to allow the buyer before the reload — is deliberately left alone: the
+    # post is merely omitted from this one response and shows up on the next
+    # request. That matches the pre-optimization behavior (a single query
+    # also worked from one point-in-time snapshot and couldn't see edits made
+    # after it ran), and closing it would mean reloading full rows for every
+    # rejected post, which is exactly the cost this split avoids.
     seller_profile_posts = check_filters.call(reloaded_seller_profile_posts)
     seller_posts = check_filters.call(emailed_seller_posts) + seller_profile_posts
 

--- a/spec/models/purchase/purchase_installments_spec.rb
+++ b/spec/models/purchase/purchase_installments_spec.rb
@@ -46,6 +46,23 @@ describe "PurchaseInstallments", :vcr do
       expect(Purchase.product_installments(purchase_ids: [purchase_2.id])).to eq([installment_2])
     end
 
+    it "returns fully-loaded records for profile-only seller posts" do
+      # The buyer-filter pass over a seller's profile-only posts runs on slim
+      # rows (only the columns the filters read) to avoid materializing every
+      # post's LONGTEXT message body for prolific sellers (#6009). The posts
+      # handed back to callers must still be full records — serializers read
+      # `message` and other unselected columns, which would raise
+      # MissingAttributeError on a slim row.
+      purchase = create(:purchase)
+      post = create(:seller_installment, send_emails: false, shown_on_profile: true, seller: purchase.link.user, published_at: 10.minutes.ago,
+                                         message: "full message body")
+
+      posts = Purchase.product_installments(purchase_ids: [purchase.id])
+
+      expect(posts).to eq([post])
+      expect(posts.first.message).to eq("full message body")
+    end
+
     context "when purchased product(s) have should_show_all_posts enabled" do
       let(:enabled_product) { create(:product, should_show_all_posts: true) }
       let(:enabled_product_variant) { create(:variant, variant_category: create(:variant_category, link: enabled_product)) }


### PR DESCRIPTION
Part of #6009 — the second dominant query shape from the Sentry traces, deliberately left out of #6123.

## What

`Api::Mobile::PurchasesController#search` → `purchases_to_json` → `Purchase.preload_product_updates_data!` → `Purchase.product_installments` fetches `Installment.profile_only_for_sellers(seller_ids)` with `installments.*` — every profile-only seller post the seller has EVER published, including each post's LONGTEXT `message` body, just so the Ruby-side buyer filters (`purchase_passes_filters`) can read `json_data`. For mega-sellers this single fetch was **1.273s of a 2.06s request** (Sentry event `57c0426f97fe4f1fb59077a582d44988`, 62% of the trace).

## How

Run the buyer-filter pass on slim rows selecting only the columns the filters read (`json_data`, `seller_id`, plus type/flag/timestamp columns), then load full records for only the posts the buyer can actually see — typically a handful instead of thousands. The id→record round-trip preserves the scope's row order so the final stable sort's tie-breaking is unchanged.

## Why this shape

- No behavior change: same posts returned, fully loaded (serializers read `message` etc.).
- The filter predicates live in JSON (`json_data`), so pushing them into SQL isn't a small change; slimming the filter pass gets ~all of the win with none of the semantic risk.

## QA / test notes

Backend perf change, no UI. New spec asserts returned profile-only seller posts are fully-loaded records (a slim row would raise `MissingAttributeError` when serializers read `message`).

Local test results:
- `spec/models/purchase/purchase_installments_spec.rb` — 53 examples, 0 failures
- `spec/models/concerns/with_filtering_spec.rb` + `spec/controllers/api/mobile/purchases_controller_spec.rb` + installments spec — 199 examples, 0 failures
- Rubocop clean

## Post-deploy verification

Same signals as #6123: `Api::Mobile::PurchasesController#search` p95/p99 in Sentry (target sub-300ms p95 from #6009's checklist) and GUMROAD-8T (120s Rack timeouts) decay.

🤖 Authored by gumclaw (AI agent).
