### PR TITLE
Resend-to-non-openers: move recipient computation out of the request (fixes large-audience timeouts)

### DIFF
--- a/app/controllers/api/internal/installments/non_opener_resends_controller.rb
+++ b/app/controllers/api/internal/installments/non_opener_resends_controller.rb
@@ -4,6 +4,11 @@ class Api::Internal::Installments::NonOpenerResendsController < Api::Internal::B
   RESEND_THROTTLE = 24.hours
   MAX_RESENDS = 3
   IN_FLIGHT_GRACE = 1.hour
+  # Computing the non-opener count means scanning every emailed recipient, every open
+  # event, and the seller's full audience. For very large sends (hundreds of thousands
+  # of recipients) that cannot finish inside a web request, so each query is capped and
+  # the endpoint degrades to "count unavailable" instead of erroring the whole page.
+  COUNT_PREVIEW_QUERY_TIMEOUT_SECONDS = 10
 
   before_action :authenticate_user!
   before_action :set_installment
@@ -12,8 +17,21 @@ class Api::Internal::Installments::NonOpenerResendsController < Api::Internal::B
   def show
     authorize @installment, :resend_to_non_openers?
 
-    count = @installment.unopened_recipients_count
-    audience_filtered_out = count.zero? && @installment.unopened_recipient_emails.any?
+    count = nil
+    audience_filtered_out = false
+    begin
+      WithMaxExecutionTime.timeout_queries(seconds: COUNT_PREVIEW_QUERY_TIMEOUT_SECONDS) do
+        count = @installment.unopened_recipients_count
+        audience_filtered_out = count.zero? && @installment.unopened_recipient_emails.any?
+      end
+    rescue WithMaxExecutionTime::QueryTimeoutError
+      # The audience is too large to count within the request. A null count tells the
+      # UI to offer the resend without a recipient number — the actual send happens in
+      # a background job, so a missing preview count doesn't block anything.
+      count = nil
+      audience_filtered_out = false
+    end
+
     render json: { count:, recently_resent: recently_resent?, audience_filtered_out: }
   end
 
@@ -33,17 +51,6 @@ class Api::Internal::Installments::NonOpenerResendsController < Api::Internal::B
         next
       end
 
-      @count = @installment.unopened_recipients_count
-      if @count.zero?
-        message = if @installment.unopened_recipient_emails.any?
-          "There are no non-openers left to email — the remaining unopened recipients are no longer eligible for this email's audience."
-        else
-          "Everyone who was emailed has already opened this."
-        end
-        error_response = [{ success: false, error: message }, :unprocessable_entity]
-        next
-      end
-
       blast = PostEmailBlast.create!(
         post: @installment,
         requested_at: Time.current,
@@ -56,8 +63,13 @@ class Api::Internal::Installments::NonOpenerResendsController < Api::Internal::B
       return render json:, status:
     end
 
+    # Recipient eligibility is intentionally NOT computed here: for large audiences
+    # that computation takes minutes and used to time the request out before the blast
+    # was even created. The job resolves the recipient list itself, and a blast that
+    # turns out to have zero eligible recipients simply completes with delivery_count 0
+    # (which doesn't count toward the resend cap or the 24h throttle).
     SendPostBlastEmailsJob.perform_async(blast.id)
-    render json: { success: true, count: @count }
+    render json: { success: true }
   end
 
   private

--- a/app/controllers/api/internal/installments/non_opener_resends_controller.rb
+++ b/app/controllers/api/internal/installments/non_opener_resends_controller.rb
@@ -6,9 +6,13 @@ class Api::Internal::Installments::NonOpenerResendsController < Api::Internal::B
   IN_FLIGHT_GRACE = 1.hour
   # Computing the non-opener count means scanning every emailed recipient, every open
   # event, and the seller's full audience. For very large sends (hundreds of thousands
-  # of recipients) that cannot finish inside a web request, so each query is capped and
-  # the endpoint degrades to "count unavailable" instead of erroring the whole page.
-  COUNT_PREVIEW_QUERY_TIMEOUT_SECONDS = 10
+  # of recipients) that cannot finish inside a web request, so the whole preview shares
+  # one total time budget and the endpoint degrades to "count unavailable" instead of
+  # erroring the whole page. The budget is enforced as a shrinking per-statement cap:
+  # each query runs under whatever is LEFT of the budget (not a fresh 10 seconds), so
+  # several individually-fast statements can't add up past the budget and hit the HTTP
+  # request deadline instead.
+  COUNT_PREVIEW_TOTAL_BUDGET_SECONDS = 10
 
   before_action :authenticate_user!
   before_action :set_installment
@@ -20,12 +24,21 @@ class Api::Internal::Installments::NonOpenerResendsController < Api::Internal::B
     count = nil
     audience_filtered_out = false
     begin
-      WithMaxExecutionTime.timeout_queries(seconds: COUNT_PREVIEW_QUERY_TIMEOUT_SECONDS) do
-        count = @installment.unopened_recipients_count
-        audience_filtered_out = count.zero? && @installment.unopened_recipient_emails.any?
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + COUNT_PREVIEW_TOTAL_BUDGET_SECONDS
+
+      unopened_emails = within_preview_budget(deadline) { @installment.unopened_recipient_emails }
+      if unopened_emails.empty?
+        count = 0
+      else
+        # Reuse the emails computed above rather than letting the model recompute them —
+        # they are the expensive part, and running them twice would double the time spent.
+        count = within_preview_budget(deadline) do
+          @installment.resendable_to_non_openers_emails(candidates: unopened_emails).size
+        end
+        audience_filtered_out = count.zero?
       end
     rescue WithMaxExecutionTime::QueryTimeoutError
-      # The audience is too large to count within the request. A null count tells the
+      # The audience is too large to count within the budget. A null count tells the
       # UI to offer the resend without a recipient number — the actual send happens in
       # a background job, so a missing preview count doesn't block anything.
       count = nil
@@ -73,6 +86,17 @@ class Api::Internal::Installments::NonOpenerResendsController < Api::Internal::B
   end
 
   private
+    # Runs the block under a MySQL statement cap equal to the time REMAINING until
+    # `deadline`, so consecutive queries share one overall budget instead of each
+    # getting the full amount. A budget that is already spent raises the same
+    # QueryTimeoutError a slow statement would, keeping one degrade path.
+    def within_preview_budget(deadline, &block)
+      remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      raise WithMaxExecutionTime::QueryTimeoutError, "count preview budget exhausted" if remaining <= 0
+
+      WithMaxExecutionTime.timeout_queries(seconds: remaining, &block)
+    end
+
     def set_installment
       @installment = current_seller.installments.alive.find_by_external_id(params[:id])
       (skip_authorization and e404_json) unless @installment&.resendable_to_non_openers?

--- a/app/javascript/components/EmailsPage/shared.tsx
+++ b/app/javascript/components/EmailsPage/shared.tsx
@@ -107,6 +107,9 @@ export const ResendToNonOpenersButton = ({ installment }: { installment: SavedIn
   const [loadingCount, setLoadingCount] = React.useState(false);
   const [confirming, setConfirming] = React.useState(false);
   const [count, setCount] = React.useState<number | null>(null);
+  // Distinguishes "count is null because the audience was too large to count in time"
+  // from "count hasn't loaded yet" — the resend still works without a count.
+  const [countUnavailable, setCountUnavailable] = React.useState(false);
   const [recentlyResent, setRecentlyResent] = React.useState(false);
   const [audienceFilteredOut, setAudienceFilteredOut] = React.useState(false);
   const [resending, setResending] = React.useState(false);
@@ -121,6 +124,7 @@ export const ResendToNonOpenersButton = ({ installment }: { installment: SavedIn
         audience_filtered_out,
       } = await getNonOpenerCount(installment.external_id);
       setCount(nonOpenerCount);
+      setCountUnavailable(nonOpenerCount === null);
       setRecentlyResent(recently_resent);
       setAudienceFilteredOut(audience_filtered_out);
       setConfirming(true);
@@ -135,11 +139,8 @@ export const ResendToNonOpenersButton = ({ installment }: { installment: SavedIn
   const handleResend = asyncVoid(async () => {
     setResending(true);
     try {
-      const { count: sentCount } = await resendToNonOpeners(installment.external_id);
-      showAlert(
-        `Resending to ${formatStatNumber({ value: sentCount })} people who haven't opened this yet.`,
-        "success",
-      );
+      await resendToNonOpeners(installment.external_id);
+      showAlert("Resending to everyone who hasn't opened this yet. This may take a while.", "success");
       setRecentlyResent(true);
       setConfirming(false);
       router.reload();
@@ -151,7 +152,7 @@ export const ResendToNonOpenersButton = ({ installment }: { installment: SavedIn
     }
   });
 
-  const disableResend = resending || recentlyResent || count === null || count === 0;
+  const disableResend = resending || recentlyResent || (!countUnavailable && (count === null || count === 0));
 
   return (
     <>
@@ -159,7 +160,7 @@ export const ResendToNonOpenersButton = ({ installment }: { installment: SavedIn
         <Envelope pack="filled" className="size-5" />
         {loadingCount ? "Loading..." : "Resend to non-openers"}
       </Button>
-      {confirming && count !== null ? (
+      {confirming ? (
         <Modal
           open
           allowClose={!resending}
@@ -179,11 +180,13 @@ export const ResendToNonOpenersButton = ({ installment }: { installment: SavedIn
           <h4>
             {recentlyResent
               ? "You've already resent this to non-openers recently. Try again in 24 hours."
-              : count === 0
-                ? audienceFilteredOut
-                  ? "The remaining unopened recipients are no longer eligible for this email's audience."
-                  : "Everyone who was emailed has already opened this."
-                : `This will resend "${installment.name}" to ${formatStatNumber({ value: count })} people who were emailed but haven't opened it yet.`}
+              : countUnavailable
+                ? `This will resend "${installment.name}" to everyone who was emailed but hasn't opened it yet. Your audience is too large to preview an exact count.`
+                : count === 0
+                  ? audienceFilteredOut
+                    ? "The remaining unopened recipients are no longer eligible for this email's audience."
+                    : "Everyone who was emailed has already opened this."
+                  : `This will resend "${installment.name}" to ${formatStatNumber({ value: count ?? 0 })} people who were emailed but haven't opened it yet.`}
           </h4>
         </Modal>
       ) : null}

--- a/app/javascript/data/installments.ts
+++ b/app/javascript/data/installments.ts
@@ -152,7 +152,9 @@ export async function getNonOpenerCount(externalId: string) {
   });
 
   if (!response.ok) throw new ResponseError();
-  return typia.assert<{ count: number; recently_resent: boolean; audience_filtered_out: boolean }>(
+  // `count` is null when the audience is too large to count within the request; the
+  // resend itself still works (recipients are resolved in a background job).
+  return typia.assert<{ count: number | null; recently_resent: boolean; audience_filtered_out: boolean }>(
     await response.json(),
   );
 }
@@ -166,7 +168,7 @@ export async function resendToNonOpeners(externalId: string) {
 
   const json: unknown = await response.json();
   if (!response.ok) throw new ResponseError(typia.assert<{ error: string }>(json).error);
-  return typia.assert<{ count: number }>(json);
+  return typia.assert<{ success: boolean }>(json);
 }
 
 export async function previewInstallment(externalId: string) {

--- a/app/models/installment.rb
+++ b/app/models/installment.rb
@@ -779,8 +779,11 @@ class Installment < ApplicationRecord
     emailed_emails - opened_emails
   end
 
-  def resendable_to_non_openers_emails
-    candidates = unopened_recipient_emails.to_set
+  # Accepts a precomputed `candidates` list so callers that already have the unopened
+  # recipient emails (e.g. the resend preview endpoint) don't pay for the expensive
+  # email-diffing pipeline a second time.
+  def resendable_to_non_openers_emails(candidates: unopened_recipient_emails)
+    candidates = candidates.to_set
     return [] if candidates.empty?
 
     AudienceMember
@@ -791,8 +794,8 @@ class Installment < ApplicationRecord
       .select { candidates.include?(_1) }
   end
 
-  def unopened_recipients_count
-    resendable_to_non_openers_emails.size
+  def unopened_recipients_count(candidates: unopened_recipient_emails)
+    resendable_to_non_openers_emails(candidates:).size
   end
 
   # Whether a "resend to non-openers" blast is applicable to this post.

--- a/app/sidekiq/send_post_blast_emails_job.rb
+++ b/app/sidekiq/send_post_blast_emails_job.rb
@@ -19,7 +19,13 @@ class SendPostBlastEmailsJob
     @members = load_audience_members
 
     if @blast.to_non_openers?
-      keep_emails = @post.unopened_recipient_emails.to_set
+      # Resolving who was emailed and who opened plucks hundreds of thousands of rows
+      # for large sends — the same query shape that can exceed the database's default
+      # statement cap. Run it under the same raised, Redis-tunable cap the audience
+      # load above uses so a huge blast doesn't die on a 5-minute statement timeout.
+      keep_emails = WithMaxExecutionTime.timeout_queries(seconds: audience_load_timeout_seconds) do
+        @post.unopened_recipient_emails.to_set
+      end
       @members.select! { _1.email.present? && keep_emails.include?(_1.email.downcase) }
       remove_members_already_sent_in_this_blast
     else

--- a/spec/controllers/api/internal/installments/non_opener_resends_controller_spec.rb
+++ b/spec/controllers/api/internal/installments/non_opener_resends_controller_spec.rb
@@ -73,6 +73,14 @@ describe Api::Internal::Installments::NonOpenerResendsController do
       get :show, params: { id: draft.external_id }
       expect(response).to have_http_status(:not_found)
     end
+
+    it "returns a null count instead of erroring when the count queries time out" do
+      expect(WithMaxExecutionTime).to receive(:timeout_queries).and_raise(WithMaxExecutionTime::QueryTimeoutError.new("maximum statement execution time exceeded"))
+
+      get :show, params: { id: installment.external_id }
+      expect(response).to be_successful
+      expect(response.parsed_body).to eq({ "count" => nil, "recently_resent" => false, "audience_filtered_out" => false })
+    end
   end
 
   describe "POST create" do
@@ -93,31 +101,26 @@ describe Api::Internal::Installments::NonOpenerResendsController do
         .and change { SendPostBlastEmailsJob.jobs.size }.by(1)
 
       expect(response).to be_successful
-      expect(response.parsed_body).to eq({ "success" => true, "count" => 1 })
+      expect(response.parsed_body).to eq({ "success" => true })
     end
 
-    it "returns 422 when everyone who was emailed has already opened" do
+    it "does not compute the recipient count in the request (large audiences would time out)" do
+      expect_any_instance_of(Installment).not_to receive(:unopened_recipients_count)
+      expect_any_instance_of(Installment).not_to receive(:unopened_recipient_emails)
+
+      post :create, params: { id: installment.external_id }
+      expect(response).to be_successful
+    end
+
+    it "still creates a blast when everyone who was emailed has already opened (job completes it with zero deliveries)" do
       create(:creator_contacting_customers_email_info_opened, installment: installment, purchase: unopened_sale)
 
       expect do
         post :create, params: { id: installment.external_id }
-      end.not_to change { PostEmailBlast.where(post: installment).count }
+      end.to change { PostEmailBlast.to_non_openers.where(post: installment).count }.by(1)
+        .and change { SendPostBlastEmailsJob.jobs.size }.by(1)
 
-      expect(response).to have_http_status(:unprocessable_entity)
-      expect(response.parsed_body["success"]).to eq(false)
-      expect(response.parsed_body["error"]).to include("already opened")
-    end
-
-    it "returns a distinct 422 message when unopened recipients exist but no longer match the audience filter" do
-      not_bought_product = create(:product, user: seller)
-      installment.update!(not_bought_products: [product.unique_permalink], bought_products: [not_bought_product.unique_permalink])
-
-      expect do
-        post :create, params: { id: installment.external_id }
-      end.not_to change { PostEmailBlast.where(post: installment).count }
-
-      expect(response).to have_http_status(:unprocessable_entity)
-      expect(response.parsed_body["error"]).to include("no longer eligible")
+      expect(response).to be_successful
     end
 
     it "throttles a second resend within the window" do

--- a/spec/controllers/api/internal/installments/non_opener_resends_controller_spec.rb
+++ b/spec/controllers/api/internal/installments/non_opener_resends_controller_spec.rb
@@ -81,6 +81,42 @@ describe Api::Internal::Installments::NonOpenerResendsController do
       expect(response).to be_successful
       expect(response.parsed_body).to eq({ "count" => nil, "recently_resent" => false, "audience_filtered_out" => false })
     end
+
+    it "gives later preview queries only the remaining time budget, not a fresh cap each" do
+      seconds_used = []
+      allow(WithMaxExecutionTime).to receive(:timeout_queries).and_wrap_original do |original, seconds:, &block|
+        seconds_used << seconds
+        original.call(seconds:, &block)
+      end
+
+      get :show, params: { id: installment.external_id }
+      expect(response).to be_successful
+      expect(seconds_used.size).to eq(2)
+      expect(seconds_used.first).to be <= described_class::COUNT_PREVIEW_TOTAL_BUDGET_SECONDS
+      expect(seconds_used.second).to be < seconds_used.first
+    end
+
+    it "returns a null count when the budget runs out partway through the preview queries" do
+      calls = 0
+      allow(WithMaxExecutionTime).to receive(:timeout_queries).and_wrap_original do |original, seconds:, &block|
+        calls += 1
+        raise WithMaxExecutionTime::QueryTimeoutError, "maximum statement execution time exceeded" if calls == 2
+        original.call(seconds:, &block)
+      end
+
+      get :show, params: { id: installment.external_id }
+      expect(response).to be_successful
+      expect(response.parsed_body).to eq({ "count" => nil, "recently_resent" => false, "audience_filtered_out" => false })
+    end
+
+    it "raises the timeout error without running a query when the budget is already spent" do
+      expect(WithMaxExecutionTime).not_to receive(:timeout_queries)
+      spent_deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) - 1
+
+      expect do
+        controller.send(:within_preview_budget, spent_deadline) { raise "should not run" }
+      end.to raise_error(WithMaxExecutionTime::QueryTimeoutError)
+    end
   end
 
   describe "POST create" do

--- a/spec/requests/emails/resend_to_non_openers_spec.rb
+++ b/spec/requests/emails/resend_to_non_openers_spec.rb
@@ -45,7 +45,10 @@ describe("Resend to non-openers flow", :js, type: :system) do
       click_on "Resend"
     end
 
-    expect(page).to have_alert(text: "Resending to 2 people who haven't opened this yet.")
+    # The success alert intentionally doesn't include a recipient count anymore — the
+    # count is no longer computed inside the resend request (it could time out for
+    # large audiences); the job resolves the recipient list in the background.
+    expect(page).to have_alert(text: "Resending to everyone who hasn't opened this yet. This may take a while.")
 
     resend_blast = installment.blasts.where(recipient_filter: "unopened").sole
     expect(resend_blast.recipient_filter).to eq("unopened")

--- a/spec/sidekiq/send_post_blast_emails_job_spec.rb
+++ b/spec/sidekiq/send_post_blast_emails_job_spec.rb
@@ -370,6 +370,17 @@ describe SendPostBlastEmailsJob, :freeze_time do
 
       expect(SentPostEmail.where(post:).count).to eq(3)
     end
+
+    it "resolves the unopened-recipient emails under the raised statement execution cap" do
+      blast = create(:blast, :just_requested, post:, recipient_filter: "unopened")
+
+      # Once for the audience load, once for the unopened-recipient email resolution.
+      expect(WithMaxExecutionTime).to receive(:timeout_queries).with(seconds: 1.hour.to_i).twice.and_call_original
+      described_class.new.perform(blast.id)
+
+      expect_sent_count 2
+      expect(blast.reload.completed_at).to be_present
+    end
   end
 
   describe "audience load statement timeout" do


### PR DESCRIPTION
## What

Stops computing the eligible non-opener recipient list synchronously inside the resend-to-non-openers HTTP request, which timed out for sellers with large audiences.

- `NonOpenerResendsController#create` no longer computes any recipient count in-request. It runs the cheap throttle/cap checks, creates the `PostEmailBlast`, enqueues `SendPostBlastEmailsJob`, and returns immediately. A blast that turns out to have zero eligible recipients simply completes in the job with `delivery_count: 0` — which already doesn't count toward the 3-resend lifetime cap or the 24h throttle, so those safeguards are unaffected.
- `NonOpenerResendsController#show` (the count preview) caps its queries at 10 seconds via `WithMaxExecutionTime` and returns `count: null` on timeout instead of erroring. The confirmation modal then offers the resend without an exact number ("Your audience is too large to preview an exact count") instead of failing the whole flow.
- `SendPostBlastEmailsJob` now resolves the unopened-recipient emails under the same raised, Redis-tunable statement cap it already uses for the audience load, so the job itself doesn't die on the database's default statement timeout for huge blasts.
- Frontend: `resendToNonOpeners` response type drops the count; the success toast no longer promises a specific number (the real list is resolved in the job).

## Why

For a ~349k-recipient post, `Installment#unopened_recipients_count` plucks all emailed purchase emails, all opened purchase emails, and then runs a full `AudienceMember.filter(...).pluck(:email)` over the seller's entire audience — three unbounded scans that cannot finish inside a web request. Both the count preview and the actual resend failed for exactly the large senders who most need the feature, and the request died before `PostEmailBlast.create!`, so nothing was ever enqueued.

Fixes antiwork/gumroad-private#1264. Related history: the same audience-load query shape previously caused `ActiveRecord::StatementTimeout` in `SendPostBlastEmailsJob` (gumroad-private#1076 / #5862), which is why the job already had the raised-cap machinery this PR reuses.

## Before / After

Not applicable as screenshots — the degraded path only triggers when the count queries exceed 10 seconds, which requires a six-figure audience and can't be reproduced on a preview app. Behavior delta:

| | Before | After |
|---|---|---|
| Count preview, huge audience | Request times out, generic error alert | `count: null`, modal offers resend with "audience too large to preview an exact count" |
| Resend, huge audience | Request times out before blast creation, nothing sent | Blast created + job enqueued immediately, recipients resolved in the job under the raised statement cap |
| Resend, zero eligible | 422 with explanatory message | Blast created, job completes it with `delivery_count: 0` (no cap/throttle consumption) |
| Small audiences | unchanged | unchanged (count preview still shows the exact number) |

## QA steps

1. Open Emails → Published, pick a sent email, click "Resend to non-openers".
2. Confirm the modal still shows the exact count for a normal-size audience and the resend enqueues (toast: "Resending to everyone who hasn't opened this yet.").
3. Throttle/cap behavior unchanged: resending twice within 24h still 422s.

## Test Results

- `spec/controllers/api/internal/installments/non_opener_resends_controller_spec.rb` — updated: `#create` no longer 422s on zero-eligible (asserts blast creation + enqueue, and that no count methods run in-request); `#show` returns null count on query timeout.
- `spec/sidekiq/send_post_blast_emails_job_spec.rb` — new example asserting the unopened-email resolution runs under the raised statement cap; existing zero-eligible example already covers the job completing an empty blast.
- Local run blocked: the `purchase` factory's card charge fails identically on unmodified `origin/main` in this environment today (env issue, not this diff). CI will verify.
- Lint: rubocop clean on all touched Ruby files; prettier + eslint clean on both touched TS files.

## Screenshots (hosted preview app)

Captured on https://fix-non-opener-resend-async-coun.apps.staging.gumroad.org (seeded installment with 7 recipients / 2 openers; the "audience too large" state forced by temporarily setting the preview budget to 0 in the running container, then restored).

**Normal audience — modal still shows the exact count:**

![resend modal with exact count](https://raw.githubusercontent.com/antiwork/gumroad/677720990a2d54fcffba1f5b239018b8e432dde0/qa-media/pr-6192-modal-count.png)

**Degraded path — count queries exceed the budget, modal offers the resend without a number:**

![resend modal, count unavailable](https://raw.githubusercontent.com/antiwork/gumroad/677720990a2d54fcffba1f5b239018b8e432dde0/qa-media/pr-6192-modal-unavailable.png)

**After clicking Resend on the degraded path — blast created + job enqueued, count-free toast:**

![success toast without a count](https://raw.githubusercontent.com/antiwork/gumroad/677720990a2d54fcffba1f5b239018b8e432dde0/qa-media/pr-6192-resend-toast.png)

---

## AI disclosure

Authored by Claude Fable 5 (Hermes agent), triggered by the "Fix" directive on gumroad-private#1264. Instructions: fix the resend-to-non-openers timeout for large audiences by moving recipient computation out of the request path.

