### PR TITLE
Pin the chargeback date in the refund-cutover spec instead of using Time.current

### DIFF
--- a/spec/models/concerns/purchase/reportable_spec.rb
+++ b/spec/models/concerns/purchase/reportable_spec.rb
@@ -162,7 +162,14 @@ describe Purchase::Reportable do
       end
 
       it "returns 0 (chargeback attribution is unchanged by the refund cutover)" do
-        purchase.update!(chargeback_date: Time.current)
+        # This example is about the REFUND cutover leaving legacy chargeback handling alone, so
+        # the chargeback has to stay on the legacy path. That path is selected by comparing
+        # chargeback_date against CHARGEBACK_REPORTING_CUTOVER, a fixed calendar date. Using
+        # Time.current here silently changed the case under test the moment the wall clock
+        # reached that date: the chargeback became event-dated, which reports the sale gross
+        # (100) rather than zeroing it, and the example started failing on every branch.
+        # Pin the date before the chargeback cutover so the legacy path is chosen explicitly.
+        purchase.update!(chargeback_date: Purchase::Reportable::CHARGEBACK_REPORTING_CUTOVER.beginning_of_day - 1.day)
 
         expect(purchase.price_cents_for_tax_reporting).to eq(0)
       end


### PR DESCRIPTION
A spec in `spec/models/concerns/purchase/reportable_spec.rb` started failing on every open PR at midnight UTC on 27 July 2026. It is unrelated to any of those PRs.

## The failure

```
Purchase::Reportable#price_cents_for_tax_reporting when the purchase is chargedback and not reversed
  returns 0 (chargeback attribution is unchanged by the refund cutover)
  expected: 0
       got: 100
```

## Why it started now

`CHARGEBACK_REPORTING_CUTOVER` is the fixed calendar date `Date.new(2026, 7, 27)`.

The example asserts the *legacy* chargeback treatment, where a lost chargeback zeroes the sale's reported amounts. `tax_reporting_cents` only takes that path when `chargeback_event_dated_for_tax_reporting?` is false, and that method returns false only when `chargeback_date` is before the cutover.

The example set `chargeback_date: Time.current`. Before 27 July that was pre-cutover and the legacy path ran, giving 0. From 00:00 UTC on 27 July `Time.current` is on/after the cutover, so the chargeback became event-dated — the sale is reported gross with the clawback as a separate negative leg — and the method correctly returns 100.

So the assertion silently changed which branch it was exercising as the wall clock moved.

## The fix

Pin `chargeback_date` to one day before `CHARGEBACK_REPORTING_CUTOVER` so the example keeps testing the legacy path it was written for.

Production behaviour is correct and unchanged; this only removes a wall-clock dependency from a test fixture. The nearby `Time.current` on line 17 is left alone — it exercises `price_cents_net_of_refunds`, which does not consult either cutover.

## Verification

Red-first was confirmed from CI rather than locally: the same example fails identically on unrelated PRs #6362 (`b9ffe382c`) and #6364 (`24f089049`), neither of which touches this spec, this concern, or anything tax-related. Both branches show it as their only test failure across otherwise-clean shards. Once this lands, those PRs should go green without changes of their own.

Note that `main`'s own recent CI runs only executed report jobs, not test shards, which is why this landed unnoticed on main and only surfaced on PR branches.