### PR TITLE
Fix flaky UTM link validation errors by clearing per field instead of the whole form

### DIFF
--- a/app/javascript/components/UtmLinks/UtmLinkForm.test.tsx
+++ b/app/javascript/components/UtmLinks/UtmLinkForm.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { UtmLinkForm, type UtmLinkFormProps } from "$app/components/UtmLinks/UtmLinkForm";
+
+// The form renders inside an Inertia app with Rails routes exposed as a `Routes` global.
+// Neither exists under vitest, so stub the routes with placeholder hrefs — these tests
+// assert which validation errors are displayed, not navigation.
+vi.stubGlobal("Routes", new Proxy({}, { get: () => () => "#" }));
+
+// Keep the real useForm (its error state is what's under test) but stub the router, which
+// otherwise tries to read/write Inertia history state that does not exist here.
+vi.mock("@inertiajs/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@inertiajs/react")>();
+  return {
+    ...actual,
+    router: { ...actual.router, restore: () => undefined, remember: () => undefined, reload: () => undefined },
+  };
+});
+
+// These subtrees need the logged-in-user context, tooltips, or clipboard APIs that are
+// irrelevant to validation error state.
+vi.mock("$app/components/Analytics/AnalyticsLayout", () => ({
+  AnalyticsLayout: ({ children, actions }: { children: React.ReactNode; actions?: React.ReactNode }) => (
+    <div>
+      {actions}
+      {children}
+    </div>
+  ),
+}));
+vi.mock("$app/components/server-components/Alert", () => ({ showAlert: vi.fn() }));
+vi.mock("$app/components/CopyToClipboard", () => ({
+  CopyToClipboard: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock("$app/components/WithTooltip", () => ({
+  WithTooltip: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+const props: UtmLinkFormProps = {
+  context: {
+    destination_options: [{ id: "product-abc", label: "Product — Product A", url: "https://example.com/l/abc" }],
+    short_url: "https://gum.new/u/shortlink",
+    utm_fields_values: { campaigns: [], mediums: [], sources: [], terms: [], contents: [] },
+  },
+  utm_link: null,
+};
+
+const isFlagged = (label: string) =>
+  screen.getByLabelText(label).closest("fieldset")?.classList.contains("danger") ?? false;
+
+describe("UtmLinkForm validation errors", () => {
+  afterEach(cleanup);
+
+  it("clears only the edited field's error, leaving other fields' errors in place", () => {
+    render(<UtmLinkForm {...props} />);
+
+    // Nothing filled in: the first missing field (Title) is flagged.
+    fireEvent.click(screen.getByRole("button", { name: "Add link" }));
+    expect(isFlagged("Title")).toBe(true);
+
+    // Filling Title clears its own error.
+    fireEvent.change(screen.getByLabelText("Title"), { target: { value: "Test Link" } });
+    expect(isFlagged("Title")).toBe(false);
+
+    // Next submit flags Destination instead.
+    fireEvent.click(screen.getByRole("button", { name: "Add link" }));
+    expect(isFlagged("Destination")).toBe(true);
+
+    // Editing an unrelated field must NOT wipe the Destination error. The form used to clear
+    // every error from an effect keyed on the whole form data, which both dropped errors the
+    // user had not addressed and could race a freshly-set error from the next submit — the
+    // flake in spec/requests/analytics/utm_links_spec.rb "shows validation errors" (#6487).
+    fireEvent.change(screen.getByLabelText("Title"), { target: { value: "Test Link renamed" } });
+    expect(isFlagged("Destination")).toBe(true);
+  });
+});

--- a/app/javascript/components/UtmLinks/UtmLinkForm.tsx
+++ b/app/javascript/components/UtmLinks/UtmLinkForm.tsx
@@ -142,10 +142,19 @@ export const UtmLinkForm = (pageProps: UtmLinkFormProps | UtmLinkEditProps) => {
   // validation: the click would set a fresh "Must be present" error and the queued clear would then
   // wipe it, so the field never turned red. That interleaving is the flake in
   // spec/requests/analytics/utm_links_spec.rb "shows validation errors" (issue #6487).
+  //
+  // Read the errors through a ref rather than the closed-over value, because one caller (the
+  // permalink refresh below) runs in an async callback whose closure was captured before the
+  // request started, and by then the error state may have moved on.
+  const errorsRef = React.useRef(errors);
+  errorsRef.current = errors;
+
+  // Skipping the call when nothing is set matters: clearErrors always produces a new errors object,
+  // which would re-fire the scroll effect below on every keystroke.
   const clearFieldErrors = (...attrNames: FieldAttrName[]) => {
     const keys = attrNames
       .map((attrName) => `utm_link.${attrName}` as const)
-      .filter((key) => errors[key] !== undefined);
+      .filter((key) => errorsRef.current[key] !== undefined);
     if (keys.length > 0) form.clearErrors(...keys);
   };
 

--- a/app/javascript/components/UtmLinks/UtmLinkForm.tsx
+++ b/app/javascript/components/UtmLinks/UtmLinkForm.tsx
@@ -136,9 +136,18 @@ export const UtmLinkForm = (pageProps: UtmLinkFormProps | UtmLinkEditProps) => {
 
   const titleRef = React.useRef<HTMLInputElement>(null);
 
-  React.useEffect(() => {
-    if (Object.keys(errors).length > 0) form.clearErrors();
-  }, [data]);
+  // Clear the error for the field the user just edited, from inside the same event that changed it.
+  // This used to be an effect that wiped every error whenever `data` changed. Because effects run
+  // after the render, that clear could still be pending when the next "Add link" click ran its own
+  // validation: the click would set a fresh "Must be present" error and the queued clear would then
+  // wipe it, so the field never turned red. That interleaving is the flake in
+  // spec/requests/analytics/utm_links_spec.rb "shows validation errors" (issue #6487).
+  const clearFieldErrors = (...attrNames: FieldAttrName[]) => {
+    const keys = attrNames
+      .map((attrName) => `utm_link.${attrName}` as const)
+      .filter((key) => errors[key] !== undefined);
+    if (keys.length > 0) form.clearErrors(...keys);
+  };
 
   React.useLayoutEffect(() => {
     if (Object.keys(errors).length > 0) {
@@ -192,6 +201,7 @@ export const UtmLinkForm = (pageProps: UtmLinkFormProps | UtmLinkEditProps) => {
         if (newPermalink) {
           setShortUrl((shortUrl) => ({ ...shortUrl, permalink: newPermalink }));
           setData("utm_link.permalink", newPermalink);
+          clearFieldErrors("permalink");
         }
       },
       onError: () => {
@@ -296,7 +306,10 @@ export const UtmLinkForm = (pageProps: UtmLinkFormProps | UtmLinkEditProps) => {
               type="text"
               value={data.utm_link.title}
               ref={titleRef}
-              onChange={(e) => setData("utm_link.title", e.target.value)}
+              onChange={(e) => {
+                setData("utm_link.title", e.target.value);
+                clearFieldErrors("title");
+              }}
             />
             {getFieldError("title") ? <FieldsetDescription>{getFieldError("title")}</FieldsetDescription> : null}
           </Fieldset>
@@ -318,6 +331,7 @@ export const UtmLinkForm = (pageProps: UtmLinkFormProps | UtmLinkEditProps) => {
                 setDestination(newDest);
                 const { target_resource_type, target_resource_id } = computeTargetResource(newDest);
                 setData("utm_link", { ...data.utm_link, target_resource_type, target_resource_id });
+                clearFieldErrors("target_resource_id", "target_resource_type");
               }}
             />
             {getFieldError("target_resource_id") || getFieldError("target_resource_type") ? (
@@ -385,7 +399,10 @@ export const UtmLinkForm = (pageProps: UtmLinkFormProps | UtmLinkEditProps) => {
                 id={`${uid}-source`}
                 baseOptionValues={context.utm_fields_values.sources}
                 value={data.utm_link.utm_source}
-                onChange={(value) => setData("utm_link.utm_source", value)}
+                onChange={(value) => {
+                  setData("utm_link.utm_source", value);
+                  clearFieldErrors("utm_source");
+                }}
               />
               {getFieldError("utm_source") ? (
                 <FieldsetDescription>{getFieldError("utm_source")}</FieldsetDescription>
@@ -401,7 +418,10 @@ export const UtmLinkForm = (pageProps: UtmLinkFormProps | UtmLinkEditProps) => {
                 id={`${uid}-medium`}
                 baseOptionValues={context.utm_fields_values.mediums}
                 value={data.utm_link.utm_medium}
-                onChange={(value) => setData("utm_link.utm_medium", value)}
+                onChange={(value) => {
+                  setData("utm_link.utm_medium", value);
+                  clearFieldErrors("utm_medium");
+                }}
               />
               {getFieldError("utm_medium") ? (
                 <FieldsetDescription>{getFieldError("utm_medium")}</FieldsetDescription>
@@ -418,7 +438,10 @@ export const UtmLinkForm = (pageProps: UtmLinkFormProps | UtmLinkEditProps) => {
               id={`${uid}-campaign`}
               baseOptionValues={context.utm_fields_values.campaigns}
               value={data.utm_link.utm_campaign}
-              onChange={(value) => setData("utm_link.utm_campaign", value)}
+              onChange={(value) => {
+                setData("utm_link.utm_campaign", value);
+                clearFieldErrors("utm_campaign");
+              }}
             />
             {getFieldError("utm_campaign") ? (
               <FieldsetDescription>{getFieldError("utm_campaign")}</FieldsetDescription>
@@ -434,7 +457,10 @@ export const UtmLinkForm = (pageProps: UtmLinkFormProps | UtmLinkEditProps) => {
               id={`${uid}-term`}
               baseOptionValues={context.utm_fields_values.terms}
               value={data.utm_link.utm_term}
-              onChange={(value) => setData("utm_link.utm_term", value)}
+              onChange={(value) => {
+                setData("utm_link.utm_term", value);
+                clearFieldErrors("utm_term");
+              }}
             />
             {getFieldError("utm_term") ? (
               <FieldsetDescription>{getFieldError("utm_term")}</FieldsetDescription>
@@ -450,7 +476,10 @@ export const UtmLinkForm = (pageProps: UtmLinkFormProps | UtmLinkEditProps) => {
               id={`${uid}-content`}
               baseOptionValues={context.utm_fields_values.contents}
               value={data.utm_link.utm_content}
-              onChange={(value) => setData("utm_link.utm_content", value)}
+              onChange={(value) => {
+                setData("utm_link.utm_content", value);
+                clearFieldErrors("utm_content");
+              }}
             />
             {getFieldError("utm_content") ? (
               <FieldsetDescription>{getFieldError("utm_content")}</FieldsetDescription>


### PR DESCRIPTION
## What

The UTM link create/edit form cleared every validation error from an effect keyed on the whole form data object:

```tsx
React.useEffect(() => {
  if (Object.keys(errors).length > 0) form.clearErrors();
}, [data]);
```

That effect is gone. Each field now clears its own error inside the same event that changed its value, via a small `clearFieldErrors(...attrNames)` helper wired into every `onChange` (and into the permalink refresh success handler).

## Why

Effects run after the render that scheduled them, so a clear queued by selecting a combo-box option could still be pending when the next "Add link" click ran the form's own validation. The click called `form.setError("utm_link.utm_campaign", "Must be present")`, then the queued clear landed and wiped it, so the Campaign fieldset never received `state="danger"`.

That is the intermittent failure in `spec/requests/analytics/utm_links_spec.rb:465` ("shows validation errors"), issue #6487. The spec walks Title → Destination → Source → Medium → Campaign, selecting an option and resubmitting at each step; only the last field in the chain trips, and only under CI load, which is what a lost-race-with-a-queued-effect looks like. The example failed all three rspec-retry attempts on a main commit that only touched help-center documentation.

Clearing per field also fixes a smaller correctness problem the old effect had: editing one field silently dropped errors on fields the user had not addressed yet.

Fixes #6487

## Before / After

The change is deliberately invisible outside the race: the same fieldset turns red at the same moment, and typing in a field still clears that field's error. What changes is that the clear can no longer be swallowed by a pending effect, and it no longer reaches fields the user did not touch.

Hosted preview app is deploying (`preview` label applied) — walkthrough video and before/after captures of the error states will be attached from the preview and this section replaced. Local capture was not possible in this worktree: every Inertia page fails to hydrate with `TypeError: (void 0) is not a function` from the built `vendor-*.js` bundle, including untouched pages like account settings, so no local system spec can render the form. That is environmental, not from this diff.

## Test Results

New component test, `app/javascript/components/UtmLinks/UtmLinkForm.test.tsx`, pins the mechanism: submit with an empty form flags Title, filling Title clears Title, resubmitting flags Destination, and then editing Title again must leave the Destination error in place.

Proof it is load-bearing — with the test kept and the component restored to main's version, it fails at exactly the assertion the change is about:

```
$ git checkout origin/main -- app/javascript/components/UtmLinks/UtmLinkForm.tsx
$ npx vitest run app/javascript/components/UtmLinks/UtmLinkForm.test.tsx
 ❯ app/javascript/components/UtmLinks/UtmLinkForm.test.tsx (1 test | 1 failed)
   × clears only the edited field's error, leaving other fields' errors in place
AssertionError: expected false to be true
 ❯ app/javascript/components/UtmLinks/UtmLinkForm.test.tsx:76:38
     76|     expect(isFlagged("Destination")).toBe(true);
 Test Files  1 failed (1)

$ # restore the fix
$ npx vitest run app/javascript/components/UtmLinks/UtmLinkForm.test.tsx
 ✓ app/javascript/components/UtmLinks/UtmLinkForm.test.tsx (1 test)
 Test Files  1 passed (1)
```

The flaky request spec itself cannot be run locally here for the hydration reason above; CI is the arbiter for it. Full branch CI was green on the first commit (73 jobs, 1 skipped, 0 failures). The second commit hit one failure in `Test Minitest` — `LinksControllerSaveContractTest#test_flag_on: naming one variant while the collection is omitted deletes only that variant`, a product-variant deletion contract test with no relationship to a UTM form component; the same job passed on this branch's previous commit and on the last four main runs. Rerun in flight.

The race is not reproducible in the component test harness, and that limit is worth stating plainly: `fireEvent` runs inside `act()`, which flushes effects before the next event, so the specific interleaving (a queued clear landing after a later `setError`) cannot be constructed. The test asserts the strongest thing that is expressible — that no cross-field clear happens on edit — and the race is removed by construction, because every clear is now dispatched synchronously inside the event that changed the value.

## QA steps

On the preview app, as a seller:

1. Go to Analytics → UTM links → **Create link**.
2. Click **Add link** with the form empty. The Title fieldset turns red with "Must be present".
3. Type a title. The red state clears immediately.
4. Click **Add link** again. Destination turns red.
5. Pick a destination, click **Add link**, and repeat through Source, Medium, and Campaign. Each field in turn must turn red, and selecting a value must clear it.
6. The step that used to flake: after selecting a Medium and immediately clicking **Add link**, Campaign must turn red. Repeat that click a few times in quick succession — the error must appear every time.
7. Now check the cross-field behavior that changed: get Destination into its red state (step 4), then edit the Title field. Destination must stay red, because you have not addressed it yet. Previously any edit cleared it.

## Review

Ran the local adversarial (fable-5) pre-merge review on the branch before opening. Verdict: READY-TO-MERGE, no P1s. Findings and disposition:

| Finding | Verdict |
|---|---|
| P3 — the async permalink refresh callback reads a stale `errors` closure, so a clear could be skipped if a submit failed while the reload was in flight | Fixed in `2a93568`: the helper reads errors through a ref. |
| P3 — the uniqueness error lands on `target_resource_id`, and the utm_* fields that would resolve the conflict do not clear it, so it persists until resubmit | Declined. `validate()` clears everything at the top of every submit, so it cannot stick; clearing a Destination error from a Campaign edit would be the cross-field behavior this PR is removing. |
| P3 (informational) — remembered errors now survive back-navigation instead of being wiped on mount | Accepted as correct: the restored error matches the restored data. |
| P2 (process) — visual evidence required | Preview-app media pending, noted above. |

Confirmed safe by the review, and independently: all seven `setData` call sites are paired with the right clear key; the client's `utm_link.${attr}` template matches what the controller returns (`redirect_to ..., inertia: { errors: { "utm_link.#{error.attribute}" => error.message } }`); the Destination change clears both keys `getFieldError` pairs; every server-returnable error key maps to a clearing interaction; and the `if (keys.length > 0)` guard is load-bearing because `clearErrors` always produces a new errors object, which would otherwise re-fire the scroll effect on every keystroke.

---

Written by Claude Opus 5 (`claude-opus-5`). It was asked to fix the flaky test in issue #6487, diagnosed the pending-effect race in `UtmLinkForm.tsx`, replaced the whole-form clear with per-field clears, wrote the component test, ran the adversarial pre-merge review against the branch, and fixed the one finding worth fixing.
