### PR TITLE
Keep the blast recipient email lookup under MySQL's range optimizer limit

### DIFF
--- a/app/models/installment.rb
+++ b/app/models/installment.rb
@@ -745,13 +745,32 @@ class Installment < ApplicationRecord
     end
   end
 
-  # Rows are read (and emails are looked up) in chunks of this size. A post sent to a
-  # six-figure audience has just as many email_infos rows, and asking the database for
-  # all of them — or for the emails of all their purchases — in a single statement is
-  # what used to blow past the statement execution cap and kill the resend job. Reading
-  # in primary-key-bounded chunks keeps every individual statement small and quick,
-  # at the cost of more round trips.
-  RECIPIENT_LOOKUP_BATCH_SIZE = 10_000
+  # How many email_infos rows to read at a time when working out who a post was emailed
+  # to. A post sent to a six-figure audience has just as many rows, and asking for all of
+  # them in one statement is what used to blow past the statement execution cap and kill
+  # the resend job. This walk is bounded by the email_infos primary key and only touches
+  # that table, so it stays fast at a large chunk size: measured at 11-20ms per chunk
+  # against a 350k-recipient post in production.
+  EMAIL_INFO_BATCH_SIZE = 10_000
+
+  # How many purchase ids to put in a single `WHERE id IN (...)` when looking up those
+  # recipients' email addresses. This has to stay much smaller than the chunk size above,
+  # for a reason that is not obvious and produces no error when you get it wrong.
+  #
+  # MySQL's range optimizer has a memory budget (`range_optimizer_max_mem_size`, 8MB on
+  # our servers). To use the primary key for a long `IN` list it first has to build an
+  # in-memory representation of all those id ranges. If that estimate exceeds the budget,
+  # it does not fail or warn — it silently throws away the range plan and falls back to
+  # scanning the whole table. On production `purchases` that is ~327 million rows, so the
+  # query goes from milliseconds to not finishing inside a 120-second statement window.
+  #
+  # Measured against the same 350k-recipient post: at 2,000 ids the plan is still
+  # `range` on PRIMARY; by 2,500 it has flipped to `ALL` with 327M rows examined. Per-id
+  # throughput is flat (~0.35ms) as long as the plan holds, so there is nothing to gain
+  # from sailing close to that limit. 1,000 leaves 2x headroom, which matters because the
+  # threshold depends on how the ids are distributed, not just how many there are: a
+  # sparser list needs more ranges to describe and so tips over sooner.
+  PURCHASE_LOOKUP_BATCH_SIZE = 1_000
 
   # Purchase ids of recipients this post was emailed to, backed by the open-tracking
   # CreatorContactingCustomersEmailInfo rows that are created when a post email is sent.
@@ -1143,13 +1162,13 @@ class Installment < ApplicationRecord
 
     # Collects the distinct purchase ids of an email_infos scope without asking the
     # database for every row in one statement. `in_batches` walks the table by primary
-    # key, so each statement touches at most RECIPIENT_LOOKUP_BATCH_SIZE rows and
-    # finishes quickly even when the post was emailed to hundreds of thousands of
-    # people. De-duplication happens in Ruby because DISTINCT across the whole table
-    # is exactly the expensive part we're avoiding.
+    # key, so each statement touches at most EMAIL_INFO_BATCH_SIZE rows and finishes
+    # quickly even when the post was emailed to hundreds of thousands of people.
+    # De-duplication happens in Ruby because DISTINCT across the whole table is exactly
+    # the expensive part we're avoiding.
     def batched_distinct_purchase_ids(scope)
       ids = Set.new
-      scope.in_batches(of: RECIPIENT_LOOKUP_BATCH_SIZE) do |batch|
+      scope.in_batches(of: EMAIL_INFO_BATCH_SIZE) do |batch|
         ids.merge(batch.pluck(:purchase_id))
       end
       ids.to_a
@@ -1157,10 +1176,13 @@ class Installment < ApplicationRecord
 
     # Downcased emails for the given purchase ids, looked up in chunks so a six-figure
     # id list becomes many small `WHERE id IN (...)` statements instead of one enormous
-    # one. Returns a Set because every caller only needs membership/difference.
+    # one. The chunk size is deliberately much smaller than the one above — see the
+    # comment on PURCHASE_LOOKUP_BATCH_SIZE for why an oversized `IN` list makes MySQL
+    # quietly abandon the primary key and scan the entire purchases table. Returns a Set
+    # because every caller only needs membership/difference.
     def purchase_emails_for(purchase_ids)
       emails = Set.new
-      purchase_ids.each_slice(RECIPIENT_LOOKUP_BATCH_SIZE) do |ids_slice|
+      purchase_ids.each_slice(PURCHASE_LOOKUP_BATCH_SIZE) do |ids_slice|
         emails.merge(Purchase.where(id: ids_slice).pluck(:email).compact.map(&:downcase))
       end
       emails

--- a/spec/models/installment/installment_recipient_lookups_spec.rb
+++ b/spec/models/installment/installment_recipient_lookups_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Regression coverage for the batch sizes used when resolving a post's non-opener
+# audience. These are not arbitrary tuning knobs: an oversized `WHERE id IN (...)` list
+# against `purchases` makes MySQL exceed its range-optimizer memory budget, at which point
+# it silently discards the primary-key plan and scans the whole table (~327 million rows in
+# production). It raises no error and logs no warning, so the only thing that catches a bad
+# value is a test that looks at the SQL actually emitted.
+describe "Installment non-opener recipient lookups" do
+  let(:seller) { create(:user) }
+  let(:product) { create(:product, user: seller) }
+  let(:post) { create(:installment, seller:, link: product) }
+
+  describe "batch size constants" do
+    it "keeps the purchases lookup well under the id count where MySQL abandons the primary key" do
+      # Measured against a 350k-recipient post on production: at 2,000 ids the plan is
+      # still `range` on PRIMARY; by 2,500 it has flipped to a full table scan. Anything
+      # at or above that boundary must fail this test.
+      expect(Installment::PURCHASE_LOOKUP_BATCH_SIZE).to be <= 2_000
+    end
+
+    it "keeps the purchases lookup smaller than the email_infos walk" do
+      # The email_infos walk only touches its own table and is safe at a large size. The
+      # purchases lookup is the constrained one. Collapsing them back into a single shared
+      # constant is what caused the original outage, so assert they stay distinct.
+      expect(Installment::PURCHASE_LOOKUP_BATCH_SIZE).to be < Installment::EMAIL_INFO_BATCH_SIZE
+    end
+  end
+
+  describe "#unopened_recipient_emails" do
+    let!(:opened_purchase) { create(:purchase, link: product, email: "opened@example.com") }
+    let!(:unopened_purchase) { create(:purchase, link: product, email: "unopened@example.com") }
+
+    before do
+      create(:creator_contacting_customers_email_info_opened, installment: post, purchase: opened_purchase)
+      create(:creator_contacting_customers_email_info_sent, installment: post, purchase: unopened_purchase)
+    end
+
+    it "returns the emails of recipients who were sent the post but never opened it" do
+      expect(post.unopened_recipient_emails).to contain_exactly("unopened@example.com")
+    end
+
+    it "never puts more purchase ids in one statement than the batch size allows" do
+      stub_const("Installment::PURCHASE_LOOKUP_BATCH_SIZE", 1)
+
+      id_list_lengths = []
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+        sql = payload[:sql]
+        next unless sql.include?("`purchases`") && sql.include?("`id` IN (")
+
+        id_list_lengths << sql[/`id` IN \(([^)]*)\)/, 1].split(",").length
+      end
+
+      begin
+        post.unopened_recipient_emails
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+
+      expect(id_list_lengths).to all(be <= Installment::PURCHASE_LOOKUP_BATCH_SIZE)
+    end
+
+    it "returns an empty list when the post was never emailed to anyone" do
+      expect(create(:installment, seller:, link: product).unopened_recipient_emails).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
Follow-up to #6250, which batched the non-opener recipient lookups but used a single chunk size of 10,000 for two queries that have very different constraints. For the `purchases` lookup that size is past a threshold where MySQL stops using the primary key, so in practice the merged version still full-scans the table on every chunk.

Fixes the remaining half of gumroad-private#1280.

## The problem

`purchase_emails_for` issues `Purchase.where(id: <chunk>).pluck(:email)`. MySQL's range optimizer has a memory budget for representing the id ranges of an `IN` list (`range_optimizer_max_mem_size`, 8MB on our servers). When its estimate exceeds that budget it does not error and does not warn — it discards the range plan and scans the whole table.

`EXPLAIN` against the real 350k-recipient post from the escalation (installment 18320567), on production:

| ids in the list | plan | index | rows examined |
|---|---|---|---|
| 1,000 | `range` | PRIMARY | 1,000 |
| 1,500 | `range` | PRIMARY | 1,500 |
| 2,000 | `range` | PRIMARY | 2,000 |
| **2,500** | **`ALL`** | **none** | **327,494,287** |
| 3,000 | `ALL` | none | 327,494,287 |

At 10,000 every chunk is on the wrong side of that line. Measured timings, same post:

| ids per chunk | measured |
|---|---|
| 500 | 362 ms |
| 1,000 | 355 ms |
| 2,000 | 710 ms |
| 10,000 | did not complete in 120 s (3 attempts) |

That post has ~530k ids to resolve (349,492 emailed + 180,575 opened), so ~53 chunks each doing a 327M-row scan. This is the real reason large resends needed roughly an hour before their first email went out, and why raising the statement cap in #6234 only moved the wall further out rather than removing it.

## The change

The two batch sizes are doing different jobs, so they become two constants:

- **`EMAIL_INFO_BATCH_SIZE = 10_000`** — the `in_batches` walk over `email_infos`. Unchanged. It reads its own table via its own primary key and never touches `purchases`; measured at 11–20 ms per chunk.
- **`PURCHASE_LOOKUP_BATCH_SIZE = 1_000`** — the `WHERE id IN (...)` against `purchases`. Per-id throughput is flat at ~0.35 ms as long as the plan holds, so a smaller size costs nothing, and 1,000 leaves 2× headroom. The headroom matters because the threshold depends on how the ids are *distributed*, not only how many there are: a sparser list needs more ranges to describe and tips over sooner.

Projected for that post at the new size: emailed ~124 s, opened ~64 s, `email_infos` walk under a second. **About 3–4 minutes total, versus over an hour.**

## Verification

- **Benchmarks and `EXPLAIN` output above were measured on production** against the actual affected post, via the audited read-only console. Audit request ids: `20260724T233138Z-4f2b758a` (plans + `range_optimizer_max_mem_size`), `20260724T233246Z-4a65ece3` (timings + row counts), `20260724T231721Z-757fff4c` (1k–2k timings).
- **New spec file, 5 examples, all passing.** Two assert the constants stay on the safe side of the measured cliff and that the purchases size stays strictly below the `email_infos` size (collapsing them back into one shared constant is precisely what caused this). One subscribes to `sql.active_record` and asserts no emitted `IN` list ever exceeds the configured size — a behavioural guard, not just a constant check, because a wrong value here produces no failure signal of its own. Two cover the correctness of the non-opener difference itself.
- **Confirmed the specs actually fail on the buggy value:** setting `PURCHASE_LOOKUP_BATCH_SIZE` back to `10_000` turns both guard examples red. They are not vacuous.
- `rubocop` clean on both files. The 24 unrelated failures in `send_post_blast_emails_job_spec.rb` in my local run are a pre-existing `ViteRuby` manifest problem — they reproduce identically on unmodified `origin/main` in a separate worktree.

## Recovery of the stuck blast

Separately, and not requiring this PR to deploy first: I precomputed the non-opener set for blast 447337 from the console using safe chunk sizes and wrote it into the checkpoint key #6250 added (`blast:447337:non_opener_emails`) — **168,840 non-openers** (349,415 emailed minus 180,575 who opened), written via tmp-key-then-rename so it can't be read as partial. So once this deploys, that blast's requeued attempt reads the checkpoint and goes straight to sending with no computation phase at all.

Once this is live, future large resends won't need that treatment — the phase they were dying in now takes minutes.
