### PR TITLE
Make the purchases (email, link_id) index migration a documented no-op

### DIFF
--- a/db/migrate/20261206000004_add_email_and_link_id_index_to_purchases.rb
+++ b/db/migrate/20261206000004_add_email_and_link_id_index_to_purchases.rb
@@ -1,32 +1,50 @@
 # frozen_string_literal: true
 
+# Intentionally a no-op.
+#
+# This originally added a composite `(email(191), link_id)` index to `purchases` to
+# speed up the mobile library's "hasn't bought X" existence probes. It never took
+# effect in production, and it is no longer worth building. Both halves are worth
+# writing down: the first is a trap, and the second is the reason not to simply
+# retry it.
+#
+# It never ran. Production recorded this migration's version, but the index was
+# never created. `purchases` schema changes go through the Alterity gem, which hands
+# every ALTER to pt-online-schema-change, and pt-osc creates a trigger set named
+# after the table it is altering. `purchases` was still carrying an abandoned
+# trigger set of exactly those names, left behind by an earlier pt-osc run that was
+# killed without cleanup, so pt-osc failed on "Trigger already exists" within
+# seconds and left no trace in the database — a migration that reported success and
+# produced nothing. Those leftovers have since been removed and `purchases` DDL
+# works again; the full investigation is in gumroad-private#1417.
+#
+# It is no longer worth building, because the query it was written for is gone. The
+# per-seller probe loop it targeted (whole-history scans for mega-sellers, because
+# MySQL drove off `index_purchases_on_seller_id` and then filtered on link_id/email)
+# was replaced in gumroad#6206 by a single prefetch per request in
+# Purchase::SellerPostProbeBatch, which reads:
+#
+#   SELECT seller_id, id, link_id FROM purchases WHERE email = ? AND seller_id IN (...)
+#
+# `link_id` is selected there but never filtered on, so a `(email, link_id)` index
+# adds no selectivity over the `index_purchases_on_email_long` this query already
+# uses, and it cannot cover the read either, because `seller_id` is not in it. There
+# is no better plan for the optimizer to pick, so the index would cost a large
+# amount of storage and a full pt-online-schema-change copy of one of the biggest
+# tables in the database in exchange for nothing. Measurements are in
+# gumroad-private#1417.
+#
+# This stays as a no-op rather than being deleted so the version keeps recording
+# cleanly across environments — the same treatment 20261201000006 got after its own
+# `purchases` ALTER hung a deploy. If some non-production environment did create the
+# index (a database loaded from db/schema.rb before this change, for instance), it is
+# a harmless unused index, to be dropped out of band and never through a deploy-time
+# migration on this table. See docs/migrations.md for why `purchases` and `users` are
+# frozen.
 class AddEmailAndLinkIdIndexToPurchases < ActiveRecord::Migration[7.1]
-  disable_ddl_transaction!
+  def up
+  end
 
-  def change
-    # The mobile library endpoints (Api::Mobile::PurchasesController#search /
-    # #index) serialize each purchase's product-updates feed, and posts with
-    # "hasn't bought X" targeting run an existence probe of the shape:
-    #
-    #   SELECT 1 FROM purchases
-    #   WHERE seller_id = ? AND link_id = ? AND email = ? AND <flag predicates>
-    #   LIMIT 1
-    #
-    # MySQL was driving this off the single-column seller_id index and then
-    # scanning that seller's entire purchase history to check link_id/email —
-    # instant for small sellers, 7-12 seconds per probe for mega-sellers
-    # (antiwork/gumroad#6009: two such probes were 19.9s of a 22.0s request).
-    #
-    # A composite (email, link_id) index lets the optimizer satisfy both
-    # equality predicates directly, reducing the probe to a handful of row
-    # lookups regardless of how large the seller is. Email leads because it is
-    # the most selective predicate and also serves existing email-only lookups
-    # if the optimizer prefers this index over index_purchases_on_email_long.
-    # The 191-character prefix matches that existing email index (the column is
-    # TEXT, so a prefix length is required, and 191 keeps it within the 767-byte
-    # InnoDB key limit under utf8mb4).
-    add_index :purchases, [:email, :link_id],
-              name: "index_purchases_on_email_and_link_id",
-              length: { email: 191 }
+  def down
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2049,7 +2049,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_12_06_000012) do
     t.index ["card_type", "card_visual", "created_at", "stripe_fingerprint"], name: "index_purchases_on_card_type_visual_date_fingerprint"
     t.index ["card_type", "card_visual", "stripe_fingerprint"], name: "index_purchases_on_card_type_visual_fingerprint"
     t.index ["created_at"], name: "index_purchases_on_created_at"
-    t.index ["email", "link_id"], name: "index_purchases_on_email_and_link_id", length: { email: 191 }
     t.index ["email"], name: "index_purchases_on_email_long", length: 191
     t.index ["full_name"], name: "index_purchases_on_full_name"
     t.index ["ip_address"], name: "index_purchases_on_ip_address"


### PR DESCRIPTION
## What

Turns migration `20261206000004` (`AddEmailAndLinkIdIndexToPurchases`, from #6123) into a documented no-op, and removes `index_purchases_on_email_and_link_id` from `db/schema.rb`.

No runtime code changes. The diff is a migration body replaced by a comment, plus one line of `schema.rb`.

## Why

**The index was never actually created in production.** The version is recorded in `schema_migrations`, but the index does not exist. `purchases` schema changes run through Alterity, which hands every ALTER to pt-online-schema-change, and pt-osc creates a trigger set named after the table it is altering. `purchases` was still carrying an abandoned pt-osc trigger set of exactly those names, left by an earlier run that was killed without cleanup, so pt-osc failed on "Trigger already exists" within seconds and left no trace in the database — a migration that reported success and produced nothing. Reproduced with the same pt-osc version and flags; the leftovers have since been removed, so `purchases` DDL works again. Full investigation in gumroad-private#1417.

**It is not worth building now.** The per-seller probe loop it was written for was replaced in #6206 by a single batched prefetch per request (`Purchase::SellerPostProbeBatch`):

```sql
SELECT seller_id, id, link_id FROM purchases WHERE email = ? AND seller_id IN (...)
```

`link_id` is selected but never filtered on, so `(email(191), link_id)`:

- adds no selectivity over the `index_purchases_on_email_long` this query already uses — same leading column, second column unused in the predicate;
- cannot cover the read, because `seller_id` is not in it, so every matched row still needs a primary-key lookup.

There is no plan the optimizer would prefer it for, and building it would mean a full pt-online-schema-change copy of one of the largest tables in the database. `docs/migrations.md` and CONTRIBUTING both list index changes on `purchases` as off limits. Measurements behind that call are in gumroad-private#1417.

The alternative — deleting the `schema_migrations` row and rebuilding the index out of band — buys a plan MySQL has no reason to choose, at that cost.

**Why also `schema.rb`:** it is what fresh development and CI databases load. Leaving the index there gives every local database an index production does not have, which is exactly the divergence that makes a query look fine locally and behave differently in production.

The migration stays as a no-op rather than being deleted so the version keeps recording cleanly across environments — the same treatment `20261201000006` got after its own `purchases` ALTER hung a deploy.

## Before / After

No user-visible surface, so there is nothing to record. The behavioural difference is in the schema, not the product:

| | Before | After |
|---|---|---|
| Production `purchases` | no `index_purchases_on_email_and_link_id`; `schema_migrations` says otherwise | unchanged, and the file now says so too |
| Fresh dev/CI database | has the index | matches production |
| Next `db:migrate` | would never build it (version already recorded) | explicitly a no-op, with the reason in the file |

## Test Results

`bundle exec rubocop` clean on the changed migration; `ruby -c` clean. I could not run the suite or `bin/test-confidence` on this machine — the local MySQL is not running and `ANTHROPIC_API_KEY` is unset — so CI is the check here. Nothing in `spec/` references the index; the two specs covering this query path (`spec/models/purchase/seller_post_probe_batch_spec.rb`, `spec/models/concerns/with_filtering_spec.rb`) assert on results, not on query plans, and are unaffected by an index that production never had.

Deploy note: changing a file under `db/migrate` changes that directory's tree hash, so the next deploy runs the migration job instead of taking the fast path. It will find nothing pending and exit clean — one slower deploy.

---
Written with Claude Opus 5.
