### PR TITLE
Stop dating a chargeback spec off Time.current, which broke at the cutover

### DIFF
--- a/spec/models/concerns/purchase/reportable_spec.rb
+++ b/spec/models/concerns/purchase/reportable_spec.rb
@@ -162,7 +162,11 @@ describe Purchase::Reportable do
       end
 
       it "returns 0 (chargeback attribution is unchanged by the refund cutover)" do
-        purchase.update!(chargeback_date: Time.current)
+        # The point of this example is the REFUND cutover, so the chargeback has to stay on the
+        # legacy attribution path. Date it before the chargeback cutover explicitly: using
+        # Time.current made the example pass only while "now" happened to precede that date, and
+        # it started failing on its own the day the chargeback cutover arrived.
+        purchase.update!(chargeback_date: Purchase::Reportable::CHARGEBACK_REPORTING_CUTOVER.beginning_of_day - 1.day)
 
         expect(purchase.price_cents_for_tax_reporting).to eq(0)
       end


### PR DESCRIPTION
## What

`spec/models/concerns/purchase/reportable_spec.rb:164` sets its chargeback's date with `Time.current`. That example is about the **refund** cutover, so the chargeback has to stay on the legacy attribution path — but `Time.current` only kept it there while "now" happened to precede `Purchase::Reportable::CHARGEBACK_REPORTING_CUTOVER`, which is `Date.new(2026, 7, 27)`.

That date has now arrived. `chargeback_event_dated_for_tax_reporting?` returns false only when `chargeback_date < chargeback_reporting_cutover_time`, so as of today the purchase takes the event-dated path and `price_cents_for_tax_reporting` returns the gross amount instead of 0:

```
rspec ./spec/models/concerns/purchase/reportable_spec.rb:164
# Purchase::Reportable#price_cents_for_tax_reporting when the purchase is
#   chargedback and not reversed returns 0
expected: 0
     got: 100
```

The fix dates the chargeback off the constant (`CHARGEBACK_REPORTING_CUTOVER.beginning_of_day - 1.day`) the way every other cutover spec in the suite already does, so the example tests the refund cutover instead of today's date.

## Why

This fails on every branch, with no code change behind it — it is a date rolling over, not a regression. I hit it on an unrelated PR (#6365, a receipt tax-label wording change that does not touch this file at all: 0-line diff against `reportable.rb` and its spec, and no reference anywhere in them to anything that PR changes). The same failure will redden any run started from today onward, including main, so it is worth fixing on its own rather than inside whichever PR happens to notice it.

Every other spec that straddles this cutover — in `create_vat_report_job_spec.rb`, `generate_sales_report_job_spec.rb`, `create_global_sales_tax_summary_report_job_spec.rb`, `create_india_sales_report_job_spec.rb`, `generate_canada_sales_report_job_spec.rb`, `upload_us_states_sales_tax_to_taxjar_job_spec.rb`, `create_us_states_sales_summary_report_job_spec.rb`, `create_canada_monthly_sales_report_job_spec.rb`, `generate_fees_by_creator_location_report_job_spec.rb`, and elsewhere in this same file — already derives its dates from `CHARGEBACK_REPORTING_CUTOVER`. This one example was the outlier.

I swept the rest of the suite for the same shape (`chargeback_date: Time.current` / `Time.zone.now` / `DateTime.current`). The other hits are in specs that never reach the cutover branch — `review_reminder_job_spec`, `purchase_installments_spec`, `disputable_spec`, `blockable_spec`, `customer_presenter_spec` and friends — plus `reportable_spec.rb:17`, which asserts on `price_cents_net_of_refunds`, a method that does not consult the chargeback cutover at all. Those are safe and left alone.

## Before / After

Not applicable — test-only change, no user-visible surface. The behaviour under test is unchanged; only the date the fixture uses moves.

## Test Results

This spec file cannot be executed on my machine: every example in it dies in `create(:purchase)` with `Validation failed: We couldn't charge your card` (a local Stripe/environment limitation that also makes `charge_spec.rb` unrunnable here), on this branch and on unmodified `main` alike. I am not going to dress that up as a passing local run.

Instead I verified the actual predicate the fix turns on, through `bin/rails runner` against the test environment:

```
cutover=2026-07-27  today=2026-07-27
OLD spec value (Time.current)  >= cutover ? true   <- event-dated path, returns 100 (the failure)
NEW spec value (2026-07-26)    >= cutover ? false  <- legacy path, returns 0 (the expectation)
```

CI on this PR is the authoritative check that the example is green again.

---

## AI disclosure

Written by Hermes Agent running `claude-opus-5`.

Instructions given: while shipping an unrelated receipt tax-label fix, CI failed on a single spec twice in a row. The agent was asked to determine whether the failure belonged to that change or not; it traced the failure to this date-dependent fixture, confirmed the diff under review did not touch the file, verified the cutover arithmetic against the live constant, swept the suite for the same pattern, and opened this as a separate PR.
