### PR TITLE
Require the buyer's full name when Bancontact is selected

### DIFF
--- a/app/javascript/components/Checkout/payment.test.ts
+++ b/app/javascript/components/Checkout/payment.test.ts
@@ -1229,6 +1229,44 @@ describe("reduceCheckoutState", () => {
       expect(next.status).toEqual({ type: "input", errors: new Set(["zipCode"]) });
     });
   });
+
+  // Bancontact needs billing_details.name for Stripe's authorization to succeed, but unlike UPI
+  // it leaves the address to checkout's own form ("form" collection mode), so the element-full
+  // rules above never fire for it. Without its own gate a digital-cart buyer reached Stripe's
+  // confirm with a blank name and got an un-actionable failure — no Bancontact purchase could
+  // ever complete (gumroad-private#1306).
+  describe("Bancontact billing-name validation", () => {
+    const bancontactState = (overrides: Partial<State> = {}) =>
+      state({
+        checkoutPayment: paymentElementClientConfirmConfig,
+        paymentElementType: "bancontact",
+        ...overrides,
+      });
+
+    it("requires a full name when Bancontact is the selected method", () => {
+      const next = reduceCheckoutState(bancontactState({ fullName: "" }), { type: "offer" });
+      expect(next.status).toEqual({ type: "input", errors: new Set(["fullName"]) });
+    });
+
+    it("offers normally once the full name is present", () => {
+      const next = reduceCheckoutState(bancontactState({ fullName: "Marie Peeters" }), { type: "offer" });
+      expect(next.status).toEqual({ type: "offering" });
+    });
+
+    it("still requires the US ZIP — Bancontact leaves the address to checkout's own form", () => {
+      const next = reduceCheckoutState(bancontactState({ fullName: "Marie Peeters", zipCode: "" }), {
+        type: "offer",
+      });
+      expect(next.status).toEqual({ type: "input", errors: new Set(["zipCode"]) });
+    });
+
+    it("releases the requirement when the buyer switches away to PayPal", () => {
+      const next = reduceCheckoutState(bancontactState({ fullName: "", paymentMethod: "paypal" }), {
+        type: "offer",
+      });
+      expect(next.status).toEqual({ type: "offering" });
+    });
+  });
 });
 
 const loadedSurcharges = (

--- a/app/javascript/components/Checkout/payment.ts
+++ b/app/javascript/components/Checkout/payment.ts
@@ -682,6 +682,18 @@ export const paymentElementCollectsFullBillingDetails = (state: State) =>
   !hasShipping(state) &&
   (canUseStripePaymentElement(state) || canUseStripePaymentElementClientConfirm(state));
 
+// Whether the currently selected Payment Element method needs `billing_details.name` from
+// checkout's own Full name field. Mirrors paymentElementRequiresBillingName in
+// card_payment_method_data.ts for the same module-cycle reason as above. Bancontact is the case
+// this exists for: Stripe rejects its authorization without a name, but unlike UPI it stays in
+// "form" collection mode, so paymentElementCollectsFullBillingDetails is false for it and the
+// name would otherwise never be required on a digital cart (gumroad-private#1306). Guarded on
+// the card/element lane for the same reason: switching to PayPal must not keep the requirement.
+export const paymentElementRequiresBillingNameForSelection = (state: State) =>
+  state.paymentMethod === "card" &&
+  (state.paymentElementType === "upi" || state.paymentElementType === "bancontact") &&
+  (canUseStripePaymentElement(state) || canUseStripePaymentElementClientConfirm(state));
+
 export const getErrors = (state: State) => (state.status.type === "input" ? state.status.errors : new Set());
 
 export const loadSurcharges = (state: State, abortSignal?: AbortSignal) => {
@@ -746,10 +758,17 @@ function validatePaymentMethodIndependentFields(state: State) {
     errors.add("zipCode");
   // Stripe requires billing_details.name to confirm a UPI payment, and on the element-full
   // mode the pane's own name field is pinned to "never" — checkout's Full name field is the
-  // only source (see paymentElementBillingDetailsOverride). Without this gate a blank name
-  // reaches Stripe's confirm and fails server-side with parameter_missing and no
-  // last_payment_error — the un-actionable failure shape of gumroad-private#933.
-  if (requiresPayment(state) && paymentElementCollectsFullBillingDetails(state) && !state.fullName)
+  // only source (see paymentElementBillingDetailsOverride). Bancontact needs the name too
+  // (Stripe: "your customer's name is required for the Bancontact authorization to succeed"),
+  // but stays in "form" collection mode, so it isn't covered by the element-full check —
+  // gumroad-private#1306. Without this gate a blank name reaches Stripe's confirm and fails
+  // server-side with parameter_missing and no last_payment_error — the un-actionable failure
+  // shape of gumroad-private#933.
+  if (
+    requiresPayment(state) &&
+    (paymentElementCollectsFullBillingDetails(state) || paymentElementRequiresBillingNameForSelection(state)) &&
+    !state.fullName
+  )
     errors.add("fullName");
   if (state.gift?.type === "normal" && !isValidEmail(state.gift.email)) errors.add("gift");
   return errors;

--- a/app/javascript/components/Checkout/payment.ts
+++ b/app/javascript/components/Checkout/payment.ts
@@ -3,6 +3,7 @@ import { groupBy } from "lodash-es";
 import * as React from "react";
 
 import { getSurcharges, SurchargesResponse } from "$app/data/customer_surcharge";
+import { paymentElementRequiresBillingName } from "$app/data/payment_element_methods";
 import { PurchasePaymentMethod } from "$app/data/purchase";
 import { SavedCreditCard } from "$app/parsers/card";
 import { CustomFieldDescriptor, ProductNativeType } from "$app/parsers/product";
@@ -683,15 +684,16 @@ export const paymentElementCollectsFullBillingDetails = (state: State) =>
   (canUseStripePaymentElement(state) || canUseStripePaymentElementClientConfirm(state));
 
 // Whether the currently selected Payment Element method needs `billing_details.name` from
-// checkout's own Full name field. Mirrors paymentElementRequiresBillingName in
-// card_payment_method_data.ts for the same module-cycle reason as above. Bancontact is the case
-// this exists for: Stripe rejects its authorization without a name, but unlike UPI it stays in
-// "form" collection mode, so paymentElementCollectsFullBillingDetails is false for it and the
-// name would otherwise never be required on a digital cart (gumroad-private#1306). Guarded on
-// the card/element lane for the same reason: switching to PayPal must not keep the requirement.
+// checkout's own Full name field. The list of such methods lives in
+// $app/data/payment_element_methods (a cycle-free module, since card_payment_method_data.ts and
+// this module import each other). Bancontact is the case this exists for: Stripe rejects its
+// authorization without a name, but unlike UPI it stays in "form" collection mode, so
+// paymentElementCollectsFullBillingDetails is false for it and the name would otherwise never be
+// required on a digital cart (gumroad-private#1306). Guarded on the card/element lane for the
+// same reason as above: switching to PayPal must not keep the requirement.
 export const paymentElementRequiresBillingNameForSelection = (state: State) =>
   state.paymentMethod === "card" &&
-  (state.paymentElementType === "upi" || state.paymentElementType === "bancontact") &&
+  paymentElementRequiresBillingName(state.paymentElementType) &&
   (canUseStripePaymentElement(state) || canUseStripePaymentElementClientConfirm(state));
 
 export const getErrors = (state: State) => (state.status.type === "input" ? state.status.errors : new Set());

--- a/app/javascript/data/card_payment_method_data.ts
+++ b/app/javascript/data/card_payment_method_data.ts
@@ -104,6 +104,19 @@ export const paymentElementBillingDetailsCollection = (
   return "form";
 };
 
+// Payment methods whose authorization Stripe rejects without `billing_details.name`. A digital
+// (non-shipping) cart hides checkout's Full name field — nothing else on that checkout needs a
+// name — so selecting one of these has to require it, or the confirm fails with
+// `parameter_missing` and the buyer sees an error they cannot act on. This is what made UPI
+// unusable in July 2026 (gumroad-private#933) and Bancontact in the same way
+// (gumroad-private#1306): Stripe's Bancontact docs state the customer's name is required for the
+// authorization to succeed. UPI additionally needs a full street address, which is why it also
+// switches the element into "element-full" collection above; Bancontact needs only the name, so
+// it stays in "form" mode and checkout's own field supplies it.
+const PAYMENT_ELEMENT_TYPES_REQUIRING_BILLING_NAME = ["upi", "bancontact"];
+export const paymentElementRequiresBillingName = (type: string | null | undefined) =>
+  type != null && PAYMENT_ELEMENT_TYPES_REQUIRING_BILLING_NAME.includes(type);
+
 // Client-side details about the wallet that paid through the Payment Element, read off the
 // tokenized PaymentMethod (or ConfirmationToken preview). The billing address feeds the
 // tax-location logic in checkout (the wallet sheet is the buyer's source of truth for wallet

--- a/app/javascript/data/card_payment_method_data.ts
+++ b/app/javascript/data/card_payment_method_data.ts
@@ -104,19 +104,6 @@ export const paymentElementBillingDetailsCollection = (
   return "form";
 };
 
-// Payment methods whose authorization Stripe rejects without `billing_details.name`. A digital
-// (non-shipping) cart hides checkout's Full name field — nothing else on that checkout needs a
-// name — so selecting one of these has to require it, or the confirm fails with
-// `parameter_missing` and the buyer sees an error they cannot act on. This is what made UPI
-// unusable in July 2026 (gumroad-private#933) and Bancontact in the same way
-// (gumroad-private#1306): Stripe's Bancontact docs state the customer's name is required for the
-// authorization to succeed. UPI additionally needs a full street address, which is why it also
-// switches the element into "element-full" collection above; Bancontact needs only the name, so
-// it stays in "form" mode and checkout's own field supplies it.
-const PAYMENT_ELEMENT_TYPES_REQUIRING_BILLING_NAME = ["upi", "bancontact"];
-export const paymentElementRequiresBillingName = (type: string | null | undefined) =>
-  type != null && PAYMENT_ELEMENT_TYPES_REQUIRING_BILLING_NAME.includes(type);
-
 // Client-side details about the wallet that paid through the Payment Element, read off the
 // tokenized PaymentMethod (or ConfirmationToken preview). The billing address feeds the
 // tax-location logic in checkout (the wallet sheet is the buyer's source of truth for wallet

--- a/app/javascript/data/payment_element_methods.test.ts
+++ b/app/javascript/data/payment_element_methods.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { paymentElementRequiresBillingName } from "$app/data/payment_element_methods";
+
+describe("paymentElementRequiresBillingName", () => {
+  it("requires a billing name for the methods Stripe rejects without one", () => {
+    expect(paymentElementRequiresBillingName("upi")).toBe(true);
+    expect(paymentElementRequiresBillingName("bancontact")).toBe(true);
+  });
+
+  it("does not require a billing name for other methods", () => {
+    expect(paymentElementRequiresBillingName("card")).toBe(false);
+    expect(paymentElementRequiresBillingName("ideal")).toBe(false);
+    expect(paymentElementRequiresBillingName("link")).toBe(false);
+    expect(paymentElementRequiresBillingName("apple_pay")).toBe(false);
+  });
+
+  it("treats an unknown selection as not requiring a name", () => {
+    expect(paymentElementRequiresBillingName(null)).toBe(false);
+    expect(paymentElementRequiresBillingName(undefined)).toBe(false);
+  });
+});

--- a/app/javascript/data/payment_element_methods.ts
+++ b/app/javascript/data/payment_element_methods.ts
@@ -1,0 +1,20 @@
+// Facts about individual Stripe Payment Element payment methods that both the checkout form
+// (app/javascript/components/Checkout/payment.ts) and the tokenization code
+// (app/javascript/data/card_payment_method_data.ts) need. It lives in its own module because
+// those two import each other, so anything shared has to sit outside both of them to avoid a
+// module cycle.
+
+// Payment methods whose authorization Stripe rejects without `billing_details.name`. A digital
+// (non-shipping) cart never otherwise needs a name, so checkout's Full name field is optional
+// there — selecting one of these has to make it required, or the confirm fails with
+// `parameter_missing` and the buyer sees an error they cannot act on. This is what made UPI
+// unusable in July 2026 (gumroad-private#933) and Bancontact in the same way
+// (gumroad-private#1306): Stripe's Bancontact docs state the customer's name is required for the
+// authorization to succeed. UPI additionally needs a full street address, which is why it also
+// switches the element into "element-full" collection mode (see
+// paymentElementBillingDetailsCollection in card_payment_method_data.ts); Bancontact needs only
+// the name, so it stays in "form" mode and checkout's own field supplies it.
+const PAYMENT_ELEMENT_TYPES_REQUIRING_BILLING_NAME = ["upi", "bancontact"];
+
+export const paymentElementRequiresBillingName = (type: string | null | undefined) =>
+  type != null && PAYMENT_ELEMENT_TYPES_REQUIRING_BILLING_NAME.includes(type);


### PR DESCRIPTION
## What

Requires the buyer's full name when Bancontact is the selected payment method at checkout.

## Why

Bancontact was ramped to 100% on 2026-07-27 and produced **zero completed purchases**, which Sahil flagged on gumroad-private#1306 ("if there hasn't been a successful example it's obviously broken").

Stripe [documents](https://docs.stripe.com/js/payment_intents/confirm_bancontact_payment) that *"your customer's name is required for the Bancontact authorization to succeed."* Checkout does collect a Full name field on digital carts, but **never requires it** — nothing else on a digital checkout needs a name, so it is optional. A Belgian buyer could therefore select Bancontact, leave the name blank, submit, and hit a confirm failure with no actionable message. No Bancontact purchase could ever complete.

This is the same defect class as the July 2026 UPI ramp-down (gumroad-private#933), and the reason it slipped past that fix is a subtle one worth stating: UPI needs a name **and** a full street address, so it switches the Payment Element into `element-full` collection mode, and the name requirement was written to key off *that mode*. Bancontact needs only the name and leaves the address to checkout's own form (`form` mode) — so it never matched the condition.

## How

The requirement now keys off the **selected method** rather than the collection mode:

- `paymentElementRequiresBillingName` in the new `data/payment_element_methods.ts` lists the methods Stripe rejects without a name (`upi`, `bancontact`). It sits in its own module because `card_payment_method_data.ts` and `Checkout/payment.ts` import each other, so a value shared between them cannot live in either without creating a module cycle.
- `validatePaymentMethodIndependentFields` adds a `fullName` error when either the element-full mode is active (UPI, unchanged) **or** the selected method requires a billing name (new — covers Bancontact).
- Both are guarded on the card/element lane being active, so switching to PayPal releases the requirement.

Behavior is unchanged for every other method: cards, Link, iDEAL and wallets never gain a name requirement, and the US ZIP rules are untouched (Bancontact keeps checkout's own address fields, unlike UPI).

## Test results

`npx vitest run app/javascript/components/Checkout/payment.test.ts app/javascript/data/card_payment_method_data.test.ts app/javascript/data/payment_element_methods.test.ts` → **136 passed**.

Red/green verified on the four new specs: with the fix reverted and the specs kept, `requires a full name when Bancontact is the selected method` **fails**; with the fix applied it passes. Prettier and ESLint clean.

## Rollout

`checkout_local_method_bancontact` was **ramped down to 0% before this PR was opened** (audited write `20260727T145744Z-848e5a5c`, verified off on every gate: state=off, boolean false, 0% actors, 0% time, no actors, no groups). It stays off until this ships and a real completed Bancontact purchase is observed.

## AI disclosure

Written by Gumclaw (claude-opus-5) — investigation, root cause, fix and specs. Production reads are audited console queries linked in gumroad-private#1306.

