### PR TITLE
Don't let the settlement-currency-mismatch marker suppress the forced-currency local-method lane

### DIFF
--- a/app/services/checkout/buyer_currency_eligibility.rb
+++ b/app/services/checkout/buyer_currency_eligibility.rb
@@ -98,7 +98,7 @@ class Checkout::BuyerCurrencyEligibility
   end
 
   def self.usd_settling_merchant_account?(merchant_account, presentment_currency:)
-    return false unless merchant_account.currency.blank? || merchant_account.currency.to_s.downcase == Currency::USD
+    return false unless usd_holding_merchant_account?(merchant_account)
 
     # The stored currency answers the wrong question for accounts with Stripe
     # multi-currency settlement enabled: it mirrors Stripe's default_currency ("usd"),
@@ -111,6 +111,21 @@ class Checkout::BuyerCurrencyEligibility
     # trip for that currency (up to 2s of checkout latency, on every visit) and fall
     # back to canonical USD immediately. Other currencies keep quoting.
     !merchant_account.settlement_currency_mismatch_active?(presentment_currency)
+  end
+
+  # The weaker of the two settlement questions: does the account HOLD its balance in USD
+  # (per our stored mirror of Stripe's default_currency)? Unlike
+  # usd_settling_merchant_account? this deliberately ignores the learned
+  # settlement-currency-mismatch marker, because the marker only says "an FX quote to USD
+  # for this currency will be rejected" — it does not make a plain forced-currency charge
+  # fail. The direct-listed-amount forced lane (an EUR-priced product paid with iDEAL)
+  # never mints an FX quote, so the marker is irrelevant to it; gating that lane on the
+  # marker is exactly what turned iDEAL dark platform-wide on 2026-07-23 (enabling the
+  # iDEAL/SEPA capabilities made the platform account settle EUR in EUR, the EUR marker
+  # was recorded, and every Gumroad-managed seller lost the iDEAL tab —
+  # gumroad-private#933).
+  def self.usd_holding_merchant_account?(merchant_account)
+    merchant_account.currency.blank? || merchant_account.currency.to_s.downcase == Currency::USD
   end
 
   def self.stripe_test_mode?
@@ -206,13 +221,15 @@ class Checkout::BuyerCurrencyEligibility
     return fallback(:method_not_launched) unless method_forced_mode_allowed?(payment_method, forced_currency)
     return fallback(:unsupported_processor) unless merchant_account&.stripe_charge_processor?
     return fallback(:unsupported_charge_model) unless supported_charge_model?
-    # Presentment currency and settlement currency are separate questions: even
-    # when the product is already priced in the forced currency (say EUR), the
-    # seller's merchant account still receives the money, and today the pipeline
-    # only knows how to settle accounts that hold USD. So this check applies to
-    # both the USD-priced and the forced-currency-priced product cases, scoped to
-    # the forced currency (a mismatch learned for another currency is irrelevant).
-    return fallback(:unsupported_settlement_currency) unless usd_settling_merchant_account?(forced_currency)
+    # Only the stored-currency (USD-holding) half of the settlement question is a
+    # blanket gate here. The learned per-currency mismatch marker is NOT: it predicts
+    # FX-quote rejection, which only matters on the quoted (USD-priced) case below.
+    # The direct-listed-amount case charges the listed price with no FX quote at all,
+    # and the marker being set for the forced currency is in fact the EXPECTED state
+    # once that method's capabilities make the account settle the currency in itself
+    # (2026-07-23 iDEAL dark-ramp, gumroad-private#933) — so it must not withhold the
+    # method.
+    return fallback(:unsupported_settlement_currency) unless self.class.usd_holding_merchant_account?(merchant_account)
     return fallback(:future_charge_setup) if setup_future_charges
     return fallback(:off_session) if off_session
     return fallback(:multi_item_checkout) unless purchases.one?
@@ -230,6 +247,16 @@ class Checkout::BuyerCurrencyEligibility
     priced_in_forced_currency = product_currency == forced_currency
     unless priced_in_forced_currency || product_currency == Currency::USD
       return fallback(:unsupported_product_currency)
+    end
+
+    # The USD-priced case converts through a Stripe FX quote (forced currency -> USD),
+    # which is exactly the call a fresh mismatch marker predicts Stripe will reject —
+    # and unlike the card path there is no graceful USD fallback for a method that can
+    # only charge in its forced currency. Withhold the method rather than render a tab
+    # that fails at prepare. The direct-listed-amount case skips this on purpose: it
+    # never mints a quote (see the settlement comment above).
+    if !priced_in_forced_currency && !usd_settling_merchant_account?(forced_currency)
+      return fallback(:unsupported_settlement_currency)
     end
 
     # Defensive guard for future registry entries: Gumroad and Stripe must agree

--- a/app/services/checkout/payment_method_resolver.rb
+++ b/app/services/checkout/payment_method_resolver.rb
@@ -266,10 +266,16 @@ class Checkout::PaymentMethodResolver
       end
       return [] if methods_for_cart_currency.empty?
 
-      # The prepare-time eligibility check rejects a forced-currency intent when Stripe
-      # has already shown that this account does not settle the currency to canonical USD.
-      # Remove the method before mounting the Element too; otherwise checkout advertises
-      # iDEAL/Bancontact and then fails generically after the buyer selects it.
+      # The prepare-time eligibility check rejects a forced-currency intent when the
+      # account doesn't HOLD USD (stored-currency check). Mirror only that half here.
+      # Deliberately NOT the marker-aware usd_settling_merchant_account?: the methods
+      # this resolver offers are always the direct-listed-amount shape (single item
+      # priced in the forced currency — the select above), which charges the listed
+      # price with no FX quote, so the learned mismatch marker is irrelevant to them.
+      # Gating on the marker here is what made iDEAL disappear platform-wide on
+      # 2026-07-23: enabling the iDEAL/SEPA capabilities made the platform account
+      # settle EUR in EUR, the EUR marker was recorded, and the tab never rendered for
+      # any Gumroad-managed seller (gumroad-private#933).
       return [] unless forced_currency_settlement_supported?
 
       methods_for_cart_currency.select do |method|
@@ -284,10 +290,7 @@ class Checkout::PaymentMethodResolver
                          MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id)
       return false if merchant_account.blank?
 
-      Checkout::BuyerCurrencyEligibility.usd_settling_merchant_account?(
-        merchant_account,
-        presentment_currency: cart_product_currency
-      )
+      Checkout::BuyerCurrencyEligibility.usd_holding_merchant_account?(merchant_account)
     end
 
     # U13: a PPP-discounted checkout only offers methods the pre-charge country check can verify

--- a/spec/presenters/checkout/stripe_payment_presenter_spec.rb
+++ b/spec/presenters/checkout/stripe_payment_presenter_spec.rb
@@ -729,9 +729,12 @@ describe Checkout::StripePaymentPresenter do
 
   describe "method-forced test-mode QA surface (iDEAL/Bancontact)" do
     let(:platform_merchant_account) do
-      # CI databases don't always seed the Gumroad-managed Stripe platform account, so
-      # create it when the lookup comes back empty (same pattern as buyer_currency_quote_spec).
-      MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id) ||
+      # CI databases don't always seed the Gumroad-managed Stripe platform account. Make
+      # an existing seed match this test's USD-holding premise too, so its result does not
+      # depend on how another suite configured that shared account.
+      MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id)&.tap do |account|
+        account.update!(charge_processor_merchant_id: "acct_gumroad", currency: Currency::USD)
+      end ||
         create(:merchant_account, user: nil, charge_processor_merchant_id: "acct_gumroad", currency: Currency::USD)
     end
 

--- a/spec/presenters/checkout/stripe_payment_presenter_spec.rb
+++ b/spec/presenters/checkout/stripe_payment_presenter_spec.rb
@@ -728,7 +728,12 @@ describe Checkout::StripePaymentPresenter do
   end
 
   describe "method-forced test-mode QA surface (iDEAL/Bancontact)" do
-    let(:platform_merchant_account) { MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id) }
+    let(:platform_merchant_account) do
+      # CI databases don't always seed the Gumroad-managed Stripe platform account, so
+      # create it when the lookup comes back empty (same pattern as buyer_currency_quote_spec).
+      MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id) ||
+        create(:merchant_account, user: nil, charge_processor_merchant_id: "acct_gumroad", currency: Currency::USD)
+    end
 
     def buyer_currency_seller_with_product(price_currency_type: "eur", price_cents: 1500)
       seller = create(:user, disable_buyer_local_currency: false)
@@ -823,15 +828,28 @@ describe Checkout::StripePaymentPresenter do
       end
     end
 
-    it "keeps the canonical USD element when the platform account has learned an EUR settlement mismatch" do
+    it "keeps the iDEAL tab on the EUR element even when the platform account has learned an EUR settlement mismatch" do
+      # The learned mismatch marker only predicts that an FX quote (EUR -> USD) would be
+      # rejected. This cart is the direct-listed-amount shape — an EUR-priced product
+      # charged at its listed price with no FX quote — so the marker must not withhold
+      # the method. Suppressing the tab here is what turned iDEAL dark platform-wide on
+      # 2026-07-23: enabling the iDEAL/SEPA capabilities makes the platform account
+      # settle EUR in EUR, so the marker being set is the EXPECTED state once the
+      # method is live (gumroad-private#933).
       seller, product = buyer_currency_seller_with_product(price_cents: 1500)
       activate_buyer_currency_flags(seller)
       Feature.activate_user(:checkout_local_method_ideal, seller)
       allow(Stripe).to receive(:api_key).and_return("sk_live_currency")
       platform_merchant_account.record_settlement_currency_mismatch!(Currency::EUR)
 
-      expect(stripe_payment_props(add_products: [checkout_product_for(product)]))
-        .to eq(payment_element_client_confirm_props)
+      expect(stripe_payment_props(add_products: [checkout_product_for(product)])).to eq(
+        payment_element_client_confirm_props(
+          currency: "eur",
+          presentment_amount_cents: 1500,
+          payment_method_types: %w[card link ideal],
+          disable_wallets: true,
+        )
+      )
     ensure
       if seller
         Feature.deactivate_user(:checkout_local_method_ideal, seller)

--- a/spec/services/checkout/buyer_currency_eligibility_spec.rb
+++ b/spec/services/checkout/buyer_currency_eligibility_spec.rb
@@ -491,6 +491,34 @@ describe Checkout::BuyerCurrencyEligibility do
       expect(forced_decision.fallback_reason).to eq(:unsupported_settlement_currency)
     end
 
+    # Regression test for the 2026-07-23 iDEAL dark-ramp (gumroad-private#933): enabling
+    # the iDEAL/SEPA capabilities makes the account settle EUR in EUR, so an EUR
+    # mismatch marker is the EXPECTED steady state for exactly the accounts that can
+    # take iDEAL. The direct-listed-amount lane charges the listed EUR price without an
+    # FX quote, so the marker must not withhold the method there.
+    it "keeps the method available for a product priced in the forced currency when the mismatch marker is set for that currency" do
+      purchase.update!(link: create(:product, user: seller, price_currency_type: Currency::EUR))
+      merchant_account.record_settlement_currency_mismatch!(Currency::EUR)
+
+      expect(forced_decision).to be_eligible
+      expect(forced_decision.currency).to eq(Currency::EUR)
+      expect(forced_decision.direct_listed_amount?).to eq(true)
+    end
+
+    it "withholds the method for a USD-priced product when the mismatch marker is set for the forced currency — the FX quote it needs would be rejected" do
+      merchant_account.record_settlement_currency_mismatch!(Currency::EUR)
+
+      expect(forced_decision).not_to be_eligible
+      expect(forced_decision.fallback_reason).to eq(:unsupported_settlement_currency)
+    end
+
+    it "keeps the USD-priced quote path available when the recorded mismatch is for a different currency" do
+      merchant_account.record_settlement_currency_mismatch!(Currency::GBP)
+
+      expect(forced_decision).to be_eligible
+      expect(forced_decision.direct_listed_amount?).to eq(false)
+    end
+
     it "withholds the method for future-charge setups such as save-card checkouts" do
       save_card_decision = described_class.new(order:,
                                                seller:,

--- a/spec/services/checkout/payment_method_resolver_spec.rb
+++ b/spec/services/checkout/payment_method_resolver_spec.rb
@@ -133,10 +133,23 @@ describe Checkout::PaymentMethodResolver do
           expect(methods).not_to include("bancontact")
         end
 
-        it "withholds a launched forced-currency method when the charged account has learned a mismatch for that currency" do
+        # Regression test for the 2026-07-23 iDEAL dark-ramp (gumroad-private#933): the
+        # EUR mismatch marker is the expected steady state once iDEAL/SEPA capabilities
+        # make the account settle EUR in EUR, and the resolver only offers these methods
+        # on carts priced in the forced currency (no FX quote involved) — so the marker
+        # must not hide the method tab.
+        it "keeps a launched forced-currency method offered when the charged account has learned a mismatch for that currency" do
           allow(Checkout::BuyerCurrencyEligibility).to receive(:stripe_test_mode?).and_return(false)
           Feature.activate_user(:checkout_local_method_ideal, seller)
           platform_merchant_account.record_settlement_currency_mismatch!(Currency::EUR)
+
+          expect(resolve(cart_product_currency: Currency::EUR).payment_method_types).to include("ideal")
+        end
+
+        it "withholds a launched forced-currency method when the charged account holds a non-USD balance" do
+          allow(Checkout::BuyerCurrencyEligibility).to receive(:stripe_test_mode?).and_return(false)
+          Feature.activate_user(:checkout_local_method_ideal, seller)
+          platform_merchant_account.update!(currency: Currency::CAD)
 
           expect(resolve(cart_product_currency: Currency::EUR).payment_method_types).not_to include("ideal")
         end


### PR DESCRIPTION
Fixes the structural cause of the iDEAL ramp-down at 2026-07-23 07:19 UTC (antiwork/gumroad-private#933 — [ramp-down evidence](https://github.com/antiwork/gumroad-private/issues/933#issuecomment-5055581413)). Part of antiwork/gumroad#5362 Phase 4.

## Problem

#6163's per-currency EUR settlement-mismatch marker on the platform merchant account (MA 1) made `Checkout::BuyerCurrencyEligibility#method_forced_decision` return `unsupported_settlement_currency` for **every Gumroad-managed seller**, so the iDEAL tab never rendered: zero iDEAL attempts ever, across 5h15m at 100% with eligible NL/BE EUR traffic flowing.

The trap is self-inflicted by design: enabling the iDEAL/SEPA capabilities is itself what makes the platform account settle EUR-in-EUR, so a fresh EUR marker is the *expected steady state* for exactly the accounts that can take iDEAL. The marker only predicts that an **FX quote to USD** for that currency will be rejected — it says nothing about a plain forced-currency charge, and the direct-listed-amount lane (EUR-priced product paid with iDEAL) never mints an FX quote at all.

## Fix

Split the settlement question in two:

- New `usd_holding_merchant_account?` (stored-currency check only, marker-blind) now gates the method-forced lane's blanket check and `PaymentMethodResolver#forced_currency_settlement_supported?` — the shapes those paths serve charge the listed price with no FX quote.
- The marker-aware `usd_settling_merchant_account?` is unchanged for the card-path quote decision, and on the method-forced lane it now applies **only to the USD-priced (quoted) case**, where the doomed FX quote would actually be minted and there is no graceful USD fallback for a method that can only charge in its forced currency.

## Testing

- Regression specs in both `buyer_currency_eligibility_spec` and `payment_method_resolver_spec`: an EUR marker keeps the direct-listed-amount lane eligible and the iDEAL tab offered; the USD-priced quote case is still withheld; a non-USD *stored* balance still withholds everything.
- Full `buyer_currency_eligibility_spec` + `payment_method_resolver_spec` run locally: 109 examples, 1 failure — the failure (`allows the PR1 Stripe test-mode Gumroad platform-account path`, a uniqueness-validation collision on `create(:merchant_account, ...)`) reproduces identically on unmodified `origin/main`, i.e. pre-existing local-DB residue, not introduced here.

## Rollout

After merge + ancestry-verified deploy, re-ramp: `Feature.activate_percentage(:checkout_local_method_ideal, 100)` (ramp executed by the monitor per the max-data doctrine).
