### PR TITLE
Clear stale SendGrid suppressions when re-sending confirmation emails

### DIFF
--- a/app/controllers/library_controller.rb
+++ b/app/controllers/library_controller.rb
@@ -74,7 +74,9 @@ class LibraryController < Sellers::BaseController
       return if logged_in_user.confirmed?
 
       if logged_in_user.confirmation_sent_at.blank? || logged_in_user.confirmation_sent_at < RESEND_CONFIRMATION_EMAIL_TIME_LIMIT.ago
-        logged_in_user.send_confirmation_instructions
+        # resend_confirmation_instructions clears any stale SendGrid suppression
+        # on the address first, so this resend can't be silently dropped.
+        logged_in_user.resend_confirmation_instructions
       end
 
       flash[:warning] = "Please check your email to confirm your address before you can see that."

--- a/app/controllers/settings/main_controller.rb
+++ b/app/controllers/settings/main_controller.rb
@@ -41,7 +41,9 @@ class Settings::MainController < Settings::BaseController
 
   def resend_confirmation_email
     if current_seller.unconfirmed_email.present? || !current_seller.confirmed?
-      current_seller.send_confirmation_instructions
+      # resend_confirmation_instructions (not send_) clears any stale SendGrid
+      # suppression on the address first, so a resend can't be silently dropped.
+      current_seller.resend_confirmation_instructions
       return redirect_to settings_main_path, status: :see_other, notice: "Confirmation email resent!"
     end
     redirect_to settings_main_path, alert: "Sorry, something went wrong. Please try again."

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1201,6 +1201,23 @@ class User < ApplicationRecord
     has_completed_payouts?
   end
 
+  # Devise routes every confirmation *resend* through this method — the public
+  # "resend confirmation" form, the Settings resend button, and the library
+  # gate all land here. A prior transient delivery failure may have left the
+  # target address on SendGrid's bounce/block suppression list, which silently
+  # drops every later send including this one, so we clear those suppressions
+  # before re-sending (see ResendConfirmationEmailJob for the full rationale).
+  #
+  # Initial-signup sends go through send_confirmation_instructions instead, so
+  # this override adds no suppression lookups to the signup path. We keep
+  # Devise's pending_any_confirmation guard so an already-confirmed address
+  # still gets the usual "already confirmed" error rather than a pointless send.
+  def resend_confirmation_instructions
+    pending_any_confirmation do
+      ResendConfirmationEmailJob.perform_async(id)
+    end
+  end
+
   protected
     def after_confirmation
       # The password reset link sent to the old email should be invalidated

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1212,8 +1212,22 @@ class User < ApplicationRecord
   # this override adds no suppression lookups to the signup path. We keep
   # Devise's pending_any_confirmation guard so an already-confirmed address
   # still gets the usual "already confirmed" error rather than a pointless send.
+  #
+  # We stamp confirmation_sent_at here, at enqueue time, because the callers that
+  # throttle resends (e.g. the library gate) read it synchronously — if it only
+  # updated when the low-priority job actually sends, every request in between
+  # would see a stale timestamp and enqueue another duplicate resend.
+  #
+  # The one-minute floor bounds double-clicks and the public "resend confirmation"
+  # form (which has no rack_attack throttle): each enqueue costs SendGrid
+  # suppression-API calls in the job, so an unbounded per-user enqueue rate would
+  # hand an attacker who knows an unconfirmed address a free API-hammering lever.
+  RESEND_CONFIRMATION_ENQUEUE_FLOOR = 1.minute
+
   def resend_confirmation_instructions
     pending_any_confirmation do
+      return if confirmation_sent_at.present? && confirmation_sent_at > RESEND_CONFIRMATION_ENQUEUE_FLOOR.ago
+      update_column(:confirmation_sent_at, Time.current)
       ResendConfirmationEmailJob.perform_async(id)
     end
   end

--- a/app/sidekiq/resend_confirmation_email_job.rb
+++ b/app/sidekiq/resend_confirmation_email_job.rb
@@ -34,7 +34,17 @@ class ResendConfirmationEmailJob
     # For an email change awaiting re-confirmation the link goes to the pending
     # address; otherwise it goes to the account's current email.
     address = user.unconfirmed_email.presence || user.email
-    EmailSuppressionManager.new(address).remove_from_lists(DELIVERABILITY_SUPPRESSION_LISTS)
+
+    # Best-effort: the send is the critical payload. If SendGrid's suppression API
+    # is down, raising here would burn the job's retries and the user would never
+    # get the email — the exact silent failure this job exists to prevent. An
+    # address that wasn't suppressed loses nothing; a suppressed one is no worse
+    # off than before and gets cleared by the nightly stale-suppression sweep.
+    begin
+      EmailSuppressionManager.new(address).remove_from_lists(DELIVERABILITY_SUPPRESSION_LISTS)
+    rescue => e
+      ErrorNotifier.notify(e, user_id: user.id)
+    end
 
     user.send_confirmation_instructions
   end

--- a/app/sidekiq/resend_confirmation_email_job.rb
+++ b/app/sidekiq/resend_confirmation_email_job.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Re-sends a user's account-confirmation email after first clearing any stale
+# SendGrid deliverability suppressions for the target address.
+#
+# Why the unsuppress step: a one-off transient delivery failure (greylisting, a
+# receiving-server timeout, or DNS still propagating on a brand-new domain) can
+# land an address on SendGrid's bounce or block suppression list. Once it's
+# there, every later send to that address is silently dropped *before* it goes
+# out — so a plain resend never reaches the user, and a brand-new seller can be
+# locked out of confirming their account with no visible cause. Clearing the
+# deliverability lists first lets the resend actually deliver.
+#
+# We only ever clear the bounce/block lists — never spam_reports or global
+# unsubscribes, which record a person's explicit choice not to hear from us and
+# must be respected.
+#
+# The work runs in the background (rather than inline in the request) so a slow
+# or unavailable SendGrid API can't add latency to, or fail, the user-facing
+# resend action.
+class ResendConfirmationEmailJob
+  include Sidekiq::Job
+  sidekiq_options retry: 3, queue: :low
+
+  DELIVERABILITY_SUPPRESSION_LISTS = [:bounces, :blocks].freeze
+
+  def perform(user_id)
+    user = User.alive.find_by(id: user_id)
+    return if user.nil?
+    # The user may have confirmed between requesting the resend and this job
+    # running; if there's nothing left to confirm, don't send anything.
+    return if user.confirmed? && user.unconfirmed_email.blank?
+
+    # For an email change awaiting re-confirmation the link goes to the pending
+    # address; otherwise it goes to the account's current email.
+    address = user.unconfirmed_email.presence || user.email
+    EmailSuppressionManager.new(address).remove_from_lists(DELIVERABILITY_SUPPRESSION_LISTS)
+
+    user.send_confirmation_instructions
+  end
+end

--- a/spec/controllers/confirmations_controller_spec.rb
+++ b/spec/controllers/confirmations_controller_spec.rb
@@ -8,6 +8,28 @@ describe ConfirmationsController do
     @user = create(:user, confirmed_at: nil)
   end
 
+  describe "#create" do
+    context "when the address still needs to be confirmed" do
+      it "enqueues a resend that clears stale suppressions first, rather than sending inline" do
+        expect do
+          post :create, params: { user: { email: @user.email } }
+        end.to change { ResendConfirmationEmailJob.jobs.size }.by(1)
+
+        expect(ResendConfirmationEmailJob).to have_enqueued_sidekiq_job(@user.id)
+      end
+    end
+
+    context "when the address is already confirmed" do
+      before { @user.confirm }
+
+      it "does not enqueue a resend" do
+        expect do
+          post :create, params: { user: { email: @user.email } }
+        end.not_to change { ResendConfirmationEmailJob.jobs.size }
+      end
+    end
+  end
+
   describe "#show" do
     describe "already confirmed" do
       before do

--- a/spec/controllers/confirmations_controller_spec.rb
+++ b/spec/controllers/confirmations_controller_spec.rb
@@ -10,12 +10,28 @@ describe ConfirmationsController do
 
   describe "#create" do
     context "when the address still needs to be confirmed" do
+      before do
+        # Signup stamped confirmation_sent_at just now; move past the one-minute
+        # enqueue floor the way a real "I never got the email" resend would be.
+        @user.update_column(:confirmation_sent_at, 2.minutes.ago)
+      end
+
       it "enqueues a resend that clears stale suppressions first, rather than sending inline" do
         expect do
           post :create, params: { user: { email: @user.email } }
         end.to change { ResendConfirmationEmailJob.jobs.size }.by(1)
 
         expect(ResendConfirmationEmailJob).to have_enqueued_sidekiq_job(@user.id)
+      end
+    end
+
+    context "when a resend was already enqueued moments ago" do
+      it "does not enqueue another one (per-user enqueue floor)" do
+        @user.update_column(:confirmation_sent_at, 10.seconds.ago)
+
+        expect do
+          post :create, params: { user: { email: @user.email } }
+        end.not_to change { ResendConfirmationEmailJob.jobs.size }
       end
     end
 

--- a/spec/controllers/library_controller_spec.rb
+++ b/spec/controllers/library_controller_spec.rb
@@ -166,6 +166,21 @@ describe LibraryController, :vcr, type: :controller, inertia: true do
           get :index
         end
       end
+
+      context "when the page is refreshed while the queued resend hasn't run yet" do
+        before do
+          user.update_attribute(:confirmation_sent_at, nil)
+        end
+
+        it "enqueues exactly one resend, because confirmation_sent_at is stamped at enqueue time" do
+          allow(controller).to receive(:current_user).and_return(user)
+
+          expect do
+            get :index
+            get :index
+          end.to change { ResendConfirmationEmailJob.jobs.size }.by(1)
+        end
+      end
     end
 
     describe "suspended (tos) user" do

--- a/spec/controllers/library_controller_spec.rb
+++ b/spec/controllers/library_controller_spec.rb
@@ -125,7 +125,7 @@ describe LibraryController, :vcr, type: :controller, inertia: true do
       shared_examples "sends confirmation instructions" do
         it "disallows access and sends confirmation instructions" do
           allow(controller).to receive(:current_user).and_return(user)
-          expect(user).to receive(:send_confirmation_instructions)
+          expect(user).to receive(:resend_confirmation_instructions)
 
           get :index
 
@@ -161,7 +161,7 @@ describe LibraryController, :vcr, type: :controller, inertia: true do
 
         it "doesn't send duplicate confirmation instructions" do
           allow(controller).to receive(:current_user).and_return(user)
-          expect(user).not_to receive(:send_confirmation_instructions)
+          expect(user).not_to receive(:resend_confirmation_instructions)
 
           get :index
         end

--- a/spec/controllers/settings/main_controller_spec.rb
+++ b/spec/controllers/settings/main_controller_spec.rb
@@ -535,9 +535,12 @@ describe Settings::MainController, type: :controller, inertia: true do
   describe "POST resend_confirmation_email" do
     shared_examples_for "resends email confirmation" do
       it "resends email confirmation" do
+        # The resend clears any stale SendGrid suppression first, so it runs in
+        # the background via ResendConfirmationEmailJob rather than sending inline.
         expect { post :resend_confirmation_email }
-          .to have_enqueued_mail(UserSignupMailer, :confirmation_instructions)
+          .to change { ResendConfirmationEmailJob.jobs.size }.by(1)
 
+        expect(ResendConfirmationEmailJob).to have_enqueued_sidekiq_job(seller.id)
         expect(response).to redirect_to(settings_main_path)
         expect(response).to have_http_status :see_other
         expect(flash[:notice]).to eq("Confirmation email resent!")
@@ -547,7 +550,7 @@ describe Settings::MainController, type: :controller, inertia: true do
     shared_examples_for "doesn't resend email confirmation" do
       it "doesn't resend email confirmation" do
         expect { post :resend_confirmation_email }
-          .not_to have_enqueued_mail(UserSignupMailer)
+          .not_to change { ResendConfirmationEmailJob.jobs.size }
 
         expect(response).to redirect_to(settings_main_path)
         expect(response).to have_http_status :found

--- a/spec/controllers/settings/main_controller_spec.rb
+++ b/spec/controllers/settings/main_controller_spec.rb
@@ -570,6 +570,9 @@ describe Settings::MainController, type: :controller, inertia: true do
       before do
         seller.confirm
         seller.update_attribute(:email, "some@gumroad.com")
+        # The email change just stamped confirmation_sent_at; a real resend click
+        # comes later ("I never got it"), past the one-minute enqueue floor.
+        seller.update_column(:confirmation_sent_at, 2.minutes.ago)
       end
 
       it_behaves_like "resends email confirmation"

--- a/spec/sidekiq/resend_confirmation_email_job_spec.rb
+++ b/spec/sidekiq/resend_confirmation_email_job_spec.rb
@@ -31,6 +31,16 @@ describe ResendConfirmationEmailJob do
 
         described_class.new.perform(user.id)
       end
+
+      it "still sends the confirmation email when the suppression API fails" do
+        # The send is the critical payload — a SendGrid suppression outage must not
+        # burn the job's retries and silently strand the user unconfirmed.
+        allow(suppression_manager).to receive(:remove_from_lists).and_raise(SocketError, "sendgrid down")
+        expect(ErrorNotifier).to receive(:notify)
+        expect_any_instance_of(User).to receive(:send_confirmation_instructions)
+
+        described_class.new.perform(user.id)
+      end
     end
 
     context "when the user is confirming a changed email address" do

--- a/spec/sidekiq/resend_confirmation_email_job_spec.rb
+++ b/spec/sidekiq/resend_confirmation_email_job_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ResendConfirmationEmailJob do
+  let(:suppression_manager) { instance_double(EmailSuppressionManager) }
+
+  describe "#perform" do
+    context "when the user still needs to confirm their account" do
+      let(:user) { create(:user, confirmed_at: nil) }
+
+      before do
+        allow(EmailSuppressionManager).to receive(:new).with(user.email).and_return(suppression_manager)
+        allow(suppression_manager).to receive(:remove_from_lists)
+      end
+
+      it "clears the bounce and block suppressions for the address before re-sending the confirmation email" do
+        # Order matters: if we re-send before clearing the suppression, SendGrid
+        # drops the send. Record the calls in sequence to prove unsuppress-first.
+        sequence = []
+        allow(suppression_manager).to receive(:remove_from_lists) { |lists| sequence << [:remove_from_lists, lists] }
+        allow_any_instance_of(User).to receive(:send_confirmation_instructions) { sequence << :send_confirmation_instructions }
+
+        described_class.new.perform(user.id)
+
+        expect(sequence).to eq([[:remove_from_lists, [:bounces, :blocks]], :send_confirmation_instructions])
+      end
+
+      it "never touches the spam-report or unsubscribe consent surfaces" do
+        expect(suppression_manager).to receive(:remove_from_lists).with([:bounces, :blocks])
+
+        described_class.new.perform(user.id)
+      end
+    end
+
+    context "when the user is confirming a changed email address" do
+      let(:user) do
+        create(:user).tap do |u|
+          u.confirm
+          u.update!(email: "changed@example.com")
+        end
+      end
+
+      it "clears suppressions for the pending unconfirmed address, not the current one" do
+        expect(user.unconfirmed_email).to eq("changed@example.com")
+        expect(EmailSuppressionManager).to receive(:new).with("changed@example.com").and_return(suppression_manager)
+        expect(suppression_manager).to receive(:remove_from_lists).with([:bounces, :blocks])
+
+        described_class.new.perform(user.id)
+      end
+    end
+
+    context "when the user confirmed before the job ran" do
+      let(:user) { create(:user) }
+
+      it "does nothing" do
+        expect(EmailSuppressionManager).not_to receive(:new)
+        expect_any_instance_of(User).not_to receive(:send_confirmation_instructions)
+
+        described_class.new.perform(user.id)
+      end
+    end
+
+    context "when the user no longer exists" do
+      it "does nothing" do
+        expect(EmailSuppressionManager).not_to receive(:new)
+
+        described_class.new.perform(0)
+      end
+    end
+
+    context "when the user has been deleted" do
+      let(:user) { create(:user, confirmed_at: nil) }
+
+      before { user.mark_deleted! }
+
+      it "does nothing" do
+        expect(EmailSuppressionManager).not_to receive(:new)
+
+        described_class.new.perform(user.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

Every confirmation-email *resend* now clears any stale SendGrid deliverability suppression on the target address before re-sending, so a resend can't be silently dropped.

- `User#resend_confirmation_instructions` is overridden to enqueue a new `ResendConfirmationEmailJob` (keeping Devise's `pending_any_confirmation` guard, so an already-confirmed address still gets the normal "already confirmed" error instead of a pointless send).
- `ResendConfirmationEmailJob` removes the address from SendGrid's **bounce/block** lists via the existing `EmailSuppressionManager#remove_from_lists`, then re-sends. It never touches `spam_reports` or unsubscribes — those record a person's explicit choice and must be respected. It runs in the background so SendGrid latency/downtime can't slow or fail the user-facing resend.
- The three resend surfaces all funnel through this: the public "resend confirmation" form (`confirmations#create`, via the model override), the Settings resend button, and the library confirmation gate.
- Initial-signup sends go through `send_confirmation_instructions`, not `resend_`, so the signup path gets zero extra suppression lookups.

## Why

A one-off transient SMTP failure — greylisting, a receiving-server timeout, or DNS still propagating on a brand-new business domain — can land a seller's address on SendGrid's bounce/block suppression list. Once suppressed, **every later send is silently dropped before it goes out, including the confirmation resend itself**, so a brand-new seller is locked out of confirming their account with no visible cause and a human has to clear the suppression from the console.

This is deliberately the *lightweight* fix. It was split out of #6073 (closed), which added a full auto-retry state machine — a new table, a reason classifier, per-address backoff, and an in-flight claim — to also cover users who hit a transient failure and *never* click resend. That population isn't sized by data yet. Paired with the nightly stale-suppression sweep (#6154, which clears the stale backlog), unsuppress-on-resend gives a suppressed seller **same-session recovery the moment they click resend** — the natural recovery path for a confirmation email — at a fraction of the code. If funnel data later shows a meaningful cohort abandoning after a transient bounce without ever resending, that's the evidence to revisit the auto-retry.

Part of antiwork/gumroad-private#1210.

## Before/After

Backend-only change — a Sidekiq job plus a model override, with no user-visible surface, so there is nothing to screenshot for before/after.

Reviewer path to exercise it end-to-end in a console (staging):

```ruby
user = User.last                       # any unconfirmed user
user.resend_confirmation_instructions  # public form / Settings button / library gate all land here
ResendConfirmationEmailJob.jobs.last   # enqueued with the user id
# running the job clears bounces/blocks for the address, then re-sends the confirmation
```

## Test Results

- `spec/sidekiq/resend_confirmation_email_job_spec.rb` + `spec/controllers/confirmations_controller_spec.rb` + `spec/controllers/settings/main_controller_spec.rb` → **58 examples, 0 failures**
- The three library confirmation-gate specs pass; the other `library_controller_spec` failures are pre-existing on `main` (Elasticsearch-dependent, unrelated to this change).
- `bundle exec rubocop` on all 8 touched files → **no offenses detected**

---
🤖 AI disclosure: authored with Claude Opus 4.8.
