### PR TITLE
Fix 404 on the license-key lookup button from seller domains

### DIFF
--- a/app/javascript/components/Product/index.tsx
+++ b/app/javascript/components/Product/index.tsx
@@ -43,6 +43,7 @@ import {
   CartItemTitle,
 } from "$app/components/CartItemList";
 import { CopyToClipboard } from "$app/components/CopyToClipboard";
+import { useDomains } from "$app/components/DomainSettings";
 import { useLoggedInUser } from "$app/components/LoggedInUser";
 import { Modal } from "$app/components/Modal";
 import { PaginationProps } from "$app/components/Pagination";
@@ -862,18 +863,27 @@ const LicenseKeyRow = ({ licenseKey }: { licenseKey: string }) => (
 // For a licensed product where we could not identify the visitor as a past buyer, point
 // them at the existing self-serve lookup page instead of leaving them to contact the
 // seller. The page emails their receipt (including the license key) to the purchase email.
-const LicenseKeyLookupPrompt = () => (
-  <section className="border-t border-border p-6">
-    <Card>
-      <CardContent asChild>
-        <li>
-          <h3 className="grow">Already bought this?</h3>
-          <NavigationButton href={Routes.license_key_lookup_path()}>View your information</NavigationButton>
-        </li>
-      </CardContent>
-    </Card>
-  </section>
-);
+const LicenseKeyLookupPrompt = () => {
+  // Absolute root-domain URL, not a path: this section renders on the seller's subdomain
+  // and custom domain too, and /license-key-lookup is only drawn under
+  // GumroadDomainConstraint, so a relative href 404s there.
+  const { scheme, rootDomain } = useDomains();
+
+  return (
+    <section className="border-t border-border p-6">
+      <Card>
+        <CardContent asChild>
+          <li>
+            <h3 className="grow">Already bought this?</h3>
+            <NavigationButton href={Routes.license_key_lookup_url({ protocol: scheme, host: rootDomain })}>
+              View your information
+            </NavigationButton>
+          </li>
+        </CardContent>
+      </Card>
+    </section>
+  );
+};
 
 export const RatingsHistogramRow = ({ rating, percentage }: { rating: number; percentage: number }) => {
   const formattedPercentage = `${percentage}%`;

--- a/spec/requests/products/show/license_key_spec.rb
+++ b/spec/requests/products/show/license_key_spec.rb
@@ -24,11 +24,13 @@ describe "License key on the product page", :js, type: :system do
   end
 
   context "when the visitor is not a recognized buyer" do
-    it "links the license key lookup page" do
+    # Asserted as an absolute root-domain URL on purpose: the product page also renders on the
+    # seller's subdomain, where /license-key-lookup is not routed (GumroadDomainConstraint).
+    it "links the license key lookup page on the root domain" do
       visit short_link_path(product)
 
       expect(page).to have_text("Already bought this?")
-      expect(page).to have_link("View your information", href: license_key_lookup_path)
+      expect(page).to have_link("View your information", href: license_key_lookup_url(protocol: PROTOCOL, host: ROOT_DOMAIN))
     end
   end
 


### PR DESCRIPTION
## What

The "Already bought this? → View your information" button on a licensed product page linked to a relative `/license-key-lookup` path. That route is only drawn inside `GumroadDomainConstraint` (`config/routes.rb`), so it does not exist on a seller subdomain or custom domain. Since product pages are normally served from the seller's own host, the button 404'd for essentially every buyer who saw it.

Reported by a seller via support (`minnix.gumroad.com`), who diagnosed it correctly themselves: the button should point at the global lookup page on the root domain.

## Why

This button is the only self-serve path we offer a buyer we cannot identify as a past purchaser. Landing them on a 404 sends them to the seller's inbox instead, which is exactly what the button was added to avoid.

## Before / After

Verified live against the reporter's storefront:

| URL | Status |
|---|---|
| `https://minnix.gumroad.com/license-key-lookup` (what the button linked to) | **404** |
| `https://gumroad.com/license-key-lookup` (where the page lives) | **200** |

After: the button href is an absolute root-domain URL built from `useDomains()`, so it resolves to `https://gumroad.com/license-key-lookup` no matter which host the product page is served from. Same pattern already used by `PoweredByFooter` and `EmailAction/Layout` for root-domain links out of subdomain-rendered pages.

## Tests

`spec/requests/products/show/license_key_spec.rb` already asserted this link; the assertion is tightened from `license_key_lookup_path` to `license_key_lookup_url(protocol: PROTOCOL, host: ROOT_DOMAIN)`, which is the regression guard — a relative path can no longer satisfy it.

`npx tsc --noEmit` clean.
