### PR TITLE
Stop re-stamping deleted_at on already-deleted variants

### DIFF
--- a/app/services/product/variant_category_updater_service.rb
+++ b/app/services/product/variant_category_updater_service.rb
@@ -177,9 +177,25 @@ class Product::VariantCategoryUpdaterService
       variant_ids = variants.respond_to?(:pluck) ? variants.pluck(:id) : variants.map(&:id)
       return if variant_ids.empty?
 
+      # Only stamp rows that are still alive. `variants` is derived from
+      # `existing_variants - keep_variants`, which can include variants that were
+      # already soft-deleted by an earlier save; an unscoped write would move
+      # their `deleted_at` forward every time an unrelated save happened to
+      # include them, making the timestamp describe the most recent save rather
+      # than the deletion. Support relies on that timestamp to scope restores to
+      # the window of the save that actually caused a wipe (see the restores in
+      # gumroad-private#1230), and moving it drags unrelated rows into that
+      # window. The deletion-intent guard just above is already scoped this way
+      # -- it passes `variants_to_delete.select(&:alive?)` -- so this makes the
+      # write agree with the guard that authorised it.
       now = Time.current
-      BaseVariant.where(id: variant_ids).update_all(deleted_at: now, updated_at: now)
+      already_deleted_ids = BaseVariant.where(id: variant_ids).where.not(deleted_at: nil).pluck(:id)
+      variant_ids_to_delete = variant_ids - already_deleted_ids
+      BaseVariant.where(id: variant_ids_to_delete).update_all(deleted_at: now, updated_at: now) if variant_ids_to_delete.any?
 
+      # Cleanup still runs for every id in the batch: an earlier soft-delete may
+      # have stamped the variant without its rich content or file archives being
+      # cleaned up, and both workers are idempotent.
       variant_ids.each do |variant_id|
         DeleteProductRichContentWorker.perform_async(product.id, variant_id)
         DeleteProductFilesArchivesWorker.perform_async(product.id, variant_id)

--- a/spec/services/product/variant_category_updater_service_spec.rb
+++ b/spec/services/product/variant_category_updater_service_spec.rb
@@ -233,6 +233,33 @@ describe Product::VariantCategoryUpdaterService do
 
         expect { perform_deletion }.to change { variant.reload.deleted_at }.from(nil)
       end
+
+      it "leaves an already-deleted variant's deleted_at where it was" do
+        # A variant deleted by an earlier save is still present in
+        # `existing_variants - keep_variants` on every later save that omits it,
+        # so it reaches batch_delete_variants again. Its deletion timestamp has to
+        # keep describing the save that actually deleted it: support scopes
+        # restores to that window (gumroad-private#1230), and dragging the
+        # timestamp forward pulls unrelated rows into an incident's window.
+        variant = create(:variant, variant_category: @variant_category)
+        original_deleted_at = 3.days.ago.change(usec: 0)
+        variant.update_columns(deleted_at: original_deleted_at)
+
+        expect { perform_deletion }.not_to change { variant.reload.deleted_at }
+        expect(variant.reload.deleted_at).to eq(original_deleted_at)
+      end
+
+      it "deletes a live variant in the same batch as an already-deleted one" do
+        # The scoping must not become an early return: a batch containing one
+        # stale row and one live row still has to delete the live row.
+        already_deleted = create(:variant, variant_category: @variant_category)
+        original_deleted_at = 3.days.ago.change(usec: 0)
+        already_deleted.update_columns(deleted_at: original_deleted_at)
+        live = create(:variant, variant_category: @variant_category)
+
+        expect { perform_deletion }.to change { live.reload.deleted_at }.from(nil)
+        expect(already_deleted.reload.deleted_at).to eq(original_deleted_at)
+      end
     end
 
     context "when deleting multiple obsolete variants" do


### PR DESCRIPTION
## What

`batch_delete_variants` soft-deletes with an unscoped `update_all`:

```ruby
BaseVariant.where(id: variant_ids).update_all(deleted_at: now, updated_at: now)
```

`variant_ids` comes from `existing_variants - keep_variants`, which includes variants an earlier save already soft-deleted — any later save that omits them puts them back in the batch. For those rows this rewrites `deleted_at` to `now`, so the timestamp ends up describing **the most recent save that happened to omit the variant**, not the save that actually deleted it.

## Why it matters

That timestamp is load-bearing for incident recovery. Support scopes wipe restores to the window of the causing save — the restores on gumroad-private#1230 were window-scoped un-soft-deletes across four model types. A drifting `deleted_at` both drags unrelated rows into that window and hides when the deletion really happened.

## The tell

The deletion-intent guard immediately above is already scoped correctly:

```ruby
self.class.ensure_deletion_intent!(product:, variants: variants_to_delete.select(&:alive?), ...)
```

The guard only considers alive rows; the write did not. **The write was the outlier**, and this makes it agree with the guard that authorised it.

## Note on the cleanup workers

They still run for every id in the batch, not just the newly-deleted ones. An earlier soft-delete may have stamped the variant without its rich content or file archives being cleaned up, and both workers are idempotent — so narrowing them would risk leaving orphaned content behind. Only the timestamp write is scoped.

## Tests

Two examples added to the existing deletion context:

1. An already-deleted variant keeps its original `deleted_at`.
2. A batch mixing one stale row with one live row **still deletes the live row** — guarding against the scoping accidentally becoming an early return.

**Verified red before the fix:** with the production change stashed and the specs kept, both fail. Full file is 35/35 green with the fix applied.

Fixes gumroad-private#1362