### PR TITLE
Teach the store agent valid email audience values

### DIFF
--- a/app/services/ai/store_agent_api_catalog.rb
+++ b/app/services/ai/store_agent_api_catalog.rb
@@ -181,7 +181,7 @@ module Ai::StoreAgentApiCatalog
     # edit_emails too (not view_sales) to match the real contract.
     ep("list_emails", :get, "/emails", "List the creator's email posts. Returns 10 per page; when the response includes next_page_key, pass it back as page_key to fetch the next page.", read: true, scope: "edit_emails", params: %w[page_key]),
     ep("get_email", :get, "/emails/:id", "Get one email post.", read: true, scope: "edit_emails", path_params: %w[id]),
-    ep("create_email", :post, "/emails", "Draft a new email post to subscribers/customers.", scope: "edit_emails", params: %w[subject body audience product_id link_id publish draft]),
+    ep("create_email", :post, "/emails", "Draft a new email post to subscribers/customers. audience must be one of: all, audience, customers, seller, followers, follower, product. Use product only with product_id/link_id.", scope: "edit_emails", params: %w[subject body audience product_id link_id publish draft]),
     ep("preview_email", :post, "/emails/:id/preview", "Send a preview of an email to the creator.", scope: "edit_emails", path_params: %w[id]),
     ep("send_email", :post, "/emails/:id/send", "Send an email post to its audience.", scope: "edit_emails", path_params: %w[id]),
     ep("delete_email", :delete, "/emails/:id", "Delete an email post.", scope: "edit_emails", path_params: %w[id]),

--- a/spec/services/ai/store_agent_api_catalog_spec.rb
+++ b/spec/services/ai/store_agent_api_catalog_spec.rb
@@ -53,6 +53,15 @@ describe Ai::StoreAgentApiCatalog do
     end
   end
 
+  describe ".manifest" do
+    it "lists the allowed create_email audience values before the model proposes the write" do
+      manifest = described_class.manifest(:write)
+
+      expect(manifest).to include("create_email")
+      expect(manifest).to include("audience must be one of: all, audience, customers, seller, followers, follower, product")
+    end
+  end
+
   describe "profile custom HTML endpoints" do
     it "exposes a targeted-edit write so an existing page never has to be fully regenerated" do
       endpoint = described_class.find("edit_user_custom_html")


### PR DESCRIPTION
## What

Adds the allowed `create_email` audience values directly to the store-agent API catalog manifest:

`all`, `audience`, `customers`, `seller`, `followers`, `follower`, `product`

The manifest is the text the model reads before proposing an `api_write`, so the model no longer has to infer the enum from the param name alone.

## Why

The new confirm-action telemetry from #6296/#6318 made the 422 bucket separable. On 07-26, `create_email` produced 10 identical confirm rejections:

> Invalid audience. Valid values are: all, audience, customers, seller, followers, follower, product.

That is a proposal-quality failure, not a confirm-path failure: the API already knows the enum, but the tool manifest only said `audience` was an accepted param. This PR puts the enum at the point where the model chooses the write payload.

## Before / After

No UI change. This changes only the agent's endpoint manifest.

Before: `create_email` listed `audience` as a param but did not tell the model which values the API accepts.

After: the `create_email` manifest states the exact allowed values and notes that `product` should be used only with `product_id`/`link_id`.

## QA steps

1. Inspect `Ai::StoreAgentApiCatalog.manifest(:write)`.
2. Confirm the `create_email` line includes the allowed audience values.
3. Confirm the API catalog spec pins the manifest text.

## Test Results

```
bundle exec rubocop -a app/services/ai/store_agent_api_catalog.rb spec/services/ai/store_agent_api_catalog_spec.rb
# 2 files inspected, no offenses detected

DISABLE_SPRING=1 bundle exec rspec spec/services/ai/store_agent_api_catalog_spec.rb
# 23 examples, 0 failures
```

Backend-only / prompt-manifest-only change; no rendered UI surface to screenshot.

---

Written with AI assistance using claude-opus-5. The model was asked to follow up on the post-deploy confirm-action failure breakdown from gp#1341, identify the self-contained `create_email` invalid-audience fix, and implement and test the catalog change.
