### PR TITLE
Cover the nil and blank product support email cases separately

### DIFF
--- a/spec/services/post_resend_api_spec.rb
+++ b/spec/services/post_resend_api_spec.rb
@@ -268,9 +268,16 @@ describe PostResendApi, :freeze_time do
     end
 
     it "falls back to the account address when the product has no support email of its own" do
-      # update_column skips validation on purpose: the column rejects blanks today, but older
-      # rows can still hold an empty string, and those must fall back rather than send an
-      # empty Reply-To.
+      @post.link.update!(support_email: nil)
+      send_default_email
+
+      expect(sent_email[:reply_to]).to include("account@example.com")
+    end
+
+    it "falls back to the account address when the product's support email is blank" do
+      # A blank support email is rejected by the model validation, so update_column is the only
+      # way to reproduce a row saved before that validation existed. Those rows have to fall
+      # back rather than send an empty Reply-To.
       @post.link.update_column(:support_email, "")
       send_default_email
 

--- a/spec/services/post_sendgrid_api_spec.rb
+++ b/spec/services/post_sendgrid_api_spec.rb
@@ -255,9 +255,16 @@ describe PostSendgridApi, :freeze_time do
     end
 
     it "falls back to the account address when the product has no support email of its own" do
-      # update_column skips validation on purpose: the column rejects blanks today, but older
-      # rows can still hold an empty string, and those must fall back rather than send an
-      # empty Reply-To.
+      @post.link.update!(support_email: nil)
+      send_default_email
+
+      expect(sent_email[:reply_to]).to include("account@example.com")
+    end
+
+    it "falls back to the account address when the product's support email is blank" do
+      # A blank support email is rejected by the model validation, so update_column is the only
+      # way to reproduce a row saved before that validation existed. Those rows have to fall
+      # back rather than send an empty Reply-To.
       @post.link.update_column(:support_email, "")
       send_default_email
 


### PR DESCRIPTION
## What

Splits the product support email fallback spec into its two distinct cases, one example each:

- `support_email` is `nil` — the ordinary state for a product whose seller never set one.
- `support_email` is blank — only reachable on rows saved before the model validation existed, pinned with `update_column`.

Also corrects a comment that attributed the blank rejection to the database column; it's the model validation at `link.rb:188`, and there is no DB-level constraint.

Tests only — no production code changes.

## Why

#6301 replaced the `nil` example with a blank one rather than adding alongside it, so the `nil` branch of `Installment#reply_to_email`'s presence check lost its explicit coverage. Both branches are worth pinning: `nil` is the common case, and blank is the one that distinguishes `.presence` from a bare `||`.

Refs antiwork/gumroad-private#1342.

## Test results

`bundle exec rspec spec/services/post_resend_api_spec.rb spec/services/post_sendgrid_api_spec.rb -e "reply-to for a post about one product"` → 8 examples, 0 failures.

Revert check: degrading `.presence` to a bare `||` in `Installment#reply_to_email` fails exactly the two blank-support-email examples and leaves the `nil` ones green — which is the split this PR exists to make.

## QA steps

No user-facing change. Verification is the spec run above.

---

## AI disclosure

Written by Hermes Agent running `claude-opus-5`. Instructions given: the two P3 fixes from the adversarial review of #6301 were pushed after that PR was merged and did not land, so re-apply them against current main as a small tests-only PR.
