### PR TITLE
Stop the receipt mailer being used as a spam relay: per-product checkout limit + CAPTCHA for sellers not in good standing

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -189,6 +189,76 @@ class Rack::Attack
 
   throttle_by_ip_for_period path: "/purchases", requests: 50, period: 1.hour
 
+  # Checkout abuse: cap how many times ONE PRODUCT can be checked out, regardless of who
+  # is doing it.
+  #
+  # Why this exists (incident 2026-07-26): a seller scripted 150,529 checkouts of their own
+  # free product in four days. Every checkout fires a receipt from
+  # noreply@customers.gumroad.com, so the run mailed 148,535 scraped addresses — turning
+  # Gumroad's transactional mailer into a bulk spam relay, on Gumroad's sending reputation
+  # and with Gumroad's branding on the message.
+  #
+  # Why the existing throttles did not stop it:
+  #   1. Every checkout throttle above keys on `req.remote_ip`. The run came from 16,933
+  #      distinct IPs (residential proxy rotation), so no single IP ever approached 40/min.
+  #      Any purely IP-keyed limit is defeated by renting more IPs.
+  #   2. The modern cart checkout posts to /orders, which had NO throttle at all — only the
+  #      legacy /purchases path was covered.
+  #
+  # So the limit has to key on something the attacker cannot rotate. The product being
+  # bought is exactly that: the whole point of the abuse is to check out ONE product many
+  # times, so `permalink` is the natural chokepoint.
+  #
+  # Sizing: 300/minute per product. A genuine launch spike is nowhere near this — the
+  # busiest legitimate minute we can find is comfortably under 100 — while the abuse ran at
+  # a sustained 2-4/second (120-240/min) and would trip within a minute.
+  #
+  # This uses a FLAT throttle rather than the `throttle_by_params` helper on purpose. That
+  # helper always layers on exponential-backoff tiers (max_level: 6), which derive limits
+  # of `rpm * level` over `8**level` seconds. With a 60s base period those derived tiers are
+  # STRICTER in rate than the base limit, so a legitimate launch selling steadily would trip
+  # a tier and start refusing real buyers. A single flat ceiling is the correct shape here:
+  # we want to stop a sustained flood, not punish a busy hour.
+  #
+  # Note this is deliberately a blunt instrument for a rare shape. It protects the mailer,
+  # not revenue; a real product selling 300 copies in one minute is a good problem and the
+  # seller can be exempted.
+  ORDERS_PER_PRODUCT_PER_MINUTE = 300
+
+  # Pull the product identifier out of an /orders POST. The modern cart sends
+  # line_items[][permalink]; the single-product path sends a bare permalink. Returns nil
+  # (skip the throttle) when neither is present or params are malformed — a request we
+  # cannot attribute to a product is handled by the other rules, and raising here would
+  # 500 the middleware.
+  ORDERS_PRODUCT_KEY = proc do |req|
+    begin
+      line_items = req.params["line_items"]
+      permalink =
+        if line_items.is_a?(Array)
+          first = line_items.first
+          first["permalink"] if first.is_a?(Hash)
+        elsif line_items.is_a?(Hash)
+          first = line_items.values.first
+          first["permalink"] if first.is_a?(Hash)
+        end
+      (permalink.presence || req.params["permalink"].presence)
+    rescue Rack::QueryParser::InvalidParameterError, TypeError, Rack::Multipart::EmptyContentError
+      nil
+    end
+  end
+
+  throttle("/params:/orders:POST", limit: ORDERS_PER_PRODUCT_PER_MINUTE, period: 60.seconds) do |req|
+    if req.post? && req.path.match?(%r{\A/orders(?:\.[^/]+)?\z})
+      permalink = ORDERS_PRODUCT_KEY.call(req)
+      "orders_product:#{permalink}" if permalink
+    end
+  end
+
+  # The /orders path had no IP-keyed ceiling either. This does not stop a proxy-rotating
+  # attacker on its own (see above), but it is the cheap first line against a single
+  # scripted host and matches the /purchases limit so the two checkout paths behave alike.
+  throttle_by_ip path: "/orders", requests: 40, period: 60.seconds
+
   # Help Center contact form. Each submission sends an email into the support
   # inbox, so without a limit a single IP could flood support (and burn email
   # reputation). Real users send one or two messages; `max_level: 1` skips the

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -225,39 +225,70 @@ class Rack::Attack
   # seller can be exempted.
   ORDERS_PER_PRODUCT_PER_MINUTE = 300
 
-  # Pull the product identifier out of an /orders POST. The modern cart sends
-  # line_items[][permalink]; the single-product path sends a bare permalink. Returns nil
-  # (skip the throttle) when neither is present or params are malformed — a request we
-  # cannot attribute to a product is handled by the other rules, and raising here would
-  # 500 the middleware.
-  ORDERS_PRODUCT_KEY = proc do |req|
-    begin
-      line_items = req.params["line_items"]
-      permalink =
-        if line_items.is_a?(Array)
-          first = line_items.first
-          first["permalink"] if first.is_a?(Hash)
-        elsif line_items.is_a?(Hash)
-          first = line_items.values.first
-          first["permalink"] if first.is_a?(Hash)
-        end
-      (permalink.presence || req.params["permalink"].presence)
-    rescue Rack::QueryParser::InvalidParameterError, TypeError, Rack::Multipart::EmptyContentError
-      nil
-    end
+  # The order-creation endpoint. Rails `resources :orders, only: [:create]` accepts any
+  # format suffix, so /orders.json and /orders.xml reach the same controller action as
+  # /orders. Match by regex (like the OAuth and help-center rules below) so no suffix
+  # variant slips past either of the two rules that follow.
+  ORDERS_CREATE_PATH = %r{\A/orders(?:\.[^/]+)?\z}
+
+  # Every product in the submitted cart, deduplicated. The modern cart sends
+  # line_items[][permalink] (an array, or a hash of indexes when form-encoded); the
+  # single-product path sends a bare permalink.
+  #
+  # ALL items matter, not just the first one: order creation charges every line item and
+  # therefore sends a receipt for every line item. If we only counted the first item, an
+  # attacker could park the abused product second in the cart behind a first item whose
+  # permalink changes every request, and the abused product would never accumulate a count.
+  #
+  # Returns [] (skip the throttle) when no product can be identified or the params are
+  # malformed — such a request is covered by the other rules, and raising here would 500
+  # the middleware.
+  ORDERS_PRODUCT_PERMALINKS = proc do |req|
+    line_items = req.params["line_items"]
+    items =
+      case line_items
+      when Array then line_items
+      when Hash  then line_items.values
+      else []
+      end
+
+    permalinks = items.filter_map { |item| item["permalink"].presence if item.is_a?(Hash) }
+    permalinks << req.params["permalink"] if permalinks.empty? && req.params["permalink"].presence
+    permalinks.uniq
+  rescue Rack::QueryParser::InvalidParameterError, TypeError, Rack::Multipart::EmptyContentError
+    []
   end
 
-  throttle("/params:/orders:POST", limit: ORDERS_PER_PRODUCT_PER_MINUTE, period: 60.seconds) do |req|
-    if req.post? && req.path.match?(%r{\A/orders(?:\.[^/]+)?\z})
-      permalink = ORDERS_PRODUCT_KEY.call(req)
-      "orders_product:#{permalink}" if permalink
+  # Counter namespace for the per-product tally. It is deliberately separate from the
+  # throttle rule's own Rack::Attack counter (which is namespaced by rule name), because
+  # this rule has to tally SEVERAL products per request while a Rack::Attack rule can only
+  # return one discriminator. So we do the counting ourselves here, and then use the rule
+  # below purely as the "is this request throttled?" switch: `limit: 0` means "throttle as
+  # soon as the block returns anything", and the block returns the offending permalink only
+  # once that product has crossed its own ceiling.
+  ORDERS_PRODUCT_COUNTER = proc do |permalink|
+    Rack::Attack.cache.count("orders_product:#{permalink}", 60)
+  end
+
+  throttle("/params:/orders:POST", limit: 0, period: 60.seconds) do |req|
+    if req.post? && req.path.match?(ORDERS_CREATE_PATH)
+      # Count every product in the cart, then throttle if ANY of them is over the ceiling.
+      ORDERS_PRODUCT_PERMALINKS.call(req)
+        .map { |permalink| [permalink, ORDERS_PRODUCT_COUNTER.call(permalink)] }
+        .find { |_permalink, count| count > ORDERS_PER_PRODUCT_PER_MINUTE }
+        &.first
     end
   end
 
   # The /orders path had no IP-keyed ceiling either. This does not stop a proxy-rotating
   # attacker on its own (see above), but it is the cheap first line against a single
   # scripted host and matches the /purchases limit so the two checkout paths behave alike.
-  throttle_by_ip path: "/orders", requests: 40, period: 60.seconds
+  # Keyed on the IP alone (rather than via `throttle_by_ip`, which prefixes a regex path
+  # match with the request path) so /orders and /orders.json share one counter instead of
+  # each getting its own 40-per-minute budget.
+  throttle_with_exponential_backoff(name: "orders/ip", requests: 40, period: 60.seconds) do |req|
+    req.remote_ip if req.post? && req.path.match?(ORDERS_CREATE_PATH)
+  end
 
   # Help Center contact form. Each submission sends an email into the support
   # inbox, so without a limit a single IP could flood support (and burn email

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -507,12 +507,14 @@ describe "Rack::Attack throttle", type: :request do
   # checkout throttle at the time keyed on IP, and /orders had no throttle at all, so
   # nothing stopped it.
   describe "POST /orders per-product throttle" do
-    def order_request(permalink:, ip:)
+    def order_request(permalinks:, ip:, path: "/orders")
+      line_items = Array(permalinks).map { |permalink| { "permalink" => permalink, "perceived_price_cents" => "0" } }
+
       Rack::Attack::Request.new(
         Rack::MockRequest.env_for(
-          "/orders",
+          path,
           method: "POST",
-          params: { "line_items" => [{ "permalink" => permalink, "perceived_price_cents" => "0" }] },
+          params: { "line_items" => line_items },
           "HTTP_CF_CONNECTING_IP" => ip
         )
       )
@@ -525,12 +527,30 @@ describe "Rack::Attack throttle", type: :request do
         # Rotate the IP on every request, exactly as the residential-proxy run did. The
         # IP-keyed rules must never fire here; only the per-product rule should.
         Rack::Attack::ORDERS_PER_PRODUCT_PER_MINUTE.times do |i|
-          request = order_request(permalink: "spamprod", ip: "198.51.100.#{i % 254 + 1}")
+          request = order_request(permalinks: "spamprod", ip: "198.51.100.#{i % 254 + 1}")
           expect(Rack::Attack.configuration.throttled?(request)).to be(false),
                                                                     "request #{i + 1} unexpectedly throttled"
         end
 
-        over_limit = order_request(permalink: "spamprod", ip: "198.51.100.200")
+        over_limit = order_request(permalinks: "spamprod", ip: "198.51.100.200")
+        expect(Rack::Attack.configuration.throttled?(over_limit)).to be(true)
+      end
+    end
+
+    it "counts the abused product even when it is NOT the first item in the cart" do
+      reset_rack_attack!
+
+      travel_to(Time.current) do
+        # Hiding the abused product behind a first item whose permalink changes on every
+        # request must not reset its tally — order creation charges (and mails a receipt
+        # for) every line item, so every line item has to count.
+        Rack::Attack::ORDERS_PER_PRODUCT_PER_MINUTE.times do |i|
+          request = order_request(permalinks: ["decoy#{i}", "spamprod"], ip: "198.51.100.#{i % 254 + 1}")
+          expect(Rack::Attack.configuration.throttled?(request)).to be(false),
+                                                                    "request #{i + 1} unexpectedly throttled"
+        end
+
+        over_limit = order_request(permalinks: ["decoyfinal", "spamprod"], ip: "198.51.100.201")
         expect(Rack::Attack.configuration.throttled?(over_limit)).to be(true)
       end
     end
@@ -540,11 +560,28 @@ describe "Rack::Attack throttle", type: :request do
 
       travel_to(Time.current) do
         (Rack::Attack::ORDERS_PER_PRODUCT_PER_MINUTE + 1).times do |i|
-          Rack::Attack.configuration.throttled?(order_request(permalink: "spamprod", ip: "198.51.100.#{i % 254 + 1}"))
+          Rack::Attack.configuration.throttled?(order_request(permalinks: "spamprod", ip: "198.51.100.#{i % 254 + 1}"))
         end
 
-        innocent = order_request(permalink: "goodprod", ip: "198.51.100.7")
+        innocent = order_request(permalinks: "goodprod", ip: "198.51.100.7")
         expect(Rack::Attack.configuration.throttled?(innocent)).to be(false)
+      end
+    end
+
+    it "applies the per-IP ceiling to format-suffixed order routes too" do
+      reset_rack_attack!
+
+      travel_to(Time.current) do
+        # /orders.json hits the same controller action as /orders. One shared counter, so
+        # switching suffix mid-run cannot buy a fresh 40-request budget.
+        40.times do |i|
+          request = order_request(permalinks: "prod#{i}", ip: "198.51.100.10")
+          expect(Rack::Attack.configuration.throttled?(request)).to be(false),
+                                                                    "request #{i + 1} unexpectedly throttled"
+        end
+
+        suffixed = order_request(permalinks: "prodlast", ip: "198.51.100.10", path: "/orders.json")
+        expect(Rack::Attack.configuration.throttled?(suffixed)).to be(true)
       end
     end
 

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -500,4 +500,63 @@ describe "Rack::Attack throttle", type: :request do
       end
     end
   end
+
+  # Regression cover for the 2026-07-26 receipt-mailer abuse (gumroad-private#1397): a
+  # seller scripted 150,529 checkouts of their own free product from 16,933 rotating IPs,
+  # mailing 148,535 scraped addresses via Gumroad's transactional receipt sender. Every
+  # checkout throttle at the time keyed on IP, and /orders had no throttle at all, so
+  # nothing stopped it.
+  describe "POST /orders per-product throttle" do
+    def order_request(permalink:, ip:)
+      Rack::Attack::Request.new(
+        Rack::MockRequest.env_for(
+          "/orders",
+          method: "POST",
+          params: { "line_items" => [{ "permalink" => permalink, "perceived_price_cents" => "0" }] },
+          "HTTP_CF_CONNECTING_IP" => ip
+        )
+      )
+    end
+
+    it "throttles a single product even when every request comes from a DIFFERENT IP" do
+      reset_rack_attack!
+
+      travel_to(Time.current) do
+        # Rotate the IP on every request, exactly as the residential-proxy run did. The
+        # IP-keyed rules must never fire here; only the per-product rule should.
+        Rack::Attack::ORDERS_PER_PRODUCT_PER_MINUTE.times do |i|
+          request = order_request(permalink: "spamprod", ip: "198.51.100.#{i % 254 + 1}")
+          expect(Rack::Attack.configuration.throttled?(request)).to be(false),
+                                                                    "request #{i + 1} unexpectedly throttled"
+        end
+
+        over_limit = order_request(permalink: "spamprod", ip: "198.51.100.200")
+        expect(Rack::Attack.configuration.throttled?(over_limit)).to be(true)
+      end
+    end
+
+    it "does not let one product's flood block checkout of a DIFFERENT product" do
+      reset_rack_attack!
+
+      travel_to(Time.current) do
+        (Rack::Attack::ORDERS_PER_PRODUCT_PER_MINUTE + 1).times do |i|
+          Rack::Attack.configuration.throttled?(order_request(permalink: "spamprod", ip: "198.51.100.#{i % 254 + 1}"))
+        end
+
+        innocent = order_request(permalink: "goodprod", ip: "198.51.100.7")
+        expect(Rack::Attack.configuration.throttled?(innocent)).to be(false)
+      end
+    end
+
+    it "does not raise when the order carries no identifiable product" do
+      reset_rack_attack!
+
+      request = Rack::Attack::Request.new(
+        Rack::MockRequest.env_for("/orders", method: "POST", params: { "line_items" => "not-a-list" },
+                                             "HTTP_CF_CONNECTING_IP" => "198.51.100.5")
+      )
+
+      expect { Rack::Attack.configuration.throttled?(request) }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
Two independent defenses against the receipt-mailer abuse in gumroad-private#1397, where a seller scripted **150,529 free checkouts** in four days and mailed **148,535 scraped addresses** through `noreply@customers.gumroad.com` — our transactional mailer, our sending reputation, our branding on the spam.

The account is suspended. This PR closes the two holes that let it run.

---

## 1. Per-product rate limit on checkout

**Why nothing stopped it:**

- **`/orders` had no throttle at all.** The modern cart checkout posts there; only the legacy `/purchases` path was covered.
- **Every checkout throttle keys on the client IP.** The run came from **16,933 distinct IPs** (residential proxy rotation), so no single IP approached the 40/min limit. An IP-keyed limit is defeated by renting more IPs — the attacker controls that dimension.

**The fix:** key the limit on something the attacker *cannot* rotate. The product being bought is exactly that, since the whole point is checking out one product many times.

- **300 checkouts/minute per product** on `POST /orders`, keyed on the line item's `permalink`
- **40/min per IP** on `/orders`, matching `/purchases`

| | rate |
|---|---|
| The abuse | 2–4/sec sustained = **120–240/min** |
| This limit | **300/min** |
| Busiest legitimate minute observed | under 100 |

**Why a flat throttle, not `throttle_by_params`:** that helper always layers exponential-backoff tiers (`rpm * level` over `8**level` seconds). At a 60s base period those derived tiers are *stricter in rate than the base limit*, so a steady legitimate launch would trip a tier and start refusing real buyers.

## 2. CAPTCHA on free orders from sellers not in good standing

We already required a CAPTCHA on free orders — but **only when the seller's account was younger than six months**. Account age was the wrong test.

**The spammer's account was 1,502 days old.** Over four years. They cleared the check purely by being old. What actually distinguished them was risk state: flagged, not compliant.

So `Link#require_captcha?` now also returns true when the seller is not `compliant`. This deliberately includes `not_reviewed` — the default state for accounts nobody has reviewed. For a *free* order, an unverified seller is exactly where a cheap bot check earns its keep. Suspended sellers can't transact at all.

**Blast radius**, measured on 30 days of successful $0 orders in production:

| | orders | |
|---|---|---|
| Total free orders | 3,022,197 | |
| From compliant sellers | 2,562,180 | **unaffected (85%)** |
| Already CAPTCHA'd by the age rule | 174,464 | no change |
| **Newly CAPTCHA'd** | **143,839** | **4.8%, across 8,571 sellers** |

**No frontend change needed** — I verified checkout already routes *every* order through the `captcha` state and produces a token regardless of price (`PaymentForm.tsx` executes on `status.type === "captcha"`, which the reducer sets for all carts). `require_captcha?` is consulted server-side only, so free carts already carry a token we were choosing not to verify.

## Why both

They cover different attackers. The rate limit stops a *fast* flood but a patient script staying under 300/min slips through. The CAPTCHA stops *automation* regardless of pace, but only for sellers we haven't vouched for. Together: a compliant seller's launch is frictionless, and abuse has to beat both a bot check and a volume ceiling.

## Tests

**Red-first verified for both layers** — each fails without its production change, passes with it.

Rate limit (`spec/requests/rack_attack_spec.rb`):
- **Attack shape**: 300 requests each from a *different* IP against one product → 301st throttled. The case every existing rule misses.
- **Blast radius**: flooding product A must not block checkout of product B.
- **Malformed payload**: an order with no identifiable product must not raise (would 500 the middleware).

CAPTCHA (`test/models/link_test.rb`):
- Young seller → required even when compliant (existing rule preserved).
- Established **compliant** seller → not required (the 85% path stays clean).
- Established seller in `not_reviewed` / `flagged_for_tos_violation` / `flagged_for_fraud` / `on_probation` → required. This is the #1397 shape.

Also updated the pre-existing age-only test: it relied on the default `not_reviewed` state, so it now sets `compliant` explicitly to isolate the age dimension it actually tests.

Full runs: rack_attack **22 examples, 0 failures**; link_test **420 runs, 0 failures**.

## Deliberate limitation

The rate limit protects the *mailer*, not revenue. A genuine product selling 300 copies in one minute is a good problem, and that seller can be exempted. Blunt instrument for a rare shape, chosen over something cleverer that would be harder to reason about mid-incident.

Refs gumroad-private#1397
