### PR TITLE
Allow trusted-fork checkout in pull_request_target CI (companion to #6176)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,26 +26,39 @@ jobs:
     # The repo is still PUBLIC, though, so anyone can fork it and open a PR —
     # "no external contributions" is policy, not something GitHub enforces for us.
     # This step enforces it: fork-headed pull_request_target runs proceed only when
-    # the PR author is a trusted internal account. Every test job below depends on
-    # this job, so an untrusted fork PR fails here before any fork code is checked
-    # out or any secrets are exposed. Extend the allowlist if another internal
-    # account ever needs to open fork-headed PRs.
+    # BOTH the PR author AND the owner of the fork the code comes from are trusted
+    # internal accounts. Checking the author alone is not enough: GitHub lets anyone
+    # open a PR from a branch in someone else's fork ("compare across forks"), so a
+    # trusted author could — deliberately or via a compromised account — open a PR
+    # whose executed commits live in an untrusted fork. The head-repo owner check
+    # ties trust to who actually controls the code being run. Every test job below
+    # depends on this job, so an untrusted fork PR fails here before any fork code
+    # is checked out or any secrets are exposed. Extend the allowlist if another
+    # internal account ever needs to open fork-headed PRs.
     steps:
-      - name: Verify fork PR author is trusted
+      - name: Verify fork PR author and head-repo owner are trusted
         if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository }}
         env:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          HEAD_REPO_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
         run: |
-          case "$PR_AUTHOR" in
-            gumclaw|slavingia)
-              echo "Fork PR author '$PR_AUTHOR' is a trusted internal account — proceeding."
-              ;;
-            *)
-              echo "Fork PR author '$PR_AUTHOR' is not on the trusted allowlist."
-              echo "This repository does not accept external contributions, so CI does not run fork code from other accounts."
-              exit 1
-              ;;
-          esac
+          is_trusted() {
+            case "$1" in
+              gumclaw|slavingia) return 0 ;;
+              *) return 1 ;;
+            esac
+          }
+          if ! is_trusted "$PR_AUTHOR"; then
+            echo "Fork PR author '$PR_AUTHOR' is not on the trusted allowlist."
+            echo "This repository does not accept external contributions, so CI does not run fork code from other accounts."
+            exit 1
+          fi
+          if ! is_trusted "$HEAD_REPO_OWNER"; then
+            echo "PR head repository is owned by '$HEAD_REPO_OWNER', which is not on the trusted allowlist."
+            echo "The PR author is trusted, but the executed code comes from the head repository — trust must cover its owner too."
+            exit 1
+          fi
+          echo "Fork PR author '$PR_AUTHOR' and head-repo owner '$HEAD_REPO_OWNER' are trusted internal accounts — proceeding."
       - run: true
 
   lint_js:
@@ -58,9 +71,10 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           # Fork heads are safe to check out here because the ci_gate job (which this
-          # job depends on) fails the run unless the fork PR's author is a trusted
-          # internal account. The repo is public but takes no external contributions
-          # (Sahil, 2026-07-23), and ci_gate is what enforces that for CI.
+          # job depends on) fails the run unless both the fork PR's author and the
+          # owner of the fork holding the code are trusted internal accounts. The
+          # repo is public but takes no external contributions (Sahil, 2026-07-23),
+          # and ci_gate is what enforces that for CI.
           allow-unsafe-pr-checkout: true
           persist-credentials: false
       - uses: actions/setup-node@v4
@@ -84,9 +98,10 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           # Fork heads are safe to check out here because the ci_gate job (which this
-          # job depends on) fails the run unless the fork PR's author is a trusted
-          # internal account. The repo is public but takes no external contributions
-          # (Sahil, 2026-07-23), and ci_gate is what enforces that for CI.
+          # job depends on) fails the run unless both the fork PR's author and the
+          # owner of the fork holding the code are trusted internal accounts. The
+          # repo is public but takes no external contributions (Sahil, 2026-07-23),
+          # and ci_gate is what enforces that for CI.
           allow-unsafe-pr-checkout: true
           persist-credentials: false
       - uses: ruby/setup-ruby@v1
@@ -110,9 +125,10 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           # Fork heads are safe to check out here because the ci_gate job (which this
-          # job depends on) fails the run unless the fork PR's author is a trusted
-          # internal account. The repo is public but takes no external contributions
-          # (Sahil, 2026-07-23), and ci_gate is what enforces that for CI.
+          # job depends on) fails the run unless both the fork PR's author and the
+          # owner of the fork holding the code are trusted internal accounts. The
+          # repo is public but takes no external contributions (Sahil, 2026-07-23),
+          # and ci_gate is what enforces that for CI.
           allow-unsafe-pr-checkout: true
           persist-credentials: false
       - name: Login to Docker Hub
@@ -390,9 +406,10 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           # Fork heads are safe to check out here because the ci_gate job (which this
-          # job depends on) fails the run unless the fork PR's author is a trusted
-          # internal account. The repo is public but takes no external contributions
-          # (Sahil, 2026-07-23), and ci_gate is what enforces that for CI.
+          # job depends on) fails the run unless both the fork PR's author and the
+          # owner of the fork holding the code are trusted internal accounts. The
+          # repo is public but takes no external contributions (Sahil, 2026-07-23),
+          # and ci_gate is what enforces that for CI.
           allow-unsafe-pr-checkout: true
           persist-credentials: false
 
@@ -428,9 +445,10 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           # Fork heads are safe to check out here because the ci_gate job (which this
-          # job depends on) fails the run unless the fork PR's author is a trusted
-          # internal account. The repo is public but takes no external contributions
-          # (Sahil, 2026-07-23), and ci_gate is what enforces that for CI.
+          # job depends on) fails the run unless both the fork PR's author and the
+          # owner of the fork holding the code are trusted internal accounts. The
+          # repo is public but takes no external contributions (Sahil, 2026-07-23),
+          # and ci_gate is what enforces that for CI.
           allow-unsafe-pr-checkout: true
           persist-credentials: false
       - name: Login to Docker Hub
@@ -616,9 +634,10 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           # Fork heads are safe to check out here because the ci_gate job (which this
-          # job depends on) fails the run unless the fork PR's author is a trusted
-          # internal account. The repo is public but takes no external contributions
-          # (Sahil, 2026-07-23), and ci_gate is what enforces that for CI.
+          # job depends on) fails the run unless both the fork PR's author and the
+          # owner of the fork holding the code are trusted internal accounts. The
+          # repo is public but takes no external contributions (Sahil, 2026-07-23),
+          # and ci_gate is what enforces that for CI.
           allow-unsafe-pr-checkout: true
           persist-credentials: false
       - name: Login to Docker Hub

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,9 +21,31 @@ jobs:
     runs-on: ubicloud-standard-2
     # The 'ci-protected' environment approval gate used to sit here for fork-headed
     # pull requests. Removed 2026-07-23 (Sahil): the repo takes no external
-    # contributions, so every fork PR is from a trusted internal account (e.g.
-    # gumclaw's fork) and the manual approve-this-run step only stalled CI.
+    # contributions, so the manual approve-this-run step only stalled CI.
+    #
+    # The repo is still PUBLIC, though, so anyone can fork it and open a PR —
+    # "no external contributions" is policy, not something GitHub enforces for us.
+    # This step enforces it: fork-headed pull_request_target runs proceed only when
+    # the PR author is a trusted internal account. Every test job below depends on
+    # this job, so an untrusted fork PR fails here before any fork code is checked
+    # out or any secrets are exposed. Extend the allowlist if another internal
+    # account ever needs to open fork-headed PRs.
     steps:
+      - name: Verify fork PR author is trusted
+        if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository }}
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          case "$PR_AUTHOR" in
+            gumclaw|slavingia)
+              echo "Fork PR author '$PR_AUTHOR' is a trusted internal account — proceeding."
+              ;;
+            *)
+              echo "Fork PR author '$PR_AUTHOR' is not on the trusted allowlist."
+              echo "This repository does not accept external contributions, so CI does not run fork code from other accounts."
+              exit 1
+              ;;
+          esac
       - run: true
 
   lint_js:
@@ -35,8 +57,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
-          # Fork heads are trusted here: the repo takes no external contributions (Sahil,
-          # 2026-07-23), so fork-headed PRs only come from internal accounts (gumclaw's fork).
+          # Fork heads are safe to check out here because the ci_gate job (which this
+          # job depends on) fails the run unless the fork PR's author is a trusted
+          # internal account. The repo is public but takes no external contributions
+          # (Sahil, 2026-07-23), and ci_gate is what enforces that for CI.
           allow-unsafe-pr-checkout: true
           persist-credentials: false
       - uses: actions/setup-node@v4
@@ -59,8 +83,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
-          # Fork heads are trusted here: the repo takes no external contributions (Sahil,
-          # 2026-07-23), so fork-headed PRs only come from internal accounts (gumclaw's fork).
+          # Fork heads are safe to check out here because the ci_gate job (which this
+          # job depends on) fails the run unless the fork PR's author is a trusted
+          # internal account. The repo is public but takes no external contributions
+          # (Sahil, 2026-07-23), and ci_gate is what enforces that for CI.
           allow-unsafe-pr-checkout: true
           persist-credentials: false
       - uses: ruby/setup-ruby@v1
@@ -83,8 +109,10 @@ jobs:
         timeout-minutes: 5
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
-          # Fork heads are trusted here: the repo takes no external contributions (Sahil,
-          # 2026-07-23), so fork-headed PRs only come from internal accounts (gumclaw's fork).
+          # Fork heads are safe to check out here because the ci_gate job (which this
+          # job depends on) fails the run unless the fork PR's author is a trusted
+          # internal account. The repo is public but takes no external contributions
+          # (Sahil, 2026-07-23), and ci_gate is what enforces that for CI.
           allow-unsafe-pr-checkout: true
           persist-credentials: false
       - name: Login to Docker Hub
@@ -361,8 +389,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
-          # Fork heads are trusted here: the repo takes no external contributions (Sahil,
-          # 2026-07-23), so fork-headed PRs only come from internal accounts (gumclaw's fork).
+          # Fork heads are safe to check out here because the ci_gate job (which this
+          # job depends on) fails the run unless the fork PR's author is a trusted
+          # internal account. The repo is public but takes no external contributions
+          # (Sahil, 2026-07-23), and ci_gate is what enforces that for CI.
           allow-unsafe-pr-checkout: true
           persist-credentials: false
 
@@ -397,8 +427,10 @@ jobs:
         timeout-minutes: 5
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
-          # Fork heads are trusted here: the repo takes no external contributions (Sahil,
-          # 2026-07-23), so fork-headed PRs only come from internal accounts (gumclaw's fork).
+          # Fork heads are safe to check out here because the ci_gate job (which this
+          # job depends on) fails the run unless the fork PR's author is a trusted
+          # internal account. The repo is public but takes no external contributions
+          # (Sahil, 2026-07-23), and ci_gate is what enforces that for CI.
           allow-unsafe-pr-checkout: true
           persist-credentials: false
       - name: Login to Docker Hub
@@ -583,8 +615,10 @@ jobs:
         timeout-minutes: 5
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
-          # Fork heads are trusted here: the repo takes no external contributions (Sahil,
-          # 2026-07-23), so fork-headed PRs only come from internal accounts (gumclaw's fork).
+          # Fork heads are safe to check out here because the ci_gate job (which this
+          # job depends on) fails the run unless the fork PR's author is a trusted
+          # internal account. The repo is public but takes no external contributions
+          # (Sahil, 2026-07-23), and ci_gate is what enforces that for CI.
           allow-unsafe-pr-checkout: true
           persist-credentials: false
       - name: Login to Docker Hub

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          # Fork heads are trusted here: the repo takes no external contributions (Sahil,
+          # 2026-07-23), so fork-headed PRs only come from internal accounts (gumclaw's fork).
+          allow-unsafe-pr-checkout: true
           persist-credentials: false
       - uses: actions/setup-node@v4
         with:
@@ -56,6 +59,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          # Fork heads are trusted here: the repo takes no external contributions (Sahil,
+          # 2026-07-23), so fork-headed PRs only come from internal accounts (gumclaw's fork).
+          allow-unsafe-pr-checkout: true
           persist-credentials: false
       - uses: ruby/setup-ruby@v1
         with:
@@ -77,6 +83,9 @@ jobs:
         timeout-minutes: 5
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          # Fork heads are trusted here: the repo takes no external contributions (Sahil,
+          # 2026-07-23), so fork-headed PRs only come from internal accounts (gumclaw's fork).
+          allow-unsafe-pr-checkout: true
           persist-credentials: false
       - name: Login to Docker Hub
         uses: nick-fields/retry@v3
@@ -352,6 +361,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          # Fork heads are trusted here: the repo takes no external contributions (Sahil,
+          # 2026-07-23), so fork-headed PRs only come from internal accounts (gumclaw's fork).
+          allow-unsafe-pr-checkout: true
           persist-credentials: false
 
       - name: Set up Ruby
@@ -385,6 +397,9 @@ jobs:
         timeout-minutes: 5
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          # Fork heads are trusted here: the repo takes no external contributions (Sahil,
+          # 2026-07-23), so fork-headed PRs only come from internal accounts (gumclaw's fork).
+          allow-unsafe-pr-checkout: true
           persist-credentials: false
       - name: Login to Docker Hub
         uses: nick-fields/retry@v3
@@ -568,6 +583,9 @@ jobs:
         timeout-minutes: 5
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          # Fork heads are trusted here: the repo takes no external contributions (Sahil,
+          # 2026-07-23), so fork-headed PRs only come from internal accounts (gumclaw's fork).
+          allow-unsafe-pr-checkout: true
           persist-credentials: false
       - name: Login to Docker Hub
         uses: nick-fields/retry@v3


### PR DESCRIPTION
## Summary

Follow-up to #6176 (removing the ci-protected approval gate). The first ungated fork-headed run (#6147, run 29989783992) started immediately — but `actions/checkout` has its own second defense: it refuses to check out fork code in a `pull_request_target` workflow unless `allow-unsafe-pr-checkout: true` is set.

This PR sets that flag on all 6 conditional checkouts in tests.yml — **and adds the enforcement that makes it safe**: the repo is still publicly forkable, so "no external contributions" (Sahil, 2026-07-23) is policy, not a GitHub guarantee. `ci_gate` now fails any fork-headed `pull_request_target` run whose PR author is not on a trusted allowlist (`gumclaw`, `slavingia`). Every test job depends on `ci_gate`, so an untrusted fork PR gets a fast red X before any fork code is checked out or any secrets are exposed. Trusted internal fork PRs run immediately with no manual approval — the goal of #6176 stays intact.

ci-green.yml has no checkout step (pure gate) — untouched.

If external contributions ever open up: revert this AND #6176 together, restoring the environment approval gate.

## QA steps
- Re-run CI on #6147 (fork-headed, gumclaw-authored) — ci_gate passes the allowlist check and Lint JS/TS proceeds past checkout instead of failing in 7s.
- This PR's own run exercises the same-repo path (allowlist step skipped, ci_gate noop).

## Test Results
YAML parses clean (python yaml.safe_load); this PR's CI run + the #6147 retrigger are the test.

## AI disclosure
🤖 Generated with claude-fable-5 via Hermes agent (gumclaw).
