### PR TITLE
Send affiliate workflow emails when purchase filters are also set

### DIFF
--- a/app/models/audience_member.rb
+++ b/app/models/audience_member.rb
@@ -159,6 +159,24 @@ class AudienceMember < ApplicationRecord
         ))
       SQL
       json_filter = json_filter.joins("INNER JOIN #{json_table} AS jt")
+      # MySQL expands sibling JSON_TABLE paths into disjoint rows. A purchase predicate keeps
+      # only purchase rows, and an affiliate-product predicate keeps only affiliate rows; asking
+      # one `jt` row to satisfy both made affiliate posts with purchase filters resolve nobody.
+      # For affiliate posts, keep purchase predicates on `jt` and read affiliate identity from a
+      # second expansion (`affiliate_jt`) that is filtered only by affiliate-specific constraints.
+      if params[:type] == "affiliate"
+        affiliate_json_table = <<~SQL.squish
+          JSON_TABLE(details, '$.affiliates[*]' COLUMNS (
+            affiliate_id INT PATH '$.id',
+            affiliate_product_id INT PATH '$.product_id',
+            affiliate_created_at DATETIME PATH '$.created_at'
+          ))
+        SQL
+        json_filter = json_filter.joins("INNER JOIN #{affiliate_json_table} AS affiliate_jt")
+        json_filter = json_filter.where("affiliate_jt.affiliate_product_id IN (?)", params[:affiliate_product_ids]) if params[:affiliate_product_ids]
+        json_filter = json_filter.where("affiliate_jt.affiliate_created_at > ?", params[:created_after]) if params[:created_after]
+        json_filter = json_filter.where("affiliate_jt.affiliate_created_at < ?", params[:created_before]) if params[:created_before]
+      end
       json_filter = json_filter.where("jt.purchase_price_cents > ?", params[:paid_more_than_cents]) if params[:paid_more_than_cents]
       json_filter = json_filter.where("jt.purchase_price_cents < ?", params[:paid_less_than_cents]) if params[:paid_less_than_cents]
       if params[:active_customers_only]
@@ -188,15 +206,15 @@ class AudienceMember < ApplicationRecord
           %w[follower_created_at]
         end
       elsif params[:type] == "affiliate"
-        %w[affiliate_created_at]
+        []
       else
         %w[purchase_created_at follower_created_at affiliate_created_at]
       end
-      if params[:created_after]
+      if params[:created_after] && timestamp_columns.any?
         where_conditions = timestamp_columns.map { "jt.#{_1} > :date" }.join(" OR ")
         json_filter = json_filter.where(where_conditions, date: params[:created_after])
       end
-      if params[:created_before]
+      if params[:created_before] && timestamp_columns.any?
         where_conditions = timestamp_columns.map { "jt.#{_1} < :date" }.join(" OR ")
         json_filter = json_filter.where(where_conditions, date: params[:created_before])
       end
@@ -206,7 +224,7 @@ class AudienceMember < ApplicationRecord
         json_filter = json_filter.where("jt.purchase_product_id IN (?)", params[:bought_product_ids]) if params[:bought_product_ids]
         json_filter = json_filter.where("jt.purchase_variant_id IN (?)", params[:bought_variant_ids]) if params[:bought_variant_ids]
       end
-      if params[:affiliate_product_ids]
+      if params[:affiliate_product_ids] && params[:type] != "affiliate"
         json_filter = json_filter.where("jt.affiliate_product_id IN (?)", params[:affiliate_product_ids])
       end
       # COLLATE makes this binary-exact like the JSON_CONTAINS country subquery above and the
@@ -236,7 +254,12 @@ class AudienceMember < ApplicationRecord
         else
           "jt.follower_id"
         end
-        json_filter = json_filter.select("audience_members.*, max(jt.purchase_id) AS purchase_id, #{follower_id_select} AS follower_id, max(jt.affiliate_id) AS affiliate_id")
+        affiliate_id_select = if params[:type] == "affiliate"
+          "max(affiliate_jt.affiliate_id)"
+        else
+          "max(jt.affiliate_id)"
+        end
+        json_filter = json_filter.select("audience_members.*, max(jt.purchase_id) AS purchase_id, #{follower_id_select} AS follower_id, #{affiliate_id_select} AS affiliate_id")
         json_filter_sql = json_filter.to_sql
       elsif json_filter.where_clause.present?
         json_filter_sql = json_filter.to_sql

--- a/spec/sidekiq/send_workflow_post_emails_job_spec.rb
+++ b/spec/sidekiq/send_workflow_post_emails_job_spec.rb
@@ -145,6 +145,19 @@ describe SendWorkflowPostEmailsJob, :freeze_time do
         expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(@post.id, @post_rule.version, nil, nil, @affiliates[0].affiliate_user_id).at(20.hours.from_now)
       end
 
+      it "when affiliate_type? is true and a bought-product filter is set, it still resolves the matching affiliate" do
+        create(:purchase, link: @products[0], email: @affiliates[0].affiliate_user.email, created_at: 2.hours.ago)
+        @post.update!(installment_type: Installment::AFFILIATE_TYPE, affiliate_products: [@products[0].unique_permalink], bought_products: [@products[0].unique_permalink])
+
+        member = AudienceMember.filter(seller_id: @post.seller_id, params: @post.audience_members_filter_params, with_ids: true).sole
+        expect(member.affiliate_id).to eq(@affiliates[0].id)
+
+        described_class.new.perform(@post.id)
+
+        expect(SendWorkflowInstallmentWorker.jobs.size).to eq(1)
+        expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(@post.id, @post_rule.version, nil, nil, @affiliates[0].affiliate_user_id).at(20.hours.from_now)
+      end
+
       it "enqueues an affiliate id the worker can actually resolve to a user" do
         @post.update!(installment_type: Installment::AFFILIATE_TYPE, affiliate_products: [@products[0].unique_permalink])
         described_class.new.perform(@post.id)


### PR DESCRIPTION
## What

Affiliate-type workflow posts can be scoped both to affiliates of specific products and to audience members who also bought something. That combination resolved **zero recipients** and silently sent nothing.

This fixes the SQL shape so the audience member can satisfy both facts without requiring them to be true on the same expanded JSON row.

## Why

Tracking issue: antiwork/gumroad-private#1381

The filter used one `JSON_TABLE` alias for sibling paths:

```sql
jt.affiliate_product_id IN (...)
jt.purchase_product_id IN (...)
```

But MySQL expands sibling paths in `JSON_TABLE` into **disjoint rows**:

- affiliate rows have `NULL` purchase columns
- purchase rows have `NULL` affiliate columns

So no row can satisfy both predicates. The query drops every otherwise-eligible member before the send job even sees them.

## Fix

For affiliate posts, keep purchase predicates on the existing `jt` alias and add a second `JSON_TABLE` expansion, `affiliate_jt`, filtered only by affiliate-specific constraints. The query now proves both facts about the same audience member without forcing them onto the same JSON_TABLE row.

This matters for both workflows and blasts:

- workflows later translate the resolved `DirectAffiliate` id to `affiliate_user_id`
- blasts consume `member.affiliate_id` directly, so the fix has to live in `AudienceMember.filter`, not just in the workflow fallback

## Verification

- `bundle exec rubocop app/models/audience_member.rb spec/sidekiq/send_workflow_post_emails_job_spec.rb` — no offenses
- `bundle exec rspec spec/sidekiq/send_workflow_post_emails_job_spec.rb` — 16 examples, 0 failures

Red-first mutation:

- Reverting only `app/models/audience_member.rb` while keeping the new spec makes the regression fail with `ActiveRecord::RecordNotFound` at the query line — the audience is empty, which is the production failure.

Broader local checks:

- `spec/sidekiq/send_post_blast_emails_job_spec.rb` is blocked locally by the existing Vite test-manifest/node_modules problem (`Vite Ruby can't find entrypoints/email.ts`). The same class of failure happens on origin/main before this change.
- `spec/models/concerns/audience_member/searchable_spec.rb:324` fails on origin/main before this change (`Expected 0 to eq 1`), so it is unrelated.

No UI surface changes; this is background email recipient resolution.

---

AI disclosure: written by Gumclaw (claude-opus-5) as an urgent follow-up to the workflow-recipient fix.
