### PR TITLE
Fix email-confirmation form accessibility and input semantics

### DIFF
--- a/app/javascript/pages/HelpCenter/Layout.tsx
+++ b/app/javascript/pages/HelpCenter/Layout.tsx
@@ -18,8 +18,8 @@ function HelpCenterHeader({ showSearchButton = false }: { showSearchButton?: boo
     <div className="flex gap-2">
       {showSearchButton ? (
         <Button asChild>
-          <Link href={Routes.help_center_root_path()} aria-label="Search" title="Search">
-            <Search className="size-5" />
+          <Link href={Routes.help_center_root_path()} aria-label="Search">
+            <Search className="size-5" aria-hidden="true" />
           </Link>
         </Button>
       ) : (

--- a/app/javascript/pages/UrlRedirects/ConfirmPage.tsx
+++ b/app/javascript/pages/UrlRedirects/ConfirmPage.tsx
@@ -86,17 +86,21 @@ const EmailConfirmation = ({
         action={Routes.confirm_redirect_path()}
         method="post"
         onSubmit={handleSubmit}
-        className="flex flex-col gap-4"
-        style={{ width: "calc(min(428px, 100%))" }}
+        className="flex w-full max-w-[428px] flex-col gap-4"
       >
         <input type="hidden" name="utf8" value="✓" />
         <input type="hidden" name="authenticity_token" value={authenticity_token} />
         <input type="hidden" name="id" value={data.id} />
         <input type="hidden" name="destination" value={data.destination} />
         <input type="hidden" name="display" value={data.display} />
+        <label htmlFor="confirm-email" className="sr-only">
+          Email address
+        </label>
         <Input
-          type="text"
+          id="confirm-email"
+          type="email"
           name="email"
+          autoComplete="email"
           placeholder="Email address"
           onChange={(e) => setData("email", e.target.value)}
           defaultValue={confirmation_info.email ?? ""}

--- a/spec/requests/download_page/download_page_spec.rb
+++ b/spec/requests/download_page/download_page_spec.rb
@@ -699,9 +699,12 @@ describe("Download Page", type: :system, js: true) do
       expect(page).to have_text(product.name)
     end
 
-    it "renders the same page if the email is invalid" do
+    it "renders the same page if the email is wrong" do
       expect(page).to have_text("You've viewed this product a few times already")
-      fill_in "Email address", with: "invalid"
+      # A well-formed address that doesn't match the purchase — malformed input
+      # (e.g. "invalid") no longer reaches the server now that the field is
+      # type="email" with native browser validation.
+      fill_in "Email address", with: "wrong@example.com"
       click_on "Confirm email"
       expect(page).to have_alert(text: "Wrong email. Please try again.")
       expect(page).to have_text("You've viewed this product a few times already")


### PR DESCRIPTION
## Summary

An external design review ([Rams.ai score for this repo](https://www.rams.ai/score/antiwork/gumroad): 59/100, 1 critical + 5 serious) flagged the download **email-confirmation page** — the form buyers must fill to regain access to a purchase. This fixes the valid findings:

- **Critical — unlabeled email input**: only a placeholder, which vanishes on focus and is never announced to screen readers. Added a visually hidden `<label>` associated via `htmlFor`/`id`.
- **Serious — `type="text"`, no `autoComplete`**: mobile users got the generic keyboard; autofill/password managers had nothing to match. Now `type="email"` + `autoComplete="email"`.
- **Serious — inline `calc()` width**: replaced with Tailwind utilities (`w-full max-w-[428px]`) so the form follows the app's width scale.
- **Serious — duplicate `title` + `aria-label` on Help Center's icon-only search link**: VoiceOver reads "Search, Search". Dropped `title`, added `aria-hidden` on the icon.

**Triaged, not changed** — "no inline error feedback on failed confirmation": the controller redirects with `flash[:alert] = "Wrong email. Please try again."`, which the Inertia layout already surfaces as an alert toast — users do get actionable feedback. Moving it inline next to the field would need controller changes disproportionate to the gain; happy to do as a follow-up if wanted.

## Test plan
- Copy/markup-only changes; `tsc --noEmit` clean, prettier applied. The eslint `Routes`-typed errors in these files are the known fresh-worktree js-routes-not-generated artifact, present on untouched lines too.
- QA: open a purchase's confirm-email page → field announces "Email address" to screen readers, mobile shows email keyboard, autofill offers stored emails; Help Center search icon reads once.

🤖 Authored by gumclaw (agent), prompted by @gianfrancopiana via the Rams.ai review thread.
