### PR TITLE
Record actual Stripe payment method type (UPI etc.) on purchases

### DIFF
--- a/app/business/payments/charging/base_processor_charge.rb
+++ b/app/business/payments/charging/base_processor_charge.rb
@@ -5,7 +5,13 @@ class BaseProcessorCharge
                 :card_fingerprint, :card_instance_id,
                 :card_last4, :card_number_length, :card_expiry_month, :card_expiry_year, :card_zip_code,
                 :card_type, :card_country, :zip_check_result,
-                :flow_of_funds, :risk_level, :card_mandate
+                :flow_of_funds, :risk_level, :card_mandate,
+                # The processor's own name for the payment method family ("card", "upi",
+                # "ideal", ...). Unlike card_type — which mixes card brands and non-card
+                # methods for display — this is the raw classification, recorded so
+                # payment-method volume can be measured from our database instead of by
+                # walking the processor's API. Only Stripe populates it today.
+                :payment_method_type
 
   # Public: Access attributes of BaseProcessorCharge via charge[:attribute].
   # Historically the code base used the Stripe::Charge object which

--- a/app/business/payments/charging/implementations/stripe/stripe_card_type.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_card_type.rb
@@ -19,7 +19,12 @@ class StripeCardType
     "jcb" => CardType::JCB,
     "diners" => CardType::DINERS_CLUB,
     "unionpay" => CardType::UNION_PAY,
-    "link" => CardType::LINK
+    "link" => CardType::LINK,
+    # Local bank-transfer methods (Stripe reports them in payment_method_details.type,
+    # never as a card brand). Mapping them here means a UPI or iDEAL charge records its
+    # real method instead of falling through to "generic_card".
+    "upi" => CardType::UPI,
+    "ideal" => CardType::IDEAL
   }.freeze
 
   def self.to_card_type(stripe_card_type)

--- a/app/business/payments/charging/implementations/stripe/stripe_charge.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge.rb
@@ -40,6 +40,9 @@ class StripeCharge < BaseProcessorCharge
       billing_details = stripe_charge[:billing_details]
       payment_card = payment_method_details[:card]
       self.card_instance_id = stripe_charge[:payment_method]
+      # Record Stripe's own classification of the method ("card", "upi", "ideal", ...) so
+      # non-card payment volume is measurable from our records without querying Stripe.
+      self.payment_method_type = payment_method_details[:type]
       # Inline non-card methods (e.g. Link on the client-confirmed path) carry no card block, so
       # record what the method exposes instead of dereferencing a nil card.
       if payment_card.nil?

--- a/app/business/payments/charging/implementations/stripe/stripe_chargeable_payment_method.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_chargeable_payment_method.rb
@@ -73,7 +73,15 @@ class StripeChargeablePaymentMethod
   end
 
   def card_type
-    StripeCardType.to_new_card_type(card[:brand]) if card.present? && card[:brand].present?
+    return StripeCardType.to_new_card_type(card[:brand]) if card.present? && card[:brand].present?
+
+    # Non-card methods (UPI, iDEAL, Link, ...) have no card block, which used to leave
+    # purchases.card_type nil and made their volume invisible in payment-method metrics.
+    # Record the method's own type instead, but only when it maps to a known CardType —
+    # an unrecognized method keeps the historical nil rather than leaking "generic_card".
+    method_type = payment_method&.type
+    mapped = StripeCardType.to_new_card_type(method_type) if method_type.present?
+    mapped unless mapped == CardType::UNKNOWN
   end
 
   def country
@@ -82,6 +90,12 @@ class StripeChargeablePaymentMethod
 
   def card
     @merchant_account&.is_a_stripe_connect_account? ? @payment_method_on_connect_account&.card : @payment_method&.card
+  end
+
+  # The Stripe::PaymentMethod backing this chargeable (fetched by #prepare!). Mirrors the
+  # connect-account selection in #card so both read the same object.
+  def payment_method
+    @merchant_account&.is_a_stripe_connect_account? ? @payment_method_on_connect_account : @payment_method
   end
 
   def reusable_token!(user)

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -3260,6 +3260,8 @@ class Purchase < ApplicationRecord
     self.was_zipcode_check_performed = !processor_charge.zip_check_result.nil?
     save!
 
+    record_stripe_payment_method_type(processor_charge)
+
     check_indian_card_mandate_was_registered(processor_charge)
 
     charge.update_charge_details_from_processor!(processor_charge) if charge.present?
@@ -3267,6 +3269,25 @@ class Purchase < ApplicationRecord
 
     load_flow_of_funds(processor_charge)
     true
+  end
+
+  # The purchase_payment_flows row is written at checkout time with a "card" placeholder,
+  # before the charge exists — at that point the server only knows the buyer paid through
+  # the Payment Element, not with which method. Once the processor tells us the real
+  # method family ("upi", "ideal", ...), correct the row so payment-method rollout
+  # metrics don't count every local method as a card. Observability only: never let a
+  # metrics correction break charge processing.
+  def record_stripe_payment_method_type(processor_charge)
+    return unless stripe_charge_processor?
+
+    method_type = processor_charge.payment_method_type
+    return if method_type.blank?
+    return if purchase_payment_flow.nil?
+    return if purchase_payment_flow.stripe_payment_method_type == method_type
+
+    purchase_payment_flow.update!(stripe_payment_method_type: method_type)
+  rescue => e
+    ErrorNotifier.notify(e, purchase: external_id)
   end
 
   # A charge that rebills a card the buyer saved earlier: subscription renewals and

--- a/app/presenters/receipt_presenter/payment_info.rb
+++ b/app/presenters/receipt_presenter/payment_info.rb
@@ -161,7 +161,9 @@ class ReceiptPresenter::PaymentInfo
 
     def credit_card_note
       return if orderable.card_type.blank?
-      return if orderable.card_type.in?([CardType::PAYPAL, CardType::LINK])
+      # Non-card methods: PayPal/Link wallets and local bank-transfer methods (UPI, iDEAL).
+      # None of them produce a credit card statement line, so the note would be wrong.
+      return if orderable.card_type.in?([CardType::PAYPAL, CardType::LINK, CardType::UPI, CardType::IDEAL])
 
       # TODO: Update when multiple charges per receipt are supported
       "The charge will be listed as GUMRD.COM* on your credit card statement."

--- a/app/services/exports/purchase_export_service.rb
+++ b/app/services/exports/purchase_export_service.rb
@@ -24,6 +24,16 @@ class Exports::PurchaseExportService
   ].freeze
   SYNCHRONOUS_EXPORT_THRESHOLD = 2_000
 
+  # Human-readable labels for the non-card payment methods stored in purchases.card_type.
+  # Anything not listed here (visa, mastercard, Link, ...) is charged as a card, so the
+  # export falls back to "Card". Without this, local bank-transfer methods like UPI and
+  # iDEAL would be mislabeled as card payments in creators' sales CSVs.
+  PAYMENT_TYPE_LABELS = {
+    CardType::PAYPAL => "PayPal",
+    CardType::UPI => "UPI",
+    CardType::IDEAL => "iDEAL",
+  }.freeze
+
   def initialize(purchases)
     @purchases = purchases
   end
@@ -181,7 +191,7 @@ class Exports::PurchaseExportService
         "License Key" => main_or_giftee_purchase&.license_key,
         "License Key Activation Count" => main_or_giftee_purchase&.license&.uses,
         "License Key Enabled?" => main_or_giftee_purchase&.license&.then { |l| l.disabled? ? 0 : 1 },
-        "Payment Type" => ((purchase.card_type == "paypal" ? "PayPal" : "Card") if purchase.card_type.present?),
+        "Payment Type" => payment_type_label(purchase.card_type),
         "PayPal Transaction ID" => (purchase.stripe_transaction_id if purchase.paypal_order_id?),
         "PayPal Fee Amount" => (purchase.processor_fee_dollars if purchase.paypal_order_id?),
         "PayPal Fee Currency" => (purchase.processor_fee_cents_currency if purchase.paypal_order_id?),
@@ -201,6 +211,11 @@ class Exports::PurchaseExportService
       raise "This data is not JSON safe: #{data.inspect}" if !Rails.env.production? && !data.eql?(JSON.load(JSON.dump(data)))
 
       [data, custom_fields_data]
+    end
+
+    def payment_type_label(card_type)
+      return if card_type.blank?
+      PAYMENT_TYPE_LABELS.fetch(card_type, "Card")
     end
 
     def pseudo_transliterate(string)

--- a/lib/utilities/card_type.rb
+++ b/lib/utilities/card_type.rb
@@ -13,4 +13,10 @@ class CardType
   # Stripe Link is a wallet, not a card network; mirrors the PAYPAL precedent for
   # non-card payment methods surfaced through card_type.
   LINK = "link"
+  # Local bank-transfer methods offered through Stripe's Payment Element (UPI in India,
+  # iDEAL in the Netherlands). Like PAYPAL and LINK above, these are not card networks,
+  # but recording the method here keeps every purchase's payment method queryable from
+  # the database instead of requiring a walk of Stripe's API to classify them.
+  UPI = "upi"
+  IDEAL = "ideal"
 end

--- a/spec/business/payments/charging/implementations/stripe/stripe_charge_spec.rb
+++ b/spec/business/payments/charging/implementations/stripe/stripe_charge_spec.rb
@@ -167,6 +167,73 @@ describe StripeCharge, :vcr do
       end
     end
 
+    describe "with a stripe charge paid with a local bank-transfer method (UPI)" do
+      let(:stripe_charge_hash) do
+        {
+          id: "ch_test_upi",
+          status: "succeeded",
+          refunded: false,
+          dispute: nil,
+          currency: "inr",
+          amount: 100_00,
+          payment_method_details: { type: "upi", upi: { vpa: "buyer@upi" } },
+          billing_details: { address: { postal_code: nil } },
+          payment_method: "pm_test_upi",
+          outcome: { risk_level: "normal" },
+        }
+      end
+
+      let(:stripe_charge_balance_transaction) do
+        {
+          currency: "inr",
+          amount: 100_00,
+          fee_details: [{ type: "stripe_fee", currency: "inr", amount: 3_00 }],
+        }
+      end
+
+      let(:subject) { described_class.new(Stripe::Charge.construct_from(stripe_charge_hash), stripe_charge_balance_transaction, nil, nil, nil) }
+
+      it "records the real method type instead of a generic card" do
+        expect(subject.card_type).to eq(CardType::UPI)
+        expect(subject.payment_method_type).to eq("upi")
+        expect(subject.card_instance_id).to eq("pm_test_upi")
+        expect(subject.card_last4).to be_nil
+        expect(subject.card_fingerprint).to eq("pm_test_upi")
+      end
+    end
+
+    describe "with a stripe charge paid with iDEAL" do
+      let(:stripe_charge_hash) do
+        {
+          id: "ch_test_ideal",
+          status: "succeeded",
+          refunded: false,
+          dispute: nil,
+          currency: "eur",
+          amount: 10_00,
+          payment_method_details: { type: "ideal", ideal: { bank: "ing" } },
+          billing_details: { address: { postal_code: "1011" } },
+          payment_method: "pm_test_ideal",
+          outcome: { risk_level: "normal" },
+        }
+      end
+
+      let(:stripe_charge_balance_transaction) do
+        {
+          currency: "eur",
+          amount: 10_00,
+          fee_details: [{ type: "stripe_fee", currency: "eur", amount: 30 }],
+        }
+      end
+
+      let(:subject) { described_class.new(Stripe::Charge.construct_from(stripe_charge_hash), stripe_charge_balance_transaction, nil, nil, nil) }
+
+      it "records the real method type instead of a generic card" do
+        expect(subject.card_type).to eq(CardType::IDEAL)
+        expect(subject.payment_method_type).to eq("ideal")
+      end
+    end
+
     describe "with a destination charge but nil destination payment balance transaction" do
       let(:stripe_charge_hash) do
         {

--- a/spec/business/payments/charging/implementations/stripe/stripe_chargeable_payment_method_spec.rb
+++ b/spec/business/payments/charging/implementations/stripe/stripe_chargeable_payment_method_spec.rb
@@ -66,6 +66,44 @@ describe StripeChargeablePaymentMethod, :vcr do
     end
   end
 
+  describe "#card_type" do
+    context "with a non-card payment method (UPI)" do
+      let(:payment_method_id) { "pm_test_upi" }
+      let(:stripe_payment_method_object) do
+        OpenStruct.new(id: payment_method_id, type: "upi", customer: nil, card: nil,
+                       billing_details: { address: { postal_code: nil } })
+      end
+      let(:chargeable) { StripeChargeablePaymentMethod.new(payment_method_id, zip_code: nil, product_permalink: "xx") }
+
+      before do
+        allow(Stripe::PaymentMethod).to receive(:retrieve).with(payment_method_id).and_return(stripe_payment_method_object)
+      end
+
+      it "records the method's own type instead of leaving card_type nil" do
+        chargeable.prepare!
+        expect(chargeable.card_type).to eq(CardType::UPI)
+      end
+    end
+
+    context "with a non-card payment method Gumroad does not recognize" do
+      let(:payment_method_id) { "pm_test_other" }
+      let(:stripe_payment_method_object) do
+        OpenStruct.new(id: payment_method_id, type: "some_future_method", customer: nil, card: nil,
+                       billing_details: { address: { postal_code: nil } })
+      end
+      let(:chargeable) { StripeChargeablePaymentMethod.new(payment_method_id, zip_code: nil, product_permalink: "xx") }
+
+      before do
+        allow(Stripe::PaymentMethod).to receive(:retrieve).with(payment_method_id).and_return(stripe_payment_method_object)
+      end
+
+      it "keeps the historical nil rather than recording generic_card" do
+        chargeable.prepare!
+        expect(chargeable.card_type).to be_nil
+      end
+    end
+  end
+
   describe "#stripe_charge_params" do
     it "returns the original customer and payment method details if merchant account is not a stripe connect account" do
       allow_any_instance_of(StripeChargeablePaymentMethod).to receive(:get_merchant_account).and_return(create(:merchant_account))

--- a/spec/models/purchase_payment_flow_spec.rb
+++ b/spec/models/purchase_payment_flow_spec.rb
@@ -153,4 +153,48 @@ describe PurchasePaymentFlow do
       expect(described_class.attributes_for_checkout_params(payment_details_source: "payment_element", confirmation_token: "ctoken_123", paypal_order_id: "PAY-123")).to be_nil
     end
   end
+
+  # The row is created with a "card" placeholder before the charge exists; the real method
+  # type is corrected from the processor charge in Purchase#save_charge_data.
+  describe "correcting stripe_payment_method_type from the processor charge" do
+    let(:purchase) { create(:purchase, charge_processor_id: StripeChargeProcessor.charge_processor_id) }
+    let!(:flow) { create(:purchase_payment_flow, purchase:) }
+
+    def processor_charge(payment_method_type)
+      charge = StripeCharge.new(nil, nil, nil, nil, nil)
+      charge.payment_method_type = payment_method_type
+      charge
+    end
+
+    it "rewrites the placeholder when the charge was paid with a local method" do
+      purchase.send(:record_stripe_payment_method_type, processor_charge("upi"))
+      expect(flow.reload.stripe_payment_method_type).to eq("upi")
+    end
+
+    it "leaves the row untouched for a card charge" do
+      expect do
+        purchase.send(:record_stripe_payment_method_type, processor_charge("card"))
+      end.not_to change { flow.reload.updated_at }
+    end
+
+    it "is a no-op when the charge does not report a method type" do
+      purchase.send(:record_stripe_payment_method_type, processor_charge(nil))
+      expect(flow.reload.stripe_payment_method_type).to eq("card")
+    end
+
+    it "is a no-op when the purchase has no payment flow row" do
+      purchase_without_flow = create(:purchase, charge_processor_id: StripeChargeProcessor.charge_processor_id)
+      expect do
+        purchase_without_flow.send(:record_stripe_payment_method_type, processor_charge("upi"))
+      end.not_to raise_error
+    end
+
+    it "never lets a failure break charge processing" do
+      allow(purchase.purchase_payment_flow).to receive(:update!).and_raise(ActiveRecord::StatementInvalid)
+      expect(ErrorNotifier).to receive(:notify)
+      expect do
+        purchase.send(:record_stripe_payment_method_type, processor_charge("upi"))
+      end.not_to raise_error
+    end
+  end
 end

--- a/spec/services/exports/purchase_export_service_spec.rb
+++ b/spec/services/exports/purchase_export_service_spec.rb
@@ -400,6 +400,12 @@ describe Exports::PurchaseExportService do
       @purchase.update!(card_type: "mastercard")
       expect(field_value(last_data_row, "Payment Type")).to eq("Card")
 
+      @purchase.update!(card_type: "upi")
+      expect(field_value(last_data_row, "Payment Type")).to eq("UPI")
+
+      @purchase.update!(card_type: "ideal")
+      expect(field_value(last_data_row, "Payment Type")).to eq("iDEAL")
+
       @purchase.update!(card_type: nil)
       expect(field_value(last_data_row, "Payment Type")).to eq(nil)
     end


### PR DESCRIPTION
## Summary

UPI purchases are invisible in payment-method metrics. Verified in production today (first day of UPI, launched via #6174):

- `purchases.card_type` ends up **nil** for UPI charges — the card_type derivation only handled `payment_method_details.card` brands (plus Link), so local bank-transfer methods fell through.
- `purchase_payment_flows.stripe_payment_method_type` recorded **0 upi rows** — the row is written at checkout time with a hardcoded `"card"` placeholder, before the charge exists.

Measuring today's UPI GMV required walking Stripe PaymentIntents directly and classifying by `payment_method_details.type == "upi"`. iDEAL will have the same gap when it launches.

## What this does

Metrics/recording only — no behavior change to charging, receipts content, or risk.

1. **`CardType::UPI` / `CardType::IDEAL`** added (precedent: `paypal`, `link` for non-card methods surfaced through `card_type`), and mapped in `StripeCardType::NEW_CARD_TYPES`.
2. **`StripeChargeablePaymentMethod#card_type`** falls back to the PaymentMethod's own `type` when there is no card block — but only for types that map to a known `CardType`, so an unrecognized future method keeps the historical `nil` instead of leaking `generic_card`. This covers the server-confirm lane (`purchases.card_type` is copied from the chargeable in `prepare_for_charge!`).
3. **`StripeCharge#payment_method_type`** now records the raw `payment_method_details.type` (`"card"`, `"upi"`, `"ideal"`, ...). `StripeCharge#card_type` already handled the non-card path via the Link fix; UPI/iDEAL now map to their own types instead of `generic_card`. This covers the client-confirm lane (`Purchase::FinalizeConfirmedChargeService` copies `processor_charge.card_type`).
4. **`Purchase#save_charge_data`** corrects the `purchase_payment_flows.stripe_payment_method_type` placeholder from the processor charge once the real method is known. Wrapped in a rescue + `ErrorNotifier` so a metrics correction can never break charge processing.
5. **Receipt statement-descriptor note**: the "charge will be listed as GUMRD.COM* on your credit card statement" note now skips UPI/iDEAL the same way it skips PayPal/Link — no card statement exists for these methods.

After this, UPI volume is queryable directly:

```sql
SELECT COUNT(*), SUM(price_cents) FROM purchases WHERE card_type = 'upi' AND purchase_state = 'successful';
```

## Consumer audit (card_type consumers checked)

- **Receipts** (`ReceiptPresenter::PaymentInfo`): renders `card_type.upcase` without a visual for non-card methods (Link precedent) → UPI renders as "UPI", correct. Statement-descriptor note fixed here (see above).
- **Sales CSV export** (`purchase_export_service.rb`): `"Payment Type"` previously mapped `paypal → "PayPal"` and everything else with a card_type → `"Card"`, which would have mislabeled UPI/iDEAL as card payments. Fixed in this PR: the column now maps through a label lookup (`upi → "UPI"`, `ideal → "iDEAL"`, `paypal → "PayPal"`, card networks → `"Card"`), with spec coverage.
- **Searchable / risk**: `card_type == CardType::PAYPAL` comparisons only; no whitelist that breaks on a new value. No risk rules key off card_type values.
- **Subscription card-decline emails** (`customer_low_priority_mailer`): renders `CARD_TYPE *last4` only when both card_type **and** card_visual are present; UPI has no visual → unchanged.
- **JS `CreditCardType` union** (`parsers/card.ts`): only used for saved credit cards; UPI payment methods are not saveable as credit cards, so no sync needed (same as `link`, which is also absent there).

## QA steps

1. Checkout a product in the forced-INR lane with Stripe test UPI (per #6174 QA flow).
2. After the charge succeeds: `purchase.card_type` → `"upi"`, `purchase.purchase_payment_flow.stripe_payment_method_type` → `"upi"`.
3. Card checkout regression: `purchase.card_type` still `"visa"` / `"mastercard"`, flow row stays `"card"`.
4. Receipt for the UPI purchase shows "Payment method: UPI" and no "GUMRD.COM* on your credit card statement" note.

## Test results

```
bundle exec rspec spec/models/purchase_payment_flow_spec.rb \
  spec/business/payments/charging/implementations/stripe/stripe_charge_spec.rb
69 examples, 0 failures

bundle exec rspec spec/business/payments/charging/implementations/stripe/stripe_chargeable_payment_method_spec.rb \
  spec/presenters/receipt_presenter/payment_info_spec.rb
135 examples, 0 failures

bundle exec rspec spec/services/purchase/finalize_confirmed_charge_service_spec.rb \
  spec/lib/utilities/credit_card_utility_spec.rb
8 examples, 0 failures

bundle exec rspec spec/services/purchase/create_service_spec.rb
230 examples, 4 failures — all 4 are the known ViteRuby manifest issue in fresh
worktrees (email entrypoint resolution), unrelated to this change.
```

Rubocop: all touched files pass, no offenses.

Follow-up (Greptile review fix): `rspec spec/services/exports/purchase_export_service_spec.rb -e "includes payment type"` — 1 example, 0 failures (covers PayPal/Card/UPI/iDEAL/nil).

New specs: UPI + iDEAL stubbed Stripe charges → `card_type` == `upi`/`ideal` and `payment_method_type` recorded; card charges keep brand extraction (existing specs); unrecognized non-card method keeps nil card_type; flow-row correction covered for upi/card/nil/missing-row/failure cases.

🤖 Generated with claude-fable-5 via Hermes agent (gumclaw)

