### PR TITLE
RTL: dir=auto on product name surfaces (page title, cards, cart line item)

### DIFF
--- a/app/javascript/components/Checkout/index.tsx
+++ b/app/javascript/components/Checkout/index.tsx
@@ -695,7 +695,8 @@ const CartItemComponent = ({
           per line. */}
       <CartItemMain className="min-w-2/5">
         <CartItemTitle>
-          <a href={item.product.url} className="no-underline">
+          {/* dir="auto" lets RTL product names render right-to-left (gumroad-private#1259). */}
+          <a href={item.product.url} className="no-underline" dir="auto">
             {item.product.name}
           </a>
         </CartItemTitle>

--- a/app/javascript/components/Product/Card.tsx
+++ b/app/javascript/components/Product/Card.tsx
@@ -35,7 +35,9 @@ export const Card = ({
       {product.quantity_remaining != null ? <Ribbon>{product.quantity_remaining} left</Ribbon> : null}
       <ProductCardHeader>
         <StretchedLink href={product.url}>
-          <h4 itemProp="name" className="line-clamp-4 lg:text-xl">
+          {/* dir="auto" on product names lets RTL text (Hebrew, Arabic) pick its own
+              base direction (gumroad-private#1259). */}
+          <h4 itemProp="name" dir="auto" className="line-clamp-4 lg:text-xl">
             {product.name}
           </h4>
         </StretchedLink>
@@ -91,11 +93,11 @@ export const HorizontalCard = ({ product, big, eager }: { product: CardProduct; 
         <ProductCardHeader className="lg:border-b-0 lg:p-0">
           <StretchedLink href={product.url} draggable="false">
             {big ? (
-              <h2 itemProp="name" className="line-clamp-3 gap-3">
+              <h2 itemProp="name" dir="auto" className="line-clamp-3 gap-3">
                 {product.name}
               </h2>
             ) : (
-              <h3 itemProp="name" className="truncate">
+              <h3 itemProp="name" dir="auto" className="truncate">
                 {product.name}
               </h3>
             )}

--- a/app/javascript/components/Product/index.tsx
+++ b/app/javascript/components/Product/index.tsx
@@ -400,7 +400,13 @@ export const Product = ({
       {product.quantity_remaining !== null ? <Ribbon>{product.quantity_remaining} left</Ribbon> : null}
       <section className="lg:border-r">
         <header className="grid gap-4 p-6 not-first:border-t">
-          <h1 itemProp="name">{product.name}</h1>
+          {/* dir="auto" lets an RTL product name (Hebrew, Arabic) render right-to-left
+              instead of inheriting the document's LTR base direction, which misplaces
+              neutral characters like quotes and digits (gumroad-private#1259; same
+              rationale as the description fix in #6138). */}
+          <h1 itemProp="name" dir="auto">
+            {product.name}
+          </h1>
         </header>
         <section className="grid grid-cols-[auto_1fr] gap-[1px] border-t border-border p-0 sm:grid-cols-[auto_auto_minmax(max-content,1fr)]">
           {showPrice ? (


### PR DESCRIPTION
## Summary

Follow-up to #6138 (`dir="auto"` on creator-authored content containers, shipped v2026.07.22.5). The Hebrew-language seller who hit the shipped description fix reports the **product page title** still renders LTR (gumroad-private#1259) — the `<h1 itemProp="name">` had no `dir` attribute, so Hebrew/Arabic titles inherit the document's `dir="ltr"`, misplacing neutral characters (quotes, digits) at run boundaries. Live example: `תוך 7 ימים תגש לכל בחורה שאתה רוצה מבלי לפחד לקבל "דחייה"` on https://alphastarting.gumroad.com/l/ukbuc.

## Changes

Same pattern and rationale as #6138 — `dir="auto"` on the elements that render `product.name`:

- `Product/index.tsx` — the product page `<h1>` (the reported surface)
- `Product/Card.tsx` — vertical card `<h4>` and horizontal card `<h2>`/`<h3>` name headings (audit of sibling name surfaces per the issue)
- `Checkout/index.tsx` — cart line item title link

No layout or styling changes; `dir="auto"` picks the base direction from the first strong-direction character, so LTR names are untouched.

## Before / After

Draft with `preview` label — hosted preview screenshots of the Hebrew title rendering RTL on the product page (and an LTR product unchanged, confirming no impact on existing pages) will be attached from the preview app once the deploy is up. Local rendering is banned for PR evidence per convention.

## Issue

gumroad-private#1259 (guard key `rtl-title-dir-auto`).

---

## AI disclosure

🤖 Generated with **claude-fable-5** (Anthropic), running as the autonomous-dev-dispatcher cron.
Prompts/instructions given: standing order (Sahil 2026-07-19) to autonomously build qualifying issues; gumroad-private#1259 issue body used as the spec (verified fix sketch, seller-reported follow-up to #6138).
