### PR TITLE
Compute the next scheduled payout date from this week, not a 2012 anchor

### DIFF
--- a/app/modules/user/payout_schedule.rb
+++ b/app/modules/user/payout_schedule.rb
@@ -99,6 +99,13 @@ module User::PayoutSchedule
 
   # Public: Returns the upcoming payout date, not taking a user into account.
   #
+  # This is the platform's payout RUN date — the Friday the payout job fires — and it is
+  # deliberately seller-agnostic. An individual seller can be on a daily, weekly, monthly,
+  # or quarterly frequency, so anything a seller sees must come from the per-seller
+  # #next_payout_date above (which branches on payout_frequency), never from here. The
+  # weekly run only actually pays a seller whose own next payout date has come up; see the
+  # per-user check in Payouts.
+  #
   # Scheduled payouts run every Friday, so this is simply the next Friday (today, if
   # today is a Friday). It used to be computed by starting at a hardcoded 2012 date and
   # stepping forward a week at a time until the result caught up to today, which meant

--- a/app/modules/user/payout_schedule.rb
+++ b/app/modules/user/payout_schedule.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 module User::PayoutSchedule
-  PAYOUT_STARTING_DATE = Date.new(2012, 12, 21)
-  PAYOUT_RECURRENCE_DAYS = 7
   PAYOUT_DELAY_DAYS = 7
 
   WEEKLY = "weekly"
@@ -100,10 +98,16 @@ module User::PayoutSchedule
   end
 
   # Public: Returns the upcoming payout date, not taking a user into account.
+  #
+  # Scheduled payouts run every Friday, so this is simply the next Friday (today, if
+  # today is a Friday). It used to be computed by starting at a hardcoded 2012 date and
+  # stepping forward a week at a time until the result caught up to today, which meant
+  # every call looped ~700 times and grew by one iteration a week forever. The anchor
+  # date carried no meaning beyond "a Friday", so anchoring to the current week instead
+  # gives the same answer in constant time and can't drift.
   def self.next_scheduled_payout_date
-    scheduled_payout_date = PAYOUT_STARTING_DATE
-    scheduled_payout_date += PAYOUT_RECURRENCE_DAYS while scheduled_payout_date < Date.today
-    scheduled_payout_date
+    today = Date.today
+    today.friday? ? today : today.next_occurring(:friday)
   end
 
   # Public: Returns the upcoming payout's end date, not taking a user into account.

--- a/spec/modules/user/payout_schedule_spec.rb
+++ b/spec/modules/user/payout_schedule_spec.rb
@@ -133,6 +133,78 @@ describe User::PayoutSchedule do
     end
   end
 
+  describe ".next_scheduled_payout_date" do
+    # These use a local-time midday so the frozen clock lands on the intended calendar
+    # day regardless of the machine's timezone — the method reads Date.today, which is
+    # the system date rather than the Rails-zone date.
+    it "returns today when today is already a Friday" do
+      travel_to(Time.local(2026, 7, 24, 12)) do
+        expect(described_class.next_scheduled_payout_date).to eq Date.new(2026, 7, 24)
+      end
+    end
+
+    it "returns the coming Friday on every other day of the week" do
+      {
+        Time.local(2026, 7, 25, 12) => Date.new(2026, 7, 31), # Saturday
+        Time.local(2026, 7, 26, 12) => Date.new(2026, 7, 31), # Sunday
+        Time.local(2026, 7, 27, 12) => Date.new(2026, 7, 31), # Monday
+        Time.local(2026, 7, 28, 12) => Date.new(2026, 7, 31), # Tuesday
+        Time.local(2026, 7, 29, 12) => Date.new(2026, 7, 31), # Wednesday
+        Time.local(2026, 7, 30, 12) => Date.new(2026, 7, 31), # Thursday
+      }.each do |today, expected_payout_date|
+        travel_to(today) do
+          expect(described_class.next_scheduled_payout_date).to eq expected_payout_date
+        end
+      end
+    end
+
+    it "crosses month and year boundaries" do
+      travel_to(Time.local(2026, 12, 31, 12)) do # Thursday
+        expect(described_class.next_scheduled_payout_date).to eq Date.new(2027, 1, 1)
+      end
+    end
+
+    # This method describes the platform-wide payout run (the Friday cron), not any
+    # individual seller's schedule. A seller on a monthly or quarterly frequency is paid
+    # on their own date, which comes from the per-seller #next_payout_date below. Nothing
+    # shown to a seller should be derived from this method — see the spec that follows.
+    it "describes the platform-wide Friday run, not an individual seller's payout date" do
+      travel_to(Time.local(2026, 7, 22, 12)) do # Wednesday
+        monthly_seller = create(:user, payment_address: "monthly@example.com")
+        monthly_seller.update!(payout_frequency: User::PayoutSchedule::MONTHLY)
+        create(:balance, user: monthly_seller, amount_cents: 10_000, date: Date.new(2026, 7, 1))
+
+        expect(described_class.next_scheduled_payout_date).to eq Date.new(2026, 7, 24)
+        expect(monthly_seller.next_payout_date).to eq Date.new(2026, 7, 31)
+      end
+    end
+  end
+
+  describe "seller-facing payout dates respect the seller's own frequency" do
+    # Guards the accuracy concern raised on the change that made
+    # .next_scheduled_payout_date compute from the current week: everything a seller
+    # sees (Payouts page, settings, emails, admin "next payout date") reads
+    # #next_payout_date, which branches on the seller's payout_frequency.
+    it "returns a different date per frequency for the same balance and clock" do
+      travel_to(Time.local(2026, 7, 22, 12)) do # Wednesday
+        balances_for = lambda do |frequency, email|
+          create(:user, payment_address: email).tap do |seller|
+            seller.update!(payout_frequency: frequency)
+            create(:balance, user: seller, amount_cents: 10_000, date: Date.new(2026, 7, 1))
+          end
+        end
+
+        weekly_seller = balances_for.call(User::PayoutSchedule::WEEKLY, "weekly@example.com")
+        monthly_seller = balances_for.call(User::PayoutSchedule::MONTHLY, "monthly@example.com")
+        quarterly_seller = balances_for.call(User::PayoutSchedule::QUARTERLY, "quarterly@example.com")
+
+        expect(weekly_seller.next_payout_date).to eq Date.new(2026, 7, 24)
+        expect(monthly_seller.next_payout_date).to eq Date.new(2026, 7, 31)
+        expect(quarterly_seller.next_payout_date).to eq Date.new(2026, 9, 25)
+      end
+    end
+  end
+
   describe ".manual_payout_end_date" do
     it "returns the date upto which creators are expected to have been automatically paid out till now" do
       today = Date.today


### PR DESCRIPTION
`User::PayoutSchedule.next_scheduled_payout_date` computed "the next Friday" by starting at a hardcoded `Date.new(2012, 12, 21)` and stepping forward a week at a time until it caught up to the present:

```ruby
scheduled_payout_date = PAYOUT_STARTING_DATE
scheduled_payout_date += PAYOUT_RECURRENCE_DAYS while scheduled_payout_date < Date.today
scheduled_payout_date
```

That loop runs **709 iterations as of today** and gains one more every week, forever. The 2012 anchor carried no business meaning beyond happening to be a Friday, so this anchors to the current week instead:

```ruby
today = Date.today
today.friday? ? today : today.next_occurring(:friday)
```

`PAYOUT_STARTING_DATE` and `PAYOUT_RECURRENCE_DAYS` had no other references anywhere in the repo, so they're removed rather than left as dead constants.

## Why this is safe

Brute-forced both implementations across **every date from 2020-01-01 through 2030-01-01: zero mismatches**. The behavior is identical, including the "today is a Friday" edge case, which the old loop got right by terminating on `<` rather than `<=`.

Callers are unchanged: `next_scheduled_payout_end_date`, `manual_payout_end_date`, `PerformPayoutsUpToDelayDaysAgoWorker`, `StripeBalanceCheckService`, `PaypalBalanceCheckService`, `RetryFailedPaypalPayoutsWorker`.

## Test results

`spec/modules/user/payout_schedule_spec.rb`, `spec/sidekiq/perform_payouts_up_to_delay_days_ago_worker_spec.rb`, `spec/models/concerns/user/payout_info_spec.rb` → **27 examples, 4 failures, and the same 4 failures with the identical names occur on unmodified `main` on this machine** (verified by stashing the change and re-running). They're date-sensitive specs and today is a Friday; unrelated to this change. Deferring to CI on a non-Friday for a fully green run.

🤖 Written by claude-opus-5 via Hermes agent (gumclaw)

## Seller payout schedules

`next_scheduled_payout_date` is the platform's payout **run** date (the Friday the job fires) and is seller-agnostic by construction — it's a module method with no seller in scope. Individual sellers can be on daily, weekly, monthly, or quarterly frequency, and every seller-facing date comes from the per-seller `User#next_payout_date`, which branches on `payout_frequency` (last Friday of the week / month / quarter). The weekly run skips a seller whose own next payout date hasn't come up yet (`date + PAYOUT_DELAY_DAYS >= user.next_payout_date` in `Payouts`).

That split is now documented on the method and pinned by specs: for one balance and one frozen clock (Wed 2026-07-22) a weekly seller gets 2026-07-24, monthly 2026-07-31, quarterly 2026-09-25, while the platform run date is 2026-07-24. Plus direct coverage of the new implementation for every weekday, the "today is a Friday" case, and a year boundary.
