### PR TITLE
Serialize production deploys so concurrent merges stop killing each other

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -56,6 +56,24 @@ steps:
     branches: "main"
     command: ".buildkite/scripts/deploy_production.sh"
     timeout_in_minutes: 120
+    # Serialize production deploys. A deploy holds a Consul lock for its whole run
+    # (median 23 minutes), and deploy_production.sh exits 1 immediately if the lock is
+    # already held. Without this, two commits merged inside one deploy window race: the
+    # second starts, finds the lock, and dies ~30 seconds in. Failed deploys are not
+    # retried, so main silently stops shipping until someone notices and pushes again.
+    #
+    # On 2026-07-25 that was 9 of 11 deploy failures in 30 builds — a 37% failure rate,
+    # every one a lost race rather than a real problem with the commit.
+    #
+    # concurrency_group makes Buildkite queue these steps instead: the second deploy
+    # waits for the first to finish and then runs, which is what the Consul lock was
+    # trying to express but could only enforce by failing.
+    concurrency_group: "gumroad/production-deploy"
+    concurrency: 1
+    # Left on the default concurrency_method ("ordered"): queued deploys run in the order
+    # they were queued. That matters here — deploys ship a specific revision, so running
+    # them out of order could put an older revision live after a newer one. "eager" only
+    # removes the ordering guarantee; it does not mean newest-first.
     plugins:
       - docker-login#v3.0.0:
           username: "gumroadteam"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -62,12 +62,19 @@ steps:
     # second starts, finds the lock, and dies ~30 seconds in. Failed deploys are not
     # retried, so main silently stops shipping until someone notices and pushes again.
     #
-    # On 2026-07-25 that was 9 of 11 deploy failures in 30 builds — a 37% failure rate,
-    # every one a lost race rather than a real problem with the commit.
+    # On 2026-07-25, 11 of 30 main deploy jobs failed — a 37% failure rate — and 9 of the
+    # 11 were provably lost races (each started inside a concurrently-successful deploy's
+    # hold window and died in 25-32s). The other two failed for unrelated reasons.
     #
     # concurrency_group makes Buildkite queue these steps instead: the second deploy
     # waits for the first to finish and then runs, which is what the Consul lock was
     # trying to express but could only enforce by failing.
+    #
+    # Scope: this serializes deploys started from THIS step only. A lock held by anything
+    # else — a manual nomad/production/lock_deployment.sh run, or one leaked by a deploy
+    # that died mid-flight — still fails a queued deploy exactly as it does today. That
+    # residual case is what antiwork/gumroad-deployment#43 addresses, by recording who
+    # holds the lock and why, and auto-releasing it when a deploy dies.
     concurrency_group: "gumroad/production-deploy"
     concurrency: 1
     # Left on the default concurrency_method ("ordered"): queued deploys run in the order


### PR DESCRIPTION
## What

Adds `concurrency_group: "gumroad/production-deploy"` + `concurrency: 1` to the **Deploy to Production** step, so production deploys queue instead of racing each other.

## Why — 37% of our deploys are failing, and almost all of it is a lost race

A deploy holds a Consul lock for its whole run, and `deploy_production.sh` exits 1 immediately if the lock is already held. Nothing stopped two deploys overlapping, so a commit merged inside another deploy's window started, hit the lock, and died ~30 seconds in.

Measured on the **last 30 `main` builds** (2026-07-25): **11 of 30 deploy jobs failed**. **9 of those 11 are provably collisions** — each failed deploy started *inside* a concurrently-successful deploy's hold window:

| Failed | Died after | Was inside |
|---|---|---|
| 15642 | 32s | 15635 (01:52:29–02:19:19) |
| 15663 | 32s | 15662 (03:36:19–04:01:01) |
| 15671 | 32s | 15668 (04:01:25–04:37:13) |
| 15682 | 25s | 15673 (04:43:40–05:06:22) |
| 15704 | 26s | 15692 (05:39:58–06:02:14) |
| 15721 | 26s | 15708 (06:08:36–06:35:57) |
| 15725 | 31s | 15723 (06:38:00–07:01:00) |
| 15741 | 25s | 15740 (09:48:43–10:11:41) |
| 15760 | 27s | 15753 (10:41:26–11:06:15) |

**Median successful hold is 23 minutes**, so on a day with steady merges a large share of commits land inside someone else's window. The ~30-second failure duration is the tell: these never got as far as doing any work.

## The consequence is worse than a red build

**Failed deploys are not retried, so `main` silently stops shipping.** Today production sat on `1406b478` for hours with three commits queued behind it, and it only moved because a human noticed and pushed again. Two separate times I diagnosed this as a *stuck* lock before the data showed it was a *contended* one — the log line is only `🔒 Deployment is locked`, which reads like a broken deploy rather than a scheduling conflict, so debugging time goes to the wrong place.

## Why a concurrency group rather than fixing the lock

The Consul lock can only **refuse** — it cannot **wait**. `concurrency_group` makes Buildkite hold the second deploy until the first finishes and then run it, which is what the lock was trying to express. The queued commit ships on its own instead of needing a human to re-trigger it.

Left on the default `concurrency_method` (`"ordered"`) deliberately: deploys ship a specific revision, so running them out of order risks putting an older revision live after a newer one. `eager` only removes the ordering guarantee — it does not mean newest-first.

This **does not remove the Consul lock**, which still protects deploys started outside Buildkite (the manual `lock_deployment.sh` path). Making that lock debuggable is the companion change in antiwork/gumroad-deployment#43, which records who took each lock and why, and auto-releases it when a deploy dies mid-flight.

Together: #43 makes a held lock explain itself, this makes deploys stop fighting over it.

## Test plan

- [x] `.buildkite/pipeline.yml` parses as valid YAML, and the deploy step resolves to `{'concurrency_group': 'gumroad/production-deploy', 'concurrency': 1}`.
- [x] Field names and semantics verified against Buildkite's command-step documentation (`concurrency_group` requires `concurrency`; `concurrency_method` defaults to `ordered`).
- [ ] Observational: over the next day of merges, deploy-job failures with a ~30s duration and a `Deployment is locked` log line should go to zero, and no commit should need a manual re-trigger to ship.

There is no way to unit-test Buildkite's scheduler; the verification is that the collision signature disappears from the build history.

## Before / After

Not applicable — CI configuration change with no user-facing surface, so the diff is the reviewable artifact.

---

Written by Claude Opus 5 (Anthropic), operating as the Gumclaw Hermes agent. Instruction given: "ensure we deploy soon and debug why we haven't and if we can improve our process."
