### PR TITLE
Point the affiliate credit add-back specs at a method that still exists

### DIFF
--- a/spec/modules/user/stats_spec.rb
+++ b/spec/modules/user/stats_spec.rb
@@ -421,10 +421,22 @@ describe User::Stats, :vcr do
                                   affiliate_credit_success_balance: create(:balance, user: affiliate_user))
       end
 
+      # #affiliate_credit_sum_from_scope is private, so these examples drive it through
+      # #affiliate_credits_sum_for_credits_created_between — the only public caller left on
+      # User::Stats that still routes into it. The window is deliberately wider than the
+      # examples' lifetime so it selects every credit they create and the date filter has no
+      # bearing on the figures asserted below; what is under test is the add-back, not the
+      # window. The dashboard entrypoint these examples originally called,
+      # #affiliate_credits_sum_total, was removed in #6420 in favour of the unfiltered
+      # #affiliate_credits_total_revenue_cents, which does not use the add-back at all.
+      def affiliate_credit_sum
+        affiliate_user.affiliate_credits_sum_for_credits_created_between(1.year.ago, 1.year.from_now)
+      end
+
       it "counts an untouched credit at its full value" do
         affiliate_credit_for_new_purchase
 
-        expect(affiliate_user.affiliate_credits_sum_total).to eq 200
+        expect(affiliate_credit_sum).to eq 200
       end
 
       it "counts only the retained remainder of a partially reversed credit" do
@@ -435,7 +447,7 @@ describe User::Stats, :vcr do
 
         # 200 earned, 75 clawed back, 125 retained. The credit is out of `paid` because the
         # refund balance is set, so this figure comes entirely from the add-back.
-        expect(affiliate_user.affiliate_credits_sum_total).to eq 125
+        expect(affiliate_credit_sum).to eq 125
       end
 
       it "counts nothing for a credit that was clawed back in full" do
@@ -445,7 +457,7 @@ describe User::Stats, :vcr do
         # No affiliate_partial_refund row: Purchase only creates one when the affiliate credit
         # was reversed by less than its full value, so its absence means a full claw-back.
 
-        expect(affiliate_user.affiliate_credits_sum_total).to eq 0
+        expect(affiliate_credit_sum).to eq 0
       end
 
       it "counts a credit reversed over several partial refunds only once" do
@@ -457,7 +469,7 @@ describe User::Stats, :vcr do
 
         # 200 earned, 80 clawed back over two refunds, 120 retained. Guards against restricting
         # the add-back with a join, which would add the 200 once per refund row.
-        expect(affiliate_user.affiliate_credits_sum_total).to eq 120
+        expect(affiliate_credit_sum).to eq 120
       end
 
       it "keeps a fully clawed-back credit at zero even when the affiliate has other refunded credits" do
@@ -474,7 +486,7 @@ describe User::Stats, :vcr do
         # per credit whether an affiliate_partial_refunds row exists for THAT credit, so this
         # is what pins the subquery to the outer row: if it merely asked whether any refund row
         # exists at all, the fully reversed credit would be added back too and this would be 325.
-        expect(affiliate_user.affiliate_credits_sum_total).to eq 125
+        expect(affiliate_credit_sum).to eq 125
       end
 
       it "combines an untouched credit with a fully clawed-back one" do
@@ -483,7 +495,7 @@ describe User::Stats, :vcr do
         reversed.purchase.update!(stripe_partially_refunded: true)
         reversed.update!(affiliate_credit_refund_balance: create(:balance, user: affiliate_user))
 
-        expect(affiliate_user.affiliate_credits_sum_total).to eq 200
+        expect(affiliate_credit_sum).to eq 200
       end
     end
 


### PR DESCRIPTION
## What

Six examples in `spec/modules/user/stats_spec.rb` call `User#affiliate_credits_sum_total`, which no longer exists on `main`. Point them at `#affiliate_credits_sum_for_credits_created_between`, which still routes into the same private method under test.

## Why

This is a merge race between two PRs that were both green, neither of which is wrong on its own.

| | PR | merged | did |
|---|---|---|---|
| A | #6445 Stop crediting affiliates for commissions clawed back in full | `716f5830c`, 23:37 UTC | added six examples asserting on `affiliate_user.affiliate_credits_sum_total` |
| B | #6420 Show plain paid-credit total on the affiliated products dashboard | `b9e0dfa22`, 23:03 UTC | **deleted** `#affiliate_credits_sum_total`, replacing the dashboard's figure with the unfiltered `#affiliate_credits_total_revenue_cents` |

B removed the method A's new specs call. Each branch's CI ran against a base without the other's change, so both passed, and the breakage only exists in the merged result. `main` is now deterministically red:

```
undefined method 'affiliate_credits_sum_total' for #<User:0x00007f8e49e71e20>
```

six times, in `Test Fast 16`. It is not a flake and it is not confined to one PR — every open PR that rebases onto or merges current `main` inherits it. Confirmed the method is absent from the whole tree, not merely moved:

```
$ git grep -n "affiliate_credits_sum_total" origin/main -- app lib
(no output — the only hits are the six spec call sites)
```

## The fix

The behaviour under test is `#affiliate_credit_sum_from_scope`, the private method that adds back the retained portion of a partially refunded commission. That method is untouched by both PRs and is still exactly what #6445 fixed. Only its *entrypoint* went away.

`#affiliate_credits_sum_for_credits_created_between` is the remaining public caller that routes into it, so the examples now go through that, with a date window wide enough that the filter selects every credit they create and has no bearing on the figures asserted:

```ruby
def affiliate_credit_sum
  affiliate_user.affiliate_credits_sum_for_credits_created_between(1.year.ago, 1.year.from_now)
end
```

Nothing in `app/` changes. The deletion in #6420 was deliberate and well-argued — the dashboard wanted a gross figure that does not adjust for partial refunds, and it carried a measured ~70% request-time improvement (Sentry GUMROAD-H8). Restoring `#affiliate_credits_sum_total` just to satisfy a spec would undo that for no caller, so this fixes the test's reach rather than reviving dead production code.

## Test results

Ruby 3.4.3, local MySQL/Redis/Elasticsearch/MongoDB, on a detached `origin/main` worktree.

Shipped:

```
$ bundle exec rspec spec/modules/user/stats_spec.rb -e "affiliate_credit_sum_from_scope"
6 examples, 0 failures
```

**Red-first, to prove the specs are still load-bearing through the new entrypoint.** The concern with swapping an entrypoint is that the examples might pass for a reason unrelated to the behaviour they claim to pin. Re-applying the exact bug #6445 removed — dropping the `EXISTS` restriction so full claw-backs get added back — reddens precisely the three claw-back cases and leaves the genuinely-partial ones green:

```
Failure/Error: expect(affiliate_credit_sum).to eq 0     Expected 200 to eq 0.
Failure/Error: expect(affiliate_credit_sum).to eq 125   Expected 325 to eq 125.
Failure/Error: expect(affiliate_credit_sum).to eq 200   Expected 400 to eq 200.
6 examples, 3 failures
```

That is the same signature #6445 documented for this mutation, including the `325` case that its pre-merge review added specifically to catch an uncorrelated subquery. Restored to green afterwards, `git diff` confirms `app/` is untouched.

`bundle exec rubocop spec/modules/user/stats_spec.rb` — no offenses.

## QA steps

No user-visible surface. The affiliated products dashboard keeps rendering `#affiliate_credits_total_revenue_cents` exactly as #6420 shipped it — this PR changes only which method a spec calls. CI's `Test Fast 16` going green is the verification.

---

🤖 Written by Hermes Agent using **claude-opus-5**.

Instructions given: a CI watcher reported PR #6454 newly red. Triage found the failure was not that PR's — it reproduces on `origin/main` from a merge race between #6445 and #6420 — so the fix was made on its own branch off `main` rather than inside the unrelated PR.
