### PR TITLE
Stop a named version from sweeping a grouping whose id collides

### DIFF
--- a/app/services/product/variants_updater_service.rb
+++ b/app/services/product/variants_updater_service.rb
@@ -155,7 +155,31 @@ class Product::VariantsUpdaterService
       # Deleted ids name versions OR groupings — the editor removes a whole
       # grouping by naming it, and removes versions by naming them. A grouping
       # is swept only when it is named directly.
-      existing_categories.select { ids.include?(_1.external_id) }
+      #
+      # An external id does not say WHICH KIND of row it names. `external_id` is
+      # `ObfuscateIds.encrypt(id)` of the primary key with nothing mixed in to
+      # identify the table (see ExternalId), and `variants` and
+      # `variant_categories` are separate tables with independent auto-increment
+      # counters. So a version and a grouping whose primary keys happen to line
+      # up have the SAME external id string — an everyday coincidence, not an
+      # exotic one, and the reason the save-contract controller test covering a
+      # second grouping was intermittently red.
+      #
+      # Matching every named id against grouping external ids therefore let a
+      # request that deletes one VERSION sweep an unrelated GROUPING whose
+      # primary key collided with that version's, taking every version in it and
+      # leaving the version the seller actually named alive. When an id names a
+      # version of this product, read it as a version: that is what the editor
+      # meant, and it is the interpretation that cannot destroy data the seller
+      # never mentioned.
+      version_ids = BaseVariant.where(variant_category_id: existing_categories.map(&:id))
+                               .where(id: ids.filter_map { BaseVariant.from_external_id(_1) })
+                               .pluck(:id)
+                               .to_set
+
+      existing_categories.select do |category|
+        ids.include?(category.external_id) && !version_ids.include?(category.id)
+      end
     end
 
     # A grouping whose versions have purchases is never swept by omission. This

--- a/test/controllers/links_controller_test.rb
+++ b/test/controllers/links_controller_test.rb
@@ -6893,6 +6893,47 @@ class LinksControllerSaveContractTest < ActionController::TestCase
     assert kept.reload.alive?
   end
 
+  # Regression test for the intermittent red that this file's sibling test above
+  # hit on main (run 30431791476): a version and a grouping can share an external
+  # id, because ExternalId#external_id is ObfuscateIds.encrypt(id) of the primary
+  # key with no table discriminator, and `variants` / `variant_categories` are
+  # separate tables with independent auto-increment counters. Whether the two
+  # counters happened to line up decided whether the save was correct, so the
+  # sibling test passed or failed depending on how many rows earlier tests in the
+  # shard had created. Forcing the collision makes the bug deterministic.
+  test "flag on: a named version is not read as a grouping when their ids collide" do
+    enable_contract!
+    kept = create_variant(variant_category: @category, name: "Kept")
+    other_category = create_variant_category(link: @product, title: "Formats")
+    removed = create_variant(variant_category: other_category, name: "Removed elsewhere")
+    sibling = create_variant(variant_category: other_category, name: "Sibling elsewhere")
+
+    # Give the version the seller names for deletion the same primary key as the
+    # grouping that must survive, so the two carry the same external id.
+    collided_id = VariantCategory.maximum(:id).to_i + BaseVariant.maximum(:id).to_i + 1
+    other_category.update_columns(id: collided_id)
+    removed.update_columns(id: collided_id, variant_category_id: collided_id)
+    sibling.update_columns(variant_category_id: collided_id)
+    other_category = VariantCategory.find(collided_id)
+    removed = Variant.find(collided_id)
+    assert_equal removed.external_id, other_category.external_id,
+                 "this test is only meaningful while the two ids collide"
+
+    post :update, params: @params.merge(
+      variants: [{ id: kept.external_id, name: "Kept" }],
+      editor_revision: current_revision,
+      deletion_operations: { deleted_ids: { variants: [removed.external_id] } },
+    ), format: :json
+    assert_response :success
+
+    # The id named a version, so a version is what gets deleted.
+    assert_not removed.reload.alive?
+    # ...and the grouping that merely shares its id keeps everything in it.
+    assert other_category.reload.alive?
+    assert sibling.reload.alive?
+    assert kept.reload.alive?
+  end
+
   test "flag on: a second grouping is left alone when the save names no deletions" do
     enable_contract!
     kept = create_variant(variant_category: @category, name: "Kept")


### PR DESCRIPTION
## What

`Product::VariantsUpdaterService#contract_scoped_category_deletions` matched every id in the save contract's `deleted_ids(:variants)` against the external ids of the product's version groupings, on the reasoning that a deleted id names either a version or a grouping. An id that names a version of this product is now read as a version, so only an id that really names a grouping can sweep one.

## Why

An external id does not say which kind of row it names. `ExternalId#external_id` is `ObfuscateIds.encrypt(id)` of the primary key with nothing mixed in to identify the table, and `variants` and `variant_categories` are separate tables with independent auto-increment counters. A version and a grouping whose primary keys happen to line up therefore carry the same external id string — an everyday coincidence, not an exotic one.

So a save that named one version for deletion could soft-delete an entire unrelated grouping instead: every version in it goes away, and the version the seller actually named stays alive. The save still returns 200.

This is what made `flag on: a named variant in a grouping the editor does not address is still deleted` intermittently red. It failed on **main** in [run 30431791476](https://github.com/antiwork/gumroad/actions/runs/30431791476) as `Expected false to be truthy` on `assert other_category.reload.alive?`. Whether the two auto-increment counters collided depended on how many rows the earlier tests in that Minitest shard had created, which is why the same seed passed or failed depending on the shard's composition — and why this reproduced on `f5cbc20926` but not on its parent, even though that commit only touched two unrelated Minitest builders.

The behaviour is only reachable with `product_editor_save_contract` enabled.

## Before / After

Not applicable — no user-facing surface changes. The difference is which rows a save deletes: before, a colliding grouping and all its versions; after, only the version the request named.

## Test Results

New test `flag on: a named version is not read as a grouping when their ids collide` forces the collision rather than waiting for the counters to line up, so the behaviour is pinned deterministically instead of by luck of shard composition.

`bin/rails test test/controllers/links_controller_test.rb --seed 48611` (the exact seed CI failed on) — **471 runs, 1742 assertions, 0 failures, 0 errors**.

Mutation-verified: reverting only the service change turns the new test red with the same message CI reported.

```
Failure:
Expected false to be truthy.
1 runs, 4 assertions, 1 failures
```

`rubocop` clean on both files.

## QA steps

No UI to click through. To verify locally:

1. `bin/rails test test/controllers/links_controller_test.rb -n "/ids_collide/"` — passes.
2. Revert the `contract_scoped_category_deletions` change and re-run — fails with `Expected false to be truthy`.

---

## AI disclosure

Written by claude-opus-5 running as the Hermes agent, dispatched by the red-main watcher after run 30431791476 failed. Working steps: re-verified main was still red, pulled the failing Minitest shard's log and read the real assertion, ruled out the suspect merge (`f5cbc20926`, a test-builder-only change) by running the failing test against it and its parent, bisected the non-determinism to an `external_id` collision between `Variant` and `VariantCategory`, reproduced it deterministically through the real controller by forcing the primary keys to line up, wrote the fix and the regression test, mutation-verified the assertion, and confirmed the full file green on CI's seed.
