### PR TITLE
Stop the installment publish! tests failing on their own runtime

### DIFF
--- a/test/models/installment_test.rb
+++ b/test/models/installment_test.rb
@@ -597,8 +597,13 @@ const b = 2;</code></pre>
 
   test "publish! publishes the installment" do
     assert_nil @installment.published_at
-    @installment.publish!
-    assert_in_delta Time.current.to_f, @installment.published_at.to_f, 1.0
+    # Frozen so the assertion compares against the same instant publish! stamped. Comparing a
+    # timestamp taken on entry to publish! against Time.current after it returns makes the
+    # tolerance absorb the method's own runtime, which is why this flaked on slow runners.
+    freeze_time do
+      @installment.publish!
+      assert_equal Time.current, @installment.published_at
+    end
   end
 
   test "publish! sets published_at to the provided argument" do
@@ -632,19 +637,25 @@ const b = 2;</code></pre>
   end
 
   test "publish! skips the content moderation check for VIP creators" do
-    @installment.user.stub(:vip_creator?, true) do
-      ContentModeration::ModerateRecordService.stub(:check, ->(*) { flunk "moderation check should be skipped for VIP creators" }) do
-        @installment.publish!
+    freeze_time do
+      @installment.user.stub(:vip_creator?, true) do
+        ContentModeration::ModerateRecordService.stub(:check, ->(*) { flunk "moderation check should be skipped for VIP creators" }) do
+          @installment.publish!
+        end
       end
+      # to_i because published_at has no sub-second precision in the schema, so the reloaded
+      # value is truncated to the whole second.
+      assert_equal Time.current.to_i, @installment.reload.published_at.to_i
     end
-    assert_in_delta Time.current.to_f, @installment.reload.published_at.to_f, 2.0
   end
 
   test "publish! succeeds when the content moderation check passes" do
-    ContentModeration::ModerateRecordService.stub(:check, moderation_result(passed: true)) do
-      @installment.publish!
+    freeze_time do
+      ContentModeration::ModerateRecordService.stub(:check, moderation_result(passed: true)) do
+        @installment.publish!
+      end
+      assert_equal Time.current.to_i, @installment.reload.published_at.to_i
     end
-    assert_in_delta Time.current.to_f, @installment.reload.published_at.to_f, 2.0
   end
 
   test "publish! clears the publishing flag after it completes" do


### PR DESCRIPTION
## What

Freezes time around the three `Installment#publish!` tests that assert `published_at` lands at "now", and replaces their `assert_in_delta` tolerances with exact equality.

## Why

`publish!` stamps `published_at = Time.current` on entry, then does real work before returning — `transcode_videos!`, the content-moderation check, and a `save!`. These tests took `Time.current` *after* the call returned and compared it to that entry-time stamp, so the tolerance was not absorbing clock skew, it was absorbing `publish!`'s own runtime.

That means the pass/fail line was "did `publish!` finish in under a second", which is a property of how loaded the runner is rather than anything about the code under test. On a slow CI box it goes red:

```
InstallmentTest#test_publish!_publishes_the_installment [test/models/installment_test.rb:601]:
Expected |1784992827.0021424 - 1784992826.0| (1.0021424293518066) to be <= 1.0.
```

That is 2 milliseconds over a one-second budget. It surfaced as a red `Test Minitest` job on an unrelated PR (#6298), which is the actual cost here — a timing flake on `main` charges its debugging time to whoever's PR happens to catch it.

Reproduced on unmodified `main` before changing anything: the test fails roughly 1 run in 3 on this machine, with no branch changes involved. After the fix, 3 consecutive runs pass and the full file is green (111 runs, 0 failures).

Two sibling tests below it (`skips the content moderation check for VIP creators`, `succeeds when the content moderation check passes`) had the same construction with a 2.0s tolerance. They had not gone red yet, but they fail the same way under enough load, so they are fixed in the same pass rather than left to flake later. Those two compare `.to_i` because `installments.published_at` is declared `precision: nil`, so the value truncates to the whole second on reload.

The test that passes an explicit `published_at:` argument was already deterministic and is untouched.

## Test plan

- `bin/rails test test/models/installment_test.rb -n "/publish!_publishes_the_installment/"` — 3 consecutive runs, green each time (the same invocation failed 1-in-3 on `main`).
- `bin/rails test test/models/installment_test.rb` — full file, 111 runs, 205 assertions, 0 failures, 0 errors, 1 skip.

No application code changes, so there is no behavior to QA — the assertions still pin that `publish!` sets `published_at` to the current time, just against a clock that does not move mid-test.

## AI disclosure

Written by Gumclaw running `claude-opus-5`. Found while triaging a red `Test Minitest` job on #6298: this failure was in that run but was not caused by that branch, so it was confirmed pre-existing on `main` by reproducing it there and split out into its own PR.
