### PR TITLE
Let the long-running-job healthcheck survive its own rollout

### DIFF
--- a/.buildkite/scripts/deploy_production.sh
+++ b/.buildkite/scripts/deploy_production.sh
@@ -12,20 +12,41 @@ logger() {
 # Redis while they run (see DeployBlockingJobTracking) and the matching healthcheck answers
 # 503 for as long as any of them is registered.
 #
-# wait_for_healthcheck <label> <url> <max attempts> <on-timeout: proceed|skip> <fail-safe window test>
+# wait_for_healthcheck <label> <url> <max attempts> <on-timeout: proceed|skip> <fail-safe window test> [pre-rollout window test]
 #
 # Polls every 3 minutes. Meanings of the answers:
 #   200 -> nothing in flight, deploy now.
 #   503 -> something is in flight, keep waiting.
+#   404 -> the app currently in production does not serve this endpoint at all, i.e. it
+#     predates the deploy that adds it. See the pre-rollout note below.
 #   anything else (unreachable, 5xx from the LB, ...) -> we cannot tell, so fall back to the
 #     conservative clock window this check replaced: skip the deploy if we are inside it,
 #     proceed if we are not. A broken healthcheck can then never be worse than the old
 #     time-based behaviour.
 #
-# The fail-safe window test is a shell snippet evaluated with `eval`; it should succeed when
-# the current time is inside the window.
+# Why 404 is handled separately from "we cannot tell":
+#
+# The deploy script runs BEFORE the app it is deploying is live, so on the single deploy that
+# first ships a new healthcheck endpoint, the still-running old app answers 404. That is not an
+# ambiguous failure — it is the old app telling us definitively that none of the new tracking
+# code is live yet, so nothing can be registered and this check has nothing to report on. If we
+# treated it as "cannot tell" and applied the wide fail-safe window, that window would skip the
+# very deploy that installs the endpoint, and keep skipping it for as long as the window lasts.
+# The endpoint can only start answering by being deployed, so the check would be blocking its
+# own bootstrap.
+#
+# Instead, a 404 falls back to the narrower clock window that was actually protecting these jobs
+# BEFORE this mechanism existed (the pre-rollout window). That is the honest answer: on an app
+# without the tracking code, the old clock guard is the only protection there ever was, so
+# reproducing it exactly is neither weaker nor stronger than the behaviour we are replacing.
+# Once the endpoint is live it answers 200/503 and neither window is consulted again.
+#
+# The window tests are shell snippets evaluated with `eval`; each should succeed when the
+# current time is inside its window. The pre-rollout test defaults to the fail-safe test when
+# not supplied, which is the right behaviour for a check whose endpoint is already deployed.
 wait_for_healthcheck() {
   local label="$1" url="$2" max_attempts="$3" on_timeout="$4" failsafe_window_test="$5"
+  local prerollout_window_test="${6:-$5}"
   local attempt hc_status
 
   for attempt in $(seq 1 "$max_attempts"); do
@@ -38,6 +59,13 @@ wait_for_healthcheck() {
     elif [ "$hc_status" = "503" ]; then
       logger "$label in flight (healthcheck 503) — waiting 3 minutes (attempt $attempt/$max_attempts)"
       sleep 180
+    elif [ "$hc_status" = "404" ]; then
+      if eval "$prerollout_window_test"; then
+        logger "$label healthcheck not deployed yet (HTTP 404) and we are inside the pre-rollout window — skipping deployment"
+        exit 0
+      fi
+      logger "$label healthcheck not deployed yet (HTTP 404) and we are outside the pre-rollout window — proceeding so the endpoint can ship"
+      return 0
     else
       if eval "$failsafe_window_test"; then
         logger "$label healthcheck unreachable (HTTP $hc_status) inside the fail-safe window — skipping deployment"
@@ -90,8 +118,16 @@ wait_for_healthcheck "Payout batch" "https://gumroad.com/healthcheck/payouts" 15
 #   UTC 11:00 finances / deferred refunds / Stripe balance summaries reports
 # => hours 00-05 and 08-13. Outside those we proceed, because nothing that registers here
 # is scheduled to be running.
+#
+# The last argument is the PRE-ROLLOUT window, used only while production still 404s this
+# endpoint (see wait_for_healthcheck). It reproduces the guard this check replaced — the
+# midnight-6am ET block that used to live in .github/workflows/tests.yml — expressed in UTC:
+# ET is UTC-4 on EDT, so ET 00:00-05:59 is UTC 04:00-09:59. Deliberately NOT the wider fail-safe
+# window above: on an app that has none of the tracking code, the old block is exactly the
+# protection that existed, and widening it here would only delay this endpoint's own rollout.
 wait_for_healthcheck "Long-running job" "https://gumroad.com/healthcheck/long_running_jobs" 40 skip \
-  '[ "$(date -u +%-H)" -le 5 ] || { [ "$(date -u +%-H)" -ge 8 ] && [ "$(date -u +%-H)" -le 13 ]; }'
+  '[ "$(date -u +%-H)" -le 5 ] || { [ "$(date -u +%-H)" -ge 8 ] && [ "$(date -u +%-H)" -le 13 ]; }' \
+  '[ "$(date -u +%-H)" -ge 4 ] && [ "$(date -u +%-H)" -le 9 ]'
 
 ECR_REGISTRY=${ECR_REGISTRY}
 WEB_REPO=${ECR_REGISTRY}/gumroad/web

--- a/.buildkite/scripts/deploy_production.sh
+++ b/.buildkite/scripts/deploy_production.sh
@@ -39,7 +39,8 @@ logger() {
 # BEFORE this mechanism existed (the pre-rollout window). That is the honest answer: on an app
 # without the tracking code, the old clock guard is the only protection there ever was, so
 # reproducing it exactly is neither weaker nor stronger than the behaviour we are replacing.
-# Once the endpoint is live it answers 200/503 and neither window is consulted again.
+# Once the endpoint is live it answers 200/503 on the healthy paths; the windows stay in place
+# for the abnormal ones (a 5xx or an unreachable host still falls back to the fail-safe window).
 #
 # The window tests are shell snippets evaluated with `eval`; each should succeed when the
 # current time is inside its window. The pre-rollout test defaults to the fail-safe test when
@@ -61,10 +62,10 @@ wait_for_healthcheck() {
       sleep 180
     elif [ "$hc_status" = "404" ]; then
       if eval "$prerollout_window_test"; then
-        logger "$label healthcheck not deployed yet (HTTP 404) and we are inside the pre-rollout window — skipping deployment"
+        logger "$label healthcheck absent (HTTP 404) and we are inside the pre-rollout window — skipping deployment"
         exit 0
       fi
-      logger "$label healthcheck not deployed yet (HTTP 404) and we are outside the pre-rollout window — proceeding so the endpoint can ship"
+      logger "$label healthcheck absent (HTTP 404) and we are outside the pre-rollout window — proceeding so the endpoint can ship"
       return 0
     else
       if eval "$failsafe_window_test"; then
@@ -121,13 +122,25 @@ wait_for_healthcheck "Payout batch" "https://gumroad.com/healthcheck/payouts" 15
 #
 # The last argument is the PRE-ROLLOUT window, used only while production still 404s this
 # endpoint (see wait_for_healthcheck). It reproduces the guard this check replaced — the
-# midnight-6am ET block that used to live in .github/workflows/tests.yml — expressed in UTC:
-# ET is UTC-4 on EDT, so ET 00:00-05:59 is UTC 04:00-09:59. Deliberately NOT the wider fail-safe
-# window above: on an app that has none of the tracking code, the old block is exactly the
-# protection that existed, and widening it here would only delay this endpoint's own rollout.
+# midnight-6am ET block that used to live in .github/workflows/tests.yml — and it is written in
+# ET, exactly as that block was (TZ=America/New_York, hours 0-5). Note this one is deliberately
+# NOT in UTC even though the fail-safe window above is: the fail-safe window is read off the
+# UTC cron schedule, which does not move with daylight saving, whereas this window reproduces a
+# human "midnight to 6am local" rule, so hardcoding a UTC offset would silently be wrong for the
+# ~4.5 months of EST (during EST, ET 05:00 is UTC 10:00 — the busiest scheduled hour, when the
+# quarterly financial reports run).
+#
+# It is also deliberately NARROWER than the fail-safe window: on an app that has none of the
+# tracking code, the old block is exactly the protection that existed, and widening it here
+# would only delay this endpoint's own rollout.
+#
+# REMOVE THIS LAST ARGUMENT once the endpoint is confirmed live in production. It exists only to
+# let the endpoint bootstrap itself. Left in place it would apply this narrow window to every
+# FUTURE 404 as well — a removed route, a web-only rollback, an edge 404 — and those are cases
+# where the tracking code IS live, so the wide fail-safe window is the right answer for them.
 wait_for_healthcheck "Long-running job" "https://gumroad.com/healthcheck/long_running_jobs" 40 skip \
   '[ "$(date -u +%-H)" -le 5 ] || { [ "$(date -u +%-H)" -ge 8 ] && [ "$(date -u +%-H)" -le 13 ]; }' \
-  '[ "$(date -u +%-H)" -ge 4 ] && [ "$(date -u +%-H)" -le 9 ]'
+  '[ "$(TZ=America/New_York date +%-H)" -le 5 ]'
 
 ECR_REGISTRY=${ECR_REGISTRY}
 WEB_REPO=${ECR_REGISTRY}/gumroad/web

--- a/.buildkite/scripts/deploy_production_test.sh
+++ b/.buildkite/scripts/deploy_production_test.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# Harness for wait_for_healthcheck in .buildkite/scripts/deploy_production.sh
+#
+# That script is never executed by CI (it only ever gets `bash -n`), so this harness is the
+# only test the deploy gate has. It drives the SHIPPED function, extracted from the real file
+# with awk rather than retyped, so the test cannot drift from the code that deploys.
+#
+# The `date` stub resolves real timezones from a fixed epoch via python zoneinfo, so the
+# EST/EDT cases below exercise genuine daylight-saving behaviour rather than a hardcoded offset.
+#
+# Usage: ./deploy_production_test.sh            run the cases
+#        ./deploy_production_test.sh --mutate   also prove each case FAILS against broken
+#                                               variants of the real script (anti-vacuity check)
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/deploy_production.sh"
+STUB_DIR=$(mktemp -d)
+trap 'rm -rf "$STUB_DIR"' EXIT
+
+# --- stub `date`: honours -u and $TZ against $FAKE_EPOCH, real tzdata rules ---
+cat > "$STUB_DIR/date" <<'STUB'
+#!/usr/bin/env bash
+python3 - "$@" <<'PY'
+import os, sys, datetime
+from zoneinfo import ZoneInfo
+args = sys.argv[1:]
+tz = ZoneInfo("UTC") if "-u" in args else ZoneInfo(os.environ.get("TZ") or "UTC")
+t = datetime.datetime.fromtimestamp(int(os.environ["FAKE_EPOCH"]), tz)
+fmt = next((a for a in args if a.startswith("+")), "+%c")[1:]
+out = fmt.replace("%-H", str(t.hour)).replace("%H", f"{t.hour:02d}")
+out = out.replace("%u", str(t.isoweekday()))
+print(out)
+PY
+STUB
+# `sleep` must not really sleep (the 503 path waits 3 minutes per attempt)
+printf '#!/bin/bash\nexit 0\n' > "$STUB_DIR/sleep"
+chmod +x "$STUB_DIR/date" "$STUB_DIR/sleep"
+
+# --- extract the shipped function + its logger, no retyping ---
+extract() {
+  { awk '/^logger\(\) \{/,/^\}/' "$SCRIPT"
+    awk '/^wait_for_healthcheck\(\) \{/,/^\}/' "$SCRIPT"
+  } > "$STUB_DIR/fn.sh"
+  [ -s "$STUB_DIR/fn.sh" ] || { echo "FATAL: extraction failed"; exit 1; }
+}
+
+# The real call sites, so the harness tests the ARGUMENTS that actually ship too.
+LONG_ARGS=$(awk '/^wait_for_healthcheck "Long-running job"/,/^$/' "$SCRIPT" | tr -d '\\\n')
+PAYOUT_ARGS=$(awk '/^wait_for_healthcheck "Payout batch"/,/^$/' "$SCRIPT" | tr -d '\\\n')
+
+# epoch for a given UTC hour on a date (2026-01-15 = EST, 2026-07-15 = EDT)
+epoch_for() { python3 -c "
+import datetime,sys
+from zoneinfo import ZoneInfo
+d,h=sys.argv[1],int(sys.argv[2])
+print(int(datetime.datetime.strptime(d,'%Y-%m-%d').replace(hour=h,minute=30,tzinfo=ZoneInfo('UTC')).timestamp()))" "$1" "$2"; }
+
+# Run one scenario -> prints DEPLOY or SKIP
+# args: <status-sequence> <date> <utc-hour> <call: long|payouts>
+run_case() {
+  local statuses="$1" day="$2" hour="$3" which="$4"
+  local call; [ "$which" = "long" ] && call="$LONG_ARGS" || call="$PAYOUT_ARGS"
+  # curl is invoked inside $( ), i.e. a subshell, so the status queue has to live in a FILE
+  # rather than a shell variable or each call would pop from an unmodified copy.
+  local queue="$STUB_DIR/queue"; printf '%s\n' $statuses > "$queue"
+  FAKE_EPOCH=$(epoch_for "$day" "$hour") \
+  QUEUE="$queue" PATH="$STUB_DIR:$PATH" \
+  bash -c "
+    set -e
+    curl() {
+      local s; s=\$(head -1 \"\$QUEUE\")
+      # last entry repeats forever, mimicking a persistently unhealthy endpoint
+      [ \$(wc -l < \"\$QUEUE\") -gt 1 ] && tail -n +2 \"\$QUEUE\" > \"\$QUEUE.t\" && mv \"\$QUEUE.t\" \"\$QUEUE\"
+      echo \"\$s\"
+    }
+    source '$STUB_DIR/fn.sh'
+    $call
+    echo REACHED_DEPLOY_BODY
+  " 2>/dev/null | grep -q REACHED_DEPLOY_BODY && echo DEPLOY || echo SKIP
+}
+
+PASS=0; FAIL=0
+check() { # <desc> <expected> <statuses> <day> <hour> <call>
+  local desc="$1" exp="$2"; shift 2
+  local got; got=$(run_case "$@")
+  if [ "$got" = "$exp" ]; then PASS=$((PASS+1)); [ -n "${QUIET:-}" ] || echo "PASS: $desc -> $got"
+  else FAIL=$((FAIL+1)); echo "FAIL: $desc -> got $got, expected $exp"; fi
+}
+
+cases() {
+  EDT=2026-07-15; EST=2026-01-15
+  # --- steady state: endpoint deployed and answering ---
+  check "200 nothing in flight deploys"                    DEPLOY "200" $EDT 2  long
+  check "200 deploys even inside every window"             DEPLOY "200" $EDT 5  long
+  # --- 503 in-flight loop then clear (the sleep path, previously untested) ---
+  check "503 then 200 waits then deploys"                  DEPLOY "503 503 200" $EDT 2 long
+  # --- the bootstrap case this PR fixes ---
+  check "404 at 02 UTC (outside old ET block) SHIPS"       DEPLOY "404" $EDT 2  long
+  # --- narrow-window-DISTINCT hours: inside ET block but OUTSIDE the wide window.
+  #     These are what make the 404 branch non-vacuous; deleting it flips them. ---
+  check "404 at 06 UTC = 02:00 EDT waits (narrow-only)"    SKIP   "404" $EDT 6  long
+  check "404 at 07 UTC = 03:00 EDT waits (narrow-only)"    SKIP   "404" $EDT 7  long
+  # --- DST correctness: UTC 10 is ET 06:00 in EDT (deploy) but ET 05:00 in EST (skip).
+  #     A hardcoded UTC window cannot satisfy both rows. UTC 04 is the mirror case. ---
+  check "404 at 10 UTC in EDT = 06:00 ET SHIPS"            DEPLOY "404" $EDT 10 long
+  check "404 at 10 UTC in EST = 05:00 ET waits"            SKIP   "404" $EST 10 long
+  check "404 at 04 UTC in EST = 23:00 ET SHIPS"            DEPLOY "404" $EST 4  long
+  check "404 at 04 UTC in EDT = 00:00 ET waits"            SKIP   "404" $EDT 4  long
+  # --- genuinely broken endpoint still uses the WIDE fail-safe window ---
+  check "500 at 02 UTC skips (conservative)"               SKIP   "500" $EDT 2  long
+  check "500 at 12 UTC skips (report window)"              SKIP   "500" $EDT 12 long
+  check "000 unreachable at 20 UTC proceeds"               DEPLOY "000" $EDT 20 long
+  check "500 at 20 UTC outside all windows proceeds"       DEPLOY "500" $EDT 20 long
+  # --- the 5-arg payouts call: guards the ${6:-$5} default. Tue UTC 10 is its window. ---
+  check "payouts 404 inside its window skips (5-arg)"      SKIP   "404" 2026-07-14 10 payouts
+  check "payouts 404 outside its window proceeds (5-arg)"  DEPLOY "404" $EDT 20 payouts
+  check "payouts 500 inside its window skips"              SKIP   "500" 2026-07-14 10 payouts
+}
+
+extract
+echo "=== wait_for_healthcheck cases ==="
+cases
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+BASE_FAIL=$FAIL
+
+# ---------------------------------------------------------------------------
+# Mutation testing: each mutation below MUST make the suite fail. This is what
+# proves the cases are load-bearing rather than vacuously passing.
+# ---------------------------------------------------------------------------
+if [ "${1:-}" = "--mutate" ]; then
+  echo
+  echo "=== mutation testing (each mutant MUST be caught) ==="
+  mutate() { # <desc> <sed-expr>
+    local desc="$1" expr="$2"
+    cp "$SCRIPT" "$STUB_DIR/orig.sh"
+    perl -0pi -e "$expr" "$SCRIPT"
+    if diff -q "$STUB_DIR/orig.sh" "$SCRIPT" >/dev/null; then
+      echo "SKIP (mutation did not apply): $desc"; cp "$STUB_DIR/orig.sh" "$SCRIPT"; return
+    fi
+    extract
+    LONG_ARGS=$(awk '/^wait_for_healthcheck "Long-running job"/,/^$/' "$SCRIPT" | tr -d '\\\n')
+    PAYOUT_ARGS=$(awk '/^wait_for_healthcheck "Payout batch"/,/^$/' "$SCRIPT" | tr -d '\\\n')
+    PASS=0; FAIL=0; QUIET=1 cases
+    if [ "$FAIL" -gt 0 ]; then echo "CAUGHT ($FAIL failing): $desc"
+    else echo "ESCAPED -- suite is vacuous for: $desc"; ESCAPES=$((ESCAPES+1)); fi
+    cp "$STUB_DIR/orig.sh" "$SCRIPT"
+    extract
+    LONG_ARGS=$(awk '/^wait_for_healthcheck "Long-running job"/,/^$/' "$SCRIPT" | tr -d '\\\n')
+    PAYOUT_ARGS=$(awk '/^wait_for_healthcheck "Payout batch"/,/^$/' "$SCRIPT" | tr -d '\\\n')
+  }
+  ESCAPES=0
+  mutate "delete the whole 404 branch (falls through to wide fail-safe)" \
+    's/    elif \[ "\$hc_status" = "404" \]; then.*?      return 0\n(    else)/$1/s'
+  mutate "pre-rollout window hardcoded to UTC 04-09 (the DST bug this review found)" \
+    "s/'\\[ \"\\\$\\(TZ=America\\/New_York date \\+%-H\\)\" -le 5 \\]'/'[ \"\\\$(date -u +%-H)\" -ge 4 ] \\&\\& [ \"\\\$(date -u +%-H)\" -le 9 ]'/"
+  mutate "drop the \${6:-\$5} default (payouts 404 evals an empty test)" \
+    's/\$\{6:-\$5\}/$6/'
+  mutate "off-by-one: -le 5 becomes -le 6 in the pre-rollout window" \
+    "s/(TZ=America\\/New_York date \\+%-H\\)\" -le )5/\${1}6/"
+  mutate "404 skip uses return instead of exit (deploy proceeds anyway)" \
+    's/(inside the pre-rollout window — skipping deployment"\n        )exit 0/${1}return 0/'
+  echo
+  echo "MUTANTS_ESCAPED=$ESCAPES"
+  [ "$ESCAPES" -eq 0 ] && [ "$BASE_FAIL" -eq 0 ] && echo "ALL GREEN: cases pass, every mutant caught"
+fi
+
+[ "$BASE_FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## What

#6261 pointed the production deploy gate at `/healthcheck/long_running_jobs` — an endpoint that ships in that same commit. This makes a 404 from that endpoint its own case, falling back to the narrower pre-rollout window instead of the wide one.

## Why

The deploy script runs *before* the app it is deploying is live, so on the one deploy that first ships a new healthcheck endpoint, the still-running old app answers 404. In #6261 a 404 landed in the `else` branch — "we cannot tell" — which applies the wide fail-safe window (UTC 00–05 and 08–13) and `exit 0`s the deploy.

So the deploy that installs the endpoint gets skipped, and so does every retry that falls inside that window. The endpoint can only begin answering by being deployed, so the check was blocking its own bootstrap. That is 12 of every 24 hours in which #6261 cannot ship itself, and the window it picked contains the hour it merged.

This is live right now on `main`:

```
$ curl -s -o /dev/null -w '%{http_code}' https://gumroad.com/healthcheck/long_running_jobs
404
```

Driving the shipped `wait_for_healthcheck` from `main` against that 404, at the current time (02:2x UTC, inside the window):

```
LOG: Long-running job healthcheck unreachable (HTTP 404) inside the fail-safe window — skipping deployment
subshell exit=0        # "REACHED DEPLOY BODY" never printed
```

A 404 is not actually ambiguous. It is the old app telling us definitively that none of the tracking code is live, so nothing can be registered and there is nothing to wait for. Unreachable and 5xx are genuinely ambiguous and keep the old conservative behaviour.

## What the 404 branch falls back to, and why it is not weaker

The pre-rollout window reproduces the guard this mechanism replaced — the midnight–6am ET block that lived in `.github/workflows/tests.yml` — and, like that block, it is written in **ET** (`TZ=America/New_York`, hours 0–5), not in a hardcoded UTC offset. The first version of this PR hardcoded UTC 04–09 on the reasoning "ET is UTC-4 on EDT"; the pre-merge review caught that this is only true for about 7.5 months of the year. See the review comment below — it was a real bug, and the harness now pins it in both directions.

That is the honest answer for an app with none of the tracking code: the old clock block was the only protection that ever existed there, so reproducing it exactly is neither weaker nor stronger than the behaviour being replaced. Using the *wider* window instead would not buy protection — the jobs it covers cannot register on an app that lacks the concern — it would only delay the endpoint's own rollout.

The parameter defaults to the fail-safe test when not supplied, so the payouts check is unchanged (its endpoint has been deployed since #6160).

**This argument is meant to be removed.** It exists only so the endpoint can bootstrap itself. Once production answers 200/503, the argument should come out (tracked below), because a *future* 404 — a removed route, a web-only rollback, an edge 404 — happens while the tracking code IS live, and the wide fail-safe window is the right answer for those.

## Test results

The harness is now committed as `.buildkite/scripts/deploy_production_test.sh` rather than living in this description. `deploy_production.sh` is never executed by CI, so `bash -n` was the only automated check the gate ever got.

It drives the **shipped** `wait_for_healthcheck`, extracted from the real file with `awk` rather than retyped, so the test cannot drift from the code that deploys. `date` is stubbed through python `zoneinfo`, so the EST/EDT cases exercise real daylight-saving rules instead of a hardcoded offset.

```
=== wait_for_healthcheck cases ===
PASS: 200 nothing in flight deploys -> DEPLOY
PASS: 200 deploys even inside every window -> DEPLOY
PASS: 503 then 200 waits then deploys -> DEPLOY
PASS: 404 at 02 UTC (outside old ET block) SHIPS -> DEPLOY
PASS: 404 at 06 UTC = 02:00 EDT waits (narrow-only) -> SKIP
PASS: 404 at 07 UTC = 03:00 EDT waits (narrow-only) -> SKIP
PASS: 404 at 10 UTC in EDT = 06:00 ET SHIPS -> DEPLOY
PASS: 404 at 10 UTC in EST = 05:00 ET waits -> SKIP
PASS: 404 at 04 UTC in EST = 23:00 ET SHIPS -> DEPLOY
PASS: 404 at 04 UTC in EDT = 00:00 ET waits -> SKIP
PASS: 500 at 02 UTC skips (conservative) -> SKIP
PASS: 500 at 12 UTC skips (report window) -> SKIP
PASS: 000 unreachable at 20 UTC proceeds -> DEPLOY
PASS: 500 at 20 UTC outside all windows proceeds -> DEPLOY
PASS: payouts 404 inside its window skips (5-arg) -> SKIP
PASS: payouts 404 outside its window proceeds (5-arg) -> DEPLOY
PASS: payouts 500 inside its window skips -> SKIP

PASS=17 FAIL=0
```

The four `UTC 04 / UTC 10` rows are the DST pins: UTC 10 is ET 06:00 in summer (deploy) but ET 05:00 in winter (skip), so no hardcoded UTC window can satisfy both. `UTC 06/07` are the only hours where the narrow window skips and the wide one does not — without them, deleting the whole 404 branch still passes.

`--mutate` re-runs every case against five broken variants of the real script and asserts each is caught, so the cases cannot rot into vacuous passes:

```
=== mutation testing (each mutant MUST be caught) ===
CAUGHT (5 failing): delete the whole 404 branch (falls through to wide fail-safe)
CAUGHT (2 failing): pre-rollout window hardcoded to UTC 04-09 (the DST bug this review found)
CAUGHT (4 failing): drop the ${6:-$5} default (payouts 404 evals an empty test)
CAUGHT (1 failing): off-by-one: -le 5 becomes -le 6 in the pre-rollout window
CAUGHT (5 failing): 404 skip uses return instead of exit (deploy proceeds anyway)

MUTANTS_ESCAPED=0
ALL GREEN: cases pass, every mutant caught
```

`bash -n` clean on both files.

## Before / After

No user-facing surface: one internal endpoint's client-side status handling inside the deploy script. No app, job, mailer, or API behaviour changes.

## Note on #6262

#6262 is the sibling implementation of this same request and is now `CONFLICTING` against `main` since #6261 landed first. It independently hit the mirror-image version of this bug (Greptile P1: renaming `/healthcheck/payouts` → `/healthcheck/deploy_safe` made the new script poll a path the old app does not serve) and fixed it caller-side. Worth closing as superseded or rebasing, but that is a separate call from this fix.

---

## AI disclosure

Written by Claude Opus 5 acting as Gumroad's engineering agent, and revised after its own adversarial pre-merge review (verdict in the comments) found a daylight-saving bug in the first version. Found while verifying that #6261 reached production after its merge watcher reported MERGED: the merge commit was not in the live `x-revision`, and probing the new endpoint against production returned 404, which the shipped gate turns into a skip. The agent reproduced the deadlock by extracting and running the real `wait_for_healthcheck`, then wrote the fix and the ten-case matrix above.

