### PR TITLE
Bound the deliverable storage check by time instead of a file count

### DIFF
--- a/app/services/content_moderation/moderate_record_service.rb
+++ b/app/services/content_moderation/moderate_record_service.rb
@@ -8,6 +8,10 @@ class ContentModeration::ModerateRecordService
   # whether a listing delivers anything (see `has_deliverable_file?`).
   MAX_FILES_CHECKED_FOR_STORAGE = 5
 
+  # How many of those lookups go to the most recently created rows. The rest go
+  # to the oldest ones — see `has_deliverable_file?` for why both ends matter.
+  NEWEST_FILES_CHECKED_FOR_STORAGE = 3
+
   CheckResult = Struct.new(:passed, :reasons, keyword_init: true)
 
   CATEGORY_LABELS = {
@@ -241,16 +245,25 @@ class ContentModeration::ModerateRecordService
     # MAX_FILES_CHECKED_FOR_STORAGE of those are made — enough to prove a
     # deliverable exists without turning a save into a long series of lookups.
     #
-    # Those lookups go newest row first. The only file a row cannot answer for is
-    # one that has never been analyzed, and there are two ways to get there: the
-    # seller uploaded it moments ago and AnalyzeFileWorker hasn't run yet, or the
-    # upload never finished and never will. The first kind is the most recently
-    # created row, so newest-first spends the lookups on the file most likely to
-    # be a real deliverable. Without it, a seller whose genuine new upload sits
-    # behind MAX_FILES_CHECKED_FOR_STORAGE abandoned rows would be told their
-    # listing delivers nothing. Sorting by id is deliberate: alive_product_files
-    # is ordered by the seller's chosen `position`, which says nothing about
-    # which row was created last.
+    # Which files get those lookups is chosen by creation order, from both ends.
+    # The only file a row cannot answer for is one that has never been analyzed,
+    # and there are two ways to get there. Either the seller uploaded it moments
+    # ago and AnalyzeFileWorker hasn't run yet, which makes it one of the most
+    # recently created rows, or analysis never finished — usually because the
+    # upload itself never finished (nothing deletes that row afterwards), but
+    # sometimes because a genuinely stored file ran out of analysis retries long
+    # ago and stayed behind. So the newest rows are checked first and the leftover
+    # lookups go to the oldest rows: between them they cover the fresh upload and
+    # the long-stored file whose analysis never completed, instead of spending the
+    # whole budget on whichever end of a pile of abandoned uploads sorts first.
+    # Ordering by id is deliberate: alive_product_files is ordered by the seller's
+    # chosen `position`, which says nothing about when a row was created, so on a
+    # listing with more abandoned rows than the cap the real file could sit past
+    # the cap and never be queried at all.
+    #
+    # Ordering only decides which honest sellers we can confirm cheaply; it can
+    # never let an empty listing through, because passing still requires an object
+    # to actually be in storage.
     def has_deliverable_file?(owner)
       unverifiable_from_row = []
 
@@ -261,10 +274,20 @@ class ContentModeration::ModerateRecordService
         end
       end
 
-      unverifiable_from_row
-        .sort_by { -_1.id }
-        .first(MAX_FILES_CHECKED_FOR_STORAGE)
-        .any?(&:stored_file_present?)
+      files_to_check(unverifiable_from_row).any?(&:stored_file_present?)
+    end
+
+    # At most MAX_FILES_CHECKED_FOR_STORAGE files, taken from the newest and
+    # oldest rows by creation order. `max_by`/`min_by` with a count pick those
+    # ends without ordering the whole collection, which matters because the number
+    # of rows here is up to the caller submitting the save.
+    def files_to_check(files)
+      return files if files.size <= MAX_FILES_CHECKED_FOR_STORAGE
+
+      newest = files.max_by(NEWEST_FILES_CHECKED_FOR_STORAGE, &:id)
+      oldest = files.min_by(MAX_FILES_CHECKED_FOR_STORAGE - NEWEST_FILES_CHECKED_FOR_STORAGE, &:id)
+
+      newest + oldest
     end
 
     # Rich content with something in the body, ignoring pages that only have a

--- a/app/services/content_moderation/moderate_record_service.rb
+++ b/app/services/content_moderation/moderate_record_service.rb
@@ -240,6 +240,17 @@ class ContentModeration::ModerateRecordService
     # cannot answer for cost a request to storage, and at most
     # MAX_FILES_CHECKED_FOR_STORAGE of those are made — enough to prove a
     # deliverable exists without turning a save into a long series of lookups.
+    #
+    # Those lookups go newest row first. The only file a row cannot answer for is
+    # one that has never been analyzed, and there are two ways to get there: the
+    # seller uploaded it moments ago and AnalyzeFileWorker hasn't run yet, or the
+    # upload never finished and never will. The first kind is the most recently
+    # created row, so newest-first spends the lookups on the file most likely to
+    # be a real deliverable. Without it, a seller whose genuine new upload sits
+    # behind MAX_FILES_CHECKED_FOR_STORAGE abandoned rows would be told their
+    # listing delivers nothing. Sorting by id is deliberate: alive_product_files
+    # is ordered by the seller's chosen `position`, which says nothing about
+    # which row was created last.
     def has_deliverable_file?(owner)
       unverifiable_from_row = []
 
@@ -251,6 +262,7 @@ class ContentModeration::ModerateRecordService
       end
 
       unverifiable_from_row
+        .sort_by { -_1.id }
         .first(MAX_FILES_CHECKED_FOR_STORAGE)
         .any?(&:stored_file_present?)
     end

--- a/app/services/content_moderation/moderate_record_service.rb
+++ b/app/services/content_moderation/moderate_record_service.rb
@@ -4,13 +4,11 @@ class ContentModeration::ModerateRecordService
   AUTHOR_NAME = "ContentModeration"
   ADMIN_COMMENT_DEDUP_WINDOW = 5.minutes
 
-  # How many attached files we're willing to look up in storage while deciding
-  # whether a listing delivers anything (see `has_deliverable_file?`).
-  MAX_FILES_CHECKED_FOR_STORAGE = 5
-
-  # How many of those lookups go to the most recently created rows. The rest go
-  # to the oldest ones — see `has_deliverable_file?` for why both ends matter.
-  NEWEST_FILES_CHECKED_FOR_STORAGE = 3
+  # How long we're willing to spend looking files up in storage while deciding
+  # whether a listing delivers anything (see `has_deliverable_file?`). This is a
+  # time budget rather than a file count so that no attached file is excluded
+  # from the check by its position in the list.
+  STORAGE_CHECK_TIME_BUDGET_SECONDS = 2.0
 
   CheckResult = Struct.new(:passed, :reasons, keyword_init: true)
 
@@ -241,29 +239,37 @@ class ContentModeration::ModerateRecordService
     #
     # Most files answer from the row alone (an analyzed file, an external link, a
     # purged object), so those are settled first and for free. Only files the row
-    # cannot answer for cost a request to storage, and at most
-    # MAX_FILES_CHECKED_FOR_STORAGE of those are made — enough to prove a
-    # deliverable exists without turning a save into a long series of lookups.
+    # cannot answer for cost a request to storage, and those are bounded by a time
+    # budget rather than a file count.
     #
-    # Which files get those lookups is chosen by creation order, from both ends.
-    # The only file a row cannot answer for is one that has never been analyzed,
-    # and there are two ways to get there. Either the seller uploaded it moments
-    # ago and AnalyzeFileWorker hasn't run yet, which makes it one of the most
-    # recently created rows, or analysis never finished — usually because the
-    # upload itself never finished (nothing deletes that row afterwards), but
-    # sometimes because a genuinely stored file ran out of analysis retries long
-    # ago and stayed behind. So the newest rows are checked first and the leftover
-    # lookups go to the oldest rows: between them they cover the fresh upload and
-    # the long-stored file whose analysis never completed, instead of spending the
-    # whole budget on whichever end of a pile of abandoned uploads sorts first.
-    # Ordering by id is deliberate: alive_product_files is ordered by the seller's
-    # chosen `position`, which says nothing about when a row was created, so on a
-    # listing with more abandoned rows than the cap the real file could sit past
-    # the cap and never be queried at all.
+    # A count-based cap had to choose WHICH files to spend it on, and every choice
+    # left a real deliverable unreachable. A file a row cannot answer for has
+    # never been analyzed successfully, and a genuinely stored file lands in that
+    # state at either end of creation order: it was uploaded moments ago and
+    # AnalyzeFileWorker hasn't run yet (the newest such row), or its analysis will
+    # never succeed even though the object is really there — the worker exhausted
+    # its retries, or it's a video whose metadata can't be read, which clears the
+    # flag deliberately (see WithFileProperties#video_analysis_failed) and which
+    # nothing ever revisits, so it ages into being the oldest such row. Checking
+    # the newest few plus the oldest few covers both, but then a stored file
+    # sitting BETWEEN two runs of abandoned uploads falls in the gap and the
+    # seller is told their listing delivers nothing.
     #
-    # Ordering only decides which honest sellers we can confirm cheaply; it can
-    # never let an empty listing through, because passing still requires an object
-    # to actually be in storage.
+    # There is no ordering that fixes this, because the save API takes each file's
+    # storage URL from the client: whatever slice we pick, a caller can submit
+    # enough dead rows to push a real file out of it, and a legitimate seller can
+    # land there by accident. So instead every unverifiable file is eligible, and
+    # what's capped is the time spent — we stop asking once the budget is gone.
+    # Ordering newest-first still matters, since the freshly-uploaded file is the
+    # single likeliest deliverable and usually answers on the first request.
+    #
+    # A listing carrying many dead rows therefore costs a bounded amount of time
+    # instead of a bounded number of files, and no attached file is excluded from
+    # the check by its position in the list.
+    #
+    # This can only decide how cheaply an honest seller is confirmed; it can never
+    # let an empty listing through, because passing still requires an object to
+    # actually be in storage.
     def has_deliverable_file?(owner)
       unverifiable_from_row = []
 
@@ -274,20 +280,16 @@ class ContentModeration::ModerateRecordService
         end
       end
 
-      files_to_check(unverifiable_from_row).any?(&:stored_file_present?)
-    end
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + STORAGE_CHECK_TIME_BUDGET_SECONDS
 
-    # At most MAX_FILES_CHECKED_FOR_STORAGE files, taken from the newest and
-    # oldest rows by creation order. `max_by`/`min_by` with a count pick those
-    # ends without ordering the whole collection, which matters because the number
-    # of rows here is up to the caller submitting the save.
-    def files_to_check(files)
-      return files if files.size <= MAX_FILES_CHECKED_FOR_STORAGE
+      unverifiable_from_row
+        .sort_by { -_1.id }
+        .each do |file|
+          return true if file.stored_file_present?
+          break if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+        end
 
-      newest = files.max_by(NEWEST_FILES_CHECKED_FOR_STORAGE, &:id)
-      oldest = files.min_by(MAX_FILES_CHECKED_FOR_STORAGE - NEWEST_FILES_CHECKED_FOR_STORAGE, &:id)
-
-      newest + oldest
+      false
     end
 
     # Rich content with something in the body, ignoring pages that only have a

--- a/spec/services/content_moderation/moderate_record_service_spec.rb
+++ b/spec/services/content_moderation/moderate_record_service_spec.rb
@@ -494,6 +494,25 @@ RSpec.describe ContentModeration::ModerateRecordService, :vcr do
         expect(described_class.check(product.reload, :product).passed).to eq(true)
       end
 
+      # A seller who abandoned a run of uploads and then finished a real one must
+      # not be told their listing delivers nothing just because the dead rows
+      # outnumber the lookups we're willing to pay for.
+      it "publishes when a just-uploaded file sits behind more abandoned uploads than the cap" do
+        abandoned = Array.new(described_class::MAX_FILES_CHECKED_FOR_STORAGE + 3) do |index|
+          create(:product_file, analyze_completed: false, position: index)
+        end
+        # Created last and ordered last, so the seller's own `position` ordering
+        # buries it past the cap and only creation order can pick it out.
+        finished = create(:product_file, analyze_completed: false, position: abandoned.size)
+        allow_any_instance_of(ProductFile).to receive(:s3_object) do |file|
+          double("s3_object", exists?: file.id == finished.id)
+        end
+        (abandoned + [finished]).each { product.product_files << _1 }
+        product.save!
+
+        expect(described_class.check(product.reload, :product).passed).to eq(true)
+      end
+
       # The save API takes each file's storage URL from the client, so submitting
       # a long list of never-uploaded rows costs a caller nothing. Attaching many
       # of them must not buy what attaching one doesn't.

--- a/spec/services/content_moderation/moderate_record_service_spec.rb
+++ b/spec/services/content_moderation/moderate_record_service_spec.rb
@@ -513,6 +513,23 @@ RSpec.describe ContentModeration::ModerateRecordService, :vcr do
         expect(described_class.check(product.reload, :product).passed).to eq(true)
       end
 
+      # The other way a file goes unanalyzed forever is that it really was stored
+      # but analysis ran out of retries, which can leave a real deliverable as the
+      # oldest row on a listing that has collected abandoned uploads since.
+      it "publishes when a long-stored unanalyzed file sits in front of more abandoned uploads than the cap" do
+        stored = create(:product_file, analyze_completed: false, position: 1)
+        abandoned = Array.new(described_class::MAX_FILES_CHECKED_FOR_STORAGE + 3) do |index|
+          create(:product_file, analyze_completed: false, position: index + 2)
+        end
+        allow_any_instance_of(ProductFile).to receive(:s3_object) do |file|
+          double("s3_object", exists?: file.id == stored.id)
+        end
+        ([stored] + abandoned).each { product.product_files << _1 }
+        product.save!
+
+        expect(described_class.check(product.reload, :product).passed).to eq(true)
+      end
+
       # The save API takes each file's storage URL from the client, so submitting
       # a long list of never-uploaded rows costs a caller nothing. Attaching many
       # of them must not buy what attaching one doesn't.

--- a/spec/services/content_moderation/moderate_record_service_spec.rb
+++ b/spec/services/content_moderation/moderate_record_service_spec.rb
@@ -334,6 +334,18 @@ RSpec.describe ContentModeration::ModerateRecordService, :vcr do
     # listing that actually delivers something we keep it as a reviewable note
     # rather than blocking the publish.
     context "when the spam preset flags a product that has a deliverable" do
+      # Enough abandoned rows that any fixed-size slice of the file list would
+      # have left the genuine file out.
+      let(:abandoned_upload_count) { 8 }
+
+      # Only `only` is really in storage; every other file's lookup says missing.
+      # Pass `only: nil` for a listing where nothing was ever really uploaded.
+      def stub_storage_presence(only:)
+        allow_any_instance_of(ProductFile).to receive(:s3_object) do |file|
+          double("s3_object", exists?: only.present? && file.id == only.id)
+        end
+      end
+
       before do
         allow(ContentModeration::Strategies::PromptStrategy).to receive(:new).and_return(
           instance_double(ContentModeration::Strategies::PromptStrategy,
@@ -496,17 +508,15 @@ RSpec.describe ContentModeration::ModerateRecordService, :vcr do
 
       # A seller who abandoned a run of uploads and then finished a real one must
       # not be told their listing delivers nothing just because the dead rows
-      # outnumber the lookups we're willing to pay for.
-      it "publishes when a just-uploaded file sits behind more abandoned uploads than the cap" do
-        abandoned = Array.new(described_class::MAX_FILES_CHECKED_FOR_STORAGE + 3) do |index|
+      # outnumber what we'd previously pay to look up.
+      it "publishes when a just-uploaded file sits behind a pile of abandoned uploads" do
+        abandoned = Array.new(abandoned_upload_count) do |index|
           create(:product_file, analyze_completed: false, position: index)
         end
         # Created last and ordered last, so the seller's own `position` ordering
-        # buries it past the cap and only creation order can pick it out.
+        # buries it and only creation order picks it out first.
         finished = create(:product_file, analyze_completed: false, position: abandoned.size)
-        allow_any_instance_of(ProductFile).to receive(:s3_object) do |file|
-          double("s3_object", exists?: file.id == finished.id)
-        end
+        stub_storage_presence(only: finished)
         (abandoned + [finished]).each { product.product_files << _1 }
         product.save!
 
@@ -514,17 +524,34 @@ RSpec.describe ContentModeration::ModerateRecordService, :vcr do
       end
 
       # The other way a file goes unanalyzed forever is that it really was stored
-      # but analysis ran out of retries, which can leave a real deliverable as the
-      # oldest row on a listing that has collected abandoned uploads since.
-      it "publishes when a long-stored unanalyzed file sits in front of more abandoned uploads than the cap" do
+      # but analysis never succeeded — retries ran out, or it's a video whose
+      # metadata can't be read. That leaves a real deliverable as the oldest row
+      # on a listing that has collected abandoned uploads since.
+      it "publishes when a long-stored unanalyzed file sits in front of a pile of abandoned uploads" do
         stored = create(:product_file, analyze_completed: false, position: 1)
-        abandoned = Array.new(described_class::MAX_FILES_CHECKED_FOR_STORAGE + 3) do |index|
+        abandoned = Array.new(abandoned_upload_count) do |index|
           create(:product_file, analyze_completed: false, position: index + 2)
         end
-        allow_any_instance_of(ProductFile).to receive(:s3_object) do |file|
-          double("s3_object", exists?: file.id == stored.id)
-        end
+        stub_storage_presence(only: stored)
         ([stored] + abandoned).each { product.product_files << _1 }
+        product.save!
+
+        expect(described_class.check(product.reload, :product).passed).to eq(true)
+      end
+
+      # The case no fixed slice of the list can reach: the real file is neither
+      # the newest nor the oldest row, because abandoned uploads surround it on
+      # both sides. Every file has to stay eligible for a lookup.
+      it "publishes when the stored file sits between two runs of abandoned uploads" do
+        older = Array.new(abandoned_upload_count) do |index|
+          create(:product_file, analyze_completed: false, position: index)
+        end
+        stored = create(:product_file, analyze_completed: false, position: older.size)
+        newer = Array.new(abandoned_upload_count) do |index|
+          create(:product_file, analyze_completed: false, position: older.size + 1 + index)
+        end
+        stub_storage_presence(only: stored)
+        (older + [stored] + newer).each { product.product_files << _1 }
         product.save!
 
         expect(described_class.check(product.reload, :product).passed).to eq(true)
@@ -534,20 +561,31 @@ RSpec.describe ContentModeration::ModerateRecordService, :vcr do
       # a long list of never-uploaded rows costs a caller nothing. Attaching many
       # of them must not buy what attaching one doesn't.
       it "still blocks when many attached files are all unfinished uploads" do
-        storage_lookups = 0
-        allow_any_instance_of(ProductFile).to receive(:s3_object) do
-          storage_lookups += 1
-          double("s3_object", exists?: false)
-        end
-        (described_class::MAX_FILES_CHECKED_FOR_STORAGE + 3).times do
+        stub_storage_presence(only: nil)
+        (abandoned_upload_count + 3).times do
           product.product_files << create(:product_file, analyze_completed: false)
         end
         product.save!
 
         expect(described_class.check(product.reload, :product).passed).to eq(false)
-        # Only as many lookups as we said we'd pay for, so a long list can't turn
-        # one save into an unbounded run of requests to storage.
-        expect(storage_lookups).to eq(described_class::MAX_FILES_CHECKED_FOR_STORAGE)
+      end
+
+      # The list length is up to the caller, so a save must not turn into an
+      # unbounded run of requests to storage. Once the time budget is gone we
+      # stop asking, however many rows are left.
+      it "stops checking storage once the time budget is spent" do
+        storage_lookups = 0
+        # Each lookup burns the whole budget, so the very next one is not made.
+        allow_any_instance_of(ProductFile).to receive(:s3_object) do
+          storage_lookups += 1
+          sleep(described_class::STORAGE_CHECK_TIME_BUDGET_SECONDS)
+          double("s3_object", exists?: false)
+        end
+        5.times { product.product_files << create(:product_file, analyze_completed: false) }
+        product.save!
+
+        expect(described_class.check(product.reload, :product).passed).to eq(false)
+        expect(storage_lookups).to eq(1)
       end
 
       # A file that finished analyzing is answered from its own row, so a real
@@ -555,7 +593,7 @@ RSpec.describe ContentModeration::ModerateRecordService, :vcr do
       # and still costs nothing to confirm.
       it "publishes without checking storage when one of many attached files has been analyzed" do
         expect_any_instance_of(ProductFile).not_to receive(:s3_object)
-        (described_class::MAX_FILES_CHECKED_FOR_STORAGE + 3).times do
+        abandoned_upload_count.times do
           product.product_files << create(:product_file, analyze_completed: false)
         end
         product.product_files << uploaded_file


### PR DESCRIPTION
Follow-up to #6320, fixing a bug that PR introduced.

#6320 capped how many storage lookups a save will pay for while proving a product has a real deliverable: it collects the files whose database rows can't answer the question, then checked at most five of them.

The problem was which five. That list arrives ordered by the seller's own `position` — the order they dragged their files into — which says nothing about when a row was created. A seller who abandoned a run of uploads and then finished a real one gets told their listing delivers nothing: the abandoned rows sort ahead of the genuine file, consume the whole budget, and the real upload is never queried.

That's the mirror image of the bug #6320 fixed, and in the more expensive direction. The original bug let an empty listing through; this one blocks a legitimate seller from publishing a product that does have a file attached.

## The fix

Two attempts at picking a better five both left a real file unreachable, which is the useful finding here. A row can only be unanswerable when the file was never analyzed successfully, and a genuinely stored file lands in that state at either end of creation order:

- it was uploaded moments ago and `AnalyzeFileWorker` hasn't run yet — the newest such row
- analysis will never succeed even though the object is really there, because the worker exhausted its retries or the file is a video whose metadata can't be read (which clears the flag deliberately and is never revisited) — so it ages into being the oldest such row

Checking the newest few plus the oldest few covers both, and then a stored file sitting *between* two runs of abandoned uploads falls in the gap. There is no ordering that fixes this: the save API takes each file's storage URL from the client, so whatever slice is picked, enough dead rows push a real file out of it, and an honest seller can land there by accident.

So the bound is on time rather than on file count. Every unverifiable file stays eligible for a lookup — no file is ruled out in advance by its position — and the scan stops once `STORAGE_CHECK_TIME_BUDGET_SECONDS` (2s) is gone. Ordering is still newest-first, because a just-uploaded file is the single likeliest deliverable and normally answers on the first request — a listing with one fresh upload costs one lookup, as before.

**What this narrows rather than closes.** A spent budget still stops the scan, so a stored file late in the order can go unqueried and the check fails on a listing that does have a file attached. The difference from the count cap is what it takes to get there: dead rows no longer skip a real file merely by existing — exhausting the budget requires seconds of genuinely slow storage responses. The seller who hit #6320's cap would not hit this. Exhaustion deliberately keeps failing closed, because the save API takes each file's storage URL from the client, so passing on "we ran out of time" would make submitting enough rows a way to publish with nothing attached. The durable fix — recording a confirmed-absent lookup so dead rows stop consuming the budget at all — needs a schema decision and is tracked in gumroad-private#1370.

A listing carrying many dead rows now costs a bounded amount of *time* instead of a bounded number of files. Those rows are still pure waste — nothing ever deletes a row whose upload never finished — and retiring them is tracked separately in gumroad-private#1370.

This can only change how cheaply an honest seller is confirmed. It can't let an empty listing through: passing still requires an object to actually be in storage.

## Testing

Three regression specs, one per way a real file was missed:

- a genuine just-uploaded file buried behind a pile of abandoned rows, with `position` putting it last so only creation order finds it
- a genuine long-stored unanalyzed file as the oldest row, with abandoned rows created after it
- the stored file between two runs of abandoned uploads — the case no fixed slice reaches

Each verified RED → GREEN against the selection it rules out: restoring the count cap fails the interior case specifically, newest-only fails the oldest-row case, and the original `position` ordering fails the first. The bound itself is asserted rather than assumed — a stubbed lookup that burns the whole budget means exactly one lookup is made — and a listing whose files are all unfinished uploads still fails the check.

Whole file green on two seeds: `67 examples, 0 failures`. RuboCop clean on both files.

One tradeoff worth naming: the budget spec sleeps for the budget to prove the cutoff, which adds ~2s to this file. That seemed a fair price for asserting the bound holds.

## QA steps

No user-visible surface changes: this is the internal deliverable check behind the spam flag, reached only from a product save. There is no page or component to screenshot; the spec run is the artifact.

To exercise it by hand on a preview app: attach a file to a draft product, kill the upload before it completes, repeat several times, then upload one real file and save. Before this change the save is rejected as having no deliverable; after it the product publishes.

---

## AI disclosure

Written by `claude-opus-5` (Anthropic) running as the Gumclaw Hermes agent.

Instructions given: follow up on #6320's capped storage check, which selected the files to look up in the seller's display order and so could miss a real deliverable; then address each review finding on this PR in turn — that newest-first still misses an older genuinely-stored file whose analysis never completed, that sorting the whole seller-controlled collection before applying the cap adds needless synchronous work, and that a two-ended split still misses a stored file in the interior of creation order.

