### PR TITLE
Refuse follows for suspended and deleted accounts

### DIFF
--- a/app/services/follower/create_service.rb
+++ b/app/services/follower/create_service.rb
@@ -16,6 +16,21 @@ class Follower::CreateService
 
   def perform
     return if followed_user.blank? || follower_email.blank?
+    # Refuse to create (or revive) a follow for a suspended or deleted seller.
+    #
+    # Creating a Follower row sends a "Please confirm your follow request" email
+    # to whatever address was submitted, from Gumroad's own sending domain. That
+    # makes this endpoint an email relay pointed at arbitrary third parties, and
+    # suspending the seller does NOT close it: /follow is a plain POST that never
+    # loads the storefront, so a banned account whose pages 404 keeps accepting
+    # submissions and keeps sending mail. A ring of accounts used exactly that to
+    # deliver loan-phishing lures to hundreds of thousands of harvested addresses,
+    # and kept going after every account in it was banned.
+    #
+    # `account_active?` is `alive? && !suspended?` — once we have decided an
+    # account may no longer transact, it should not be able to make us send mail
+    # on its behalf either.
+    return unless followed_user.account_active?
 
     @follower = followers.find_by(email: follower_email)
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -80,11 +80,25 @@ class Rack::Attack
   end
 
   # Throttle by request parameters
-  def self.throttle_by_params(path:, requests:, period:, throttle_params:, method: nil)
-    block_proc = proc { |req| throttle_identifier(path:, method:, request: req, identifier: "#{throttle_params.call(req)}") }
+  #
+  # `max_level` mirrors `throttle_by_ip`: the default adds exponential-backoff
+  # tiers on top of the base limit, but a long base `period` makes those tiers
+  # *stricter* than the limit you asked for (the `rpm * level` arithmetic rounds
+  # down to single digits), so pass `max_level: 1` for hour-scale limits to get
+  # exactly the base rule and nothing else.
+  def self.throttle_by_params(path:, requests:, period:, throttle_params:, max_level: 6, method: nil)
+    block_proc = proc do |req|
+      value = throttle_params.call(req)
+      # A blank extracted value would make every request that omits the param
+      # share a single throttle bucket, so real traffic would be blocked by
+      # unrelated malformed requests. Skip the rule instead.
+      next if value.blank?
+
+      throttle_identifier(path:, method:, request: req, identifier: "#{value}")
+    end
     name = throttle_name(prefix: "/params", path:, method:)
 
-    throttle_with_exponential_backoff(name:, requests:, period:, max_level: 6, &block_proc)
+    throttle_with_exponential_backoff(name:, requests:, period:, max_level:, &block_proc)
   end
 
   # Throttle by IP with exponential backoff
@@ -127,6 +141,29 @@ class Rack::Attack
     throttle_by_ip path: "/signup.json",                    requests: 3,  period: 20.seconds # Initial: 9rpm,   Max: 45  requests/9 hours
     throttle_by_ip path: "/follow", method: :post,          requests: 3,  period: 20.seconds # Initial: 9rpm,   Max: 45  requests/9 hours
     throttle_by_ip path: "/follow_from_embed_form",         requests: 3,  period: 20.seconds # Initial: 9rpm,   Max: 45  requests/9 hours
+
+    # Cap follow requests per TARGET SELLER, not just per source IP.
+    #
+    # Every follow creates a "Please confirm your follow request" email to
+    # whatever address was submitted, so /follow is an email-sending endpoint
+    # aimed at arbitrary third parties. The per-IP limits above are the wrong
+    # key against a distributed sender: a ring that harvested addresses and
+    # pointed them at its own storefronts ran one account per proxy IP at a few
+    # follows per minute each, which is orders of magnitude under 3-per-20s and
+    # so never tripped anything, while delivering hundreds of thousands of
+    # phishing lures from our sending domain.
+    #
+    # The seller being followed is the one identifier the sender cannot rotate:
+    # the whole point of the abuse is to drive victims to a specific storefront.
+    # 60/hour is far above organic demand (a viral launch is a burst of page
+    # views, and each visitor follows at most once) while making bulk relay
+    # impossible regardless of how many IPs the sender controls.
+    #
+    # `max_level: 1` skips the exponential-backoff tiers: with a 1-hour base
+    # period the `rpm * level` arithmetic rounds below 1 and would start
+    # blocking well under the intended limit.
+    throttle_by_params path: "/follow", method: :post, requests: 60, period: 1.hour, max_level: 1,
+                       throttle_params: ->(req) { req.params["seller_id"].presence }
     throttle_by_ip path: "/forgot_password.json",           requests: 3,  period: 20.seconds # Initial: 9rpm,   Max: 45  requests/9 hours
     throttle_by_ip path: "/forgot_password",                requests: 3,  period: 20.seconds # Initial: 9rpm,   Max: 45  requests/9 hours
     throttle_by_ip path: "/users/auth/facebook",            requests: 3,  period: 20.seconds # Initial: 9rpm,   Max: 45  requests/9 hours

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -80,25 +80,11 @@ class Rack::Attack
   end
 
   # Throttle by request parameters
-  #
-  # `max_level` mirrors `throttle_by_ip`: the default adds exponential-backoff
-  # tiers on top of the base limit, but a long base `period` makes those tiers
-  # *stricter* than the limit you asked for (the `rpm * level` arithmetic rounds
-  # down to single digits), so pass `max_level: 1` for hour-scale limits to get
-  # exactly the base rule and nothing else.
-  def self.throttle_by_params(path:, requests:, period:, throttle_params:, max_level: 6, method: nil)
-    block_proc = proc do |req|
-      value = throttle_params.call(req)
-      # A blank extracted value would make every request that omits the param
-      # share a single throttle bucket, so real traffic would be blocked by
-      # unrelated malformed requests. Skip the rule instead.
-      next if value.blank?
-
-      throttle_identifier(path:, method:, request: req, identifier: "#{value}")
-    end
+  def self.throttle_by_params(path:, requests:, period:, throttle_params:, method: nil)
+    block_proc = proc { |req| throttle_identifier(path:, method:, request: req, identifier: "#{throttle_params.call(req)}") }
     name = throttle_name(prefix: "/params", path:, method:)
 
-    throttle_with_exponential_backoff(name:, requests:, period:, max_level:, &block_proc)
+    throttle_with_exponential_backoff(name:, requests:, period:, max_level: 6, &block_proc)
   end
 
   # Throttle by IP with exponential backoff
@@ -141,29 +127,6 @@ class Rack::Attack
     throttle_by_ip path: "/signup.json",                    requests: 3,  period: 20.seconds # Initial: 9rpm,   Max: 45  requests/9 hours
     throttle_by_ip path: "/follow", method: :post,          requests: 3,  period: 20.seconds # Initial: 9rpm,   Max: 45  requests/9 hours
     throttle_by_ip path: "/follow_from_embed_form",         requests: 3,  period: 20.seconds # Initial: 9rpm,   Max: 45  requests/9 hours
-
-    # Cap follow requests per TARGET SELLER, not just per source IP.
-    #
-    # Every follow creates a "Please confirm your follow request" email to
-    # whatever address was submitted, so /follow is an email-sending endpoint
-    # aimed at arbitrary third parties. The per-IP limits above are the wrong
-    # key against a distributed sender: a ring that harvested addresses and
-    # pointed them at its own storefronts ran one account per proxy IP at a few
-    # follows per minute each, which is orders of magnitude under 3-per-20s and
-    # so never tripped anything, while delivering hundreds of thousands of
-    # phishing lures from our sending domain.
-    #
-    # The seller being followed is the one identifier the sender cannot rotate:
-    # the whole point of the abuse is to drive victims to a specific storefront.
-    # 60/hour is far above organic demand (a viral launch is a burst of page
-    # views, and each visitor follows at most once) while making bulk relay
-    # impossible regardless of how many IPs the sender controls.
-    #
-    # `max_level: 1` skips the exponential-backoff tiers: with a 1-hour base
-    # period the `rpm * level` arithmetic rounds below 1 and would start
-    # blocking well under the intended limit.
-    throttle_by_params path: "/follow", method: :post, requests: 60, period: 1.hour, max_level: 1,
-                       throttle_params: ->(req) { req.params["seller_id"].presence }
     throttle_by_ip path: "/forgot_password.json",           requests: 3,  period: 20.seconds # Initial: 9rpm,   Max: 45  requests/9 hours
     throttle_by_ip path: "/forgot_password",                requests: 3,  period: 20.seconds # Initial: 9rpm,   Max: 45  requests/9 hours
     throttle_by_ip path: "/users/auth/facebook",            requests: 3,  period: 20.seconds # Initial: 9rpm,   Max: 45  requests/9 hours

--- a/spec/services/follower/create_service_spec.rb
+++ b/spec/services/follower/create_service_spec.rb
@@ -192,4 +192,64 @@ describe Follower::CreateService do
       end.not_to have_enqueued_mail(FollowerMailer, :confirm_follower)
     end
   end
+
+  # A Follower row is what triggers the "Please confirm your follow request" email,
+  # so an inactive seller must not be able to create one. /follow is a bare POST
+  # that never loads the storefront, which means a suspended seller whose pages
+  # already 404 would otherwise keep making us send mail to arbitrary addresses.
+  context "when the followed user is not active" do
+    shared_examples "refuses the follow" do
+      it "creates no follower and sends no confirmation email" do
+        expect do
+          expect(
+            Follower::CreateService.perform(
+              followed_user: user,
+              follower_email: "stranger@example.com"
+            )
+          ).to be_nil
+        end.not_to have_enqueued_mail(FollowerMailer, :confirm_follower)
+
+        expect(Follower.find_by(email: "stranger@example.com")).to be_nil
+      end
+
+      it "does not revive an existing cancelled follower" do
+        deleted_follower
+
+        expect do
+          Follower::CreateService.perform(
+            followed_user: user,
+            follower_email: deleted_follower.email
+          )
+        end.not_to have_enqueued_mail(FollowerMailer, :confirm_follower)
+
+        expect(deleted_follower.reload.deleted?).to be(true)
+      end
+    end
+
+    context "when suspended for a TOS violation" do
+      before do
+        admin = create(:admin_user)
+        user.flag_for_tos_violation!(author_id: admin.id, product_id: create(:product, user:).id)
+        user.suspend_for_tos_violation!(author_id: admin.id)
+      end
+
+      it_behaves_like "refuses the follow"
+    end
+
+    context "when suspended for fraud" do
+      before do
+        admin = create(:admin_user)
+        user.flag_for_fraud!(author_id: admin.id)
+        user.suspend_for_fraud!(author_id: admin.id)
+      end
+
+      it_behaves_like "refuses the follow"
+    end
+
+    context "when the account is deleted" do
+      before { user.update!(deleted_at: Time.current) }
+
+      it_behaves_like "refuses the follow"
+    end
+  end
 end


### PR DESCRIPTION
## What

`Follower::CreateService` now refuses to create (or revive) a follow when the followed user is not `account_active?` — i.e. suspended or deleted.

That is the whole diff. An earlier revision of this PR also added a per-seller rate limit on `POST /follow`; I measured it against production and removed it, because the numbers show it cannot work. Details in the review section below.

## Why

A ring of 76 accounts was POSTing harvested third-party email addresses to the public follow form. Each submission made Gumroad send that address a *"Please confirm your follow request"* email **from our own sending domain**, and the confirm link landed the recipient on a storefront profile page dressed up as a transactional loan-approval notice ("Action Required: Confirm Your Email Address", "Your Fund Request Was Successfully Approved"). Every account had **0 products and 0 sales** — the storefront existed only to be the phishing landing page.

It ran for eight weeks and accumulated ~389,000 follower rows, ~364,000 of which were never confirmed. The payload is the email *we* send, so there is no off-platform link on the account to find and every per-account risk signal read clean. Detection was accidental: a member of the public emailed support to say he'd received mail for a service he'd never heard of and called it fraud.

Full incident writeup and takedown record: gumroad-private#1465.

### Suspending the seller does not close the endpoint

After all 76 accounts were suspended and their storefronts were returning 404, I probed the endpoint directly and it still created a follower row.

> **⚠️ CORRECTION (2026-07-28 11:30 UTC) — the "46 rows after suspension" figure I originally published here was wrong.** I re-measured against production before asking anyone to merge this, and the real number is **1**. The original claim overstated this PR's urgency; the corrected numbers below are what should be reviewed. Full reconciliation in the *Verification in production* section.

**What actually happened, measured per account:** the batch suspension ran 09:57:55–09:59:37 UTC. Seven ring rows landed inside that 102-second rollout window, but six of them hit accounts that had not been banned *yet* — so they prove nothing. Exactly **one** row landed on an account after that account's own ban: `cashadvance`, at `09:58:53`, **7 seconds after** its ban at `09:58:46`, carrying a real harvested Gmail address. The endpoint accepted a write to an account Gumroad had already banned, and would have mailed that address.

The other post-suspension row I originally counted was on `paydayloan` at `09:46:04` — that one was **my own probe** (`probe-test-gumclaw@example.invalid`), not a victim. It is still evidence that the endpoint answers for a banned account, but it is my traffic, not the attacker's, and it should never have been added to a "harvested rows" total.

`/follow` is a bare POST that never loads the storefront, so a 404 page stops nothing. `Follower::CreateService#perform` guarded only on `followed_user.blank?`, and `FollowersController#create_follower` only on `nil?` — neither consulted risk state.

The guard goes in the service rather than the controller so it covers every entry point (`#create`, `#from_embed_form`, the custom-page bridge, `User#add_follower`) and, importantly, the `reactivate_follower` path: without it a re-follow can revive a cancelled row and fire a fresh confirmation email.

`account_active?` (`alive? && !suspended?`) rather than a bare `suspended?` check, because deleted accounts have the same property, and because it matches what the codebase already does — `FollowersController#confirm` gates on exactly this predicate, and `RemoveSuspendedAccountFollowsWorker` exists to strip follows *off* suspended accounts. Refusing to create them in the first place is the same policy, one step earlier.

## Test results

`spec/services/follower/create_service_spec.rb` — **18 examples, 0 failures** (6 new). Together with `spec/requests/rack_attack_spec.rb`: 37 examples, 0 failures.

New coverage: `suspended_for_tos_violation`, `suspended_for_fraud`, and `deleted_at`, each asserting both *"no row created and no mail enqueued"* and *"does not revive an existing cancelled follower"*.

**RED verified before GREEN.** With only the guard line removed, all 6 new examples fail with exactly the bug this fixes:

```
expected not to enqueue FollowerMailer.confirm_follower at least 1 time but enqueued 1
6 examples, 6 failures
```

`spec/controllers/concerns/throttling_spec.rb` shows 5-6 failures both here and on unmodified `origin/main` in the same worktree — pre-existing order-dependent leakage in a Redis-counter concern this diff doesn't touch. `throttling_spec.rb:159` in fact **passes** on this branch and **fails** on main in isolation, which is the signature of ordering rather than a regression.

## Adversarial pre-merge review (fable-5)

Verdict on `1667c150b`: **CHANGES-REQUIRED** — 2×P2, 1×P3. All three were correct.

| Finding | Disposition |
|---|---|
| **P2** — per-seller 60/hour throttle would 429 legitimate viral creators; nothing previously imposed a global per-seller ceiling | Rate limit removed in `fad13d73`. **⚠️ My justification for that removal was later disproved by re-measurement — see below. The reviewer's concern was reasonable, but the production data does not support it.** |
| **P2** — `/follow_from_embed_form` got no equivalent per-seller cap, so a sender could just use the other endpoint | **Genuinely correct, and unaffected by the above.** The `account_active?` guard was never asymmetric: it sits in the service, which both endpoints funnel through, so this PR's actual protection covers both paths. |
| **P3** — the `max_level: 1` comment claimed the backoff tiers "round below 1", which is false at `requests: 60, period: 1.hour` (rpm is exactly 1.0; tiers would be 2/64s, 3/512s). The reviewer noted the reasoning was copied from the Walks rule where it genuinely applies. | **Correct — a real error, not a wording nit**: I reasoned about the arithmetic instead of computing it. Moot in this diff since the rule is gone. |

### ⚠️ Correction: my stated reason for deleting the rate limit was wrong

**This does not change what this PR ships** — the diff is the `account_active?` guard and its specs either way, and the guard stands on the platform-wide numbers in *Verification in production*. But the reasoning I published for dropping the rate limit was wrong, and I'd rather say so than leave it as the record.

What I originally claimed: *"111 legitimate seller-hours exceeded 60 follows/hour, peak 421/hour, while the ring ran 25-42/hour — so any ceiling sparing real creators sits above the attacker's rate."*

Re-measured over the same 7-day window, one pass, bucketing every (seller, hour) pair and classifying it (request `20260728T113910Z-f173e0da`, `20260728T114019Z-173e03cf`, `20260728T114202Z-56e134ba`):

| Population | account-hours > 60/hr | peak hour |
|---|---|---|
| The ring | **19** | **121** |
| Non-ring, active sellers | 109 | 421 |
| …of which **`gumroad`** (uid 768, `noreply@gumroad.com`, 2.38M followers) | **109 — all of them** | 421 |
| **Independent creators, house account excluded** | **0** | **43** |

Two errors, both pointing the same way — toward the conclusion I'd already reached:

1. **I compared the ring's daily average to the creators' peak hour.** The "25-42/hour" was a per-day total divided across the day (measured: ~15/hour average). The ring's actual *peak* hour was **121**, and it exceeded 60/hour 19 times. It was never below the limit.
2. **The entire false-positive population was Gumroad's own account.** All 109 hours over 60 belong to uid 768. Not one independent creator exceeded 60 follows/hour in seven days; the highest was 43.

So the distributions do **not** overlap the wrong way round — they separate cleanly, with a gap between 43 (highest real creator) and 121 (ring peak). A per-seller cap in that band, with the house account exempted, would have blocked zero real creators and would have caught the ring. **The rate limit was viable and I removed it on bad arithmetic.**

I am deliberately *not* re-adding it to this PR: it's a separate control, it needs the embed-form parity the reviewer correctly asked for (finding 2), it needs an explicit house-account exemption, and this guard is ready now and independently justified. Re-opened on gumroad-private#1465 with these numbers so it gets designed rather than reflexively restored.

The confirm-rate signal is still the stronger discriminator (ring accounts sat at 4-10% confirmed vs 15% on the house account and far higher on ordinary creators), and a cap on *unconfirmed* followers per seller remains the better long-term control. That also needs its own blast-radius measurement — same tracker.

Worth stating plainly: a reviewer raised a hypothesis, I "measured" it, and the measurement is what was wrong. The pre-existing per-IP rule (3/20s) genuinely never fired here — the ring ran one account per proxy IP — and that part stands.

### Confirmed safe by the review

- **No bypass**: every production follower creation funnels through `User#add_follower` → `Follower::CreateService.perform`. The only other caller is a mailer preview. No API, mobile, importer, or seeder path builds a `Follower` directly.
- **Nil return handled, no 500, no info leak**: `#create` and `#from_embed_form` both map a nil return to a generic message / 404. Neither reveals that the account is suspended, and no caller dereferences the return.
- **Specs are not vacuous**: all three contexts fail on revert, and `Deletable#alive?` reads `deleted_at.nil?` directly, so the deleted-account test exercises a real path.

## Verification in production

Re-measured against the audited read-only console immediately before requesting review (requests `20260728T111603Z-397bb51a`, `20260728T111806Z-85421f3f`, `20260728T111902Z-c0847bf1`, `20260728T112105Z-70c1a6c2`, `20260728T112447Z-c5da5243`, `20260728T112815Z-3d603917`).

**The bug, reproduced on prod.** Endpoint probe against a suspended seller created a follower row (cleaned up afterwards; audited console request `20260728T094716Z-e56bd05b`).

**The bug's cost — corrected.** My original "46 harvested rows in 6 minutes" was wrong; see the correction notice above. Reconciliation:

| Window | Ring rows | What it proves |
|---|---|---|
| 10 min before first ban | 70 | attacker's baseline throughput (~7/min ring-wide) |
| during the 102s ban rollout (09:57:55–09:59:37) | 7 | mostly accounts not yet banned — not evidence |
| after each account's **own** ban | **1** | `cashadvance`, +7s, real harvested address — **this is the bug** |
| after the last ban completed | **0** | the ring stopped when the operator's tooling stopped |

The honest reading: the ring's sender stopped on its own once every account was banned, so the endpoint's openness cost **one** extra email in this incident, not hundreds. What produced the wrong number was measuring a 6-minute window that straddled the rollout and attributing rows from not-yet-banned accounts to already-banned ones. The ring has now been silent since `09:58:53` (verified 0 rows in the last 60 minutes, against a platform control of 511 rows/hour, so the zero is a real zero and not a dead probe).

**The guard's real justification is platform-wide, not this ring.** The number that actually argues for merging is that this is not one attacker's trick — the endpoint routinely accepts follows for accounts we have already banned:

- **100,805** follower rows created in the last 7 days for sellers who are suspended or deleted — **58% of all 173,440 rows** created platform-wide in that period.
- Excluding this entire ring: still **2,630** rows across **22 distinct** suspended-or-deleted sellers (2,537 suspended, 93 deleted).

So even with the ring gone, ~22 banned or deleted accounts a week keep collecting followers and keep making Gumroad send confirmation mail on their behalf. That is the ongoing condition this one-line guard closes, and it does not depend on any claim about the ring's post-ban behaviour.

**Takedown state.** All **76** ring accounts read back independently as `suspended_for_tos_violation`, and all 76 return `account_active? == false`, which is exactly the predicate this guard consults — so the guard covers every one of them the moment it ships. The 76 are the 74 enumerated in the batch plus the two sellers named in the original customer complaint (`financepluss`, `paydayloan`), which were suspended earlier during the investigation.

