### PR TITLE
Keep the blast audience revalidation under MySQL's range optimizer limit

### DIFF
--- a/app/sidekiq/send_post_blast_emails_job.rb
+++ b/app/sidekiq/send_post_blast_emails_job.rb
@@ -59,6 +59,19 @@ class SendPostBlastEmailsJob
     # that an abandoned blast doesn't hold hundreds of thousands of entries forever.
     AUDIENCE_SNAPSHOT_TTL = 3.days
 
+    # How many snapshotted member ids to revalidate per statement. Small on purpose:
+    # MySQL's range optimizer has a memory budget for representing an `IN (...)` list as
+    # primary-key ranges, and once the list is big enough to blow that budget it silently
+    # abandons the primary key and scans an index over the whole table instead. Measured
+    # on production, the audience filter flips from a 1,000-row primary-key range to a
+    # 145-million-row index scan somewhere between 6,000 and 7,000 ids — with no error to
+    # tell you it happened. 1,000 keeps every slice on the primary key with plenty of
+    # headroom, and measures ~90 ms per slice against the real 350k-member audience.
+    REVALIDATION_SLICE_SIZE = 1_000
+
+    # Redis list/set writes only — no SQL — so this can stay large.
+    REDIS_WRITE_SLICE_SIZE = 10_000
+
     # Loads the recipient list for the blast. For sellers with very large audiences
     # (hundreds of thousands of members) the filter query is the slowest, most fragile
     # part of the job: it can exceed the database's default 5-minute statement cap, and a
@@ -118,7 +131,7 @@ class SendPostBlastEmailsJob
       # path above is protected. Run the revalidation under the same raised,
       # Redis-tunable cap the fresh load uses.
       members = WithMaxExecutionTime.timeout_queries(seconds: audience_load_timeout_seconds) do
-        snapshotted_ids.each_slice(10_000).flat_map do |ids_slice|
+        snapshotted_ids.each_slice(REVALIDATION_SLICE_SIZE).flat_map do |ids_slice|
           AudienceMember.filter(seller_id: @post.seller_id, params: @filters, with_ids: true, ids: ids_slice)
             .select(:id, :email, :purchase_id, :follower_id, :affiliate_id).to_a
         end
@@ -140,7 +153,7 @@ class SendPostBlastEmailsJob
 
       tmp_key = "#{snapshot_key}:tmp"
       $redis.del(tmp_key)
-      members.each_slice(10_000) do |slice|
+      members.each_slice(REDIS_WRITE_SLICE_SIZE) do |slice|
         $redis.rpush(tmp_key, slice.map(&:id))
       end
       $redis.expire(tmp_key, AUDIENCE_SNAPSHOT_TTL.to_i)
@@ -191,7 +204,7 @@ class SendPostBlastEmailsJob
 
       tmp_key = "#{checkpoint_key}:tmp"
       $redis.del(tmp_key)
-      emails.each_slice(10_000) do |slice|
+      emails.each_slice(REDIS_WRITE_SLICE_SIZE) do |slice|
         $redis.sadd(tmp_key, slice)
       end
       $redis.expire(tmp_key, AUDIENCE_SNAPSHOT_TTL.to_i)

--- a/app/sidekiq/send_post_blast_emails_job.rb
+++ b/app/sidekiq/send_post_blast_emails_job.rb
@@ -62,11 +62,17 @@ class SendPostBlastEmailsJob
     # How many snapshotted member ids to revalidate per statement. Small on purpose:
     # MySQL's range optimizer has a memory budget for representing an `IN (...)` list as
     # primary-key ranges, and once the list is big enough to blow that budget it silently
-    # abandons the primary key and scans an index over the whole table instead. Measured
-    # on production, the audience filter flips from a 1,000-row primary-key range to a
-    # 145-million-row index scan somewhere between 6,000 and 7,000 ids — with no error to
-    # tell you it happened. 1,000 keeps every slice on the primary key with plenty of
-    # headroom, and measures ~90 ms per slice against the real 350k-member audience.
+    # abandons the primary key and looks the rows up through the (seller_id, email) index
+    # instead — which for a seller with a six-figure audience means searching that
+    # seller's whole membership per statement rather than the ids the slice asked for.
+    # Measured on production against the real 350k-member audience: the plan holds
+    # `range`/`PRIMARY` up to 6,000 ids and has flipped to `ref`/seller_id_and_email by
+    # 6,500, with no error to tell you it happened. The cost shows up as tail latency —
+    # ~57 ms per statement at 1,000 ids versus ~600-1,200 ms at 10,000 — so a slow
+    # replica or a busy window is far likelier to push a 10,000-id statement into the
+    # execution cap. Total revalidation wall time is roughly the same either way (the
+    # work is proportional to the audience, not the slice count), so 1,000 buys tail
+    # safety at no throughput cost. It leaves ~6x headroom under the measured flip.
     REVALIDATION_SLICE_SIZE = 1_000
 
     # Redis list/set writes only — no SQL — so this can stay large.

--- a/spec/sidekiq/send_post_blast_emails_job_spec.rb
+++ b/spec/sidekiq/send_post_blast_emails_job_spec.rb
@@ -516,6 +516,36 @@ describe SendPostBlastEmailsJob, :freeze_time do
       $redis.del(snapshot_key)
     end
 
+    it "revalidates the snapshot in slices small enough to stay on the primary key" do
+      post = basic_post_with_audience
+      create(:active_follower, user: @seller)
+      create(:active_follower, user: @seller)
+      blast = create(:blast, :just_requested, post:)
+      snapshot_key = RedisKey.blast_audience_snapshot(blast.id)
+      snapshotted_ids = AudienceMember.where(seller_id: post.seller_id).pluck(:id)
+      expect(snapshotted_ids.size).to be >= 3
+      $redis.rpush(snapshot_key, snapshotted_ids)
+
+      # A big `IN (...)` list makes MySQL abandon the primary key and scan the whole
+      # table, so the revalidation must never hand the filter more ids than the slice
+      # size — regardless of how large the audience is.
+      stub_const("#{described_class}::REVALIDATION_SLICE_SIZE", 2)
+      slice_sizes = []
+      allow(AudienceMember).to receive(:filter).and_wrap_original do |original, **kwargs|
+        slice_sizes << kwargs[:ids].size
+        original.call(**kwargs)
+      end
+
+      described_class.new.perform(blast.id)
+
+      expect(slice_sizes.size).to eq((snapshotted_ids.size / 2.0).ceil)
+      expect(slice_sizes).to all(be <= 2)
+      expect(slice_sizes.sum).to eq(snapshotted_ids.size)
+      expect(blast.reload.completed_at).to be_present
+    ensure
+      $redis.del(snapshot_key)
+    end
+
     it "drops snapshotted members who have since left the audience" do
       post = basic_post_with_audience
       blast = create(:blast, :just_requested, post:)


### PR DESCRIPTION
## Summary

Follow-up to #6256. That PR fixed the recipient **email** lookup; the retry path of the same job has the identical problem one layer up and was missed. `SendPostBlastEmailsJob#revalidate_snapshotted_members` hands the audience filter **10,000** snapshotted member ids per slice.

## Why 10,000 is the wrong number here

Benchmarked on the audited production console against the real audience behind the dead-lettered blast — 350,274 snapshotted member ids, seller audience 590,667 rows, filter `{type: "customer", bought_product_ids: [...]}`. The first pass of these numbers used a synthetic id sample and separate console sessions, which produced a misleading table; everything below is re-measured on the **real snapshotted ids** with both slice sizes **interleaved in one session on one host**, so the two arms see the same replica load.

### Where the plan flips

`EXPLAIN` on the ids-bounded derived subquery over `audience_members`:

| ids in slice | plan | est. rows |
|---|---|---|
| 4,000 | `range` / `PRIMARY` | 4,000 |
| 5,000 | `range` / `PRIMARY` | 5,000 |
| 6,000 | `range` / `PRIMARY` | 6,000 |
| **6,500** | **`ref` / `index_audience_members_on_seller_id_and_email`** | 60 |
| 10,000 | `ref` / `index_audience_members_on_seller_id_and_email` | 60 |

The flip is between 6,000 and 6,500 ids. Past it MySQL stops representing the `IN (...)` list as primary-key ranges and reaches the rows through the `(seller_id, email)` index instead — for a six-figure-audience seller that means searching that seller's whole membership per statement rather than the ids the slice asked for. Nothing errors; the estimate even *drops* to 60, which is why this is easy to miss.

### What it costs — interleaved A/B, same host, same ids

30,000 ids covered per round, 3 rounds, order alternated between rounds:

| | 1,000-id slices | 10,000-id slices |
|---|---|---|
| per-statement p50 | **57 ms** | 607 ms |
| per-statement p95 | **69 ms** | 785 ms |
| per-statement max | **112 ms** | 785 ms |
| wall time for the same 30,000 ids (median of 3) | 1,735 ms | 1,906 ms |

A separate 6-consecutive-slice tail check on a different id window: 1,000 → `[99, 78, 73, 88, 71, 83]` ms; 10,000 → `[732, 1175, 763, 905, 821, 644]` ms.

### The correction worth calling out

**This is not a throughput win, and the PR should not have implied one.** Total revalidation wall time is roughly the same at both slice sizes — the work scales with the audience, not the slice count. Two full-audience runs (55-60s time-boxed, extrapolated) came out at 178s for 1,000 vs 111s for 10,000, but those were on different hosts at different times, and the controlled interleaved test above shows the two within ~10% of each other. I don't have evidence that 1,000 is *faster*, and I'm not claiming it.

What the measurements do support is **tail latency and headroom**:

- Worst single statement: ~112 ms at 1,000 vs ~1,175 ms at 10,000 — an order of magnitude. The failure mode here is a statement hitting the execution cap, and that risk tracks the worst statement, not the average.
- 1,000 sits ~6x under the measured flip point, so the plan stays on the primary key even as this seller's audience grows or another seller's filter shifts the boundary. 10,000 is already past it.

That's the case for the change: same throughput, 10x better worst case, and it can't silently fall off the primary key.

Why this path specifically: the snapshot is written on the **first** attempt, so every **retry** of a large blast goes through it. The dead-lettered blast had exhausted all 10 retries this way.

## Changes

- `REVALIDATION_SLICE_SIZE = 1_000` for the SQL slice.
- The Redis list/set writes in the same job also used a bare `10_000`. Those aren't SQL and don't have this problem, so they keep the larger size but are now named `REDIS_WRITE_SLICE_SIZE`. Naming them apart is the point: it stops the next person from either "fixing" a constant that isn't broken, or raising the SQL one because its neighbour is bigger.
- Spec asserts the revalidation never hands the filter more ids than the slice size, regardless of audience size.
- The code comment now carries the corrected numbers, states that wall time is unchanged, and says the justification is tail latency plus headroom rather than speed.

## Sweep results — the other candidates, and why they're already fine

Every remaining `each_slice`/`in_batches` over an id list that feeds SQL:

- **Payouts (`Payouts::BANK_ACCOUNT_LOOKUP_BATCH_SIZE = 10_000`)** — measured rather than assumed. `EXPLAIN` on the exact statement (`BankAccount.alive.where(user_id: ids, type: ...)`) holds `type=range` on `index_ach_accounts_on_user_id` at 1,000 / 2,000 / 3,000 / 5,000 / 7,000 / 10,000, with the estimate tracking the list size exactly (`rows: 10000` at n=10,000). It never flips — `bank_accounts` is small enough that representing 10,000 ids as ranges stays inside the optimizer's memory budget. **Leaving it at 10,000**; lowering it would add 10x the round trips for no gain.
- `Payouts::HOLDING_BALANCE_ID_BATCH_SIZE = 25_000` — a keyset cursor (`WHERE user_id > ? ... LIMIT`), not an `IN (...)` list. Not affected.
- `Installment::EMAIL_INFO_BATCH_SIZE = 10_000` — `in_batches`, walks by primary key. Not affected (already documented as such in #6256).
- `ScheduleAbandonedCartEmailsJob::SCAN_BATCH_SIZE = 10_000` — keyset cursor over `carts.id`. Not affected.
- Everything else that builds an `IN (...)` list is already at 1,000 or below.

One more real spot (this PR); the payouts one is measurably fine.

Also worth recording: the flip threshold is **per query**, not a number to reuse. `purchases` flipped at 2,000-2,500 in #6256; `audience_members` flips at 6,000-6,500. It depends on the table's index widths, so each candidate has to be measured.

## Test evidence

`spec/sidekiq/send_post_blast_emails_job_spec.rb` — the new example passes:

```
SendPostBlastEmailsJob audience snapshot for retry resume
  revalidates the snapshot in slices small enough to stay on the primary key
1 example, 0 failures
```

The file has 18 pre-existing local failures (`create(:purchase)` → "We couldn't charge your card") that are identical on unmodified `main` at the same SHA — 18 before, 18 after, differing only by my one new passing example. Local card-charging stubs, unrelated to this change; CI is the check that matters.

`rubocop` clean on both files.

All benchmark queries above were read-only, run through the audited prod console wrapper (audit records under `gumclaw/production-console-access/2026/07/25/`).

## Risk

Backend-only, no user-visible surface — no UI, mailer, or API-response change, so there is no adjacent surface to screenshot. Strictly fewer rows per statement on a path that currently dead-letters; the slice boundary is internal to one method and the spec pins that the whole set is still covered (`slice_sizes.sum == snapshotted_ids.size`).

---
🤖 Written by Gumclaw. Model: Claude Opus 5. Instructions: measure the plan flip on the audited prod console before changing any constant; verify the payouts candidate rather than assuming it needs the same change; when asked to prove the benchmarks, re-run them interleaved on one host against the real ids and correct any claim the new data doesn't support.
