### PR TITLE
Run the PayPal merchant-account event specs that were never running

### DIFF
--- a/spec/business/payments/events/paypal/paypal_event_handler_spec.rb
+++ b/spec/business/payments/events/paypal/paypal_event_handler_spec.rb
@@ -17,13 +17,12 @@ describe PaypalEventHandler do
 
     context "when event is from Integrated signup API" do
       PaypalEventType::MERCHANT_ACCOUNT_EVENTS.each do |event_type|
-        before do
-          @event_info = { "event_type" => event_type }
+        it "schedules the #{event_type} event for processing" do
+          event_info = { "event_type" => event_type }
 
-          it do
-            described_class.new(@event_info).schedule_paypal_event_processing
-            expect(HandlePaypalEventWorker).to have_enqueued_sidekiq_job(@event_info)
-          end
+          described_class.new(event_info).schedule_paypal_event_processing
+
+          expect(HandlePaypalEventWorker).to have_enqueued_sidekiq_job(event_info)
         end
       end
     end


### PR DESCRIPTION
## What

Seven examples in `spec/business/payments/events/paypal/paypal_event_handler_spec.rb` were never running. This makes them run.

## Why

The examples for `PaypalEventType::MERCHANT_ACCOUNT_EVENTS` were written *inside* a `before` block instead of beside it:

```ruby
PaypalEventType::MERCHANT_ACCOUNT_EVENTS.each do |event_type|
  before do
    @event_info = { "event_type" => event_type }

    it do            # <- inside the hook, not the group
      described_class.new(@event_info).schedule_paypal_event_processing
      expect(HandlePaypalEventWorker).to have_enqueued_sidekiq_job(@event_info)
    end
  end
end
```

RSpec collects examples when it evaluates the example *group*, not when a hook later runs. `it` called from inside a `before` block is simply ignored, so that `context` defined zero examples — and because `before` hooks only run if some example exists to run them for, the hook body never executed either. The context was inert in both directions, which is why nothing ever failed and nobody noticed.

The practical effect: scheduling was untested for every event type in `MERCHANT_ACCOUNT_EVENTS`, one of the two PayPal event families this class routes.

I found this while sweeping the repo for a different problem (unfrozen scheduled-job timing assertions, #6490), and it is unrelated to that fix, so it gets its own PR.

## Before / After

**Before:** the file reports 17 examples. The Integrated-signup-API context contributes none.

**After:** the file reports 24 examples. The 7 that appear are the ones that were always meant to run, one per event type in `MERCHANT_ACCOUNT_EVENTS`.

The examples also get real names (`"schedules the MERCHANT_PARTNER_CONSENT_REVOKED event for processing"` and so on) instead of the bare `it do` they had, so a future failure names the event type that broke. The ivar becomes a local, since there is no longer a hook to carry state across.

No production code changed.

## Test results

Run locally, same file, unmodified `origin/main` versus this branch:

| | Examples | Failures |
|---|---|---|
| `origin/main` | 17 | 0 |
| this branch | 24 | 0 |

The 7 newly-collected examples pass, which is the good outcome — the scheduling behaviour they assert was already correct, so this closes a coverage hole rather than uncovering a live bug. Worth stating plainly: had any of them failed, that would have been a production defect this PR surfaced, and the fix would have belonged here too.

The example-count jump from 17 to 24 is itself the proof the examples were previously not running — there is no mutation to perform, because the change adds no assertions, it only lets existing ones execute.

## Pre-merge review

Found by the local adversarial (fable-5) review on the sibling flake-fix branch, which flagged it as a drive-by while sweeping every scheduled-job timing assertion in the repo. I verified the claim directly by reading the file and by the example-count comparison above rather than taking the finding on trust.

The reviewer's other findings on that branch were in-scope there and are fixed there; this one is a different code path, so it is deliberately split out rather than smuggled into a flake fix.
