### PR TITLE
Deploy freeze from payout-batch state: /healthcheck/payouts + deploy-script polling

### DIFF
--- a/.buildkite/scripts/deploy_production.sh
+++ b/.buildkite/scripts/deploy_production.sh
@@ -7,17 +7,36 @@ logger() {
   echo -e "${GREEN}$(date "+%Y/%m/%d %H:%M:%S") deploy_production.sh: $1${NC}"
 }
 
-# Skip deploys only while a weekly payout batch may be running.
-# Batches are enqueued at UTC 10:00 on Tue-Fri (cross-border/non-US/US/PayPal+Connect)
-# and complete in 10-30 minutes (measured from payments.created_at bursts, July 2026;
-# worst observed: ~30 min on the US batch). One hour gives 2x headroom.
-# Sat/Sun/Mon have no weekly batch, so deploys are never blocked on those days.
-current_utc_hour=$(date -u +%H)
-current_utc_dow=$(date -u +%u) # 1=Mon .. 7=Sun
-if [ "$current_utc_dow" -ge 2 ] && [ "$current_utc_dow" -le 5 ] && [ "$current_utc_hour" -eq 10 ]; then
-  logger "Skipping deployment to production during weekly payout batch (Tue-Fri UTC 10:00 to 11:00)"
-  exit 0
-fi
+# Hold deploys only while a payout batch is ACTUALLY running, by asking the app
+# (PerformPayoutsUpToDelayDaysAgoWorker maintains a Redis flag; /healthcheck/payouts
+# returns 503 while any per-type batch job is in flight). Poll for up to 45 minutes —
+# batches complete in 10-30 min (measured July 2026) — then proceed with a warning
+# rather than dropping the deploy silently.
+# Fallback: if the healthcheck is unreachable (non-200/503 answer), fall back to the
+# static window (Tue-Fri UTC 10:00-10:59, when weekly batches are enqueued) so a
+# broken healthcheck can never let a deploy land mid-batch.
+payouts_healthcheck_url="https://gumroad.com/healthcheck/payouts"
+for attempt in $(seq 1 15); do
+  hc_status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$payouts_healthcheck_url" || echo "000")
+  if [ "$hc_status" = "200" ]; then
+    break
+  elif [ "$hc_status" = "503" ]; then
+    logger "Payout batch in flight (healthcheck 503) — waiting 3 minutes (attempt $attempt/15)"
+    sleep 180
+  else
+    current_utc_hour=$(date -u +%H)
+    current_utc_dow=$(date -u +%u) # 1=Mon .. 7=Sun
+    if [ "$current_utc_dow" -ge 2 ] && [ "$current_utc_dow" -le 5 ] && [ "$current_utc_hour" -eq 10 ]; then
+      logger "Payouts healthcheck unreachable (HTTP $hc_status) during the static batch window (Tue-Fri UTC 10:00-11:00) — skipping deployment"
+      exit 0
+    fi
+    logger "Payouts healthcheck unreachable (HTTP $hc_status) outside the static batch window — proceeding"
+    break
+  fi
+  if [ "$attempt" = "15" ]; then
+    logger "WARNING: payout batch still in flight after 45 minutes — proceeding with deploy anyway (batch jobs are deploy-safe Sidekiq jobs with retries; this warning means the batch is unusually slow and worth a look)"
+  fi
+done
 
 ECR_REGISTRY=${ECR_REGISTRY}
 WEB_REPO=${ECR_REGISTRY}/gumroad/web

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -18,11 +18,20 @@ class HealthcheckController < ApplicationController
   end
 
   # Reports whether a weekly payout batch is currently running (see
-  # PerformPayoutsUpToDelayDaysAgoWorker, which maintains the flag). The deploy
-  # pipeline polls this before deploying to production so deploys are held only
-  # while payouts are actually in flight, not on a fixed clock window.
+  # PerformPayoutsUpToDelayDaysAgoWorker, which registers a token per running job).
+  # The deploy pipeline polls this before deploying to production so deploys are held
+  # only while payouts are actually in flight, not on a fixed clock window.
+  #
+  # Only entries younger than the worker's per-entry TTL count: the key-level EXPIRE
+  # is refreshed whenever any job registers, so score-based filtering here is what
+  # actually ages out an entry left behind by a job that died mid-batch.
   def payouts
-    in_flight = $redis.get(RedisKey.payout_batch_in_flight).to_i > 0
+    key = RedisKey.payout_batch_in_flight
+    oldest_valid_score = PerformPayoutsUpToDelayDaysAgoWorker::IN_FLIGHT_ENTRY_TTL.ago.to_i
+    # Prune expired entries first so a dead job's leftover token gets removed rather
+    # than lingering until the whole key expires.
+    $redis.zremrangebyscore(key, "-inf", "(#{oldest_valid_score}")
+    in_flight = $redis.zcard(key) > 0
     status = in_flight ? :service_unavailable : :ok
     message = in_flight ? "batch in flight" : "no batch in flight"
 

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -17,6 +17,18 @@ class HealthcheckController < ApplicationController
     render plain: "Sidekiq: #{status}", status:
   end
 
+  # Reports whether a weekly payout batch is currently running (see
+  # PerformPayoutsUpToDelayDaysAgoWorker, which maintains the flag). The deploy
+  # pipeline polls this before deploying to production so deploys are held only
+  # while payouts are actually in flight, not on a fixed clock window.
+  def payouts
+    in_flight = $redis.get(RedisKey.payout_batch_in_flight).to_i > 0
+    status = in_flight ? :service_unavailable : :ok
+    message = in_flight ? "batch in flight" : "no batch in flight"
+
+    render plain: "Payouts: #{message}", status:
+  end
+
   def paypal_balance
     topup_not_needed = $redis.get(RedisKey.paypal_topup_needed) == "false"
     status = topup_not_needed ? :ok : :service_unavailable

--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -59,6 +59,10 @@ class RedisKey
     def unreviewed_users_data = "admin:unreviewed_users_data"
     def unreviewed_users_cutoff_date = "admin:unreviewed_users_cutoff_date"
     def paypal_topup_needed = "paypal:topup_needed"
+    # Set (with a TTL) by each weekly payout batch job while it runs, so the
+    # deploy pipeline can ask "is a payout batch in flight right now?" instead
+    # of freezing deploys on a fixed clock window. See HealthcheckController#payouts.
+    def payout_batch_in_flight = "payouts:batch_in_flight"
     def stripe_balance_topup_needed = "stripe:balance_topup_needed"
     def min_successful_purchases_in_last_10_minutes = "healthcheck:min_successful_purchases_in_last_10_minutes"
     def email_router_fallback(user_id) = "email_router_fallback:#{user_id}"

--- a/app/sidekiq/perform_payouts_up_to_delay_days_ago_worker.rb
+++ b/app/sidekiq/perform_payouts_up_to_delay_days_ago_worker.rb
@@ -16,6 +16,32 @@ class PerformPayoutsUpToDelayDaysAgoWorker
     ErrorNotifier.notify(exception, payout_processor_type:, bank_account_types:)
   end
 
+  # Both scripts below run as single atomic Redis operations (a Lua script can't be
+  # interleaved with other commands). The atomicity matters for correctness, not tidiness:
+  #
+  # Raising the flag: if INCR and EXPIRE were two separate calls, a transient Redis error
+  # between them could leave a positive counter with no TTL — the healthcheck would then
+  # report "payouts in flight" forever and every deploy would stall until someone deleted
+  # the key by hand.
+  RAISE_IN_FLIGHT_FLAG_SCRIPT = <<~LUA
+    local count = redis.call('INCR', KEYS[1])
+    redis.call('EXPIRE', KEYS[1], ARGV[1])
+    return count
+  LUA
+
+  # Lowering the flag: the last job out deletes the key, but if DECR and DEL were two
+  # separate calls, a sibling per-type job could INCR in between and have its count
+  # deleted — the healthcheck would report "clear" while that sibling was still paying
+  # out, letting a deploy land mid-batch. The <= 0 guard also removes any stray negative
+  # value so it can't linger and absorb a future batch's increment.
+  LOWER_IN_FLIGHT_FLAG_SCRIPT = <<~LUA
+    local count = redis.call('DECR', KEYS[1])
+    if count <= 0 then
+      redis.call('DEL', KEYS[1])
+    end
+    return count
+  LUA
+
   def perform(payout_processor_type, bank_account_types = nil)
     # Fan a multi-bank-type batch out into one job per bank account type. Processing the types
     # sequentially inside a single job meant one slow `holding_balance` query aborted every
@@ -38,8 +64,9 @@ class PerformPayoutsUpToDelayDaysAgoWorker
     # stay up until the LAST one finishes. The TTL is a crash safety net: if a job
     # dies without the ensure running, the flag clears itself instead of freezing
     # deploys forever. 3 hours covers the 2-hour query budget below with headroom.
-    $redis.incr(RedisKey.payout_batch_in_flight)
-    $redis.expire(RedisKey.payout_batch_in_flight, 3.hours.to_i)
+    # `counted` tracks whether the increment actually landed, so the ensure never
+    # decrements a count it didn't add.
+    counted = false
 
     # The database connection defaults to a 5-minute statement cap (config/database.yml).
     # The `holding_balance` eligibility query for a large bank-account-type cohort (US ACH,
@@ -50,6 +77,9 @@ class PerformPayoutsUpToDelayDaysAgoWorker
     # long-running query here is expected, so give it a 2-hour budget instead of letting
     # the default cap kill the batch.
     begin
+      $redis.eval(RAISE_IN_FLIGHT_FLAG_SCRIPT, keys: [RedisKey.payout_batch_in_flight], argv: [3.hours.to_i])
+      counted = true
+
       WithMaxExecutionTime.timeout_queries(seconds: 2.hours) do
         if bank_account_types
           Payouts.create_payments_for_balances_up_to_date_for_bank_account_types(payout_period_end_date, payout_processor_type, bank_account_types)
@@ -58,11 +88,9 @@ class PerformPayoutsUpToDelayDaysAgoWorker
         end
       end
     ensure
-      # Last concurrent per-type job out turns the light off. DECR below zero can't
-      # happen in practice (every INCR has a matching ensure), but guard anyway so a
-      # stray negative value doesn't read as "in flight" forever.
-      remaining = $redis.decr(RedisKey.payout_batch_in_flight)
-      $redis.del(RedisKey.payout_batch_in_flight) if remaining <= 0
+      # Last concurrent per-type job out turns the light off — atomically, so a sibling
+      # job's count can never be deleted out from under it (see the script's comment).
+      $redis.eval(LOWER_IN_FLIGHT_FLAG_SCRIPT, keys: [RedisKey.payout_batch_in_flight]) if counted
     end
 
     Rails.logger.info("AUTOMATED PAYOUTS: #{payout_period_end_date}, #{payout_processor_type} #{bank_account_types} (Finished)")

--- a/app/sidekiq/perform_payouts_up_to_delay_days_ago_worker.rb
+++ b/app/sidekiq/perform_payouts_up_to_delay_days_ago_worker.rb
@@ -31,6 +31,16 @@ class PerformPayoutsUpToDelayDaysAgoWorker
 
     Rails.logger.info("AUTOMATED PAYOUTS: #{payout_period_end_date}, #{payout_processor_type}, #{bank_account_types} (Started)")
 
+    # Mark a payout batch as in flight so the deploy pipeline can hold production
+    # deploys only while payouts are actually running (see HealthcheckController#payouts
+    # and .buildkite/scripts/deploy_production.sh). A counter (not a boolean) because
+    # the multi-bank-type batch fans out to concurrent per-type jobs — the flag must
+    # stay up until the LAST one finishes. The TTL is a crash safety net: if a job
+    # dies without the ensure running, the flag clears itself instead of freezing
+    # deploys forever. 3 hours covers the 2-hour query budget below with headroom.
+    $redis.incr(RedisKey.payout_batch_in_flight)
+    $redis.expire(RedisKey.payout_batch_in_flight, 3.hours.to_i)
+
     # The database connection defaults to a 5-minute statement cap (config/database.yml).
     # The `holding_balance` eligibility query for a large bank-account-type cohort (US ACH,
     # India, UK) regularly exceeds that cap during the 10:00 UTC batch window, and because
@@ -39,12 +49,20 @@ class PerformPayoutsUpToDelayDaysAgoWorker
     # 2026-07-08 UK batch). Payouts are a weekly batch job, not a user-facing request — a
     # long-running query here is expected, so give it a 2-hour budget instead of letting
     # the default cap kill the batch.
-    WithMaxExecutionTime.timeout_queries(seconds: 2.hours) do
-      if bank_account_types
-        Payouts.create_payments_for_balances_up_to_date_for_bank_account_types(payout_period_end_date, payout_processor_type, bank_account_types)
-      else
-        Payouts.create_payments_for_balances_up_to_date(payout_period_end_date, payout_processor_type)
+    begin
+      WithMaxExecutionTime.timeout_queries(seconds: 2.hours) do
+        if bank_account_types
+          Payouts.create_payments_for_balances_up_to_date_for_bank_account_types(payout_period_end_date, payout_processor_type, bank_account_types)
+        else
+          Payouts.create_payments_for_balances_up_to_date(payout_period_end_date, payout_processor_type)
+        end
       end
+    ensure
+      # Last concurrent per-type job out turns the light off. DECR below zero can't
+      # happen in practice (every INCR has a matching ensure), but guard anyway so a
+      # stray negative value doesn't read as "in flight" forever.
+      remaining = $redis.decr(RedisKey.payout_batch_in_flight)
+      $redis.del(RedisKey.payout_batch_in_flight) if remaining <= 0
     end
 
     Rails.logger.info("AUTOMATED PAYOUTS: #{payout_period_end_date}, #{payout_processor_type} #{bank_account_types} (Finished)")

--- a/app/sidekiq/perform_payouts_up_to_delay_days_ago_worker.rb
+++ b/app/sidekiq/perform_payouts_up_to_delay_days_ago_worker.rb
@@ -16,30 +16,28 @@ class PerformPayoutsUpToDelayDaysAgoWorker
     ErrorNotifier.notify(exception, payout_processor_type:, bank_account_types:)
   end
 
-  # Both scripts below run as single atomic Redis operations (a Lua script can't be
-  # interleaved with other commands). The atomicity matters for correctness, not tidiness:
-  #
-  # Raising the flag: if INCR and EXPIRE were two separate calls, a transient Redis error
-  # between them could leave a positive counter with no TTL — the healthcheck would then
-  # report "payouts in flight" forever and every deploy would stall until someone deleted
-  # the key by hand.
-  RAISE_IN_FLIGHT_FLAG_SCRIPT = <<~LUA
-    local count = redis.call('INCR', KEYS[1])
-    redis.call('EXPIRE', KEYS[1], ARGV[1])
-    return count
-  LUA
+  # How long a job's in-flight entry stays valid. This is the crash safety net: if a
+  # job dies without its ensure running (or Redis is unreachable during cleanup), the
+  # entry stops counting after this long, so a dead job can never freeze deploys
+  # forever. 3 hours covers the 2-hour query budget below with headroom. The
+  # healthcheck (HealthcheckController#payouts) only counts entries younger than this.
+  IN_FLIGHT_ENTRY_TTL = 3.hours
 
-  # Lowering the flag: the last job out deletes the key, but if DECR and DEL were two
-  # separate calls, a sibling per-type job could INCR in between and have its count
-  # deleted — the healthcheck would report "clear" while that sibling was still paying
-  # out, letting a deploy land mid-batch. The <= 0 guard also removes any stray negative
-  # value so it can't linger and absorb a future batch's increment.
-  LOWER_IN_FLIGHT_FLAG_SCRIPT = <<~LUA
-    local count = redis.call('DECR', KEYS[1])
-    if count <= 0 then
-      redis.call('DEL', KEYS[1])
-    end
-    return count
+  # Each running payout job registers its own unique token in a Redis sorted set,
+  # scored by start time, rather than incrementing a shared counter. A shared counter
+  # has an unfixable ambiguity: when Redis executes an increment but the client loses
+  # the response (network blip), the job cannot know whether it owns a count — so it
+  # must either leak one (stale "in flight" that stalls deploys) or risk decrementing
+  # a concurrent sibling job's count (deploy lands mid-batch). With per-job tokens the
+  # cleanup is removing our OWN token: idempotent, safe to run no matter how the
+  # registration attempt ended, and it can never touch a sibling's entry.
+  #
+  # ZADD and EXPIRE run as one atomic Lua script so a transient error between them
+  # can't leave the key without its expiry backstop.
+  RAISE_IN_FLIGHT_FLAG_SCRIPT = <<~LUA
+    redis.call('ZADD', KEYS[1], ARGV[1], ARGV[2])
+    redis.call('EXPIRE', KEYS[1], ARGV[3])
+    return redis.call('ZCARD', KEYS[1])
   LUA
 
   def perform(payout_processor_type, bank_account_types = nil)
@@ -59,14 +57,12 @@ class PerformPayoutsUpToDelayDaysAgoWorker
 
     # Mark a payout batch as in flight so the deploy pipeline can hold production
     # deploys only while payouts are actually running (see HealthcheckController#payouts
-    # and .buildkite/scripts/deploy_production.sh). A counter (not a boolean) because
-    # the multi-bank-type batch fans out to concurrent per-type jobs — the flag must
-    # stay up until the LAST one finishes. The TTL is a crash safety net: if a job
-    # dies without the ensure running, the flag clears itself instead of freezing
-    # deploys forever. 3 hours covers the 2-hour query budget below with headroom.
-    # `counted` tracks whether the increment actually landed, so the ensure never
-    # decrements a count it didn't add.
-    counted = false
+    # and .buildkite/scripts/deploy_production.sh). Each job registers a unique token
+    # (a set of tokens, not a boolean) because the multi-bank-type batch fans out to
+    # concurrent per-type jobs — the flag must stay up until the LAST one finishes.
+    # The per-entry TTL (via the score, enforced by the healthcheck reader) means a
+    # crashed job's entry expires on its own instead of freezing deploys forever.
+    in_flight_token = "#{Process.pid}-#{SecureRandom.uuid}"
 
     # The database connection defaults to a 5-minute statement cap (config/database.yml).
     # The `holding_balance` eligibility query for a large bank-account-type cohort (US ACH,
@@ -77,8 +73,11 @@ class PerformPayoutsUpToDelayDaysAgoWorker
     # long-running query here is expected, so give it a 2-hour budget instead of letting
     # the default cap kill the batch.
     begin
-      $redis.eval(RAISE_IN_FLIGHT_FLAG_SCRIPT, keys: [RedisKey.payout_batch_in_flight], argv: [3.hours.to_i])
-      counted = true
+      $redis.eval(
+        RAISE_IN_FLIGHT_FLAG_SCRIPT,
+        keys: [RedisKey.payout_batch_in_flight],
+        argv: [Time.current.to_i, in_flight_token, IN_FLIGHT_ENTRY_TTL.to_i]
+      )
 
       WithMaxExecutionTime.timeout_queries(seconds: 2.hours) do
         if bank_account_types
@@ -88,9 +87,17 @@ class PerformPayoutsUpToDelayDaysAgoWorker
         end
       end
     ensure
-      # Last concurrent per-type job out turns the light off — atomically, so a sibling
-      # job's count can never be deleted out from under it (see the script's comment).
-      $redis.eval(LOWER_IN_FLIGHT_FLAG_SCRIPT, keys: [RedisKey.payout_batch_in_flight]) if counted
+      # Remove our own token. This is idempotent (removing an absent member is a no-op)
+      # and scoped to this job's entry, so it runs unconditionally: even if the
+      # registration above failed — or Redis executed it but the response was lost —
+      # cleanup can neither leak our entry nor touch a concurrent sibling job's.
+      begin
+        $redis.zrem(RedisKey.payout_batch_in_flight, in_flight_token)
+      rescue Redis::BaseError => e
+        # A failed cleanup self-heals via the entry's TTL; don't let it mask the
+        # batch's own outcome (success, or the exception already propagating).
+        ErrorNotifier.notify(e, redis_key: RedisKey.payout_batch_in_flight)
+      end
     end
 
     Rails.logger.info("AUTOMATED PAYOUTS: #{payout_period_end_date}, #{payout_processor_type} #{bank_account_types} (Finished)")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ end
 Rails.application.routes.draw do
   get "/healthcheck" => "healthcheck#index"
   get "/healthcheck/sidekiq" => "healthcheck#sidekiq"
+  get "/healthcheck/payouts" => "healthcheck#payouts"
   get "/healthcheck/paypal_balance" => "healthcheck#paypal_balance"
   get "/healthcheck/stripe_balance" => "healthcheck#stripe_balance"
   get "/healthcheck/purchases" => "healthcheck#purchases"

--- a/spec/controllers/healthcheck_controller_spec.rb
+++ b/spec/controllers/healthcheck_controller_spec.rb
@@ -68,6 +68,44 @@ describe HealthcheckController do
     end
   end
 
+  describe "GET 'payouts'" do
+    context "when no payout batch is in flight (Redis key absent)" do
+      it "returns 200" do
+        $redis.del(RedisKey.payout_batch_in_flight)
+
+        get :payouts
+
+        expect(response.status).to eq(200)
+        expect(response.body).to eq("Payouts: no batch in flight")
+      end
+    end
+
+    context "when a payout batch is in flight (counter above zero)" do
+      it "returns 503" do
+        $redis.set(RedisKey.payout_batch_in_flight, 2)
+
+        get :payouts
+
+        expect(response.status).to eq(503)
+        expect(response.body).to eq("Payouts: batch in flight")
+      ensure
+        $redis.del(RedisKey.payout_batch_in_flight)
+      end
+    end
+
+    context "when the counter has decayed to zero without being deleted" do
+      it "returns 200" do
+        $redis.set(RedisKey.payout_batch_in_flight, 0)
+
+        get :payouts
+
+        expect(response.status).to eq(200)
+      ensure
+        $redis.del(RedisKey.payout_batch_in_flight)
+      end
+    end
+  end
+
   describe "GET 'paypal_balance'" do
     context "when PayPal topup is not needed (Redis key is false)" do
       before do

--- a/spec/controllers/healthcheck_controller_spec.rb
+++ b/spec/controllers/healthcheck_controller_spec.rb
@@ -80,9 +80,9 @@ describe HealthcheckController do
       end
     end
 
-    context "when a payout batch is in flight (counter above zero)" do
+    context "when a payout batch is in flight (a fresh job entry exists)" do
       it "returns 503" do
-        $redis.set(RedisKey.payout_batch_in_flight, 2)
+        $redis.zadd(RedisKey.payout_batch_in_flight, Time.current.to_i, "job-token")
 
         get :payouts
 
@@ -93,13 +93,31 @@ describe HealthcheckController do
       end
     end
 
-    context "when the counter has decayed to zero without being deleted" do
-      it "returns 200" do
-        $redis.set(RedisKey.payout_batch_in_flight, 0)
+    context "when the only entries are older than the per-entry TTL (job died mid-batch)" do
+      it "returns 200 and prunes the stale entry" do
+        stale_score = (PerformPayoutsUpToDelayDaysAgoWorker::IN_FLIGHT_ENTRY_TTL + 1.minute).ago.to_i
+        $redis.zadd(RedisKey.payout_batch_in_flight, stale_score, "dead-job-token")
 
         get :payouts
 
         expect(response.status).to eq(200)
+        expect($redis.zcard(RedisKey.payout_batch_in_flight)).to eq(0)
+      ensure
+        $redis.del(RedisKey.payout_batch_in_flight)
+      end
+    end
+
+    context "when a stale entry sits alongside a fresh one" do
+      it "returns 503 and prunes only the stale entry" do
+        stale_score = (PerformPayoutsUpToDelayDaysAgoWorker::IN_FLIGHT_ENTRY_TTL + 1.minute).ago.to_i
+        $redis.zadd(RedisKey.payout_batch_in_flight, stale_score, "dead-job-token")
+        $redis.zadd(RedisKey.payout_batch_in_flight, Time.current.to_i, "live-job-token")
+
+        get :payouts
+
+        expect(response.status).to eq(503)
+        expect($redis.zscore(RedisKey.payout_batch_in_flight, "dead-job-token")).to be_nil
+        expect($redis.zscore(RedisKey.payout_batch_in_flight, "live-job-token")).to be_present
       ensure
         $redis.del(RedisKey.payout_batch_in_flight)
       end

--- a/spec/sidekiq/perform_payouts_up_to_delay_days_ago_worker_spec.rb
+++ b/spec/sidekiq/perform_payouts_up_to_delay_days_ago_worker_spec.rb
@@ -16,13 +16,13 @@ describe PerformPayoutsUpToDelayDaysAgoWorker do
 
       it "is set (with a TTL safety net) while the batch runs and cleared afterwards" do
         expect(Payouts).to receive(:create_payments_for_balances_up_to_date) do
-          expect($redis.get(RedisKey.payout_batch_in_flight).to_i).to be > 0
+          expect($redis.zcard(RedisKey.payout_batch_in_flight)).to be > 0
           expect($redis.ttl(RedisKey.payout_batch_in_flight)).to be_between(1, 3.hours.to_i)
         end
 
         described_class.new.perform(payout_processor_type)
 
-        expect($redis.get(RedisKey.payout_batch_in_flight).to_i).to eq(0)
+        expect($redis.zcard(RedisKey.payout_batch_in_flight)).to eq(0)
       end
 
       it "is cleared even when the batch raises" do
@@ -32,20 +32,21 @@ describe PerformPayoutsUpToDelayDaysAgoWorker do
           described_class.new.perform(payout_processor_type)
         end.to raise_error(ActiveRecord::StatementTimeout)
 
-        expect($redis.get(RedisKey.payout_batch_in_flight).to_i).to eq(0)
+        expect($redis.zcard(RedisKey.payout_batch_in_flight)).to eq(0)
       end
 
       it "stays up until the last concurrent per-type job finishes" do
         expect(Payouts).to receive(:create_payments_for_balances_up_to_date_for_bank_account_types) do
           # Simulate a sibling per-type job still running alongside this one.
-          expect($redis.get(RedisKey.payout_batch_in_flight).to_i).to be >= 2
+          expect($redis.zcard(RedisKey.payout_batch_in_flight)).to be >= 2
         end
 
-        $redis.incr(RedisKey.payout_batch_in_flight) # the sibling
+        $redis.zadd(RedisKey.payout_batch_in_flight, Time.current.to_i, "sibling-token")
         described_class.new.perform(PayoutProcessorType::STRIPE, ["AchAccount"])
 
-        # This job's decrement leaves the sibling's count in place.
-        expect($redis.get(RedisKey.payout_batch_in_flight).to_i).to eq(1)
+        # This job removes only its own token, leaving the sibling's entry in place.
+        expect($redis.zcard(RedisKey.payout_batch_in_flight)).to eq(1)
+        expect($redis.zscore(RedisKey.payout_batch_in_flight, "sibling-token")).to be_present
       end
 
       it "is not touched by the fan-out dispatcher itself" do
@@ -53,12 +54,12 @@ describe PerformPayoutsUpToDelayDaysAgoWorker do
 
         described_class.new.perform(PayoutProcessorType::STRIPE, ["AchAccount", "UkBankAccount"])
 
-        expect($redis.get(RedisKey.payout_batch_in_flight).to_i).to eq(0)
+        expect($redis.zcard(RedisKey.payout_batch_in_flight)).to eq(0)
       end
 
-      it "raises the flag and applies the TTL as one atomic operation" do
-        # The INCR and EXPIRE must land together — a positive counter with no TTL
-        # would hold deploys until someone deleted the key by hand.
+      it "registers the token and applies the TTL as one atomic operation" do
+        # The ZADD and EXPIRE must land together — a token in a key with no TTL would
+        # have no crash backstop if the healthcheck-side score pruning ever regressed.
         expect(Payouts).to receive(:create_payments_for_balances_up_to_date) do
           expect($redis.ttl(RedisKey.payout_batch_in_flight)).to be > 0
         end
@@ -66,11 +67,11 @@ describe PerformPayoutsUpToDelayDaysAgoWorker do
         described_class.new.perform(payout_processor_type)
       end
 
-      it "does not decrement a count it never added when raising the flag fails" do
-        # Simulate a sibling job's count already present, then a transient Redis error
-        # while this job raises the flag. The ensure must not decrement the sibling's
-        # count (that would falsely report the batch as finished).
-        $redis.incr(RedisKey.payout_batch_in_flight)
+      it "never removes a sibling's entry when registering its own token fails" do
+        # Simulate a sibling job's entry already present, then a transient Redis error
+        # while this job registers. Cleanup removes only this job's token (a no-op if
+        # it never landed), so the sibling's entry survives.
+        $redis.zadd(RedisKey.payout_batch_in_flight, Time.current.to_i, "sibling-token")
 
         allow($redis).to receive(:eval).and_call_original
         expect($redis).to receive(:eval)
@@ -81,18 +82,40 @@ describe PerformPayoutsUpToDelayDaysAgoWorker do
           described_class.new.perform(payout_processor_type)
         end.to raise_error(Redis::TimeoutError)
 
-        expect($redis.get(RedisKey.payout_batch_in_flight).to_i).to eq(1)
+        expect($redis.zcard(RedisKey.payout_batch_in_flight)).to eq(1)
+        expect($redis.zscore(RedisKey.payout_batch_in_flight, "sibling-token")).to be_present
       end
 
-      it "cleans up a stray negative counter instead of leaving it behind" do
-        # A negative value should never survive a job finishing — left in place it
-        # would silently absorb a future batch's increment back to zero.
+      it "cleans up its own entry even when Redis executed the registration but the response was lost" do
+        # The ambiguous-outcome case: the registration script runs on the server but the
+        # client sees an error. Because cleanup removes this job's own token
+        # unconditionally, the entry cannot go stale and stall deploys for hours.
+        registered_token = nil
+        allow($redis).to receive(:eval).and_wrap_original do |original, *args, **kwargs|
+          original.call(*args, **kwargs) # Redis DID execute the script...
+          registered_token = kwargs[:argv][1]
+          raise Redis::TimeoutError # ...but the response never made it back.
+        end
+        expect(Payouts).not_to receive(:create_payments_for_balances_up_to_date)
+
+        expect do
+          described_class.new.perform(payout_processor_type)
+        end.to raise_error(Redis::TimeoutError)
+
+        expect(registered_token).to be_present
+        expect($redis.zcard(RedisKey.payout_batch_in_flight)).to eq(0)
+      end
+
+      it "does not let a cleanup failure mask the batch outcome" do
+        # A dead Redis during the ensure would otherwise replace the batch's own
+        # result; the entry self-heals via its TTL, so report and move on.
         expect(Payouts).to receive(:create_payments_for_balances_up_to_date)
+        allow($redis).to receive(:zrem).and_raise(Redis::CannotConnectError)
+        expect(ErrorNotifier).to receive(:notify).with(instance_of(Redis::CannotConnectError), redis_key: RedisKey.payout_batch_in_flight)
 
-        $redis.set(RedisKey.payout_batch_in_flight, -1)
-        described_class.new.perform(payout_processor_type)
-
-        expect($redis.exists?(RedisKey.payout_batch_in_flight)).to eq(false)
+        expect do
+          described_class.new.perform(payout_processor_type)
+        end.not_to raise_error
       end
     end
 

--- a/spec/sidekiq/perform_payouts_up_to_delay_days_ago_worker_spec.rb
+++ b/spec/sidekiq/perform_payouts_up_to_delay_days_ago_worker_spec.rb
@@ -10,6 +10,53 @@ describe PerformPayoutsUpToDelayDaysAgoWorker do
       described_class.new.perform(payout_processor_type)
     end
 
+    describe "the in-flight deploy-freeze flag" do
+      before { $redis.del(RedisKey.payout_batch_in_flight) }
+      after  { $redis.del(RedisKey.payout_batch_in_flight) }
+
+      it "is set (with a TTL safety net) while the batch runs and cleared afterwards" do
+        expect(Payouts).to receive(:create_payments_for_balances_up_to_date) do
+          expect($redis.get(RedisKey.payout_batch_in_flight).to_i).to be > 0
+          expect($redis.ttl(RedisKey.payout_batch_in_flight)).to be_between(1, 3.hours.to_i)
+        end
+
+        described_class.new.perform(payout_processor_type)
+
+        expect($redis.get(RedisKey.payout_batch_in_flight).to_i).to eq(0)
+      end
+
+      it "is cleared even when the batch raises" do
+        expect(Payouts).to receive(:create_payments_for_balances_up_to_date).and_raise(ActiveRecord::StatementTimeout)
+
+        expect do
+          described_class.new.perform(payout_processor_type)
+        end.to raise_error(ActiveRecord::StatementTimeout)
+
+        expect($redis.get(RedisKey.payout_batch_in_flight).to_i).to eq(0)
+      end
+
+      it "stays up until the last concurrent per-type job finishes" do
+        expect(Payouts).to receive(:create_payments_for_balances_up_to_date_for_bank_account_types) do
+          # Simulate a sibling per-type job still running alongside this one.
+          expect($redis.get(RedisKey.payout_batch_in_flight).to_i).to be >= 2
+        end
+
+        $redis.incr(RedisKey.payout_batch_in_flight) # the sibling
+        described_class.new.perform(PayoutProcessorType::STRIPE, ["AchAccount"])
+
+        # This job's decrement leaves the sibling's count in place.
+        expect($redis.get(RedisKey.payout_batch_in_flight).to_i).to eq(1)
+      end
+
+      it "is not touched by the fan-out dispatcher itself" do
+        allow(described_class).to receive(:perform_async)
+
+        described_class.new.perform(PayoutProcessorType::STRIPE, ["AchAccount", "UkBankAccount"])
+
+        expect($redis.get(RedisKey.payout_batch_in_flight).to_i).to eq(0)
+      end
+    end
+
     context "with a single bank account type" do
       it "processes the type directly without fanning out" do
         expect(Payouts).to receive(:create_payments_for_balances_up_to_date_for_bank_account_types)

--- a/spec/sidekiq/perform_payouts_up_to_delay_days_ago_worker_spec.rb
+++ b/spec/sidekiq/perform_payouts_up_to_delay_days_ago_worker_spec.rb
@@ -55,6 +55,45 @@ describe PerformPayoutsUpToDelayDaysAgoWorker do
 
         expect($redis.get(RedisKey.payout_batch_in_flight).to_i).to eq(0)
       end
+
+      it "raises the flag and applies the TTL as one atomic operation" do
+        # The INCR and EXPIRE must land together — a positive counter with no TTL
+        # would hold deploys until someone deleted the key by hand.
+        expect(Payouts).to receive(:create_payments_for_balances_up_to_date) do
+          expect($redis.ttl(RedisKey.payout_batch_in_flight)).to be > 0
+        end
+
+        described_class.new.perform(payout_processor_type)
+      end
+
+      it "does not decrement a count it never added when raising the flag fails" do
+        # Simulate a sibling job's count already present, then a transient Redis error
+        # while this job raises the flag. The ensure must not decrement the sibling's
+        # count (that would falsely report the batch as finished).
+        $redis.incr(RedisKey.payout_batch_in_flight)
+
+        allow($redis).to receive(:eval).and_call_original
+        expect($redis).to receive(:eval)
+          .with(described_class::RAISE_IN_FLIGHT_FLAG_SCRIPT, any_args)
+          .and_raise(Redis::TimeoutError)
+
+        expect do
+          described_class.new.perform(payout_processor_type)
+        end.to raise_error(Redis::TimeoutError)
+
+        expect($redis.get(RedisKey.payout_batch_in_flight).to_i).to eq(1)
+      end
+
+      it "cleans up a stray negative counter instead of leaving it behind" do
+        # A negative value should never survive a job finishing — left in place it
+        # would silently absorb a future batch's increment back to zero.
+        expect(Payouts).to receive(:create_payments_for_balances_up_to_date)
+
+        $redis.set(RedisKey.payout_batch_in_flight, -1)
+        described_class.new.perform(payout_processor_type)
+
+        expect($redis.exists?(RedisKey.payout_batch_in_flight)).to eq(false)
+      end
     end
 
     context "with a single bank account type" do


### PR DESCRIPTION
## Summary

Item 3 of the deploy-window optimization (Sahil, 2026-07-22: "Ship 1, 2, and 3 as a separate PR"). Items 1+2 (shrink the static freeze to Tue-Fri 10:00-11:00 UTC) are #6153; this PR replaces the clock with **state**: deploys hold only while a payout batch is actually running.

- `PerformPayoutsUpToDelayDaysAgoWorker` registers a **unique per-job token** in a Redis sorted set (`payouts:batch_in_flight`, scored by start time) — atomically ZADD+EXPIRE (one Lua script) on each per-type job start, ZREM of its own token in `ensure` — because the multi-bank-type batch fans out to concurrent per-type jobs and the flag must stay up until the LAST one finishes. Per-job tokens (rather than a shared counter) make cleanup idempotent and self-scoped: it runs unconditionally, so even a Redis command that executes with a lost response can't leak a stale "in flight" entry or wipe a sibling job's. Crashed jobs age out via score-based pruning in the healthcheck (3-hour per-entry TTL, covering the worker's 2-hour query budget) plus a key-level EXPIRE backstop — a dead job can never freeze deploys forever.
- New `GET /healthcheck/payouts` (same pattern as `paypal_balance`): prunes entries older than the per-entry TTL, then 503 while any live entry remains, 200 otherwise. Verified reachable unauthenticated at `https://gumroad.com/healthcheck` (the app.gumroad.com host 301s there — script uses the canonical host).
- `deploy_production.sh` polls the healthcheck: batch in flight → wait 3 min, up to 45 min (batches complete in 10-30 min, measured from `payments.created_at` bursts July 2026), then proceeds with a loud warning instead of dropping the deploy silently. **Fail-safe**: if the healthcheck is unreachable, fall back to #6153's static Tue-Fri 10:00-11:00 window — a broken healthcheck can never let a deploy land mid-batch, and can never brick deploys outside the window either.

Net effect vs today (daily 10:00-12:00 blanket skip): deploy freeze shrinks from 14 h/week to ~80 real minutes/week, self-adjusting as payout volume grows, and mid-window deploys queue instead of silently disappearing.

## QA steps
- rspec: worker flag lifecycle (set with TTL, cleared on finish, cleared on raise, survives concurrent siblings, untouched by the fan-out dispatcher, cleaned up even when the registration response is lost, cleanup failures reported without masking the batch outcome) + healthcheck 200/503/stale-entry-pruning cases.
- `bash -n` on the deploy script; logic table: 200→deploy, 503→wait/poll, unreachable in window→skip, unreachable out of window→deploy.

## Test Results
`bundle exec rspec spec/sidekiq/perform_payouts_up_to_delay_days_ago_worker_spec.rb spec/controllers/healthcheck_controller_spec.rb` → **38 examples, 0 failures** (after the token-set redesign addressing Greptile's ambiguous-Redis-response finding). Rubocop: 4 files, no offenses.

## AI disclosure
🤖 Generated with claude-fable-5 via Hermes agent (gumclaw).
