### PR TITLE
Document the off-platform-fulfillment publish block

### DIFF
--- a/app/views/help_center/articles/contents/_155-things-you-cant-sell-on-gumroad.html.erb
+++ b/app/views/help_center/articles/contents/_155-things-you-cant-sell-on-gumroad.html.erb
@@ -41,7 +41,7 @@
     <li>A Discord or Circle community Gumroad itself gives buyers access to through an <a href="295-external-integration">integration</a>, where the invite is the delivery.</li>
     <li>Links to your socials, newsletter, portfolio, or YouTube, and support contacts like "email me if a link breaks".</li>
     <li>Calls, commissions, and coffee products, where the work you do is what the buyer is paying for.</li>
-    <li>Memberships and newsletters with nothing attached yet because the content is published later.</li>
+    <li>Memberships and newsletters with nothing attached yet because you publish the content later. Having nothing attached is never the problem by itself.</li>
   </ul>
   <p>A product that has real files or content is never affected by this, no matter how its description mentions other platforms.</p>
   <h3>Dealing with violation of our Terms</h3>

--- a/app/views/help_center/articles/contents/_155-things-you-cant-sell-on-gumroad.html.erb
+++ b/app/views/help_center/articles/contents/_155-things-you-cant-sell-on-gumroad.html.erb
@@ -32,15 +32,16 @@
     <li>No products that promote meeting up with strangers for any reason, including but not limited to dating, hookups, or any other social interaction.</li>
   </ul>
   <h3 id="Delivering-off-Gumroad-Ln4vT">Delivering your product off Gumroad</h3>
-  <p>Buyers need to receive what they paid for on Gumroad, so you cannot sell a product whose only way of delivering it is telling buyers to message you somewhere else. If a product has nothing attached for the buyer and its description says something like "after you subscribe, DM me on Telegram for the content", it will not publish. You will see this message instead:</p>
+  <p>Buyers need to receive what they paid for on Gumroad, so you cannot sell a product whose only way of delivering it is telling buyers to message you somewhere else. If a product has nothing attached for the buyer and its description says something like "after you subscribe, DM me on Telegram for the content", it will be blocked when you publish it, or when you save a change to the name or description of a product that is already published. You will see this message:</p>
   <p><i>Buyers need to receive what they paid for on Gumroad. This product has no content attached and directs buyers to message you on another platform to get it, which we don’t allow. Add the files, videos, or written content buyers should get when they buy, then publish again.</i></p>
-  <p>Once the product has content, publish it again and it will go through.</p>
+  <p>Once the product has files, videos, or written content buyers can get on Gumroad, try publishing again. This particular block will no longer apply, though the product still has to follow the rest of our content guidelines.</p>
   <p>This only applies to products that have nothing at all for the buyer on Gumroad. Mentioning other platforms is fine on its own, and none of these are affected:</p>
   <ul>
     <li>A Discord, Telegram, or Slack community offered alongside your content, or as a perk of a membership.</li>
     <li>A Discord or Circle community Gumroad itself gives buyers access to through an <a href="295-external-integration">integration</a>, where the invite is the delivery.</li>
     <li>Links to your socials, newsletter, portfolio, or YouTube, and support contacts like "email me if a link breaks".</li>
-    <li>Calls, commissions, and coffee products, where the work you do is what the buyer is paying for.</li>
+    <li>Calls and commissions, where the work you do for the buyer is the deliverable, and coffee products, which have no deliverable by design.</li>
+    <li>Bundles, where buyers receive the products you put inside the bundle.</li>
     <li>Memberships and newsletters with nothing attached yet because you publish the content later. Having nothing attached is never the problem by itself.</li>
   </ul>
   <p>A product that has real files or content is never affected by this, no matter how its description mentions other platforms.</p>

--- a/app/views/help_center/articles/contents/_155-things-you-cant-sell-on-gumroad.html.erb
+++ b/app/views/help_center/articles/contents/_155-things-you-cant-sell-on-gumroad.html.erb
@@ -31,6 +31,19 @@
     <li>Products that feature cruelty to animals</li>
     <li>No products that promote meeting up with strangers for any reason, including but not limited to dating, hookups, or any other social interaction.</li>
   </ul>
+  <h3 id="Delivering-off-Gumroad-Ln4vT">Delivering your product off Gumroad</h3>
+  <p>Buyers need to receive what they paid for on Gumroad, so you cannot sell a product whose only way of delivering it is telling buyers to message you somewhere else. If a product has nothing attached for the buyer and its description says something like "after you subscribe, DM me on Telegram for the content", it will not publish. You will see this message instead:</p>
+  <p><i>Buyers need to receive what they paid for on Gumroad. This product has no content attached and directs buyers to message you on another platform to get it, which we don’t allow. Add the files, videos, or written content buyers should get when they buy, then publish again.</i></p>
+  <p>Once the product has content, publish it again and it will go through.</p>
+  <p>This only applies to products that have nothing at all for the buyer on Gumroad. Mentioning other platforms is fine on its own, and none of these are affected:</p>
+  <ul>
+    <li>A Discord, Telegram, or Slack community offered alongside your content, or as a perk of a membership.</li>
+    <li>A Discord or Circle community Gumroad itself gives buyers access to through an <a href="295-external-integration">integration</a>, where the invite is the delivery.</li>
+    <li>Links to your socials, newsletter, portfolio, or YouTube, and support contacts like "email me if a link breaks".</li>
+    <li>Calls, commissions, and coffee products, where the work you do is what the buyer is paying for.</li>
+    <li>Memberships and newsletters with nothing attached yet because the content is published later.</li>
+  </ul>
+  <p>A product that has real files or content is never affected by this, no matter how its description mentions other platforms.</p>
   <h3>Dealing with violation of our Terms</h3>
   <p>If you share, promote, or sell content that violates the guidelines listed above, it is a violation of our Terms of Service. </p>
   <p>Depending on the situation, we may be forced to suspend your account and refund your sales. This is our prerogative as detailed in section 11.3 of <a href="https://gumroad.com/terms" target="_blank">our Terms</a>.</p>


### PR DESCRIPTION
## What

Documents the off-platform-fulfillment publish block shipped in #6275 in `_155-things-you-cant-sell-on-gumroad`, the article that catalogs what you can't sell on Gumroad.

The new section "Delivering your product off Gumroad" states the rule, quotes the seller-facing error verbatim (so a creator who pastes it into help-center search lands here), names when the check runs (on publish, and when the name or description of an already-published product changes), and lists the cases it deliberately never touches: a community offered alongside real content, a Gumroad-provisioned Discord/Circle integration, social and support links, calls and commissions, coffee products, bundles, and memberships or newsletters with nothing attached yet.

## Why

#6275 introduced a rule creators can hit at publish time — a product with no files, no rich content, and a description that routes buyers to Telegram/X/Discord for what they paid for is now rejected — and nothing in the help center described it. Grepping the article bodies for the message's distinctive phrases ("receive what they paid for", "no content attached", "message you on another platform") returned zero hits, so a creator who hits the block had no article to land on.

The false-positive worry is the reason the section spends most of its length on what is allowed. The check only runs when a product genuinely has nothing attached, so the practical question a creator asks after seeing the error is "does this mean I can't link my Discord?" — the answer needs to be on the page.

Every claim is drawn from the merged code rather than the PR summary:

- Emptiness gate and exclusions: `ModerateRecordService#check_off_platform_fulfillment?` — skips physical, bundles, `Link::SERVICE_TYPES` (commission, call, coffee), and products with an active integration; requires no alive product files at product or variant level and no reader-visible rich content.
- Integration carve-out: `#gumroad_managed_integration?` (Discord/Circle invites are the deliverable, provisioned by Gumroad).
- Verbatim error text: `ModerateRecordService::OFF_PLATFORM_FULFILLMENT_MESSAGE` formatted with the product noun.
- When the check runs: the `Link` validation guard `publishing? || (persisted? && published? && (name_changed? || description_changed?))`.
- "Nothing attached yet is fine": the `OFF_PLATFORM_FULFILLMENT_RULES` ALLOW list explicitly covers memberships and newsletters whose content is published later.

`articles.yml` is untouched — the article's title, description, and category are unchanged, and the new section sits mid-article ahead of "Dealing with violation of our Terms".

## Before / After

Not applicable — help-center copy change, no product surface.

## QA steps

1. Visit help.gumroad.com/help/article/155-things-you-cant-sell-on-gumroad.
2. The "Delivering your product off Gumroad" section appears between the high-risk products list and "Dealing with violation of our Terms".
3. The "integration" link resolves to article 295 (Integrating products with external services).

## Test Results

- Partial renders in the real view context: `ApplicationController.render(partial: "help_center/articles/contents/155-things-you-cant-sell-on-gumroad")` → 6581 bytes, new copy present.
- ERB compiles (`ERB.new(...).src`).
- Tag-balance check across `div/p/ul/li/h3/a/i/strong/ol` — all balanced (the file had no pre-existing mismatches).
- Prettier has no ERB parser and `articles.yml` is untouched, so there is nothing to format.

---

## Review

fable-5 adversarial review run locally against the branch, checking every documented claim against the merged code. No P1s; three P2s and one P3, all fixed in b4ce4ec38 (republish scope, retry wording that overpromised, missing bundle exemption, coffee described as work performed). Full verdict posted as a PR comment.

---

## AI disclosure

Written by Claude Opus 4.5 running as the Gumclaw Hermes agent, triggered by the merge of #6275. Instructions given: check whether the merged PR changes anything documented in the help center, and if so update the affected articles to match, verifying every documented fact against the merged code rather than the PR description.
