### PR TITLE
Make logged-out marketing pages edge-cacheable (fix 9.7s cold hits on gumroad.com)

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,6 +3,37 @@
 class HomeController < ApplicationController
   layout "home"
 
+  # Static marketing pages served on the root domain. Their content doesn't
+  # depend on who is asking, so we let the CDN (Cloudflare) cache them for
+  # anonymous visitors instead of paying a full origin round trip on every
+  # first visit (cold hits on gumroad.com were measured at ~9.7s vs ~25ms of
+  # actual origin work).
+  #
+  # We only mark a response as publicly cacheable when the request carries NO
+  # cookies at all. That condition is deliberate:
+  # - A signed-in visitor always carries the session cookie
+  #   (_gumroad_app_session, see config/initializers/session_store.rb), so
+  #   they bypass the shared cache and keep seeing the "Dashboard" nav instead
+  #   of a cached "Log in" variant.
+  # - A returning anonymous visitor carries _gumroad_guid; they also bypass.
+  # - The remaining population — first-time, cookie-less visitors — is exactly
+  #   the cold-hit traffic we want served from the edge, and for them the
+  #   session is empty so there is nothing user-specific to leak.
+  #
+  # For those cacheable responses we must not emit Set-Cookie (CDNs refuse to
+  # cache, and a shared cache must never capture a visitor's cookies), so we
+  # skip the session write and the _gumroad_guid analytics cookie. Requests
+  # with UTM parameters are excluded because UTM visit tracking
+  # (UtmLinkTracking) needs the _gumroad_guid cookie to exist.
+  #
+  # Note: these headers are advisory until a Cloudflare Cache Rule makes HTML
+  # eligible for caching; without that rule behavior is unchanged in
+  # production.
+  EDGE_CACHEABLE_ACTIONS = %w[about features features_md pricing terms privacy prohibited dpa hackathon saas small_bets].freeze
+
+  prepend_before_action :prepare_edge_cacheable_response, if: :edge_cacheable_request?
+  after_action :set_edge_cache_headers, if: -> { @edge_cacheable_response }
+
   before_action :hide_layouts
 
   def about
@@ -112,5 +143,58 @@ class HomeController < ApplicationController
   private
     def hide_layouts
       @hide_layouts = true
+    end
+
+    def edge_cacheable_request?
+      request.get? && request.cookies.empty? && !user_signed_in? &&
+        EDGE_CACHEABLE_ACTIONS.include?(action_name) &&
+        params.keys.none? { |key| key.start_with?("utm_") }
+    end
+
+    # Runs before ApplicationController's callbacks (prepend_before_action) so
+    # the session is already marked as skipped by the time callbacks like
+    # set_recommender_model_name and set_signup_referrer try to write to it —
+    # otherwise those writes would emit a Set-Cookie and defeat CDN caching.
+    def prepare_edge_cacheable_response
+      @edge_cacheable_response = true
+      request.session_options[:skip] = true
+    end
+
+    # ApplicationController sets a _gumroad_guid analytics cookie for every
+    # visitor that doesn't have one. Skip it on edge-cacheable responses: a
+    # Set-Cookie header prevents CDN caching, and a shared cache must never
+    # hand one visitor's guid to another. The guid gets assigned on the
+    # visitor's first non-marketing-page request instead.
+    def set_gumroad_guid
+      return if @edge_cacheable_response
+
+      super
+    end
+
+    # inertia_rails adds an after_action that writes an XSRF-TOKEN cookie
+    # whenever forgery protection is on. These marketing pages are GET-only —
+    # the footer's follow form already posts without an authenticity token
+    # (it's static HTML) and relies on the app's null-session forgery
+    # strategy — so on edge-cacheable responses we turn forgery protection
+    # off to keep the response cookie-free. A per-visitor CSRF token baked
+    # into shared cached HTML would be useless anyway: every visitor would
+    # receive the same token.
+    def protect_against_forgery?
+      return false if @edge_cacheable_response
+
+      super
+    end
+
+    def set_edge_cache_headers
+      return unless response.status == 200
+      # Belt and braces: if anything still wrote a cookie, keep the default
+      # private cache behavior rather than letting a shared cache store it.
+      return if response.headers["Set-Cookie"].present?
+
+      # Browsers revalidate after 60s; the CDN keeps a copy for 5 minutes
+      # (s-maxage) and may serve it stale for up to an hour while it refetches
+      # in the background (stale-while-revalidate). Rails serializes this as:
+      # "max-age=60, public, stale-while-revalidate=3600, s-maxage=300".
+      expires_in 1.minute, public: true, "s-maxage": 5.minutes, stale_while_revalidate: 1.hour
     end
 end

--- a/spec/requests/home_pages_caching_spec.rb
+++ b/spec/requests/home_pages_caching_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# The static marketing pages (/, /about, /pricing, ...) opt in to CDN caching
+# for first-time anonymous visitors: when a GET request arrives with no
+# cookies at all, the response carries a public Cache-Control and writes no
+# cookies, so Cloudflare can serve it from the edge. Any request that carries
+# cookies (returning visitors, signed-in users) keeps the default private,
+# per-request behavior. See HomeController for the full rationale.
+describe "Marketing page edge caching", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  before do
+    host! ROOT_DOMAIN
+    allow(GithubStarsController).to receive(:cached_count).and_return(1234)
+  end
+
+  let(:public_cache_control) { "max-age=60, public, stale-while-revalidate=3600, s-maxage=300" }
+
+  describe "anonymous request without any cookies" do
+    it "returns a publicly cacheable response with no Set-Cookie for the homepage" do
+      get "/"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers["Cache-Control"]).to eq(public_cache_control)
+      expect(response.headers["Set-Cookie"]).to be_nil
+    end
+
+    HomeController::EDGE_CACHEABLE_ACTIONS.each do |action|
+      path = {
+        "about" => "/about",
+        "features" => "/features",
+        "features_md" => "/features.md",
+        "pricing" => "/pricing",
+        "terms" => "/terms",
+        "privacy" => "/privacy",
+        "prohibited" => "/prohibited",
+        "dpa" => "/dpa",
+        "hackathon" => "/hackathon",
+        "saas" => "/saas",
+        "small_bets" => "/small-bets",
+      }.fetch(action)
+
+      it "returns a publicly cacheable response with no Set-Cookie for #{path}" do
+        get path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.headers["Cache-Control"]).to eq(public_cache_control)
+        expect(response.headers["Set-Cookie"]).to be_nil
+      end
+    end
+
+    it "keeps the default private behavior when the request has UTM parameters" do
+      # UTM visit tracking needs the _gumroad_guid cookie, so these requests
+      # must not be served from a shared cache.
+      get "/?utm_source=twitter&utm_medium=social&utm_campaign=launch"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers["Cache-Control"]).to include("private")
+    end
+  end
+
+  describe "request carrying cookies" do
+    it "keeps the default private cache behavior for a returning anonymous visitor" do
+      # A returning anonymous visitor carries the _gumroad_guid analytics
+      # cookie, which disqualifies the request from shared caching.
+      get "/pricing", headers: { "Cookie" => "_gumroad_guid=abc123" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers["Cache-Control"]).to include("private")
+      expect(response.headers["Cache-Control"]).not_to include("public")
+    end
+
+    it "keeps the default private cache behavior when any cookie is present" do
+      get "/pricing", headers: { "Cookie" => "some_cookie=1" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers["Cache-Control"]).to include("private")
+      expect(response.headers["Cache-Control"]).not_to include("public")
+    end
+  end
+
+  describe "signed-in user" do
+    let(:user) { create(:user) }
+
+    before { sign_in user }
+
+    it "keeps the default private cache behavior" do
+      get "/about"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers["Cache-Control"]).to include("private")
+      expect(response.headers["Cache-Control"]).not_to include("public")
+    end
+  end
+
+  describe "dynamic pages" do
+    it "does not mark /discover as publicly cacheable" do
+      get "/discover"
+
+      expect(response.headers["Cache-Control"].to_s).not_to include("s-maxage")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

A cold anonymous hit on https://gumroad.com was measured at **9.7s** (second attempt: 7.2s) while warm requests are ~100–150ms and origin `x-runtime` is ~25ms. The cause: logged-out marketing pages ship `Cache-Control: max-age=0, private, must-revalidate` plus three `Set-Cookie` headers (`_gumroad_guid`, `XSRF-TOKEN`, `_gumroad_app_session`), so Cloudflare marks every response `cf-cache-status: DYNAMIC` and every anonymous first visit pays a full origin round trip — inheriting any origin/queueing tail. These pages are static marketing content.

This PR makes `HomeController`'s marketing actions (`about`, `features`, `features.md`, `pricing`, `terms`, `privacy`, `prohibited`, `dpa`, `hackathon`, `saas`, `small_bets`) edge-cacheable for exactly the population that hits the cold path:

- **Only when the request carries NO cookies at all** (and is not signed in, and has no `utm_*` params): the response gets `Cache-Control: max-age=60, public, stale-while-revalidate=3600, s-maxage=300` and writes **zero cookies** (session write skipped, `_gumroad_guid` skipped, inertia's `XSRF-TOKEN` after_action skipped via `protect_against_forgery?` override — these pages are GET-only and the footer follow form posts without an authenticity token already).
- Any request carrying any cookie (returning anonymous visitor with `_gumroad_guid`, or a signed-in user with the session cookie) keeps the existing `max-age=0, private, must-revalidate` behavior unchanged. This is what makes the shared cache safe: the `signed_in?` nav branch (Dashboard vs Log in) can never leak across users, because signed-in users always carry cookies and therefore always bypass.
- Requests with UTM params stay private because UTM visit tracking needs the `_gumroad_guid` cookie to exist.
- `/discover` and everything on the app subdomain are untouched.

**Set-Cookie findings**: yes, Rails was unconditionally writing three cookies on these pages — the session cookie (from before_action session writes like `set_recommender_model_name`/`is_mobile?`), `_gumroad_guid` (analytics guid in `ApplicationController#set_gumroad_guid`), and `XSRF-TOKEN` (an `after_action` added by inertia_rails whenever `protect_against_forgery?` is true). All three had to be suppressed for the cookie-less case; any one of them would prevent CDN caching.

**Edge prerequisite**: these headers are advisory until Cloudflare gets a Cache Rule making HTML eligible for caching (keyed on cookie absence, "Origin Cache Control: on"). `config/initializers/cloudflare.rb` only defines a cache size limit constant — there is no existing CF page-caching config in the repo, so the infra step is for @ershad-nr / @sahil. The app change is safe standalone: production behavior is byte-identical for every request that carries a cookie, and cookie-less responses merely gain cache headers no edge currently acts on.

## QA steps

1. `curl -sI https://gumroad.com/` (production, before): shows `cache-control: max-age=0, private, must-revalidate`, three `set-cookie` headers, `cf-cache-status: DYNAMIC`.
2. On this branch, cookie-less `GET /` returns `Cache-Control: max-age=60, public, stale-while-revalidate=3600, s-maxage=300` and **no** `Set-Cookie`.
3. Same request with any cookie (e.g. `Cookie: _gumroad_guid=x`) returns the old `max-age=0, private, must-revalidate` and normal cookie behavior.
4. Signed-in request returns private as before.

Backend/headers only — no UI change, so curl/header output is the reviewable artifact.

**Before (production today):**
```
cache-control: max-age=0, private, must-revalidate
set-cookie: _gumroad_guid=…; set-cookie: XSRF-TOKEN=…; set-cookie: _gumroad_app_session=…
cf-cache-status: DYNAMIC
x-runtime: 0.024669
```

**After (this branch, integration test dump):**
```
--- ANONYMOUS COOKIE-LESS GET / ---
Cache-Control: "max-age=60, public, stale-while-revalidate=3600, s-maxage=300"
Set-Cookie: nil
--- GET / WITH COOKIE ---
Cache-Control: "max-age=0, private, must-revalidate"
Set-Cookie: "XSRF-TOKEN=…; _gumroad_app_session_test=…"   (unchanged)
```

## Test Results

```
$ bundle exec rspec spec/requests/home_pages_caching_spec.rb
17 examples, 0 failures

$ bundle exec rspec spec/controllers/home_controller_spec.rb
4 examples, 0 failures

$ bundle exec rubocop app/controllers/home_controller.rb spec/requests/home_pages_caching_spec.rb
2 files inspected, no offenses detected
```

(Only RSpec coverage exists for HomeController — no Minitest duplicate to update.)

## AI disclosure

🤖 Generated with claude-fable-5, Hermes agent
