### PR TITLE
Docs: document per-folder "Start expanded" setting for download-page folders

### DIFF
--- a/app/views/help_center/articles/contents/_149-adding-a-product.html.erb
+++ b/app/views/help_center/articles/contents/_149-adding-a-product.html.erb
@@ -64,7 +64,7 @@
   <h3 id="Group-files-to-create-folders-kEinr">Group files to create folders</h3>
   <p>Creating folders is as easy as dragging your files together into a stack. You can give your folder a name, reorder the files within, or drag files out to move them out or add them to another folder.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/654464d347c2cc43ca283cd3/file-vBC1icRBJ9.gif" %></figure>
-  <p>On the download page, folders start collapsed by default, and your customers click a folder to see the files inside. To make a folder start expanded instead, click its actions menu in the content editor, choose <strong>Settings</strong>, and turn on <strong>Start expanded on the download page</strong>. If your product's content has only one top-level folder, it always starts expanded so customers can see their files right away.</p>
+  <p>On the download page, folders start collapsed by default, and your customers click a folder to see the files inside. To make a folder start expanded instead, click its actions menu in the content editor, choose <strong>Settings</strong>, and turn on <strong>Start expanded on the download page</strong>. If a page has only one top-level folder, that folder always starts expanded so customers can see their files right away.</p>
   <h3 id="Track-clicks-on-your-URLs-B4Mtb">Track clicks on your URLs</h3>
   <div data-html-block>
     <p>If you control any URL(s) mentioned in your content, you can track/listen to clicks on them with the <code>__sale_info__</code> query parameter.</p>

--- a/app/views/help_center/articles/contents/_149-adding-a-product.html.erb
+++ b/app/views/help_center/articles/contents/_149-adding-a-product.html.erb
@@ -64,6 +64,7 @@
   <h3 id="Group-files-to-create-folders-kEinr">Group files to create folders</h3>
   <p>Creating folders is as easy as dragging your files together into a stack. You can give your folder a name, reorder the files within, or drag files out to move them out or add them to another folder.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/654464d347c2cc43ca283cd3/file-vBC1icRBJ9.gif" %></figure>
+  <p>On the download page, folders start collapsed by default, and your customers click a folder to see the files inside. To make a folder start expanded instead, click its actions menu in the content editor, choose <strong>Settings</strong>, and turn on <strong>Start expanded on the download page</strong>. If your product's content has only one top-level folder, it always starts expanded so customers can see their files right away.</p>
   <h3 id="Track-clicks-on-your-URLs-B4Mtb">Track clicks on your URLs</h3>
   <div data-html-block>
     <p>If you control any URL(s) mentioned in your content, you can track/listen to clicks on them with the <code>__sale_info__</code> query parameter.</p>


### PR DESCRIPTION
## What

Updates the help-center article **Adding a product** (`_149-adding-a-product.html.erb`) to document the download-page folder expansion behavior shipped in #6164: folders start collapsed by default, sellers can enable a per-folder **Start expanded on the download page** switch (folder actions menu → **Settings** in the content editor), and pages with a single top-level folder always start expanded.

## Why

#6164 (merged) added seller-visible behavior with no help-center coverage. The "Group files to create folders" section was the natural home — it describes creating folders but said nothing about how they appear on the download page. The switch label and menu path are quoted verbatim from `ProductEdit/ContentTab/FileEmbedGroup.tsx` (`label="Start expanded on the download page"`, `<span>Settings</span>`); the single-folder auto-expand claim matches `Download/RichContent.tsx` / `FileList.tsx` (exactly one top-level folder → expanded regardless of the setting).

Body-only edit; `articles.yml` untouched (no title/description change needed). Existing anchor IDs preserved.

## QA steps

1. Open help.gumroad.com/help/article/149-adding-a-product
2. Scroll to "Group files to create folders"
3. Verify the new paragraph after the folder GIF describing collapsed-by-default, the per-folder Settings switch, and single-folder auto-expand

## Test results

- ERB syntax check: OK
- Tag-balance check on the edited partial: all tags balanced
- Partial renders in the real view context (`ApplicationController.render`) with the new copy present: `render OK (9710 bytes)`
- `bundle exec rspec spec/models/help_center`: 1 example, 0 failures

Autoreview skipped (docs copy only, no logic). Docs-only — the diff is the reviewable artifact (single additive paragraph, no media).

---

## AI disclosure

Authored by Claude Fable 5 (Hermes agent), triggered automatically by the merge of #6164 via the merged-PR → help-center doc-sync pipeline.
