### PR TITLE
Point the affiliate credit sum specs at the method they test

### DIFF
--- a/spec/modules/user/stats_spec.rb
+++ b/spec/modules/user/stats_spec.rb
@@ -421,10 +421,20 @@ describe User::Stats, :vcr do
                                   affiliate_credit_success_balance: create(:balance, user: affiliate_user))
       end
 
+      # Exercises the method under test over the affiliate's whole credit history. These are
+      # the scopes every caller narrows from: the `paid` rows the sum starts with, and the
+      # unfiltered set it looks in for partially refunded credits to add back.
+      def lifetime_affiliate_credit_sum
+        affiliate_user.affiliate_credit_sum_from_scope(
+          affiliate_user.affiliate_credits.paid,
+          affiliate_user.affiliate_credits
+        )
+      end
+
       it "counts an untouched credit at its full value" do
         affiliate_credit_for_new_purchase
 
-        expect(affiliate_user.affiliate_credits_sum_total).to eq 200
+        expect(lifetime_affiliate_credit_sum).to eq 200
       end
 
       it "counts only the retained remainder of a partially reversed credit" do
@@ -435,7 +445,7 @@ describe User::Stats, :vcr do
 
         # 200 earned, 75 clawed back, 125 retained. The credit is out of `paid` because the
         # refund balance is set, so this figure comes entirely from the add-back.
-        expect(affiliate_user.affiliate_credits_sum_total).to eq 125
+        expect(lifetime_affiliate_credit_sum).to eq 125
       end
 
       it "counts nothing for a credit that was clawed back in full" do
@@ -445,7 +455,7 @@ describe User::Stats, :vcr do
         # No affiliate_partial_refund row: Purchase only creates one when the affiliate credit
         # was reversed by less than its full value, so its absence means a full claw-back.
 
-        expect(affiliate_user.affiliate_credits_sum_total).to eq 0
+        expect(lifetime_affiliate_credit_sum).to eq 0
       end
 
       it "counts a credit reversed over several partial refunds only once" do
@@ -457,7 +467,7 @@ describe User::Stats, :vcr do
 
         # 200 earned, 80 clawed back over two refunds, 120 retained. Guards against restricting
         # the add-back with a join, which would add the 200 once per refund row.
-        expect(affiliate_user.affiliate_credits_sum_total).to eq 120
+        expect(lifetime_affiliate_credit_sum).to eq 120
       end
 
       it "keeps a fully clawed-back credit at zero even when the affiliate has other refunded credits" do
@@ -474,7 +484,7 @@ describe User::Stats, :vcr do
         # per credit whether an affiliate_partial_refunds row exists for THAT credit, so this
         # is what pins the subquery to the outer row: if it merely asked whether any refund row
         # exists at all, the fully reversed credit would be added back too and this would be 325.
-        expect(affiliate_user.affiliate_credits_sum_total).to eq 125
+        expect(lifetime_affiliate_credit_sum).to eq 125
       end
 
       it "combines an untouched credit with a fully clawed-back one" do
@@ -483,7 +493,7 @@ describe User::Stats, :vcr do
         reversed.purchase.update!(stripe_partially_refunded: true)
         reversed.update!(affiliate_credit_refund_balance: create(:balance, user: affiliate_user))
 
-        expect(affiliate_user.affiliate_credits_sum_total).to eq 200
+        expect(lifetime_affiliate_credit_sum).to eq 200
       end
     end
 


### PR DESCRIPTION
## What

Fixes red `main`. `spec/modules/user/stats_spec.rb` calls `User#affiliate_credits_sum_total`, which no longer exists.

## Why main is red

Two of my PRs merged 34 minutes apart and collided semantically without ever conflicting textually:

- **#6420** (`b9e0dfa22`, 19:03) renamed `affiliate_credits_sum_total` → `affiliate_credits_total_revenue_cents` and rewrote it to a plain gross sum.
- **#6445** (`716f5830c`, 19:37) added six examples for the partial-refund add-back, written against the *old* name.

#6445 branched before #6420 landed, so git merged both cleanly. The result is specs calling a method that is defined nowhere:

```
Failure/Error: expect(affiliate_user.affiliate_credits_sum_total).to eq 200
NoMethodError:
  undefined method 'affiliate_credits_sum_total' for an instance of User
```

Six failures, on whichever fast shard Knapsack hands `stats_spec.rb`. Run [30317384472](https://github.com/antiwork/gumroad/actions/runs/30317384472) (Test Fast 11) on `6201d5ad6`. Every open PR based past `716f5830c` inherits it — it also reddened #6457 and #6458.

## The fix

The `describe` block is titled `affiliate_credit_sum_from_scope`, and that is the method whose behaviour these examples pin — the removed wrapper was only supplying the lifetime scopes. So call it directly with those scopes via a small helper:

```ruby
def lifetime_affiliate_credit_sum
  affiliate_user.affiliate_credit_sum_from_scope(
    affiliate_user.affiliate_credits.paid,
    affiliate_user.affiliate_credits
  )
end
```

**No `app/` code changes.** Restoring the old name would be wrong: #6420 deliberately moved the dashboard stat to an unfiltered gross sum for a documented performance reason (Sentry GUMROAD-H8), so the wrapper's disappearance is intended and its behaviour is not what these examples describe.

## Test results

```
6 examples, 0 failures
```

Red-first verified, so the examples are still load-bearing rather than merely passing. Mutating the add-back's `EXISTS` correlation away — the exact defect #6445 fixed — reddens precisely the three full-claw-back cases and leaves the partial-refund cases green:

```
6 examples, 3 failures

rspec ./spec/modules/user/stats_spec.rb:451 # counts nothing for a credit that was clawed back in full
rspec ./spec/modules/user/stats_spec.rb:473 # keeps a fully clawed-back credit at zero even when the affiliate has other refunded credits
rspec ./spec/modules/user/stats_spec.rb:490 # combines an untouched credit with a fully clawed-back one
```

Source restored afterwards; `git diff` against `app/` is empty. `rubocop` clean.

---

🤖 Written by Hermes Agent using **claude-opus-5**, triaging a red-build watcher alert.
