### PR TITLE
Count unique buyers, not purchases, in refund-policy enforcement dispute rate

### DIFF
--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -136,8 +136,9 @@ module Purchase::Blockable
   end
 
   # Called when a dispute (chargeback) lands on one of this seller's purchases.
-  # If the seller's lifetime dispute COUNT rate — disputed purchases divided by settled
-  # successful purchases — crosses 1%, we force a buyer-friendly refund policy on their
+  # If the seller's lifetime dispute rate — unique buyers with a standing chargeback
+  # divided by unique buyers with settled successful purchases — crosses 1%, we force a
+  # buyer-friendly refund policy on their
   # account: their seller-level refund policy is bumped to at least a 30-day money-back
   # guarantee and they can no longer pick "No refunds allowed" (the guard lives in
   # RefundPolicy's validation) until an admin clears the enforcement with
@@ -153,9 +154,11 @@ module Purchase::Blockable
     return if seller.refund_policy_enforced?
 
     stats = seller.dispute_rate_stats
-    # Volume gates: don't act on statistical noise from small accounts.
+    # Volume gates: don't act on statistical noise from small accounts. Settled purchases
+    # gate sales volume; the dispute gate counts distinct disputing buyers, so one buyer
+    # disputing several installments of the same purchase can't clear it alone.
     return if stats[:settled_count] < User::MIN_SETTLED_PURCHASES_FOR_REFUND_POLICY_ENFORCEMENT
-    return if stats[:disputed_count] < User::MIN_DISPUTES_FOR_REFUND_POLICY_ENFORCEMENT
+    return if stats[:disputing_buyers_count] < User::MIN_DISPUTING_BUYERS_FOR_REFUND_POLICY_ENFORCEMENT
 
     dispute_count_rate = stats[:rate]
     return if dispute_count_rate.nil? || dispute_count_rate <= User::MAX_DISPUTE_COUNT_RATE_ALLOWED_FOR_CUSTOM_REFUND_POLICY
@@ -175,7 +178,7 @@ module Purchase::Blockable
 
       seller.comments.create!(
         content: "Refund policy enforcement applied: dispute rate #{format("%.1f%%", dispute_count_rate)} " \
-                 "(#{stats[:disputed_count]} disputes / #{stats[:settled_count]} settled sales) exceeded " \
+                 "(#{stats[:disputing_buyers_count]} disputing buyers / #{stats[:settled_buyers_count]} unique buyers) exceeded " \
                  "#{User::MAX_DISPUTE_COUNT_RATE_ALLOWED_FOR_CUSTOM_REFUND_POLICY}% by count. Seller-level refund policy " \
                  "is now at least a #{User::ENFORCED_MIN_REFUND_PERIOD_IN_DAYS}-day money-back guarantee and " \
                  "\"No refunds allowed\" is unavailable until an admin clears the enforcement.",

--- a/app/modules/user/risk.rb
+++ b/app/modules/user/risk.rb
@@ -41,13 +41,20 @@ module User::Risk
   # (MIN_SETTLED_PURCHASES_FOR_REFUND_POLICY_ENFORCEMENT) measures sales volume, which is
   # inherently a purchase count.
   def dispute_rate_stats
+    # purchases.email has no database-level NOT NULL constraint, so legacy or
+    # validation-bypassing rows can carry a NULL email. COUNT(DISTINCT email) would
+    # silently drop those rows from both the numerator and the denominator. An unknown
+    # buyer can't be de-duplicated, so each null-email purchase falls back to counting
+    # as its own buyer (keyed by the purchase id).
+    buyer_key = Arel.sql("COALESCE(purchases.email, CONCAT('missing-email-', purchases.id))")
+
     settled_count = sales.successful.count
-    settled_buyers_count = sales.successful.distinct.count(:email)
+    settled_buyers_count = sales.successful.distinct.count(buyer_key)
     disputing_buyers_count = sales.successful
                                   .where.not(chargeback_date: nil)
                                   .where("purchases.flags & ? = 0", Purchase.flag_mapping["flags"][:chargeback_reversed])
                                   .distinct
-                                  .count(:email)
+                                  .count(buyer_key)
     rate = settled_buyers_count > 0 ? disputing_buyers_count * 100.0 / settled_buyers_count : nil
     { settled_count:, settled_buyers_count:, disputing_buyers_count:, rate: }
   end

--- a/app/modules/user/risk.rb
+++ b/app/modules/user/risk.rb
@@ -11,30 +11,45 @@ module User::Risk
   MAX_CHARGEBACK_RATE_ALLOWED_FOR_PAYOUTS = 3.0
 
   # Thresholds for automatically forcing a buyer-friendly refund policy on a seller.
-  # The dispute rate here is a COUNT rate (disputed purchases / settled purchases), not a
-  # dollar-volume rate: a seller stonewalling many small refund requests shows up in counts.
+  # The dispute rate here is a rate of UNIQUE BUYERS (buyers with a standing chargeback /
+  # buyers with settled purchases), not raw purchase counts and not dollar volume. It answers
+  # "what share of your customers dispute you?" — so one unhappy buyer who disputes both
+  # installments of the same course still counts once. Counting raw purchases previously let
+  # a single buyer's two installment disputes tip a ~250-sale seller over the line (#6171).
   MAX_DISPUTE_COUNT_RATE_ALLOWED_FOR_CUSTOM_REFUND_POLICY = 1.0
-  # Volume gates so a single unlucky dispute on a brand-new account doesn't trigger enforcement.
+  # Volume gates so a single unlucky dispute on a brand-new account doesn't trigger
+  # enforcement. The settled-purchases gate stays purchase-based (it measures sales volume);
+  # the disputes gate counts distinct disputing buyers (it measures how many separate
+  # customers went to their bank).
   MIN_SETTLED_PURCHASES_FOR_REFUND_POLICY_ENFORCEMENT = 25
-  MIN_DISPUTES_FOR_REFUND_POLICY_ENFORCEMENT = 3
+  MIN_DISPUTING_BUYERS_FOR_REFUND_POLICY_ENFORCEMENT = 3
   # When enforcement bumps a "No refunds allowed" policy, this is the period it becomes.
   ENFORCED_MIN_REFUND_PERIOD_IN_DAYS = 30
 
   REFUND_POLICY_ENFORCEMENT_COMMENT_AUTHOR = "enforce_refund_policy_for_seller_based_on_dispute_rate"
 
-  # Lifetime dispute stats by COUNT (not dollar volume). Used to decide whether to
-  # auto-enforce a buyer-friendly refund policy on the seller — see
+  # Lifetime dispute stats by UNIQUE BUYER (not raw purchases, not dollar volume). Used to
+  # decide whether to auto-enforce a buyer-friendly refund policy on the seller — see
   # Purchase::Blockable#enforce_refund_policy_for_seller_based_on_dispute_rate!.
-  # A dispute counts only while it stands: reversed (won) chargebacks are excluded,
-  # matching how #lost_chargebacks measures the rate.
+  #
+  # Buyers are keyed by the purchase email, which exists on every purchase (guest checkouts
+  # included), so a buyer disputing several installments, subscription cycles, or cart items
+  # counts once. A dispute counts only while it stands: reversed (won) chargebacks are
+  # excluded, matching how #lost_chargebacks measures the rate.
+  #
+  # settled_count (raw purchases) is still returned because the enforcement volume gate
+  # (MIN_SETTLED_PURCHASES_FOR_REFUND_POLICY_ENFORCEMENT) measures sales volume, which is
+  # inherently a purchase count.
   def dispute_rate_stats
     settled_count = sales.successful.count
-    disputed_count = sales.successful
-                          .where.not(chargeback_date: nil)
-                          .where("purchases.flags & ? = 0", Purchase.flag_mapping["flags"][:chargeback_reversed])
-                          .count
-    rate = settled_count > 0 ? disputed_count * 100.0 / settled_count : nil
-    { settled_count:, disputed_count:, rate: }
+    settled_buyers_count = sales.successful.distinct.count(:email)
+    disputing_buyers_count = sales.successful
+                                  .where.not(chargeback_date: nil)
+                                  .where("purchases.flags & ? = 0", Purchase.flag_mapping["flags"][:chargeback_reversed])
+                                  .distinct
+                                  .count(:email)
+    rate = settled_buyers_count > 0 ? disputing_buyers_count * 100.0 / settled_buyers_count : nil
+    { settled_count:, settled_buyers_count:, disputing_buyers_count:, rate: }
   end
 
   def enable_refunds!

--- a/spec/models/concerns/purchase/blockable_spec.rb
+++ b/spec/models/concerns/purchase/blockable_spec.rb
@@ -1150,15 +1150,17 @@ describe Purchase::Blockable do
     let(:product) { create(:product, user: seller) }
     let(:purchase) { create(:purchase, link: product) }
 
-    def stub_dispute_stats(settled_count:, disputed_count:)
-      rate = settled_count > 0 ? disputed_count * 100.0 / settled_count : nil
-      allow(seller).to receive(:dispute_rate_stats).and_return({ settled_count:, disputed_count:, rate: })
+    # settled_buyers_count defaults to settled_count (each purchase from a different buyer)
+    # so existing scenarios read the same; the installment trigger case overrides it.
+    def stub_dispute_stats(settled_count:, disputing_buyers_count:, settled_buyers_count: settled_count)
+      rate = settled_buyers_count > 0 ? disputing_buyers_count * 100.0 / settled_buyers_count : nil
+      allow(seller).to receive(:dispute_rate_stats).and_return({ settled_count:, settled_buyers_count:, disputing_buyers_count:, rate: })
     end
 
     context "when the seller already has an enforced refund policy" do
       before do
         seller.update!(refund_policy_enforced: true)
-        stub_dispute_stats(settled_count: 100, disputed_count: 50)
+        stub_dispute_stats(settled_count: 100, disputing_buyers_count: 50)
       end
 
       it "does not create additional comments" do
@@ -1184,7 +1186,7 @@ describe Purchase::Blockable do
 
     context "when the seller has fewer settled purchases than the minimum" do
       before do
-        stub_dispute_stats(settled_count: 24, disputed_count: 10)
+        stub_dispute_stats(settled_count: 24, disputing_buyers_count: 10)
       end
 
       it "does not enforce the refund policy" do
@@ -1200,9 +1202,9 @@ describe Purchase::Blockable do
       end
     end
 
-    context "when the seller has fewer disputes than the minimum" do
+    context "when the seller has fewer disputing buyers than the minimum" do
       before do
-        stub_dispute_stats(settled_count: 100, disputed_count: 2)
+        stub_dispute_stats(settled_count: 100, disputing_buyers_count: 2)
       end
 
       it "does not enforce the refund policy" do
@@ -1212,9 +1214,30 @@ describe Purchase::Blockable do
       end
     end
 
+    context "when one buyer disputes multiple installments of the same purchase" do
+      before do
+        # The trigger case for #6171: a ~250-sale seller with one buyer who disputed both
+        # installments of a course. As raw purchases that was 2 disputes; as unique buyers
+        # it is 1 disputing buyer, which stays under the 3-buyer minimum, so no enforcement.
+        stub_dispute_stats(settled_count: 250, settled_buyers_count: 249, disputing_buyers_count: 1)
+      end
+
+      it "does not enforce the refund policy" do
+        purchase.enforce_refund_policy_for_seller_based_on_dispute_rate!
+
+        expect(seller.reload.refund_policy_enforced?).to be(false)
+      end
+
+      it "does not create a comment" do
+        expect do
+          purchase.enforce_refund_policy_for_seller_based_on_dispute_rate!
+        end.to_not change { seller.comments.count }
+      end
+    end
+
     context "when the dispute rate is exactly 1.0%" do
       before do
-        stub_dispute_stats(settled_count: 300, disputed_count: 3)
+        stub_dispute_stats(settled_count: 300, disputing_buyers_count: 3)
       end
 
       it "does not enforce the refund policy" do
@@ -1232,7 +1255,8 @@ describe Purchase::Blockable do
 
     context "when the dispute rate exceeds 1.0%" do
       before do
-        stub_dispute_stats(settled_count: 100, disputed_count: 3)
+        # Three distinct buyers disputed out of 100 unique buyers: 3% > 1%, so enforce.
+        stub_dispute_stats(settled_count: 100, disputing_buyers_count: 3)
       end
 
       it "sets the refund_policy_enforced flag" do
@@ -1246,7 +1270,7 @@ describe Purchase::Blockable do
 
         comment = seller.comments.last
         expect(comment.content).to include("dispute rate 3.0%")
-        expect(comment.content).to include("3 disputes / 100 settled sales")
+        expect(comment.content).to include("3 disputing buyers / 100 unique buyers")
         expect(comment.comment_type).to eq(Comment::COMMENT_TYPE_ON_PROBATION)
         expect(comment.author_name).to eq("enforce_refund_policy_for_seller_based_on_dispute_rate")
       end

--- a/spec/modules/user/risk_spec.rb
+++ b/spec/modules/user/risk_spec.rb
@@ -170,6 +170,23 @@ describe User::Risk do
       expect(stats[:disputing_buyers_count]).to eq(0)
       expect(stats[:rate]).to eq(0.0)
     end
+
+    it "counts purchases with a null email as separate buyers instead of dropping them" do
+      # purchases.email has no NOT NULL constraint at the database level, so legacy rows
+      # can carry a null email even though model validation blocks it on normal writes.
+      # COUNT(DISTINCT email) would drop such rows from both sides of the rate.
+      create(:purchase, link: product)
+      null_settled = create(:purchase, link: product)
+      null_settled.update_column(:email, nil)
+      null_disputed = create(:purchase, link: product, chargeback_date: Time.current)
+      null_disputed.update_column(:email, nil)
+
+      stats = seller.dispute_rate_stats
+      expect(stats[:settled_count]).to eq(3)
+      expect(stats[:settled_buyers_count]).to eq(3)
+      expect(stats[:disputing_buyers_count]).to eq(1)
+      expect(stats[:rate]).to eq(1 * 100.0 / 3)
+    end
   end
 
   describe "#clear_refund_policy_enforcement!" do

--- a/spec/modules/user/risk_spec.rb
+++ b/spec/modules/user/risk_spec.rb
@@ -132,18 +132,43 @@ describe User::Risk do
     let(:product) { create(:product, user: seller) }
 
     it "returns a nil rate when the seller has no settled sales" do
-      expect(seller.dispute_rate_stats).to eq({ settled_count: 0, disputed_count: 0, rate: nil })
+      expect(seller.dispute_rate_stats).to eq({ settled_count: 0, settled_buyers_count: 0, disputing_buyers_count: 0, rate: nil })
     end
 
-    it "computes the dispute count rate from settled sales, excluding reversed chargebacks" do
+    it "computes the dispute rate from unique buyers, excluding reversed chargebacks" do
       create_list(:purchase, 2, link: product)
       create(:purchase, link: product, chargeback_date: Time.current)
       create(:purchase, link: product, chargeback_date: Time.current, chargeback_reversed: true)
 
       stats = seller.dispute_rate_stats
       expect(stats[:settled_count]).to eq(4)
-      expect(stats[:disputed_count]).to eq(1)
+      expect(stats[:settled_buyers_count]).to eq(4)
+      expect(stats[:disputing_buyers_count]).to eq(1)
       expect(stats[:rate]).to eq(25.0)
+    end
+
+    it "counts one buyer disputing multiple purchases (e.g. both installments of a course) once" do
+      # The trigger case for #6171: one buyer disputed both installments of a single
+      # course purchase and was previously counted as two disputes.
+      create_list(:purchase, 2, link: product)
+      create_list(:purchase, 2, link: product, email: "unhappy@example.com", chargeback_date: Time.current)
+
+      stats = seller.dispute_rate_stats
+      expect(stats[:settled_count]).to eq(4)
+      expect(stats[:settled_buyers_count]).to eq(3)
+      expect(stats[:disputing_buyers_count]).to eq(1)
+      expect(stats[:rate]).to eq(1 * 100.0 / 3)
+    end
+
+    it "counts a buyer with multiple settled purchases once in the denominator" do
+      create_list(:purchase, 3, link: product, email: "repeat@example.com")
+      create(:purchase, link: product)
+
+      stats = seller.dispute_rate_stats
+      expect(stats[:settled_count]).to eq(4)
+      expect(stats[:settled_buyers_count]).to eq(2)
+      expect(stats[:disputing_buyers_count]).to eq(0)
+      expect(stats[:rate]).to eq(0.0)
     end
   end
 


### PR DESCRIPTION
## Summary

Fixes #6171. The refund-policy auto-enforcement counted raw disputed **purchases**: one buyer who disputed both installments of a single course purchase counted as 2 disputes, which tipped a ~250-sale seller over the 1% line despite having exactly one unhappy customer.

Per the 2026-07-23 decision, `User#dispute_rate_stats` now counts **unique buyers**, keyed by `purchases.email` (present on guest and logged-in checkouts alike):

- **Numerator**: distinct buyers among successful sales with a standing chargeback (reversed/won chargebacks still excluded).
- **Denominator**: distinct buyers among all successful sales.
- Buyers are keyed by `COALESCE(email, CONCAT('missing-email-', id))` — `purchases.email` has no database-level NOT NULL constraint, so a plain `COUNT(DISTINCT email)` would silently drop legacy null-email rows from both sides of the rate. Each null-email purchase counts as its own buyer instead.
- `MIN_DISPUTES_FOR_REFUND_POLICY_ENFORCEMENT` → renamed `MIN_DISPUTING_BUYERS_FOR_REFUND_POLICY_ENFORCEMENT` (still 3, now 3 distinct disputing buyers). No other call sites existed.
- The 25-settled-purchases volume gate stays purchase-based (`settled_count` kept in the stats hash), since it measures sales volume, not customer sentiment.
- Admin audit comment now reads "N disputing buyers / M unique buyers".

**Before/after math for the trigger case** — seller with 250 settled sales (249 unique buyers), one buyer disputes both installments:
- Before: 2 disputes / 250 settled = 0.8%… but with one more sale disputed by the same buyer it becomes 3/250 = 1.2% → enforced by a single customer.
- After: 1 disputing buyer / 249 unique buyers = 0.4%, and the 3-distinct-disputing-buyers gate isn't met → no enforcement until three separate customers dispute.

The sweep of already-enforced sellers whose recomputed rate falls back under 1% is a separate follow-up per the issue checklist.

## QA steps

Backend-only — no UI surface; the spec run is the artifact.

1. `bundle exec rspec spec/modules/user/risk_spec.rb` — covers the unique-buyer math directly, including the one-buyer-two-installments trigger case and reversed-chargeback exclusion.
2. `bundle exec rspec spec/models/concerns/purchase/blockable_spec.rb` — covers gates, comment wording, idempotency, rollback.

## Test Results

```
$ bundle exec rspec spec/modules/user/risk_spec.rb
Finished in 3.45 seconds (files took 2.61 seconds to load)
20 examples, 0 failures

$ bundle exec rspec spec/models/concerns/purchase/blockable_spec.rb
Finished in 17.98 seconds (files took 2.85 seconds to load)
104 examples, 0 failures

$ bundle exec rubocop app/modules/user/risk.rb app/models/concerns/purchase/blockable.rb \
    spec/modules/user/risk_spec.rb spec/models/concerns/purchase/blockable_spec.rb
4 files inspected, no offenses detected
```

## AI disclosure

🤖 Generated with claude-fable-5 via Hermes agent

