### PR TITLE
Regenerate an avatar whose resized file has gone missing from storage

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -464,36 +464,13 @@ class User < ApplicationRecord
   def avatar_url
     return ActionController::Base.helpers.image_url("gumroad-default-avatar-5.png") unless avatar.attached?
 
-    # The version suffix on the cache key lets us abandon previously cached
-    # URLs without a backfill: every user's avatar URL is simply recomputed on
-    # its next read, and the old entries are left behind for memcached to
-    # evict. "_v2" moved us from 128x128 to 400x400 variants. "_v3" abandons
-    # the entries written before this method checked that the variant file
-    # still exists, some of which pointed at files that had disappeared from
-    # storage and so returned 403 forever.
-    cache_key = "attachment_#{avatar.id}_variant_url_v3"
-    cached_variant_url = Rails.cache.read(cache_key).presence
-
-    if cached_variant_url.nil?
-      # Confirm against storage rather than the presence cache here: this URL is
-      # about to be remembered for a day, so it has to be checked at the moment
-      # we write it. Otherwise a variant that vanished just after its presence
-      # was confirmed could be served for the presence lifetime and then get a
-      # fresh full-length URL entry on top of it.
-      cached_variant_url = avatar_variant(verify_storage: true)&.url.presence
-      # Only ever cache a real URL. A blank value here means we could not work
-      # out where the variant lives on this pass, and caching that would leave
-      # the seller with no profile picture until the entry expired, with no way
-      # for them to fix it. The expiry bounds how long any single cached URL
-      # can outlive the file it points at.
-      Rails.cache.write(cache_key, cached_variant_url, expires_in: AVATAR_VARIANT_URL_CACHE_TTL) if cached_variant_url
-    end
+    variant_url = cached_avatar_variant_url
 
     # Falling back to the original upload, which is the size the seller
     # uploaded but is otherwise correct, beats showing no avatar at all.
-    return avatar.url if cached_variant_url.nil?
+    return avatar.url if variant_url.blank?
 
-    cdn_url_for(cached_variant_url)
+    cdn_url_for(variant_url)
   rescue => e
     Rails.logger.warn("User#avatar_url error (#{id}): #{e.class} => #{e.message}")
     avatar.url
@@ -1282,6 +1259,47 @@ class User < ApplicationRecord
     end
 
   private
+    # The cached avatar variant URL, resolving and caching it when there is no
+    # usable entry.
+    #
+    # The version suffix on the cache key lets us abandon previously cached
+    # URLs without a backfill: every user's avatar URL is simply recomputed on
+    # its next read, and the old entries are left behind for memcached to
+    # evict. "_v2" moved us from 128x128 to 400x400 variants. "_v3" abandons
+    # the entries written before we checked that the variant file still
+    # exists, some of which pointed at files that had disappeared from storage
+    # and so returned 403 forever.
+    def cached_avatar_variant_url
+      cache_key = "attachment_#{avatar.id}_variant_url_v3"
+      cached = Rails.cache.read(cache_key)
+
+      # A cached URL is only worth serving while the file behind it is still
+      # there, so the variant's storage key is cached next to the URL and
+      # checked on every hit. Without that check a variant that disappeared
+      # just after its URL was written would 403 for the rest of the day. The
+      # check is normally answered by the short-lived presence entry, so it
+      # costs at most one storage lookup per variant per hour.
+      if cached.is_a?(Hash) && cached[:url].present? && cached[:key].present? &&
+         avatar_variant_file_present?(cached[:key])
+        return cached[:url]
+      end
+
+      # Ask storage directly rather than trusting the presence entry: this URL
+      # is about to be remembered for a day, so it has to be true at the moment
+      # we write it.
+      variant = avatar_variant(verify_storage: true)
+      url = variant&.url.presence
+      # Only ever cache a real URL. A blank value here means we could not work
+      # out where the variant lives on this pass, and caching that would leave
+      # the seller with no profile picture until the entry expired, with no way
+      # for them to fix it. The expiry bounds how long any single cached URL
+      # can outlive the file it points at.
+      if url && variant.key.present?
+        Rails.cache.write(cache_key, { url:, key: variant.key }, expires_in: AVATAR_VARIANT_URL_CACHE_TTL)
+      end
+      url
+    end
+
     # Returns the resized avatar, having confirmed that the resized file is
     # really still in storage.
     #
@@ -1299,7 +1317,7 @@ class User < ApplicationRecord
     # the original upload, which is normally still intact.
     def stored_avatar_variant(verify_storage: false, **transformations)
       variant = avatar.variant(**transformations).processed
-      return variant if avatar_variant_file_present?(variant, verify_storage:)
+      return variant if avatar_variant_file_present?(variant.key, verify_storage:)
 
       Rails.logger.warn("User#stored_avatar_variant (#{id}): variant file missing from storage, regenerating it")
       variant.destroy
@@ -1314,8 +1332,7 @@ class User < ApplicationRecord
     # storage directly. Callers that are about to remember the resulting URL for
     # a long time pass it, so the answer they cache was true at the moment they
     # cached it.
-    def avatar_variant_file_present?(variant, verify_storage: false)
-      key = variant.key
+    def avatar_variant_file_present?(key, verify_storage: false)
       # No key at all means Active Storage has nothing to check; let the caller
       # deal with the empty URL that follows rather than resizing in a loop.
       return true if key.blank?
@@ -1323,7 +1340,7 @@ class User < ApplicationRecord
       cache_key = "active_storage_variant_present_#{key}"
       return true if !verify_storage && Rails.cache.read(cache_key)
 
-      unless variant.service.exist?(key)
+      unless avatar.blob.service.exist?(key)
         # Drop any stale confirmation so another caller does not trust it.
         Rails.cache.delete(cache_key)
         return false

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,14 +40,21 @@ class User < ApplicationRecord
   # How long a resolved avatar variant URL stays cached. Avatar URLs are stable
   # for as long as the seller keeps the same picture, so this is only about
   # bounding how long a cached URL can keep being served after the file behind
-  # it goes away.
-  AVATAR_VARIANT_URL_CACHE_TTL = 1.week
+  # it goes away. A day is short enough that a seller whose variant disappears
+  # right after a cache write is not left without a picture for a week, and long
+  # enough that virtually every read still hits the cache.
+  AVATAR_VARIANT_URL_CACHE_TTL = 1.day
 
   # How long we remember that an avatar variant's file was confirmed present in
   # storage, so a normal page view does not pay for a storage lookup. Only
   # confirmations are remembered, never absences, so a seller whose avatar is
   # repaired sees it immediately.
-  AVATAR_VARIANT_PRESENCE_CACHE_TTL = 1.week
+  #
+  # Kept far shorter than the URL cache above on purpose. This entry exists only
+  # to spare repeated storage lookups inside a burst of reads; if it lived as
+  # long as a cached URL, a variant that disappeared right after being confirmed
+  # could keep being served for one presence lifetime *plus* one URL lifetime.
+  AVATAR_VARIANT_PRESENCE_CACHE_TTL = 1.hour
 
   has_many :affiliate_credits, foreign_key: "affiliate_user_id"
   has_many :affiliate_partial_refunds, foreign_key: "affiliate_user_id"
@@ -468,7 +475,12 @@ class User < ApplicationRecord
     cached_variant_url = Rails.cache.read(cache_key).presence
 
     if cached_variant_url.nil?
-      cached_variant_url = avatar_variant&.url.presence
+      # Confirm against storage rather than the presence cache here: this URL is
+      # about to be remembered for a day, so it has to be checked at the moment
+      # we write it. Otherwise a variant that vanished just after its presence
+      # was confirmed could be served for the presence lifetime and then get a
+      # fresh full-length URL entry on top of it.
+      cached_variant_url = avatar_variant(verify_storage: true)&.url.presence
       # Only ever cache a real URL. A blank value here means we could not work
       # out where the variant lives on this pass, and caching that would leave
       # the seller with no profile picture until the entry expired, with no way
@@ -487,12 +499,12 @@ class User < ApplicationRecord
     avatar.url
   end
 
-  def avatar_variant
+  def avatar_variant(verify_storage: false)
     return unless avatar.attached?
 
     # 400x400 so avatars stay sharp on Retina/high-DPI screens: the profile
     # settings preview box is 200 CSS px, which is 400 device px at 2x.
-    stored_avatar_variant(resize_to_limit: [400, 400])
+    stored_avatar_variant(verify_storage:, resize_to_limit: [400, 400])
   end
 
   def username
@@ -1285,9 +1297,9 @@ class User < ApplicationRecord
     #
     # When the file is gone we throw the stale row away and resize again from
     # the original upload, which is normally still intact.
-    def stored_avatar_variant(**transformations)
+    def stored_avatar_variant(verify_storage: false, **transformations)
       variant = avatar.variant(**transformations).processed
-      return variant if avatar_variant_file_present?(variant)
+      return variant if avatar_variant_file_present?(variant, verify_storage:)
 
       Rails.logger.warn("User#stored_avatar_variant (#{id}): variant file missing from storage, regenerating it")
       variant.destroy
@@ -1298,15 +1310,24 @@ class User < ApplicationRecord
       avatar.variant(**transformations).processed
     end
 
-    def avatar_variant_file_present?(variant)
+    # verify_storage skips the "we saw this file recently" shortcut and asks
+    # storage directly. Callers that are about to remember the resulting URL for
+    # a long time pass it, so the answer they cache was true at the moment they
+    # cached it.
+    def avatar_variant_file_present?(variant, verify_storage: false)
       key = variant.key
       # No key at all means Active Storage has nothing to check; let the caller
       # deal with the empty URL that follows rather than resizing in a loop.
       return true if key.blank?
 
       cache_key = "active_storage_variant_present_#{key}"
-      return true if Rails.cache.read(cache_key)
-      return false unless variant.service.exist?(key)
+      return true if !verify_storage && Rails.cache.read(cache_key)
+
+      unless variant.service.exist?(key)
+        # Drop any stale confirmation so another caller does not trust it.
+        Rails.cache.delete(cache_key)
+        return false
+      end
 
       Rails.cache.write(cache_key, true, expires_in: AVATAR_VARIANT_PRESENCE_CACHE_TTL)
       true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,6 +37,18 @@ class User < ApplicationRecord
 
   MIN_SALES_CENTS_VALUE_FOR_AI_PRODUCT_GENERATION = 10_000
 
+  # How long a resolved avatar variant URL stays cached. Avatar URLs are stable
+  # for as long as the seller keeps the same picture, so this is only about
+  # bounding how long a cached URL can keep being served after the file behind
+  # it goes away.
+  AVATAR_VARIANT_URL_CACHE_TTL = 1.week
+
+  # How long we remember that an avatar variant's file was confirmed present in
+  # storage, so a normal page view does not pay for a storage lookup. Only
+  # confirmations are remembered, never absences, so a seller whose avatar is
+  # repaired sees it immediately.
+  AVATAR_VARIANT_PRESENCE_CACHE_TTL = 1.week
+
   has_many :affiliate_credits, foreign_key: "affiliate_user_id"
   has_many :affiliate_partial_refunds, foreign_key: "affiliate_user_id"
   has_many :affiliate_requests, foreign_key: :seller_id
@@ -436,7 +448,7 @@ class User < ApplicationRecord
 
   def resized_avatar_url(size:)
     return ActionController::Base.helpers.image_url("gumroad-default-avatar-5.png") unless avatar.attached?
-    cdn_url_for(avatar.variant(resize_to_limit: [size, size]).processed.url)
+    cdn_url_for(stored_avatar_variant(resize_to_limit: [size, size]).url)
   rescue ActiveStorage::FileNotFoundError, Errno::ENOENT, ActiveRecord::InvalidForeignKey => e
     Rails.logger.warn("User#resized_avatar_url error (#{id}): #{e.class} => #{e.message}")
     ActionController::Base.helpers.image_url("gumroad-default-avatar-5.png")
@@ -445,12 +457,30 @@ class User < ApplicationRecord
   def avatar_url
     return ActionController::Base.helpers.image_url("gumroad-default-avatar-5.png") unless avatar.attached?
 
-    # The "_v2" suffix versions the cache key: we previously served 128x128
-    # variants, and the old (unversioned) key still holds those URLs. Using a
-    # new key makes every user's avatar URL regenerate lazily on next read,
-    # so existing uploads get the sharper 400x400 variant without any manual
-    # backfill. Old keys are simply left behind and evicted by memcached.
-    cached_variant_url = Rails.cache.fetch("attachment_#{avatar.id}_variant_url_v2") { avatar_variant.url }
+    # The version suffix on the cache key lets us abandon previously cached
+    # URLs without a backfill: every user's avatar URL is simply recomputed on
+    # its next read, and the old entries are left behind for memcached to
+    # evict. "_v2" moved us from 128x128 to 400x400 variants. "_v3" abandons
+    # the entries written before this method checked that the variant file
+    # still exists, some of which pointed at files that had disappeared from
+    # storage and so returned 403 forever.
+    cache_key = "attachment_#{avatar.id}_variant_url_v3"
+    cached_variant_url = Rails.cache.read(cache_key).presence
+
+    if cached_variant_url.nil?
+      cached_variant_url = avatar_variant&.url.presence
+      # Only ever cache a real URL. A blank value here means we could not work
+      # out where the variant lives on this pass, and caching that would leave
+      # the seller with no profile picture until the entry expired, with no way
+      # for them to fix it. The expiry bounds how long any single cached URL
+      # can outlive the file it points at.
+      Rails.cache.write(cache_key, cached_variant_url, expires_in: AVATAR_VARIANT_URL_CACHE_TTL) if cached_variant_url
+    end
+
+    # Falling back to the original upload, which is the size the seller
+    # uploaded but is otherwise correct, beats showing no avatar at all.
+    return avatar.url if cached_variant_url.nil?
+
     cdn_url_for(cached_variant_url)
   rescue => e
     Rails.logger.warn("User#avatar_url error (#{id}): #{e.class} => #{e.message}")
@@ -462,7 +492,7 @@ class User < ApplicationRecord
 
     # 400x400 so avatars stay sharp on Retina/high-DPI screens: the profile
     # settings preview box is 200 CSS px, which is 400 device px at 2x.
-    avatar.variant(resize_to_limit: [400, 400]).processed
+    stored_avatar_variant(resize_to_limit: [400, 400])
   end
 
   def username
@@ -1240,6 +1270,54 @@ class User < ApplicationRecord
     end
 
   private
+    # Returns the resized avatar, having confirmed that the resized file is
+    # really still in storage.
+    #
+    # Active Storage decides a variant is "already processed" purely from the
+    # presence of an active_storage_variant_records row — it never asks storage
+    # whether the resized file is still there. So when a variant's file
+    # disappears but its row survives, Active Storage keeps handing out a URL
+    # for the missing file: nothing raises, the rescue fallbacks in the avatar
+    # methods above never run, and every request for that URL fails with a 403
+    # forever. The seller sees no profile picture anywhere and has no way to
+    # tell it is our problem rather than their upload having failed, so most of
+    # them never report it.
+    #
+    # When the file is gone we throw the stale row away and resize again from
+    # the original upload, which is normally still intact.
+    def stored_avatar_variant(**transformations)
+      variant = avatar.variant(**transformations).processed
+      return variant if avatar_variant_file_present?(variant)
+
+      Rails.logger.warn("User#stored_avatar_variant (#{id}): variant file missing from storage, regenerating it")
+      variant.destroy
+      # The row we just deleted may still be held by the blob's loaded
+      # association, which would make the next lookup short-circuit on it
+      # again, so drop what is loaded before resizing.
+      avatar.blob.variant_records.reset
+      avatar.variant(**transformations).processed
+    end
+
+    def avatar_variant_file_present?(variant)
+      key = variant.key
+      # No key at all means Active Storage has nothing to check; let the caller
+      # deal with the empty URL that follows rather than resizing in a loop.
+      return true if key.blank?
+
+      cache_key = "active_storage_variant_present_#{key}"
+      return true if Rails.cache.read(cache_key)
+      return false unless variant.service.exist?(key)
+
+      Rails.cache.write(cache_key, true, expires_in: AVATAR_VARIANT_PRESENCE_CACHE_TTL)
+      true
+    rescue => e
+      # A lookup that itself failed is not evidence the file is gone.
+      # Regenerating avatars for everyone because storage was briefly
+      # unreachable would be far worse than serving the URL we already have.
+      Rails.logger.warn("User#avatar_variant_file_present? error (#{id}): #{e.class} => #{e.message}")
+      true
+    end
+
     def append_http
       self.notification_endpoint = "http://#{notification_endpoint}" if notification_endpoint.present? && !notification_endpoint.include?("http")
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,11 +50,18 @@ class User < ApplicationRecord
   # confirmations are remembered, never absences, so a seller whose avatar is
   # repaired sees it immediately.
   #
-  # Kept far shorter than the URL cache above on purpose. This entry exists only
-  # to spare repeated storage lookups inside a burst of reads; if it lived as
-  # long as a cached URL, a variant that disappeared right after being confirmed
-  # could keep being served for one presence lifetime *plus* one URL lifetime.
-  AVATAR_VARIANT_PRESENCE_CACHE_TTL = 1.hour
+  # This is the ceiling on how long a broken avatar can keep being served. A
+  # page that lists many sellers (a profile, a review list, a community thread)
+  # asks for one avatar URL per person, so checking storage on every read is not
+  # affordable and this entry is what makes the check cheap. But while the entry
+  # says "present", a variant that has since disappeared keeps being handed out
+  # and every request for it fails with a 403.
+  #
+  # Minutes rather than an hour is the balance we want: a seller whose variant
+  # vanishes is missing their picture for a few minutes rather than most of an
+  # afternoon, and the cost is at most one storage lookup per variant per window
+  # across the whole fleet, since the entry is shared through memcached.
+  AVATAR_VARIANT_PRESENCE_CACHE_TTL = 5.minutes
 
   has_many :affiliate_credits, foreign_key: "affiliate_user_id"
   has_many :affiliate_partial_refunds, foreign_key: "affiliate_user_id"
@@ -1276,9 +1283,14 @@ class User < ApplicationRecord
       # A cached URL is only worth serving while the file behind it is still
       # there, so the variant's storage key is cached next to the URL and
       # checked on every hit. Without that check a variant that disappeared
-      # just after its URL was written would 403 for the rest of the day. The
-      # check is normally answered by the short-lived presence entry, so it
-      # costs at most one storage lookup per variant per hour.
+      # just after its URL was written would 403 for the rest of the day.
+      #
+      # The check is usually answered by the short-lived presence entry rather
+      # than by storage, which is what keeps a page full of avatars cheap. That
+      # entry is also the remaining gap: a variant that disappears while it says
+      # "present" keeps being served until it expires, so its lifetime
+      # (AVATAR_VARIANT_PRESENCE_CACHE_TTL, a few minutes) is deliberately the
+      # worst case for a broken avatar.
       if cached.is_a?(Hash) && cached[:url].present? && cached[:key].present? &&
          avatar_variant_file_present?(cached[:key])
         return cached[:url]

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -343,6 +343,25 @@ describe User, :vcr do
 
         expect(@user.reload.avatar_url).to eq("https://public-files.gumroad.com/#{variant_key}")
       end
+
+      it "regenerates the avatar even when the missing file was confirmed present earlier" do
+        # The presence cache only exists to spare repeated storage lookups. It
+        # must never be what a freshly cached URL is based on, or a variant that
+        # disappears just after being confirmed would be served for the presence
+        # lifetime and then get a fresh URL entry on top of it.
+        orphaned = @user.avatar.variant(resize_to_limit: [400, 400]).processed
+        orphaned_key = orphaned.key
+        Rails.cache.write("active_storage_variant_present_#{orphaned_key}", true)
+        @user.avatar.blob.service.delete(orphaned_key)
+
+        url = @user.reload.avatar_url
+
+        expect(url).not_to include(orphaned_key)
+        expect(Rails.cache.read("active_storage_variant_present_#{orphaned_key}")).to be_nil
+        rebuilt_key = @user.reload.avatar_variant.key
+        expect(url).to eq("https://public-files.gumroad.com/#{rebuilt_key}")
+        expect(@user.avatar.blob.service.exist?(rebuilt_key)).to be(true)
+      end
     end
 
     describe "#avatar_variant" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -421,6 +421,28 @@ describe User, :vcr do
         expect(User::AVATAR_VARIANT_PRESENCE_CACHE_TTL).to be <= 5.minutes
         expect(User::AVATAR_VARIANT_PRESENCE_CACHE_TTL).to be < User::AVATAR_VARIANT_URL_CACHE_TTL
       end
+
+      it "does not extend the cached URL's lifetime when serving it" do
+        # The bound above only holds because a cache hit returns without
+        # rewriting the URL entry. If a hit rewrote it, the day-long expiry
+        # would be pushed back on every read, so a frequently viewed seller's
+        # entry would never expire and the storage key cached beside it would
+        # be the only thing left catching a variant that had gone missing.
+        @user.avatar_url
+        url_cache_key = "attachment_#{@user.avatar.id}_variant_url_v3"
+        cached_entry = Rails.cache.read(url_cache_key)
+        expect(cached_entry[:url]).to be_present
+
+        url_cache_writes = 0
+        allow(Rails.cache).to receive(:write).and_wrap_original do |original, *args, **kwargs|
+          url_cache_writes += 1 if args.first == url_cache_key
+          original.call(*args, **kwargs)
+        end
+
+        # The cache holds the raw storage URL; avatar_url serves it through the CDN.
+        expect(@user.reload.avatar_url).to include(cached_entry[:key])
+        expect(url_cache_writes).to eq(0)
+      end
     end
 
     describe "#avatar_variant" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -270,6 +270,17 @@ describe User, :vcr do
         variant = @user.avatar.variant(resize_to_limit: [256, 256]).processed.key
         expect(@user.resized_avatar_url(size: 256)).to match("https://public-files.gumroad.com/#{variant}")
       end
+
+      it "regenerates the resized avatar when its file is gone from storage" do
+        orphaned_key = @user.avatar.variant(resize_to_limit: [256, 256]).processed.key
+        @user.avatar.blob.service.delete(orphaned_key)
+
+        url = @user.reload.resized_avatar_url(size: 256)
+
+        expect(url).not_to include(orphaned_key)
+        expect(url).to start_with("https://public-files.gumroad.com/")
+        expect(@user.avatar.blob.service.exist?(url.split("/").last)).to be(true)
+      end
     end
 
     describe "#avatar_url" do
@@ -282,13 +293,55 @@ describe User, :vcr do
       end
 
       it "caches the variant URL under a versioned key so previously cached 128px URLs are not reused" do
-        # The old, unversioned cache key holds URLs for the smaller 128x128
-        # variants we used to serve. A stale value there must not leak into
-        # what we serve now — only the "_v2" key should be read.
+        # The older cache keys hold URLs for the smaller 128x128 variants we
+        # used to serve, and for variants written before we checked that the
+        # resized file still existed. A stale value there must not leak into
+        # what we serve now — only the newest key should be read.
         Rails.cache.write("attachment_#{@user.avatar.id}_variant_url", "https://example.com/stale-128px-url")
+        Rails.cache.write("attachment_#{@user.avatar.id}_variant_url_v2", "https://example.com/stale-unchecked-url")
 
         expect(@user.avatar_url).not_to include("stale-128px-url")
-        expect(Rails.cache.read("attachment_#{@user.avatar.id}_variant_url_v2")).to eq(@user.avatar_variant.url)
+        expect(@user.avatar_url).not_to include("stale-unchecked-url")
+        expect(Rails.cache.read("attachment_#{@user.avatar.id}_variant_url_v3")).to eq(@user.avatar_variant.url)
+      end
+
+      it "regenerates the resized avatar and serves a working URL when its file is gone from storage" do
+        # Active Storage treats a variant as processed as soon as its database
+        # row exists, so without the storage check this would serve a URL for a
+        # file that is no longer there — a 403 for the seller, forever.
+        orphaned = @user.avatar.variant(resize_to_limit: [400, 400]).processed
+        orphaned_key = orphaned.key
+        orphaned_record_id = orphaned.image.record.id
+        @user.avatar.blob.service.delete(orphaned_key)
+
+        url = @user.reload.avatar_url
+
+        expect(ActiveStorage::VariantRecord.where(id: orphaned_record_id)).not_to exist
+        expect(url).not_to include(orphaned_key)
+        rebuilt_key = @user.reload.avatar_variant.key
+        expect(url).to eq("https://public-files.gumroad.com/#{rebuilt_key}")
+        expect(@user.avatar.blob.service.exist?(rebuilt_key)).to be(true)
+      end
+
+      it "does not cache a blank URL" do
+        # A blank URL means we could not work out where the variant lives right
+        # now. Caching it would leave the seller with no picture until the entry
+        # expired, so we fall back to the original upload and try again later.
+        allow(@user).to receive(:avatar_variant).and_return(nil)
+
+        expect(@user.avatar_url).to eq(@user.avatar.url)
+        expect(Rails.cache.read("attachment_#{@user.avatar.id}_variant_url_v3")).to be_nil
+      end
+
+      it "keeps serving the existing URL when the storage lookup itself fails" do
+        # A failed lookup is not evidence the file is gone, and regenerating
+        # every avatar because storage was briefly unreachable would be worse
+        # than serving the URL we already have.
+        variant_key = @user.avatar_variant.key
+        Rails.cache.clear
+        allow_any_instance_of(ActiveStorage::Service::S3Service).to receive(:exist?).and_raise(Aws::S3::Errors::ServiceError.new(nil, "boom"))
+
+        expect(@user.reload.avatar_url).to eq("https://public-files.gumroad.com/#{variant_key}")
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -386,6 +386,41 @@ describe User, :vcr do
         expect(url).to eq("https://public-files.gumroad.com/#{rebuilt_key}")
         expect(@user.avatar.blob.service.exist?(rebuilt_key)).to be(true)
       end
+
+      it "heals a variant that disappeared while it was cached as present, once that entry expires" do
+        # Checking storage on every read is not affordable on pages that show
+        # many sellers, so a confirmation is remembered for a few minutes and a
+        # variant that vanishes inside that window keeps being served. This
+        # pins how long that can last: once the confirmation expires the next
+        # read notices the file is gone and rebuilds the avatar, without having
+        # to wait for the much longer URL entry to expire.
+        stale_url = @user.avatar_url
+        stale_key = @user.reload.avatar_variant.key
+        expect(stale_url).to include(stale_key)
+
+        @user.avatar.blob.service.delete(stale_key)
+
+        # Still inside the confirmation window: the dead URL is served.
+        expect(@user.reload.avatar_url).to eq(stale_url)
+
+        travel_to(User::AVATAR_VARIANT_PRESENCE_CACHE_TTL.from_now + 1.second) do
+          url = @user.reload.avatar_url
+
+          expect(url).not_to include(stale_key)
+          rebuilt_key = @user.reload.avatar_variant.key
+          expect(url).to eq("https://public-files.gumroad.com/#{rebuilt_key}")
+          expect(@user.avatar.blob.service.exist?(rebuilt_key)).to be(true)
+        end
+      end
+
+      it "bounds how long a broken avatar is served to minutes, not the URL cache lifetime" do
+        # The confirmation window is the worst case for a seller whose variant
+        # disappears, so it must stay far below the day-long URL cache. If
+        # someone lengthens it, this fails rather than quietly restoring the
+        # hours-long outage the storage check was added to remove.
+        expect(User::AVATAR_VARIANT_PRESENCE_CACHE_TTL).to be <= 5.minutes
+        expect(User::AVATAR_VARIANT_PRESENCE_CACHE_TTL).to be < User::AVATAR_VARIANT_URL_CACHE_TTL
+      end
     end
 
     describe "#avatar_variant" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -302,7 +302,31 @@ describe User, :vcr do
 
         expect(@user.avatar_url).not_to include("stale-128px-url")
         expect(@user.avatar_url).not_to include("stale-unchecked-url")
-        expect(Rails.cache.read("attachment_#{@user.avatar.id}_variant_url_v3")).to eq(@user.avatar_variant.url)
+        expect(Rails.cache.read("attachment_#{@user.avatar.id}_variant_url_v3")).to eq(
+          { url: @user.avatar_variant.url, key: @user.avatar_variant.key }
+        )
+      end
+
+      it "regenerates the avatar when the file behind an already cached URL disappears" do
+        # The cached URL is served for a day, so a variant that vanishes after
+        # the entry is written must not keep being handed out for the rest of
+        # that day. The variant's storage key is cached next to the URL so
+        # every cache hit can confirm the file is still there.
+        stale_url = @user.avatar_url
+        stale_key = @user.reload.avatar_variant.key
+        expect(stale_url).to include(stale_key)
+
+        @user.avatar.blob.service.delete(stale_key)
+        # Clear only the presence shortcut: the URL entry stays, which is
+        # exactly the situation being tested.
+        Rails.cache.delete("active_storage_variant_present_#{stale_key}")
+
+        url = @user.reload.avatar_url
+
+        expect(url).not_to include(stale_key)
+        rebuilt_key = @user.reload.avatar_variant.key
+        expect(url).to eq("https://public-files.gumroad.com/#{rebuilt_key}")
+        expect(@user.avatar.blob.service.exist?(rebuilt_key)).to be(true)
       end
 
       it "regenerates the resized avatar and serves a working URL when its file is gone from storage" do


### PR DESCRIPTION
## The symptom

A seller reported their profile picture missing everywhere — product page, storefront, dashboard — on an account that looked correctly configured. The avatar URL we served returned **403, permanently**.

## Why it happens

`ActiveStorage::VariantWithRecord#processed?` is literally `record.present?`. Active Storage decides a variant is "already processed" from the presence of an `active_storage_variant_records` row — it never asks storage whether the resized file is still there.

So when a variant's file disappears but its row survives:

1. `.processed` returns immediately without re-processing.
2. `.url` builds a valid-looking URL for the dead key.
3. **Nothing raises**, so the `rescue` fallbacks in the avatar methods never run — even though the *original* upload was intact and would have rendered fine.
4. `avatar_url` then memoized that dead URL, so it outlived any cache churn.

## Blast radius

The affected seller cannot tell this is our bug rather than their upload having failed, so most never report it. Scanning sellers who made a successful sale in the last 24 hours: **roughly 3–4% of those with an avatar are in this state** — about 400 sellers in that cohort alone, discovered from one report. The platform-wide number is larger, since that cohort is only sellers who sold in a single day.

## The fix (read path)

- **`stored_avatar_variant`** confirms the resized file is really in storage before the URL is handed out. When it's gone, the stale row is destroyed and the variant is resized again from the original. The blob's loaded `variant_records` association is reset first, or the next lookup short-circuits on the row we just deleted.
- **A failed storage lookup is treated as "present."** A lookup that itself errored is not evidence the file is gone, and regenerating every avatar because storage was briefly unreachable would be far worse than serving the URL we already have.
- **Only confirmations are cached, never absences** — a normal page view doesn't pay for a storage lookup, while a repaired avatar appears immediately. `avatar_url` is called once per person on pages that list many sellers (profiles, review lists, community threads), so a storage call on every read isn't affordable and this entry is what keeps the check cheap.
- **That presence entry is the ceiling on how long a broken avatar can be served, so it's five minutes.** While it says "present", a variant that has since disappeared keeps being handed out. The entry is shared through memcached and keyed on the variant's storage key, so shortening it costs at most one storage lookup per variant per window across the fleet, while dropping the worst case for a seller from most of an afternoon to a few minutes.
- **A cached avatar URL is only served while its file is still there.** The variant's storage key is cached alongside the URL and checked on every cache hit; a hit whose file has gone falls through to the same regenerate-from-original path as a cold miss. Without this, a variant that disappeared just after its URL was written kept 403ing for the rest of the day.
- **`avatar_url` no longer caches a blank value.** `Rails.cache.fetch` happily memoizes `""`, which left sellers with no picture until the entry expired and no way to fix it. A blank result now falls back to the original upload and retries on the next read.
- **Cached URLs now expire** (one day) rather than living forever, bounding how long any single entry can outlive the file behind it.
- **Cache key moves to `_v3`**, abandoning entries written before this check existed — same lazy regeneration the `_v2` bump used, no backfill needed for the read path.
- **`resized_avatar_url` gets the same treatment**; it had the identical blind spot.

## Tests

Eight specs, one per way this failed:

| spec | asserts |
|---|---|
| missing file on `avatar_url` | stale row destroyed, working URL served |
| missing file on `resized_avatar_url` | same, on the sized path |
| file disappears *after* the URL was cached | cache hit re-checks storage, regenerates |
| file disappears after presence was confirmed | write path ignores the presence shortcut |
| file disappears *inside* the presence window | dead URL served until the entry expires, then the next read heals it — without waiting on the day-long URL entry |
| presence TTL | stays at or below five minutes and strictly below the URL cache, so lengthening it fails loudly |
| blank URL | never cached; falls back to original |
| storage lookup raises | keeps serving the current URL |

**Verified red-first:** each guard was removed in turn with the specs kept, and the matching spec fails (e.g. dropping the cache-hit storage check fails with `Expected "https://public-files.gumroad.com/<key>" not to include "<key>"`). All **28 avatar examples green** with the fix in place. Rubocop clean. Rebased on current `main`.

## Deliberately not in this PR

**Bulk remediation of the ~400+ sellers already in this state.** It runs *after* this merges, so healed avatars aren't re-poisoned by the old caching behaviour. Note for that backfill: purging a stale variant and re-reading in the *same* process returns an empty string (the in-memory attachment association is stale) — it needs `User.find(id)` to reload. This PR's no-blank-caching change also removes the trap.

---

**AI disclosure:** authored by Gumclaw (claude-opus-5) from a support ticket investigation.

