### PR TITLE
Correct the partial-refund comment on affiliate_credits_total_revenue_cents

### DIFF
--- a/app/modules/user/stats.rb
+++ b/app/modules/user/stats.rb
@@ -126,10 +126,12 @@ module User::Stats
   #    check after the join, so MySQL fetches each joined purchase row from the
   #    clustered index, and the cost grows with the affiliate's whole credit
   #    history even though partial refunds are rare — roughly 70% of this
-  #    page's request time (Sentry GUMROAD-H8). It also double-counted: a
-  #    partial refund leaves the credit in the `paid` scope, so the first term
-  #    of that sum already counted the credit in full and the second term added
-  #    the same amount again.
+  #    page's request time (Sentry GUMROAD-H8). What that adjustment does is
+  #    narrower than the name suggests: any refund at all, partial included,
+  #    stamps a refund or chargeback balance onto the credit and drops it out of
+  #    the `paid` scope, so the sum below adds back the slice of a partially
+  #    refunded commission the affiliate still keeps. This method skips all of
+  #    that on purpose and reports the gross figure.
   # 3. It reads HIGHER than the per-product Revenue column on the same page,
   #    which excludes credits carrying a refund or chargeback balance. That is
   #    the difference between a lifetime gross figure and a currently-earning


### PR DESCRIPTION
## What

Comment-only. Removes a claim about partial refunds from the docs on `affiliate_credits_total_revenue_cents` that production contradicts, and replaces it with what actually happens.

No behaviour change, no spec change.

## Why

#6420 documented `affiliate_credits_total_revenue_cents` partly by contrast with `affiliate_credit_sum_from_scope` below it, and described that method as double-counting:

```
#    page's request time (Sentry GUMROAD-H8). It also double-counted: a
#    partial refund leaves the credit in the `paid` scope, so the first term
#    of that sum already counted the credit in full and the second term added
#    the same amount again.
```

That is not what the data does. `Purchase#process_refund_or_chargeback_for_affiliate_credit_balance` stamps a refund or chargeback balance onto the affiliate credit on **any** refund, partial included — only the `affiliate_partial_refunds` row is conditional:

```ruby
if refund
  affiliate_credit.affiliate_credit_refund_balance = affiliate_balance_transaction.balance
elsif dispute
  affiliate_credit.affiliate_credit_chargeback_balance = affiliate_balance_transaction.balance
end
affiliate_credit.save!

if affiliate_credit_cents != refund_cents    # only THIS is conditional
  affiliate_partial_refunds.create!(...)
end
```

The stamp drops the credit out of `AffiliateCredit.paid`. So the second term is an **add-back of the commission the affiliate still keeps**, not a duplicate of the first. Checked on a read-only production replica across five id windows spanning the table's history: of the partially refunded credits in each window, **zero** were inside the `paid` scope. There are no rows of the shape the comment describes.

The comment matters more than a stale comment usually would, because it sits directly above the method it describes and pointed at a "fix" that loses money. Acting on it means deleting the add-back, which would have zeroed **$5,981.26 of correctly-counted, still-earned commission across 382 credits** to correct a $52.58 error across 22. That PR was written (#6446) before the premise was measured, and is now closed in favour of #6445, which merged.

## What changed

The double-count sentence is gone. In its place, a plain-language statement of what the adjustment below actually is, so the contrast this comment is drawing still lands:

> What that adjustment does is narrower than the name suggests: any refund at all, partial included, stamps a refund or chargeback balance onto the credit and drops it out of the `paid` scope, so the sum below adds back the slice of a partially refunded commission the affiliate still keeps. This method skips all of that on purpose and reports the gross figure.

The performance half of the same bullet — the `purchases` join costing roughly 70% of the affiliated-products page time, Sentry GUMROAD-H8 — is **kept unchanged**. It is accurate and it is the actual reason this method exists.

## Test Results

Comment-only, so there is nothing to pin with a spec. Verified the file is otherwise untouched and lints clean:

```
$ git diff --stat origin/main
 app/modules/user/stats.rb | 9 +++++----

$ bundle exec rubocop app/modules/user/stats.rb
1 file inspected, no offenses detected
```

Related: #6420 (introduced the comment), #6445 (the shipped fix), #6446 (closed), gumroad-private#1432.


## QA steps

Docs-only — the diff is the reviewable artifact. There is no runtime behaviour, no route, and no rendered surface to click through, so there is no preview URL path and no before/after media. What to check instead: read the replaced bullet against `Purchase#process_refund_or_chargeback_for_affiliate_credit_balance` (app/models/purchase.rb) and confirm the refund/chargeback balance stamp is unconditional while only the `affiliate_partial_refunds` row is gated on `affiliate_credit_cents != refund_cents`.

---

Written by Gumclaw, an AI agent running on claude-opus-5. The work was prompted by "Fix." from @slavingia on gumroad-private#1432; this particular PR came out of noticing, while closing #6446, that the comment #6420 left in this file asserts the same premise that production disproved and would send the next reader down the same path. No human wrote any part of the diff.
