### PR TITLE
Document the fork-and-email route for outside contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,13 +6,13 @@
 
 Contribute like this instead:
 
-1. **Fork the repo** and open the pull request on *your own* fork.
+1. **Fork the repo** and open the pull request on _your own_ fork.
 2. **Email [support@gumroad.com](mailto:support@gumroad.com)** with a link to it.
 3. We review it ourselves, and if we want it, **we merge it on our side.**
 
 Your PR on your fork is held to the same bar as anything we write. Concretely, at minimum:
 
-- **Visual evidence** for anything a user can see, before/after, desktop + mobile, light + dark. Video preferred. This is the #1 rule below and it is not waived for forks.
+- **Visual evidence** for anything a user can see, before/after, desktop + mobile, light + dark. Video preferred. This is the #1 rule below and it is not waived for forks. The one exception is the same one we give ourselves: a PR that only touches documentation or agent skill files needs no video, because the diff is the reviewable artifact.
 - **QA steps** someone else can actually follow to verify the change.
 - **Test results** — updated tests, and a screenshot of them passing.
 - **An AI disclosure** naming the specific model, after a `---` separator.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,8 @@
 # Contributing to Gumroad
 
-## We don't accept pull requests on this repository
+## Contributing from a fork
 
-**This repo is not open to outside pull requests.** A PR opened against `antiwork/gumroad` will be closed without review, no matter how good the change is. That is not a judgement on the work — we simply don't run an inbound review queue here.
-
-Contribute like this instead:
+We don't run an inbound review queue on this repo, so external changes come to us a different way:
 
 1. **Fork the repo** and open the pull request on _your own_ fork.
 2. **Email [support@gumroad.com](mailto:support@gumroad.com)** with a link to it.
@@ -22,7 +20,7 @@ The rest of the guidelines below apply too, with the obvious substitutions for w
 
 A fork PR that skips the evidence gets the same answer as one of ours that skips it: it isn't ready. If your change is good and documented well, the fork is not a barrier — it's just where the work lives until we pull it in.
 
-**Issues and bug reports are still welcome here.** This policy is about pull requests only — [file issues](https://github.com/antiwork/gumroad/issues) and bug reports on this repo as normal.
+**Issues and bug reports are still welcome here.** This is about pull requests only — [file issues](https://github.com/antiwork/gumroad/issues) and bug reports on this repo as normal.
 
 Merged fork commits keep your authorship, so contributions show up under your name in the history. Emailing us a link to your fork PR counts as contributing under the [license terms](#license) at the bottom of this guide.
 
@@ -220,7 +218,7 @@ A great bug report includes:
 
 ## Help
 
-- Any issue with label `help wanted` is one we'd welcome a fix for - [view open issues](https://github.com/antiwork/gumroad/issues?q=state%3Aopen%20label%3A%22help%20wanted%22). Work it on your fork and email [support@gumroad.com](mailto:support@gumroad.com) with the link, per [the policy at the top of this guide](#we-dont-accept-pull-requests-on-this-repository) — don't open the PR here.
+- Any issue with label `help wanted` is one we'd welcome a fix for - [view open issues](https://github.com/antiwork/gumroad/issues?q=state%3Aopen%20label%3A%22help%20wanted%22). Work it on your fork and email [support@gumroad.com](mailto:support@gumroad.com) with the link, per [the route at the top of this guide](#contributing-from-a-fork).
 
 ## When you're corrected, fix the docs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,25 @@
 # Contributing to Gumroad
 
+## We don't accept pull requests on this repository
+
+**This repo is not open to outside pull requests.** A PR opened against `antiwork/gumroad` will be closed without review, no matter how good the change is. That is not a judgement on the work — we simply don't run an inbound review queue here.
+
+Contribute like this instead:
+
+1. **Fork the repo** and open the pull request on *your own* fork.
+2. **Email [support@gumroad.com](mailto:support@gumroad.com)** with a link to it.
+3. We review it ourselves, and if we want it, **we merge it on our side.**
+
+Your PR on your fork has to meet the exact same bar as anything we write, because it gets held to the same guidelines — everything below in this document applies. Concretely, that means at minimum:
+
+- **Visual evidence** for anything a user can see, before/after, desktop + mobile, light + dark. Video preferred. This is the #1 rule below and it is not waived for forks.
+- **QA steps** someone else can actually follow to verify the change.
+- **Test results** — updated tests, and a screenshot of them passing.
+- **An AI disclosure** naming the specific model, after a `---` separator.
+- **A self-review** comment on your own diff, and a **What / Why / Before-After / Test Results** description.
+
+A fork PR that skips these gets the same answer as one of ours that skips them: it isn't ready. If your change is good and documented well, the fork is not a barrier — it's just where the work lives until we pull it in.
+
 ## Overall
 
 Use native-sounding English in all communication with no excessive capitalization (e.g HOW IS THIS GOING), multiple question marks (how's this going???), grammatical errors (how's dis going), or typos (thnx fr update).
@@ -190,7 +210,7 @@ A great bug report includes:
 
 ## Help
 
-- Any issue with label `help wanted` is open for contributions - [view open issues](https://github.com/antiwork/gumroad/issues?q=state%3Aopen%20label%3A%22help%20wanted%22)
+- Any issue with label `help wanted` is one we'd welcome a fix for - [view open issues](https://github.com/antiwork/gumroad/issues?q=state%3Aopen%20label%3A%22help%20wanted%22). Work it on your fork and email [support@gumroad.com](mailto:support@gumroad.com) with the link, per [the policy at the top of this guide](#we-dont-accept-pull-requests-on-this-repository) — don't open the PR here.
 
 ## When you're corrected, fix the docs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Contribute like this instead:
 2. **Email [support@gumroad.com](mailto:support@gumroad.com)** with a link to it.
 3. We review it ourselves, and if we want it, **we merge it on our side.**
 
-Your PR on your fork has to meet the exact same bar as anything we write, because it gets held to the same guidelines — everything below in this document applies. Concretely, that means at minimum:
+Your PR on your fork is held to the same bar as anything we write. Concretely, at minimum:
 
 - **Visual evidence** for anything a user can see, before/after, desktop + mobile, light + dark. Video preferred. This is the #1 rule below and it is not waived for forks.
 - **QA steps** someone else can actually follow to verify the change.
@@ -18,7 +18,15 @@ Your PR on your fork has to meet the exact same bar as anything we write, becaus
 - **An AI disclosure** naming the specific model, after a `---` separator.
 - **A self-review** comment on your own diff, and a **What / Why / Before-After / Test Results** description.
 
-A fork PR that skips these gets the same answer as one of ours that skips them: it isn't ready. If your change is good and documented well, the fork is not a barrier — it's just where the work lives until we pull it in.
+The rest of the guidelines below apply too, with the obvious substitutions for working outside this repo: reference `qa-media/` files by your own fork's raw URL (`raw.githubusercontent.com/<your-username>/gumroad/<branch>/...`, not `antiwork/gumroad`), name them `pr-<your-fork-pr-number>-<description>`, and skip the steps that depend on this repo's own infrastructure — preview-app deploys and `@claude review once` both need org credentials you won't have, so we run those ourselves once we pull the change in. Substituting for those is expected; skipping the evidence itself is not.
+
+A fork PR that skips the evidence gets the same answer as one of ours that skips it: it isn't ready. If your change is good and documented well, the fork is not a barrier — it's just where the work lives until we pull it in.
+
+**Issues and bug reports are still welcome here.** This policy is about pull requests only — [file issues](https://github.com/antiwork/gumroad/issues) and bug reports on this repo as normal.
+
+Merged fork commits keep your authorship, so contributions show up under your name in the history. Emailing us a link to your fork PR counts as contributing under the [license terms](#license) at the bottom of this guide.
+
+We read every submission, but we can't promise a reply to each one or a timeline for review.
 
 ## Overall
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Non-trivial PRs should follow this structure:
 - **Before/After** — Video is required for all PRs, except PRs that only touch documentation or agent skill files, where the diff itself is the reviewable artifact. For user-facing changes, show before/after with desktop and mobile, light and dark mode. For non-user-facing changes, include a short video walking through the relevant existing functionality.
 - **Test Results** — Screenshot of tests passing locally.
 
-Store screenshots and videos in `qa-media/` using the naming convention `pr-<number>-<description>.<ext>`. Reference them in PR descriptions with raw GitHub URLs:
+Store screenshots and videos in `qa-media/` using the naming convention `pr-<number>-<description>.<ext>`. From a fork, use your own fork's PR number — it won't match any number here, and that's fine. Reference them in PR descriptions with raw GitHub URLs:
 
 ```markdown
 ![description](https://raw.githubusercontent.com/antiwork/gumroad/<branch>/qa-media/pr-5160-pagination-page1.png)
@@ -99,6 +99,8 @@ git rebase origin/main
 ```
 
 Resolve conflicts locally before pushing. PRs with stale branches will not be merged.
+
+Working from a fork, `origin` is your fork — and your fork's `main` goes stale the moment this repo moves. Add this repo as `upstream` once (`git remote add upstream https://github.com/antiwork/gumroad.git`) and rebase onto `upstream/main` instead.
 
 ### Code review
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,17 @@
   </a>
 </p>
 
+## Contributing
+
+**We don't accept pull requests on this repository.** A PR opened here will be closed without review.
+
+If you want to contribute a change: **fork the repo, open the pull request on your own fork, then email [support@gumroad.com](mailto:support@gumroad.com) with a link to it.** We'll review it and merge it on our side if we want it.
+
+Your PR still has to meet the same bar as our own work — visual evidence for anything user-facing, QA steps, test results, and an AI disclosure naming the model. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guidelines; they apply to fork PRs exactly as written.
+
 ## Table of Contents
 
+- [Contributing](#contributing)
 - [Getting Started](#getting-started)
   - [Prerequisites](#prerequisites)
   - [Installation](#installation)

--- a/README.md
+++ b/README.md
@@ -24,9 +24,11 @@
 
 **We don't accept pull requests on this repository.** A PR opened here will be closed without review.
 
-If you want to contribute a change: **fork the repo, open the pull request on your own fork, then email [support@gumroad.com](mailto:support@gumroad.com) with a link to it.** We'll review it and merge it on our side if we want it.
+If you want to contribute a change: **fork the repo, open the pull request on your own fork, then email [support@gumroad.com](mailto:support@gumroad.com) with a link to it.** We read every submission and merge the ones we want on our side, keeping your authorship — though we can't promise a reply to each one or a timeline.
 
-Your PR still has to meet the same bar as our own work — visual evidence for anything user-facing, QA steps, test results, and an AI disclosure naming the model. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guidelines; they apply to fork PRs exactly as written.
+Your PR still has to meet the same bar as our own work — visual evidence for anything user-facing, QA steps, test results, and an AI disclosure naming the model. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guidelines and the substitutions that apply when working from a fork.
+
+**Issues and bug reports are still welcome here** — this policy is about pull requests only.
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -22,13 +22,11 @@
 
 ## Contributing
 
-**We don't accept pull requests on this repository.** A PR opened here will be closed without review.
-
-If you want to contribute a change: **fork the repo, open the pull request on your own fork, then email [support@gumroad.com](mailto:support@gumroad.com) with a link to it.** We read every submission and merge the ones we want on our side, keeping your authorship — though we can't promise a reply to each one or a timeline.
+We don't run an inbound review queue on this repo. To contribute a change: **fork the repo, open the pull request on your own fork, then email [support@gumroad.com](mailto:support@gumroad.com) with a link to it.** We read every submission and merge the ones we want on our side, keeping your authorship — though we can't promise a reply to each one or a timeline.
 
 Your PR still has to meet the same bar as our own work — visual evidence for anything user-facing, QA steps, test results, and an AI disclosure naming the model. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guidelines and the substitutions that apply when working from a fork.
 
-**Issues and bug reports are still welcome here** — this policy is about pull requests only.
+**Issues and bug reports are still welcome here** — this is about pull requests only.
 
 ## Table of Contents
 


### PR DESCRIPTION
## What

States in both `README.md` and `CONTRIBUTING.md` how an outside change actually reaches us: fork the repo, open the PR on your own fork, and email support@gumroad.com with a link — we review it and merge it on our side.

- **README** — a short `## Contributing` section directly above the table of contents (added to the TOC), so it's visible without scrolling and before anyone starts setting up a dev environment.
- **CONTRIBUTING** — `## Contributing from a fork` as the first section, above "Overall", with the numbered fork → email → we-merge route and an explicit list of what a fork PR still has to carry.
- **`help wanted`** — that line previously read as an open invitation to contribute on issues in this repo. Rewritten to point at the fork route.

## Why

Nothing in either file said how to contribute from outside, so a would-be contributor's first signal was the absence of a route. The reasoning is the useful part: there's no inbound review queue here, so the work lives on your fork until we pull it in.

The wording deliberately guards against the obvious misreading, which is that a fork PR is a lower-standards side door. Both notices say the same guidelines apply, and CONTRIBUTING spells out the minimum: visual evidence for anything user-facing (before/after, desktop + mobile, light + dark), QA steps someone else can follow, updated tests plus a screenshot of them passing, an AI disclosure naming the specific model, and a self-review with the What/Why/Before-After/Test Results structure. A fork PR that skips those gets the same answer one of ours would.

It also names the substitutions that are expected rather than optional — raw URLs point at your own fork, PR numbers in `qa-media/` filenames are your fork's, and the two steps that need org credentials (preview-app deploys, `@claude review once`) we run ourselves once the change is in. Skipping the evidence itself is still not on.

The README stays short and CONTRIBUTING carries the full list, rather than duplicating requirements in both — one source of truth to keep current.

## Before / After

Not applicable — documentation only, no user-facing surface. Per this repo's own guidelines, PRs that only touch documentation don't require a video, since the diff is the reviewable artifact.

Rendered result:

**README.md**, new section above the table of contents:

> We don't run an inbound review queue on this repo. To contribute a change: **fork the repo, open the pull request on your own fork, then email support@gumroad.com with a link to it.** We read every submission and merge the ones we want on our side, keeping your authorship — though we can't promise a reply to each one or a timeline.

**CONTRIBUTING.md**, new first section:

> We don't run an inbound review queue on this repo, so external changes come to us a different way:
>
> 1. **Fork the repo** and open the pull request on _your own_ fork.
> 2. **Email support@gumroad.com** with a link to it.
> 3. We review it ourselves, and if we want it, **we merge it on our side.**

## QA steps

1. Open `README.md` on the branch — the `## Contributing` section renders above the table of contents, and the TOC's new `- [Contributing](#contributing)` entry jumps to it.
2. Open `CONTRIBUTING.md` — `## Contributing from a fork` is the first section after the title.
3. Click the `the route at the top of this guide` link in the `## Help` section — the `#contributing-from-a-fork` anchor resolves to the new heading.
4. Both `support@gumroad.com` mailto links open a compose window.

## Test Results

No code changed, so no test suite applies. `prettier --write` reports both files unchanged (already formatted). Markdown verified by rendering both files and checking the anchor and mailto links resolve.

---

Written by Claude Opus 5 running as the Gumclaw Hermes agent. Instructions given: note in the README and contributing guidelines that contributions go through a fork and an email to support@gumroad.com — we'll review and merge on our own, and it must follow the same guidelines including QA steps, AI disclosure, etc. Follow-up: drop the "a PR opened here will be closed" framing, since pull requests are already disabled on the repo — keep only the reasoning.
