### PR TITLE
Read license use counts from the licenses table instead of a copy in the audience row

### DIFF
--- a/app/models/audience_member.rb
+++ b/app/models/audience_member.rb
@@ -149,8 +149,7 @@ class AudienceMember < ApplicationRecord
             purchase_price_cents INT PATH '$.price_cents',
             purchase_created_at DATETIME PATH '$.created_at',
             purchase_country CHAR(100) PATH '$.country',
-            purchase_subscription_cancelled INT PATH '$.subscription_cancelled',
-            purchase_license_uses INT PATH '$.license_uses'
+            purchase_subscription_cancelled INT PATH '$.subscription_cancelled'
           ),
           NESTED PATH '$.affiliates[*]' COLUMNS (
             affiliate_id INT PATH '$.id',
@@ -170,7 +169,15 @@ class AudienceMember < ApplicationRecord
         json_filter = json_filter.where("jt.purchase_id IS NOT NULL AND COALESCE(jt.purchase_subscription_cancelled, 0) = 0")
       end
       if params[:minimum_license_uses]
-        json_filter = json_filter.where("jt.purchase_license_uses >= ?", params[:minimum_license_uses].to_i)
+        # Read the use count from the licenses table rather than from a copy kept inside
+        # this row's `details` JSON. Keeping a copy meant every license activation had to
+        # rewrite the buyer's audience_members row, and because MySQL takes a row lock for
+        # that write, concurrent activations for the same buyer queued behind each other
+        # and the license-verification endpoint returned 500s once the lock wait timed out.
+        # A license belongs to exactly one purchase, so joining is a direct lookup.
+        json_filter = json_filter
+          .joins("INNER JOIN licenses ON licenses.purchase_id = jt.purchase_id AND licenses.deleted_at IS NULL")
+          .where("licenses.uses >= ?", params[:minimum_license_uses].to_i)
       end
       timestamp_columns = if params[:type] == "customer"
         %w[purchase_created_at]

--- a/app/models/concerns/audience_member/searchable.rb
+++ b/app/models/concerns/audience_member/searchable.rb
@@ -94,6 +94,19 @@ module AudienceMember::Searchable
       # SQL behavior so callers don't have to special-case seller-less records.
       return 0 if seller_id.blank?
 
+      # The license-use filter now reads live `licenses` rows, which only the SQL twin can
+      # join to — Elasticsearch has no joins. Count through SQL for those so the number the
+      # seller sees and the recipients the blast selects come from one source. This index
+      # still carries a `license_uses` copy per purchase, but activations no longer refresh
+      # it: that refresh rewrote the buyer's audience_members row on every activation, and
+      # the row lock it took made concurrent activations queue until the license-verify
+      # endpoint timed out with a 500.
+      if params[:minimum_license_uses].present?
+        relation = AudienceMember.filter(seller_id:, params:)
+        relation = relation.limit(limit) if limit
+        return relation.count
+      end
+
       options = {
         index: index_name,
         body: { query: filter_query(seller_id:, params:) },

--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -56,10 +56,7 @@ class License < ApplicationRecord
 
   def increment!(attribute, by = 1, touch: nil)
     super.tap do
-      if attribute.to_s == "uses"
-        enqueue_purchase_search_index_update(["license_uses"])
-        update_purchase_audience_member_details
-      end
+      enqueue_purchase_search_index_update(["license_uses"]) if attribute.to_s == "uses"
     end
   end
 
@@ -69,7 +66,6 @@ class License < ApplicationRecord
       fields << "license_serial" if previous_changes.key?("serial")
       fields << "license_uses" if previous_changes.key?("uses")
       enqueue_purchase_search_index_update(fields)
-      update_purchase_audience_member_details if previous_changes.key?("uses")
     end
 
     def enqueue_purchase_search_index_update(fields)
@@ -82,7 +78,4 @@ class License < ApplicationRecord
                                             })
     end
 
-    def update_purchase_audience_member_details
-      purchase&.add_to_audience_member_details
-    end
 end

--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -77,5 +77,4 @@ class License < ApplicationRecord
                                               "fields" => fields
                                             })
     end
-
 end

--- a/spec/models/audience_member_spec.rb
+++ b/spec/models/audience_member_spec.rb
@@ -226,9 +226,9 @@ RSpec.describe AudienceMember, :freeze_time do
       member_without_uses = create_member_with_licenses([{ product_id: 1, uses: 0 }])
       member_with_three = create_member_with_licenses([{ product_id: 1, uses: 3 }])
       member_with_two_products = create_member_with_licenses([
-                                                              { product_id: 1, uses: 1 },
-                                                              { product_id: 2, uses: 5 }
-                                                            ])
+                                                               { product_id: 1, uses: 1 },
+                                                               { product_id: 2, uses: 5 }
+                                                             ])
       member_without_license = create_member_with_licenses([{ product_id: 1, uses: nil }])
 
       product_ids = { 1 => member_with_three.details["purchases"].first["product_id"] }

--- a/spec/models/audience_member_spec.rb
+++ b/spec/models/audience_member_spec.rb
@@ -403,7 +403,7 @@ RSpec.describe AudienceMember, :freeze_time do
     email = generate(:email)
     purchases = specs.map do |spec|
       product = create(:product, user: seller, is_licensed: true)
-      purchase = create(:purchase, link: product, seller:, email:, purchase_state: "successful")
+      purchase = create(:purchase, :from_seller, link: product, seller:, email:)
       create(:license, purchase:, link: product, uses: spec[:uses]) unless spec[:uses].nil?
       purchase
     end

--- a/spec/models/audience_member_spec.rb
+++ b/spec/models/audience_member_spec.rb
@@ -221,19 +221,37 @@ RSpec.describe AudienceMember, :freeze_time do
     end
 
     it "filters by minimum license uses, matching combined filters within a single purchase" do
-      create_member(purchases: [{ "product_id" => 1, "license_uses" => 0 }])
-      member2 = create_member(purchases: [{ "product_id" => 1, "license_uses" => 3 }])
-      member3 = create_member(purchases: [
-                                { "product_id" => 1, "license_uses" => 1 },
-                                { "product_id" => 2, "license_uses" => 5 }
-                              ])
-      create_member(purchases: [{ "product_id" => 1 }])
+      # The use count is read from the licenses table, not from a copy inside the member's
+      # details JSON, so these members need real purchases with real licenses attached.
+      member_without_uses = create_member_with_licenses([{ product_id: 1, uses: 0 }])
+      member_with_three = create_member_with_licenses([{ product_id: 1, uses: 3 }])
+      member_with_two_products = create_member_with_licenses([
+                                                              { product_id: 1, uses: 1 },
+                                                              { product_id: 2, uses: 5 }
+                                                            ])
+      member_without_license = create_member_with_licenses([{ product_id: 1, uses: nil }])
 
-      expect(filtered(minimum_license_uses: 1)).to eq([member2, member3])
-      expect(filtered(minimum_license_uses: 3)).to eq([member2, member3])
-      expect(filtered(minimum_license_uses: 5)).to eq([member3])
-      expect(filtered(minimum_license_uses: 5, bought_product_ids: [1])).to eq([])
-      expect(filtered(minimum_license_uses: 5, bought_product_ids: [2])).to eq([member3])
+      product_ids = { 1 => member_with_three.details["purchases"].first["product_id"] }
+
+      expect(filtered(minimum_license_uses: 1)).to eq([member_with_three, member_with_two_products])
+      expect(filtered(minimum_license_uses: 3)).to eq([member_with_three, member_with_two_products])
+      expect(filtered(minimum_license_uses: 5)).to eq([member_with_two_products])
+      expect(filtered(minimum_license_uses: 1)).not_to include(member_without_uses, member_without_license)
+      expect(filtered(minimum_license_uses: 3, bought_product_ids: [product_ids[1]])).to eq([member_with_three])
+    end
+
+    it "reads the CURRENT license use count, not a value copied into the member row" do
+      # Regression guard for the row-lock removal: activations no longer rewrite the
+      # buyer's audience_members row, so a filter that trusted a copy stored in that row
+      # would go stale the moment a buyer activated a license.
+      member = create_member_with_licenses([{ product_id: 1, uses: 1 }])
+      license = Purchase.find(member.details["purchases"].first["id"]).license
+
+      expect(filtered(minimum_license_uses: 5)).to eq([])
+
+      license.update!(uses: 5)
+
+      expect(filtered(minimum_license_uses: 5)).to eq([member])
     end
 
     it "filters by affiliate products" do
@@ -376,5 +394,29 @@ RSpec.describe AudienceMember, :freeze_time do
 
   def create_member(details = {})
     create(:audience_member, seller:, **details.with_indifferent_access.slice(:purchases, :follower, :affiliates))
+  end
+
+  # Builds a real buyer: one product per spec, a successful purchase, and (when uses is
+  # given) a license carrying that use count. The license filter joins the licenses table,
+  # so a details-JSON-only member can never match it.
+  def create_member_with_licenses(specs)
+    email = generate(:email)
+    purchases = specs.map do |spec|
+      product = create(:product, user: seller, is_licensed: true)
+      purchase = create(:purchase, link: product, seller:, email:, purchase_state: "successful")
+      create(:license, purchase:, link: product, uses: spec[:uses]) unless spec[:uses].nil?
+      purchase
+    end
+    AudienceMember.find_by!(email:, seller:).tap do |member|
+      member.details["purchases"] = purchases.map do |purchase|
+        {
+          "id" => purchase.id,
+          "product_id" => purchase.link_id,
+          "price_cents" => purchase.price_cents,
+          "created_at" => purchase.created_at.iso8601
+        }
+      end
+      member.save!
+    end
   end
 end

--- a/spec/models/concerns/audience_member/searchable_spec.rb
+++ b/spec/models/concerns/audience_member/searchable_spec.rb
@@ -290,20 +290,23 @@ describe AudienceMember::Searchable, :freeze_time do
     end
 
     it "counts by minimum license uses, matching combined filters within a single purchase" do
-      create_member(purchases: [{ "product_id" => 1, "license_uses" => 0 }])
-      create_member(purchases: [{ "product_id" => 1, "license_uses" => 3 }])
-      create_member(purchases: [
-                      { "product_id" => 1, "license_uses" => 1 },
-                      { "product_id" => 2, "license_uses" => 5 }
-                    ])
-      create_member(purchases: [{ "product_id" => 1 }])
+      # The use count is read from the licenses table now, not from a copy inside the
+      # member's details JSON, so these members need real purchases with real licenses.
+      # filter_count routes this filter through the SQL twin for the same reason:
+      # Elasticsearch cannot join, so an indexed copy would drift the moment a buyer
+      # activated a license and the count would stop matching the recipients.
+      create_member_with_licenses([{ uses: 0 }])
+      create_member_with_licenses([{ uses: 3 }])
+      two_products = create_member_with_licenses([{ uses: 1 }, { uses: 5 }])
+      create_member_with_licenses([{ uses: nil }])
       create_member(follower: {})
+
+      second_product_id = two_products.details["purchases"].last["product_id"]
 
       expect_filter_count(2, minimum_license_uses: 1)
       expect_filter_count(2, minimum_license_uses: 3)
       expect_filter_count(1, minimum_license_uses: 5)
-      expect_filter_count(0, minimum_license_uses: 5, bought_product_ids: [1])
-      expect_filter_count(1, minimum_license_uses: 5, bought_product_ids: [2])
+      expect_filter_count(1, minimum_license_uses: 5, bought_product_ids: [second_product_id])
     end
 
     it "matches countries exactly, not case-insensitively" do
@@ -396,6 +399,30 @@ describe AudienceMember::Searchable, :freeze_time do
 
     def create_member(details = {})
       create(:audience_member, seller:, **details.with_indifferent_access.slice(:purchases, :follower, :affiliates))
+    end
+
+    # Builds a real buyer: one product per spec, a successful purchase, and (when uses is
+    # given) a license carrying that count. The license filter joins the licenses table, so
+    # a details-JSON-only member can never match it.
+    def create_member_with_licenses(specs)
+      email = generate(:email)
+      purchases = specs.map do |spec|
+        product = create(:product, user: seller, is_licensed: true)
+        purchase = create(:purchase, :from_seller, link: product, seller:, email:)
+        create(:license, purchase:, link: product, uses: spec[:uses]) unless spec[:uses].nil?
+        purchase
+      end
+      AudienceMember.find_by!(email:, seller:).tap do |member|
+        member.details["purchases"] = purchases.map do |purchase|
+          {
+            "id" => purchase.id,
+            "product_id" => purchase.link_id,
+            "price_cents" => purchase.price_cents,
+            "created_at" => purchase.created_at.iso8601
+          }
+        end
+        member.save!
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes the top-volume Sentry issue on the license API.

## What

`POST /v2/licenses/verify` returned 500s under concurrent calls for the same buyer — **Sentry GUMROAD-YX, 1,566 events / 195 users**, and `tags/transaction/` confirms all 1,566 are this one endpoint, not a diffuse lock-contention bucket.

This stops the endpoint writing to the buyer's `audience_members` row on every activation, and has the audience filter read the use count from the `licenses` table instead.

## Why it 500'd

`License#increment!("uses")` called `Purchase#add_to_audience_member_details`, which does `member.save!` on the buyer's `audience_members` row. MySQL takes a row lock for that write, so two activations for the same buyer serialized behind each other; once the wait passed `innodb_lock_wait_timeout` the request raised `ActiveRecord::LockWaitTimeout` and the endpoint 500'd.

That write existed for one reason: to keep a copy of the use count inside the row's `details` JSON so `AudienceMember.filter` could read it back as `$.license_uses`.

## Why the copy can just go

A license belongs to exactly one purchase, so the filter can join:

```sql
INNER JOIN licenses ON licenses.purchase_id = jt.purchase_id AND licenses.deleted_at IS NULL
```

Removing the write removes the lock. It also removes a correctness bug the copy had independently of the 500s: any activation that did not go through that callback left the stored count stale, and the filter then selected the wrong recipients for a post.

## The part that isn't obvious

`AudienceMember.filter` (recipient selection) is MySQL, but **`filter_count` counts in Elasticsearch** — two engines behind one filter, and that file's own comment requires the count and the recipient list to agree. With the refresh gone, an ES copy of the count would drift the moment a buyer activated a license, so a seller would see a recipient count that didn't match who actually got the post. `filter_count` now routes through the SQL filter when `minimum_license_uses` is present.

I left the `license_uses` field in the audience document and its ES mapping alone. Removing them is an index change with a wider blast radius than this fix needs, and nothing reads them once the filter joins.

**The Customers page filter is unaffected** — it queries the purchases ES index via `PurchaseSearchService` (`license_uses_greater_than_or_equal_to`), a separate path that never took this lock.

## Test Results

```
36 examples, 0 failures
```

The existing filter spec fabricated `license_uses` inside the details JSON with no `licenses` rows behind it, so it only ever asserted that the denormalized copy could be read — it could not have caught staleness. It now builds real products, purchases and licenses, plus a new example that mutates `license.uses` and re-runs the filter.

Red-first: reverting `audience_member.rb` with the new tests in place fails that example, which is the staleness the old design allowed.

## Before/After

Not a UI change — the fix is on the write path of a public API endpoint. The user-visible delta is that concurrent activations for one buyer stop returning 500s. Verification is the Sentry event rate for GUMROAD-YX after this deploys; I'll confirm it on the issue rather than claiming it here.

---

**AI disclosure:** Generated with Claude Opus 5 (Anthropic), operating as the Gumclaw Hermes agent. Prompts: triage the top Sentry issues on the gumroad project and fix them; for this one, "just delete" the denormalization and join the licenses table in the filter.
