### PR TITLE
Require a CAPTCHA on free checkouts when the seller is not in good standing

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -508,8 +508,36 @@ class Link < ApplicationRecord
   end
   alias_method :streamable, :streamable?
 
+  # Whether a $0 checkout of this product must still solve a CAPTCHA.
+  #
+  # Free checkouts are the cheapest thing to automate on Gumroad: there is no card to
+  # decline and no money at risk, but every completed checkout still sends a receipt from
+  # our transactional mailer. That makes a free product an attractive way to relay mail
+  # through Gumroad's sending reputation.
+  #
+  # Two independent reasons to require the check:
+  #
+  # 1. NEW SELLER. An account younger than REQUIRE_CAPTCHA_FOR_SELLERS_YOUNGER_THAN has no
+  #    track record, so we ask for the check by default.
+  #
+  # 2. SELLER IS NOT IN GOOD STANDING. Account age alone turned out to be the wrong test:
+  #    in July 2026 a seller whose account was over four years old scripted 150,529 free
+  #    checkouts of their own product in four days, mailing 148,535 scraped addresses
+  #    (gumroad-private#1397). They sailed past the age check purely by being old. What
+  #    actually distinguished them was risk state — they were flagged, not compliant.
+  #
+  #    So we also require the check whenever the seller is not `compliant`. Note that
+  #    `not_reviewed` is the DEFAULT state for the long tail of accounts that have simply
+  #    never been looked at, so this deliberately covers "unknown" as well as "known bad" —
+  #    for a free order, an unverified seller is exactly the case where a cheap bot check is
+  #    worth it. Suspended sellers cannot transact at all, so they never reach here.
+  #
+  # Compliant sellers — reviewed and cleared, and the source of ~85% of legitimate free
+  # checkout volume — are unaffected, so the common path stays frictionless.
   def require_captcha?
-    user.created_at > REQUIRE_CAPTCHA_FOR_SELLERS_YOUNGER_THAN.ago
+    return true if user.created_at > REQUIRE_CAPTCHA_FOR_SELLERS_YOUNGER_THAN.ago
+
+    !user.compliant?
   end
 
   def stream_only?

--- a/test/models/link_test.rb
+++ b/test/models/link_test.rb
@@ -3394,11 +3394,50 @@ class LinkTest < ActiveSupport::TestCase
 
   # --- #require_captcha? ------------------------------------------------------
 
-  test "require_captcha? is false for sellers older than 6 months, true for younger" do
+  test "require_captcha? keys on seller age for compliant sellers" do
+    # Age is only half the rule now — an established seller must ALSO be compliant to skip
+    # the check, so these two must be explicitly compliant to isolate the age dimension.
     older = create_user(created_at: 6.months.ago - 1.day)
+    older.update!(user_risk_state: "compliant")
     assert_equal false, create_product(user: older).require_captcha?
+
     younger = create_user(created_at: 6.months.ago + 1.day)
+    younger.update!(user_risk_state: "compliant")
     assert_equal true, create_product(user: younger).require_captcha?
+  end
+
+  # More #require_captcha? coverage — the risk-state dimension.
+  #
+  # Free checkouts are the cheapest thing on Gumroad to automate: no card to decline, no
+  # money at risk, but every completed checkout still sends a receipt from our
+  # transactional mailer. gumroad-private#1397: a seller whose account was over four years
+  # old scripted 150,529 free checkouts and mailed 148,535 scraped addresses, sailing past
+  # the age-only check purely by being old. Risk state, not age, was what distinguished
+  # them.
+
+  test "require_captcha? is true for a young seller even when compliant" do
+    seller = create_user(created_at: 1.day.ago)
+    seller.update!(user_risk_state: "compliant")
+
+    assert create_product(user: seller).require_captcha?
+  end
+
+  test "require_captcha? is false for an established compliant seller" do
+    seller = create_user(created_at: (Link::REQUIRE_CAPTCHA_FOR_SELLERS_YOUNGER_THAN + 1.month).ago)
+    seller.update!(user_risk_state: "compliant")
+
+    assert_not create_product(user: seller).require_captcha?
+  end
+
+  test "require_captcha? is true for an established seller who is not compliant" do
+    # The gumroad-private#1397 shape: old enough to clear the age check, but flagged.
+    %w[not_reviewed flagged_for_tos_violation flagged_for_fraud on_probation].each do |state|
+      seller = create_user(created_at: (Link::REQUIRE_CAPTCHA_FOR_SELLERS_YOUNGER_THAN + 1.month).ago)
+      seller.update!(user_risk_state: state)
+
+      assert create_product(user: seller).require_captcha?,
+             "expected require_captcha? for an established seller in state #{state}"
+    end
   end
 
   # --- #toggle_community_chat! -----------------------------------------------
@@ -3872,4 +3911,5 @@ class LinkTest < ActiveSupport::TestCase
       ].each { |m| product.define_singleton_method(m) { |*| true } }
       product.define_singleton_method(:auto_transcode_videos?) { false }
     end
+
 end

--- a/test/models/link_test.rb
+++ b/test/models/link_test.rb
@@ -3911,5 +3911,4 @@ class LinkTest < ActiveSupport::TestCase
       ].each { |m| product.define_singleton_method(m) { |*| true } }
       product.define_singleton_method(:auto_transcode_videos?) { false }
     end
-
 end


### PR DESCRIPTION
Second of two defenses against the receipt-mailer abuse in gumroad-private#1397, where a seller scripted **150,529 free checkouts** in four days and mailed **148,535 scraped addresses** through `noreply@customers.gumroad.com` — our transactional mailer, our sending reputation, our branding on the spam.

The rate-limit half is #6368. This is the CAPTCHA half, and it's independent: they stop different attackers.

## Why nothing stopped it

We already require a CAPTCHA on free orders — but **only when the seller's account is younger than six months**.

Account age was the wrong test. **The spammer's account was 1,502 days old.** Over four years. They cleared the check purely by being old.

What actually distinguished them was risk state: they were **flagged**, not compliant.

## The change

`Link#require_captcha?` now returns true when the seller is not `compliant`, in addition to the existing age rule.

```ruby
def require_captcha?
  return true if user.created_at > REQUIRE_CAPTCHA_FOR_SELLERS_YOUNGER_THAN.ago

  !user.compliant?
end
```

This deliberately includes `not_reviewed` — the default state for the long tail of accounts nobody has looked at. For a **free** order, an unverified seller is exactly the case where a cheap bot check earns its keep. Suspended sellers can't transact at all, so they never reach this path.

## Blast radius

Measured against 30 days of successful $0 orders in production:

| | orders | |
|---|---|---|
| Total free orders | 3,022,197 | |
| From compliant sellers | 2,562,180 | **unaffected (85%)** |
| Already CAPTCHA'd by the age rule | 174,464 | no change |
| **Newly CAPTCHA'd** | **143,839** | **4.8%, across 8,571 sellers** |

The common path — a reviewed, cleared seller giving away a free file — stays frictionless.

## No frontend change needed

I verified checkout already routes **every** order through the `captcha` state and produces a token regardless of price: `PaymentForm.tsx` calls `recaptcha.execute()` whenever `status.type === "captcha"`, and the reducer sets that state for all carts, free or paid. `require_captcha?` is consulted server-side only.

So free carts were **already carrying a token we were choosing not to verify**. This just verifies it.

## Why this and not just the rate limit

They cover different attackers:

- **#6368's rate limit** stops a *fast* flood, but a patient script staying under 300/min slips through.
- **This CAPTCHA** stops *automation regardless of pace*, but only for sellers we haven't vouched for.

Together, abuse has to beat both a bot check and a volume ceiling, while a compliant seller's launch is untouched by either.

## Tests

**Red-first verified** — the not-compliant cases fail against unpatched `link.rb` and pass with it.

- Young seller → required even when compliant (existing rule preserved)
- Established **compliant** seller → not required (the 85% path stays clean)
- Established seller in `not_reviewed` / `flagged_for_tos_violation` / `flagged_for_fraud` / `on_probation` → required — **this is the #1397 shape**

Also updated the pre-existing age-only test: it created users without setting risk state, so it inherited the `not_reviewed` default and would now expect the wrong answer. It sets `compliant` explicitly to isolate the age dimension it actually tests.

`test/models/link_test.rb`: **420 runs, 928 assertions, 0 failures.**

Refs gumroad-private#1397
