### PR TITLE
Drive tax-period chargeback scopes off disputes to avoid a full purchases scan

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -707,6 +707,21 @@ class Purchase < ApplicationRecord
     }
   end
 
+  # Purchase ids whose Dispute recorded `date_column` (event_created_at for the chargeback
+  # debit leg, won_at for the reversal leg) inside [starts_at, ends_at], resolved through both
+  # the direct purchase link and the Charge link (multi-purchase carts). Driving the tax-period
+  # chargeback scopes off the small, date-indexed disputes table this way keeps them from
+  # full-scanning the very large purchases table by the unindexed chargeback_date — see
+  # chargebacks_for_tax_period_reporting. The daily/monthly windows hold at most a handful of
+  # disputes, so the resulting id list stays small.
+  def self.purchase_ids_for_disputes_in_window(date_column, starts_at, ends_at)
+    disputes = Dispute.where(date_column => starts_at..ends_at)
+    direct_ids = disputes.where.not(purchase_id: nil).pluck(:purchase_id)
+    charge_ids = disputes.where.not(charge_id: nil).pluck(:charge_id)
+    via_charge_ids = charge_ids.present? ? ChargePurchase.where(charge_id: charge_ids).pluck(:purchase_id) : []
+    (direct_ids + via_charge_ids).uniq
+  end
+
   # The sales-leg chargeback gate for the tax report jobs. Keeps, in addition to everything
   # not_chargedback_or_chargedback_reversed keeps, purchases whose chargeback is reported by
   # event date: those sales stay reported in the purchase's own period, and the chargeback is
@@ -723,32 +738,40 @@ class Purchase < ApplicationRecord
     )
   }
   # Purchases whose chargeback (debit) leg lands in [starts_at, ends_at]: event-dated
-  # chargebacks (see CHARGEBACK_EVENT_DATED_SQL) whose dispute event date —
-  # purchases.chargeback_date has always held the processor's dispute-formalized timestamp —
-  # falls inside the window.
+  # chargebacks (see CHARGEBACK_EVENT_DATED_SQL) whose dispute event date falls inside the
+  # window.
+  #
+  # We resolve the window through the disputes table rather than filtering purchases by
+  # purchases.chargeback_date directly: chargeback_date has no standalone index (only a
+  # seller_id-leading composite), so an all-sellers date range over it forces a full scan of
+  # the very large purchases table. chargeback_date mirrors the dispute's event_created_at
+  # (both are set from the same processor event when the dispute is formalized), so listing
+  # the disputes in the window and mapping them back to purchase ids yields the same set at a
+  # fraction of the cost. Any purchase the old chargeback_date predicate could return has a
+  # real charge — and therefore a Dispute row, its own or its Charge's for multi-item carts;
+  # the $0 gift/bundle child purchases that carry a chargeback_date without a Dispute row have
+  # no stripe_transaction_id and are excluded by every caller. The chargeback_date filter is
+  # kept as well so a purchase with several disputes is only selected when its own recorded
+  # chargeback_date is the one inside the window.
   scope :chargebacks_for_tax_period_reporting, lambda { |starts_at, ends_at|
-    where(chargeback_date: starts_at..ends_at)
+    where(id: purchase_ids_for_disputes_in_window(:event_created_at, starts_at, ends_at))
+      .where(chargeback_date: starts_at..ends_at)
       .where(CHARGEBACK_EVENT_DATED_SQL, **chargeback_event_dated_bind_params)
   }
   # Purchases whose chargeback-reversal (dispute won) leg lands in [starts_at, ends_at]:
   # event-dated chargebacks marked reversed, with a Dispute row — linked directly or through
   # the purchase's Charge (multi-purchase carts) — recording a won_at inside the window.
-  # EXISTS subqueries keep one row per purchase regardless of how many dispute rows match.
-  # Callers emitting per-row output should date the leg with
-  # purchase.chargeback_reversal_reporting_date (which also resolves which dispute row wins
-  # when there are several).
+  #
+  # Same reasoning as the debit scope above: drive off the disputes table's won_at (now
+  # indexed) instead of a correlated EXISTS over every purchase. This matches the old EXISTS
+  # exactly — it already required a Dispute row with won_at in the window — while turning the
+  # per-purchase subquery into one small, date-indexed lookup. Callers emitting per-row output
+  # still date the leg with purchase.chargeback_reversal_reporting_date, which also resolves
+  # which dispute row wins when a purchase has several.
   scope :chargeback_reversals_for_tax_period_reporting, lambda { |starts_at, ends_at|
-    where("purchases.chargeback_date >= ?", Purchase::Reportable::CHARGEBACK_REPORTING_CUTOVER.beginning_of_day)
+    where(id: purchase_ids_for_disputes_in_window(:won_at, starts_at, ends_at))
+      .where("purchases.chargeback_date >= ?", Purchase::Reportable::CHARGEBACK_REPORTING_CUTOVER.beginning_of_day)
       .where("purchases.flags & ? != 0", Purchase.flag_mapping["flags"][:chargeback_reversed])
-      .where(
-        "EXISTS (SELECT 1 FROM disputes WHERE disputes.purchase_id = purchases.id " \
-        "AND disputes.won_at BETWEEN :starts_at AND :ends_at) " \
-        "OR EXISTS (SELECT 1 FROM disputes INNER JOIN charge_purchases " \
-        "ON charge_purchases.charge_id = disputes.charge_id " \
-        "WHERE charge_purchases.purchase_id = purchases.id " \
-        "AND disputes.won_at BETWEEN :starts_at AND :ends_at)",
-        starts_at:, ends_at:
-      )
   }
   scope :not_additional_contribution, -> { where("purchases.flags IS NULL OR purchases.flags & ? = 0", Purchase.flag_mapping["flags"][:is_additional_contribution]) }
   scope :for_products, ->(products) { where(link_id: products) if products.present? }

--- a/db/migrate/20261206000006_add_tax_period_reporting_indexes_to_disputes.rb
+++ b/db/migrate/20261206000006_add_tax_period_reporting_indexes_to_disputes.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class AddTaxPeriodReportingIndexesToDisputes < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    # The tax-period chargeback scopes (Purchase.chargebacks_for_tax_period_reporting and
+    # .chargeback_reversals_for_tax_period_reporting, shared by every sales-tax report job)
+    # select one day's or month's charged-back purchases. They used to filter the very large
+    # purchases table by purchases.chargeback_date, which has no standalone index — only a
+    # seller_id-leading composite, unusable for an all-sellers date range — so MySQL fell back
+    # to a full table scan.
+    #
+    # The scopes now resolve those purchases through the much smaller disputes table instead:
+    # chargeback_date mirrors the dispute's event_created_at (both are set from the same
+    # processor event when the dispute is formalized), and reversals are dated by
+    # disputes.won_at. Those two columns were also only covered by seller_id-leading
+    # composites, so give each a standalone index to make the date-range lookup a fast range
+    # scan.
+    change_table :disputes, bulk: true do |t|
+      t.index :event_created_at, name: "index_disputes_on_event_created_at"
+      t.index :won_at, name: "index_disputes_on_won_at"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_12_06_000005) do
+ActiveRecord::Schema[7.1].define(version: 2026_12_06_000006) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -900,11 +900,13 @@ ActiveRecord::Schema[7.1].define(version: 2026_12_06_000005) do
     t.bigint "charge_id"
     t.datetime "formalized_side_effects_finished_at"
     t.index ["charge_id"], name: "index_disputes_on_charge_id"
+    t.index ["event_created_at"], name: "index_disputes_on_event_created_at"
     t.index ["purchase_id"], name: "index_disputes_on_purchase_id"
     t.index ["seller_id", "event_created_at"], name: "index_disputes_on_seller_id_and_event_created_at"
     t.index ["seller_id", "lost_at"], name: "index_disputes_on_seller_id_and_lost_at"
     t.index ["seller_id", "won_at"], name: "index_disputes_on_seller_id_and_won_at"
     t.index ["service_charge_id"], name: "index_disputes_on_service_charge_id"
+    t.index ["won_at"], name: "index_disputes_on_won_at"
   end
 
   create_table "dropbox_files", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/spec/models/concerns/purchase/reportable_spec.rb
+++ b/spec/models/concerns/purchase/reportable_spec.rb
@@ -372,19 +372,41 @@ describe "chargeback event-date reporting" do
 
   describe "Purchase.chargebacks_for_tax_period_reporting" do
     it "selects event-dated chargebacks whose event date falls in the window" do
+      # In production a chargeback_date is always mirrored by a Dispute row's event_created_at
+      # (both are set from the same processor event when the dispute is formalized), and the
+      # scope now resolves the window through disputes, so give each charged-back purchase its
+      # matching dispute — directly, or on its Charge for a multi-purchase cart.
       in_window = create(:purchase, chargeback_date: cutover + 5.days)
+      create(:dispute, purchase: in_window, event_created_at: cutover + 5.days)
+
+      charge_in_window = create(:purchase, chargeback_date: cutover + 6.days)
+      charge = create(:charge)
+      charge.purchases << charge_in_window
+      create(:dispute_on_charge, charge:, event_created_at: cutover + 6.days)
+
       after_window = create(:purchase, chargeback_date: cutover + 40.days)
+      create(:dispute, purchase: after_window, event_created_at: cutover + 40.days)
+
       legacy = create(:purchase, chargeback_date: cutover - 1.day)
+      create(:dispute, purchase: legacy, event_created_at: cutover - 1.day)
+
       undated_reversal = create(:purchase, chargeback_date: cutover + 5.days, chargeback_reversed: true)
+      create(:dispute, purchase: undated_reversal, event_created_at: cutover + 5.days)
+
       dated_reversal = create(:purchase, chargeback_date: cutover + 5.days, chargeback_reversed: true)
-      create(:dispute, purchase: dated_reversal, state: "won", won_at: cutover + 60.days)
+      create(:dispute, purchase: dated_reversal, state: "won", event_created_at: cutover + 5.days, won_at: cutover + 60.days)
+
+      # A chargeback_date carried without any Dispute row belongs only to the $0 gift/bundle
+      # child purchases, which every caller already excludes; the disputes-driven scope leaves
+      # it out (this is what the old chargeback_date-only scan would have wrongly included).
+      dispute_less = create(:purchase, chargeback_date: cutover + 5.days)
 
       result = Purchase.chargebacks_for_tax_period_reporting(cutover, cutover + 30.days)
 
       # The undated reversal emits no debit leg — with no real won_at its re-add leg could
       # never balance it, so it keeps the legacy treatment entirely.
-      expect(result).to include(in_window, dated_reversal)
-      expect(result).not_to include(after_window, legacy, undated_reversal)
+      expect(result).to include(in_window, charge_in_window, dated_reversal)
+      expect(result).not_to include(after_window, legacy, undated_reversal, dispute_less)
     end
   end
 

--- a/spec/sidekiq/create_canada_monthly_sales_report_job_spec.rb
+++ b/spec/sidekiq/create_canada_monthly_sales_report_job_spec.rb
@@ -244,7 +244,10 @@ describe CreateCanadaMonthlySalesReportJob do
 
       travel_to(@won_time) do
         @chargedback_purchase.update!(chargeback_reversed: true)
-        create(:dispute, purchase: @chargedback_purchase, state: "won", won_at: Time.current)
+        # One Dispute row carries both the formalization date (event_created_at, mirroring
+        # chargeback_date) and the win date (won_at); the tax-period scopes resolve each leg's
+        # window through it.
+        create(:dispute, purchase: @chargedback_purchase, state: "won", event_created_at: @event_time, won_at: Time.current)
       end
     end
 
@@ -313,6 +316,7 @@ describe CreateCanadaMonthlySalesReportJob do
                         total_transaction_cents: fully_refunded.total_transaction_cents)
       end
       fully_refunded.update!(chargeback_date: @event_time)
+      create(:dispute, purchase: fully_refunded, event_created_at: @event_time)
 
       payload = perform_and_read(@event_time.month, @event_time.year)
 

--- a/spec/sidekiq/create_global_sales_tax_summary_report_job_spec.rb
+++ b/spec/sidekiq/create_global_sales_tax_summary_report_job_spec.rb
@@ -265,7 +265,10 @@ describe CreateGlobalSalesTaxSummaryReportJob do
 
         travel_to(@won_time) do
           @chargedback_purchase.update!(chargeback_reversed: true)
-          create(:dispute, purchase: @chargedback_purchase, state: "won", won_at: Time.current)
+          # One Dispute row carries both the formalization date (event_created_at, mirroring
+          # chargeback_date) and the win date (won_at); the tax-period scopes resolve each
+          # leg's window through it.
+          create(:dispute, purchase: @chargedback_purchase, state: "won", event_created_at: @event_time, won_at: Time.current)
         end
       end
 

--- a/spec/sidekiq/create_india_sales_report_job_spec.rb
+++ b/spec/sidekiq/create_india_sales_report_job_spec.rb
@@ -462,7 +462,10 @@ describe CreateIndiaSalesReportJob do
 
         travel_to(@won_time) do
           @chargedback_purchase.update!(chargeback_reversed: true)
-          create(:dispute, purchase: @chargedback_purchase, state: "won", won_at: Time.current)
+          # One Dispute row carries both the formalization date (event_created_at, mirroring
+          # chargeback_date) and the win date (won_at); the tax-period scopes resolve each
+          # leg's window through it.
+          create(:dispute, purchase: @chargedback_purchase, state: "won", event_created_at: @event_time, won_at: Time.current)
         end
       end
 

--- a/spec/sidekiq/create_vat_report_job_spec.rb
+++ b/spec/sidekiq/create_vat_report_job_spec.rb
@@ -359,17 +359,24 @@ describe CreateVatReportJob do
       end
 
       @legacy_purchase.update!(chargeback_date: cutover - 10.days)
+      create(:dispute, purchase: @legacy_purchase, event_created_at: cutover - 10.days)
 
       travel_to(@event_quarter_time) do
         @event_dated_purchase.update!(chargeback_date: Time.current)
         @won_purchase.update!(chargeback_date: Time.current)
         @undated_reversal_purchase.update!(chargeback_date: Time.current, chargeback_reversed: true)
         @partially_refunded_purchase.update!(chargeback_date: Time.current)
+        # chargeback_date mirrors the dispute's event_created_at, so give each formalized
+        # chargeback its Dispute row — the tax-period scopes resolve the event quarter through
+        # them. @won_purchase's row is created in the won quarter below carrying both dates.
+        create(:dispute, purchase: @event_dated_purchase, event_created_at: Time.current)
+        create(:dispute, purchase: @undated_reversal_purchase, event_created_at: Time.current)
+        create(:dispute, purchase: @partially_refunded_purchase, event_created_at: Time.current)
       end
 
       travel_to(@won_quarter_time) do
         @won_purchase.update!(chargeback_reversed: true)
-        create(:dispute, purchase: @won_purchase, state: "won", won_at: Time.current)
+        create(:dispute, purchase: @won_purchase, state: "won", event_created_at: @event_quarter_time, won_at: Time.current)
       end
     end
 

--- a/spec/sidekiq/generate_canada_sales_report_job_spec.rb
+++ b/spec/sidekiq/generate_canada_sales_report_job_spec.rb
@@ -284,7 +284,10 @@ describe GenerateCanadaSalesReportJob do
 
       travel_to(@won_time) do
         @chargedback_purchase.update!(chargeback_reversed: true)
-        create(:dispute, purchase: @chargedback_purchase, state: "won", won_at: Time.current)
+        # One Dispute row carries both the formalization date (event_created_at, mirroring
+        # chargeback_date) and the win date (won_at); the tax-period scopes resolve each leg's
+        # window through it.
+        create(:dispute, purchase: @chargedback_purchase, state: "won", event_created_at: @event_time, won_at: Time.current)
       end
     end
 
@@ -350,6 +353,7 @@ describe GenerateCanadaSalesReportJob do
                         total_transaction_cents: fully_refunded.total_transaction_cents)
       end
       fully_refunded.update!(chargeback_date: @event_time)
+      create(:dispute, purchase: fully_refunded, event_created_at: @event_time)
 
       payload = perform_and_read(@event_time.month, @event_time.year)
 

--- a/spec/sidekiq/generate_fees_by_creator_location_report_job_spec.rb
+++ b/spec/sidekiq/generate_fees_by_creator_location_report_job_spec.rb
@@ -216,7 +216,10 @@ describe GenerateFeesByCreatorLocationReportJob do
 
       travel_to(@won_time) do
         @chargedback_purchase.update!(chargeback_reversed: true)
-        create(:dispute, purchase: @chargedback_purchase, state: "won", won_at: Time.current)
+        # One Dispute row carries both the formalization date (event_created_at, mirroring
+        # chargeback_date) and the win date (won_at); the tax-period scopes resolve each leg's
+        # window through it.
+        create(:dispute, purchase: @chargedback_purchase, state: "won", event_created_at: @event_time, won_at: Time.current)
       end
     end
 

--- a/spec/sidekiq/generate_sales_report_job_spec.rb
+++ b/spec/sidekiq/generate_sales_report_job_spec.rb
@@ -316,7 +316,10 @@ describe GenerateSalesReportJob do
 
       travel_to(@won_time) do
         @chargedback_purchase.update!(chargeback_reversed: true)
-        create(:dispute, purchase: @chargedback_purchase, state: "won", won_at: Time.current)
+        # One Dispute row carries both the formalization date (event_created_at, mirroring
+        # chargeback_date) and the win date (won_at); the tax-period scopes resolve each leg's
+        # window through it.
+        create(:dispute, purchase: @chargedback_purchase, state: "won", event_created_at: @event_time, won_at: Time.current)
       end
     end
 
@@ -383,6 +386,7 @@ describe GenerateSalesReportJob do
                         total_transaction_cents: fully_refunded.total_transaction_cents)
       end
       fully_refunded.update!(chargeback_date: @event_time)
+      create(:dispute, purchase: fully_refunded, event_created_at: @event_time)
 
       csv = perform_and_parse(@event_time.beginning_of_quarter, @event_time.end_of_quarter)
 

--- a/spec/sidekiq/upload_us_states_sales_tax_to_taxjar_job_spec.rb
+++ b/spec/sidekiq/upload_us_states_sales_tax_to_taxjar_job_spec.rb
@@ -304,6 +304,9 @@ describe UploadUsStatesSalesTaxToTaxjarJob do
     it "pushes a chargeback as a refund transaction dated by the dispute event date" do
       event_day = cutover + 5
       @purchase.update!(chargeback_date: event_day.to_time(:utc).change(hour: 12))
+      # chargeback_date mirrors the dispute's event_created_at in production; the tax-period
+      # scope resolves the window through disputes, so the purchase needs its Dispute row.
+      create(:dispute, purchase: @purchase, event_created_at: @purchase.chargeback_date)
 
       refund_kwargs = nil
       allow_any_instance_of(TaxjarApi).to receive(:create_refund_transaction) do |_instance, **kwargs|
@@ -337,6 +340,7 @@ describe UploadUsStatesSalesTaxToTaxjarJob do
       end
       event_day = cutover + 5
       @purchase.update!(chargeback_date: event_day.to_time(:utc).change(hour: 12))
+      create(:dispute, purchase: @purchase, event_created_at: @purchase.chargeback_date)
 
       refund_kwargs = nil
       allow_any_instance_of(TaxjarApi).to receive(:create_refund_transaction) do |_instance, **kwargs|
@@ -355,6 +359,9 @@ describe UploadUsStatesSalesTaxToTaxjarJob do
     it "does not push legs for pre-cutover chargebacks" do
       event_day = cutover - 5
       @purchase.update!(chargeback_date: event_day.to_time(:utc).change(hour: 12))
+      # A real Dispute row exists, but its event date is before the cutover, so the leg is
+      # still skipped — the exclusion comes from the cutover gate, not a missing dispute.
+      create(:dispute, purchase: @purchase, event_created_at: @purchase.chargeback_date)
       expect_any_instance_of(TaxjarApi).not_to receive(:create_refund_transaction)
       allow_any_instance_of(TaxjarApi).to receive(:create_order_transaction).and_return({})
 
@@ -364,6 +371,9 @@ describe UploadUsStatesSalesTaxToTaxjarJob do
     it "does not push legs for a reversed chargeback with no dispute row dating the win" do
       event_day = cutover + 5
       @purchase.update!(chargeback_date: event_day.to_time(:utc).change(hour: 12), chargeback_reversed: true)
+      # The formalization dispute exists (event date in the window) but records no won_at, so
+      # neither the debit leg (reversed with no win) nor the re-add leg (no reversal date) fires.
+      create(:dispute, purchase: @purchase, event_created_at: @purchase.chargeback_date)
       expect_any_instance_of(TaxjarApi).not_to receive(:create_refund_transaction)
       expect_any_instance_of(TaxjarApi).not_to receive(:create_order_transaction)
 


### PR DESCRIPTION
Fixes antiwork/gumroad-private#1257

## What

`Purchase.chargebacks_for_tax_period_reporting` and `Purchase.chargeback_reversals_for_tax_period_reporting` — the two scopes every sales-tax report job uses to pull a period's charged-back purchases — selected rows by filtering the `purchases` table on `chargeback_date`. That column has no standalone index (only a `seller_id`-leading composite), so an all-sellers date range over it made MySQL fall back to a **full table scan of `purchases`**. On the daily `UploadUsStatesSalesTaxToTaxjarJob` that scan blew past the statement timeout, so the day's US-state transactions never reached TaxJar; the same scan is a latent cost in the Canada, India, VAT, global-summary, fees, and sales report jobs that share these scopes.

This PR:

- Rewrites both scopes to resolve the window through the small `disputes` table instead of scanning `purchases` by `chargeback_date`.
- Adds standalone indexes on `disputes.event_created_at` and `disputes.won_at`.

## Why

`chargeback_date` mirrors the dispute's `event_created_at` (both are written from the same processor event when a dispute is formalized), and a reversal is dated by the dispute's `won_at`. So the purchases with a chargeback/reversal in a window can be found by listing the disputes in that window (now index-backed) and mapping them to purchase ids — directly, and through the `Charge` for multi-item carts — then filtering `purchases` by primary key.

The selection stays identical: every purchase the old `chargeback_date` predicate could return has a real charge and therefore a dispute row (its own, or its `Charge`'s). The only purchases that carry a `chargeback_date` without a dispute row are the $0 gift/bundle children, which have no `stripe_transaction_id` and were already excluded by every caller. The `chargeback_date` filter is kept alongside the id set so a purchase with several disputes is only picked up when its own recorded date falls in the window.

Alternatives considered:

- **Index `purchases.chargeback_date`** — not allowed; CONTRIBUTING forbids adding indexes to `users`/`purchases`.
- **Short-circuit the empty pre-cutover window** — stops the timeout today, but the full scan returns the moment the reporting cutover activates real rows, so it isn't a durable fix.
- **Drive off `disputes` (this PR)** — durable, fixes all six report jobs at once, and `disputes` is small so the extra lookup is cheap.

## Before / After

This is a backend/Sidekiq change with no UI surface, so there are no before/after screens. The observable change is the query plan:

- **Before:** `EXPLAIN` of the chargeback selection is a full table scan of `purchases` (`type: ALL`, no key used) → statement timeout on the daily upload.
- **After:** an indexed range scan of `disputes` (on `event_created_at` / `won_at`) plus primary-key lookups on `purchases`.

**QA steps (staging):** run `UploadUsStatesSalesTaxToTaxjarJob.new.perform("2026-07-21")` and confirm it completes without a `StatementTimeout` and logs the uploaded transaction counts. The upload is idempotent, so re-running any day is safe.

## Test Results

- `spec/models/concerns/purchase/reportable_spec.rb` — 31 examples, 0 failures. Covers both scopes: debit and reversal legs, the direct-purchase and `Charge` (multi-item cart) paths, the reporting cutover gate, and an undated reversal. Includes a new assertion that a `chargeback_date` with no dispute row is not selected — that assertion fails if this change is reverted.
- `spec/sidekiq/upload_us_states_sales_tax_to_taxjar_job_spec.rb` — 22 examples, 0 failures (the job in the incident, end to end).
- Canada, fees, India, Canada-monthly, and sales report-job chargeback specs — green.
- The global-summary and VAT specs use the same setup; they render a report email that needs a Vite build unavailable in my local environment (they fail identically on `main` for that reason), so they're covered here by the shared scope specs above and by CI.

Specs that simulate a chargeback by setting `chargeback_date` now also create the matching dispute, reflecting production.

---

AI disclosure: implemented with Claude Opus 4.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
