### PR TITLE
Revert #6176: restore ci-protected approval gate for fork-headed PRs (public repo)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,10 +19,7 @@ jobs:
   ci_gate:
     name: CI Gate${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository && ' (internal PR noop)' || '' }}
     runs-on: ubicloud-standard-2
-    # The 'ci-protected' environment approval gate used to sit here for fork-headed
-    # pull requests. Removed 2026-07-23 (Sahil): the repo takes no external
-    # contributions, so every fork PR is from a trusted internal account (e.g.
-    # gumclaw's fork) and the manual approve-this-run step only stalled CI.
+    environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'ci-protected' || '' }}
     steps:
       - run: true
 


### PR DESCRIPTION
## Summary

Reverts #6176 per Sahil (2026-07-23): "As it's public we don't want to risk this imo. Gumclaw should always work on main repo directly anyway."

He's right and the original reasoning was flawed: antiwork/gumroad is a public repo, so "no external contributions" is a policy, not a property — anyone can fork and open a PR at any time, and the `ci-protected` environment approval is the standard defense keeping `pull_request_target` secrets away from untrusted fork code. This restores it.

The companion escalation (#6177, `allow-unsafe-pr-checkout: true` — the actual dangerous half) was never merged and is now closed.

New standing policy instead: **gumclaw pushes branches to the main repo directly, never via fork** — internal PRs then never touch the fork-protection path at all, and the gate only ever fires on genuinely external PRs, where it belongs. The one stuck PR that started this (#6147) will be migrated to a main-repo branch.

## QA steps
Fork-headed PR CI runs wait for environment approval again (correct behavior); main-repo-branch PRs are unaffected.

## Test Results
Clean `git revert` of 3a7291227; workflow YAML change only — this PR's CI is the test.

## AI disclosure
🤖 Generated with claude-fable-5 via Hermes agent (gumclaw).
