### PR TITLE
Pin the wallet presentment safety properties the charge path relies on

### DIFF
--- a/app/javascript/components/Checkout/heldWalletPayment.test.ts
+++ b/app/javascript/components/Checkout/heldWalletPayment.test.ts
@@ -20,6 +20,7 @@ const paymentElementConfig: CheckoutPaymentConfig = {
   elements_options: {
     stripe_elements_mode: STRIPE_ELEMENTS_MODE_FOR_PAYMENT_INTENT,
     currency: "usd",
+    buyer_currency_presentment: false,
     payment_method_types: ["card"],
     payment_method_creation: "manual",
     stripe_link_enabled: false,
@@ -209,6 +210,91 @@ describe("resolveHeldWalletPayment", () => {
           state({ checkoutPayment: methodForcedConfig, surcharges: loadedSurcharges(180) }),
           methodForcedHeld,
         ),
+      ).toEqual({ type: "re-confirm" });
+    });
+  });
+
+  // The buyer-currency (FX-quoted) presentment lane. Here the element mounts in the buyer's
+  // currency at the quote's locked total, so `approvedAmount` — which getStripePaymentElementAmount
+  // resolves from the quote — is the presentment number the wallet sheet displayed. That makes the
+  // existing comparison already correct for this lane; these cases pin it, because nothing else
+  // covers it and the safety property is invisible: a regression here would not fail any other
+  // test, it would charge a buyer a total they never approved.
+  describe("buyer-currency presentment lane (FX-quoted element mount)", () => {
+    const fxConfig: CheckoutPaymentConfig = {
+      ...paymentElementConfig,
+      elements_options: {
+        ...paymentElementConfig.elements_options,
+        buyer_currency_presentment: true,
+      },
+    };
+
+    // A loaded surcharge response carrying an FX quote, with the presentment total tracking the
+    // canonical total at rate 1.25 so the quote stays internally consistent (the display helper
+    // rejects a quote whose line allocations do not reconcile to its total).
+    const loadedWithQuote = (taxCents: number): State["surcharges"] => {
+      const canonicalTotal = 1_000 + taxCents;
+      const presentmentTotal = Math.round(canonicalTotal * 1.25);
+      const presentmentTax = Math.round(taxCents * 1.25);
+      return {
+        type: "loaded",
+        result: {
+          vat_id_valid: false,
+          has_vat_id_input: false,
+          shipping_rate_cents: 0,
+          tax_cents: taxCents,
+          tax_included_cents: 0,
+          subtotal: 1_000,
+          buyer_currency_quote: {
+            token: "quote-token",
+            currency: "cad",
+            canonical_total_cents: canonicalTotal,
+            presentment_total_cents: presentmentTotal,
+            rate: 1.25,
+            subunit_to_unit: 100,
+            expires_at: "2099-01-01T00:00:00Z",
+            line_allocations: [
+              {
+                permalink: "product-a",
+                price_cents: presentmentTotal - presentmentTax,
+                tip_cents: 0,
+                tax_cents: presentmentTax,
+                shipping_cents: 0,
+                total_cents: presentmentTotal,
+              },
+            ],
+          },
+        },
+      };
+    };
+
+    // Approved at zero tax: the sheet showed the locked CA$12.50 (1250 minor units) while
+    // checkout's own canonical total was US$10.00.
+    const fxHeld = {
+      paymentMethod: serverConfirmPaymentMethod,
+      approvedAmount: 1_250,
+      approvedTotal: 1_000,
+    };
+
+    it("continues when the reloaded quote still matches the approved presentment total", () => {
+      expect(
+        resolveHeldWalletPayment(state({ checkoutPayment: fxConfig, surcharges: loadedWithQuote(0) }), fxHeld),
+      ).toEqual({ type: "continue", paymentMethod: serverConfirmPaymentMethod });
+    });
+
+    it("requires re-confirmation when the adopted address changes the tax", () => {
+      expect(
+        resolveHeldWalletPayment(state({ checkoutPayment: fxConfig, surcharges: loadedWithQuote(200) }), fxHeld),
+      ).toEqual({ type: "re-confirm" });
+    });
+
+    // The quote can disappear on reload (expired, or Stripe rejected the re-quote). The element
+    // amount then falls back to the canonical USD total, which no longer equals the presentment
+    // amount the buyer approved — so this must never continue, or a wallet sheet showing CA$12.50
+    // would be charged US$10.00.
+    it("requires re-confirmation when the quote is gone from the reloaded surcharges", () => {
+      expect(
+        resolveHeldWalletPayment(state({ checkoutPayment: fxConfig, surcharges: loadedSurcharges(0) }), fxHeld),
       ).toEqual({ type: "re-confirm" });
     });
   });

--- a/app/javascript/data/purchase.test.ts
+++ b/app/javascript/data/purchase.test.ts
@@ -171,4 +171,54 @@ describe("createPurchasesRequestData wallet_type threading", () => {
 
     expect(data).not.toHaveProperty("wallet_type");
   });
+
+  // Buyer-currency presentment: an eligible wallet purchase must carry the quote token, or the
+  // charge silently falls back to canonical USD and the buyer is charged a total that isn't the
+  // one their wallet sheet showed. Pinned per lane because the two lanes build their params
+  // through different branches of createPurchasesRequestData.
+  describe("with a buyer-currency quote", () => {
+    const walletPayloadWithQuote = (paymentMethod: PurchasePaymentMethod) => ({
+      ...payloadWith(paymentMethod),
+      buyerCurrencyQuote: "quote-token-abc",
+    });
+
+    it("sends the quote token alongside a server-confirm element wallet payment", () => {
+      const data = createPurchasesRequestData(
+        walletPayloadWithQuote({
+          type: "new",
+          cardParamsResult: {
+            type: "cc",
+            keepOnFile: false,
+            zipCode: null,
+            cardParams: {
+              ...cardParams,
+              wallet: { type: "apple_pay", billingAddress: { country: "US", postal_code: "10001", state: "NY" } },
+            },
+          },
+        }),
+        {},
+      );
+
+      expect(data.buyer_currency_quote).toBe("quote-token-abc");
+      expect(data.wallet_type).toBe("apple_pay");
+      expect(data.payment_details_source).toBe("payment_element");
+    });
+
+    it("sends the quote token alongside a client-confirm wallet payment", () => {
+      const data = createPurchasesRequestData(
+        walletPayloadWithQuote({
+          type: "payment-element-client-confirm",
+          confirmationTokenId: "ctoken_123",
+          cardCountry: "US",
+          walletType: "google_pay",
+          mountCurrency: "usd",
+        }),
+        {},
+      );
+
+      expect(data.buyer_currency_quote).toBe("quote-token-abc");
+      expect(data.wallet_type).toBe("google_pay");
+      expect(data.payment_details_source).toBe("payment_element");
+    });
+  });
 });


### PR DESCRIPTION
## What

Test-only. Pins two safety properties that keep a wallet (Apple Pay / Google Pay) purchase from being charged a total the buyer never approved on a buyer-currency checkout. **Both already hold on `main` — neither was covered**, so a future refactor could break either without failing a single test.

**1. An eligible wallet purchase must carry the buyer-currency quote token.** Without it the charge takes the canonical branch and the buyer pays a USD total their wallet sheet never showed. Pinned for both wallet lanes (server-confirm and client-confirm), which build their params through different branches of `createPurchasesRequestData`.

**2. The held-wallet resolver must re-confirm on the FX-quoted lane** when the wallet's post-approval billing address moves the tax location, and when the quote disappears from the reloaded surcharges (expired, or Stripe rejected the re-quote). `heldWalletPayment.test.ts` had a `describe` for the method-forced fixed-amount lane and none for this one.

Also adds the required `buyer_currency_presentment` key to the shared `paymentElementConfig` fixture, which was missing and producing a type error on the existing file.

## Why

This is what remains of PRs 2 and 3 in the plan on antiwork/gumroad-private#1436 after verifying the code. Both were scoped as production changes; both turned out to be already-working behavior with no coverage:

- PR 2 was "drop the `paymentMethod !== "card"` bail so wallets can carry the quote token." That bail never gated element wallets — a wallet payment runs with `state.paymentMethod === "card"` (`payment.ts` ~839; `reclaimCardLane` sets it). Token and source were already threading correctly on both lanes, verified by probe.
- PR 3 was "extend `resolveHeldWalletPayment` to compare the presentment total, expect the most review churn." It already does, because `approvedAmount` comes from `getStripePaymentElementAmount`, which on this lane returns the quote's locked presentment total. Probe against unmodified source returned `re-confirm` for both the tax-change and vanished-quote cases.

Merged into one test-only PR rather than shipping two PRs that change no production code.

## Test Results

`npx vitest run app/javascript/components/Checkout/ app/javascript/data/purchase.test.ts` — **13 files, 263 tests, all passing.**

New cases: 2 in `purchase.test.ts` (server-confirm and client-confirm wallet each carrying the token), 3 in `heldWalletPayment.test.ts` (quote unchanged → `continue`, tax moved → `re-confirm`, quote vanished → `re-confirm`).

**Mutation-proved load-bearing** — these are only worth adding if they fail when the property breaks:

| Mutation | Result |
| --- | --- |
| `resolveHeldWalletPayment` drops the element-amount comparison, keeping only the canonical-total one | **`requires re-confirmation when the quote is gone from the reloaded surcharges` is the ONLY failing test in the suite** (1 failed / 14 passed) |
| `getPaymentDetailsSource` reports `payment_request` for an element wallet | 2 failures, including the new server-confirm token case |

The first is the one worth noting: without this PR, deleting half of that comparison is invisible to the entire test suite.

`prettier` clean, `eslint` exit 0.

No screenshots — test-only, no rendered surface touched.

## Progress

- [x] Quote token pinned for both wallet lanes
- [x] FX-lane held-wallet re-confirm pinned (tax change, vanished quote)
- [x] Mutation-proved both properties are load-bearing
- [x] Full checkout suite green, prettier + eslint clean
- [ ] Reviewed and merged
- [ ] PR 4 — narrow `disable_wallets` in `StripePaymentPresenter` behind its own flag (the actual enable)

---

Stacked on #6438 — review that one first. Part of antiwork/gumroad-private#1436.
