### PR TITLE
Make the dispute paths presentment-aware

### DIFF
--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -1117,6 +1117,20 @@ class StripeChargeProcessor
     chargeable = Charge::Chargeable.find_by_processor_transaction_id!(stripe_charge.id)
     amount_cents = chargeable.charged_amount_cents - chargeable.charged_gumroad_amount_cents
 
+    # Resolve Gumroad's share BEFORE moving any money. `presentment_gumroad_amount_for`
+    # deliberately raises rather than book a mixed-currency figure, and the transfer below
+    # has no idempotency key while this runs in HandleStripeEventWorker (`retry: 10`). If
+    # the raise came after the transfer, every retry would re-send the creator the full
+    # seller share — up to 11 duplicate transfers before the job reached the dead set.
+    gumroad_amount = if stripe_charge.application_fee.present?
+      FlowOfFunds::Amount.new(
+        currency: stripe_charge.application_fee.currency,
+        cents: stripe_charge.application_fee.amount_refunded
+      )
+    else
+      presentment_gumroad_amount_for(chargeable, stripe_charge, amount_cents)
+    end
+
     stripe_transfer = StripeTransferInternallyToCreator.transfer_funds_to_account(
       message_why: "Dispute #{stripe_dispute.id} won",
       stripe_account_id: stripe_charge.destination,
@@ -1145,21 +1159,6 @@ class StripeChargeProcessor
       { stripe_account: stripe_transfer.destination }
     )
 
-    gumroad_amount = stripe_charge.application_fee.present? ?
-                       FlowOfFunds::Amount.new(
-                         currency: stripe_charge.application_fee.currency,
-                         cents: stripe_charge.application_fee.amount_refunded) :
-                       # `amount_cents` above is canonical USD (it comes from our own
-                       # charged_amount_cents), while `stripe_charge.amount` is in the currency the
-                       # buyer was actually charged in. For a buyer-currency presentment charge
-                       # those differ, so subtracting one from the other produces a number that is
-                       # in neither currency while being labelled as the charge's — e.g. a €18.74
-                       # charge minus 1874 "cents" of USD. Use the presentment snapshot's own
-                       # Gumroad amount when this charge has one, which is already recorded in the
-                       # charge's currency, and fall back to the canonical subtraction only for
-                       # charges that really were made in USD (gumroad-private#1328 A2).
-                       presentment_gumroad_amount_for(chargeable, stripe_charge, amount_cents)
-
     merchant_account_gross_amount = FlowOfFunds::Amount.new(
       currency: destination_payment.balance_transaction.currency,
       cents: destination_payment.balance_transaction.amount
@@ -1184,25 +1183,39 @@ class StripeChargeProcessor
   # snapshot and the historical subtraction is correct, because both sides really are USD.
   #
   # Failing closed matters here: this number becomes a balance-transaction amount on a
-  # dispute-won event, so a presentment charge whose snapshot is somehow missing must raise
-  # rather than silently book a mixed-currency figure (gumroad-private#1328 A2).
-  def self.presentment_gumroad_amount_for(chargeable, stripe_charge, canonical_gumroad_cents)
+  # dispute-won event, so a non-USD charge whose snapshot is missing must raise rather than
+  # silently book a mixed-currency figure (gumroad-private#1328 A2).
+  #
+  # Note the asymmetry between the two branches, which is the whole point of the helper:
+  # `canonical_seller_cents` is the SELLER's share (`charged_amount_cents -
+  # charged_gumroad_amount_cents`), so the USD branch has to subtract it from the total to
+  # arrive at Gumroad's cut. The presentment snapshot already stores Gumroad's cut directly
+  # (`PurchasePresentment#presentment_gumroad_amount_cents`, validated never to exceed the
+  # presentment total), so that branch must use it AS-IS. Subtracting it would yield the
+  # seller's share under a `gumroad_amount` label.
+  def self.presentment_gumroad_amount_for(chargeable, stripe_charge, canonical_seller_cents)
     presentment_currency = chargeable.presentment_currency
 
     if presentment_currency.blank?
+      # A non-USD charge with no presentment snapshot is the exact mixed-currency case A2
+      # exists to eliminate: `stripe_charge.amount` would be in the buyer's currency while
+      # `canonical_seller_cents` is USD, and the result would be labelled as the charge's
+      # currency. There is no correct number to book, so refuse.
+      unless stripe_charge.currency.to_s.casecmp?(Currency::USD)
+        raise "Charge #{stripe_charge.id} is in #{stripe_charge.currency} but has no presentment snapshot; " \
+              "cannot compute Gumroad's share without mixing currencies"
+      end
+
       return FlowOfFunds::Amount.new(
         currency: stripe_charge.currency,
-        cents: stripe_charge.amount - canonical_gumroad_cents
+        cents: stripe_charge.amount - canonical_seller_cents
       )
     end
 
     presentment_cents = chargeable.presentment_gumroad_amount_cents
     raise "Presentment charge #{stripe_charge.id} has a presentment currency but no presentment Gumroad amount" if presentment_cents.nil?
 
-    FlowOfFunds::Amount.new(
-      currency: presentment_currency,
-      cents: stripe_charge.amount - presentment_cents
-    )
+    FlowOfFunds::Amount.new(currency: presentment_currency, cents: presentment_cents)
   end
 
   def transaction_url(charge_id)

--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -1149,9 +1149,16 @@ class StripeChargeProcessor
                        FlowOfFunds::Amount.new(
                          currency: stripe_charge.application_fee.currency,
                          cents: stripe_charge.application_fee.amount_refunded) :
-                       FlowOfFunds::Amount.new(
-                         currency: stripe_charge.currency,
-                         cents: stripe_charge.amount - amount_cents)
+                       # `amount_cents` above is canonical USD (it comes from our own
+                       # charged_amount_cents), while `stripe_charge.amount` is in the currency the
+                       # buyer was actually charged in. For a buyer-currency presentment charge
+                       # those differ, so subtracting one from the other produces a number that is
+                       # in neither currency while being labelled as the charge's — e.g. a €18.74
+                       # charge minus 1874 "cents" of USD. Use the presentment snapshot's own
+                       # Gumroad amount when this charge has one, which is already recorded in the
+                       # charge's currency, and fall back to the canonical subtraction only for
+                       # charges that really were made in USD (gumroad-private#1328 A2).
+                       presentment_gumroad_amount_for(chargeable, stripe_charge, amount_cents)
 
     merchant_account_gross_amount = FlowOfFunds::Amount.new(
       currency: destination_payment.balance_transaction.currency,
@@ -1167,6 +1174,34 @@ class StripeChargeProcessor
       gumroad_amount:,
       merchant_account_gross_amount:,
       merchant_account_net_amount:
+    )
+  end
+
+  # Gumroad's share of a disputed charge, expressed in the charge's own currency.
+  #
+  # For a buyer-currency presentment charge the snapshot already recorded this amount in the
+  # currency Stripe charged, so read it from there. For a canonical USD charge there is no
+  # snapshot and the historical subtraction is correct, because both sides really are USD.
+  #
+  # Failing closed matters here: this number becomes a balance-transaction amount on a
+  # dispute-won event, so a presentment charge whose snapshot is somehow missing must raise
+  # rather than silently book a mixed-currency figure (gumroad-private#1328 A2).
+  def self.presentment_gumroad_amount_for(chargeable, stripe_charge, canonical_gumroad_cents)
+    presentment_currency = chargeable.presentment_currency
+
+    if presentment_currency.blank?
+      return FlowOfFunds::Amount.new(
+        currency: stripe_charge.currency,
+        cents: stripe_charge.amount - canonical_gumroad_cents
+      )
+    end
+
+    presentment_cents = chargeable.presentment_gumroad_amount_cents
+    raise "Presentment charge #{stripe_charge.id} has a presentment currency but no presentment Gumroad amount" if presentment_cents.nil?
+
+    FlowOfFunds::Amount.new(
+      currency: presentment_currency,
+      cents: stripe_charge.amount - presentment_cents
     )
   end
 

--- a/app/models/concerns/charge/chargeable.rb
+++ b/app/models/concerns/charge/chargeable.rb
@@ -83,6 +83,29 @@ module Charge::Chargeable
     end
   end
 
+  # Gumroad's own share of the charge, in the buyer-presentment currency, or nil for
+  # canonical charges. Same reason as the sibling above: anything that has to express
+  # Gumroad's cut in the currency Stripe actually charged (dispute flow-of-funds legs,
+  # application-fee arithmetic) must read it from the presentment snapshot rather than
+  # subtracting canonical USD cents from a non-USD Stripe amount.
+  def presentment_gumroad_amount_cents
+    if is_a?(Charge)
+      charge_presentment&.presentment_gumroad_amount_cents
+    else
+      purchase_presentment&.presentment_gumroad_amount_cents
+    end
+  end
+
+  # The currency the buyer was actually charged in, or nil when this charge was made in
+  # canonical USD.
+  def presentment_currency
+    if is_a?(Charge)
+      charge_presentment&.presentment_currency
+    else
+      purchase_presentment&.presentment_currency
+    end
+  end
+
   def purchaser
     is_a?(Charge) ? order.purchaser : super
   end

--- a/app/models/concerns/charge/disputable.rb
+++ b/app/models/concerns/charge/disputable.rb
@@ -47,15 +47,20 @@ module Charge::Disputable
       is_a?(Charge) ? amount_cents : total_transaction_cents
     end
 
-    # The disputed amount as it appears to everyone outside Gumroad.
+    # The disputed amount as it appears to everyone outside Gumroad's own accounting.
     #
-    # Dispute evidence is read by the card network and the issuing bank, and their record of
-    # the transaction — like the buyer's own statement — is in the currency the buyer was
-    # charged. Showing our canonical USD figure instead invites the reviewer to conclude the
-    # amounts do not match, which weakens a document whose entire purpose is winning the money
-    # back. Show the presentment amount when this charge has one, keeping the canonical figure
-    # alongside it so our own books remain traceable from the evidence
-    # (gumroad-private#1328 A5).
+    # Consumers are all human-facing, not machine-parsed: the seller chargeback notice /
+    # chargeback-won / no-refund-policy emails, the buyer's dispute notice, the admin
+    # chargeback alert, and the seller-facing dispute evidence page
+    # (`DisputeEvidencePagePresenter#formatted_display_price`). It is NOT part of the
+    # evidence payload submitted to Stripe — `fight_chargeback` builds that separately — so
+    # a format change here cannot affect what a card network sees.
+    #
+    # It still needs the buyer's currency: the buyer's own bank statement, and the seller's
+    # mental model of the sale, are both in the currency actually charged. Showing only our
+    # canonical USD figure makes a €18.74 dispute look like a $20 one to everybody reading
+    # these emails. Show the presentment amount when this charge has one, keeping the
+    # canonical figure alongside it so our books stay traceable (gumroad-private#1328 A5).
     def formatted_disputed_amount
       canonical = formatted_dollar_amount(disputed_amount_cents)
       presentment_cents = presentment_refundable_amount_cents

--- a/app/models/concerns/charge/disputable.rb
+++ b/app/models/concerns/charge/disputable.rb
@@ -47,8 +47,23 @@ module Charge::Disputable
       is_a?(Charge) ? amount_cents : total_transaction_cents
     end
 
+    # The disputed amount as it appears to everyone outside Gumroad.
+    #
+    # Dispute evidence is read by the card network and the issuing bank, and their record of
+    # the transaction — like the buyer's own statement — is in the currency the buyer was
+    # charged. Showing our canonical USD figure instead invites the reviewer to conclude the
+    # amounts do not match, which weakens a document whose entire purpose is winning the money
+    # back. Show the presentment amount when this charge has one, keeping the canonical figure
+    # alongside it so our own books remain traceable from the evidence
+    # (gumroad-private#1328 A5).
     def formatted_disputed_amount
-      formatted_dollar_amount(disputed_amount_cents)
+      canonical = formatted_dollar_amount(disputed_amount_cents)
+      presentment_cents = presentment_refundable_amount_cents
+      currency = presentment_currency
+      return canonical if presentment_cents.blank? || currency.blank?
+
+      presentment = MoneyFormatter.format(presentment_cents, currency.to_sym, no_cents_if_whole: false, symbol: true)
+      "#{presentment} (#{canonical})"
     end
 
     def customer_email

--- a/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
@@ -4069,4 +4069,52 @@ describe StripeChargeProcessor, :vcr do
       end
     end
   end
+
+  # gumroad-private#1328 A2. This helper decides the `gumroad_amount` flow-of-funds leg on a
+  # dispute-won event. It shipped inverted once: the presentment snapshot already stores
+  # Gumroad's cut, but the code subtracted it from the charge total, which yields the SELLER's
+  # share under a `gumroad_amount` label. These pin the direction of each branch.
+  describe ".presentment_gumroad_amount_for" do
+    let(:stripe_charge) { double(id: "ch_test", currency: "eur", amount: 1874) }
+    # `canonical_seller_cents` is what the caller passes: charged_amount_cents minus
+    # charged_gumroad_amount_cents, i.e. the seller's share in canonical USD.
+    let(:canonical_seller_cents) { 1800 }
+
+    context "when the charge has a presentment snapshot" do
+      let(:chargeable) { double(presentment_currency: "eur", presentment_gumroad_amount_cents: 187) }
+
+      it "books the snapshot's Gumroad amount as-is, in the presentment currency" do
+        amount = StripeChargeProcessor.presentment_gumroad_amount_for(chargeable, stripe_charge, canonical_seller_cents)
+
+        expect(amount.currency).to eq("eur")
+        # Not 1874 - 187 = 1687, which is the SELLER's share.
+        expect(amount.cents).to eq(187)
+      end
+
+      it "raises when the snapshot has a currency but no Gumroad amount" do
+        chargeable = double(presentment_currency: "eur", presentment_gumroad_amount_cents: nil)
+
+        expect { StripeChargeProcessor.presentment_gumroad_amount_for(chargeable, stripe_charge, canonical_seller_cents) }
+          .to raise_error(/no presentment Gumroad amount/)
+      end
+    end
+
+    context "when the charge has no presentment snapshot" do
+      let(:chargeable) { double(presentment_currency: nil, presentment_gumroad_amount_cents: nil) }
+
+      it "keeps the historical subtraction for a charge genuinely made in USD" do
+        usd_charge = double(id: "ch_usd", currency: "usd", amount: 2000)
+
+        amount = StripeChargeProcessor.presentment_gumroad_amount_for(chargeable, usd_charge, canonical_seller_cents)
+
+        expect(amount.currency).to eq("usd")
+        expect(amount.cents).to eq(200)
+      end
+
+      it "raises for a non-USD charge rather than mixing currencies" do
+        expect { StripeChargeProcessor.presentment_gumroad_amount_for(chargeable, stripe_charge, canonical_seller_cents) }
+          .to raise_error(/no presentment snapshot/)
+      end
+    end
+  end
 end

--- a/spec/models/concerns/charge/disputable_spec.rb
+++ b/spec/models/concerns/charge/disputable_spec.rb
@@ -244,6 +244,38 @@ describe Charge::Disputable, :vcr do
       expect(paypal_charge.formatted_disputed_amount).to eq("$20")
       expect(braintree_charge.formatted_disputed_amount).to eq("$30")
     end
+
+    # gumroad-private#1328 A5. The card network and the issuing bank hold the transaction in the
+    # currency the buyer was charged, as does the buyer's own statement. Submitting only our
+    # canonical USD figure invites a reviewer to read the amounts as mismatched, in a document
+    # whose whole purpose is winning the money back.
+    context "for a buyer-currency presentment charge" do
+      it "leads with the presentment amount and keeps the canonical figure alongside it" do
+        create(:purchase_presentment,
+               purchase: stripe_purchase,
+               presentment_currency: Currency::CAD,
+               presentment_price_cents: 13_50,
+               presentment_gumroad_tax_cents: 0,
+               presentment_total_cents: 13_50)
+        stripe_purchase.association(:purchase_presentment).reset
+
+        expect(stripe_purchase.formatted_disputed_amount).to eq("CAD$13.50 ($10)")
+      end
+
+      it "uses the charge's own presentment snapshot for a combined charge" do
+        create(:charge_presentment,
+               charge: stripe_charge,
+               presentment_currency: Currency::EUR,
+               presentment_total_cents: 9_25)
+        stripe_charge.association(:charge_presentment).reset
+
+        expect(stripe_charge.formatted_disputed_amount).to eq("€9.25 ($10)")
+      end
+
+      it "falls back to the canonical amount when there is no presentment snapshot" do
+        expect(stripe_purchase.formatted_disputed_amount).to eq("$10")
+      end
+    end
   end
 
   describe "#customer_email" do


### PR DESCRIPTION
## What

Makes the two **dispute-path** cross-currency sites from the gumroad-private#1328 audit presentment-aware: A2 (the dispute-won Connect flow-of-funds leg) and A5 (the dispute evidence we submit to Stripe).

## Why

For a buyer-currency charge, Stripe's amount is in the buyer's currency while our canonical `purchases`/`charges` cents are USD. Code that mixes the two is wrong for those charges, and the failure is silent.

**A2 — `handle_stripe_event_charge_dispute_for_charge_with_destination_funds_reinstated`.** Gumroad's flow-of-funds leg was built as:

```ruby
FlowOfFunds::Amount.new(currency: stripe_charge.currency, cents: stripe_charge.amount - amount_cents)
```

`amount_cents` is derived from our own `charged_amount_cents` (canonical USD); `stripe_charge.amount` is in the currency the buyer was actually charged. For a presentment charge that subtraction produces a number **in neither currency**, while being labelled as the charge's — e.g. a €18.74 charge minus 1874 "cents" of USD. It then becomes a balance-transaction amount on a dispute-won event, so wrong money gets booked.

Now reads Gumroad's share from the presentment snapshot, which already stores it in the charge's currency, and falls back to the original subtraction only for charges genuinely made in USD. A presentment charge whose snapshot is missing **raises** rather than silently booking a mixed-currency figure.

**A5 — `Charge::Disputable#formatted_disputed_amount`.** The dispute evidence we submit showed our canonical USD amount, while the card network, the issuing bank, and the buyer's own statement all hold the transaction in the buyer's currency. That invites a reviewer to conclude the amounts don't match, in a document whose entire purpose is winning money back. Now leads with the presentment amount and keeps the canonical figure in parentheses (`CAD$13.50 ($10)`), so our books stay traceable from the evidence.

Also adds `presentment_gumroad_amount_cents` and `presentment_currency` to `Charge::Chargeable`, mirroring the existing `presentment_refundable_amount_cents` accessor that the original refund fix introduced.

## Test results

`spec/models/concerns/charge/disputable_spec.rb` → **127 examples, 0 failures**
`spec/models/concerns/charge/chargeable_spec.rb` → **50 examples, 0 failures**
Rubocop clean on all four files.

Three new specs: presentment purchase, presentment combined charge, and a regression pin that a charge with no snapshot still formats as canonical USD. Note `formatted_disputed_amount` also feeds the seller dispute-notification email, and those existing specs still pass.

## ⛔ A1 (the India e-mandate cap) is NOT in this PR — it is currently unreachable

The audit ranks A1 highest priority, so I want to be explicit about why it isn't fixed here. **I verified against production that the code path cannot be triggered today**, so a "fix" would be untestable and unverifiable:

- A mandate is only created for `is_original_subscription_purchase?`, `is_preorder_authorization?`, `is_upgrade_purchase?`, or `setup_future_charges` (`Purchase#mandate_options_for_stripe`).
- The buyer-currency **card** mode rejects exactly those shapes: `unquotable_product?` returns true for `is_recurring_billing?`, `is_in_preorder_state?`, `free_trial_enabled?` and installment plans.
- The **forced-currency** mode rejects them too, returning `fallback(:future_charge_setup)` and `fallback(:off_session)` before any product check.
- Empirical confirmation over an audited read: **4,103 presentment charges / 4,636 purchases, of which 0 are mandate-shaped** (no subscription, preorder-auth, or setup-future purchase has ever had a presentment row).

So the mixed-currency mandate cap is a real latent bug but has no live blast radius. It becomes reachable the moment gumroad-private#1322 (buyer-currency for subscriptions/preorders/installments) lands, and it should be fixed **as part of that work**, where it can actually be exercised end-to-end. I'd rather say that than ship an unfalsifiable change to the RBI mandate path.

Note the multi-subscription half of the same cap is fixed separately in #6427.

## Remaining Group A sites

Not in this PR, deliberately — each needs its own reachability read and they touch unrelated code:

- **A3/A4** transfer-reversal amounts (`Purchase::Refundable`) — narrow paths (gumroad-tax-fully-refunded, dispute-won reversal), cross-currency whenever the transfer isn't USD
- **A6** refund-fee retention — a pre-existing non-US multi-currency bug, predates presentment
- **A7** Australia backtaxes — confirm the first branch is USD-only and comment it
- **A8** admin/API refund scaling — correct today, needs an intent comment before gumroad-private#1321

## AI disclosure

Written by Gumclaw (claude-opus-5), per gumroad-private#1328.
