### PR TITLE
Retry Stripe rate limits inside cassettes that ignore the Stripe host

### DIFF
--- a/spec/lib/stripe_rate_limit_retries_spec.rb
+++ b/spec/lib/stripe_rate_limit_retries_spec.rb
@@ -88,6 +88,22 @@ describe "Stripe rate-limit retries in the test environment" do
       end
     end
 
+    it "retries inside a cassette that ignores the Stripe host, where Stripe is live" do
+      # The shipping and taxjar specs record TaxJar only and let every other host
+      # through, so a cassette is open while Stripe is being called for real.
+      # Treating that as a replay is what left ten Test Slow shards red on
+      # 2026-07-29 with 46 unretried 429s.
+      error = stripe_error(Stripe::RateLimitError, "Request rate limit exceeded", status: 429)
+
+      vcr_turned_on do
+        only_matching_vcr_request_from(["taxjar"]) do
+          VCR.use_cassette("stripe_rate_limit_retries_guard", record: :none, allow_unused_http_interactions: true) do
+            expect(should_retry?(error, num_retries: 0)).to be true
+          end
+        end
+      end
+    end
+
     it "does not retry unrelated Stripe errors" do
       card_error = Stripe::CardError.new("Your card was declined", "number", http_status: 402)
       bad_request = stripe_error(Stripe::InvalidRequestError, "No such customer", status: 400)

--- a/spec/lib/stripe_rate_limit_retries_spec.rb
+++ b/spec/lib/stripe_rate_limit_retries_spec.rb
@@ -91,8 +91,6 @@ describe "Stripe rate-limit retries in the test environment" do
     it "retries inside a cassette that ignores the Stripe host, where Stripe is live" do
       # The shipping and taxjar specs record TaxJar only and let every other host
       # through, so a cassette is open while Stripe is being called for real.
-      # Treating that as a replay is what left ten Test Slow shards red on
-      # 2026-07-29 with 46 unretried 429s.
       error = stripe_error(Stripe::RateLimitError, "Request rate limit exceeded", status: 429)
 
       vcr_turned_on do

--- a/spec/support/stripe_rate_limit_retries.rb
+++ b/spec/support/stripe_rate_limit_retries.rb
@@ -131,9 +131,8 @@ module StripeTestRateLimitRetries
     # An OPEN cassette does not mean Stripe is coming from it. The shipping and
     # taxjar specs wrap themselves in only_matching_vcr_request_from(["taxjar"])
     # (see spec_helper), which tells VCR to ignore every host but TaxJar — so
-    # Stripe inside those cassettes is live and rate-limitable, and refusing to
-    # retry there is what reddens those shards. Ask VCR whether it would
-    # intercept a Stripe request, not whether a cassette happens to be open.
+    # Stripe inside those cassettes is live and rate-limitable. Ask VCR whether
+    # it would intercept a Stripe request, not whether a cassette is open.
     def stripe_served_from_a_cassette?
       return false unless defined?(VCR) && VCR.current_cassette.present?
 

--- a/spec/support/stripe_rate_limit_retries.rb
+++ b/spec/support/stripe_rate_limit_retries.rb
@@ -38,8 +38,10 @@
 #
 # What this does NOT cover: :js specs drive Stripe Elements in the browser, so
 # card tokenization goes Chrome → Stripe directly and the Ruby gem never sees it.
-# A rate limit on that path is out of reach here. Both observed failure shapes
-# were server-side, so this addresses what actually broke.
+# A rate limit on that path is out of reach here. The server-side half of a :js
+# spec — the charge the Rails app makes when the form is submitted — IS covered,
+# including inside a cassette that ignores the Stripe host; see
+# stripe_served_from_a_cassette? below for why that case needs asking about.
 module StripeTestRateLimitRetries
   # Stripe does not always set an HTTP status or a machine-readable code on
   # these: account-creation throttling arrives as a Stripe::InvalidRequestError
@@ -77,7 +79,7 @@ module StripeTestRateLimitRetries
   BACKING_OFF_FOR_RATE_LIMIT = :stripe_test_backing_off_for_rate_limit
 
   def should_retry?(error, num_retries:, config: Stripe.config)
-    if rate_limited?(error) && !replaying_a_cassette?
+    if rate_limited?(error) && !stripe_served_from_a_cassette?
       if num_retries < MAX_RETRIES
         # The gem retries silently. Without a line here, a CI shard spending a
         # minute waiting out the shared Stripe test account looks like a slow
@@ -124,13 +126,21 @@ module StripeTestRateLimitRetries
     # Under VCR there is no live Stripe to back off from: the 429 came out of a
     # recorded cassette, and a dozen cassettes in spec/support/fixtures do
     # contain one. Retrying would sleep for nothing and then ask VCR for an
-    # interaction it has already played, which raises instead of replaying. The
-    # helper this file replaces had the same guard, for the same reason.
-    def replaying_a_cassette?
-      defined?(VCR) && VCR.current_cassette.present?
+    # interaction it has already played, which raises instead of replaying.
+    #
+    # An OPEN cassette does not mean Stripe is coming from it. The shipping and
+    # taxjar specs wrap themselves in only_matching_vcr_request_from(["taxjar"])
+    # (see spec_helper), which tells VCR to ignore every host but TaxJar — so
+    # Stripe inside those cassettes is live and rate-limitable, and refusing to
+    # retry there is what reddens those shards. Ask VCR whether it would
+    # intercept a Stripe request, not whether a cassette happens to be open.
+    def stripe_served_from_a_cassette?
+      return false unless defined?(VCR) && VCR.current_cassette.present?
+
+      !VCR.request_ignorer.ignore?(VCR::Request.new(:post, "#{Stripe.api_base}/v1/", nil, {}))
     rescue StandardError
-      # If VCR itself cannot answer, assume a cassette is in play: declining to
-      # retry only restores the Stripe gem's own default behaviour.
+      # If VCR itself cannot answer, assume a cassette is serving Stripe:
+      # declining to retry only restores the gem's own default behaviour.
       true
     end
 end


### PR DESCRIPTION
## What

`spec/support/stripe_rate_limit_retries.rb` declined to retry any Stripe 429 while a VCR cassette was open. It now asks VCR whether it would actually intercept a request to Stripe, rather than whether a cassette happens to be open.

Nine lines of spec support. No production code.

## Why

CI is red across the fleet and it is not the 3DS problem tracked in #6562 (fixed and merged as #6565). Measured across every `push` run in the repo since 18:20Z today — **10 branches, 53 failed `Test Slow` shards, 44 of them carrying Stripe rate-limit lines, 856 lines in total**:

| Branch | shards with 429s / failed shards |
|---|---|
| `feat/profile-font-and-colors` | 9/9 |
| `fix/editor-handles-stale-deletion-conflict` | 8/8 |
| `fix/heal-mid-migration-company-ownership` | 6/7 |
| `chore/trim-clear-mistaken-buyer-blocks-comments` | 5/6 |
| `fix/route-cc-recipients-at-blocked-domains` | 5/7 |
| `fix/product-file-parent-validation` | 4/5 |
| `fix/dispute-evidence-backstop-sweep` | 4/4 |
| `fix/blocked-external-account-is-terminal` | 2/3 |
| `fix/related-products-per-purchase-fanout-cap` | 1/1 |
| `fix/price-touch-profile-cache` | 0/3 |

The `chore/` branch there changes comments only and went red on 5 of 6 shards, which is what makes this a helper bug rather than anyone's regression.

The failure presents as a checkout assertion, not as a rate limit:

```
expected to find alert with text "Your purchase was successful! We sent a receipt to test@gumroad.com"
  but there were no matches. Also found "", "There is a temporary problem, please try again
  (your card was not charged)."
```

The Capybara screenshot shows only that banner. The app log beside it has the cause:

```
Charge processor error: (Status 429) Request rate limit exceeded.
Error charging order (9):: ChargeProcessorErrorRateLimit
  .../stripe/resources/payment_intent.rb:126:in 'Stripe::PaymentIntent#confirm'
```

Fifty `Test Slow` shards run concurrently against one Stripe test account. #6500 and #6503 added the retry helper precisely so that contention gets waited out — but the cassette guard was too coarse:

```ruby
def replaying_a_cassette?
  defined?(VCR) && VCR.current_cassette.present?
end
```

The specs in every affected shard declare `shipping: true` or `taxjar: true`, which routes them through `only_matching_vcr_request_from(["taxjar"])` in `spec_helper`. That installs an `ignore_request` hook telling VCR to ignore **every host but TaxJar** — so Stripe inside those cassettes is live, hits the real API, and is fully rate-limitable. The guard saw the open TaxJar cassette and refused to retry.

Probed against vcr-6.2.0 directly rather than reasoned about:

```
--- inside cassette, stripe IGNORED by the taxjar filter ---
current_cassette present?            true
taxjar ignored?  false   (VCR handles it)
stripe ignored?  true    (passed through live)
  => old guard replaying_a_cassette?  true   (declines retry)  ← the bug
  => new guard                        false  (allows retry)

--- inside cassette, NO ignore filter (a plain VCR spec) ---
stripe ignored?  false
  => new guard                        true   (declines retry, unchanged)
```

Supporting evidence that retrying is the right answer and the budget is adequate: across those same shards the logs show `retry 1 of 8` … `retry 3 of 8` succeeding all over the place, and **not one** `still rate limited after 8 retries, giving up`. Every failure is a 429 that was never retried at all.

## Before / After

Not a UI change; the observable difference is whether a 429 raised under a host-ignoring cassette is retried.

| | Before | After |
|---|---|---|
| 429, no cassette open | retried (8 attempts) | retried (unchanged) |
| 429, cassette open, Stripe **ignored** by it | not retried → shard red | retried |
| 429, cassette open, Stripe **served** by it | not retried | not retried (unchanged) |
| VCR cannot answer | not retried | not retried (unchanged) |

## Test Results

`spec/lib/stripe_rate_limit_retries_spec.rb` — **19 examples, 0 failures**. One new example, `retries inside a cassette that ignores the Stripe host, where Stripe is live`, built with the same `vcr_turned_on` + `only_matching_vcr_request_from` wrappers the real specs use.

Mutation proof — reverting the guard body to the old open-cassette-means-replay logic:

```
19 examples, 1 failure

Failed examples:
rspec ./spec/lib/stripe_rate_limit_retries_spec.rb:91 # retries inside a cassette that
  ignores the Stripe host, where Stripe is live
```

Exactly the new example reddens. The pre-existing `does not retry a rate limit that came out of a VCR cassette` example stays green under both versions, which is the point — the fix narrows the guard without removing it.

`bundle exec rubocop` on both files: no offenses.

## Pre-merge review

Local adversarial (fable-5) review dispatched against the pushed SHA in a detached worktree: **READY-TO-MERGE, no P1s.** It verified the load-bearing claims against the installed gem sources rather than taking this PR's word for them:

- `VCR.request_ignorer` (vcr.rb:370/:473), `RequestIgnorer#ignore?(request)` (request_ignorer.rb:40-42) and `VCR::Request.new(method, uri, body, headers)` (structs.rb:176) all exist on the locked **vcr 6.2.0** — so the probe is not silently landing in the `rescue` and reporting success. VCR itself uses the identical pattern internally at vcr.rb:392, and `spec_helper.rb:553` already reaches into `request_ignorer`, so this adds no new coupling.
- `Stripe.api_base` is `"https://api.stripe.com"` (full scheme+host, no trailing slash), and the taxjar hook matches on `request.uri.match?(host)` — so the probe URI classifies on the host as intended. Method (`:post` vs `:get`) is irrelevant to both registered hook kinds.
- **The dangerous overlap does not exist in the tree.** Twelve cassettes replay a `code: 429`, but none live under `ShippingScenarios/` or `Taxjar/` — structurally guaranteed, since under `only_matching_vcr_request_from(["taxjar"])` Stripe interactions are ignored and can never be recorded into those cassettes in the first place.
- The pre-existing `does not retry a rate limit that came out of a VCR cassette` example genuinely pins the guard's true branch (it would fail if the guard were deleted outright), and the new example fails against the old guard for the reason claimed — stripe's own `should_retry?` retries a 429 only on `lock_timeout` or a `stripe-should-retry` header, and this error carries neither.
- `replaying_a_cassette` has zero remaining references, so there is no half-fixed second copy of the coarse guard. `only_matching_vcr_request_from` has one other caller (`signup_after_purchase_spec.rb:41`, `["pwnedpasswords"]`) with the same property — a second site this correctly un-blocks.

Both P2s were comment-convention findings (incident narration — shard counts and a date — against AGENTS.md "comments are for a reader who already knows this codebase"), fixed in e5d52ab1d. Re-ran after the trim: **19 examples, 0 failures**; rubocop clean on both files.

Two P3s accepted without change and recorded here: the `rescue StandardError → true` fallback reverts to the coarse behaviour if a future VCR upgrade renames the API, but the new example goes red in that world, so CI catches it rather than shards silently reddening again; and while a cassette is *recording*, Stripe is live yet the predicate still declines to retry — identical to the old guard's behaviour, and retrying-while-recording has its own trap (the recorded 429 would replay unretryable later).

## QA

1. `bundle exec rspec spec/lib/stripe_rate_limit_retries_spec.rb`
2. The real check is CI on this branch: `Test Slow` shards that were red on sibling branches should pass, and any shard that does hit throttling should log `retry N of 8` instead of failing a checkout assertion.

---

**AI disclosure:** Generated with `claude-opus-5`. Root cause found while triaging why #6566's CI stayed red after #6565 merged: the ten failed shards' logs and Capybara screenshot were read, the 429s counted per shard across the fleet from raw job logs, and the guard's behaviour probed against the installed vcr-6.2.0 before any code was written.

