### PR TITLE
Help center: guest checkouts count toward existing-customer discounts

### DIFF
--- a/app/views/help_center/articles/contents/_128-discount-codes.html.erb
+++ b/app/views/help_center/articles/contents/_128-discount-codes.html.erb
@@ -71,6 +71,7 @@
   <h3 id="limit-to-existing-customers">Limit to existing customers</h3>
   <p>Restrict a discount code to buyers who already own one of your products. Open the discount, scroll to <b>Settings</b>, and turn on <b>Limit to existing customers</b>. Under <b>Must have purchased</b>, pick the product (or products) the buyer must already own for the code to apply.</p>
   <figure><%= image_tag "help_center/discount-existing-customers.png", alt: "Limit to existing customers toggle with the Must have purchased product picker" %></figure>
+  <p>Guest checkouts count too. If a buyer bought the required product without an account, the code still applies as long as they are signed in to a Gumroad account whose confirmed email matches the email they used at that checkout. If their account email is not confirmed yet, only purchases already attached to the account count, so ask them to confirm their email address.</p>
   <p>A few common setups:</p>
   <ul>
     <li><b>Reward repeat buyers.</b> Pick Product A under <b>Must have purchased</b>, then set the discount to apply to Product B. Buyers who already own A get the discount on B.</li>
@@ -91,6 +92,7 @@
     <li>Tier discounts require the <b>Percentage</b> discount type — fixed amounts aren't supported.</li>
     <li>Tiers replace <b>Discount duration for memberships</b>. When tiers are on, that option is hidden — the tiers control the schedule.</li>
     <li>Combine with <a href="#limit-to-existing-customers">Limit to existing customers</a> if you want to require the buyer to own a specific product before any tier applies.</li>
+    <li>Ownership is counted from the buyer's oldest qualifying purchase, and it is matched the same way as <a href="#limit-to-existing-customers">Limit to existing customers</a>, so a guest checkout under the buyer's confirmed account email counts toward their duration.</li>
   </ul>
   <h3 id="edit-discount-codes">Edit discount codes</h3>
   <p>Click any discount you want to edit, and a side panel will open. </p>


### PR DESCRIPTION
## What

Updates the `Limit to existing customers` and `Tier discount by ownership duration` sections of the discount codes help article (`_128-discount-codes.html.erb`) to say that guest checkouts count toward existing-customer eligibility, and that the buyer's account email has to be confirmed for that matching to happen.

## Why

Triggered by merged PR #6254, which widened `OfferCode#ownership_months_for` to resolve a buyer's prior purchases by `purchases.purchaser_id` OR the signed-in buyer's confirmed account email. Before that change a guest purchase (where `purchaser_id` is NULL until the buyer claims it) did not count, and the article described the restriction as if only account-linked purchases qualified. Two claims were now wrong:

- The existing-customer section said only "buyers who already own one of your products" with no mention of how ownership is matched, so sellers had no way to know guest buyers were excluded (that gap is what produced the support report behind the fix).
- The ownership-duration tier section relies on the same lookup, so a guest purchase now also sets the buyer's duration.

The confirmed-email condition is stated because it is a real user-visible gate: the email leg is guarded on `buyer.confirmed?` in the merged diff, so an unconfirmed account still only gets ownership through the account link.

Articles changed: `_128-discount-codes` (body only). No removals. No `articles.yml` change — no title, description or category change.

## Test plan

- ERB syntax check on the edited partial: OK.
- Tag balance count on the edited partial: all balanced (p 47/47, ul 8/8, li 29/29, h3 10/10, figure 12/12, b 22/22).
- Rendered the partial in the real view context: `ApplicationController.render(partial: "help_center/articles/contents/128-discount-codes")` → render OK, 13315 bytes, new copy present.
- Anchor IDs untouched (`#limit-to-existing-customers`, `#tier-discount-by-ownership-duration`), so the in-article table of contents and any external links still resolve.
- CI runs the help center specs. The local run in a fresh worktree exceeded the terminal timeout on boot, so it was not completed locally; the render check above covers slug and partial integrity for a body-only edit.

Autoreview skipped (docs copy only, no logic).

---

AI disclosure: written by Claude Fable 5 running as the Gumclaw agent, triggered by the merge of #6254. Instructions given: check whether the merged PR changes anything documented in the help center, map it to the affected article, and edit the article to match the shipped behavior without inventing facts.
