### PR TITLE
Sync CLAUDE.md with the AGENTS.md comment convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,4 +6,13 @@ Project skills live in `.agents/skills/<name>/SKILL.md`. The `.claude/skills/<na
 
 ## Code comments
 
-Write comments for a reader who is new to the codebase but familiar with the goal of the project. Avoid jargon-dense shorthand: explain *why* the code does what it does in plain language, spell out non-obvious context (invariants, gotchas, links to the decision), and don't assume the reader knows internal nicknames, prior incidents, or module history. A good test: someone on day one who knows what the product does should understand the comment without grepping elsewhere.
+Write comments for a reader who already knows this codebase. They are a colleague, not a
+student — so say the one thing the code cannot say, and stop.
+
+Keep: the non-obvious *why*, ordering constraints, and traps that will bite the next person
+to edit this. Cut: vendor or company history, anything restating the line below it, narration
+of how the bug was found, and re-explanations of a named constant the reader can click
+through to. If a comment runs past about three lines, ask what you would delete.
+
+A good test: would a maintainer who knows this file find this line worth reading? If not, it
+is noise — and noise is what teaches people to skip the comments that matter.


### PR DESCRIPTION
## What

Copies the `## Code comments` section from `AGENTS.md` into `CLAUDE.md`. The two files are byte identical again.

## Why

#6544 rewrote the comment convention in `AGENTS.md` but not `CLAUDE.md`, so the two files gave opposite instructions: `AGENTS.md` says write for a maintainer who already knows the codebase, `CLAUDE.md` still said write for someone on day one. Whichever file an agent happened to read decided which convention it followed.

## Before / After

Before, `diff AGENTS.md CLAUDE.md` reported the whole comment section as divergent. After, the files are identical.

## Test Results

Docs only, no code paths touched.

```
$ diff AGENTS.md CLAUDE.md && echo IDENTICAL
IDENTICAL
```

## QA steps

Not applicable — no user-facing surface. `git show --stat` shows a single markdown file.

---

## AI disclosure

Written by claude-opus-5 (Anthropic) via Hermes Agent. Instructions given: a review on #6556 noted that #6544 changed the comment convention in `AGENTS.md` but not `CLAUDE.md`, leaving the two files contradictory; bring `CLAUDE.md` in line.
