### PR TITLE
Fix flaky video-URL spec that compared two signed URLs across a second boundary

### DIFF
--- a/spec/models/url_redirect_spec.rb
+++ b/spec/models/url_redirect_spec.rb
@@ -580,21 +580,28 @@ describe UrlRedirect do
     end
 
     it "returns the video URL and GUID for the file" do
-      expected_video_url = @multifile_url_redirect.signed_video_url(@file_1)
-      expected_guid = expected_video_url[described_class::GUID_GETTER_FROM_S3_URL_REGEX, 1]
-      expected_video_url.sub!(expected_guid, described_class::FAKE_VIDEO_URL_GUID_FOR_OBFUSCATION)
+      # The URL we compare against is a second signed URL for the same file, and the signature
+      # covers the moment of signing: the credential scope and expiry are both derived from the
+      # current time. Generating the expected URL and the actual one at two different instants
+      # produces two different signatures whenever those instants land on opposite sides of a
+      # second boundary, so both have to be signed at the same frozen time to be comparable.
+      freeze_time do
+        expected_video_url = @multifile_url_redirect.signed_video_url(@file_1)
+        expected_guid = expected_video_url[described_class::GUID_GETTER_FROM_S3_URL_REGEX, 1]
+        expected_video_url.sub!(expected_guid, described_class::FAKE_VIDEO_URL_GUID_FOR_OBFUSCATION)
 
-      video_url, guid = @multifile_url_redirect.send(:html5_video_url_and_guid_for_product_file, @file_1)
-      expect(video_url).to eq(expected_video_url)
-      expect(guid).to eq(expected_guid)
+        video_url, guid = @multifile_url_redirect.send(:html5_video_url_and_guid_for_product_file, @file_1)
+        expect(video_url).to eq(expected_video_url)
+        expect(guid).to eq(expected_guid)
 
-      expected_video_url = @multifile_url_redirect.signed_video_url(@file_2)
-      expected_guid = expected_video_url[described_class::GUID_GETTER_FROM_S3_URL_REGEX, 1]
-      expected_video_url.sub!(expected_guid, described_class::FAKE_VIDEO_URL_GUID_FOR_OBFUSCATION)
+        expected_video_url = @multifile_url_redirect.signed_video_url(@file_2)
+        expected_guid = expected_video_url[described_class::GUID_GETTER_FROM_S3_URL_REGEX, 1]
+        expected_video_url.sub!(expected_guid, described_class::FAKE_VIDEO_URL_GUID_FOR_OBFUSCATION)
 
-      video_url, guid = @multifile_url_redirect.send(:html5_video_url_and_guid_for_product_file, @file_2)
-      expect(video_url).to eq(expected_video_url)
-      expect(guid).to eq(expected_guid)
+        video_url, guid = @multifile_url_redirect.send(:html5_video_url_and_guid_for_product_file, @file_2)
+        expect(video_url).to eq(expected_video_url)
+        expect(guid).to eq(expected_guid)
+      end
     end
   end
 


### PR DESCRIPTION
`spec/models/url_redirect_spec.rb:582` fails intermittently on unrelated PRs. It just failed CI on #6326, which touches nothing near this code:

```
1) UrlRedirect#html5_video_url_and_guid_for_product_file returns the video URL and GUID for the file
   Failure/Error: expect(video_url).to eq(expected_video_url)

     expected: "...chapter2.mp4?...X-Amz-Signature=a1eccc554865d1f1610cf9a3e69fdcbe062d904de87de6399ec7ae04dd4a8db1"
          got: "...chapter2.mp4?...X-Amz-Signature=eefe09ee62bcc324969c81510b702102eee340bf6bb35ffdec591b001c18ac0c"
```

The two URLs are identical apart from the signature.

## Why it fails

The spec builds its expected value by signing the same file a second time, then compares the two signed URLs. A presigned URL's signature covers the moment of signing — both the credential scope date and the expiry are derived from the current time — so two signings of the same object only agree if they happen within the same clock second. When the pair straddles a second boundary the `X-Amz-Date` differs by one second and the signature changes with it, so the comparison fails on a test whose subject never changed.

This is timing, not load: the window is however long it takes to sign once, and it opens on every run that happens to start late in a second.

## The fix

Wrap the example in `freeze_time` so both signings see one instant. This is what the sibling spec for the same URL-signing path already does — `spec/controllers/url_redirects_controller_spec.rb:2398` compares `media_urls` output against a freshly signed URL inside `freeze_time` for exactly this reason.

Nothing about what's asserted changes; the example still checks the real URL and GUID against an independently signed URL, only now at a fixed time.

## Testing

The race and its fix were both demonstrated directly, in a throwaway spec that signed the same file twice with a real 1.1 second delay between the calls:

- without `freeze_time`, the two URLs differ — `X-Amz-Date=20260726T022514Z` vs `20260726T022515Z`, and different signatures. This is the CI failure reproduced on demand rather than waited for.
- with `freeze_time` around the same 1.1 second delay, the two URLs are byte-identical.

So the failure mode is confirmed to be the clock, and `freeze_time` is confirmed to close it.

The example itself passes on the branch. The whole file is `73 examples, 2 failures`, and those two failures — `#enqueue_job_to_regenerate_deleted_transcoded_videos`, both examples — are present unchanged on `main` with this diff stashed, so they are pre-existing and unrelated. RuboCop clean.

## QA steps

None: this is a test-only change with no production code touched and no user-visible surface.

---

## AI disclosure

Written by `claude-opus-5` (Anthropic) running as the Gumclaw Hermes agent.

Instructions given: CI on #6326 came back red; diagnose it. The failure turned out to be this unrelated flaky spec, so fix the flake at its root cause rather than re-running the shard.
