### PR TITLE
Bound and coalesce the related-products counter writes

### DIFF
--- a/app/models/sales_related_products_info.rb
+++ b/app/models/sales_related_products_info.rb
@@ -18,38 +18,65 @@ class SalesRelatedProductsInfo < ApplicationRecord
     retry
   end
 
+  # How many product pairs to touch per SQL statement. Each pair contributes one short
+  # VALUES tuple, so this bounds the size of every statement we send regardless of how
+  # many products the buyer owns.
+  SALES_COUNT_UPSERT_BATCH_SIZE = 100
+
+  # Applies +1 (or -1) to the pairwise sales counter between `product_id` and each of
+  # `related_product_ids`, creating the pair row if it does not exist yet.
+  #
+  # This runs once per successful purchase for every product the buyer already owns, so a
+  # single sale can touch a lot of pairs. Two properties matter more than they look:
+  #
+  # 1. **Every statement is bounded.** An earlier version read the matching rows, then ran
+  #    `where(id: [...]).in_batches(of: 1_000).update_all(...)`. `in_batches` only takes its
+  #    cheap primary-key `BETWEEN` path on an *unscoped* relation — applied to a relation
+  #    that already carries `where(id: [...])`, it re-ships the whole id list in every batch
+  #    and merely adds a range predicate on top, so "batching" produced several copies of
+  #    one huge statement instead of splitting it up. Slicing the ids ourselves is what
+  #    actually bounds statement size.
+  # 2. **One statement per slice, no read-then-write.** Reading which pairs exist and then
+  #    updating them is racy: two concurrent purchases of the same pair can both see it
+  #    missing and both try to insert, and whichever insert loses previously had its
+  #    increment silently dropped by `INSERT IGNORE`. A single
+  #    `INSERT ... ON DUPLICATE KEY UPDATE` against the unique index on
+  #    (smaller_product_id, larger_product_id) lets MySQL resolve that per row, so a
+  #    concurrent racer's increment is applied rather than discarded.
+  #
+  # Production MySQL runs `binlog_format = MIXED`, so a deterministic statement is binlogged
+  # as a statement and every replica re-executes it on a single applier thread. That is why
+  # statement size here shows up as replica lag (#1353) rather than just primary CPU.
   def self.update_sales_counts(product_id:, related_product_ids:, increment:)
-    return if related_product_ids.empty?
     raise ArgumentError, "product_id must be an integer" unless product_id.is_a?(Integer)
     raise ArgumentError, "related_product_ids must be an array of integers" unless related_product_ids.all? { _1.is_a?(Integer) }
 
+    # A product is never paired with itself (the model requires smaller < larger), and a
+    # repeated id must not count twice — the caller derives these from purchase history,
+    # which can legitimately list the same product more than once.
+    pair_product_ids = related_product_ids.uniq - [product_id]
+    return if pair_product_ids.empty?
+
     now_string = %("#{Time.current.to_fs(:db)}")
     sales_count_change = increment ? 1 : -1
-
-    # Update existing
-    larger_ids, smaller_ids = related_product_ids.partition { _1 > product_id }
-    existing = where(smaller_product_id: product_id, larger_product_id: larger_ids)
-      .or(where(smaller_product_id: smaller_ids, larger_product_id: product_id))
-      .pluck(:id, :smaller_product_id, :larger_product_id)
-
-    where(id: existing.map(&:first))
-      .in_batches(of: 1_000)
-      .update_all("sales_count = sales_count + #{sales_count_change}, updated_at = #{now_string}")
-
-    # Insert remaining
-    remaining = related_product_ids - existing.map { [_2, _3] }.flatten.uniq - [product_id]
-    return if remaining.empty?
-
+    # A pair we are seeing for the first time starts at 1 for a sale. For a reversal
+    # (refund, chargeback) there was no counted sale to take away, so it starts at 0 rather
+    # than going negative.
     new_sales_count = increment ? 1 : 0
-    remaining.each_slice(100) do |remaining_slice|
-      inserts_sql = remaining_slice.map do |related_product_id|
-        smaller_id, larger_id = [product_id, related_product_id].sort
-        [smaller_id, larger_id, new_sales_count, now_string, now_string].join(", ")
-      end.map { "(#{_1})" }.join(", ")
 
+    pair_product_ids.each_slice(SALES_COUNT_UPSERT_BATCH_SIZE) do |slice|
+      values_sql = slice.map do |related_product_id|
+        smaller_id, larger_id = [product_id, related_product_id].sort
+        "(#{[smaller_id, larger_id, new_sales_count, now_string, now_string].join(', ')})"
+      end.join(", ")
+
+      # `sales_count` is incremented from its stored value rather than from VALUES(), because
+      # the amount to add differs from the amount to insert: a reversal inserts 0 but must
+      # subtract 1 from a pair that already exists.
       query = <<~SQL
-        INSERT IGNORE INTO #{table_name} (smaller_product_id, larger_product_id, sales_count, created_at, updated_at)
-        VALUES #{inserts_sql};
+        INSERT INTO #{table_name} (smaller_product_id, larger_product_id, sales_count, created_at, updated_at)
+        VALUES #{values_sql}
+        ON DUPLICATE KEY UPDATE sales_count = sales_count + (#{sales_count_change}), updated_at = #{now_string};
       SQL
       ApplicationRecord.connection.execute(query)
     end

--- a/spec/models/sales_related_products_info_spec.rb
+++ b/spec/models/sales_related_products_info_spec.rb
@@ -53,6 +53,68 @@ describe SalesRelatedProductsInfo do
       # created record
       expect(described_class.find_by(smaller_product: products[1], larger_product: products[4]).sales_count).to eq(0)
     end
+
+    it "keeps every statement bounded to the batch size regardless of how many pairs there are" do
+      product = create(:product)
+      related = create_list(:product, 5)
+      stub_const("#{described_class}::SALES_COUNT_UPSERT_BATCH_SIZE", 2)
+
+      statements = []
+      allow(ApplicationRecord.connection).to receive(:execute).and_wrap_original do |original, sql, *args|
+        statements << sql if sql.include?(described_class.table_name)
+        original.call(sql, *args)
+      end
+
+      described_class.update_sales_counts(product_id: product.id, related_product_ids: related.map(&:id), increment: true)
+
+      # 5 pairs at 2 per statement => 3 statements, none carrying more than 2 VALUES tuples.
+      expect(statements.size).to eq(3)
+      expect(statements.map { _1.scan(/\(\d+, \d+, \d+, /).size }).to eq([2, 2, 1])
+      expect(related.all? { described_class.find_by(smaller_product_id: [product.id, _1.id].min, larger_product_id: [product.id, _1.id].max).sales_count == 1 }).to be(true)
+    end
+
+    it "accumulates repeated increments on the same pair" do
+      # Note this passes on the old read-then-write code too: sequential calls are not a
+      # real race. It is here as a regression guard on the upsert's arithmetic, since
+      # `ON DUPLICATE KEY UPDATE` is where a wrong increment source would show up. The
+      # concurrent case the upsert actually fixes (two callers both finding the pair
+      # missing, one increment lost to INSERT IGNORE) cannot be reproduced in-process.
+      product1 = create(:product)
+      product2 = create(:product)
+
+      2.times do
+        described_class.update_sales_counts(product_id: product1.id, related_product_ids: [product2.id], increment: true)
+      end
+
+      info = described_class.find_by(smaller_product_id: [product1.id, product2.id].min, larger_product_id: [product1.id, product2.id].max)
+      expect(info.sales_count).to eq(2)
+      expect(described_class.where(smaller_product_id: info.smaller_product_id, larger_product_id: info.larger_product_id).count).to eq(1)
+    end
+
+    it "counts a repeated related product once and never pairs a product with itself" do
+      product = create(:product)
+      other = create(:product)
+
+      described_class.update_sales_counts(
+        product_id: product.id,
+        related_product_ids: [other.id, other.id, product.id],
+        increment: true
+      )
+
+      expect(described_class.count).to eq(1)
+      info = described_class.last
+      expect(info.sales_count).to eq(1)
+      expect([info.smaller_product_id, info.larger_product_id]).to match_array([product.id, other.id])
+    end
+
+    it "does nothing when there are no pairs to touch" do
+      product = create(:product)
+
+      expect do
+        described_class.update_sales_counts(product_id: product.id, related_product_ids: [], increment: true)
+        described_class.update_sales_counts(product_id: product.id, related_product_ids: [product.id], increment: true)
+      end.not_to change(described_class, :count)
+    end
   end
 
   describe ".related_products" do


### PR DESCRIPTION
The first two deliverables of the related-products redesign tracked internally — both marked there as "small and independently shippable" and separable from the redesign itself.

`UpdateSalesRelatedProductsInfosJob` is disabled by feature flag because it stalled replication on `production-worker-replica-1` (tracked internally). This does not re-enable it; it removes two of the reasons it was expensive.

**The `in_batches` misuse.** `update_sales_counts` read the matching pair rows, then ran `where(id: [...]).in_batches(of: 1_000).update_all(...)`. `in_batches` only takes its cheap primary-key `BETWEEN` path on an *unscoped* relation — applied to a relation that already carries `where(id: [...])`, it re-ships the whole id list in every batch and merely adds a range predicate on top. So "batching" produced several copies of one large statement rather than splitting it into small ones. Now the ids are sliced directly, which is what actually bounds statement size.

This is why statement size shows up as replica lag rather than just primary CPU: production MySQL runs `binlog_format = MIXED`, so a deterministic statement is binlogged as a statement and every replica re-executes it from scratch on a single applier thread, with the other appliers queued behind it.

**The read-then-write.** Reading which pairs exist and then updating them was also racy — two concurrent purchases of the same pair could both see it missing, and the losing `INSERT IGNORE` silently discarded its increment. One `INSERT ... ON DUPLICATE KEY UPDATE` per slice, against the existing unique index on `(smaller_product_id, larger_product_id)`, lets MySQL resolve that per row, and removes the large `id IN (...)` UPDATE entirely.

`sales_count` is incremented from its stored value rather than `VALUES()`, because the amount to add differs from the amount to insert: a reversal inserts 0 but must subtract 1 from a pair that already exists.

## Verification

15 examples, 0 failures in `spec/models/sales_related_products_info_spec.rb`; 5 more in the two job specs. `rubocop` clean on both files.

Four new specs. Being precise about which are red-before-green, since not all are:

- **statement bounding** — genuinely red on `main`. Reverted the model and it fails `expect(statements.size).to eq(3)`, which is the `in_batches` bug reproduced directly: it stubs the batch size to 2, sends 5 pairs, and asserts 3 statements each carrying at most 2 VALUES tuples.
- **repeated increments accumulate** — passes on `main` too, and the spec says so in a comment. Sequential calls are not a real race; the concurrent case the upsert actually fixes can't be reproduced in-process. It's a regression guard on the upsert's arithmetic, not evidence.
- **dedup / self-pair** and **empty input** — guards on the new `uniq - [product_id]` line. The only caller already passes `distinct` ids and returns early on empty, so these are defensive rather than behavioural.

The remaining three deliverables on the internal tracking issue (capping per-purchase fan-out, moving counter maintenance off the purchase path, re-enabling the flag) are the actual redesign and are untouched here. **Do not flip `update_sales_related_products_infos` on the strength of this PR** — it makes each write cheaper, and nothing here bounds the per-purchase fan-out, which is the other half of the original stall.

Closes nothing.

