### PR TITLE
Shard the Minitest CI job two ways (#5801)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -313,13 +313,6 @@ jobs:
     if: ${{ github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name != github.repository }}
     runs-on: ubuntu-22.04
     timeout-minutes: 15
-    # Sharded because the single-runner job had grown to ~12 minutes against this
-    # 15-minute limit, and every file still to be ported from RSpec (#5801) adds
-    # to it — the next few big ones would have pushed it into timing out, which
-    # reads like a broken suite rather than a suite that outgrew its runner.
-    # Files are split by bin/minitest-shard; see that script for how, and why not
-    # Knapsack Pro. Shards are independent processes with their own database, so
-    # raising ci_node_total is the only change needed to add more.
     strategy:
       fail-fast: false
       matrix:
@@ -422,11 +415,8 @@ jobs:
       - name: Run Minitest
         run: |
           FILES=$(bin/minitest-shard "$CI_NODE_INDEX" "$CI_NODE_TOTAL")
-          # Log the manifest: when a shard fails you want to know what it covered
-          # without recomputing the split by hand.
           echo "Shard $CI_NODE_INDEX of $CI_NODE_TOTAL — $(echo "$FILES" | wc -w) files:"
           echo "$FILES" | tr ' ' '\n' | sed 's/^/  /'
-          # Unquoted on purpose: the file list has to word-split into arguments.
           bundle exec rails test $FILES
         env:
           RUBY_YJIT_ENABLE: 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -308,11 +308,23 @@ jobs:
           fi
 
   test_minitest:
-    name: Test Minitest${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository && ' (internal PR noop)' || '' }}
+    name: Test Minitest ${{ matrix.ci_node_index }}${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository && ' (internal PR noop)' || '' }}
     needs: ci_gate
     if: ${{ github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name != github.repository }}
     runs-on: ubuntu-22.04
     timeout-minutes: 15
+    # Sharded because the single-runner job had grown to ~12 minutes against this
+    # 15-minute limit, and every file still to be ported from RSpec (#5801) adds
+    # to it — the next few big ones would have pushed it into timing out, which
+    # reads like a broken suite rather than a suite that outgrew its runner.
+    # Files are split by bin/minitest-shard; see that script for how, and why not
+    # Knapsack Pro. Shards are independent processes with their own database, so
+    # raising ci_node_total is the only change needed to add more.
+    strategy:
+      fail-fast: false
+      matrix:
+        ci_node_total: [2]
+        ci_node_index: [0, 1]
 
     services:
       mysql:
@@ -408,10 +420,19 @@ jobs:
           curl -fsS http://localhost:9200/_cluster/health || { echo "Elasticsearch did not become ready"; exit 1; }
 
       - name: Run Minitest
-        run: bundle exec rails test
+        run: |
+          FILES=$(bin/minitest-shard "$CI_NODE_INDEX" "$CI_NODE_TOTAL")
+          # Log the manifest: when a shard fails you want to know what it covered
+          # without recomputing the split by hand.
+          echo "Shard $CI_NODE_INDEX of $CI_NODE_TOTAL — $(echo "$FILES" | wc -w) files:"
+          echo "$FILES" | tr ' ' '\n' | sed 's/^/  /'
+          # Unquoted on purpose: the file list has to word-split into arguments.
+          bundle exec rails test $FILES
         env:
           RUBY_YJIT_ENABLE: 1
           CI: true
+          CI_NODE_INDEX: ${{ matrix.ci_node_index }}
+          CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
 
   test_fast:
     name: Test Fast ${{ matrix.ci_node_index }}${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository && ' (internal PR noop)' || '' }}

--- a/bin/minitest-shard
+++ b/bin/minitest-shard
@@ -1,50 +1,10 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Prints the Minitest files belonging to one CI shard, so the `Test Minitest`
-# job can run as a matrix instead of one runner working through the whole tree.
-#
-# Usage:
-#   bin/minitest-shard <index> <total>     # files for shard <index> of <total>
-#   bin/minitest-shard --report <total>    # per-shard file/weight summary (no run)
-#
-#   bundle exec rails test $(bin/minitest-shard 0 2)
-#
-# ## How files are distributed
-#
-# Longest-processing-time-first: sort files by weight descending, then hand each
-# one to whichever shard is currently lightest. For a set where a few files
-# dominate — and this suite has several thousand-test files — that lands much
-# closer to even than round-robin or splitting an alphabetical list in half.
-#
-# The weight is a file's byte size, adjusted by WEIGHT_PER_BYTE for files whose
-# runtime is nothing like their size. That list exists because size is only a
-# proxy: stripe_payout_processor_test.rb replays a VCR cassette for most of its
-# tests, so it costs several times what its bytes suggest, while a file that is
-# mostly long expected-JSON literals costs less. Sizes come from disk, so adding
-# tests re-balances the shards on the next run with no table to maintain.
-#
-# ## Why not Knapsack Pro (which the RSpec lane uses)
-#
-# Knapsack splits by recorded timings from its API, which is the right tool at 18
-# and 50 shards. At 2 shards the win over a static split is small, and it would
-# put a network dependency and an API token in front of a job whose whole point
-# is to stay lean. Revisit if this job ever needs more than a handful of shards.
-#
-# Determinism matters more than perfection here: both shards must agree on the
-# partition without talking to each other, and every file must land in exactly
-# one shard. `--report` prints the split so the balance can be checked.
-
 TEST_GLOB = "test/**/*_test.rb"
 
-# Multipliers for files whose wall time is badly predicted by their size.
-# Keep this short and justified — it is a hint, not a schedule.
 WEIGHT_PER_BYTE = {
-  # ~2/3 of these tests replay Stripe cassettes through the VCR bridge; the HTTP
-  # replay, not the file, is the cost.
   "test/business/payments/payouts/processor/stripe/stripe_payout_processor_test.rb" => 3.0,
-  # Indexes into a real Elasticsearch cluster and queries it back (product
-  # search, page-view analytics), which no other file does at this scale.
   "test/controllers/links_controller_test.rb" => 1.5,
 }.freeze
 
@@ -57,7 +17,6 @@ def weight(path)
   File.size(path) * (WEIGHT_PER_BYTE[path] || 1.0)
 end
 
-# Returns an array of `total` arrays of paths.
 def partition(total)
   files = Dir[TEST_GLOB].sort
   abort "bin/minitest-shard: no files matched #{TEST_GLOB}" if files.empty?
@@ -65,8 +24,6 @@ def partition(total)
   shards = Array.new(total) { [] }
   loads = Array.new(total, 0.0)
 
-  # Sort by weight descending, then by path so equal-weight files always land the
-  # same way regardless of the order the filesystem returned them in.
   files.sort_by { |path| [-weight(path), path] }.each do |path|
     lightest = loads.each_with_index.min_by { |load, index| [load, index] }.last
     shards[lightest] << path
@@ -96,7 +53,8 @@ usage! if index.nil? || index.negative? || index >= total
 
 shards, = partition(total)
 files = shards[index]
-# An empty shard would make `rails test` run the WHOLE tree (no file arguments
-# means every test), silently multiplying the work instead of doing none of it.
-abort "bin/minitest-shard: shard #{index} of #{total} is empty" if files.empty?
+if files.empty?
+  abort "bin/minitest-shard: shard #{index} of #{total} is empty; " \
+        "running `rails test` with no files would run the whole tree"
+end
 puts files.join(" ")

--- a/bin/minitest-shard
+++ b/bin/minitest-shard
@@ -1,0 +1,102 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Prints the Minitest files belonging to one CI shard, so the `Test Minitest`
+# job can run as a matrix instead of one runner working through the whole tree.
+#
+# Usage:
+#   bin/minitest-shard <index> <total>     # files for shard <index> of <total>
+#   bin/minitest-shard --report <total>    # per-shard file/weight summary (no run)
+#
+#   bundle exec rails test $(bin/minitest-shard 0 2)
+#
+# ## How files are distributed
+#
+# Longest-processing-time-first: sort files by weight descending, then hand each
+# one to whichever shard is currently lightest. For a set where a few files
+# dominate — and this suite has several thousand-test files — that lands much
+# closer to even than round-robin or splitting an alphabetical list in half.
+#
+# The weight is a file's byte size, adjusted by WEIGHT_PER_BYTE for files whose
+# runtime is nothing like their size. That list exists because size is only a
+# proxy: stripe_payout_processor_test.rb replays a VCR cassette for most of its
+# tests, so it costs several times what its bytes suggest, while a file that is
+# mostly long expected-JSON literals costs less. Sizes come from disk, so adding
+# tests re-balances the shards on the next run with no table to maintain.
+#
+# ## Why not Knapsack Pro (which the RSpec lane uses)
+#
+# Knapsack splits by recorded timings from its API, which is the right tool at 18
+# and 50 shards. At 2 shards the win over a static split is small, and it would
+# put a network dependency and an API token in front of a job whose whole point
+# is to stay lean. Revisit if this job ever needs more than a handful of shards.
+#
+# Determinism matters more than perfection here: both shards must agree on the
+# partition without talking to each other, and every file must land in exactly
+# one shard. `--report` prints the split so the balance can be checked.
+
+TEST_GLOB = "test/**/*_test.rb"
+
+# Multipliers for files whose wall time is badly predicted by their size.
+# Keep this short and justified — it is a hint, not a schedule.
+WEIGHT_PER_BYTE = {
+  # ~2/3 of these tests replay Stripe cassettes through the VCR bridge; the HTTP
+  # replay, not the file, is the cost.
+  "test/business/payments/payouts/processor/stripe/stripe_payout_processor_test.rb" => 3.0,
+  # Indexes into a real Elasticsearch cluster and queries it back (product
+  # search, page-view analytics), which no other file does at this scale.
+  "test/controllers/links_controller_test.rb" => 1.5,
+}.freeze
+
+def usage!
+  warn "usage: bin/minitest-shard <index> <total> | bin/minitest-shard --report <total>"
+  exit 1
+end
+
+def weight(path)
+  File.size(path) * (WEIGHT_PER_BYTE[path] || 1.0)
+end
+
+# Returns an array of `total` arrays of paths.
+def partition(total)
+  files = Dir[TEST_GLOB].sort
+  abort "bin/minitest-shard: no files matched #{TEST_GLOB}" if files.empty?
+
+  shards = Array.new(total) { [] }
+  loads = Array.new(total, 0.0)
+
+  # Sort by weight descending, then by path so equal-weight files always land the
+  # same way regardless of the order the filesystem returned them in.
+  files.sort_by { |path| [-weight(path), path] }.each do |path|
+    lightest = loads.each_with_index.min_by { |load, index| [load, index] }.last
+    shards[lightest] << path
+    loads[lightest] += weight(path)
+  end
+
+  [shards.map(&:sort), loads]
+end
+
+report = ARGV.delete("--report")
+usage! unless ARGV.size == (report ? 1 : 2)
+
+total = Integer(ARGV.last, exception: false)
+usage! if total.nil? || total < 1
+
+if report
+  shards, loads = partition(total)
+  shards.each_with_index do |paths, index|
+    puts format("shard %d: %3d files, weight %.1fk", index, paths.size, loads[index] / 1024.0)
+    paths.each { |path| puts "  #{path}" }
+  end
+  exit 0
+end
+
+index = Integer(ARGV.first, exception: false)
+usage! if index.nil? || index.negative? || index >= total
+
+shards, = partition(total)
+files = shards[index]
+# An empty shard would make `rails test` run the WHOLE tree (no file arguments
+# means every test), silently multiplying the work instead of doing none of it.
+abort "bin/minitest-shard: shard #{index} of #{total} is empty" if files.empty?
+puts files.join(" ")

--- a/docs/minitest-migration.md
+++ b/docs/minitest-migration.md
@@ -24,12 +24,11 @@ CI runs the whole `test/` tree as the `test_minitest` job in
 native GitHub Actions services, including Elasticsearch and MinIO). The job is
 wired into the Buildkite deployment gate alongside `test_fast`/`test_slow`.
 
-The job is a 2-shard matrix: each shard is a separate runner with its own
-services and database, running the files `bin/minitest-shard <index> <total>`
-assigns it. The split is computed from file sizes, so adding tests re-balances
-the shards on the next run — nothing to maintain per file. To add shards, raise
-`ci_node_total` and extend `ci_node_index` in the workflow matrix. Locally you
-still run the tree in one go (`bin/rails test`); sharding is a CI concern.
+The job is a 2-shard matrix; each shard runs the files
+`bin/minitest-shard <index> <total>` assigns it, split by file size so adding
+tests re-balances on the next run. Raise `ci_node_total` and extend
+`ci_node_index` to add shards. Locally, run the tree in one go with
+`bin/rails test`.
 
 ## Rules
 

--- a/docs/minitest-migration.md
+++ b/docs/minitest-migration.md
@@ -21,8 +21,15 @@ same fixture conventions, same verification steps every time.
 
 CI runs the whole `test/` tree as the `test_minitest` job in
 `.github/workflows/tests.yml` (bare runner, no Docker image — services boot as
-native GitHub Actions services). The job is wired into the Buildkite
-deployment gate alongside `test_fast`/`test_slow`.
+native GitHub Actions services, including Elasticsearch and MinIO). The job is
+wired into the Buildkite deployment gate alongside `test_fast`/`test_slow`.
+
+The job is a 2-shard matrix: each shard is a separate runner with its own
+services and database, running the files `bin/minitest-shard <index> <total>`
+assigns it. The split is computed from file sizes, so adding tests re-balances
+the shards on the next run — nothing to maintain per file. To add shards, raise
+`ci_node_total` and extend `ci_node_index` in the workflow matrix. Locally you
+still run the tree in one go (`bin/rails test`); sharding is a CI concern.
 
 ## Rules
 

--- a/test/lib/minitest_shard_test.rb
+++ b/test/lib/minitest_shard_test.rb
@@ -2,12 +2,6 @@
 
 require "test_helper"
 
-# bin/minitest-shard decides which files each CI shard runs, so a bug in it
-# silently drops coverage: a file in no shard is never run, and CI still goes
-# green. These assert the two properties the workflow depends on — every file
-# lands somewhere, and no file lands twice — plus the failure mode that would be
-# worst in practice, an empty shard, which makes `rails test` with no arguments
-# run the entire tree instead.
 class MinitestShardTest < ActiveSupport::TestCase
   SCRIPT = Rails.root.join("bin/minitest-shard").to_s
 
@@ -23,28 +17,19 @@ class MinitestShardTest < ActiveSupport::TestCase
 
   test "the shards together cover every test file exactly once" do
     [1, 2, 3, 7].each do |total|
-      shards = (0...total).map { shard(_1, total) }
-      combined = shards.flatten
+      combined = (0...total).flat_map { shard(_1, total) }
 
       assert_equal all_test_files, combined.sort, "shard set for total=#{total} does not cover the tree"
       assert_equal combined.size, combined.uniq.size, "a file appears in more than one shard for total=#{total}"
     end
   end
 
-  test "no shard comes back empty" do
-    # Not just tidiness: `rails test` with no file arguments runs everything, so
-    # an empty shard would quietly double the work rather than do none of it.
-    # The script exits non-zero in that case, which `shard` asserts against.
+  test "no shard comes back empty, since a bare rails test would run the whole tree" do
     [2, 3, 7].each do |total|
       (0...total).each { |index| assert_not_empty shard(index, total), "shard #{index} of #{total} is empty" }
     end
   end
 
-  # Deliberately not asserted here: how *evenly* the shards are balanced. That's a
-  # performance property, and pinning it to a threshold in a unit test would
-  # either measure the script against its own weighting (tautological) or fail on
-  # an arbitrary line the next added test file happens to cross. Check balance
-  # with `bin/minitest-shard --report 2` and against the real job timings in CI.
   test "an out-of-range shard index is refused rather than silently empty" do
     `#{SCRIPT} 2 2 2>/dev/null`
     assert_not_predicate $?, :success?, "index equal to total should be rejected"

--- a/test/lib/minitest_shard_test.rb
+++ b/test/lib/minitest_shard_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# bin/minitest-shard decides which files each CI shard runs, so a bug in it
+# silently drops coverage: a file in no shard is never run, and CI still goes
+# green. These assert the two properties the workflow depends on — every file
+# lands somewhere, and no file lands twice — plus the failure mode that would be
+# worst in practice, an empty shard, which makes `rails test` with no arguments
+# run the entire tree instead.
+class MinitestShardTest < ActiveSupport::TestCase
+  SCRIPT = Rails.root.join("bin/minitest-shard").to_s
+
+  def shard(index, total)
+    output = `#{SCRIPT} #{index} #{total}`
+    assert_predicate $?, :success?, "bin/minitest-shard #{index} #{total} failed"
+    output.split
+  end
+
+  def all_test_files
+    Dir.chdir(Rails.root) { Dir["test/**/*_test.rb"].sort }
+  end
+
+  test "the shards together cover every test file exactly once" do
+    [1, 2, 3, 7].each do |total|
+      shards = (0...total).map { shard(_1, total) }
+      combined = shards.flatten
+
+      assert_equal all_test_files, combined.sort, "shard set for total=#{total} does not cover the tree"
+      assert_equal combined.size, combined.uniq.size, "a file appears in more than one shard for total=#{total}"
+    end
+  end
+
+  test "no shard comes back empty" do
+    # Not just tidiness: `rails test` with no file arguments runs everything, so
+    # an empty shard would quietly double the work rather than do none of it.
+    # The script exits non-zero in that case, which `shard` asserts against.
+    [2, 3, 7].each do |total|
+      (0...total).each { |index| assert_not_empty shard(index, total), "shard #{index} of #{total} is empty" }
+    end
+  end
+
+  # Deliberately not asserted here: how *evenly* the shards are balanced. That's a
+  # performance property, and pinning it to a threshold in a unit test would
+  # either measure the script against its own weighting (tautological) or fail on
+  # an arbitrary line the next added test file happens to cross. Check balance
+  # with `bin/minitest-shard --report 2` and against the real job timings in CI.
+  test "an out-of-range shard index is refused rather than silently empty" do
+    `#{SCRIPT} 2 2 2>/dev/null`
+    assert_not_predicate $?, :success?, "index equal to total should be rejected"
+
+    `#{SCRIPT} -1 2 2>/dev/null`
+    assert_not_predicate $?, :success?, "negative index should be rejected"
+  end
+end


### PR DESCRIPTION
## What

Splits the `Test Minitest` CI job into a 2-shard matrix, so the Minitest suite stops being one runner working through the whole `test/` tree.

- **`bin/minitest-shard <index> <total>`** prints the files for one shard. Longest-processing-time-first packing: sort files by weight descending, hand each to whichever shard is currently lightest. With a handful of thousand-test files dominating the tree, that lands far closer to even than round-robin or halving an alphabetical list. `bin/minitest-shard --report 2` prints the split.
- **Weights are file sizes**, with a two-entry override table for files whose runtime isn't a function of their size: `stripe_payout_processor_test.rb` ×3 (most of its tests replay Stripe cassettes through the VCR bridge — the HTTP replay is the cost, not the file) and `links_controller_test.rb` ×1.5 (real Elasticsearch round-trips). Sizes are read off disk, so porting more specs re-balances the shards on the next run with nothing to maintain per file.
- **The workflow job** becomes `strategy.matrix` over `ci_node_index: [0, 1]` with `fail-fast: false`, matching `test_fast`/`test_slow`. Each shard is a separate runner with its own MySQL, Redis, Mongo, stripe-mock, Elasticsearch and MinIO, so they share no state at all. The run step logs its file manifest first — when a shard fails you want to see what it covered without recomputing the split by hand.
- **`test/lib/minitest_shard_test.rb`** asserts the properties CI depends on: every file lands in exactly one shard (at totals 1, 2, 3 and 7), no shard comes back empty, and an out-of-range index is refused.
- **`docs/minitest-migration.md`** updated — it still described the job as one runner over the whole tree.

## Why

The job was at **11m50s against its own `timeout-minutes: 15`** on the last green run on main ([30339200252](https://github.com/antiwork/gumroad/actions/runs/30339200252)). #6205 added Elasticsearch and MinIO startup on top of that, and the files still to be ported for #5801 include `sales_tax_calculator_spec` (125 examples), `dashboard_products_page_presenter_spec` (72) and `purchase_export_service_spec` (59) — roughly 256 more examples between them.

That trajectory ends in a timeout, and a timeout is a much worse signal than a failure: it reads as a broken suite, tells you nothing about which test is at fault, and costs a full re-run to learn anything. Sharding now means the next few ports land without anyone having to think about the clock. The daily updates on #5801 have flagged this as the cheapest remaining lever for several days.

Why not Knapsack Pro, which the RSpec lane uses: it splits by recorded timings from its API, which is the right tool at 18 and 50 shards. At 2 shards the gain over a static split is small, and it would put a network dependency and an API token in front of the one job whose whole point is staying lean. The script says so, for whoever needs more shards later.

Why not Rails' own `parallelize`: it would need a database per worker, and the real-Elasticsearch bridge namespaces indices per test-database — in-process workers would share one namespace and each `create_index!(force: true)` would wipe indices out from under its siblings. That's noted in `test/support/real_elasticsearch_bridge.rb` and would have to be solved first. Separate runners avoid the question entirely.

An empty shard is the failure mode worth guarding, and the reason the script exits non-zero on one: `rails test` with no file arguments runs the **entire** tree, so an empty shard would silently double the work rather than do none of it. Same for a file in no shard — it would never run, and CI would still go green. Hence the unit tests.

## Before / After

Not a user-facing change — no app code is touched. The change is the shape of the CI job:

**Before** — one runner, whole tree:

```
Test Minitest                      11m50s   2615 runs
```

**After** — two runners, measured on the same machine (`bin/rails test $(bin/minitest-shard N 2)`):

```
Test Minitest 0    1012 runs, 2674 assertions, 0 failures, 0 errors, 2 skips   201s
Test Minitest 1    1606 runs, 4457 assertions, 0 failures, 0 errors, 3 skips   162s
                   ----                                                       ----
                   2618 runs total                             wall 201s (was 363s)
```

The two shards run 2618 tests between them: 2615, the unsharded count on main, plus the 3 new tests in `minitest_shard_test.rb`. Skips split 2 + 3, which is main's 5. That arithmetic is the real check that no file went missing or got run twice.

Slowest shard carries 55% of the sequential time — an 11% drift from even, which is close enough that tuning the weights further would be fitting them to one laptop rather than to CI. Expect roughly 6–7 minutes per shard on the runner, against the same 15-minute limit.

## Test Results

```
$ bin/minitest-shard --report 2
shard 0:   7 files, weight 1126.6k
shard 1:  13 files, weight 1127.1k

$ CI=true RAILS_ENV=test bin/rails test $(bin/minitest-shard 0 2)
1012 runs, 2674 assertions, 0 failures, 0 errors, 2 skips

$ CI=true RAILS_ENV=test bin/rails test $(bin/minitest-shard 1 2)
1606 runs, 4457 assertions, 0 failures, 0 errors, 3 skips

$ CI=true RAILS_ENV=test bin/rails test test/lib/minitest_shard_test.rb
3 runs, 59 assertions, 0 failures, 0 errors, 0 skips
```

`bundle exec rubocop bin/minitest-shard test/lib/minitest_shard_test.rb`: no offenses. The workflow YAML parses, and the matrix doesn't disturb the wiring around it — `unblock_deployment_from_buildkite` still `needs: test_minitest` (a matrix satisfies `needs` once every leg passes), and the required `ci/green` status is derived from the whole workflow's conclusion rather than from job names, so renaming the job to `Test Minitest 0`/`1` changes nothing about branch protection.

## QA steps

1. `bin/minitest-shard --report 2` → two shards, no file in both, no file missing.
2. `CI=true RAILS_ENV=test bin/rails test $(bin/minitest-shard 0 2)` and the same with `1 2` → both green; run counts sum to what `bin/rails test` reports for the whole tree.
3. `CI=true RAILS_ENV=test bin/rails test test/lib/minitest_shard_test.rb` → 3, 0 failures.
4. On this PR's CI run, `Test Minitest 0` and `Test Minitest 1` both green, each well under the 15-minute limit.

---

## AI disclosure

Written with Claude Opus 5.
