### PR TITLE
docs: document commission payout track record and product type guidance

### DIFF
--- a/app/views/help_center/articles/contents/_70-can-i-sell-services.html.erb
+++ b/app/views/help_center/articles/contents/_70-can-i-sell-services.html.erb
@@ -19,6 +19,8 @@
   <p>Once you have completed the commission, open the customer’s drawer, upload the files, and mark the project completed. We will send an email to the customer informing them about the completion.</p>
   <figure><%= image_tag "help_center/commission-sales.png" %></figure>
   <p>After the commission is completed, we will charge the customer the remaining 50% of the total amount and credit the earnings to your Gumroad balance.</p>
+  <p><strong>Always sell commissioned work through the Commission product type</strong>, not as a regular digital product. The Commission type handles the deposit and completion flow correctly, and selling commissions any other way can trigger a review of your account.</p>
+  <p>Because commission sales involve larger one-off payments from individual customers, accounts that sell mostly commissions may need to build up a track record before payouts are released. If your account is under review, you will need at least 5 sales from distinct customers to establish that track record. We recommend selling digital products, such as finished pieces, asset packs, or tutorials, alongside your commissions. This builds your sales history faster and makes your account less likely to be held for review.</p>
   <h3 id="call">Call</h3>
   <p>The Call product features built-in scheduling, allowing you to offer seamless one-on-one sessions with your customers. </p>
   <p>After giving your product a cover, description, and base price, choose the durations you want to offer the calls for and any additional amount for each duration.</p>


### PR DESCRIPTION
## What

Adds two short notes to the Commission section of the "Can I sell services?" help article (`_70-can-i-sell-services.html.erb`):

1. Commissioned work should always be sold through the dedicated Commission product type, not as a regular digital product.
2. Accounts selling mostly commissions may need a sales track record before payouts are released: at least 5 sales from distinct customers when the account is under review. Selling digital products alongside commissions is recommended.

## Why

Commission-model sellers whose balance rests on one or two large deposits were hitting open-ended payout reviews with no documented path out. The 5-distinct-sales track-record condition is now the standing release rule for these reviews (decided in antiwork/gumroad-private#1283), and sellers should be able to read it in the help center rather than learn it from a support thread.

⚠️ Reviewer attention: this is payout-policy wording. The "5 sales from distinct customers" number and the Commission-product-type guidance come directly from the gumroad-private#1283 ruling. Deliberately omitted: the internal watchlist mechanics and suspend triggers (anti-gaming gates stay out of public docs).

## Before/After

Not applicable — help-center article body copy only; no app UI change. New paragraphs render in the existing article layout (render verified below).

## QA steps

1. Open help.gumroad.com/help/article/70-can-i-sell-services
2. Scroll to the Commission section — two new paragraphs appear after the completion-flow paragraph, before the Call section.

## Test Results

- ERB syntax check: OK
- Tag-balance check (div/p/ul/li/h3/figure/strong/a/b): all balanced
- Rendered the partial in the test env via `ApplicationController.render`: `render OK (6490 bytes)`, new copy present
- `articles.yml` untouched (body-only edit); help-center model specs guard slug↔partial integrity in CI

Autoreview skipped (docs copy only, no logic).

---

## AI disclosure

Authored by Claude Fable 5 (Hermes Agent), executing Sahil's directive on antiwork/gumroad-private#1283: codify the commission track-record payout rule and add it to the help docs.
