### PR TITLE
Stop refusing wallet payments on the buyer-currency charge path

### DIFF
--- a/app/services/checkout/buyer_currency_eligibility.rb
+++ b/app/services/checkout/buyer_currency_eligibility.rb
@@ -188,7 +188,6 @@ class Checkout::BuyerCurrencyEligibility
     return fallback(:feature_disabled) unless self.class.seller_enabled?(seller)
     return fallback(:unsupported_processor) unless merchant_account&.stripe_charge_processor?
     return fallback(:unsupported_charge_model) unless supported_charge_model?
-    return fallback(:wallet_payment_request) if wallet_type.present?
     return fallback(:future_charge_setup) if setup_future_charges
     return fallback(:off_session) if off_session
     return fallback(:no_purchases) if purchases.empty?
@@ -370,10 +369,6 @@ class Checkout::BuyerCurrencyEligibility
 
       merchant_account.is_a_stripe_connect_account? ||
         self.class.settlement_merchant_account(merchant_account)&.is_managed_by_gumroad? || false
-    end
-
-    def wallet_type
-      params[:wallet_type]
     end
 
     # True when the order's purchases span more than one seller — i.e. the order produces

--- a/spec/services/checkout/buyer_currency_eligibility_spec.rb
+++ b/spec/services/checkout/buyer_currency_eligibility_spec.rb
@@ -180,11 +180,21 @@ describe Checkout::BuyerCurrencyEligibility do
     expect(decision.currency).to eq(Currency::JPY)
   end
 
-  it "falls back for wallet payment requests" do
+  # Wallet payments are no longer refused. The Payment Request Button is deliberately not
+  # special-cased even though its sheet shows canonical USD: it cannot reach a presentment
+  # checkout at all. It is suppressed whenever the Payment Element renders wallets
+  # (PaymentForm.tsx passes `disable_wallets || payment_element_wallets` as its disabled
+  # flag), and selecting it sets checkout's paymentMethod to "stripePaymentRequest", which
+  # makes getCheckoutBuyerCurrencyDisplay return null — so no quote token is ever issued for
+  # one. Gumroad is migrating fully to Payment Element wallets, so this case is being retired
+  # rather than guarded.
+  it "allows a wallet payment" do
     params[:wallet_type] = "apple_pay"
+    params[:payment_details_source] = PurchasePaymentFlow::PAYMENT_ELEMENT
 
-    expect(decision).not_to be_eligible
-    expect(decision.fallback_reason).to eq(:wallet_payment_request)
+    expect(decision).to be_eligible
+    expect(decision.currency).to eq(Currency::CAD)
+    expect(decision.fallback_reason).to be_nil
   end
 
   it "falls back for future-charge card setups such as save-card checkouts" do


### PR DESCRIPTION
## What

`Checkout::BuyerCurrencyEligibility#decision` refused buyer-currency presentment for **any** payment carrying a `wallet_type`:

```ruby
return fallback(:wallet_payment_request) if wallet_type.present?
```

So an Apple Pay / Google Pay purchase on a presentment-eligible cart silently charged canonical USD. This removes the refusal — a net **5-line deletion** in the service.

### Why the Payment Request Button needs no special case

The obvious worry is the deprecated Payment Request Button, whose sheet is mounted from checkout's canonical USD total and knows nothing about the quote. Letting one through would charge a buyer a total their sheet never showed.

It cannot reach a presentment checkout, for two independent reasons on `main`:

1. **It isn't rendered.** `PaymentForm.tsx` passes `disable_wallets || payment_element_wallets` as the button's `disabled` flag, so it is suppressed on exactly the carts this path serves.
2. **It can't obtain a quote token.** Selecting it sets checkout's `paymentMethod` to `"stripePaymentRequest"`, and `getCheckoutBuyerCurrencyDisplay` returns `null` for any non-`"card"` method — so no token is issued, and with no token the charge path takes the canonical branch regardless.

Either one alone is sufficient. And since checkout is migrating fully to Payment Element wallets, the surface is being **retired rather than guarded** — a gate here would be dead code protecting an unreachable case, and dead money-path guards are worse than none: they read as load-bearing to the next person.

**No buyer reaches this path yet.** `StripePaymentPresenter` still sets `disable_wallets: true` for every presentment candidate and ANDs the rollout flag off. This only makes the charge path capable; PR 4 in the plan flips the presenter.

## Why

Wallets are off for exactly the buyers multi-currency exists to serve — non-US buyers, most likely paying on a phone — and the FX-quoted card lane has been live at 100% since the production rollout. First of the PRs on antiwork/gumroad-private#1436; it ships dark so the risky part lands last and alone.

## Finding worth reviewer attention

**`Order::PreparePaymentIntentService#previewed_country` needed no change.** It reads `preview[:card]&.[](:country)` first, and Apple/Google Pay **do** populate the `card` block (unlike Link, which is why the method-typed fallback exists). The PPP funding-country check already resolves for a wallet-backed PaymentMethod. The issue listed this as expected work in this PR; it wasn't.

## Test Results

`spec/services/checkout/buyer_currency_eligibility_spec.rb` — **55 examples, 1 failure**, and that failure is **pre-existing on unmodified `origin/main`**: `allows the PR1 Stripe test-mode Gumroad platform-account path` fails at `create(:merchant_account, user: nil, ...)`, a local seed/env issue unrelated to this change. Verified by checking out `main`'s copy of both the service and the spec and re-running that example alone — same failure.

The four surface-discriminating cases from the first revision are replaced by one `allows a wallet payment` example, with the reachability argument recorded as a comment above it so the next reader doesn't re-add a gate.

`bundle exec rubocop` — 2 files inspected, no offenses.

No screenshots: backend-only, and no buyer-visible surface changes while `disable_wallets` stands. Preview QA media lands on PR 4, where the sheet first becomes reachable.

## Progress

- [x] Charge path no longer refuses wallet payments
- [x] Payment Request Button unreachability verified (two independent mechanisms), documented, not guarded
- [x] `previewed_country` confirmed to need no change
- [x] Rubocop clean; sole spec failure proven pre-existing on `main`
- [ ] Reviewed and merged
- [ ] PR 4 — narrow `disable_wallets` in `StripePaymentPresenter` behind its own flag (the actual enable)
