### PR TITLE
Stop the payouts-pause email specs from failing at random

### DIFF
--- a/spec/business/payments/events/paypal/paypal_event_handler_spec.rb
+++ b/spec/business/payments/events/paypal/paypal_event_handler_spec.rb
@@ -31,7 +31,10 @@ describe PaypalEventHandler do
     context "when event is from paypal legacy API" do
       let(:event_info) { { "txn_type" => "masspay" } }
 
-      it do
+      # Frozen because the assertion checks the exact time the job is scheduled for, and the
+      # matcher truncates both that time and its own expected time to whole seconds — so a
+      # clock tick across a second boundary in between fails the test at random.
+      it "schedules the event for processing ten minutes out", :freeze_time do
         described_class.new(event_info).schedule_paypal_event_processing
         expect(HandlePaypalEventWorker).to have_enqueued_sidekiq_job(event_info).in(10.minutes)
       end

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -10843,9 +10843,11 @@ describe StripeMerchantAccountManager, :vcr do
             end
 
             # Time is frozen because the assertion below checks the exact timestamp the
-            # debounced email job is scheduled for. Without freezing, the clock can tick
-            # between the code enqueueing the job and the matcher recomputing the expected
-            # time, so the two sub-second timestamps disagree and the test fails at random.
+            # debounced email job is scheduled for. The matcher truncates both the job's
+            # scheduled time and its own expected time to whole seconds, so if the clock
+            # crosses a second boundary between the code enqueueing the job and the matcher
+            # recomputing the expected time, the two differ by one and the test fails at
+            # random. Freezing time makes both sides read the same clock.
             it "pauses payouts, records the Stripe reason as a comment, and notifies the creator by email if payouts are disabled due to info requirement", :freeze_time do
               expect(user.reload.payouts_paused_internally?).to be false
               stripe_event["data"]["object"]["requirements"]["disabled_reason"] = "requirements.past_due"
@@ -10867,6 +10869,14 @@ describe StripeMerchantAccountManager, :vcr do
               expect(comment).to be_present
               expect(comment.content).to include("requirements.past_due")
               expect(user.payouts_paused_for_reason).to eq(comment.content)
+            end
+
+            # The assertions above take the expected delay from the constant itself, so they
+            # would still pass if the debounce window shrank to nothing. This pins the actual
+            # value, because the window's length is the whole point: it has to be long enough
+            # to outlast a routine Stripe re-verification that resolves on its own.
+            it "waits half an hour before emailing, so a verification blip that resolves itself never emails the seller" do
+              expect(described_class::PAYOUTS_PAUSE_EMAIL_DEBOUNCE_DELAY).to eq(30.minutes)
             end
 
             it "applies the pause under a user lock and refreshes the merchant account so concurrent webhooks are serialized" do

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -10842,7 +10842,11 @@ describe StripeMerchantAccountManager, :vcr do
               }
             end
 
-            it "pauses payouts, records the Stripe reason as a comment, and notifies the creator by email if payouts are disabled due to info requirement" do
+            # Time is frozen because the assertion below checks the exact timestamp the
+            # debounced email job is scheduled for. Without freezing, the clock can tick
+            # between the code enqueueing the job and the matcher recomputing the expected
+            # time, so the two sub-second timestamps disagree and the test fails at random.
+            it "pauses payouts, records the Stripe reason as a comment, and notifies the creator by email if payouts are disabled due to info requirement", :freeze_time do
               expect(user.reload.payouts_paused_internally?).to be false
               stripe_event["data"]["object"]["requirements"]["disabled_reason"] = "requirements.past_due"
 
@@ -11146,7 +11150,9 @@ describe StripeMerchantAccountManager, :vcr do
                 stripe_event["data"]["object"]["requirements"]["past_due"] = []
               end
 
-              it "sends the under-review email for a non-rejected reason with no outstanding requirements" do
+              # Frozen for the same reason as the past_due case above: the matcher compares
+              # the job's scheduled-at timestamp against a freshly computed one.
+              it "sends the under-review email for a non-rejected reason with no outstanding requirements", :freeze_time do
                 stripe_event["data"]["object"]["requirements"]["disabled_reason"] = "requirements.pending_verification"
 
                 described_class.handle_stripe_event(stripe_event)

--- a/spec/sidekiq/refresh_sitemap_monthly_worker_spec.rb
+++ b/spec/sidekiq/refresh_sitemap_monthly_worker_spec.rb
@@ -4,7 +4,10 @@ require "spec_helper"
 
 describe RefreshSitemapMonthlyWorker do
   describe "#perform" do
-    it "enqueues jobs to generate sitemaps for products updated in last month" do
+    # Frozen because the assertion below checks the exact time the second job is scheduled
+    # for, and the matcher truncates both that time and its own expected time to whole
+    # seconds — so a clock tick across a second boundary in between fails the test at random.
+    it "enqueues jobs to generate sitemaps for products updated in last month", :freeze_time do
       product_1 = create(:product, created_at: 3.months.ago, updated_at: 1.month.ago)
       product_2 = create(:product, created_at: 2.months.ago, updated_at: 1.month.ago)
       described_class.new.perform


### PR DESCRIPTION
## What

Two RSpec examples covering the debounced "payouts paused" email were failing at random in CI. Both assert the exact time the delayed job is scheduled for:

```ruby
expect(StripePayoutsPausedEmailJob).to have_enqueued_sidekiq_job(...)
  .in(described_class::PAYOUTS_PAUSE_EMAIL_DEBOUNCE_DELAY)
```

This freezes the clock for those examples, does the same for the two other examples in the repo carrying the identical latent flake, and pins the debounce delay's actual value.

## Why

`rspec-sidekiq`'s `.in` matcher builds its expected time from `Time.now` at the moment the *assertion* runs, and truncates to whole seconds:

```ruby
# rspec-sidekiq-5.0.0 lib/rspec/sidekiq/matchers/base.rb:202
def in(interval)
  @expected_options["at"] = (Time.now.to_f + interval.to_f).to_i
end
# ...and compares against the job's own recorded time, also truncated (:20)
value == Time.at(job["at"]).to_i
```

Sidekiq recorded the job's time a few milliseconds earlier, inside `perform_in`. Both sides are truncated to whole seconds, so they normally agree — but when the wall clock happens to cross a second boundary in that tiny window, the two integers differ by one and the example fails. Nothing about the code under test is wrong; the test was measuring against a moving clock.

The mechanism is worth stating precisely because it decides the failure *rate*. Simulating the boundary crossing over 200,000 trials:

| Gap between enqueue and assertion | Failure rate |
|---|---|
| ~1 ms | 0.04% |
| ~10 ms | 0.54% |
| ~50 ms | 2.48% |
| frozen clock | 0.00% |

A rate that low is exactly what "fails occasionally in CI and never locally" looks like.

`:freeze_time` is the repo's existing tool for this — an `around` hook in `spec/spec_helper.rb:402` — and is already used for the same purpose in `spec/services/payout_users_service_spec.rb`, `spec/sidekiq/transcode_video_for_streaming_worker_spec.rb`, and `spec/modules/with_product_files_spec.rb`. With the clock frozen, both sides read the same value and the comparison is deterministic.

## Before / After

**Before:** the two examples pass on most runs and fail on the runs where the clock ticks across a second boundary between the enqueue and the assertion. Two further examples elsewhere in the repo (`refresh_sitemap_monthly_worker_spec.rb:13`, `paypal_event_handler_spec.rb:36`) had the same construct unprotected and could fail the same way. The debounce delay could have been changed to any value — including one so short it defeats the point of the debounce — with every spec still passing.

**After:** all four are frozen and deterministic, and one example pins the delay at 30 minutes so shrinking the window is a deliberate, visible spec change.

No production code changed.

## Test results

Run locally against the three touched files:

```
363 examples, 0 failures
```

The new pinning example is load-bearing, proved by mutation rather than assertion:

| Mutation | Expected | Result |
|---|---|---|
| `PAYOUTS_PAUSE_EMAIL_DEBOUNCE_DELAY = 30.minutes` → `1.second` | only the new pinning example fails | ✅ 3 examples, 1 failure — exactly `:10878`, the new example |

One environmental note, since it cost real debugging time: a freshly schema-loaded test database fails this spec group at `create(:balance, ...)` with `Merchant account can't be blank` *before reaching any assertion*. That reproduces identically on unmodified `origin/main`, so it is a missing-seed-data problem, not a defect in this change; `rails db:seed` fixes it. The 363/0 above is from the seeded database.

## Pre-merge review

Ran the local adversarial (fable-5) review on the branch before opening this PR. Verdict: **CHANGES-REQUIRED**, three real findings, all fixed in `00689f542`.

| # | Finding | Verdict | Disposition |
|---|---|---|---|
| P2 | The added comment said the flake was "sub-second timestamps disagreeing". Wrong: the matcher truncates both sides to whole seconds, and the mechanism as described would fail *always*, not randomly. | Real | Fixed in `00689f542` — comment now names the second-boundary crossing. On a diff whose entire payload is two tags and two comments, the comment accuracy *is* the change. |
| P2 | Incomplete over the bug class: two other examples in the repo use the same `.in(...)` construct with no frozen clock. | Real, verified by sweeping every `have_enqueued_sidekiq_job(...).in(`/`.at(` site in the repo | Fixed in `00689f542` — `refresh_sitemap_monthly_worker_spec.rb` and `paypal_event_handler_spec.rb` frozen. Every other site is already frozen or derives its expected time from a stored record timestamp rather than the clock. |
| P3 | The delay assertions are self-fulfilling: expected value comes from the same constant the code uses, and nothing pinned 30 minutes. | Real | Fixed in `00689f542` — added a pinning example, mutation-verified above. |
| P3 | Drive-by: in `paypal_event_handler_spec.rb:20-27` an `it` block is nested inside a `before` block, so that example never runs. | Real, but pre-existing and unrelated | **Not fixed here** — separate concern in a different code path; it deserves its own PR rather than being smuggled into a flake fix. |

I also graded the reviewer's own claims rather than taking them on trust: it reported the locked gem as `rspec-sidekiq 5.0.0` where I had read 5.1.0. The reviewer was right — my earlier read picked up a sibling worktree's modified `Gemfile.lock`. I verified the matcher source in 5.0.0 specifically; the truncating comparison is identical in both, so the analysis holds for what CI actually runs.

Verified safe, not changed:

- **Freezing does not break the `:vcr` cassettes.** Matching is on method + URI, record mode is `:none` on CI, and this call path invokes the handler directly with a hash — no webhook signature verification, no clock-derived values in the frozen examples' fixture.
- **No leakage into other examples.** The hook uses block-form `freeze_time`, which unfreezes via `ensure travel_back` on both pass and failure.
- **No product race is being masked.** The debounce's correctness rests on a per-user lock and a claim token rotated per pause episode, both re-checked in the job at drain time against database state, not the clock. Freezing time in a test cannot bypass that, and neighbouring examples covering the lock and token remain unfrozen.
