### PR TITLE
Help center: document resend to non-openers for published emails

### DIFF
--- a/app/views/help_center/articles/contents/_169-how-to-send-an-update.html.erb
+++ b/app/views/help_center/articles/contents/_169-how-to-send-an-update.html.erb
@@ -5,6 +5,7 @@
     <li><a href="#Audience-and-channel-selection--nhXI" target="_self">Audience and channel selection</a></li>
     <li><a href="#Preview-JaHrr">Preview</a></li>
     <li><a href="#Save-and-Publish-nYVCk">Save and publish</a></li>
+    <li><a href="#Resend-to-non-openers-xT4mq">Resend to non-openers</a></li>
     <li><a href="#comments">Comments on emails</a>
       <ul>
         <li><a href="#Leaving-a-Comment-o8OJ9">Leaving a comment</a></li>
@@ -48,6 +49,14 @@
   <p>You can either choose to publish now, or schedule your email to be published on a future date.</p>
   <figure><%= image_tag "https://lh7-us.googleusercontent.com/YXmtcRi7aCjGmfGRB5UiI3x9G3aP2MQEA4thxE3QUu4ZarJpbqdWPSsuMajCQgODpoqMseborLoic8fVdtRWDFAs1UmY-XK1YpwOP4CsPRyNjp_UWc86-Rd99yFry7WQdemPrSxPoTNJ6ks83ngPgHY" %></figure>
   <p>If you want new followers or customers to be sent an email that was published before they had signed up for your updates, just go to the <a href="https://gumroad.com/customers" target="_blank">Sales dashboard</a>, select their purchase, and send them any emails they’ve missed.</p>
+  <h3 id="Resend-to-non-openers-xT4mq">Resend to non-openers</h3>
+  <p>After a published email has gone out, you can send it again to everyone who was emailed but hasn't opened it yet. Open the <a href="https://gumroad.com/emails/published" target="_blank">Published tab</a> of your Emails dashboard, click the email to open its details, and click the "Resend to non-openers" button. A confirmation shows how many people will receive the resend before you send it.</p>
+  <br>
+  <p>Resending is available for published emails that were sent as an email to your customers (including emails targeted to a specific product, version, or tier). Emails sent only to followers or affiliates can't be resent this way, because opens aren't tracked per recipient for those audiences. Recipients who no longer match the email's audience filters (for example, customers who have since been refunded) are left out of the resend.</p>
+  <br>
+  <p>A few limits apply: you can resend to non-openers once every 24 hours, and up to 3 times per email. If your audience is very large, the confirmation may say it is too large to preview an exact count. You can still resend, and the recipient list is worked out while the emails are being sent.</p>
+  <br>
+  <p>Each completed resend appears under the original email in the Published list as its own "Resend to non-openers" row, showing the date, how many people were emailed, and the share of them who opened it. The email's details show the same list, with resends that are still sending marked as in progress. A resend's open rate counts recipients whose first open happened after that resend went out, so it tells you whether the resend reached people the original email didn't.</p>
   <h3 id="comments">Comments on emails</h3>
   <p>Comments allow you to make your customers feel more involved, and to gather quick feedback on your content.</p>
   <br>


### PR DESCRIPTION
## What

Documents the **resend to non-openers** feature for published emails in the help center. Resolves the feature-wide doc gap tracked in antiwork/gumroad-private#1278.

Adds a "Resend to non-openers" section (+ TOC entry) to `_169-how-to-send-an-update` — the article covering composing/publishing emails and the Emails dashboard.

Feature lineage: #5378 (feature) → #6192 (large-audience preview budget) → #6218 (per-resend list rows + open rates). The two open-question sibling issues cited in the tracking issue (gumroad-private#1272, #1274) are both closed, so the flow is settled.

## Every claim verified against code (not the PR bodies)

- **Entry point + audience**: `EmailSheetActions` renders `ResendToNonOpenersButton` in the email detail sheet on the Published tab; button label verbatim "Resend to non-openers" (`EmailsPage/shared.tsx`).
- **Eligibility**: `canResendToNonOpeners` / `Installment#resendable_to_non_openers?` — published + `send_emails` + installment type in `seller/product/variant`. Follower/affiliate posts excluded (no per-recipient open tracking — comment in `shared.tsx`).
- **Audience-filter exclusion**: `resendable_to_non_openers_emails` intersects unopened recipients with the CURRENT `AudienceMember.filter` result; UI shows "no longer eligible for this email's audience" when filtered to zero.
- **Limits**: `NonOpenerResendsController::RESEND_THROTTLE = 24.hours`, `MAX_RESENDS = 3` — both surfaced as user-facing errors ("once every 24 hours", "up to 3 times per email").
- **Too-large-to-count state**: `COUNT_PREVIEW_TOTAL_BUDGET_SECONDS = 0.3` degrade path → "Your audience is too large to preview an exact count" modal copy; resend still works (recipients resolved in `SendPostBlastEmailsJob`).
- **Published-list rows + attribution**: `Published.tsx` renders completed resends as "↳ Resend to non-openers" sub-rows (date, emailed count, open rate); `InstallmentPresenter#non_opener_resend_props` attributes opens by first-open-after-resend time window; in-progress resends shown as "in progress" in the detail sheet.

Deliberate wording choices: "share of them who opened it" (not a formula), no internal constant names in the article, no mention of the 1-hour in-flight grace (internal anti-double-send detail, not user guidance).

## QA steps

- `ERB.new(...).src` → syntax OK; tag-balance check across div/ul/li/p/h3/ol/figure → all balanced.
- Rendered the partial in the real view context (`ApplicationController.render`) → render OK, new copy present.
- `articles.yml` untouched (body-only edit mid-article; title/description unchanged).
- Autoreview skipped (docs copy only, no logic).

## Self-review (fable-style)

- P2 checked: adjacent-claim sweep — the article's existing "send them any emails they've missed" paragraph (per-customer missed-post resend from the Sales dashboard) is a DIFFERENT feature and remains accurate; new section doesn't conflate them.
- P2 checked: refunded-customer example verified — audience filters exclude refunded purchases via `AudienceMember` params, so the example is accurate.
- P3: article screenshots don't yet show the new sub-rows — copy doesn't depend on any screenshot; future refresh.
