### PR TITLE
Fix main CI: create matching Dispute rows in the US-states summary chargeback specs

### DIFF
--- a/spec/sidekiq/create_us_states_sales_summary_report_job_spec.rb
+++ b/spec/sidekiq/create_us_states_sales_summary_report_job_spec.rb
@@ -334,9 +334,15 @@ describe CreateUsStatesSalesSummaryReportJob do
       @chargedback_purchase.update!(chargeback_date: event_month_start + 5.days)
       @won_purchase.update!(chargeback_date: event_month_start + 6.days)
 
+      # The tax-period chargeback scopes resolve each leg's window through the Dispute row
+      # (event_created_at mirrors chargeback_date for the debit leg; won_at dates the
+      # reversal), so a simulated chargeback needs its matching dispute, as in production.
+      create(:dispute, purchase: @legacy_purchase, event_created_at: cutover.beginning_of_day - 10.days)
+      create(:dispute, purchase: @chargedback_purchase, event_created_at: event_month_start + 5.days)
+
       travel_to(won_month_start + 2.days) do
         @won_purchase.update!(chargeback_reversed: true)
-        create(:dispute, purchase: @won_purchase, state: "won", won_at: Time.current)
+        create(:dispute, purchase: @won_purchase, state: "won", event_created_at: event_month_start + 6.days, won_at: Time.current)
       end
 
       # A same-month sale so the event month has a positive base to subtract from.


### PR DESCRIPTION
## What

Main's `ci/green` has been red since [2b4e21d9d](https://github.com/antiwork/gumroad/commit/2b4e21d9d) (#6199) — `Test Fast 11` fails on every build (e.g. [run 30033549951](https://github.com/antiwork/gumroad/actions/runs/30033549951)) on the three `chargeback period attribution` examples in `spec/sidekiq/create_us_states_sales_summary_report_job_spec.rb`.

#6199 rewrote `Purchase.chargebacks_for_tax_period_reporting` / `chargeback_reversals_for_tax_period_reporting` to resolve each leg's window through the `disputes` table (`event_created_at` for the debit leg, `won_at` for the reversal) instead of scanning `purchases.chargeback_date`. It updated the sibling report-job specs to create the matching Dispute row for every simulated chargeback, but missed this file — so purchases with only a `chargeback_date` are no longer selected and the expectations miss their clawback legs.

## Fix

Same pattern #6199 applied elsewhere: each simulated chargeback gets a `Dispute` with `event_created_at` mirroring `chargeback_date`; the won purchase's dispute also carries its `event_created_at` so its debit leg still lands in the event month. Spec-only change; the legacy pre-cutover purchase's dispute is likewise dated pre-cutover so it stays excluded, as filed.

## Test Results

Locally against main + this change: the three examples fail without the fix and pass with it; full file `15 examples, 0 failures`.

Unblocks `ci/green` on main for everything queued behind it (Gate B checkout work incl. antiwork/gumroad#6191, #6202, #6209 reruns).

AI disclosure: authored by Gumclaw (agent) as part of the gumroad-private#933 rollout upkeep.