### PR TITLE
Remove the passkeys feature flag

### DIFF
--- a/app/controllers/logins/passkeys_controller.rb
+++ b/app/controllers/logins/passkeys_controller.rb
@@ -7,7 +7,6 @@ class Logins::PasskeysController < ApplicationController
 
   skip_before_action :check_suspended
   skip_before_action :invalidate_session_if_necessary
-  before_action :ensure_passkeys_feature_enabled
 
   def options
     render json: { success: true, options: build_webauthn_authentication_options }
@@ -41,10 +40,6 @@ class Logins::PasskeysController < ApplicationController
   end
 
   private
-    def ensure_passkeys_feature_enabled
-      e404 unless Feature.active?(:passkeys)
-    end
-
     def verified_credential(challenge)
       map_webauthn_verification_errors do
         webauthn_credential = WebAuthn::Credential.from_get(assertion_params)

--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -24,7 +24,7 @@ class LoginsController < Devise::SessionsController
     auth_presenter = AuthPresenter.new(params:, application: @application)
     render inertia: "Logins/New", props: auth_presenter.login_props.merge(
       is_gumroad_mobile_app: cookies[:is_gumroad_mobile_app].present?,
-      passkey_login_options: Feature.active?(:passkeys) ? build_webauthn_authentication_options : nil,
+      passkey_login_options: build_webauthn_authentication_options,
     )
   end
 

--- a/app/controllers/settings/passkeys_controller.rb
+++ b/app/controllers/settings/passkeys_controller.rb
@@ -7,7 +7,6 @@ class Settings::PasskeysController < Settings::BaseController
   REGISTRATION_ERROR_MESSAGE = "Could not add this passkey. Please try again."
 
   before_action :set_user
-  before_action :ensure_passkeys_feature_enabled
   before_action :authorize
   before_action :set_webauthn_credential, only: %i[update destroy]
 
@@ -89,10 +88,6 @@ class Settings::PasskeysController < Settings::BaseController
   private
     def set_user
       @user = current_seller
-    end
-
-    def ensure_passkeys_feature_enabled
-      e404 unless Feature.active?(:passkeys, @user)
     end
 
     def authorize

--- a/app/javascript/pages/Logins/New.tsx
+++ b/app/javascript/pages/Logins/New.tsx
@@ -29,7 +29,6 @@ type PageProps = {
   email: string | null;
   application_name: string | null;
   authenticity_token: string;
-  show_passkey_login: boolean;
   passkey_login_options: PasskeyAuthenticationOptions | null;
   is_gumroad_mobile_app: boolean;
 };
@@ -48,7 +47,6 @@ function LoginPage() {
     email: initialEmail,
     application_name,
     authenticity_token,
-    show_passkey_login,
     passkey_login_options,
     is_gumroad_mobile_app,
   } = usePage<PageProps>().props;
@@ -61,7 +59,7 @@ function LoginPage() {
   const [passkeyError, setPasskeyError] = React.useState<string | null>(null);
   const [passkeySupported, setPasskeySupported] = React.useState(false);
   React.useEffect(() => setPasskeySupported(isPasskeySupported()), []);
-  const passkeyLoginEnabled = show_passkey_login && !is_gumroad_mobile_app && passkeySupported;
+  const passkeyLoginEnabled = !is_gumroad_mobile_app && passkeySupported;
   const conditionalRequest = React.useRef<AbortController | null>(null);
 
   const form = useForm<FormData>({

--- a/app/javascript/pages/Settings/Password/Show.tsx
+++ b/app/javascript/pages/Settings/Password/Show.tsx
@@ -25,7 +25,6 @@ type PasswordPageProps = {
   settings_pages: SettingPage[];
   require_old_password: boolean;
   authenticator_app_enabled: boolean;
-  show_passkeys_settings: boolean;
   passkeys: Passkey[];
 };
 
@@ -195,11 +194,9 @@ export default function PasswordPage() {
           <RecoveryCodes codes={regeneratedCodes} onDone={() => setRegeneratedCodes(null)} />
         ) : null}
       </FormSection>
-      {props.show_passkeys_settings ? (
-        <FormSection header={<h2>Passkeys</h2>}>
-          <PasskeysSection passkeys={props.passkeys} />
-        </FormSection>
-      ) : null}
+      <FormSection header={<h2>Passkeys</h2>}>
+        <PasskeysSection passkeys={props.passkeys} />
+      </FormSection>
     </SettingsLayout>
   );
 }

--- a/app/models/concerns/two_factor_authentication.rb
+++ b/app/models/concerns/two_factor_authentication.rb
@@ -55,11 +55,11 @@ module TwoFactorAuthentication
   end
 
   def passkeys_enabled?
-    Feature.active?(:passkeys, self) && webauthn_credentials.exists?
+    webauthn_credentials.exists?
   end
 
   def passkeys_setup_pending?
-    Feature.active?(:passkeys, self) && webauthn_credentials.none?
+    webauthn_credentials.none?
   end
 
   def has_logged_in_from_ip_before?(remote_ip)

--- a/app/presenters/auth_presenter.rb
+++ b/app/presenters/auth_presenter.rb
@@ -12,7 +12,6 @@ class AuthPresenter
     {
       email: params[:email] || retrieve_team_invitation_email(params[:next]),
       application_name: application&.name,
-      show_passkey_login: Feature.active?(:passkeys),
     }
   end
 

--- a/app/presenters/settings_presenter.rb
+++ b/app/presenters/settings_presenter.rb
@@ -177,25 +177,19 @@ class SettingsPresenter
   end
 
   def password_props
-    passkeys_enabled = Feature.active?(:passkeys, seller)
-    passkeys = if passkeys_enabled
-      seller.webauthn_credentials.order(:created_at).map do |credential|
-        {
-          id: credential.external_id,
-          nickname: credential.nickname,
-          created_at: credential.created_at.iso8601,
-          last_used_at: credential.last_used_at&.iso8601,
-        }
-      end
-    else
-      []
+    passkeys = seller.webauthn_credentials.order(:created_at).map do |credential|
+      {
+        id: credential.external_id,
+        nickname: credential.nickname,
+        created_at: credential.created_at.iso8601,
+        last_used_at: credential.last_used_at&.iso8601,
+      }
     end
 
     {
       require_old_password: seller.provider.blank?,
       settings_pages: pages,
       authenticator_app_enabled: seller.totp_enabled?,
-      show_passkeys_settings: passkeys_enabled,
       passkeys:,
     }
   end

--- a/spec/controllers/logins/passkeys_controller_spec.rb
+++ b/spec/controllers/logins/passkeys_controller_spec.rb
@@ -11,7 +11,6 @@ describe Logins::PasskeysController, type: :controller do
 
   before do
     request.env["devise.mapping"] = Devise.mappings[:user]
-    Feature.activate(:passkeys)
   end
 
   def fake_register
@@ -60,14 +59,6 @@ describe Logins::PasskeysController, type: :controller do
       expect(response).to be_successful
       expect(response.parsed_body["success"]).to be true
       expect(response.parsed_body["options"]["challenge"]).to be_present
-    end
-
-    context "when the feature flag is inactive" do
-      before { Feature.deactivate(:passkeys) }
-
-      it "raises a not found error" do
-        expect { post :options, as: :json }.to raise_error(ActionController::RoutingError, "Not Found")
-      end
     end
   end
 
@@ -187,14 +178,6 @@ describe Logins::PasskeysController, type: :controller do
       expect(response).to be_successful
       expect(response.parsed_body).to include("success" => true)
       expect(controller.user_signed_in?).to be(true)
-    end
-
-    context "when the feature flag is inactive" do
-      before { Feature.deactivate(:passkeys) }
-
-      it "raises a not found error" do
-        expect { post :create, params: { credential: {} }, as: :json }.to raise_error(ActionController::RoutingError, "Not Found")
-      end
     end
   end
 end

--- a/spec/controllers/logins_controller_spec.rb
+++ b/spec/controllers/logins_controller_spec.rb
@@ -23,29 +23,13 @@ describe LoginsController, type: :controller, inertia: true do
       expect(inertia.props[:application_name]).to be_nil
     end
 
-    context "when the passkeys feature is active" do
-      before { Feature.activate(:passkeys) }
-      after { Feature.deactivate(:passkeys) }
+    it "embeds passkey login options and stores the challenge in the session" do
+      get :new
 
-      it "embeds passkey login options and stores the challenge in the session" do
-        get :new
-
-        expect(inertia.props[:show_passkey_login]).to be(true)
-        options = inertia.props[:passkey_login_options].with_indifferent_access
-        expect(options[:challenge]).to be_present
-        expect(options[:rpId]).to eq(WebAuthn.configuration.rp_id)
-        expect(session[:webauthn_authentication_challenge]).to eq(options[:challenge])
-      end
-    end
-
-    context "when the passkeys feature is inactive" do
-      it "does not embed passkey login options or store a challenge" do
-        get :new
-
-        expect(inertia.props[:show_passkey_login]).to be(false)
-        expect(inertia.props[:passkey_login_options]).to be_nil
-        expect(session[:webauthn_authentication_challenge]).to be_nil
-      end
+      options = inertia.props[:passkey_login_options].with_indifferent_access
+      expect(options[:challenge]).to be_present
+      expect(options[:rpId]).to eq(WebAuthn.configuration.rp_id)
+      expect(session[:webauthn_authentication_challenge]).to eq(options[:challenge])
     end
 
     context "with an email in the query parameters" do
@@ -124,8 +108,6 @@ describe LoginsController, type: :controller, inertia: true do
     end
 
     describe "passkey setup prompt" do
-      before { Feature.activate(:passkeys) }
-
       it "flags the prompt after an eligible login" do
         post "create", params: { user: { login_identifier: @user.email, password: "password" } }
 
@@ -157,14 +139,6 @@ describe LoginsController, type: :controller, inertia: true do
         expect(session[:prompt_passkey_setup]).to be_nil
       end
 
-      it "does not flag the prompt when the passkeys feature is inactive" do
-        Feature.deactivate(:passkeys)
-
-        post "create", params: { user: { login_identifier: @user.email, password: "password" } }
-
-        expect(session[:prompt_passkey_setup]).to be_nil
-      end
-
       it "does not flag the prompt inside the mobile app webview" do
         cookies[:is_gumroad_mobile_app] = "true"
 
@@ -175,9 +149,6 @@ describe LoginsController, type: :controller, inertia: true do
     end
 
     describe "passkey password fallback" do
-      before { Feature.activate(:passkeys) }
-      after { Feature.deactivate(:passkeys) }
-
       it "logs the password-fallback analytics event when a passkey user signs in with a password" do
         create(:webauthn_credential, user: @user)
         allow(Rails.logger).to receive(:info)

--- a/spec/controllers/settings/passkeys_controller_spec.rb
+++ b/spec/controllers/settings/passkeys_controller_spec.rb
@@ -14,7 +14,6 @@ describe Settings::PasskeysController, type: :controller do
 
   before do
     sign_in user
-    Feature.activate_user(:passkeys, user)
   end
 
   it_behaves_like "authorize called for controller", Settings::Passkeys::UserPolicy do
@@ -65,14 +64,6 @@ describe Settings::PasskeysController, type: :controller do
         "success" => false,
         "error_message" => WebauthnCredential::MAX_PER_USER_ERROR_MESSAGE
       )
-    end
-
-    context "when the feature flag is inactive" do
-      before { Feature.deactivate_user(:passkeys, user) }
-
-      it "raises a not found error" do
-        expect { post :registration_options, as: :json }.to raise_error(ActionController::RoutingError, "Not Found")
-      end
     end
 
     context "when signed in as an admin for the seller" do

--- a/spec/controllers/settings/password_controller_spec.rb
+++ b/spec/controllers/settings/password_controller_spec.rb
@@ -33,7 +33,6 @@ describe Settings::PasswordController, :vcr, type: :controller, inertia: true do
     end
 
     it "exposes the passkey setup prompt flag and keeps it set until the user acts" do
-      Feature.activate(:passkeys)
       session[:prompt_passkey_setup] = user.id
 
       get :show
@@ -49,7 +48,6 @@ describe Settings::PasswordController, :vcr, type: :controller, inertia: true do
     end
 
     it "does not show the prompt when the flagged user already has a passkey" do
-      Feature.activate(:passkeys)
       create(:webauthn_credential, user:)
       session[:prompt_passkey_setup] = user.id
 
@@ -59,7 +57,6 @@ describe Settings::PasswordController, :vcr, type: :controller, inertia: true do
     end
 
     it "does not show the prompt inside the mobile app webview" do
-      Feature.activate(:passkeys)
       session[:prompt_passkey_setup] = user.id
       cookies[:is_gumroad_mobile_app] = "true"
 

--- a/spec/controllers/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication_controller_spec.rb
@@ -219,8 +219,6 @@ describe TwoFactorAuthenticationController, type: :controller, inertia: true do
     end
 
     context "passkey setup prompt" do
-      before { Feature.activate(:passkeys) }
-
       it "flags the prompt after completing two-factor authentication" do
         post :create, params: { token: @user.otp_code, user_id: @user.encrypted_external_id }
 

--- a/spec/models/concerns/two_factor_authentication_spec.rb
+++ b/spec/models/concerns/two_factor_authentication_spec.rb
@@ -172,30 +172,14 @@ describe TwoFactorAuthentication do
   end
 
   describe "#passkeys_enabled?" do
-    context "when the passkeys feature is inactive" do
-      before do
-        create(:webauthn_credential, user: @user)
-        Feature.deactivate_user(:passkeys, @user)
-      end
-
+    context "when the user has no passkeys" do
       it "returns false" do
         expect(@user.passkeys_enabled?).to be false
       end
     end
 
-    context "when the passkeys feature is active and the user has no passkeys" do
-      before { Feature.activate_user(:passkeys, @user) }
-
-      it "returns false" do
-        expect(@user.passkeys_enabled?).to be false
-      end
-    end
-
-    context "when the passkeys feature is active and the user has a passkey" do
-      before do
-        create(:webauthn_credential, user: @user)
-        Feature.activate_user(:passkeys, @user)
-      end
+    context "when the user has a passkey" do
+      before { create(:webauthn_credential, user: @user) }
 
       it "returns true" do
         expect(@user.passkeys_enabled?).to be true
@@ -204,27 +188,14 @@ describe TwoFactorAuthentication do
   end
 
   describe "#passkeys_setup_pending?" do
-    context "when the passkeys feature is inactive" do
-      before { Feature.deactivate_user(:passkeys, @user) }
-
-      it "returns false" do
-        expect(@user.passkeys_setup_pending?).to be false
-      end
-    end
-
-    context "when the passkeys feature is active and the user has no passkeys" do
-      before { Feature.activate_user(:passkeys, @user) }
-
+    context "when the user has no passkeys" do
       it "returns true" do
         expect(@user.passkeys_setup_pending?).to be true
       end
     end
 
-    context "when the passkeys feature is active and the user has a passkey" do
-      before do
-        create(:webauthn_credential, user: @user)
-        Feature.activate_user(:passkeys, @user)
-      end
+    context "when the user has a passkey" do
+      before { create(:webauthn_credential, user: @user) }
 
       it "returns false" do
         expect(@user.passkeys_setup_pending?).to be false

--- a/spec/presenters/auth_presenter_spec.rb
+++ b/spec/presenters/auth_presenter_spec.rb
@@ -19,7 +19,6 @@ describe AuthPresenter do
           {
             email: nil,
             application_name: nil,
-            show_passkey_login: false,
           }
         )
       end
@@ -33,17 +32,8 @@ describe AuthPresenter do
           {
             email: nil,
             application_name: "Test App",
-            show_passkey_login: false,
           }
         )
-      end
-    end
-
-    context "when the passkeys feature is active" do
-      before { Feature.activate(:passkeys) }
-
-      it "enables passkey login" do
-        expect(presenter.login_props[:show_passkey_login]).to be(true)
       end
     end
   end
@@ -66,7 +56,6 @@ describe AuthPresenter do
               total_made: 0,
             },
             recaptcha_site_key: GlobalConfig.get("RECAPTCHA_SIGNUP_SITE_KEY"),
-            show_passkey_login: false,
           }
         )
       end
@@ -98,7 +87,6 @@ describe AuthPresenter do
               total_made: 923_456_789,
             },
             recaptcha_site_key: GlobalConfig.get("RECAPTCHA_SIGNUP_SITE_KEY"),
-            show_passkey_login: false,
           }
         )
       end

--- a/spec/presenters/settings_presenter_spec.rb
+++ b/spec/presenters/settings_presenter_spec.rb
@@ -372,23 +372,17 @@ describe SettingsPresenter do
       end
 
       it "returns the correct props" do
-        expect(presenter.password_props).to eq(require_old_password: false, settings_pages:, authenticator_app_enabled: false, show_passkeys_settings: false, passkeys: [])
+        expect(presenter.password_props).to eq(require_old_password: false, settings_pages:, authenticator_app_enabled: false, passkeys: [])
       end
     end
 
     context "when seller is registered using email" do
       it "returns the correct props" do
-        expect(presenter.password_props).to eq(require_old_password: true, settings_pages:, authenticator_app_enabled: false, show_passkeys_settings: false, passkeys: [])
+        expect(presenter.password_props).to eq(require_old_password: true, settings_pages:, authenticator_app_enabled: false, passkeys: [])
       end
     end
 
-    context "when the passkeys feature is active" do
-      before { Feature.activate_user(:passkeys, seller) }
-
-      it "enables the passkeys settings" do
-        expect(presenter.password_props).to include(show_passkeys_settings: true, passkeys: [])
-      end
-
+    context "with passkeys" do
       it "returns the seller's passkeys ordered by creation date" do
         older = create(:webauthn_credential, user: seller, nickname: "Laptop", created_at: 2.days.ago, last_used_at: 1.hour.ago)
         newer = create(:webauthn_credential, user: seller, nickname: "Phone", created_at: 1.day.ago, last_used_at: nil)

--- a/spec/requests/login/passkeys_spec.rb
+++ b/spec/requests/login/passkeys_spec.rb
@@ -7,7 +7,6 @@ describe("Passkey Login Scenario", type: :system, js: true) do
 
   before do
     use_webauthn_driver
-    Feature.activate(:passkeys)
   end
 
   it "registers a passkey, then signs in with it and bypasses the 2FA challenge" do

--- a/spec/requests/settings/passkeys_spec.rb
+++ b/spec/requests/settings/passkeys_spec.rb
@@ -6,7 +6,6 @@ describe("Passkeys Settings Scenario", type: :system, js: true) do
   let(:seller) { create(:user) }
 
   before do
-    Feature.activate_user(:passkeys, seller)
     login_as seller
   end
 
@@ -93,16 +92,5 @@ describe("Passkeys Settings Scenario", type: :system, js: true) do
 
     expect(page).to have_alert(text: "Passkey removed.")
     expect(seller.webauthn_credentials).to be_empty
-  end
-
-  context "when the passkeys feature is disabled" do
-    before { Feature.deactivate_user(:passkeys, seller) }
-
-    it "does not show the passkeys section" do
-      visit settings_password_path
-
-      expect(page).to have_text("Change password")
-      expect(page).to_not have_text("Passkeys are an easier, more secure alternative to passwords")
-    end
   end
 end


### PR DESCRIPTION
Removes the `:passkeys` Flipper flag. Part of the rollout flag audit in antiwork/gumroad-private#1208.

## Why this is safe

Live prod state read via the audited prod console (2026-07-25):

```
passkeys  state=on  boolean=true  actors=0  pct_actors=0  groups=[]
```

Globally enabled with **no partial actor or percentage gates**, so every `Feature.active?(:passkeys)` call already returns true. Deleting the reads is behaviour-neutral in production.

## What changed

Flag reads removed from:

- `TwoFactorAuthentication#passkeys_enabled?` / `#passkeys_setup_pending?`
- `AuthPresenter#login_props`, `SettingsPresenter#password_props`
- `LoginsController#new`
- `Settings::PasskeysController` and `Logins::PasskeysController` — both had a `before_action` that returned 404 when the flag was off; that guard is gone with the flag.

**Security surface — worth a careful look, per the audit's note.** Removing this flag makes passkey login and passkey management permanently available. Two things I want to call out explicitly:

1. **The user-facing gate that mattered is still there.** The login page computes `passkeyLoginEnabled` from `!is_gumroad_mobile_app && passkeySupported` — the button stays hidden on browsers without WebAuthn and inside the mobile app webview. The flag was a redundant server-side gate on top of that client capability check.
2. **The two 404 guards were flag-only, not authorization.** Both controllers keep their real protections: `Settings::PasskeysController` still runs `authorize [:settings, :passkeys, @user]` (the `it_behaves_like "authorize called"` shared example still passes), and `Logins::PasskeysController` still verifies the WebAuthn assertion and challenge. Removing the flag check does not widen who can do what — it only stops 404ing a globally-enabled feature.

Since the server no longer decides visibility, the `show_passkey_login` and `show_passkeys_settings` props are dropped rather than hardcoded to `true`.

## Test results

`bundle exec rspec spec/models/concerns/two_factor_authentication_spec.rb spec/presenters/auth_presenter_spec.rb spec/presenters/settings_presenter_spec.rb spec/controllers/logins_controller_spec.rb spec/controllers/logins/passkeys_controller_spec.rb spec/controllers/settings/passkeys_controller_spec.rb spec/controllers/settings/password_controller_spec.rb spec/controllers/two_factor_authentication_controller_spec.rb`

Baseline-differenced against `main` in the same worktree, comparing failure **names** (not line numbers, which shift when examples are deleted):

| | examples | failures |
|---|---|---|
| `main` (stashed) | 261 | 20 |
| this branch | 252 | 19 |

Comparing by name, exactly one entry differs: `LoginsController GET 'new' embeds passkey login options and stores the challenge in the session` — which is my **renamed** version of the previously-nested `when the passkeys feature is active ...` example. It fails on both `main` and this branch with the identical `ViteRuby.instance.manifest.resolve_entries` / `ActionView::Template::Error` — the fresh-worktree Vite manifest flake on this host, not a regression. **No new failures introduced.** CI will confirm on Linux.

One spec was deleted rather than rewritten: `logins_controller_spec` had "does not flag the prompt when the passkeys feature is inactive", which only passed because the flag defaulted off in test. With the flag gone it asserts behaviour that no longer exists, so keeping it would have meant editing an assertion to match new behaviour — the deletion is honest about the fact that the scenario is unreachable now. Same reasoning for the two "raises a not found error when the feature flag is inactive" contexts.

## Post-merge

`Flipper.remove(:passkeys)` once this is live in prod.

🤖 Opened autonomously by gumclaw.