### PR TITLE
Document when a bundle version shows no crossed-out price

### DIFF
--- a/app/views/help_center/articles/contents/_339-product-bundles.html.erb
+++ b/app/views/help_center/articles/contents/_339-product-bundles.html.erb
@@ -48,6 +48,7 @@
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/6589a7df25778b0d0faef350/file-Qrs0qewLCn.png" %></figure>
   <h3 id="Checkout-DUhSH">Checkout</h3>
   <p>Customers who purchase your bundle will see a list of the individual products included within. On the product page, the price will show the cumulative value of every product in the bundle crossed out with the new price shown next to it.</p>
+  <p><i>Note:</i> If your bundle has versions of its own, the crossed-out price only shows on a version that does not add anything to the bundle's price. The cumulative value is fixed by the product variants you picked when you built the bundle, so it does not describe what a customer gets on a version that costs extra. On those versions no crossed-out price is shown.</p>
   <p><i>Note:</i> Customers can <a href="222-product-ratings-on-gumroad">rate and review</a> the bundle itself as well as the individual products inside it. The bundle's product page shows one combined rating summary: the bundle's own reviews plus the reviews of the products it contains. Products with ratings hidden are not included in this combined summary.</p>
   <p>On the checkout page, customers will once again find a list of everything they will receive inside the bundle.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/6589a58bdcdba22513abb141/file-jsLiTIsQef.png" %></figure>


### PR DESCRIPTION
## What

Adds one sentence to the bundles help article's Checkout section explaining when the crossed-out cumulative value does and does not appear on a bundle's product page.

Article changed: `339-product-bundles` (`_339-product-bundles.html.erb`). Body only, one line added. `articles.yml` untouched — the title and description still describe the article correctly.

## Why

Triggered by #6479, which shipped a change to the bundle product page: the strikethrough "original price" is now shown only on a bundle version that adds nothing to the bundle's price. That sum is `BundleProduct#standalone_price_cents`, fixed at bundle-build time by the child variants the seller pinned, so it describes exactly one version. On a version that costs extra there is no honest comparison to draw and nothing is struck through (`getBundleComparisonPriceCents` in `app/javascript/components/Product/pricing.ts` returns `null`).

The article said, unconditionally, that "the price will show the cumulative value of every product in the bundle crossed out with the new price shown next to it". For a seller using bundle versions as licence tiers, that is now wrong for every tier above the free one, and without the explanation the absence of the crossed-out price reads as a bug.

No pricing, payout, tax, or refund wording is affected, and nothing is removed from the article. Anchor IDs are unchanged.

Refs antiwork/gumroad-private#1453

## Before / After

Before:

> Customers who purchase your bundle will see a list of the individual products included within. On the product page, the price will show the cumulative value of every product in the bundle crossed out with the new price shown next to it.

After (the paragraph above is unchanged; this note follows it):

> Note: If your bundle has versions of its own, the crossed-out price only shows on a version that does not add anything to the bundle's price. The cumulative value is fixed by the product variants you picked when you built the bundle, so it does not describe what a customer gets on a version that costs extra. On those versions no crossed-out price is shown.

## QA steps

The change is prose in a help-center article partial. Verified locally against the article as it will render:

1. `ERB.new(File.read(...)).src` — ERB syntax OK.
2. Rendered the real partial in the Rails view context: `ApplicationController.render(partial: "help_center/articles/contents/339-product-bundles")` — render OK, 6482 bytes, new copy present.
3. HTML tag-balance count across `p`, `ul`, `ol`, `li`, `div`, `h3`, `figure`, `a`, `i`, `b`, `span` — all balanced.
4. `articles.yml` not modified, so no slug/partial integrity risk; the help-center specs run on CI.

A reviewer can read the article at `help.gumroad.com/help/article/339-product-bundles` after deploy; the new sentence sits directly under the first paragraph of the Checkout section.

## Test Results

```
$ ruby -e 'require "erb"; ERB.new(File.read(ARGV[0])).src; puts "ERB syntax OK"' _339-product-bundles.html.erb
ERB syntax OK

$ DISABLE_SPRING=1 bundle exec rails runner -e test 'ApplicationController.render(partial: "help_center/articles/contents/339-product-bundles")'
render OK 6482 bytes

tag balance: p 14/14 OK, ul 4/4 OK, ol 3/3 OK, li 22/22 OK, div 3/3 OK,
h3 8/8 OK, figure 9/9 OK, a 15/15 OK, i 2/2 OK, b 1/1 OK, span 3/3 OK
```

No screenshots: the change is one sentence of body copy in a help-center article, with no rendered application surface beyond the article text itself, which is quoted verbatim above.

---

Written by Hermes Agent running `claude-opus-5`. Instructions given: the merged-PR help-center sync route, which asks it to check whether a merged `antiwork/gumroad` PR makes a help-center article inaccurate, map the change to the specific article, and ship the correction as a PR. It read #6479's diff, grepped the article bodies for the strikethrough copy, wrote the note, and ran the checks above.
