### PR TITLE
Fix main CI: US-states summary spec needs Dispute rows after #6199

### DIFF
--- a/spec/sidekiq/create_us_states_sales_summary_report_job_spec.rb
+++ b/spec/sidekiq/create_us_states_sales_summary_report_job_spec.rb
@@ -334,9 +334,17 @@ describe CreateUsStatesSalesSummaryReportJob do
       @chargedback_purchase.update!(chargeback_date: event_month_start + 5.days)
       @won_purchase.update!(chargeback_date: event_month_start + 6.days)
 
+      # The tax-period chargeback scopes now resolve each leg's reporting window through the
+      # disputes table (see Purchase.purchase_ids_for_disputes_in_window, #6199), so each
+      # event-dated chargeback needs a Dispute row whose event_created_at mirrors the
+      # purchase's chargeback_date — just setting chargeback_date is no longer enough.
+      create(:dispute, purchase: @chargedback_purchase, event_created_at: event_month_start + 5.days)
+
       travel_to(won_month_start + 2.days) do
         @won_purchase.update!(chargeback_reversed: true)
-        create(:dispute, purchase: @won_purchase, state: "won", won_at: Time.current)
+        # One Dispute row carries both the formalization date (event_created_at) and the win
+        # date (won_at); the debit leg reports in the event month, the reversal in the won month.
+        create(:dispute, purchase: @won_purchase, state: "won", event_created_at: event_month_start + 6.days, won_at: Time.current)
       end
 
       # A same-month sale so the event month has a positive base to subtract from.


### PR DESCRIPTION
## Summary
Main's push CI has been red since #6199 merged (2b4e21d9, 14:51Z today): every `Tests` run on main — and consequently on every open PR — fails on

`spec/sidekiq/create_us_states_sales_summary_report_job_spec.rb:373` ("subtracts chargebacks in the month the dispute was formalized…", expected `-110.10`, got `110.10`).

#6199 moved the tax-period chargeback scopes to resolve their reporting window through the **disputes** table (`event_created_at`/`won_at`) instead of `purchases.chargeback_date`. It updated the Canada monthly report spec fixtures accordingly, but missed the US-states summary spec, whose chargeback-attribution setup still only sets `chargeback_date` — so the disputes-driven scope finds nothing and the debit legs are never subtracted.

## Fix
Spec-only change, mirroring exactly what #6199 did for the Canada spec:
- give `@chargedback_purchase` a `Dispute` with `event_created_at` mirroring its `chargeback_date`
- add `event_created_at` to `@won_purchase`'s existing won dispute (one row carries both legs)

## Test Results
Ran locally against a fresh test DB:
```
bin/rspec spec/sidekiq/create_us_states_sales_summary_report_job_spec.rb
15 examples, 0 failures
```

Failing main runs for reference: [30033333182](https://github.com/antiwork/gumroad/actions/runs/30033333182), [30017799479](https://github.com/antiwork/gumroad/actions/runs/30017799479) (first red run, on 2b4e21d9 itself).

> [!NOTE]
> This PR was written by an AI agent (Hermes) operating gumclaw's account; reviewed output, not hand-written.

@ershad — you authored/merged #6199; flagging since this unbreaks main for everyone. Happy for you to fold it into a follow-up of yours instead if you prefer.