### PR TITLE
Record that the buyer bears Stripe's FX spread on presentment charges

### DIFF
--- a/app/models/balance.rb
+++ b/app/models/balance.rb
@@ -41,6 +41,10 @@ class Balance < ApplicationRecord
   #
   # Note that balances are keyed on holding_currency (see find_or_create_balance), so a seller
   # would get parallel same-day balances if this ever varied within a day for one account.
+  #
+  # Buyer-currency charges do not change any of the above: they settle to the canonical USD
+  # liability, and Stripe's FX spread is borne by the buyer inside the quoted price rather than
+  # by either side of this ledger (see ChargePresentment#fx_rate).
   validates :merchant_account, :currency, :holding_currency, presence: true
   validate :validate_amounts_are_only_changed_when_unpaid, on: :update
 

--- a/app/models/charge_presentment.rb
+++ b/app/models/charge_presentment.rb
@@ -5,13 +5,10 @@ class ChargePresentment < ApplicationRecord
   has_many :purchase_presentments, dependent: :destroy
 
   validates :processor, :presentment_currency, presence: true
-  # fx_rate is the rate the buyer was quoted, including Stripe's FX fee and lock premium.
-  # Stripe's fee-free base_rate is discarded in StripeFxQuote, so the spread is not
-  # reconstructible from these rows — by design: the buyer pays it inside the price they
-  # confirmed, and both legs of our ledger settle canonical (measured on gumroad-private#1318).
-  # A settled-vs-canonical gap here is rounding_delta_cents, not FX drift. Persisting base_rate
-  # to make the spread reportable was declined on that issue (antiwork/gumroad#6542).
-  #
+  # fx_rate is the rate the buyer was quoted — Stripe's spread already priced in; the fee-free
+  # base_rate is deliberately not persisted, so the spread is not reconstructible from these
+  # rows (see StripeFxQuote#parsed_rate and the note on Balance#holding_currency).
+
   # Stripe rows come in two shapes. Card-path buyer presentment locks a Stripe FX quote,
   # so those rows carry all three quote columns. Method-forced local payment methods
   # (iDEAL/Bancontact) charging a product already priced in the forced currency have no

--- a/app/models/charge_presentment.rb
+++ b/app/models/charge_presentment.rb
@@ -5,6 +5,7 @@ class ChargePresentment < ApplicationRecord
   has_many :purchase_presentments, dependent: :destroy
 
   validates :processor, :presentment_currency, presence: true
+
   # fx_rate is the rate the buyer was quoted — Stripe's spread already priced in; the fee-free
   # base_rate is deliberately not persisted, so the spread is not reconstructible from these
   # rows (see StripeFxQuote#parsed_rate and the note on Balance#holding_currency).

--- a/app/models/charge_presentment.rb
+++ b/app/models/charge_presentment.rb
@@ -5,6 +5,13 @@ class ChargePresentment < ApplicationRecord
   has_many :purchase_presentments, dependent: :destroy
 
   validates :processor, :presentment_currency, presence: true
+  # fx_rate is the rate the buyer was quoted, including Stripe's FX fee and lock premium.
+  # Stripe's fee-free base_rate is discarded in StripeFxQuote, so the spread is not
+  # reconstructible from these rows — by design: the buyer pays it inside the price they
+  # confirmed, and both legs of our ledger settle canonical (measured on gumroad-private#1318).
+  # A settled-vs-canonical gap here is rounding_delta_cents, not FX drift. Persisting base_rate
+  # to make the spread reportable was declined on that issue (antiwork/gumroad#6542).
+  #
   # Stripe rows come in two shapes. Card-path buyer presentment locks a Stripe FX quote,
   # so those rows carry all three quote columns. Method-forced local payment methods
   # (iDEAL/Bancontact) charging a product already priced in the forced currency have no


### PR DESCRIPTION
## What

Records, at the column that invites the wrong conclusion, that a buyer-currency charge converts at Stripe's **customer** rate — so the FX spread sits in the price the buyer confirmed rather than being absorbed by us.

Comments only, one file, three prose lines plus one blank separator. No code lines in the diff:

```
$ git diff origin/main -U0 | grep '^+' | grep -v '^+++' | grep -vE '^\+\s*(#|$)' | wc -l
0
```

The blank line is deliberate — without it the block visually merges with the pre-existing two-shapes comment below and mis-attributes itself to `stripe_fx_quote_fields_all_or_none` (P2 in the review below). Excluding `#`-only lines but *not* blanks reports `1`, which is that separator.

**Scope narrowed twice.** This branch originally also annotated `Balance`; a sibling session shipped that half as [#6548](https://github.com/antiwork/gumroad/pull/6548) while this was in CI, so I merged `main` and kept their wording. The adversarial review below then cut this half further: #6548 landed notes at both `StripeFxQuote#parsed_rate` and `Balance#holding_currency`, which between them already state everything except the one fact specific to this table — that the spread is not reconstructible **from these rows**. What remains is that fact plus pointers into #6548's cross-reference trail, so this is not an orphaned third copy of a comment that shipped this morning.

## Why

`StripeFxQuote::Quote` is `Struct.new(:id, :expires_at, :fx_rate)` and `parsed_rate` keeps only `rates.<from>.exchange_rate`. Stripe's fee-free `rate_details.base_rate` is discarded at parse time and appears nowhere in `app/` or `lib/`. Reading the schema alone, that looks like we convert at a marked-up rate and silently absorb the difference — which is what I concluded on gumroad-private#1318, where I filed it as a money-correctness bug and opened #6542 to "fix" it.

Measured against production it is not a defect. Re-verified independently for this change rather than carried over from the issue, over the 400 most recent quote-backed presentment rows (2026-07-27 23:05 → 2026-07-29 10:02), reversing the conversion `Charge::PresentmentOrchestrator` performs and comparing against each charge's canonical `total_transaction_amount_for_gumroad_cents`:

| | value |
|---|---|
| canonical Gumroad share | 239,220¢ |
| implied by the presented amount at the locked rate | 239,222¢ |
| delta | **+2¢ (+0.001%)** |
| delta, rows with `rounding_delta_cents = 0` (n=31) | **−1¢ (−0.018%)** |
| Gumroad-held balance transactions on those charges | **392** |
| of those, `holding_amount_net_cents != issued_amount_net_cents` | **0** (all USD) |

Per-currency deltas across all 16 currencies present are within ±0.04%. The Gumroad share round-trips essentially exactly and sellers receive the canonical USD amount every time, so any residual settled-vs-canonical gap is `rounding_delta_cents` — Gumroad deliberately absorbing price-ending rounding on the buyer's total, already documented in `PresentmentOrchestrator` — not FX.

The spread is real, but the buyer pays it inside the price they saw and confirmed, as they do under Stripe Adaptive Pricing. That makes it a pricing-and-disclosure question rather than a correctness bug, and nothing at the call site said so.

`Ref antiwork/gumroad-private#1318` — deliberately not a closing keyword, so merging does not force the issue shut while it still tracks its own follow-ups.

## Why not persist `base_rate`

That was #6542, now closed unmerged. It would have changed how `application_fee_amount` and `transfer_data[:amount]` are denominated on every buyer-currency purchase — moving a settlement that measures exact on live traffic — to buy reporting only. @slavingia's ruling on #1318 was to accept the behaviour as designed and write this note instead. If the spread is ever wanted for reporting, the shape is two read-only columns beside `fx_rate`, changing nothing about what we charge or transfer.

## Before / after

Not applicable — comments only. No rendered surface and no runtime behaviour.

## Adversarial review (fable-5)

Run locally against `633e462c8` before merge. Verdict **CHANGES-REQUIRED**, all findings dispositioned in `33bddab7a`:

| # | Finding | Disposition |
|---|---|---|
| **P1** | "A settled-vs-canonical gap here is `rounding_delta_cents`, not FX drift" is false. `rounding_delta_cents` is the designed *quote-time* price-ending adjustment, recorded before any money moves — not a settlement gap. `Checkout::PresentmentRounding` says it is recorded "so it can be monitored **alongside** foreign-exchange drift", i.e. FX drift is a separate monitored quantity this comment does not get to rule out. Other real gap sources it would tell someone to stop looking for: round-trip cent rounding, quote expiry between confirm and charge, refund/dispute-time conversion at a different rate. | **Fixed** — sentence deleted. Verified independently against `presentment_rounding.rb:24-26` before accepting. |
| **P2** | Three of the six prose lines restate, near-verbatim, the comment pair #6548 merged this same morning — an orphaned third copy outside their deliberate cross-reference trail. "Both legs of our ledger settle canonical" also overstates `Balance`'s careful "stays exact on both sides". | **Fixed** — cut to the one table-specific fact, now pointing at both existing notes. |
| **P2** | The bare `#` was not read as a separator, so the block visually merged with the pre-existing two-shapes comment and mis-attributed itself to `stripe_fx_quote_fields_all_or_none`, which it does not describe. | **Fixed** — blank line; the two-shapes block is cleanly attached to its validation again. |
| **P2** | Citing closed-unmerged #6542 as "was declined" is decision archaeology, on `AGENTS.md`'s cut list; `git blame` preserves the trail. | **Fixed** — dropped; "deliberately not persisted" keeps the durable fact. |
| **P3** | Second citation of gumroad-private#1318 for a claim already cited at `balance.rb:48`. | **Fixed** by the rewrite. |
| **P3** | `AGENTS.md` ("a reader who already knows this codebase") and `CLAUDE.md` ("a reader who is new to the codebase") state contradictory comment-audience policies. | **Not this PR** — pre-existing repo-level inconsistency, noted for a follow-up. |

Confirmed sound: `base_rate` genuinely absent from `app/` and `lib/`; `fx_rate` genuinely the customer-facing `exchange_rate` with fee and lock premium priced in; the orchestrator charges exactly the locked total and never re-quotes; no behaviour change.

Net effect of the review: seven comment lines became three, and the one sentence a future engineer would most likely have acted on was wrong.

## Test Results

A comment cannot change behaviour, but this file is money-path logic, so the full suite ran on the branch (`tests.yml` triggers on `push` for any branch):

- Run [30442257517](https://github.com/antiwork/gumroad/actions/runs/30442257517) at `633e462c8` — **73 of 75 jobs green, 1 skipped, 0 failing** after one rerun. Re-verified at that head via the check-runs API this morning: 0 failing, 0 pending.
- The first attempt had one unrelated failure: `spec/requests/purchases/product/upi_element_billing_prefill_spec.rb:53`, a Capybara timeout looking for checkout's "Card number" field. `main` was green in the same window (`a7ad25e47`), sibling PRs #6546/#6543/#6538 were all green, and a comments-only diff cannot reach a checkout render path. `gh run rerun --failed` came back clean.
- `ruby -c` and `bundle exec rubocop app/models/charge_presentment.rb` → Syntax OK, no offenses, after the review fix.
- CI has since finished on the current head `33bddab7a` and is green: **76 green, 9 skipped, 0 failing, 0 pending** across the full matrix, with both required statuses (`ci/green`, `buildkite/gumroad`) success. Read from the check-runs API rather than the PR rollup, which bundles the `pull_request_target` noop. Nothing is outstanding on CI.
- Greptile reviewed that same head and returned **5/5, "safe to merge"**, with no blocking finding and no inline comments. Its own run hit `bundler: command not found: rspec` in its sandbox, which is a setup blocker on their side and not a result about this branch.

Locally `spec/models/charge_presentment_spec.rb` hits the known `charge_processor_merchant_id` "already connected with another Gumroad account" factory collision, which reproduces on unmodified `main` on this machine — a shared-test-DB artifact, not something this diff can influence.

## QA steps

Nothing to click. To confirm the claim rather than trust it, on a read-only console:

1. `ChargePresentment.where.not(fx_rate: nil).order(id: :desc).limit(400)` — for each row, reverse the orchestrator's conversion: `(presentment_gumroad_amount_cents - rounding_delta_cents) / subunit_to_unit(presentment_currency) * fx_rate * 100`.
2. Compare against `charge.purchases.sum(&:total_transaction_amount_for_gumroad_cents)`. Expect agreement to ~0.001% in aggregate.
3. `BalanceTransaction` rows for those purchases on Gumroad-held balances: expect `holding_amount_net_cents == issued_amount_net_cents`, both USD, on every row.

Derive the minor unit from `CurrencyHelper#subunit_to_unit` rather than assuming two decimals, or the JPY rows will look wrong.

---

🤖 Written with claude-opus-5 (Hermes Agent).

Instructions given: advance the multi-currency work in `antiwork/gumroad-private` so that whenever a human opens any of it, it is already as far along as it can be without them — for each linked PR, fix failing CI, resolve conflicts, capture missing QA evidence, and run an adversarial (fable-5) review recording every P1/P2 disposition. Auto-merge deliberately not armed: this is checkout/money-path code and the merge call is @rmarescu's.

Earlier, on the same branch: Sahil's reply on gumroad-private#1318 (`1 and 2 - agree`) selected "accept as designed, no code change" plus "write the accounting note", which is this PR; item 3 (persist `base_rate` for reporting) was explicitly not agreed, so #6542 was closed unmerged in the same pass.



