### PR TITLE
Use the alive scope for the variant soft-delete write

### DIFF
--- a/app/services/product/variant_category_updater_service.rb
+++ b/app/services/product/variant_category_updater_service.rb
@@ -177,25 +177,15 @@ class Product::VariantCategoryUpdaterService
       variant_ids = variants.respond_to?(:pluck) ? variants.pluck(:id) : variants.map(&:id)
       return if variant_ids.empty?
 
-      # Only stamp rows that are still alive. `variants` is derived from
-      # `existing_variants - keep_variants`, which can include variants that were
-      # already soft-deleted by an earlier save; an unscoped write would move
-      # their `deleted_at` forward every time an unrelated save happened to
-      # include them, making the timestamp describe the most recent save rather
-      # than the deletion. Support relies on that timestamp to scope restores to
-      # the window of the save that actually caused a wipe (see the restores in
-      # gumroad-private#1230), and moving it drags unrelated rows into that
-      # window. The deletion-intent guard just above is already scoped this way
-      # -- it passes `variants_to_delete.select(&:alive?)` -- so this makes the
-      # write agree with the guard that authorised it.
+      # Only stamp variants that aren't already deleted, so a variant keeps the
+      # timestamp from the save that actually deleted it. Support uses that
+      # timestamp to find which rows a bad save wiped.
       now = Time.current
-      already_deleted_ids = BaseVariant.where(id: variant_ids).where.not(deleted_at: nil).pluck(:id)
-      variant_ids_to_delete = variant_ids - already_deleted_ids
-      BaseVariant.where(id: variant_ids_to_delete).update_all(deleted_at: now, updated_at: now) if variant_ids_to_delete.any?
+      BaseVariant.where(id: variant_ids).alive.update_all(deleted_at: now, updated_at: now)
 
-      # Cleanup still runs for every id in the batch: an earlier soft-delete may
-      # have stamped the variant without its rich content or file archives being
-      # cleaned up, and both workers are idempotent.
+      # Cleanup runs for every id, including ones deleted earlier: an earlier
+      # delete may not have finished cleaning up, and both workers are safe to
+      # run twice.
       variant_ids.each do |variant_id|
         DeleteProductRichContentWorker.perform_async(product.id, variant_id)
         DeleteProductFilesArchivesWorker.perform_async(product.id, variant_id)

--- a/spec/services/product/variant_category_updater_service_spec.rb
+++ b/spec/services/product/variant_category_updater_service_spec.rb
@@ -235,12 +235,6 @@ describe Product::VariantCategoryUpdaterService do
       end
 
       it "leaves an already-deleted variant's deleted_at where it was" do
-        # A variant deleted by an earlier save is still present in
-        # `existing_variants - keep_variants` on every later save that omits it,
-        # so it reaches batch_delete_variants again. Its deletion timestamp has to
-        # keep describing the save that actually deleted it: support scopes
-        # restores to that window (gumroad-private#1230), and dragging the
-        # timestamp forward pulls unrelated rows into an incident's window.
         variant = create(:variant, variant_category: @variant_category)
         original_deleted_at = 3.days.ago.change(usec: 0)
         variant.update_columns(deleted_at: original_deleted_at)
@@ -250,8 +244,6 @@ describe Product::VariantCategoryUpdaterService do
       end
 
       it "deletes a live variant in the same batch as an already-deleted one" do
-        # The scoping must not become an early return: a batch containing one
-        # stale row and one live row still has to delete the live row.
         already_deleted = create(:variant, variant_category: @variant_category)
         original_deleted_at = 3.days.ago.change(usec: 0)
         already_deleted.update_columns(deleted_at: original_deleted_at)


### PR DESCRIPTION
## What

Follow-up to #6314. Replaces the manual "collect already-deleted ids, subtract, guard on `any?`" block in `batch_delete_variants` with the existing `Deletable` scope:

```ruby
BaseVariant.where(id: variant_ids).alive.update_all(deleted_at: now, updated_at: now)
```

Same behavior, one query instead of two, no intermediate arrays. Also trims the comments on both the service and the two specs down to the point.

## Why

Review feedback on #6314: `.alive` (`where(deleted_at: nil)`, from `Deletable`) already expresses "only the rows that aren't deleted yet", so the extra pluck/subtract/conditional was doing by hand what the scope does in SQL. The comments explaining it were far longer than the code they described.

Behavior is unchanged: already-deleted variants keep their original `deleted_at`, live variants in the same batch still get stamped, and the cleanup workers still run for every id in the batch.

## Before / After

Not applicable — no user-facing surface. `batch_delete_variants` is an internal soft-delete write path; the resulting rows and enqueued workers are identical to #6314.

## QA steps

Nothing to click through. Verification is the spec run below; both examples added in #6314 cover the behavior this refactor has to preserve.

## Test Results

`bundle exec rspec spec/services/product/variant_category_updater_service_spec.rb` on this branch:

```
Finished in 3 minutes 11.6 seconds (files took 21.6 seconds to load)
35 examples, 0 failures
```

`rubocop` clean on both changed files.

---

## AI disclosure

Written by claude-opus-5 running as the Gumclaw agent. Instructions given: a review comment on #6314 asking whether the `.alive` scope alone would be enough to only delete live rows, and noting the code and the comment were both too verbose. The agent read `Deletable` to confirm `.alive` is `where(deleted_at: nil)`, replaced the manual filtering with the scope, cut the comments back, ran rubocop and the full spec file locally, and opened this PR.
