### PR TITLE
Help center: profile customization is agent-built custom HTML; sections are legacy

### DIFF
--- a/app/views/help_center/articles/contents/_124-your-gumroad-profile-page.html.erb
+++ b/app/views/help_center/articles/contents/_124-your-gumroad-profile-page.html.erb
@@ -1,76 +1,37 @@
 <div>
   <p><strong>In this article:</strong></p>
   <ul>
-    <li><a href="#setup" target="_self">Set up your profile</a>
+    <li><a href="#setup" target="_self">Set up your profile</a></li>
+    <li><a href="#custom-landing-page" target="_self">Build your profile page with your agent</a>
       <ul>
-        <li><a href="#font-and-colors" target="_self">Customize font and colors</a></li>
-      </ul>
-    </li>
-    <li><a href="#Create-product-categories-LYEcj" target="_self">Create pages and sections</a>
-      <ul>
-        <li><a href="#Product-sections-WxaV_" target="_self">Product sections</a>
-          <ul>
-            <li>Sort your products</li>
-            <li>Let customers filter your products</li>
-            <li>Add a featured product</li>
-          </ul>
-        </li>
-        <li><a href="#Posts-sections-y8C6f" target="_self">Posts sections</a></li>
-        <li><a href="#Subscribe-sections-cNGWx" target="_self">Subscribe sections</a></li>
-        <li><a href="#Text-sections-Zn8fk" target="_self">Text sections</a></li>
-        <li><a href="#Add-sections-to-product-pages-ABGsI" target="_self">Add sections to product pages</a></li>
+        <li><a href="#email-signup-form" target="_self">Collect email followers on a custom page</a></li>
+        <li><a href="#reset-custom-page" target="_self">Reset or update your custom page</a></li>
       </ul>
     </li>
     <li><a href="#Standalone-pages-Kw3xR" target="_self">Add standalone pages to your store</a></li>
+    <li><a href="#legacy-sections" target="_self">Legacy pages and sections</a></li>
   </ul>
-  <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/6628533d7303ea4a739d367b/file-GLfzOQP5BK.png" %></figure>
-  <p>Your profile allows you to have your own website on Gumroad. You can use it to introduce yourself with a profile picture and bio, <a href="170-audience">grow your following</a> by collecting email addresses, and showcase your products across customizable pages and sections.</p>
+  <p>Your profile allows you to have your own website on Gumroad. You can use it to introduce yourself, <a href="170-audience">grow your following</a> by collecting email addresses, and showcase your products on a fully custom page.</p>
   <p>Your profile is located at [username].gumroad.com where [username] is replaced with your unique username. You can also get there by clicking on your name and then the Profile button on the Gumroad navigation.</p>
   <h3 id="setup">Set up your profile</h3>
-  <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/63ff2813b7da6b15a7ea212e/file-Yc0TiiOjTZ.png" %></figure>
-  <p>Go to the <a href="https://gumroad.com/settings/profile" target="_blank">profile settings</a> to update the public-facing information for your customers to read, including a short bio (we’ve found that a sentence or two works best rather than overly-long descriptions of your entire career path).</p>
-  <h3 id="font-and-colors">Customize fonts and colors</h3>
-  <p>Choose from different font styles, accents, and background colors from your <a href="https://gumroad.com/settings/profile" target="_self">profile settings</a>. The custom fonts and colors will apply to your profile, product, posts, and emails; but not to your product’s content.</p>
-  <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/63ff28543c396c395ec0f4c3/file-O2U84Acgi2.png" %></figure>
-  <h3 id="Create-product-categories-LYEcj">Create pages and sections</h3>
-  <p>You can have multiple pages on your profile with each page containing multiple sections, helping you categorize your products and posts effectively.</p>
-  <p>Click on the three-dot menu and select New page to get started. On a given page, click the + icon at the bottom to create a new section to be displayed on your profile.</p>
-  <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/660a470bd00a8f46829b75dc/file-LcDS8NDJzg.gif" %></figure>
-  <p>You can also rename and reorder your pages and sections from the three-dot menu.</p>
-  <p><i>Note:</i> These profile pages appear as tabs on your profile itself. To publish separate pages at their own URLs, like an about page or FAQ, see <a href="#Standalone-pages-Kw3xR" target="_self">Add standalone pages to your store</a> below.</p>
-  <p><i>Note:</i> If you have published products but haven't added any sections yet, your profile automatically shows a section with all of your products, newest first. As soon as you save a section of your own, your layout replaces the automatic one. If you have no products for sale and no sections, your profile shows an email signup form instead.</p>
-  <h3 id="Product-sections-WxaV_">Product sections</h3>
-  <p>On a given product section, click the three-dot menu on the left to assign a name and select the products you want it to contain. You can choose whether to display the section's name or not, and automatically add any new products to a section (enabled by default on new sections).</p>
-  <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/6597f226df35c837879e8922/file-d1pwX1X2F6.gif" %></figure>
-  <p>When you're done, just click outside the box to save your changes!</p>
-  <p><b>Sort your products</b></p>
-  <p>You can manually set the order of your products, or you can set a default sort by price, rating, or recency.</p>
-  <p>To set a custom order, click Products, select your Default sort order as ‘Custom’, and drag the products by holding the 6 dots on the left.</p>
-  <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/6597f0c2baa1964909074c42/file-HwP7sCuVrA.gif" %></figure>
-  <p><b>Let customers filter your products</b></p>
-  <p>Product filters help customers organize and easily explore your products as they browse. Your products can be filtered by rating and the types of files they contain. If you do not want your customers to see the filters, you can turn them off by toggling 'Show product filters'. </p>
-  <p><i>Note:</i> Filters are disabled while editing to ensure you can see all the selected products. You can test them out after logging out from your account, or in a different browser/incognito window.</p>
-  <p><b>Add a featured product</b></p>
-  <p>Have a best-selling product you’d like to highlight, or wish to drive more attention to a new launch? You can embed an individual product on your profile with the Featured Product block. </p>
-  <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/662854315ae8353469c6ac18/file-5fQ76mlvqG.png" %></figure>
-  <h3 id="Posts-sections-y8C6f">Posts sections</h3>
-  <p>Adding a Posts section will display all eligible emails <a href="169-how-to-send-an-update" target="_self">posted on your profile</a>.</p>
-  <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/660a47e050568305fcb28b75/file-gqecfYxkl0.gif" %></figure>
-  <h3 id="Subscribe-sections-cNGWx">Subscribe sections</h3>
-  <p>Add a Subscribe block to collect email addresses for your newsletter. You can customize the section heading and the button label as well!</p>
-  <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/6628546ae66450147a8e5ae4/file-j4Rr3XN7Xl.png" %></figure>
-  <h3 id="Text-sections-Zn8fk">Text sections</h3>
-  <p>Provide additional context before a section or type a page with Rich text blocks. The formatting bar allows you to add lists, code blocks, quotes, links, buttons, and more!</p>
-  <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/66285496e66450147a8e5ae5/file-W42DTYtVQc.png" %></figure>
-  <h3 id="Add-sections-to-product-pages-ABGsI">Add sections to product pages</h3>
-  <p>Like on your profile, you can add sections like products, posts, subscribe, and text blocks on your product pages too!</p>
-  <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/66988bf35908935e84818b2b/file-h0OJRWWXyI.png" %></figure>
+  <p>Go to the <a href="https://gumroad.com/settings/profile" target="_blank">profile settings</a> to set your username, profile picture, and a short bio (we’ve found that a sentence or two works best rather than overly-long descriptions of your entire career path). Your name and bio are available to your custom page, so keep them current.</p>
+  <h3 id="custom-landing-page">Build your profile page with your agent</h3>
+  <p>Your profile page is fully custom HTML, designed and published by an AI agent — there are no fixed layouts, blocks, or sections to work around. Describe the page you want and the agent designs it, previews it, and publishes it to your profile.</p>
+  <p>From the Share tab in your profile settings, copy the ready-made prompt and paste it into your agent. The prompt asks the agent to design a unique, on-brand, fully responsive page (with light and dark mode), preview it with <code>gumroad pages preview</code>, and publish it with <code>gumroad pages push profile</code>. You can run those same CLI commands by hand if you prefer.</p>
+  <p>The published page replaces your entire profile at [username].gumroad.com (and on your custom domain if you have one connected), so have it link visitors to your product pages rather than embedding checkout elements. Custom pages are visible to search engines, with your page's description and products included in structured data automatically.</p>
+  <h3 id="email-signup-form">Collect email followers on a custom page</h3>
+  <p>To collect email addresses for your newsletter from a custom page, ask your agent to include a form marked <code>data-gumroad-follow</code> with an email input and an element marked <code>data-gumroad-follow-message</code> for the confirmation text. Gumroad wires the form to your <a href="170-audience">email audience</a> automatically when the page is served — no extra setup.</p>
+  <h3 id="reset-custom-page">Reset or update your custom page</h3>
+  <p>To change the page, ask your agent for the update — it edits and republishes the live page. To start over, use the reset button in your profile settings; this removes the custom page so you can publish a fresh one.</p>
   <h3 id="Standalone-pages-Kw3xR">Add standalone pages to your store</h3>
   <p>Beyond your profile, you can publish standalone pages on your store, like an about page, an FAQ, or licensing terms. Each page gets its own URL at [username].gumroad.com/[page-slug], and on your custom domain if you have one connected.</p>
   <p>To manage your pages, click Pages in the Gumroad navigation. The list shows your profile pinned at the top as your home page (it serves at your store's root and can't be deleted), with your other pages below it.</p>
-  <p>Click New page to create one. Give it a title, write the content in the rich text editor, and click Create page. The page's URL is generated from its title, and the pages list shows the link for each page. When editing an existing page, the preview pane on the right shows the page as visitors will see it, refreshing each time you save.</p>
+  <p>Standalone pages can be built the same two ways: ask your agent (each page's editor has a copy-ready prompt, and the agent publishes with <code>gumroad pages push [page-slug]</code>), or click New page and write the content in the rich text editor yourself. Pages built by an agent as fully custom HTML show a preview instead of the rich text editor, so the agent's design can't be accidentally overwritten.</p>
   <p>To delete a page, click the trash icon next to it in the list. Deleted pages are no longer reachable by visitors, and this can't be undone.</p>
-  <p><i>Note:</i> Pages built by an AI agent as fully custom HTML show a preview instead of the rich text editor, so the agent's design can't be accidentally overwritten. Team members with the marketing or admin role can create and edit pages; support and accountant roles can view them.</p>
+  <p><i>Note:</i> Team members with the marketing or admin role can create and edit pages; support and accountant roles can view them.</p>
+  <h3 id="legacy-sections">Legacy pages and sections</h3>
+  <p>Profiles used to be laid out with pages of stacked sections (products, posts, subscribe, and text blocks). Sections are being phased out in favor of custom pages: they were confusing to arrange and not customizable enough. If your profile still uses them, the section editor remains available from your profile settings until you publish a custom page — once your agent-built page is live, it replaces the sections layout entirely.</p>
+  <p>If you have no custom page, no products, and no sections, your profile shows an email signup form. The fonts and colors you pick in <a href="https://gumroad.com/settings/profile" target="_self">profile settings</a> still apply to product pages, posts, and emails; your custom page controls its own design.</p>
 </div>
 <div>
   <h3>Related Articles</h3>

--- a/app/views/help_center/articles/contents/_149-adding-a-product.html.erb
+++ b/app/views/help_center/articles/contents/_149-adding-a-product.html.erb
@@ -75,9 +75,7 @@
   <p>Versions can help you sell different sets of content, software access levels, or optional added services within the same product at different price points. Read <a href="126-setting-up-versions-on-a-digital-product" target="_self">this article</a> to know all about setting up versions.</p>
   <h3 id="test-publish">Publish your product</h3>
   <p>You can <a href="101-designing-your-product-page" target="_self">customize your product's checkout</a> flow and see it from your customer's point of view with <a href="62-testing-a-purchase" target="_self">a test purchase</a>. </p>
-  <p>Once you're happy with everything, click Publish at the top of the page and add it to a profile section to ensure customers can access it from your Profile page.</p>
-  <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/654465538b2e41385d8b0f70/file-phHlnRWIfJ.jpg" %></figure>
-  <p>You can also add profile sections like posts, subscribe, rich text, and even other products on your product page. Check out <a href="124-your-gumroad-profile-page#Create-product-categories-LYEcj" target="_self">this article</a> to learn more about profile sections.</p>
+  <p>Once you're happy with everything, click Publish at the top of the page. To feature it on your profile, ask your agent to add it to your <a href="124-your-gumroad-profile-page#custom-landing-page" target="_self">custom profile page</a> — or if your profile still uses the legacy sections layout, add it to a product section.</p>
 </div>
 <div>
   <h3>Related Articles</h3>


### PR DESCRIPTION
## What

Sahil (2026-07-24): seller profiles are now fully custom HTML built by the seller's agent — pages-of-sections are being phased out ("confusing and not customizable enough"). The help center still taught the legacy flow as the primary path.

- **"Your Gumroad profile page" (124)** rewritten to lead with the current reality: the Share-tab agent flow (copy the prompt → agent designs/previews with `gumroad pages preview` → publishes with `gumroad pages push profile`), the `data-gumroad-follow` email-capture bridge, reset/update flow, and SEO visibility (#6198). Pages-and-sections demoted to a "Legacy pages and sections" note that matches the in-app phase-out banner verbatim in spirit; the per-section-type how-tos (product/posts/subscribe/text sections, sorting, filters, featured product) and their stale screenshots are gone.
- **"Adding a product" (149)**: the publish step no longer instructs adding the product to a profile section; it points to the agent/custom-page path with a legacy fallback.
- Verified no other article deep-links to the removed anchors or teaches section flows.

Grounded against the code: `custom_html_pages` Flipper is fully ON in prod (audited read); `Settings/Profile/Show.tsx` hides the Pages tab once a custom landing page exists and shows the phase-out warning otherwise; `Pages/Edit.tsx` carries the agent prompt + CLI commands; `pages` table + `gumroad:follow` bridge (#5948) as documented.

## QA

Docs-only (two ERB help articles, no code paths). Anchors within 124 are self-consistent; the one inbound deep-link (from 149) was updated to the new anchor.

🤖 Generated with claude-fable-5 via Hermes agent (gumclaw)