### PR TITLE
Anchor the legacy-chargeback tax reporting spec to the cutover instead of the clock

### DIFF
--- a/spec/models/concerns/purchase/reportable_spec.rb
+++ b/spec/models/concerns/purchase/reportable_spec.rb
@@ -162,7 +162,12 @@ describe Purchase::Reportable do
       end
 
       it "returns 0 (chargeback attribution is unchanged by the refund cutover)" do
-        purchase.update!(chargeback_date: Time.current)
+        # Anchor the chargeback before CHARGEBACK_REPORTING_CUTOVER so it keeps the legacy
+        # treatment, which is what zeroes the sale's reported amounts here. Using Time.current
+        # instead would silently change what this example tests once the clock passes that
+        # cutover: the chargeback becomes event-dated, the sale stays reported at gross in its
+        # own period (the clawback is a separate negative leg), and the expectation below flips.
+        purchase.update!(chargeback_date: Purchase::Reportable::CHARGEBACK_REPORTING_CUTOVER.beginning_of_day - 1.day)
 
         expect(purchase.price_cents_for_tax_reporting).to eq(0)
       end


### PR DESCRIPTION
## What

Anchors one example in `spec/models/concerns/purchase/reportable_spec.rb` to `CHARGEBACK_REPORTING_CUTOVER` instead of `Time.current`.

## Why

This spec started failing at 00:00 UTC today on every open PR, on branches whose merge base is a green `main` and that touch nothing in the tax-reporting code. It is a time bomb, not a regression in any of those PRs.

The example is titled "when the purchase is chargedback and not reversed returns 0". Zeroing the sale's reported amounts is the **legacy** chargeback treatment, which `tax_reporting_cents` applies only when the chargeback is *not* event-dated:

```ruby
return 0 if chargedback_not_reversed? && !chargeback_event_dated_for_tax_reporting?
```

The example set `chargeback_date: Time.current`. `CHARGEBACK_REPORTING_CUTOVER` is `Date.new(2026, 7, 27)`, so as of midnight UTC today `Time.current` is on/after the cutover, the chargeback became event-dated, and the sale is now correctly reported at gross in its own period (the clawback is emitted as a separate negative leg). The method returned the gross `100`, so the assertion of `0` failed:

```
expected: 0
     got: 100
```

Setting the date one day before the cutover keeps the example exercising the legacy path its title describes, at any wall-clock time.

The rest of the file already anchors to the constant (`let(:cutover) { ...CHARGEBACK_REPORTING_CUTOVER.beginning_of_day }`, then `cutover - 1.day` / `cutover + 1.day`); this example was the one that read the clock. `Time.current` on line 17 is left alone — it covers `price_cents_net_of_refunds`, which has no cutover logic.

**Production is unaffected.** The cutover's deploy contract ("must be STRICTLY AFTER the day the change reaches production") held: production is on `b07bff773`, deployed 2026-07-26, and the cutover is 2026-07-27. This is purely a spec that read the clock.

## Test Results

Local runs of this spec file are not usable in my worktree: every example fails in the `:purchase` factory with `Validation failed: We couldn't charge your card`, including untouched examples such as line 122 that pass in CI. That is the local harness, not this diff, so CI on this branch is the authority.

I verified the root cause and the fix directly against the real method, bypassing the factory (`bundle exec rails runner`, `RAILS_ENV=test`, verbatim output):

```
cutover=2026-07-27 00:00:00 UTC  now=2026-07-27 00:46:01 UTC
OLD spec value (Time.current)      chargeback_date=2026-07-27 event_dated?=true  price_cents_for_tax_reporting=100
NEW spec value (cutover - 1.day)   chargeback_date=2026-07-26 event_dated?=false price_cents_for_tax_reporting=0
```

The old value reproduces CI's `got: 100` exactly; the new value produces the asserted `0`.

## Blast radius

`reportable_spec.rb:164` was the failing spec on PRs #6361, #6364, #6365 and #6362 — all with a green merge base and no tax-reporting changes. Each showed one real failure plus ~15 shards cancelled by fail-fast, which reads at a glance like a broad breakage.

I swept for siblings: `grep -rln "_for_tax_reporting\|for_tax_period_reporting\|chargeback_event_dated" spec/` returns only this file and `spec/sidekiq/generate_fees_by_creator_location_report_job_spec.rb`, and the latter already anchors to the constant. This was the only clock-dependent instance.

---

## AI disclosure

Written by claude-opus-5 running as the Gumroad agent. It was triaging a CI failure on an unrelated PR (#6362), traced the failure to this clock-dependent spec rather than that PR's diff, confirmed the same spec was red across four PRs with green merge bases, verified production's deploy contract was not violated, swept the spec suite for other clock-dependent cutover assertions, and verified the fix against the real method.
