### PR TITLE
Seed an audio file and url redirects for mobile e2e playback testing

### DIFF
--- a/db/seeds/030_development/mobile_app_test_data.rb
+++ b/db/seeds/030_development/mobile_app_test_data.rb
@@ -58,7 +58,24 @@ def create_mobile_purchase(seller:, buyer:, product:)
   purchase.send(:calculate_fees)
   purchase.save!
   purchase.update_columns(purchase_state: "successful", succeeded_at: Time.current)
+  purchase.create_url_redirect!
   purchase
+end
+
+# The mobile app's audio-playback e2e flow (gumroad-mobile .maestro/audio-playback.yaml) needs a
+# purchased product with a playable audio file. Uploads a small MP3 fixture to the dev S3 bucket
+# and attaches it to the product so the purchase page renders a native play button.
+def create_mobile_audio_file(product:)
+  existing = product.product_files.alive.find_by(filegroup: "audio")
+  return existing if existing.present?
+
+  s3_key = "attachments/mobile_e2e/Mobile Test Audio.mp3"
+  s3_object = Aws::S3::Resource.new.bucket(S3_BUCKET).object(s3_key)
+  s3_object.upload_file(Rails.root.join("spec", "support", "fixtures", "magic.mp3").to_s) unless s3_object.exists?
+
+  product_file = product.product_files.create!(url: "#{S3_BASE_URL}#{s3_key}")
+  product_file.analyze
+  product_file
 end
 
 seller1 = create_mobile_user(
@@ -92,6 +109,8 @@ product2 = create_mobile_product(
   price_cents: 1000,
   permalink: "secondmobileproduct"
 )
+
+create_mobile_audio_file(product: product1)
 
 create_mobile_purchase(seller: seller2, buyer: seller1, product: product2)
 

--- a/db/seeds/030_development/mobile_app_test_data.rb
+++ b/db/seeds/030_development/mobile_app_test_data.rb
@@ -40,7 +40,12 @@ end
 
 def create_mobile_purchase(seller:, buyer:, product:)
   existing = Purchase.find_by(link_id: product.id, purchaser_id: buyer.id, purchase_state: "successful")
-  return existing if existing.present?
+  if existing.present?
+    # Databases seeded before url redirects were added here need the redirect backfilled,
+    # otherwise the mobile purchase page has no content to render.
+    existing.create_url_redirect! if existing.url_redirect.blank?
+    return existing
+  end
 
   purchase = Purchase.new(
     link_id: product.id,


### PR DESCRIPTION
## What

Extends the mobile e2e seed data (`db/seeds/030_development/mobile_app_test_data.rb`) with an audio product file: uploads the `spec/support/fixtures/magic.mp3` fixture to the dev S3 bucket, attaches it to Mobile Test Product 1, and creates url redirects for the seeded purchases so the purchase page renders the native play controls.

## Why

The mobile app's new Maestro audio-playback flow (antiwork/gumroad-mobile#326, from the release-QA plan) exercises native podcast playback — play from a purchase, pause/resume, skip, background audio. That flow needs a purchased product with a playable audio file, and the current mobile seed products have no files at all (and no url redirects, so the purchase content page had nothing to render). Idempotent like the rest of the seed file: re-running skips existing users/products/files.

## Before/After

Not applicable — development seed data only, no user-facing surface. Verified by running the seed against the local dev app (output below).

## QA steps

1. Run `bin/rails runner 'load "db/seeds/030_development/mobile_app_test_data.rb"'` in a dev environment with MinIO up.
2. Confirm the audio file exists: `ProductFile.alive.where(filegroup: "audio").joins(:link).where(links: { unique_permalink: "firstmobileproduct" })` returns one analyzed mp3.
3. Log into the mobile app as the mobile buyer test account and open Mobile Test Product 1 — the play button renders.

## Test Results

Seed run against the local dev app:

```
[["http://localhost:9000/gumroad-specs/attachments/mobile_e2e/Mobile Test Audio.mp3", "audio", 46]]
[["firstmobileproduct", true], ["secondmobileproduct", true]]
```

(audio product file analyzed with 46s duration; url redirects present on both seeded purchases). `rubocop` clean, `ruby -c` passes.

---

AI disclosure: Written by Claude Fable 5 (gumclaw), as the companion seed change for the Maestro audio-playback flow requested on the mobile release-QA planning issue.
