### PR TITLE
Key Pix's IOF option on the account's country, not on who owns it

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -29,16 +29,23 @@ class Purchase < ApplicationRecord
   PROCESSOR_FEE_PER_THOUSAND = 29
   PROCESSOR_FIXED_FEE_CENTS = 30
   # IOF is a Brazilian consumer tax on any transaction that involves foreign exchange, currently
-  # 3.5% of the transaction value. It applies when the Pix payment leaves Brazil — that is, when
-  # the charge is created on a Gumroad-held account, since Gumroad is domiciled outside Brazil.
-  # For those charges Gumroad tells Stripe to bill the buyer exactly the price they agreed to
+  # 3.5% of the transaction value. It applies whenever the Pix payment leaves Brazil, which is
+  # every Pix charge except one created directly on a Brazilian seller's own Stripe account.
+  #
+  # This constant is the RECOVERY half, and it is narrower than the tax itself: it is billed only
+  # when Gumroad actually bore the cost. On a charge created on a Gumroad-held account, Gumroad
+  # tells Stripe to bill the buyer exactly the price they agreed to
   # (`amount_includes_iof=always`, see Order::PreparePaymentIntentService#pix_payment_method_options)
   # and Stripe deducts the IOF from what settles to us — so the cost has to be charged back to the
   # seller as a fee component, or it would silently come out of Gumroad's own margin instead (the
-  # decision on gumroad-private#1305 was that the seller absorbs it). A Pix charge created directly
-  # on a Brazilian seller's own Stripe account never crosses a border, so no IOF arises and neither
-  # the Stripe option nor this fee applies — see pix_iof_fee_per_thousand, which gates on the same
-  # condition.
+  # decision on gumroad-private#1305 was that the seller absorbs it).
+  #
+  # On a direct charge to a seller's own connected account the money never passes through a
+  # Gumroad-held balance, so there is no Gumroad cost to recover and this fee is not billed —
+  # whether or not the tax itself applied. That makes this gate deliberately DIFFERENT from
+  # Order::PreparePaymentIntentService#pix_iof_applies?, which decides whether the tax exists at
+  # all (a border question, keyed on the account's country) rather than who paid it. See the
+  # comment on that method.
   PIX_IOF_FEE_PER_THOUSAND = 35
 
   MAX_PRICE_RANGE = (-2_147_483_647..2_147_483_647)

--- a/app/services/order/prepare_payment_intent_service.rb
+++ b/app/services/order/prepare_payment_intent_service.rb
@@ -16,11 +16,13 @@ class Order::PreparePaymentIntentService
   # Same reasoning as the Klarna message above: a Pix amount-window rejection is deterministic for
   # this cart, so telling the buyer to try again would send them in a loop.
   PIX_AMOUNT_INELIGIBLE_MESSAGE = "This order's total is outside the amount Pix supports. Please choose a different payment method (you have not been charged)."
-  # Gumroad absorbs the Brazilian IOF tax on the buyer's behalf so the amount in their banking app
-  # matches the price checkout quoted them, and recovers it from the seller as a fee component
-  # (Purchase::PIX_IOF_FEE_PER_THOUSAND) — the ruling on gumroad-private#1305. Stripe's default is
-  # the opposite (`never`, marking the buyer's amount up 3.5%), which would undo the whole point of
-  # showing an honest local-currency price, so this option is always sent explicitly.
+  # On a cross-border Pix payment, Gumroad absorbs the Brazilian IOF tax on the buyer's behalf so
+  # the amount in their banking app matches the price checkout quoted them, and recovers it from
+  # the seller as a fee component (Purchase::PIX_IOF_FEE_PER_THOUSAND) — the ruling on
+  # gumroad-private#1305. Stripe's default is the opposite (`never`, marking the buyer's amount up
+  # 3.5%), which would undo the whole point of showing an honest local-currency price. Sent on
+  # every Pix intent except a direct charge to a Brazilian connected account, which stays inside
+  # Brazil and so incurs no IOF at all — see #pix_iof_applies?.
   PIX_AMOUNT_INCLUDES_IOF = "always"
   # How long the buyer has to pay the Pix key in their banking app before it expires. Stripe's
   # default is 4 hours; ours is 30 minutes because the purchase sits in progress until the payment
@@ -334,19 +336,20 @@ class Order::PreparePaymentIntentService
     # method is what decides whether pix rides this intent at all.
     #
     # amount_includes_iof only makes sense on a cross-border Pix payment. IOF is a Brazilian tax on
-    # transactions that involve foreign exchange, so it applies when the money leaves Brazil to a
-    # Gumroad-held account abroad; that is the case the option exists for (it tells Stripe to bill
-    # the buyer exactly the listed price and take the tax out of what settles to us — see
-    # Purchase::PIX_IOF_FEE_PER_THOUSAND). When the charge is created directly on a seller's own
-    # Brazilian Stripe account the payment never crosses a border, there is no foreign exchange and
-    # therefore no IOF, and Purchase#pix_iof_fee_per_thousand already declines to bill the seller
-    # for it. Sending the option on that intent would be asking Stripe to price a tax that does not
-    # exist, and an option Stripe does not accept makes the whole intent create fail — which takes
-    # card down with it for that checkout, the failure shape from gumroad-private#1026. So the
-    # option is scoped to the same condition the fee is: charges on a Gumroad-held account. Nothing
-    # changes for today's traffic, where every Pix intent is created on the platform account; this
-    # is the gate that keeps that true once a Brazilian connected account can reach Pix
-    # (gumroad-private#1442 widened the settlement gate that used to make it unreachable).
+    # transactions that involve foreign exchange, so it applies whenever the money leaves Brazil;
+    # that is the case the option exists for (it tells Stripe to bill the buyer exactly the listed
+    # price and take the tax out of what settles, rather than Stripe's default of marking the
+    # buyer's amount up by the tax — see Purchase::PIX_IOF_FEE_PER_THOUSAND). When the charge is
+    # created directly on a seller's own BRAZILIAN Stripe account the payment stays inside Brazil,
+    # there is no foreign exchange and therefore no IOF. Sending the option on that intent would be
+    # asking Stripe to price a tax that does not exist, and an option Stripe does not accept makes
+    # the whole intent create fail — which takes card down with it for that checkout, the failure
+    # shape from gumroad-private#1026.
+    #
+    # Nothing changes for today's traffic, where every Pix intent is created on the platform
+    # account; this is the gate that keeps the option correct once a connected account can reach
+    # Pix at all (gumroad-private#1442 widened the settlement gate that used to make it
+    # unreachable).
     #
     # expires_after_seconds is unconditional: it is a property of how long we are willing to hold
     # the purchase open, not of who settles the money.
@@ -359,13 +362,25 @@ class Order::PreparePaymentIntentService
       { pix: pix_options }
     end
 
-    # True when the Pix charge is created on an account Gumroad holds, which is what makes the
-    # payment cross-border and so subject to IOF. Mirrors Purchase#charged_using_gumroad_merchant_account?
-    # for the merchant account this intent is being created on, so the option and the fee can never
-    # disagree about whether the tax applies. A missing merchant account means the platform account,
-    # which is Gumroad-held.
+    # True when the Pix payment crosses Brazil's border, which is what makes it subject to IOF.
+    # The only Pix charge that does NOT cross the border is one created directly on a seller's own
+    # Brazilian connected account; a Gumroad-held account is domiciled outside Brazil, and so is a
+    # connected account in any other country.
+    #
+    # Deliberately keyed on the account's COUNTRY, not on who owns it, and so deliberately NOT the
+    # same question Purchase#pix_iof_fee_per_thousand asks. The two gates answer different things:
+    # this one asks "is this payment cross-border, so does the tax exist at all", while the fee asks
+    # "did Gumroad absorb the tax and therefore have a cost to recover from the seller". They part
+    # company on a direct charge to a non-Brazilian connected account — the payment is cross-border
+    # so IOF applies and the option must be sent, but the tax comes out of the seller's own
+    # settlement rather than Gumroad's, so there is nothing for Gumroad to bill back. Nothing
+    # restricts Pix to Brazilian connected accounts: Checkout::PaymentMethodResolver's
+    # BR_LOCKED_PAYMENT_METHOD_TYPES gate is on the BUYER's country, and the only per-account
+    # condition is the Stripe capability snapshot, which sellers manage themselves.
+    #
+    # A missing merchant account means the platform account, which is outside Brazil.
     def pix_iof_applies?
-      !merchant_account&.is_a_stripe_connect_account?
+      !merchant_account&.is_a_brazilian_stripe_connect_account?
     end
 
     # Server-confirm checkout runs this at charge time; client-confirm combined charges skip it at

--- a/app/services/order/prepare_payment_intent_service.rb
+++ b/app/services/order/prepare_payment_intent_service.rb
@@ -16,13 +16,18 @@ class Order::PreparePaymentIntentService
   # Same reasoning as the Klarna message above: a Pix amount-window rejection is deterministic for
   # this cart, so telling the buyer to try again would send them in a loop.
   PIX_AMOUNT_INELIGIBLE_MESSAGE = "This order's total is outside the amount Pix supports. Please choose a different payment method (you have not been charged)."
-  # On a cross-border Pix payment, Gumroad absorbs the Brazilian IOF tax on the buyer's behalf so
-  # the amount in their banking app matches the price checkout quoted them, and recovers it from
-  # the seller as a fee component (Purchase::PIX_IOF_FEE_PER_THOUSAND) — the ruling on
-  # gumroad-private#1305. Stripe's default is the opposite (`never`, marking the buyer's amount up
-  # 3.5%), which would undo the whole point of showing an honest local-currency price. Sent on
-  # every Pix intent except a direct charge to a Brazilian connected account, which stays inside
-  # Brazil and so incurs no IOF at all — see #pix_iof_applies?.
+  # On a cross-border Pix payment charged on a GUMROAD-HELD account, Gumroad absorbs the Brazilian
+  # IOF tax on the buyer's behalf so the amount in their banking app matches the price checkout
+  # quoted them, and recovers it from the seller as a fee component
+  # (Purchase::PIX_IOF_FEE_PER_THOUSAND) — the ruling on gumroad-private#1305. Stripe's default is
+  # the opposite (`never`, marking the buyer's amount up 3.5%), which would undo the whole point of
+  # showing an honest local-currency price.
+  #
+  # The option is about the buyer's amount, so it is sent on every cross-border Pix intent — not
+  # only the ones Gumroad settles. On a direct charge to a non-Brazilian connected account the tax
+  # comes out of the seller's own settlement and Gumroad absorbs nothing, so the option is sent and
+  # no fee is billed back. Withheld only on a direct charge to a Brazilian connected account, which
+  # stays inside Brazil and so incurs no IOF at all — see #pix_iof_applies?.
   PIX_AMOUNT_INCLUDES_IOF = "always"
   # How long the buyer has to pay the Pix key in their banking app before it expires. Stripe's
   # default is 4 hours; ours is 30 minutes because the purchase sits in progress until the payment

--- a/spec/models/purchase/purchase_process_spec.rb
+++ b/spec/models/purchase/purchase_process_spec.rb
@@ -982,11 +982,13 @@ describe "Purchase Process", :vcr do
     end
 
     describe "Pix IOF fee" do
-      # Every Pix payment to Gumroad is cross-border, so Stripe deducts Brazil's 3.5% IOF tax from
-      # what settles to us while the buyer pays exactly the listed price (amount_includes_iof).
-      # That cost is recovered from the seller as a fee component
+      # A Pix payment to a Gumroad-held account is cross-border, so Stripe deducts Brazil's 3.5%
+      # IOF tax from what settles to us while the buyer pays exactly the listed price
+      # (amount_includes_iof). That cost is recovered from the seller as a fee component
       # (Purchase::PIX_IOF_FEE_PER_THOUSAND, the gumroad-private#1305 ruling) — it must land in
-      # fee_cents, reducing seller proceeds, never in the buyer's total.
+      # fee_cents, reducing seller proceeds, never in the buyer's total. A direct charge to a
+      # seller's own connected account settles into that account instead, so Gumroad bears no IOF
+      # cost and bills none back.
       it "folds the IOF into the Gumroad fee for a Pix purchase, reducing seller proceeds" do
         purchase = build(:purchase, price_cents: 10_00, card_type: CardType::PIX)
 

--- a/spec/services/order/prepare_payment_intent_service_spec.rb
+++ b/spec/services/order/prepare_payment_intent_service_spec.rb
@@ -1881,6 +1881,11 @@ describe Order::PreparePaymentIntentService, :vcr do
       end
 
       it "creates the BRL intent with Pix's create-time options, charging the buyer exactly the listed price and adding no IOF on this direct charge" do
+        # A genuinely Brazilian connected account — the domestic case. The factory leaves country
+        # nil, which is a DIFFERENT lane (see the non-Brazilian example below), so set it here
+        # rather than relying on the default.
+        connect_account.update!(country: "BR")
+
         order, params = build_order
         order.purchases.each { _1.update!(ip_country: "Brazil") }
 
@@ -1890,10 +1895,11 @@ describe Order::PreparePaymentIntentService, :vcr do
         expect(create_args[:currency]).to eq(Currency::BRL)
         expect(create_args[:payment_method_types]).to include("pix")
         expect(create_args[:amount_cents]).to eq(100_00)
-        # The charge is created on the seller's own Brazilian Stripe account, so the payment is
-        # domestic: no foreign exchange, therefore no IOF for Stripe to price. amount_includes_iof
-        # is left off entirely rather than sent — the fee side already declines to bill it (asserted
-        # below), and the two must agree.
+        # The charge is created on the seller's own Brazilian Stripe account, so the payment never
+        # leaves Brazil: no foreign exchange, therefore no IOF for Stripe to price.
+        # amount_includes_iof is left off entirely rather than sent — asking Stripe to price a tax
+        # that does not apply is at best meaningless, and an option Stripe does not accept fails
+        # the whole intent create, taking card down with it for that checkout.
         expect(create_args[:payment_method_options]).to eq(
           pix: { expires_after_seconds: described_class::PIX_EXPIRES_AFTER_SECONDS }
         )
@@ -1903,19 +1909,49 @@ describe Order::PreparePaymentIntentService, :vcr do
         purchase = order.purchases.first.reload
         expect(purchase.card_type).to eq(CardType::PIX)
 
-        # This seller is a Stripe Connect (direct charge) seller, so Stripe settles into their own
-        # account and deducts Brazil's IOF from that balance itself. Recovering it again through
-        # fee_cents would bill them for the same tax twice, so pix_iof_fee_per_thousand is gated off
-        # here — as is the processor fee, on the identical condition. What is left is the 10% flat
-        # Gumroad fee plus the $0.50 fixed fee. The IOF-charging path is covered on a
-        # Gumroad-managed account in spec/models/purchase/purchase_process_spec.rb ("Pix IOF fee").
+        # Gumroad charges a Brazilian connected account no fee at all (calculate_fees returns early
+        # for is_a_brazilian_stripe_connect_account?), so there is no IOF component to look for and
+        # nothing else either. The IOF-charging path is covered on a Gumroad-managed account in
+        # spec/models/purchase/purchase_process_spec.rb ("Pix IOF fee").
         expect(purchase.charged_using_gumroad_merchant_account?).to eq(false)
         expect(purchase.send(:pix_iof_fee_per_thousand)).to eq(0)
-        expected_variable_fee_cents = (purchase.price_cents * Purchase::GUMROAD_FLAT_FEE_PER_THOUSAND / 1000.0).round
-        expect(purchase.fee_cents).to eq(expected_variable_fee_cents + Purchase::GUMROAD_FIXED_FEE_CENTS)
+        expect(purchase.fee_cents).to eq(0)
       end
 
-      # The counterpart to the direct-charge case above: on a Gumroad-held account the money leaves
+      # The other direct-charge lane, and the reason the option's gate is keyed on the account's
+      # COUNTRY rather than on who owns it. Nothing restricts Pix to Brazilian connected accounts —
+      # the resolver's BR lock is on the buyer, and the only per-account condition is the Stripe
+      # capability snapshot — so a non-Brazilian connected account with pix_payments active takes a
+      # payment that DOES leave Brazil. IOF applies, so the option must still be sent, even though
+      # the money never touches a Gumroad-held balance and there is no Gumroad cost to bill back.
+      it "still sends amount_includes_iof on a direct charge to a NON-Brazilian connected account, but bills no IOF fee" do
+        connect_account.update!(country: "US")
+
+        order, params = build_order
+        order.purchases.each { _1.update!(ip_country: "Brazil") }
+
+        create_args, responses = perform_with_pix_preview(order, params, confirmation_token: "ctoken_pix_non_br")
+
+        expect(responses["unique-id-0"][:success]).to eq(true), responses.inspect
+        expect(create_args[:currency]).to eq(Currency::BRL)
+        expect(create_args[:payment_method_types]).to include("pix")
+        expect(create_args[:payment_method_options]).to eq(
+          pix: {
+            expires_after_seconds: described_class::PIX_EXPIRES_AFTER_SECONDS,
+            amount_includes_iof: described_class::PIX_AMOUNT_INCLUDES_IOF,
+          }
+        )
+
+        purchase = order.purchases.first.reload
+        expect(purchase.card_type).to eq(CardType::PIX)
+        # Cross-border, so the tax exists and the option is sent — but the charge settles into the
+        # seller's own account, so Gumroad absorbed nothing and recovers nothing. The two gates
+        # answering differently here is the intended behaviour, not a drift.
+        expect(purchase.charged_using_gumroad_merchant_account?).to eq(false)
+        expect(purchase.send(:pix_iof_fee_per_thousand)).to eq(0)
+      end
+
+      # The counterpart to the direct-charge cases above: on a Gumroad-held account the money leaves
       # Brazil, the payment is cross-border, IOF applies, and the option must be sent — otherwise
       # Stripe's default marks the buyer's amount up by the tax and the banking-app total stops
       # matching the price checkout quoted. This is what all Pix traffic looks like today.


### PR DESCRIPTION
## What

`amount_includes_iof` is now sent on a Pix intent based on whether the payment **leaves Brazil**, rather than on whether Gumroad owns the account it is created on.

Follow-up to #6457, which merged while the pre-merge review of its last two commits was still running. Everything else in that PR stands; this corrects one predicate added late in it.

## Why

IOF is a Brazilian tax on foreign exchange, so it applies whenever a Pix payment crosses Brazil's border. #6457's `pix_iof_applies?` asked a different question — "is this account Gumroad-held?" — and deliberately mirrored the seller-fee gate, on the stated grounds that the option and the fee must always agree.

They must not, and the axis is wrong. Nothing restricts Pix to *Brazilian* connected accounts:

- `Checkout::PaymentMethodResolver::BR_LOCKED_PAYMENT_METHOD_TYPES` gates on the **buyer's** country (`payment_method_resolver.rb:320`), not the account's.
- The only per-account condition is the Stripe capability snapshot (`pix_payments == "active"`), which sellers manage themselves.
- Compare Klarna, which *does* have an explicit account-country gate on the same lane (`klarna_supported_for_account?`) precisely because Stripe's cross-border rule applies to the account the intent is created on. Pix had no equivalent.

So a non-Brazilian connected account with `pix_payments` active takes a payment that **does** cross the border. IOF applies — but the merged gate sees "connect account" and withholds the option. Stripe's default is `never`, which marks the buyer's amount up by the 3.5% tax. The buyer's banking app then shows more than the price checkout quoted them, silently, on the buyer's side of the ledger.

This class only became reachable *because* #6457 removed the settlement gate; before it, no connected account could reach Pix at all.

## The fix

Ask the border question: `!merchant_account&.is_a_brazilian_stripe_connect_account?` — the predicate `calculate_fees` already uses for the same account.

The fee gate (`Purchase#pix_iof_fee_per_thousand`) is deliberately left alone and deliberately stays different. The two answer different questions:

| | asks | direct charge, BR account | direct charge, non-BR account | Gumroad-held |
|---|---|---|---|---|
| `pix_iof_applies?` (option) | does the tax exist — is this cross-border? | no | **yes** | yes |
| `pix_iof_fee_per_thousand` (fee) | did Gumroad bear the cost and have something to recover? | no | no | yes |

The middle column is the one that was wrong. Both comments now state which question each gate answers, so the next reader doesn't "fix" the divergence back out.

## Before / after

| | before (merged) | after |
|---|---|---|
| BR connected account | option omitted ✅ | option omitted ✅ |
| non-BR connected account, Pix active | option omitted ❌ — buyer overcharged 3.5% | option sent ✅ |
| Gumroad-held account (all traffic today) | option sent ✅ | option sent ✅ |

**Today's production traffic is unaffected** — every Pix intent is currently created on the platform account, the right-hand column.

## Test results

`spec/services/order/prepare_payment_intent_service_spec.rb -e "Pix"` — **8 examples, 0 failures** (7 on `main` + 1 new).
`spec/models/purchase/purchase_process_spec.rb -e "Pix IOF fee"` — **3 examples, 0 failures**.
`rubocop` on all four files — no offenses.

All three lanes are now covered explicitly, where `main` had only two:

- Brazilian connect — no option, no fee. The fixture previously left `country` **nil**, so despite its comment saying "the seller's own Brazilian Stripe account" it was never actually Brazilian and never exercised this lane. Now set to `BR`, which also corrects the fee expectation: `calculate_fees` returns `0` outright for a Brazilian connect account, so the old flat-fee + fixed-fee assertion was describing an account the test didn't have.
- **non-Brazilian connect — option sent, no fee.** New; this is the bug.
- Gumroad-held — option sent, fee billed.

### The specs bite

Mutation-tested rather than assumed. Reverting the predicate to the merged ownership axis (`!merchant_account&.is_a_stripe_connect_account?`) turns the run red:

```
8 examples, 4 failures
rspec ./spec/services/order/prepare_payment_intent_service_spec.rb:1927 # ...still sends amount_includes_iof on a direct charge to a NON-Brazilian connected account, but bills no IOF fee
```

(plus three neighbouring Pix examples). Hardcoding `pix_iof_applies?` to `true` or to `false` each fails a different example, so neither branch is vacuous. These assertions use `eq` on the whole `payment_method_options` hash and `create_args` is captured by stubbing `StripeDeferredPaymentIntent.create`, so no VCR cassette can mask them — there are no Pix cassettes in this file.

## Also in this diff

Three comments that asserted the invariant #6457 retired, found in the same review:

- `PIX_AMOUNT_INCLUDES_IOF`'s own comment still ended "so this option is always sent explicitly" — 330 lines above the new conditional.
- `Purchase::PIX_IOF_FEE_PER_THOUSAND` described the fee as gating "on the same condition" as the option.
- `purchase_process_spec.rb:985` still said "Every Pix payment to Gumroad is cross-border".

## Not verified here

Whether Stripe currently grants cross-border Pix to non-BR connected accounts is a question for Stripe, not the codebase — but the fix is the fail-safe direction either way: sending `amount_includes_iof` on a cross-border payment is correct by definition, and the gate that decides it now matches the tax's actual rule instead of coinciding with it by accident.
