### PR TITLE
Document the save-time deletion confirmation in the versions and tiers help articles

### DIFF
--- a/app/views/help_center/articles/contents/_126-setting-up-versions-on-a-digital-product.html.erb
+++ b/app/views/help_center/articles/contents/_126-setting-up-versions-on-a-digital-product.html.erb
@@ -30,6 +30,7 @@
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/62443fabab585b230a8a678e/file-oi2PtQycd1.gif" %></figure>
   <h3 id="delete">Delete a version</h3>
   <p>Click the trash icon next to the version’s name to delete it.</p>
+  <p>When you save, Gumroad shows a summary of the versions and content pages the save will permanently delete and asks you to confirm before anything is removed.</p>
   <p>If you delete a version, its associated content will be removed as well. Your existing customers who purchased it will see the content from the current cheapest version as a fallback. If no version exists, they will see the product-level content.</p>
   <p>To avoid any confusion, we recommend that you reassign the customer to another version that will remain alive before deleting a version.</p>
   <h3 id="reassign">Reassign a customer to a different version</h3>

--- a/app/views/help_center/articles/contents/_126-setting-up-versions-on-a-digital-product.html.erb
+++ b/app/views/help_center/articles/contents/_126-setting-up-versions-on-a-digital-product.html.erb
@@ -30,7 +30,7 @@
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/62443fabab585b230a8a678e/file-oi2PtQycd1.gif" %></figure>
   <h3 id="delete">Delete a version</h3>
   <p>Click the trash icon next to the version’s name to delete it.</p>
-  <p>When you save, Gumroad shows a summary of the versions and content pages the save will permanently delete and asks you to confirm before anything is removed.</p>
+  <p>When you save, if the deleted version still has content pages or files, Gumroad shows a summary of what the save will permanently delete and asks you to confirm before anything is removed.</p>
   <p>If you delete a version, its associated content will be removed as well. Your existing customers who purchased it will see the content from the current cheapest version as a fallback. If no version exists, they will see the product-level content.</p>
   <p>To avoid any confusion, we recommend that you reassign the customer to another version that will remain alive before deleting a version.</p>
   <h3 id="reassign">Reassign a customer to a different version</h3>

--- a/app/views/help_center/articles/contents/_82-membership-products.html.erb
+++ b/app/views/help_center/articles/contents/_82-membership-products.html.erb
@@ -86,6 +86,7 @@
   <p>We will email them a receipt showing the changes.</p>
   <h3 id="What-happens-if-you-delete-an-active-tier-0nSPc">What happens if you delete an active tier?</h3>
   <p>If you delete a tier, its associated content will be removed as well. Your existing customers who purchased it will see the content from the current cheapest tier as a fallback. If no tier exists, they will see the product-level content.</p>
+  <p>When you save, Gumroad shows a summary of the tiers and content pages the save will permanently delete and asks you to confirm before anything is removed.</p>
   <p>Also, deleting the tier does not stop customers' subscriptions. They will keep paying their recurring charge until the membership is canceled. The <a href="https://gumroad.com/api#licenses" target="_self">Licenses API</a> will also keep returning the deleted tier in the variants field.</p>
   <p>To avoid any confusion, we recommend that you reassign the customer to another tier that will remain live before deleting a tier.</p>
   <h3 id="Restrictions-for-memberships-0_yOY">Restrictions for memberships</h3>

--- a/app/views/help_center/articles/contents/_82-membership-products.html.erb
+++ b/app/views/help_center/articles/contents/_82-membership-products.html.erb
@@ -86,7 +86,7 @@
   <p>We will email them a receipt showing the changes.</p>
   <h3 id="What-happens-if-you-delete-an-active-tier-0nSPc">What happens if you delete an active tier?</h3>
   <p>If you delete a tier, its associated content will be removed as well. Your existing customers who purchased it will see the content from the current cheapest tier as a fallback. If no tier exists, they will see the product-level content.</p>
-  <p>When you save, Gumroad shows a summary of the tiers and content pages the save will permanently delete and asks you to confirm before anything is removed.</p>
+  <p>When you save, if the deleted tier still has content pages or files, Gumroad shows a summary of what the save will permanently delete and asks you to confirm before anything is removed.</p>
   <p>Also, deleting the tier does not stop customers' subscriptions. They will keep paying their recurring charge until the membership is canceled. The <a href="https://gumroad.com/api#licenses" target="_self">Licenses API</a> will also keep returning the deleted tier in the variants field.</p>
   <p>To avoid any confusion, we recommend that you reassign the customer to another tier that will remain live before deleting a tier.</p>
   <h3 id="Restrictions-for-memberships-0_yOY">Restrictions for memberships</h3>


### PR DESCRIPTION
## What

Adds one sentence each to two help-center articles documenting the new save-time deletion confirmation in the product editor:

- `_126-setting-up-versions-on-a-digital-product.html.erb` — "Delete a version" section now notes that saving shows a summary confirmation when the deleted version still has content pages or files.
- `_82-membership-products.html.erb` — "What happens if you delete an active tier?" section gets the same note for tiers.

Body-only edits; `articles.yml` untouched (no title/description change).

## Why

#6178 added deletion guards to product-editor saves: removing a version/tier or content page now surfaces a "Save and delete content?" summary modal at save time, and the server blocks content deletions that lack explicit confirmation. Both articles walk sellers through deleting a version/tier and described the deletion as immediate on trash-icon click, with no mention of the confirmation step sellers will now see. This aligns the docs with the shipped flow.

Deliberate scope note: the server-side stale-save / hidden-content error messages from #6178 self-describe their remedy ("refresh the page and try again") in the product UI, so no troubleshooting doc addition is needed for them.

## QA steps

1. Open a product with versions, delete a version that has content, click Save — confirm the "Save and delete content?" summary appears (this is the behavior the new sentences describe).
2. Render the two articles at `help.gumroad.com/help/article/126-setting-up-versions-on-a-digital-product` and `.../82-membership-products` and confirm the new sentences read correctly in context.

## Test results

Both partials render successfully via `ApplicationController.render` in the test env with the new copy present:

```
126-setting-up-versions-on-a-digital-product: render OK (4552 bytes)
82-membership-products: render OK (13949 bytes)
```

ERB syntax check and HTML tag-balance check pass on both files. Autoreview skipped (docs copy only, no logic).

---

AI disclosure: authored by Claude Fable 5 (Hermes agent) as part of the merged-PR → help-center doc-sync automation, triggered by the merge of #6178.
