### PR TITLE
Write code comments for maintainers, not newcomers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,4 +6,13 @@ Project skills live in `.agents/skills/<name>/SKILL.md`. The `.claude/skills/<na
 
 ## Code comments
 
-Write comments for a reader who is new to the codebase but familiar with the goal of the project. Avoid jargon-dense shorthand: explain *why* the code does what it does in plain language, spell out non-obvious context (invariants, gotchas, links to the decision), and don't assume the reader knows internal nicknames, prior incidents, or module history. A good test: someone on day one who knows what the product does should understand the comment without grepping elsewhere.
+Write comments for a reader who already knows this codebase. They are a colleague, not a
+student — so say the one thing the code cannot say, and stop.
+
+Keep: the non-obvious *why*, ordering constraints, and traps that will bite the next person
+to edit this. Cut: vendor or company history, anything restating the line below it, narration
+of how the bug was found, and re-explanations of a named constant the reader can click
+through to. If a comment runs past about three lines, ask what you would delete.
+
+A good test: would a maintainer who knows this file find this line worth reading? If not, it
+is noise — and noise is what teaches people to skip the comments that matter.

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -32,20 +32,11 @@ class ApplicationMailer < ActionMailer::Base
   end
 
   private
-    # Safety net for the web.de / GMX policy block described in
-    # MailerInfo::UNITED_INTERNET_RECIPIENT_DOMAINS: those providers reject
-    # everything Resend sends us from, so a buyer there pays and never receives
-    # their receipt.
-    #
-    # Individual mailer methods pass `to:` to MailerInfo.random_delivery_method_options
-    # so the right provider is chosen up front. This runs afterwards and catches
-    # any mailer that did not — there are dozens of mailer methods and a new one
-    # is easy to write without knowing this constraint exists. By the time
-    # #process has returned, the message exists and its recipients are known, so
-    # the check needs no cooperation from the mailer method at all.
-    #
-    # It must run before set_custom_headers, because the X-GUM-Email-Provider
-    # header is derived from the SMTP address the message ends up with.
+    # Safety net for MailerInfo::UNITED_INTERNET_RECIPIENT_DOMAINS. Mailers pass
+    # `to:` so the provider is picked up front; this catches the ones that don't,
+    # which is easy to miss when writing a new mailer. Runs post-build so the
+    # recipients are already known, and before set_custom_headers, which derives
+    # X-GUM-Email-Provider from the SMTP address we end up with.
     def redirect_united_internet_recipients_to_sendgrid!
       return if message.class == ActionMailer::Base::NullMail
       return unless MailerInfo.force_sendgrid_for_recipients?(message.to)

--- a/app/models/mailer_info.rb
+++ b/app/models/mailer_info.rb
@@ -63,27 +63,16 @@ module MailerInfo
     decrypt(header_value)
   end
 
-  # Recipient domains operated by United Internet's 1&1 Mail & Media, which runs
-  # web.de, GMX and mail.com — together Germany's largest consumer mail estate,
-  # and all three on one inbound platform (mail.com was migrated onto the GMX
-  # platform after United Internet acquired it in 2010, and the three brands
-  # share a postmaster/blocklist operation). United Internet policy-blocks the
-  # Amazon SES IP range that Resend sends from: every send bounces with
-  # "550 Reject due to policy restrictions" (their code r1102), so a buyer at
-  # these domains who gets routed to Resend pays and never receives their
-  # receipt or download link. The very same addresses accept our SendGrid mail
-  # without issue, so we pin them to SendGrid instead of letting the random
-  # provider split pick Resend.
+  # These domains reject Resend's sending IPs outright ("550 Reject due to policy
+  # restrictions", their code r1102), so a buyer there pays and never gets their
+  # receipt. They accept our SendGrid mail, so pin them rather than letting the
+  # random provider split pick Resend.
   #
-  # Matched exactly rather than by suffix: these are consumer mailboxes that
-  # exist only at the apex, and suffix matching would also capture unrelated
-  # third-party subdomains that happen to end in one of these names.
-  #
-  # mail.com additionally fronts a large family of vanity domains (email.com,
-  # usa.com, …) on the same platform. Those are NOT listed here because the set
-  # has not been verified against United Internet's own documentation; add them
-  # if a bounce is actually observed rather than guessing at the list.
-  # See https://github.com/antiwork/gumroad-private/issues/1462
+  # Exact match, not suffix: these are consumer mailboxes that only exist at the
+  # apex, so suffix matching would catch unrelated third-party subdomains.
+  # mail.com's vanity domains (email.com, usa.com, …) are deliberately absent —
+  # add one when a bounce is observed, not on a guess.
+  # https://github.com/antiwork/gumroad-private/issues/1462
   UNITED_INTERNET_RECIPIENT_DOMAINS = %w[
     web.de
     gmx.de gmx.net gmx.com gmx.at gmx.ch gmx.us gmx.fr gmx.es gmx.co.uk


### PR DESCRIPTION
## What

Rewrites the "Code comments" convention in `AGENTS.md` to target a reader who already knows this codebase, and trims the two worst comments the old wording produced.

## Why

The current text tells agents to write for a reader *new* to the codebase and to "spell out non-obvious context". Taken literally — which is how an agent takes it — that produces essays. The United Internet mail-routing change landed a 22-line comment on a single constant, four lines of which were a 2010 corporate acquisition. Nobody maintaining that file needs the acquisition history to change a domain list.

Comments are for a colleague, not a student. The one thing the code cannot say is worth writing; the rest is noise, and noise is what teaches people to skip the comments that matter.

## Before / After

`MailerInfo::UNITED_INTERNET_RECIPIENT_DOMAINS` — 22 comment lines became 10. Everything a maintainer needs survives (the 550 r1102 rejection, why exact-match not suffix, why the vanity domains are deliberately absent); the corporate history and the restatement of the constant's own name do not.

`ApplicationMailer#redirect_united_internet_recipients_to_sendgrid!` — 14 lines became 5, keeping both load-bearing facts: it runs post-build so recipients are known, and before `set_custom_headers` because that header derives from the SMTP address.

## Test Results

`45 examples, 0 failures` locally across `mailer_info` and `application_mailer` specs. Comments only — no behaviour change, and the diff contains no non-comment lines.

CI: **green at head `2472c1ab1`** — 78 checks success, 0 failing, `ci/green` = `success`.

CI note (corrected): an earlier revision of this body claimed `Test Slow 11` was red on an unrelated UPI Payment Element Capybara spec (`upi_element_billing_prefill_spec.rb:53`) and that the failure was pre-existing on `origin/main`. **That was wrong.** Re-running only the failed job at the identical commit, with no code change, returned `SUCCESS` — so it was a flake (a Capybara wait against the Stripe Payment Element iframe), not a pre-existing breakage. Retained here rather than deleted so the record shows the correction.

