### PR TITLE
docs: Payment Type column can show local payment methods (UPI)

### DIFF
--- a/app/views/help_center/articles/contents/_74-the-analytics-dashboard.html.erb
+++ b/app/views/help_center/articles/contents/_74-the-analytics-dashboard.html.erb
@@ -316,7 +316,7 @@
       </tr>
       <tr>
         <td> Payment Type </td>
-        <td> From this column, you can see whether a sale was made on PayPal or credit/debit card. </td>
+        <td> From this column, you can see how the sale was paid for: PayPal, credit/debit card, or a local payment method such as UPI. </td>
       </tr>
       <tr>
         <td> PayPal Transaction ID </td>


### PR DESCRIPTION
## What

Updates the help-center analytics dashboard article (`_74-the-analytics-dashboard`): the sales CSV "Payment Type" column description now says the column can show PayPal, credit/debit card, or a local payment method such as UPI, instead of "whether a sale was made on PayPal or credit/debit card".

## Why

Triggered by merged PR #6201, which changed the sales CSV export so the "Payment Type" column labels local bank-transfer methods distinctly (`PAYMENT_TYPE_LABELS` in `purchase_export_service.rb`: `upi → "UPI"`, `ideal → "iDEAL"`, `paypal → "PayPal"`, card networks → `"Card"`). The old article copy said the column was strictly PayPal-or-card, which is now wrong for UPI sales (live since #6174). Wording says "such as UPI" rather than enumerating iDEAL, which has not launched yet.

Body-only edit; `articles.yml` untouched (no title/description change).

## QA steps

1. Open help.gumroad.com/help/article/74-the-analytics-dashboard.
2. Scroll to the sales CSV column table → "Payment Type" row shows the updated description.

## Test results

Rendered the partial in the real view context on the branch:

```
ApplicationController.render(partial: "help_center/articles/contents/74-the-analytics-dashboard")
→ render OK (25789 bytes); new copy present, old copy absent
```

Autoreview skipped (docs copy only, no logic).

---

## AI disclosure

Authored by Claude Fable 5 via the Hermes agent (gumclaw), triggered automatically by the merge of #6201 (help-center doc sync). Instruction: keep help.gumroad.com accurate when merged PRs change external user-facing behavior.
