### PR TITLE
Pin the seller_update mailer specs to a fixed weekday

### DIFF
--- a/spec/mailers/contacting_creator_mailer_spec.rb
+++ b/spec/mailers/contacting_creator_mailer_spec.rb
@@ -248,6 +248,19 @@ describe ContactingCreatorMailer do
   end
 
   describe "seller_update" do
+    # The mailer reports on "last week", which it defines as the seven days ending at the most
+    # recent Sunday midnight (`Date.today.beginning_of_week(:sunday)`). These examples rely on
+    # being able to create a purchase that lands *after* that window closes, so that it is
+    # excluded from the totals — they do this with `5.minutes.ago`.
+    #
+    # That only holds if "now" is comfortably past Sunday midnight. When the suite runs during the
+    # first minutes of a Sunday in UTC, the window closes at today's midnight, so `5.minutes.ago`
+    # falls back into Saturday and is counted as part of last week — the excluded purchase silently
+    # becomes an included one and the expected totals shift. Pinning the clock to a mid-week moment
+    # keeps the window boundary a fixed distance from "now", so these examples do not depend on
+    # which day of the week CI happens to run.
+    before { travel_to(Time.utc(2024, 5, 1, 12, 0, 0)) } # a Wednesday
+
     before do
       @user = create(:user)
       allow_any_instance_of(User).to receive(:secure_external_id).and_return("sample-secure-id")


### PR DESCRIPTION
The `seller_update` mailer examples took `main` red at 00:03 UTC on Sunday 2026-07-26 ([run 30180334327](https://github.com/antiwork/gumroad/actions/runs/30180334327), `Test Fast 4`):

```
Failure/Error: expect(mail.body).to include "$0.21" # 3 not-chargebacked purchases * 7¢ each.
rspec ./spec/mailers/contacting_creator_mailer_spec.rb:314
```

## Cause

The mailer defines "last week" as the seven days ending at the most recent Sunday midnight (`Date.today.beginning_of_week(:sunday)`). The `sales` example creates four purchases inside that window and one at `5.minutes.ago`, expecting the last one to fall *outside* the window so it is excluded — hence `2 sales` / `$0.21`.

That only holds if "now" is comfortably past Sunday midnight. During the first minutes of a Sunday in UTC the window closes at *today's* midnight, so `5.minutes.ago` falls back into Saturday and is counted as part of last week. The purchase meant to be excluded gets included and the totals shift to `3 sales` / `$0.28`.

This is a pre-existing latent failure, not a regression from the commit that happened to be on main — #6313 (`9b6aeb7a4`) touched only `moderate_record_service.rb` and its spec. The window is roughly the first few minutes of each Sunday UTC, which is why it had gone unnoticed.

## Fix

Pin the `seller_update` describe block to a Wednesday, so the window boundary sits a fixed distance from "now" and the examples no longer depend on which day CI runs.

## Verification

Red-first, on unmodified `origin/main` with the clock pinned to the CI wall-clock (Sunday 00:03 UTC):

```
4 examples, 1 failure
rspec ./spec/mailers/contacting_creator_mailer_spec.rb:315 # ContactingCreatorMailer seller_update sales renders properly
```

Same conditions with this fix applied:

```
4 examples, 0 failures
```

Whole file: `130 examples, 1 failure`. The one remaining failure is `chargeback notice for a dispute on Charge sends chargeback notice correctly` (:128), which fails identically on clean `origin/main` in this environment and is unrelated to this change — left alone.

`rubocop spec/mailers/contacting_creator_mailer_spec.rb` → no offenses.