### PR TITLE
Resume payout batches where a killed run stopped instead of restarting from the top

### DIFF
--- a/app/business/payments/payouts/payouts.rb
+++ b/app/business/payments/payouts/payouts.rb
@@ -15,6 +15,11 @@ class Payouts
   HOLDING_BALANCE_ID_BATCH_SIZE = 25_000
   # Max ids per `User.where(id: ...)` lookup, so the IN() list stays on MySQL's PK range plan.
   USER_LOOKUP_BATCH_SIZE = 1_000
+  # How long a batch's resume cursor survives. Long enough for a run to be retried or
+  # re-enqueued across the same payout day (including the PayPal retry job), short enough
+  # that an abandoned cursor cannot outlive its payout period. The key is also scoped by
+  # date, so expiry is a backstop rather than the correctness guarantee.
+  BATCH_CURSOR_TTL = 2.days
 
   def self.is_user_payable(user, date, processor_type: nil, add_comment: false, from_admin: false, bypass_minimum_payout: false, payout_type: Payouts::PAYOUT_TYPE_STANDARD)
     payout_date = Time.current.to_fs(:formatted_date_full_month)
@@ -82,21 +87,33 @@ class Payouts
 
   def self.create_payments_for_balances_up_to_date(date, processor_type)
     # Walk the holding-balance cohort in bounded id slices, enqueueing each slice's
-    # payments as we go — the same shape as the bank-account-type path below. The old
-    # `User.holding_balance` relation evaluated the whole ~200k-user cohort in one
-    # `users × balances` GROUP BY and then iterated every user before enqueueing a
-    # single payment. On Fridays (PayPal + Stripe Connect, no bank-account-type
-    # filter) that single pass ran for ~110 minutes; any worker restart mid-pass
-    # (deploys, instance recycling) threw ALL progress away, and sidekiq-pro's
-    # orphan recovery restarted it from the top until the job was buried in the
-    # dead set with the whole cohort unpaid (gumroad-private#1021, 2026-07-10).
-    # Slicing makes progress durable: payments for completed slices are already
-    # enqueued, so a killed pass only re-walks users whose payments were not yet
-    # created — and Payouts.create_payment no-ops once a user's balances leave
-    # `unpaid`, so overlap is safe.
-    holding_balance_user_ids = self.holding_balance_user_ids
+    # payments as we go — the same shape as the bank-account-type path below — and
+    # record how far we got in Redis so a killed run RESUMES instead of restarting.
+    #
+    # Both halves are needed, which is what the 2026-07-24 PayPal incident showed
+    # (gumroad-private#1284, a recurrence of #1021). Slicing alone (#5797) makes each
+    # completed slice's payments durable, but a restarted job still began again at the
+    # lowest user id: the cohort takes ~130 minutes to walk at ~1,570 sellers/min,
+    # longer than a worker process reliably lives (deploys, instance recycling), so
+    # every restart re-walked the same early sellers — whose payments were already
+    # enqueued, hence no visible progress — and the tail of the cohort was never
+    # reached. Sidekiq's orphan recovery kept relaunching from the top until the job
+    # was buried in the dead set with most of the cohort unpaid.
+    #
+    # With a cursor, each restart picks up after the last fully-enqueued slice, so the
+    # run finishes across however many restarts it takes. Re-walking the interrupted
+    # slice is safe: Payouts.create_payment no-ops once a user's balances leave
+    # `unpaid`, so an overlapping user is skipped rather than paid twice.
+    cursor_key = RedisKey.payout_batch_cursor(date, processor_type)
+    # A cursor is only meaningful for the payout period it was recorded in, and the key
+    # is scoped by date, so a stale key can never make a later period skip sellers.
+    resume_after_user_id = $redis.get(cursor_key).to_i
 
-    holding_balance_user_ids.each_slice(USER_LOOKUP_BATCH_SIZE) do |user_ids_batch|
+    if resume_after_user_id > 0
+      Rails.logger.info("AUTOMATED PAYOUTS: #{processor_type} resuming after user #{resume_after_user_id}")
+    end
+
+    holding_balance_user_ids(starting_after: resume_after_user_id).each_slice(USER_LOOKUP_BATCH_SIZE) do |user_ids_batch|
       users = User.where(id: user_ids_batch)
 
       if processor_type == PayoutProcessorType::STRIPE
@@ -107,16 +124,36 @@ class Payouts
       end
 
       self.create_payments_for_balances_up_to_date_for_users(date, processor_type, users, perform_async: true)
+
+      # Only advance once the slice's payments are enqueued: if the job dies partway
+      # through a slice, the cursor still points at the last COMPLETE slice and that
+      # slice is redone (harmlessly) rather than skipped. Ids come back ascending, so
+      # the last id of the slice is its high-water mark.
+      $redis.set(cursor_key, user_ids_batch.last, ex: BATCH_CURSOR_TTL.to_i)
     end
+
+    # The run walked the whole cohort, so the next run for this period (the PayPal
+    # retry job, or a manual re-enqueue) should start from the top again.
+    $redis.del(cursor_key)
   end
 
   def self.create_payments_for_balances_up_to_date_for_bank_account_types(date, processor_type, bank_account_types)
     # Materialize holding-balance user ids, then look up bank accounts in user_id chunks.
     # The old single join (users × balances × bank_accounts) full-scanned bank_accounts
     # and blew the statement timeout; splitting it keeps each piece cheap.
-    holding_balance_user_ids = self.holding_balance_user_ids
-
     bank_account_types.each do |bank_account_type|
+      # Resume where a previous killed run stopped, for the same reason as the
+      # no-bank-type path above (gumroad-private#1284). The cursor is per bank account
+      # type because these run as separate fanned-out jobs with separate lifetimes.
+      cursor_key = RedisKey.payout_batch_cursor(date, "#{processor_type}:#{bank_account_type}")
+      resume_after_user_id = $redis.get(cursor_key).to_i
+
+      if resume_after_user_id > 0
+        Rails.logger.info("AUTOMATED PAYOUTS: #{processor_type} #{bank_account_type} resuming after user #{resume_after_user_id}")
+      end
+
+      holding_balance_user_ids = self.holding_balance_user_ids(starting_after: resume_after_user_id)
+
       user_ids = holding_balance_user_ids.each_slice(BANK_ACCOUNT_LOOKUP_BATCH_SIZE).flat_map do |user_ids_batch|
         BankAccount.alive.where(user_id: user_ids_batch, type: bank_account_type).distinct.pluck(:user_id)
       end
@@ -125,10 +162,19 @@ class Payouts
       # cohort exceeds MySQL's range_optimizer_max_mem_size and full-scans the users
       # table, blowing the statement timeout (gumroad-private#955); slicing keeps each
       # lookup on the PK range plan. Enqueue is per-user, so slicing changes nothing.
-      user_ids.each_slice(USER_LOOKUP_BATCH_SIZE) do |user_ids_batch|
+      #
+      # `pluck` above does not promise ordering, so sort before slicing: the cursor is
+      # only a valid resume point if slices advance monotonically through the ids.
+      user_ids.sort.each_slice(USER_LOOKUP_BATCH_SIZE) do |user_ids_batch|
         users = User.where(id: user_ids_batch)
         self.create_payments_for_balances_up_to_date_for_users(date, processor_type, users, perform_async: true, bank_account_type:)
+
+        # Advance only after the slice is enqueued, so an interrupted slice is redone
+        # (harmlessly — create_payment no-ops for already-paid balances) not skipped.
+        $redis.set(cursor_key, user_ids_batch.last, ex: BATCH_CURSOR_TTL.to_i)
       end
+
+      $redis.del(cursor_key)
     end
   end
 
@@ -143,9 +189,13 @@ class Payouts
   # (state, user_id, amount_cents) covering index and stops. Grouping by user_id never
   # splits a user's SUM, so the union is exactly SUM > 0. Reads only balances, so ids for
   # deleted users may appear; callers resolve them via User.where(id:), which drops them.
-  def self.holding_balance_user_ids
+  #
+  # `starting_after` lets a resumed batch skip the sellers a previous run already
+  # enqueued, instead of re-walking them from the start (gumroad-private#1284). Ids come
+  # back in ascending order, which is what makes a single id a valid resume point.
+  def self.holding_balance_user_ids(starting_after: 0)
     user_ids = []
-    last_user_id = 0
+    last_user_id = starting_after
 
     loop do
       batch = Balance.unpaid

--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -64,6 +64,10 @@ class RedisKey
     # deploy pipeline can ask "is a payout batch in flight right now?" instead
     # of freezing deploys on a fixed clock window. See HealthcheckController#payouts.
     def payout_batch_in_flight = "payouts:batch_in_flight"
+    # How far through the seller cohort a payout batch has already got, so a batch
+    # that gets killed mid-run resumes where it stopped instead of starting over.
+    # Scoped per payout period and processor. See Payouts.create_payments_for_balances_up_to_date.
+    def payout_batch_cursor(date, processor_type) = "payouts:batch_cursor:#{date}:#{processor_type}"
     def stripe_balance_topup_needed = "stripe:balance_topup_needed"
     def min_successful_purchases_in_last_10_minutes = "healthcheck:min_successful_purchases_in_last_10_minutes"
     def email_router_fallback(user_id) = "email_router_fallback:#{user_id}"

--- a/spec/business/payments/payouts/payouts_spec.rb
+++ b/spec/business/payments/payouts/payouts_spec.rb
@@ -362,6 +362,88 @@ describe Payouts do
 
       described_class.create_payments_for_balances_up_to_date(payout_date, PayoutProcessorType::STRIPE)
     end
+
+    describe "resuming an interrupted batch" do
+      # Regression tests for gumroad-private#1284. Slicing alone (#5797) was not enough:
+      # a restarted job still began at the lowest user id, so on a cohort that takes
+      # longer to walk than a worker process lives, every restart re-walked the same
+      # early sellers and the tail was never reached.
+      let(:cursor_key) { RedisKey.payout_batch_cursor(payout_date, payout_processor_type) }
+
+      before { stub_const("Payouts::USER_LOOKUP_BATCH_SIZE", 2) }
+      after { $redis.del(cursor_key) }
+
+      it "records how far it got so a killed run does not restart from the beginning" do
+        users = create_list(:user, 5, unpaid_balance_cents: 100).sort_by(&:id)
+        allow(described_class).to receive(:create_payments_for_balances_up_to_date_for_users)
+
+        described_class.create_payments_for_balances_up_to_date(payout_date, payout_processor_type)
+
+        # The run completed, so the cursor is cleared and the next run starts from the top.
+        expect($redis.get(cursor_key)).to be_nil
+        expect(users.size).to eq(5)
+      end
+
+      it "advances the cursor only after each slice's payments are enqueued" do
+        users = create_list(:user, 5, unpaid_balance_cents: 100).sort_by(&:id)
+        cursor_at_each_call = []
+
+        allow(described_class).to receive(:create_payments_for_balances_up_to_date_for_users) do
+          # An interrupted slice must be redone, not skipped: when the Nth slice is being
+          # enqueued, the cursor still points at the end of slice N-1.
+          cursor_at_each_call << $redis.get(cursor_key)&.to_i
+        end
+
+        described_class.create_payments_for_balances_up_to_date(payout_date, payout_processor_type)
+
+        expect(cursor_at_each_call).to eq([nil, users[1].id, users[3].id])
+      end
+
+      it "resumes after the last fully-enqueued slice instead of re-walking the whole cohort" do
+        users = create_list(:user, 5, unpaid_balance_cents: 100).sort_by(&:id)
+        # Simulate a previous run that died after enqueueing the first two sellers.
+        $redis.set(cursor_key, users[1].id)
+
+        enqueued = []
+        allow(described_class).to receive(:create_payments_for_balances_up_to_date_for_users) do |_date, _processor, slice_users, **|
+          enqueued.concat(slice_users.to_a)
+        end
+
+        described_class.create_payments_for_balances_up_to_date(payout_date, payout_processor_type)
+
+        expect(enqueued).to match_array(users[2..])
+      end
+
+      it "walks the whole cohort when a previous run left no cursor" do
+        users = create_list(:user, 5, unpaid_balance_cents: 100)
+
+        enqueued = []
+        allow(described_class).to receive(:create_payments_for_balances_up_to_date_for_users) do |_date, _processor, slice_users, **|
+          enqueued.concat(slice_users.to_a)
+        end
+
+        described_class.create_payments_for_balances_up_to_date(payout_date, payout_processor_type)
+
+        expect(enqueued).to match_array(users)
+      end
+
+      it "does not let one payout period's cursor affect another period's run" do
+        users = create_list(:user, 5, unpaid_balance_cents: 100).sort_by(&:id)
+        # A cursor left behind by a different payout period must not skip sellers here.
+        $redis.set(RedisKey.payout_batch_cursor(payout_date - 7, payout_processor_type), users[3].id)
+
+        enqueued = []
+        allow(described_class).to receive(:create_payments_for_balances_up_to_date_for_users) do |_date, _processor, slice_users, **|
+          enqueued.concat(slice_users.to_a)
+        end
+
+        described_class.create_payments_for_balances_up_to_date(payout_date, payout_processor_type)
+
+        expect(enqueued).to match_array(users)
+      ensure
+        $redis.del(RedisKey.payout_batch_cursor(payout_date - 7, payout_processor_type))
+      end
+    end
   end
 
   describe "create_instant_payouts_for_balances_up_to_date" do
@@ -559,6 +641,45 @@ describe Payouts do
       expect(loaded_batches.map(&:size)).to all(be <= 1)
       expect(loaded_batches.flatten).to match_array([u1_2, u2_2])
     end
+
+    it "resumes after the last fully-enqueued slice when a previous run was killed" do
+      # gumroad-private#1284: a restarted fan-out job used to re-walk the cohort from the
+      # lowest user id, so on a long cohort the tail was never reached.
+      stub_const("Payouts::USER_LOOKUP_BATCH_SIZE", 1)
+      allow(Payouts).to receive(:is_user_payable).and_return(true)
+      cursor_key = RedisKey.payout_batch_cursor(payout_date, "#{payout_processor_type}:#{AustralianBankAccount.name}")
+      first_australian, second_australian = [u1_2, u2_2].sort_by(&:id)
+      $redis.set(cursor_key, first_australian.id)
+
+      enqueued = []
+      allow(described_class).to receive(:create_payments_for_balances_up_to_date_for_users) do |_date, _processor, users, **_options|
+        enqueued.concat(users.to_a)
+      end
+
+      described_class.create_payments_for_balances_up_to_date_for_bank_account_types(payout_date, payout_processor_type, [AustralianBankAccount.name])
+
+      expect(enqueued).to eq([second_australian])
+      # Cohort fully walked, so the next run for this period starts from the top.
+      expect($redis.get(cursor_key)).to be_nil
+    ensure
+      $redis.del(RedisKey.payout_batch_cursor(payout_date, "#{payout_processor_type}:#{AustralianBankAccount.name}"))
+    end
+
+    it "keeps each bank account type's resume cursor separate" do
+      # The multi-type batch fans out to concurrent per-type jobs with independent
+      # lifetimes, so one type's progress must never move another type's starting point.
+      allow(Payouts).to receive(:is_user_payable).and_return(true)
+      allow(described_class).to receive(:create_payments_for_balances_up_to_date_for_users)
+      australian_cursor = RedisKey.payout_batch_cursor(payout_date, "#{payout_processor_type}:#{AustralianBankAccount.name}")
+      canadian_cursor = RedisKey.payout_batch_cursor(payout_date, "#{payout_processor_type}:#{CanadianBankAccount.name}")
+
+      expect(australian_cursor).not_to eq(canadian_cursor)
+
+      described_class.create_payments_for_balances_up_to_date_for_bank_account_types(payout_date, payout_processor_type, [AustralianBankAccount.name, CanadianBankAccount.name])
+
+      expect($redis.get(australian_cursor)).to be_nil
+      expect($redis.get(canadian_cursor)).to be_nil
+    end
   end
 
   describe ".holding_balance_user_ids" do
@@ -600,6 +721,17 @@ describe Payouts do
       stub_const("Payouts::HOLDING_BALANCE_ID_BATCH_SIZE", 1)
 
       expect(described_class.holding_balance_user_ids.sort).to eq(User.holding_balance.ids.sort)
+    end
+
+    it "skips ids at or below starting_after so a resumed batch does not re-walk them" do
+      all_ids = described_class.holding_balance_user_ids.sort
+      resume_after = all_ids[1]
+
+      expect(described_class.holding_balance_user_ids(starting_after: resume_after)).to eq(all_ids[2..])
+    end
+
+    it "returns the whole cohort when starting_after is the default" do
+      expect(described_class.holding_balance_user_ids(starting_after: 0)).to match_array(described_class.holding_balance_user_ids)
     end
 
     it "never splits a user's balance aggregation across batches" do


### PR DESCRIPTION
Fixes the recurrence Sahil flagged on antiwork/gumroad-private#1284 ("Fix the code.").

## What broke

The Friday PayPal payout batch died mid-run on 2026-07-24 with most of the seller cohort unpaid — the same failure #5797 was supposed to end (gumroad-private#1021).

#5797 made the Friday path enqueue payments **per 1,000-seller slice** rather than only after walking the entire cohort, which made each completed slice's payments durable. That was necessary but not sufficient: a restarted run still **began again at the lowest user id**.

Measured on the live pass during the incident (audited read `20260724T224107Z-40776199`):

| | |
|---|---|
| Sellers walked by the pass | 85,479 in 54m35s |
| Walk rate | ~1,570 sellers/min |
| Full cohort walk time | ~130 minutes |
| Observed pass lifetimes | ~55–60 min |

The cohort takes longer to walk than a worker process reliably lives (deploys, instance recycling). So every restart re-walked the same early sellers — whose payments were already enqueued, which is exactly why nothing visibly progressed — and the tail of the cohort was **never reached**. Sidekiq's orphan recovery kept relaunching from the top until the job was buried in the dead set with no error.

That's the Sisyphus loop: slicing made progress durable, but nothing made progress *cumulative*.

## The fix

Each slice records its high-water user id in Redis, and a run resumes after the last fully-enqueued slice. Progress now survives any number of restarts, so the run finishes even when no single process lives long enough to do it alone.

Three details that matter:

- **The cursor advances only after a slice is enqueued**, so an interrupted slice is redone rather than skipped. Redoing it is harmless: `Payouts.create_payment` no-ops once a user's balances leave `unpaid`, so an overlapping seller is skipped, never paid twice.
- **The cursor key is scoped to the payout period and processor** (and bank account type on the fan-out path, since those run as separate jobs with independent lifetimes). One run's progress can never make a later period skip sellers. The 2-day TTL is a backstop, not the correctness guarantee.
- **The bank-account-type path gets the same treatment.** It was less exposed because it walks a smaller per-type cohort, but it had the identical restart-from-zero behavior. Its user ids are now sorted before slicing, because `pluck` makes no ordering promise and a cursor is only a valid resume point if slices advance monotonically.

## Test results

`bundle exec rspec spec/business/payments/payouts/payouts_spec.rb`

```
76 examples, 0 failures
```

Sibling specs covering the worker, the in-flight healthcheck, and the Redis keys:

`bundle exec rspec spec/sidekiq/perform_payouts_up_to_delay_days_ago_worker_spec.rb spec/controllers/healthcheck_controller_spec.rb spec/services/redis_key_spec.rb`

```
41 examples, 0 failures
```

`bundle exec rubocop` on the three changed files: `3 files inspected, no offenses detected`.

### The regression tests actually fail without the fix

9 new examples. To prove they're real regression tests rather than tests of whatever the code happens to do, I reverted just the resume behavior (made the cursor read return 0, i.e. always restart from the top) and re-ran:

```
5 examples, 1 failure

rspec ./spec/business/payments/payouts/payouts_spec.rb:402
  # resumes after the last fully-enqueued slice instead of re-walking the whole cohort
```

That example is the one that encodes the incident, and it goes red without the cursor and green with it.

Coverage added:
- resumes after the last fully-enqueued slice instead of re-walking the cohort
- advances the cursor only *after* each slice is enqueued (interrupted slice redone, not skipped)
- walks the whole cohort when no cursor exists
- clears the cursor on completion, so the next run starts fresh
- one payout period's cursor cannot affect another period's run
- each bank account type keeps a separate cursor
- `holding_balance_user_ids(starting_after:)` skips ids at or below the resume point, and returns the whole cohort by default

## QA steps

This is a batch job with no UI surface, so verification is behavioral:

1. `bundle exec rspec spec/business/payments/payouts/payouts_spec.rb` → 76 passing.
2. Confirm the resume test is load-bearing: change `resume_after_user_id = $redis.get(cursor_key).to_i` to `= 0` in `create_payments_for_balances_up_to_date` and re-run — the "resumes after the last fully-enqueued slice" example fails.
3. On the next Friday batch, `payouts:batch_cursor:<date>:PAYPAL` should appear in Redis, climb monotonically while the run walks the cohort, and be deleted when the run completes. A killed-and-recovered run should log `AUTOMATED PAYOUTS: PAYPAL resuming after user <id>` instead of starting over.

## Not in this PR

The other half of the problem is that the pass gets killed at all (~55–60 min lifetimes against a ~130 min walk). This PR makes the batch survive that rather than fixing it; worker lifetime/memory on the no-bank-type path is a separate investigation and I'd rather ship the durability fix first, since it's what unblocks sellers on the next batch either way.

The live 2026-07-24 recovery pass is still draining separately and is not affected by this change.

🤖 Written by an AI agent (Hermes, Claude Opus 5). Sahil directed the fix on gumroad-private#1284; the diagnosis, code, tests, and RED/GREEN verification above are mine and were run locally.