### PR TITLE
Skip SSL cert orders for custom domains that don't resolve to Gumroad (#6184)

### DIFF
--- a/app/services/custom_domain_verification_service.rb
+++ b/app/services/custom_domain_verification_service.rb
@@ -42,6 +42,26 @@ class CustomDomainVerificationService
     pointed_domains
   end
 
+  # Variants whose A records actually resolve to Gumroad — i.e. the addresses a
+  # Let's Encrypt HTTP-01 challenge will connect to. This is stricter than
+  # #domains_pointed_to_gumroad, which also accepts a name that merely carries a
+  # CNAME *record* pointing at CUSTOM_DOMAIN_CNAME even when the name's A record
+  # resolves somewhere else — e.g. a lapsed apex now served by a registrar
+  # parking page while a stale CNAME record lingers in the zone. Ordering a
+  # certificate for such a name makes ACME validation fail every time, and
+  # repeated failures get Let's Encrypt to pause the whole account for those
+  # hostnames (issue #6184). Only certificate ordering uses this; domain
+  # verification deliberately keeps the lenient CNAME-or-ALIAS check so that
+  # transient DNS blips don't flap a seller's domain to unverified.
+  def domains_resolving_to_gumroad
+    @_domains_resolving_to_gumroad ||= domains_pointed_to_gumroad.select do |domain_variant|
+      alias_is_setup_correctly?(domain_variant)
+    rescue => e
+      Rails.logger.info("ALIAS resolution check error for custom domain '#{domain}' (variant '#{domain_variant}'). Error: #{e.inspect}")
+      false
+    end
+  end
+
   def has_valid_ssl_certificates?
     domains_pointed_to_gumroad.all? do |domain|
       ssl_cert_check_redis_namespace.get(ssl_cert_check_cache_key(domain)) || has_valid_ssl_certificate?(domain)

--- a/app/services/ssl_certificates/generate.rb
+++ b/app/services/ssl_certificates/generate.rb
@@ -27,10 +27,14 @@ module SslCertificates
       attr_reader :domain_verification_service
 
       def order_certificates
-        domains_pointed_to_gumroad = domain_verification_service.domains_pointed_to_gumroad
+        # Only order for names whose DNS actually resolves to Gumroad. A name
+        # that merely carries a stale CNAME record but resolves elsewhere would
+        # fail ACME validation every time, and repeated failures get Let's
+        # Encrypt to pause the whole account (issue #6184).
+        resolving_domains = domain_verification_service.domains_resolving_to_gumroad
 
         all_certificates_generated = true
-        domains_pointed_to_gumroad.each do |domain|
+        resolving_domains.each do |domain|
           # `&=` will set all_certificates_generated to false if generate_certificate()
           # returns false for any of the domains.
           all_certificates_generated &= generate_certificate(domain)
@@ -38,7 +42,7 @@ module SslCertificates
 
         if all_certificates_generated
           custom_domain.set_ssl_certificate_issued_at!
-          domains_pointed_to_gumroad.each { |domain| log_message(domain, "Issued SSL certificate.") }
+          resolving_domains.each { |domain| log_message(domain, "Issued SSL certificate.") }
         else
           # Reset ssl_certificate_issued_at
           custom_domain.reset_ssl_certificate_issued_at!
@@ -70,10 +74,10 @@ module SslCertificates
         return false, "Invalid domain" unless custom_domain.valid?
 
         Rails.cache.fetch(domain_check_cache_key, expires_in: invalid_domain_cache_expires_in) do
-          if domain_verification_service.points_to_gumroad?
+          if domain_verification_service.domains_resolving_to_gumroad.any?
             return true
           else
-            return false, "No domains pointed to Gumroad"
+            return false, "No domains resolve to Gumroad"
           end
         end
       end

--- a/spec/services/custom_domain_verification_service_spec.rb
+++ b/spec/services/custom_domain_verification_service_spec.rb
@@ -118,6 +118,73 @@ describe CustomDomainVerificationService do
     end
   end
 
+  # Issue #6184: #domains_pointed_to_gumroad accepts a name that merely carries
+  # a CNAME record to CUSTOM_DOMAIN_CNAME, even when the name's A record now
+  # resolves to a registrar parking page (a lapsed apex with a stale CNAME).
+  # #domains_resolving_to_gumroad is the stricter list used for certificate
+  # ordering: only names whose A record actually resolves to Gumroad, matching
+  # what a Let's Encrypt HTTP-01 challenge connects to.
+  describe "#domains_resolving_to_gumroad" do
+    before(:each) do
+      # Both the apex and the www variant advertise a CNAME record to
+      # CUSTOM_DOMAIN_CNAME, so #domains_pointed_to_gumroad returns both.
+      allow_any_instance_of(Resolv::DNS)
+        .to receive(:getresources)
+        .with(anything, Resolv::DNS::Resource::IN::CNAME)
+        .and_return([double(name: CUSTOM_DOMAIN_CNAME)])
+
+      allow_any_instance_of(Resolv::DNS)
+        .to receive(:getresources)
+        .with(CUSTOM_DOMAIN_CNAME, Resolv::DNS::Resource::IN::A)
+        .and_return([double(address: "100.0.0.1"), double(address: "100.0.0.2")])
+
+      allow_any_instance_of(Resolv::DNS)
+        .to receive(:getresources)
+        .with(CUSTOM_DOMAIN_STATIC_IP_HOST, Resolv::DNS::Resource::IN::A)
+        .and_return([double(address: "100.0.0.10"), double(address: "100.0.0.20")])
+    end
+
+    context "when only the www variant resolves to Gumroad" do
+      before do
+        # Lapsed apex now resolves to a registrar parking page...
+        allow_any_instance_of(Resolv::DNS)
+          .to receive(:getresources)
+          .with("example.com", Resolv::DNS::Resource::IN::A)
+          .and_return([double(address: "162.0.0.9")])
+
+        # ...while www still resolves to Gumroad.
+        allow_any_instance_of(Resolv::DNS)
+          .to receive(:getresources)
+          .with("www.example.com", Resolv::DNS::Resource::IN::A)
+          .and_return([double(address: "100.0.0.1"), double(address: "100.0.0.2")])
+      end
+
+      it "returns only the variant whose A record resolves to Gumroad" do
+        expect(service.domains_pointed_to_gumroad).to eq ["example.com", "www.example.com"]
+        expect(service.domains_resolving_to_gumroad).to eq ["www.example.com"]
+      end
+    end
+
+    context "when no variant resolves to Gumroad despite a CNAME record" do
+      before do
+        allow_any_instance_of(Resolv::DNS)
+          .to receive(:getresources)
+          .with("example.com", Resolv::DNS::Resource::IN::A)
+          .and_return([double(address: "162.0.0.9")])
+
+        allow_any_instance_of(Resolv::DNS)
+          .to receive(:getresources)
+          .with("www.example.com", Resolv::DNS::Resource::IN::A)
+          .and_return([double(address: "162.0.0.9")])
+      end
+
+      it "returns an empty array" do
+        expect(service.domains_pointed_to_gumroad).to eq ["example.com", "www.example.com"]
+        expect(service.domains_resolving_to_gumroad).to eq []
+      end
+    end
+  end
+
   describe "#has_valid_ssl_certificates?" do
     before(:each) do
       allow_any_instance_of(Resolv::DNS)

--- a/spec/services/ssl_certificates/generate_spec.rb
+++ b/spec/services/ssl_certificates/generate_spec.rb
@@ -99,14 +99,13 @@ describe SslCertificates::Generate do
       end
     end
 
-    describe "CNAME/ALIAS check" do
+    describe "DNS resolution check" do
       before do
-        allow_any_instance_of(CustomDomain).to receive(:cname_is_setup_correctly?).and_return(false)
-        allow_any_instance_of(CustomDomain).to receive(:alias_is_setup_correctly?).and_return(false)
+        allow_any_instance_of(CustomDomainVerificationService).to receive(:domains_resolving_to_gumroad).and_return([])
       end
 
-      it "returns false when no domains are pointed to Gumroad" do
-        expect(@obj.send(:can_order_certificates?)).to eq [false, "No domains pointed to Gumroad"]
+      it "returns false when no domains resolve to Gumroad" do
+        expect(@obj.send(:can_order_certificates?)).to eq [false, "No domains resolve to Gumroad"]
       end
     end
   end
@@ -145,17 +144,17 @@ describe SslCertificates::Generate do
 
     context "when the certificate is successfully created" do
       before do
-        @domains_pointed_to_gumroad = ["example.com", "www.example.com"]
+        @resolving_domains = ["example.com", "www.example.com"]
         allow(@obj).to receive(:can_order_certificates?).and_return(true)
-        allow_any_instance_of(CustomDomainVerificationService).to receive(:domains_pointed_to_gumroad).and_return(@domains_pointed_to_gumroad)
+        allow_any_instance_of(CustomDomainVerificationService).to receive(:domains_resolving_to_gumroad).and_return(@resolving_domains)
 
-        @domains_pointed_to_gumroad.each do |domain|
+        @resolving_domains.each do |domain|
           allow(@obj).to receive(:generate_certificate).with(domain).and_return(true)
         end
       end
 
       it "set ssl_certificate_issued_at and logs a message" do
-        @domains_pointed_to_gumroad.each do |domain|
+        @resolving_domains.each do |domain|
           expect(@obj).to receive(:generate_certificate).with(domain)
           expect(@obj).to receive(:log_message).with(domain, "Issued SSL certificate.")
         end
@@ -173,7 +172,7 @@ describe SslCertificates::Generate do
       before do
         allow_any_instance_of(described_class).to receive(:can_order_certificates?).and_return(true)
         allow_any_instance_of(described_class).to receive(:generate_certificate).and_return(false)
-        allow_any_instance_of(CustomDomainVerificationService).to receive(:domains_pointed_to_gumroad).and_return([@custom_domain.domain])
+        allow_any_instance_of(CustomDomainVerificationService).to receive(:domains_resolving_to_gumroad).and_return([@custom_domain.domain])
 
         @custom_domain.set_ssl_certificate_issued_at!
       end
@@ -188,6 +187,70 @@ describe SslCertificates::Generate do
         @obj.process
 
         expect(@custom_domain.reload.ssl_certificate_issued_at).to be_nil
+      end
+    end
+
+    # Regression for issue #6184: a lapsed apex can keep a CNAME record pointing
+    # at CUSTOM_DOMAIN_CNAME while its A record now resolves to a registrar
+    # parking page. Such a name passes the lenient CNAME check but fails ACME
+    # validation every time, and repeated failures get Let's Encrypt to pause
+    # the whole account for those hostnames — so ordering must skip any variant
+    # that doesn't actually resolve to Gumroad.
+    context "when a variant only carries a stale CNAME record and no longer resolves to Gumroad" do
+      let(:custom_domain) { create(:custom_domain, domain: "cook-example.com") }
+      let(:obj) { described_class.new(custom_domain) }
+
+      let(:gumroad_ips) { ["100.0.0.1", "100.0.0.2", "100.0.0.3"] }
+      let(:static_ips)  { ["100.0.0.10", "100.0.0.20"] }
+      let(:parking_ips) { ["162.0.0.9"] }
+
+      def stub_a_record(host, ips)
+        allow_any_instance_of(Resolv::DNS)
+          .to receive(:getresources)
+          .with(host, Resolv::DNS::Resource::IN::A)
+          .and_return(ips.map { |ip| double(address: ip) })
+      end
+
+      before do
+        # Both apex and www advertise a CNAME record to CUSTOM_DOMAIN_CNAME, so
+        # the lenient #domains_pointed_to_gumroad returns both.
+        allow_any_instance_of(Resolv::DNS)
+          .to receive(:getresources)
+          .with(anything, Resolv::DNS::Resource::IN::CNAME)
+          .and_return([double(name: CUSTOM_DOMAIN_CNAME)])
+
+        stub_a_record(CUSTOM_DOMAIN_CNAME, gumroad_ips)
+        stub_a_record(CUSTOM_DOMAIN_STATIC_IP_HOST, static_ips)
+      end
+
+      context "when only the www variant resolves to Gumroad" do
+        before do
+          stub_a_record("cook-example.com", parking_ips)     # lapsed apex -> parking page
+          stub_a_record("www.cook-example.com", gumroad_ips) # www still points at us
+        end
+
+        it "orders a certificate only for the resolving variant" do
+          expect(obj).to receive(:generate_certificate).with("www.cook-example.com").and_return(true)
+          expect(obj).not_to receive(:generate_certificate).with("cook-example.com")
+
+          obj.process
+
+          expect(custom_domain.reload.ssl_certificate_issued_at).to be_present
+        end
+      end
+
+      context "when neither variant resolves to Gumroad" do
+        before do
+          stub_a_record("cook-example.com", parking_ips)
+          stub_a_record("www.cook-example.com", parking_ips)
+        end
+
+        it "orders no certificate and reports that no domains resolve to Gumroad" do
+          expect(obj).not_to receive(:generate_certificate)
+          expect(obj).to receive(:log_message).with("cook-example.com", "No domains resolve to Gumroad")
+
+          obj.process
+        end
       end
     end
   end


### PR DESCRIPTION
## What

`GenerateSslCertificate` no longer orders a Let's Encrypt certificate for a custom-domain hostname that doesn't actually resolve to Gumroad.

- New `CustomDomainVerificationService#domains_resolving_to_gumroad` returns only the variants whose **A records resolve to Gumroad** (reusing the existing ALIAS/A-record check) — i.e. the addresses an ACME HTTP-01 challenge will connect to.
- `SslCertificates::Generate` uses that stricter list for both the "can we order?" gate and the ordering loop. When nothing resolves, it logs `No domains resolve to Gumroad` and orders nothing.
- Domain **verification** is deliberately left on the existing lenient CNAME-or-ALIAS check, so a transient DNS blip can't flap a seller's domain to `unverified`.

## Why

Closes #6184.

`domains_pointed_to_gumroad` treats a hostname as "pointed to Gumroad" when a CNAME **record** equal to `domains.gumroad.com` merely exists in the zone — it never confirms the name actually resolves to us. When a custom domain's apex lapses to a registrar parking page but leaves a stale CNAME record behind, the hostname keeps passing that check, so the hourly renewal cron keeps ordering a certificate for it. Its ACME HTTP-01 validation lands on the parking page and fails every single time.

Let's Encrypt [pauses the whole ACME account](https://letsencrypt.org/2025/01/30/scaling-rate-limits/) after an identifier repeatedly fails validation. That pause then blocks certificate issuance for **healthy** domains on the same account and fires the #488 "SSL certificate not provisioned" alert (Sentry GUMROAD-VW) on a loop, with no way to self-resolve until the account is manually unpaused.

The two prior mitigations addressed adjacent symptoms — #5997 reschedules on the transient account-wide *order* rate limit, and #6054 rejects malformed domain labels — but neither stops us from ordering certificates for domains that can't pass validation. This PR removes that root cause: we only ask Let's Encrypt for certificates we can actually validate, so the account stops getting paused.

**Why gate on resolution rather than the CNAME record:** an HTTP-01 challenge is validated against the hostname's resolved A/AAAA addresses, not against the presence of a CNAME record. The existing ALIAS check already compares a hostname's resolved A records to Gumroad's, so it's exactly the right signal and requires no new DNS machinery. Scoping the stricter check to the ordering path (not verification) keeps the blast radius minimal.

## Before / After

Backend Sidekiq/DNS change only — no user-facing surface, so there's no UI before/after to record (same as the adjacent SSL PRs #5997 and #6054). Behavior change:

- **Before:** a parked apex with a leftover CNAME record → certificate ordered → ACME validation fails hourly → account paused → healthy domains can't renew + alert storm.
- **After:** that hostname is skipped (`No domains resolve to Gumroad`); hostnames that genuinely resolve to Gumroad are still ordered normally.

## Test Results

New specs (all red/green verified — they fail when the ordering change is reverted):

- `CustomDomainVerificationService#domains_resolving_to_gumroad` — returns only the variant whose A record resolves to Gumroad when the other only carries a stale CNAME record; returns `[]` when no variant resolves despite a CNAME record.
- `SslCertificates::Generate#process` — orders a certificate only for the resolving variant; orders nothing and reports `No domains resolve to Gumroad` when neither variant resolves.

```
$ bundle exec rspec spec/services/ssl_certificates/generate_spec.rb \
                    spec/services/custom_domain_verification_service_spec.rb
26 examples, 0 failures

# Red/green check — revert the generate.rb ordering change, new tests fail:
2 examples, 2 failures
```

`bundle exec rubocop` on the changed files: no offenses.

> Note: this is the code leg of #6184. It stops the account from being re-paused, but the account is currently paused — a one-time Let's Encrypt self-service unpause is still needed (tracked in the issue) after this ships, otherwise healthy domains stay blocked.

---

AI disclosure: implemented by Claude Opus 4.8.
