### PR TITLE
Keep the deployment repo's test files out of the app checkout during deploys

### DIFF
--- a/.buildkite/scripts/copy_secrets.sh
+++ b/.buildkite/scripts/copy_secrets.sh
@@ -32,7 +32,7 @@ copy_secrets() {
   logger "Copying files"
   cd "$CREDENTIALS_TMP_DIR"
 
-  files_to_remove=(".git" ".gitattributes" ".gitignore" "README.md" "copy_into" "docs")
+  files_to_remove=(".git" ".gitattributes" ".gitignore" "README.md" "copy_into" "docs" "test" "qa-media")
   for file in "${files_to_remove[@]}"; do
     rm -rf "$file"
   done


### PR DESCRIPTION
## Problem

Production deploy [build 17207](https://buildkite.com/gumroad-inc/gumroad/builds/17207) hung indefinitely in the **Deploy to Production** step. The tail of the job log shows the deployer waiting at an interactive prompt:

```
Your git status is not clean
  [0] Stash all files and unstash when exiting deployer
  [1] Exit deployer now
>>
```

`copy_secrets.sh` copies every file from the deployment repo into the app checkout, minus a hardcoded blocklist. gumroad-deployment#47 added `test/` and `qa-media/` directories to the deployment repo (test artifacts for the migration-wait fix); neither is blocklisted, so they landed in the app checkout as untracked files. The deployer's git-clean pre-check then prompts for a choice on stdin, which never arrives in CI, and the job hangs until it's cancelled.

## Fix

Add `test` and `qa-media` to `files_to_remove` so the deployment repo's test artifacts are stripped before the copy, alongside the already-excluded `docs` and `copy_into`.

A follow-up in the deployment repo will make the git-clean check fail fast instead of prompting when stdin isn't a TTY, so any future non-blocklisted file fails the deploy instead of hanging it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)