### PR TITLE
Stop the missed-posts spec from depending on wall-clock luck

### DIFF
--- a/spec/controllers/customers_controller_spec.rb
+++ b/spec/controllers/customers_controller_spec.rb
@@ -516,9 +516,14 @@ describe CustomersController, :vcr, type: :controller, inertia: true do
   describe "GET missed_posts" do
     before do
       @product = create(:product, user: seller)
-      @post1 = create(:installment, link: @product, published_at: Time.current)
-      @post2 = create(:installment, link: @product, published_at: Time.current)
-      @post3 = create(:installment, link: @product, published_at: Time.current)
+      # installments.published_at is a DATETIME with no sub-second precision, so
+      # three posts created with Time.current usually share one timestamp and fall
+      # back to the id tiebreak, but land out of order whenever creation happens to
+      # straddle a second boundary. Pin distinct timestamps (oldest to newest) so the
+      # newest-first ordering this endpoint promises is asserted deterministically.
+      @post1 = create(:installment, link: @product, published_at: 3.days.ago)
+      @post2 = create(:installment, link: @product, published_at: 2.days.ago)
+      @post3 = create(:installment, link: @product, published_at: 1.day.ago)
       @unpublished_post = create(:installment, link: @product)
       @purchase = create(:purchase, link: @product)
       create(:creator_contacting_customers_email_info_delivered, installment: @post1, purchase: @purchase)
@@ -535,12 +540,12 @@ describe CustomersController, :vcr, type: :controller, inertia: true do
       get :missed_posts, params: { purchase_id: @purchase.external_id, purchase_email: @purchase.email }
       expect(response).to be_successful
       expect(response.parsed_body.count).to eq(2)
-      expect(response.parsed_body[0]["name"]).to eq(@post2.name)
-      expect(response.parsed_body[0]["published_at"].to_date).to eq(@post2.published_at.to_date)
-      expect(response.parsed_body[0]["url"]).to eq(custom_domain_view_post_url(host: seller.subdomain_with_protocol, slug: @post2.slug))
-      expect(response.parsed_body[1]["name"]).to eq(@post3.name)
-      expect(response.parsed_body[1]["published_at"].to_date).to eq(@post3.published_at.to_date)
-      expect(response.parsed_body[1]["url"]).to eq(custom_domain_view_post_url(host: seller.subdomain_with_protocol, slug: @post3.slug))
+      expect(response.parsed_body[0]["name"]).to eq(@post3.name)
+      expect(response.parsed_body[0]["published_at"].to_date).to eq(@post3.published_at.to_date)
+      expect(response.parsed_body[0]["url"]).to eq(custom_domain_view_post_url(host: seller.subdomain_with_protocol, slug: @post3.slug))
+      expect(response.parsed_body[1]["name"]).to eq(@post2.name)
+      expect(response.parsed_body[1]["published_at"].to_date).to eq(@post2.published_at.to_date)
+      expect(response.parsed_body[1]["url"]).to eq(custom_domain_view_post_url(host: seller.subdomain_with_protocol, slug: @post2.slug))
       expect(response.parsed_body[2]).to eq(nil)
     end
 


### PR DESCRIPTION
## What

Makes the `CustomersController GET missed_posts` spec assert the endpoint's real newest-first ordering instead of an incidental id tiebreak, by pinning the three fixture posts to distinct `published_at` timestamps.

## Why

This spec turned `main` red on `fb73135166` ([run 30241819776](https://github.com/antiwork/gumroad/actions/runs/30241819776), shard Test Fast 13):

```
CustomersController GET missed_posts returns success true with missed updates
Failure/Error: expect(response.parsed_body[0]["name"]).to eq(@post2.name)
  expected: "It's a Battlefield"
       got: "Bury My Heart at Wounded Knee"
```

The `before` block created all three installments with `published_at: Time.current`. `installments.published_at` is a `DATETIME` with `precision: nil` — no sub-second component — so all three normally collapse to the same stored second. The endpoint orders `published_at: :desc, id: :asc`, so with equal timestamps the ordering falls through to the id tiebreak, which yields post2 then post3. That is the order the spec asserted.

That only holds while all three rows are created inside one wall-clock second. When a runner is slow enough for creation to straddle a second boundary, the later post gets a genuinely larger `published_at`, `DESC` correctly puts it first, and the name comparison fails. The assertion had encoded a timing accident rather than the newest-first contract the endpoint actually promises — and which `CustomerDetailPage.tsx` relies on when it paginates with `missedPosts.slice(0, shownMissedPosts)`.

The fix is in the spec, not the controller: the production ordering is correct and intentional. Only the test's assumption was wrong.

This is a test-only change, so per CONTRIBUTING the diff is the reviewable artifact; there is no user-visible behaviour to record.

## Before/After

No behaviour change. Only the spec's fixture timestamps and assertion order change; `customer_presenter.rb` and `customers_controller.rb` are untouched.

## Test Results

The failure is timing-dependent and does not reproduce on a fast local machine (the original spec passed 8/8 runs locally), so I proved the mechanism directly with a temporary spec that forces the exact straddle — post1/post2 in second T, post3 in second T+1:

```
2 examples, 1 failure

Failed examples:
rspec ./spec/controllers/boundary_repro_spec.rb:30 # ORIGINAL assertion: expects post2 first
  Expected "Paths of Glory" to eq "Time To Murder And Create".
```

Under the boundary straddle the original assertion reproduces the CI symptom exactly (wrong post first) while the newest-first assertion passes. That temporary file was deleted before committing; this PR contains only the spec fix.

With the fix applied, the target spec passes:

```
CustomersController GET missed_posts returns success true with missed updates
1 example, 0 failures
```

Full file: 32 examples, 6 failures — the same 6 fail identically on unmodified `origin/main` in my local environment (Inertia/Elasticsearch-dependent `GET index` and `GET show` examples that pass in CI), so they are pre-existing and unrelated. I verified this by stashing the change and re-running: byte-identical failure list.

---

AI disclosure: written with Claude Opus 4.5 (Hermes Agent).
