### PR TITLE
Fail closed on non-USD transfers before creating currency-mismatched reversals (1328 A3/A4)

### DIFF
--- a/app/modules/purchase/refundable.rb
+++ b/app/modules/purchase/refundable.rb
@@ -613,7 +613,25 @@ class Purchase
 
       transfers = Stripe::Transfer.list({ destination: merchant_account.charge_processor_merchant_id, created: { gte: dispute.won_at.to_i - 60000 },  limit: 100 })
       transfer = transfers.select { |tr| tr["description"]&.include?("Dispute #{dispute.charge_processor_dispute_id} won") }.first
-      Stripe::Transfer.create_reversal(transfer.id, { amount: amount_refundable_cents }) if transfer.present?
+      return unless transfer.present?
+
+      # Stripe denominates reversal amounts in the transfer's own currency, while
+      # amount_refundable_cents is canonical USD. The dispute-win transfer is created in
+      # USD (StripeTransferInternallyToCreator via the dispute-reinstated webhook handler
+      # always passes Currency::USD), so sending the canonical figure is correct — but
+      # only as long as that assumption holds. If the transfer we found is in any other
+      # currency (a buyer-currency presentment charge would make this mistake easy to
+      # introduce upstream), the canonical USD number would be reinterpreted in that
+      # currency and reverse the wrong amount of real money from the creator's account.
+      # Fail closed instead of guessing (gumroad-private#1328 A4).
+      if transfer.currency != Currency::USD
+        raise "Cannot reverse dispute-win transfer #{transfer.id} for purchase #{id}: " \
+              "the transfer is denominated in #{transfer.currency}, but the reversal amount " \
+              "(amount_refundable_cents) is canonical USD. Reverse it manually with a " \
+              "#{transfer.currency}-denominated amount."
+      end
+
+      Stripe::Transfer.create_reversal(transfer.id, { amount: amount_refundable_cents })
     end
 
     def debit_processor_fee_from_merchant_account!(refund)
@@ -641,6 +659,26 @@ class Purchase
 
       stripe_charge = Stripe::Charge.retrieve(refund.purchase.stripe_transaction_id)
       transfer = Stripe::Transfer.retrieve(id: stripe_charge.transfer)
+
+      # Everything below mixes our canonical USD cents with Stripe amounts that are
+      # denominated in the transfer's currency: amount_cents_to_be_reversed_usd (the
+      # seller's balance debit) is canonical USD, while the reversal amounts already on
+      # the transfer — and the amount Stripe expects for a new reversal — are in the
+      # currency of the original charge. Those are the same currency only when the charge
+      # was made in USD. For a buyer-currency presentment charge (say euros), comparing
+      # the two would misjudge whether an excess exists, and the reversal we create would
+      # pull `reversal_amount_cents_usd` euro cents — not USD cents — out of the
+      # creator's account: real money, wrong amount. The seller-net excess in the buyer's
+      # currency is not stored anywhere (refund presentment snapshots record gross
+      # components only), so there is no correct figure to send; fail closed rather than
+      # guess or convert at the live rate (gumroad-private#1328 A3).
+      if transfer.currency != Currency::USD
+        raise "Cannot reverse excess amount from transfer #{transfer.id} for refund #{refund.id}: " \
+              "the transfer is denominated in #{transfer.currency}, but the excess " \
+              "(the seller's balance debit) is canonical USD. Reconcile it manually with a " \
+              "#{transfer.currency}-denominated amount."
+      end
+
       amount_cents_already_reversed_usd = transfer.reversals.data.find { |d| d.source_refund == refund.processor_refund_id }.amount.abs
 
       return unless amount_cents_already_reversed_usd < amount_cents_to_be_reversed_usd

--- a/spec/models/purchase/purchase_refunds_spec.rb
+++ b/spec/models/purchase/purchase_refunds_spec.rb
@@ -1529,6 +1529,69 @@ describe "PurchaseRefunds", :vcr do
 
       purchase.send(:reverse_excess_amount_from_stripe_transfer, refund:)
     end
+
+    # gumroad-private#1328 A3. The excess to reverse is the seller's canonical USD balance
+    # debit, while Stripe denominates transfer reversals in the transfer's own currency.
+    # These specs pin both halves of the fix: the USD path keeps sending the exact same
+    # number as before, and a non-USD transfer fails closed instead of pulling that USD
+    # number out of the creator's account reinterpreted as buyer-currency cents.
+    context "currency handling of the reversal amount" do
+      let(:purchase) { create(:purchase, link: @product, merchant_account: @merchant_account, stripe_transaction_id: "ch_2MlrJr9e1RjUNIyY0s8AWM5s") }
+      let(:refund) { create(:refund, purchase:, processor_refund_id: "re_2MlrJr9e1RjUNIyY0dzjVFPd") }
+
+      before do
+        allow_any_instance_of(Purchase).to receive(:gumroad_tax_cents).and_return 200
+        allow_any_instance_of(Purchase).to receive(:gumroad_tax_refunded_cents).and_return 200
+
+        BalanceTransaction.create!(
+          user: purchase.seller,
+          merchant_account: purchase.merchant_account,
+          refund:,
+          dispute: nil,
+          issued_amount: BalanceTransaction::Amount.new(currency: "usd", gross_cents: -500, net_cents: -367),
+          holding_amount: BalanceTransaction::Amount.new(currency: "cad", gross_cents: -492, net_cents: -492),
+          update_user_balance: purchase.charged_using_gumroad_merchant_account?
+        )
+
+        allow(Stripe::Charge).to receive(:retrieve).with(purchase.stripe_transaction_id).and_return(double(transfer: "tr_test_123"))
+      end
+
+      def stub_transfer(currency:, already_reversed_cents:)
+        reversal = double(source_refund: refund.processor_refund_id, amount: -already_reversed_cents)
+        double(id: "tr_test_123", currency:, reversals: double(data: [reversal]))
+      end
+
+      it "reverses the USD excess on a USD transfer, exactly as before" do
+        transfer = stub_transfer(currency: "usd", already_reversed_cents: 100)
+        allow(Stripe::Transfer).to receive(:retrieve).with(id: "tr_test_123").and_return(transfer)
+
+        transfer_reversal = double(destination_payment_refund: "re_dest_1")
+        expect(Stripe::Transfer).to receive(:create_reversal).with("tr_test_123", { amount: 267 }).and_return(transfer_reversal)
+        allow(Stripe::Refund).to receive(:retrieve)
+          .with("re_dest_1", stripe_account: purchase.merchant_account.charge_processor_merchant_id)
+          .and_return(double(balance_transaction: "txn_dest_1"))
+        allow(Stripe::BalanceTransaction).to receive(:retrieve)
+          .with("txn_dest_1", stripe_account: purchase.merchant_account.charge_processor_merchant_id)
+          .and_return(double(net: -360))
+
+        expect(Credit).to receive(:create_for_partial_refund_transfer_reversal!)
+          .with(amount_cents_usd: -267, amount_cents_holding_currency: -360, merchant_account: purchase.merchant_account)
+
+        purchase.send(:reverse_excess_amount_from_stripe_transfer, refund:)
+      end
+
+      it "fails closed on a non-USD transfer instead of reversing a USD figure in the transfer's currency" do
+        transfer = stub_transfer(currency: "eur", already_reversed_cents: 100)
+        allow(Stripe::Transfer).to receive(:retrieve).with(id: "tr_test_123").and_return(transfer)
+
+        expect(Stripe::Transfer).not_to receive(:create_reversal)
+        expect(Credit).not_to receive(:create_for_partial_refund_transfer_reversal!)
+
+        expect do
+          purchase.send(:reverse_excess_amount_from_stripe_transfer, refund:)
+        end.to raise_error(/denominated in eur/)
+      end
+    end
   end
 
   describe "refund subscription purchase" do
@@ -2369,6 +2432,42 @@ describe "PurchaseRefunds", :vcr do
       expect(Stripe::Transfer).to receive(:list).and_call_original
 
       purchase.send(:reverse_the_transfer_made_for_dispute_win!)
+    end
+
+    # gumroad-private#1328 A4. amount_refundable_cents is canonical USD, while Stripe
+    # denominates reversal amounts in the transfer's own currency. The dispute-win
+    # transfer is always created in USD today, so the USD path must keep sending the
+    # exact same number as before — and a transfer in any other currency must fail
+    # closed instead of reversing that USD number reinterpreted as foreign cents.
+    context "currency handling of the reversal amount" do
+      let(:merchant_account) { create(:merchant_account, charge_processor_merchant_id: "acct_1MABWa2noRrbY6cK") }
+      let(:purchase) { create(:purchase, link: create(:product, user: merchant_account.user), merchant_account:) }
+      let!(:dispute) { create(:dispute, purchase:, state: "won", won_at: Time.at(1669749973).utc, charge_processor_dispute_id: "dp_test_123") }
+
+      def stub_transfer_list(currency:)
+        transfer = double(id: "tr_dispute_win_1", currency:)
+        allow(transfer).to receive(:[]).with("description").and_return("Dispute dp_test_123 won.")
+        allow(Stripe::Transfer).to receive(:list).and_return([transfer])
+        transfer
+      end
+
+      it "reverses the canonical amount on a USD transfer, exactly as before" do
+        stub_transfer_list(currency: "usd")
+
+        expect(Stripe::Transfer).to receive(:create_reversal).with("tr_dispute_win_1", { amount: purchase.amount_refundable_cents })
+
+        purchase.send(:reverse_the_transfer_made_for_dispute_win!)
+      end
+
+      it "fails closed on a non-USD transfer instead of reversing a USD figure in the transfer's currency" do
+        stub_transfer_list(currency: "eur")
+
+        expect(Stripe::Transfer).not_to receive(:create_reversal)
+
+        expect do
+          purchase.send(:reverse_the_transfer_made_for_dispute_win!)
+        end.to raise_error(/denominated in eur/)
+      end
     end
   end
 


### PR DESCRIPTION
## What

Makes the two `Stripe::Transfer.create_reversal` call sites in `Purchase::Refundable` currency-safe — items **A3** and **A4** of the cross-currency audit (gumroad-private#1328):

- **A3 — `reverse_excess_amount_from_stripe_transfer(refund:)`**: computed the excess to reverse from the seller's canonical-USD balance debit, compared it against `transfer.reversals[..].amount` (denominated in the **transfer's** currency), and sent the difference as a reversal amount — again in the transfer's currency. The `_usd` variable suffixes assert a currency the Stripe-side values don't necessarily have.
- **A4 — `reverse_the_transfer_made_for_dispute_win!`**: sent `amount_refundable_cents` (canonical USD) directly as a reversal amount, interpreted by Stripe in the transfer's own currency.

Both methods now check `transfer.currency` and **raise** for any non-USD transfer, before any money moves. USD transfers — every transfer these methods reach today — keep byte-identical behaviour.

## Why

These calls move real money out of creators' connected accounts. Stripe denominates reversal amounts in the transfer's currency, so a canonical-USD figure sent against a non-USD transfer is silently reinterpreted: reversing `367` against a euro-denominated transfer pulls **€3.67 instead of $3.67** — a real financial loss (over- or under-reversal depending on the rate), with no error anywhere. The A3 comparison additionally misjudges *whether* an excess exists at all when the two sides are in different currencies.

**Why raise rather than read a presentment snapshot or convert:** the amounts these methods need are Gumroad-internal — a seller balance debit net of fees, and `amount_refundable_cents` — and no stored presentment figure corresponds to them (refund presentment snapshots record gross buyer-currency components only). The dispute-win transfer is created in USD by `StripeTransferInternallyToCreator` regardless of the charge's presentment currency, so today the guard documents and enforces an invariant rather than changing behaviour. Converting at the live rate at reversal time would book an amount matching neither our balances nor the original transfer. Failing closed for manual reconciliation mirrors the convention the presentment refund paths already follow (`buyer_presentment_refund_blocked?`, #6453).

Part of gumroad-private#1328 (items A3, A4).

## Test results

`bundle exec rspec spec/models/purchase/purchase_refunds_spec.rb` (the spec file covering `Purchase::Refundable`; there is no `spec/modules/purchase/refundable_spec.rb`):

- **With the change:** 151 examples, 3 failures — all 3 pre-existing/flaky (see below).
- **Baseline (change reverted, same seed 12345):** 147 examples, 5 failures — overlapping pre-existing set.
- The failures at `:113` ("emails the buyer the presentment purchase total on a full refund") and `:1247` ("dispute after a refund event…") fail **identically on unmodified origin/main** when run alone; the `merchant_migration` and `:1451` VCR failures are order-dependent (pass alone with the change, fail intermittently on both sides). None are introduced by this PR.
- Targeted run of both affected describes: **9 examples, 0 failures**.
- `rubocop` on both touched files: **2 files inspected, no offenses detected**.

**Load-bearing verification** (each new spec fails without the fix, passes with it):
- The 4 new examples with the fix in place: **4 examples, 0 failures**.
- Same 4 examples with `app/modules/purchase/refundable.rb` reverted: **4 examples, 2 failures** — exactly the two fail-closed specs (A3 and A4 non-USD cases). The two USD-path specs pass on both sides *by design*: they pin that USD behaviour is byte-identical to the old code (amount, `Credit.create_for_partial_refund_transfer_reversal!` arguments), guarding against a regression in the fix itself.

## Notes for review

- I deliberately did **not** use the presentment snapshot here, unlike #6453: flagging explicitly that the correct buyer-currency figure for the A3 excess (seller-net of fees) is not stored anywhere, so there is no snapshot to read — raise-for-manual-reconciliation was the only non-guessing option I found. If a stored seller-net presentment figure exists that I missed, this should use it instead.

## QA steps

Backend-only guard on money-moving private methods; no UI surface. The reviewable artifacts are the diff and the load-bearing specs above — run `bundle exec rspec spec/models/purchase/purchase_refunds_spec.rb -e "currency handling of the reversal amount"` (4 examples) with and without the `app/modules/purchase/refundable.rb` hunk to reproduce the RED/GREEN evidence.

---

🤖 Written by Hermes Agent (claude-fable-5) working gumroad-private#1328 items A3/A4. Prompt: implement A3 and A4 from the cross-currency audit following the presentment conventions established in #6453, preferring fail-closed raises over guessed amounts on money-moving paths.
