### PR TITLE
Keep the buyer's cart when the whole checkout failed

### DIFF
--- a/app/services/order/create_service.rb
+++ b/app/services/order/create_service.rb
@@ -16,6 +16,14 @@ class Order::CreateService
 
   PARAMS_TO_REMOVE_IF_BLANK = [:full_name, :email].freeze
 
+  # Terminal states a purchase can reach that mean its attempt is over and bought nothing. Used to
+  # decide whether the buyer's cart survives a wholly-failed checkout. It lists every way a purchase
+  # can end badly at checkout time — an ordinary decline, a declined preorder card authorization, a
+  # giftee purchase that could not be created — rather than only the one the current code paths
+  # produce, so that a change elsewhere cannot quietly start destroying carts. See the comment at
+  # the cart-cleanup branch in `perform` for which of these are reachable today.
+  CHECKOUT_FAILURE_STATES = %w[failed preorder_authorization_failed gift_receiver_purchase_failed].freeze
+
   def initialize(params:, buyer: nil)
     @params = params
     @buyer = buyer
@@ -125,7 +133,24 @@ class Order::CreateService
       #
       # So the question asked here is the narrow one: did anything survive? If the order holds no
       # purchase that is still live, nothing was bought and nothing is pending, and the cart stays.
-      nothing_survived = order.persisted? && order.purchases.any? && order.purchases.all?(&:failed?)
+      #
+      # "Failed" has more than one name. An ordinary decline leaves a purchase in `failed`, but a
+      # preorder whose card authorization is declined lands in its own terminal state,
+      # `preorder_authorization_failed`, and a giftee purchase that cannot be created gets
+      # `gift_receiver_purchase_failed` (see the state machine in Purchase). Neither of those can
+      # reach this code today — a preorder in a cart goes through the combined-charge path, which
+      # leaves it `in_progress` for the confirm step, and a giftee purchase is never appended to
+      # the order — so asking only `failed?` would be correct right now. They are listed anyway
+      # because the cost of being wrong is destroying a buyer's cart, and the reachability of a
+      # state is a property of code elsewhere that can change without anyone looking here.
+      #
+      # `preorder_concluded_unsuccessfully` is deliberately absent: it is reached much later, when
+      # a preorder is released and its card is charged, never during checkout.
+      #
+      # Any state not listed counts as surviving, so an unfamiliar state errs towards emptying the
+      # cart rather than silently keeping one after a real purchase.
+      nothing_survived = order.persisted? && order.purchases.any? &&
+        order.purchases.all? { CHECKOUT_FAILURE_STATES.include?(_1.purchase_state) }
 
       if order.persisted?
         cart.order = order

--- a/app/services/order/create_service.rb
+++ b/app/services/order/create_service.rb
@@ -112,12 +112,26 @@ class Order::CreateService
     end
 
     if (cart = Cart.fetch_by(user: buyer, browser_guid: params[:browser_guid]))
-      all_items_handled = purchase_responses.any? && purchase_responses.values.all? { _1[:success] }
+      # The cart is emptied once the checkout got far enough that the buyer has something to show
+      # for it, and kept otherwise so they can retry without rebuilding it by hand.
+      #
+      # `order.persisted?` alone was not that test. A declined purchase is still saved (so the
+      # attempt stays auditable) and then appended to the order, which persists the order — so a
+      # checkout where *every* item was declined took this branch and destroyed the cart anyway.
+      # A declined card on a multi-item cart is the everyday way to reach that; nothing exotic is
+      # needed. `all_items_handled` is not the right test either: it demands every response be a
+      # success, but a card that needs 3-D Secure comes back as a not-yet-successful response on a
+      # purchase that is perfectly on track, and the buyer is mid-authentication on it.
+      #
+      # So the question asked here is the narrow one: did anything survive? If the order holds no
+      # purchase that is still live, nothing was bought and nothing is pending, and the cart stays.
+      nothing_survived = order.persisted? && order.purchases.any? && order.purchases.all?(&:failed?)
 
       if order.persisted?
         cart.order = order
-        cart.mark_deleted!
-      elsif all_items_handled
+        cart.mark_deleted! unless nothing_survived
+        cart.save! if cart.changed?
+      elsif purchase_responses.any? && purchase_responses.values.all? { _1[:success] }
         cart.mark_deleted!
       end
     end

--- a/spec/services/order/create_service_spec.rb
+++ b/spec/services/order/create_service_spec.rb
@@ -323,6 +323,39 @@ describe Order::CreateService, :vcr do
       expect(cart.reload).to be_alive
     end
 
+    # The example above only covers failures so early that no purchase row is ever written, which
+    # leaves the order unpersisted. The everyday failure — a real product the buyer cannot actually
+    # be sold — does write a failed purchase row, and appending that row to the order persists the
+    # order. The cart cleanup used to key off `order.persisted?` alone, so a checkout where nothing
+    # at all was bought still had its cart destroyed, and the buyer landed back on an empty checkout
+    # with no way to retry short of re-adding every item by hand.
+    #
+    # Every line item here exceeds its product's remaining stock, which is the same mechanism the
+    # "returns failure responses with correct errors" example above relies on to produce a persisted
+    # failed purchase — so this is the real service path, not a stubbed one.
+    it "keeps the cart when every line item is attempted and fails" do
+      buyer = create(:user, email: "buyer@gumroad.com")
+      cart = create(:cart, user: buyer, browser_guid:)
+
+      [product_1, product_2, product_3, product_4, product_5].each do |product|
+        product.update!(max_purchase_count: 1)
+      end
+      params[:line_items].each { _1[:quantity] = 2 }
+
+      order, purchase_responses, _ = Order::CreateService.new(params:, buyer:).perform
+
+      # The failed attempts are recorded, which is what persists the order...
+      expect(order).to be_persisted
+      expect(order.purchases).to be_present
+      expect(order.purchases.map(&:purchase_state).uniq).to eq(["failed"])
+      expect(purchase_responses.values).to all(include(success: false))
+
+      # ...but nothing was bought, so the buyer keeps their cart and can retry.
+      expect(cart.reload).to be_alive
+      # The order is still linked, so the failed attempt stays traceable to the cart it came from.
+      expect(cart.order).to eq(order)
+    end
+
     it "creates an order along with the associated purchases in progress when merchant account is a Brazilian Stripe Connect account" do
       seller_2.update!(check_merchant_account_is_linked: true)
       create(:merchant_account_stripe_connect, charge_processor_merchant_id: "acct_1QADdCGy0w4tFIUe", country: "BR", user: seller_2)


### PR DESCRIPTION
## What

Keeps the buyer's cart when a checkout fails outright.

## Why

A checkout in which **every single item was declined destroyed the buyer's cart anyway.** They were returned to an empty checkout page with no way to retry except re-adding every item by hand. A declined card on a multi-item cart is enough to reach this — nothing unusual is required, and nothing about it is currency- or feature-specific.

The cleanup keyed off `order.persisted?`:

```ruby
if order.persisted?
  cart.order = order
  cart.mark_deleted!
elsif all_items_handled
  cart.mark_deleted!
end
```

`order.persisted?` is not evidence that anything was bought. A failed purchase is still saved — so the attempt stays auditable — and it is then appended to the order, which persists the order. So the failure case took the first branch and deleted the cart.

The two branches disagreed with each other about this: the `elsif` already gated on `all_items_handled`, but the branch that actually ran in the failure case did not test success at all, and the reachable branch was the permissive one.

## How

The question asked is now the narrow one: **did anything survive?** The cart is kept only when the order holds purchases and every one of them has reached a terminal checkout-failure state.

"Failed" has more than one name, so the check tests membership of a named list (`CHECKOUT_FAILURE_STATES`) rather than `failed?`: an ordinary decline is `failed`, a declined preorder card authorization is `preorder_authorization_failed`, and a giftee purchase that cannot be created is `gift_receiver_purchase_failed`. Only the first is reachable from this service today — a preorder in a cart takes the combined-charge fork in `build_preorder` and stays `in_progress` for the confirm step, and a giftee purchase is never appended to the order — but the list names all three because the cost of being wrong here is destroying a buyer's cart, and reachability is a property of code elsewhere. Anything not on the list counts as surviving, so an unfamiliar state empties the cart rather than keeping one after a real purchase. `preorder_concluded_unsuccessfully` is excluded: it is reached when a preorder is released and charged, long after checkout.

`all_items_handled` deliberately is *not* reused as the gate. It requires every response to be a success, but a card that needs 3-D Secure comes back as a not-yet-successful response on a purchase that is perfectly on track — so gating on it would throw away carts while the buyer is mid-authentication. I know this because an earlier draft of this fix did exactly that and broke two pre-existing examples covering the ordinary successful checkout; that failure is what surfaced the 3-D Secure case.

The order is still linked to the cart in both outcomes, so a failed attempt stays traceable back to the cart it came from. Only the deletion is conditional.

## Test results

`spec/services/order/create_service_spec.rb` — **29 examples, 0 failures** (run locally against a real MySQL/Redis, not just CI).

One new example, `keeps the cart when every line item is attempted and fails`. It drives the **real service path**: every line item exceeds its product's remaining stock, which is the same mechanism the neighbouring `returns failure responses with correct errors` example relies on to produce persisted failed purchases. Nothing about the charge is stubbed.

**Mutation-checked**, because an example that cannot fail is worse than none: forcing `nothing_survived = false` — restoring the old `order.persisted?`-only behaviour — reddens **exactly** the new example (1 failure of 29) and nothing else.

The pre-existing `does not delete the cart when all line items fail` example covers only failures so early that no purchase row is ever written, leaving the order unpersisted. That is why it never caught this: it exercises the `elsif` branch, not the `if` branch where the bug lived.

## QA notes

No preview QA is included and I do not think it is needed here: the behaviour is entirely server-side in `Order::CreateService`, has no rendered surface of its own, and the assertion is "is the cart row still alive after a wholly-failed checkout" — which the spec reads directly. Happy to run a preview leg if a reviewer would rather see it end to end.

## Provenance

Found while investigating why the recovery in #6484 could not work: its `only: ['cart']` reload returned `cart: null` because the cart had already been destroyed by the failed attempt. That turned out to be this much wider bug, so it is fixed here on its own rather than buried in that PR. #6484 has since moved on to a different approach that no longer depends on it, which is why this is standalone.

## AI disclosure

Written by Gumclaw (claude-opus-5).

