### PR TITLE
Document where the presentment FX spread lands

### DIFF
--- a/app/business/payments/charging/implementations/stripe/stripe_fx_quote.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_fx_quote.rb
@@ -89,6 +89,10 @@ class StripeFxQuote
     end
 
     def parsed_rate(rates, from_currency:)
+      # Stripe returns both the customer-facing `exchange_rate` (its FX fee and lock premium
+      # already priced in) and the interbank `rate_details.base_rate`. We keep only
+      # `exchange_rate`, because that is the rate the buyer is quoted and charged at — see the
+      # note on Balance's holding_currency for where the difference between the two lands.
       rate_data = rates.fetch(from_currency.to_sym) { rates.fetch(from_currency) }
       rate = rate_data.is_a?(Hash) ? rate_data.fetch(:exchange_rate) { rate_data.fetch("exchange_rate") } : rate_data
       BigDecimal(rate.to_s)

--- a/app/models/balance.rb
+++ b/app/models/balance.rb
@@ -41,6 +41,11 @@ class Balance < ApplicationRecord
   #
   # Note that balances are keyed on holding_currency (see find_or_create_balance), so a seller
   # would get parallel same-day balances if this ever varied within a day for one account.
+  #
+  # On a buyer-presentment charge the buyer's currency is converted at the rate they were quoted,
+  # which has Stripe's FX fee priced in rather than being the interbank rate. The buyer pays that
+  # spread inside the price they confirmed; this ledger stays exact on both sides, so quoting
+  # nearer interbank would be a pricing decision, not a correctness fix (gumroad-private#1318).
   validates :merchant_account, :currency, :holding_currency, presence: true
   validate :validate_amounts_are_only_changed_when_unpaid, on: :update
 


### PR DESCRIPTION
## What

Records, next to the ledger it affects, that buyer-presentment charges convert at the rate the buyer was quoted rather than at the interbank rate Stripe also returns. Two comments, no behaviour change:

- `Balance`'s `holding_currency` note (the canonical-USD-liability block) gains a paragraph on where the FX spread lands on a presentment charge.
- `StripeFxQuote#parsed_rate` says why only `exchange_rate` is kept and `rate_details.base_rate` is discarded, and points at the `Balance` note.

The diff is comments only — every added line begins with `#`.

## Why

Stripe's FX quote payload carries two rates: the customer-facing `exchange_rate`, which has Stripe's FX fee and lock premium priced in, and the interbank `rate_details.base_rate`. `parsed_rate` keeps `exchange_rate` and drops the rest, so `base_rate` and `rate_details` appear nowhere in `app/` or `lib/`. That single rate then drives the whole presentment charge, including the Connect fee and transfer split.

That is correct — the buyer pays the spread inside the price they saw and confirmed, which is the same arrangement as Stripe's own Adaptive Pricing — but nothing said so anywhere near the ledger. Measured over every quote-backed presentment charge in the week from 23 July, Gumroad's fee lands within 0.013% of the canonical USD amount once the price-ending rounding Gumroad deliberately absorbs is excluded, and seller proceeds matched canonical USD on 54 of 54 balance transactions checked. Neither side of the ledger absorbs the spread.

The gap this closes is a documentation one, and it has already cost a full investigation: reading the code alone makes the discarded `base_rate` look like a money-correctness defect, and it was escalated as one before being measured. The note stops the next reader repeating that.

Tracking issue: gumroad-private#1318 (recommendation 2 of the scope posted there).

## Before / After

Not applicable — comment-only diff, no rendered surface and no behaviour change.

## QA steps

Nothing to click. Read the two comments in the diff and check them against the code they sit next to:

1. `app/business/payments/charging/implementations/stripe/stripe_fx_quote.rb` — `Quote` is `Struct.new(:id, :expires_at, :fx_rate)` and `parsed_rate` fetches `rates[from].exchange_rate`, so the interbank rate is unreachable downstream. `grep -rn "base_rate\|rate_details" app lib` returns nothing but these comments.
2. `app/models/balance.rb` — the new paragraph sits inside the existing `currency` / `holding_currency` block added by #6505, immediately above the presence validation.

## Test Results

```
$ bundle exec rubocop app/models/balance.rb \
    app/business/payments/charging/implementations/stripe/stripe_fx_quote.rb
Inspecting 2 files
..
2 files inspected, no offenses detected
```

Branch CI runs the full suite; a comment-only diff cannot change its result.

---

## AI disclosure

Written by claude-opus-5 running as the Gumclaw agent.

Instructions given: Sahil agreed on gumroad-private#1318 with recommendations 1 and 2 of the scope posted there — accept the presentment FX spread as designed, and write the accounting note that documents it. This PR is recommendation 2. The wording of both comments, and the decision to place the note beside the canonical-USD-liability block rather than in a separate document, were the agent's.
