### PR TITLE
Wait for the email editor debounce before publishing in the duplicate spec

### DIFF
--- a/spec/requests/emails/create_spec.rb
+++ b/spec/requests/emails/create_spec.rb
@@ -860,6 +860,10 @@ describe("Email Creation Flow", :js, type: :system) do
     uncheck "Allow comments"
     fill_in "Title", with: "Hello"
     set_rich_text_editor_input(find("[aria-label='Email message']"), to_text: "Hello, world!")
+    # The editor pushes its content into the form state through a 500ms debounce
+    # (see handleMessageChange in EmailForm.tsx), so publishing sooner than that
+    # submits an empty message and trips the "Please include a message" validation.
+    sleep 1 # wait for the message editor to update
     # Allows attaching files to the email
     upload_attachment("thing.mov")
     select_disclosure "Publish" do


### PR DESCRIPTION
## Why

`spec/requests/emails/create_spec.rb:851` ("allows duplicating and editing an already published email") went red on `main` at f85ed3cf2 ([run 30262476385](https://github.com/antiwork/gumroad/actions/runs/30262476385), Test Slow 46), failing all three rspec-retry attempts with:

```
Failure/Error: expect(page).to have_alert(text: "Email successfully sent!")
  expected to find visible alert with text "Email successfully sent!" but there were no matches.
  Also found "Please include a message as part of the update.", which matched the selector but not all filters.
```

## Root cause

Not the attachment upload, and not a flake — it is a race against a debounce.

`EmailForm.tsx` pushes editor content into the Inertia form state through a 500ms debounce:

```ts
const handleMessageChange = useDebouncedCallback((newMessage: string) => {
  form.setData("installment.message", newMessage);
}, 500);
```

`buildPayload` reads `form.data.installment.message`. The spec typed the body and then clicked Publish with no wait in between, so the debounce had not fired yet and the request went out with `message => ""`, which trips the "Please include a message as part of the update." validation. The CI request log confirms `"message" => ""` on all three attempts, while the editor DOM still showed `<p>Hello, world!</p>` — the text was never lost, it just had not been flushed into form state.

Evidence that the attachment is not involved: moving `upload_attachment` to run *before* the text is typed still fails identically, and `upload_attachment` completes in ~0.3s locally so it does not itself provide the needed delay.

Every other publish/save site in this file already has a `sleep 0.5`/`sleep 1 # wait for the message editor to update`. Line 862 was the only `set_rich_text_editor_input` followed by an immediate publish with no such wait.

## Verification

Run locally against MySQL/Redis/Elasticsearch/MongoDB/minio:

- Fails on unmodified `main` in isolation — same "Please include a message" alert. Deterministic, not a flake.
- Passes with this change: `1 example, 0 failures`.
- Full file: `17 examples, 1 failure` — the one failure is `:453` "does not upload unsupported file as a subtitle", which **also fails on pristine `main` with this change stashed**, so it is pre-existing and out of scope here.
- `rubocop` clean on the file.

## Note

A CI re-run of the original job has since gone green, so this was a narrow race rather than a hard block — but the race is real and reproduces on demand locally, so the missing wait is worth closing rather than leaving to chance.

There is also a theoretical product-side micro-race: publishing within 500ms of the last keystroke drops unflushed edits. A human cannot realistically type, attach and publish that fast, so this PR only fixes the spec. Hardening `save()`/`buildPayload` to use the existing `getCurrentMessage()` or to flush the debounce would be a separate, deliberate change.

---

## AI disclosure

Written by `claude-opus-5` running as Gumclaw.

Instructions given: a `Test Slow` job on `main` had gone red and needed diagnosing rather than retrying. The model was asked to determine from the CI logs whether the failure was a flake or a real race before changing anything, to name the specific mechanism and the `file:line` responsible, to rule out the attachment upload as a cause by experiment rather than by argument, and to reproduce the failure deterministically against unmodified `main` locally before applying a fix.
