### PR TITLE
Clarify that only full refunds remove a product rating

### DIFF
--- a/app/views/help_center/articles/contents/_352-supporting-your-customers.html.erb
+++ b/app/views/help_center/articles/contents/_352-supporting-your-customers.html.erb
@@ -50,7 +50,7 @@
   <p>You can also tell customers where you stand before they buy by setting a <a href="335-custom-refund-policy">custom refund policy</a> on a product, which is shown on its product page. Clear terms up front are the cheapest support you will ever provide, and Gumroad uses your stated policy when handling refunds or disputes on your behalf.</p>
   <h3 id="reviews-and-review-reminders">Reviews and review reminders</h3>
   <p>Customers can <a href="222-product-ratings-on-gumroad">rate and review</a> what they bought, and Gumroad sends each of them a one-time reminder asking them to do so. You can turn those reminders off for your whole account in the <b>Review reminders</b> section of your <a href="https://gumroad.com/settings">Settings</a> page.</p>
-  <p>A review you disagree with is often a support request in disguise. Reaching out to the customer and solving the underlying problem tends to work better than hiding ratings, and refunding a customer removes their rating automatically.</p>
+  <p>A review you disagree with is often a support request in disguise. Reaching out to the customer and solving the underlying problem tends to work better than hiding ratings. Fully refunding a purchase removes its rating automatically; a partial refund leaves the rating in place.</p>
   <h3 id="difficult-customers">Difficult customers</h3>
   <p>If someone abuses your products or your patience, you have two tools, both covered in <a href="329-customer-moderation">Customer moderation</a>: you can block an email address from buying from you again, and you can revoke a customer's access to content they have already bought.</p>
   <h3 id="supporting-customers-in-a-community">Supporting customers in a community</h3>


### PR DESCRIPTION
## What

Corrects one sentence in the "Supporting your customers" help center article (`_352-supporting-your-customers.html.erb`). It said that refunding a customer removes their rating automatically. That is only true for a full refund.

## Why

`Purchase::Reviews#allows_reviews` (`app/modules/purchase/reviews.rb`) excludes a purchase from reviews when it is fully refunded (`!stripe_refunded?`), but only excludes a *partially* refunded purchase when it is a bundle product purchase:

```ruby
allowed &= !stripe_refunded?
allowed &= !stripe_partially_refunded? || !is_bundle_product_purchase?
```

So a partial refund on a normal (non-bundle) product leaves the purchase review-eligible and the rating visible. The unqualified wording set creators up to expect a rating to disappear when it does not. The existing ratings article (`_222-product-ratings-on-gumroad.html.erb`) already states this correctly ("Issuing a partial refund will not remove a customer's rating"), so the new article contradicted it.

Follow-up to #6304, addressing Greptile's P1 review comment on that PR (the review landed after it merged).

## Before / After

Docs-only — the diff is the reviewable artifact. One sentence of copy in a static help center article; no UI structure, styling, or template logic changes, so there is no rendered surface to capture before/after.

**Before:** "Reaching out to the customer and solving the underlying problem tends to work better than hiding ratings, and refunding a customer removes their rating automatically."

**After:** "Reaching out to the customer and solving the underlying problem tends to work better than hiding ratings. Fully refunding a purchase removes its rating automatically; a partial refund leaves the rating in place."

## QA steps

1. Visit `/help/article/352-supporting-your-customers`.
2. Scroll to "Reviews and review reminders".
3. The closing sentence now distinguishes full refunds from partial refunds, matching `/help/article/222-product-ratings-on-gumroad`.

## Test Results

Copy-only change inside an existing article partial. No behavior, no new markup elements, no template logic — the article file already renders in the help center and the ERB tag structure is untouched (the diff is a single `<p>` text change).

---

## AI disclosure

Written by `claude-opus-5` (the model configured as `model.default`), running as the Gumclaw agent.

Instructions given: a Greptile P1 review comment on merged PR #6304 flagged that the article's claim about refunds removing ratings is wrong for partial refunds. The agent was directed to verify the finding against the production review-eligibility code and ship the fix. It read `app/modules/purchase/reviews.rb`, confirmed partial refunds only block reviews for bundle product purchases, cross-checked the wording in article 222, and edited the single sentence in article 352 to match.
