### PR TITLE
Stop a membership restart from re-firing the creator's cancellation workflow

### DIFF
--- a/app/models/installment.rb
+++ b/app/models/installment.rb
@@ -321,10 +321,8 @@ class Installment < ApplicationRecord
 
   def member_cancellation_trigger?
     return true if workflow_trigger == MEMBER_CANCELLATION_WORKFLOW_TRIGGER
-    # Workflow::ManageService copies workflow.json_data down at save time, so an installment
-    # whose workflow became cancellation-triggered afterwards still carries the old (or no)
-    # trigger. Deferring to the workflow keeps the delivery guards from leaking a goodbye
-    # email on that drift.
+    # `workflow_trigger` is copied down at save time, so it goes stale when the workflow's own
+    # trigger changes afterwards. The workflow is the source of truth.
     workflow.present? && workflow.member_cancellation_trigger?
   end
 
@@ -428,9 +426,8 @@ class Installment < ApplicationRecord
   def send_installment_from_workflow_for_purchase(purchase_id)
     sale = Purchase.find(purchase_id)
     return if sale.is_recurring_subscription_charge
-    # This branch cannot evaluate a cancellation post: it only ever runs for a live
-    # membership, so `subscription.alive?` below can never be the "has ended" state such a
-    # post is written for. Jobs enqueued before the reschedule filter existed still land here.
+    # Cancellation posts are delivered on the subscription path, which rechecks the membership
+    # is still ended. This path can't, so stale enqueued jobs bail out here.
     return if member_cancellation_trigger?
 
     sale = sale.original_purchase

--- a/app/models/installment.rb
+++ b/app/models/installment.rb
@@ -320,7 +320,12 @@ class Installment < ApplicationRecord
   end
 
   def member_cancellation_trigger?
-    workflow_trigger == MEMBER_CANCELLATION_WORKFLOW_TRIGGER
+    return true if workflow_trigger == MEMBER_CANCELLATION_WORKFLOW_TRIGGER
+    # Workflow::ManageService copies workflow.json_data down at save time, so an installment
+    # whose workflow became cancellation-triggered afterwards still carries the old (or no)
+    # trigger. Deferring to the workflow keeps the delivery guards from leaking a goodbye
+    # email on that drift.
+    workflow.present? && workflow.member_cancellation_trigger?
   end
 
   def displayed_name

--- a/app/models/installment.rb
+++ b/app/models/installment.rb
@@ -423,6 +423,10 @@ class Installment < ApplicationRecord
   def send_installment_from_workflow_for_purchase(purchase_id)
     sale = Purchase.find(purchase_id)
     return if sale.is_recurring_subscription_charge
+    # This branch cannot evaluate a cancellation post: it only ever runs for a live
+    # membership, so `subscription.alive?` below can never be the "has ended" state such a
+    # post is written for. Jobs enqueued before the reschedule filter existed still land here.
+    return if member_cancellation_trigger?
 
     sale = sale.original_purchase
     return unless sale.can_contact?

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -3241,11 +3241,9 @@ class Purchase < ApplicationRecord
     all_workflows.each do |workflow|
       next unless workflow.applies_to_purchase?(self)
 
-      # Member-cancellation posts belong to the subscription, not the purchase, and are
-      # scheduled by Subscription#schedule_member_cancellation_workflow_jobs on the next
-      # cancellation. Re-enqueueing them here dispatches them down the purchase branch,
-      # which has no "is this membership still cancelled?" check, so a restart delivers
-      # the seller's goodbye email to a buyer who just paid.
+      # Cancellation posts belong to the subscription — Subscription#schedule_member_cancellation_workflow_jobs
+      # schedules them on the next cancellation. Enqueueing them here sends them down the
+      # purchase path, which never rechecks whether the membership is still cancelled.
       next if workflow.member_cancellation_trigger?
 
       active_workflow_installments = workflow.installments.includes(:installment_rule).alive.published

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -3241,6 +3241,13 @@ class Purchase < ApplicationRecord
     all_workflows.each do |workflow|
       next unless workflow.applies_to_purchase?(self)
 
+      # Member-cancellation posts belong to the subscription, not the purchase, and are
+      # scheduled by Subscription#schedule_member_cancellation_workflow_jobs on the next
+      # cancellation. Re-enqueueing them here dispatches them down the purchase branch,
+      # which has no "is this membership still cancelled?" check, so a restart delivers
+      # the seller's goodbye email to a buyer who just paid.
+      next if workflow.member_cancellation_trigger?
+
       active_workflow_installments = workflow.installments.includes(:installment_rule).alive.published
       has_any_past_workflow_installments = active_workflow_installments.any? do |installment|
         installment.installment_rule.present? && (original_purchase.created_at + installment.installment_rule.delayed_delivery_time < Time.current)

--- a/spec/models/installment/installment_filters_spec.rb
+++ b/spec/models/installment/installment_filters_spec.rb
@@ -40,3 +40,34 @@ describe "InstallmentFilters"  do
     end
   end
 end
+
+describe "#member_cancellation_trigger?" do
+  let(:seller) { create(:user) }
+  let(:product) { create(:product, user: seller) }
+
+  it "is true when the installment carries the trigger itself" do
+    workflow = create(:workflow, seller:, link: product, workflow_trigger: Workflow::MEMBER_CANCELLATION_WORKFLOW_TRIGGER)
+    installment = create(:installment, link: product, workflow:)
+    installment.workflow_trigger = Workflow::MEMBER_CANCELLATION_WORKFLOW_TRIGGER
+
+    expect(installment.member_cancellation_trigger?).to eq(true)
+  end
+
+  it "is true from the workflow when the installment's own copy is stale" do
+    workflow = create(:workflow, seller:, link: product, workflow_trigger: Workflow::MEMBER_CANCELLATION_WORKFLOW_TRIGGER)
+    installment = create(:installment, link: product, workflow:)
+
+    expect(installment.workflow_trigger).to be_nil
+    expect(installment.member_cancellation_trigger?).to eq(true)
+  end
+
+  it "is false for a new-customer workflow post" do
+    workflow = create(:workflow, seller:, link: product)
+
+    expect(create(:installment, link: product, workflow:).member_cancellation_trigger?).to eq(false)
+  end
+
+  it "is false for a post with no workflow" do
+    expect(create(:installment).member_cancellation_trigger?).to eq(false)
+  end
+end

--- a/spec/models/installment/installment_send_installment_spec.rb
+++ b/spec/models/installment/installment_send_installment_spec.rb
@@ -93,6 +93,16 @@ describe "InstallmentSendInstallment"  do
       @purchase2 = create(:purchase, link: @product, email: "tuhinA@gumroad.com", created_at: 2.weeks.ago, price_cents: 100)
     end
 
+    it "does not send a member-cancellation post down the purchase branch" do
+      cancellation_workflow = create(:workflow, seller: @seller, link: @product,
+                                                workflow_trigger: Workflow::MEMBER_CANCELLATION_WORKFLOW_TRIGGER)
+      cancellation_installment = create(:installment, link: @product, workflow: cancellation_workflow)
+
+      expect(PostSendgridApi).to_not receive(:process)
+
+      cancellation_installment.send_installment_from_workflow_for_purchase(@purchase1.id)
+    end
+
     it "sends a purchase_installment email for the purchase" do
       expect(PostSendgridApi).to receive(:process).with(
         post: @installment,

--- a/spec/models/purchase/purchase_installments_spec.rb
+++ b/spec/models/purchase/purchase_installments_spec.rb
@@ -988,6 +988,22 @@ describe "PurchaseInstallments", :vcr do
           expect(SendWorkflowInstallmentWorker).to_not have_enqueued_sidekiq_job(abandoned_cart_workflow_installment.id, abandoned_cart_workflow_installment_rule.version, @purchase.id, nil)
         end
       end
+
+      it "does not reschedule member-cancellation workflow installments" do
+        unsubscribed_interval = 4.days
+
+        cancellation_workflow = create(:workflow, seller: @purchase.seller, link: @purchase.link,
+                                                  workflow_trigger: Workflow::MEMBER_CANCELLATION_WORKFLOW_TRIGGER,
+                                                  published_at: Time.current)
+        cancellation_installment = create(:installment, link: @purchase.link, workflow: cancellation_workflow, published_at: Time.current)
+        create(:installment_rule, installment: cancellation_installment, delayed_delivery_time: 2.days)
+
+        travel_to(@purchase.created_at + unsubscribed_interval) do
+          @purchase.reschedule_workflow_installments(send_delay: unsubscribed_interval)
+
+          expect(SendWorkflowInstallmentWorker).to_not have_enqueued_sidekiq_job(cancellation_installment.id, 1, @purchase.id, nil)
+        end
+      end
     end
   end
 end

--- a/spec/models/purchase/purchase_installments_spec.rb
+++ b/spec/models/purchase/purchase_installments_spec.rb
@@ -1001,7 +1001,10 @@ describe "PurchaseInstallments", :vcr do
         travel_to(@purchase.created_at + unsubscribed_interval) do
           @purchase.reschedule_workflow_installments(send_delay: unsubscribed_interval)
 
-          expect(SendWorkflowInstallmentWorker).to_not have_enqueued_sidekiq_job(cancellation_installment.id, 1, @purchase.id, nil)
+          expect(SendWorkflowInstallmentWorker.jobs.size).to eq(3)
+          enqueued_installment_ids = SendWorkflowInstallmentWorker.jobs.map { _1["args"].first }
+          expect(enqueued_installment_ids).to match_array([@past_installment_1.id, @past_installment_2.id, @future_installment.id])
+          expect(enqueued_installment_ids).to_not include(cancellation_installment.id)
         end
       end
     end

--- a/test/models/installment_test.rb
+++ b/test/models/installment_test.rb
@@ -188,11 +188,21 @@ class InstallmentTest < ActiveSupport::TestCase
 
   test "member cancellation does not send for non member-cancellation installments" do
     ctx = member_cancellation_workflow_context
+    # The workflow's trigger has to go too: the installment's own copy is a stale snapshot, so
+    # member_cancellation_trigger? falls back to the workflow when it's blank (gumroad-private#1525).
+    ctx[:workflow].update!(workflow_trigger: nil)
     ctx[:installment].update!(workflow_trigger: nil)
     PostSendgridApi.stub(:process, ->(**) { flunk "process should not be called" }) do
       ctx[:installment].send_installment_from_workflow_for_member_cancellation(ctx[:subscription1].id)
       ctx[:installment].send_installment_from_workflow_for_member_cancellation(ctx[:subscription2].id)
     end
+  end
+
+  test "member cancellation still sends when only the workflow carries the trigger" do
+    ctx = member_cancellation_workflow_context
+    ctx[:installment].update!(workflow_trigger: nil)
+    calls = only_recipient_calls(ctx[:installment], ctx[:subscription1].id)
+    assert_equal [{ email: ctx[:sale1].email, purchase: ctx[:sale1], subscription: ctx[:subscription1] }], calls
   end
 
   test "member cancellation does not send for alive subscriptions" do


### PR DESCRIPTION
Ref antiwork/gumroad-private#1525

## What went wrong for the buyer

A membership buyer restarted a cancelled subscription and, instead of a receipt, got the creator's **"I'm sad to see you go! Can I help?"** email. Audited in production on the reported subscription: the buyer restarted it, the new charge succeeded, and the goodbye post went out anyway.

## Cause

A restart calls `Purchase#reschedule_workflow_installments`, which re-enqueued **every** published installment in every applicable workflow — including member-cancellation posts. Those are subscription-recipient posts, so they arrived via `send_installment_from_workflow_for_purchase`, the purchase branch, which has no "is this membership still cancelled?" check. And because `deliver_at` is computed from `original_purchase.created_at + send_delay`, spanning the whole cancelled period, it lands in the past and Sidekiq runs it immediately.

## Fix

1. `Purchase#reschedule_workflow_installments` skips cancellation-triggered workflows. `Subscription#schedule_member_cancellation_workflow_jobs` already owns scheduling those, and only when the subscription is actually not `alive?` — so nothing is lost.
2. `Installment#send_installment_from_workflow_for_purchase` refuses them outright, so jobs enqueued *before* this filter existed cannot deliver either. This matters: there are already-queued jobs in the wild from past restarts.
3. `Installment#member_cancellation_trigger?` falls back to the workflow. `Workflow::ManageService` copies `workflow.json_data` down to the installment at save time, so an installment whose workflow became cancellation-triggered afterwards still carries `nil` — the guards above would silently not fire on that drift. This was not theoretical: it turned the first CI run red on `Test Fast 17` (`PostSendgridApi.process` still called, `expected: 0 times`).

## Verification

Point 3 is the load-bearing behaviour change and I verified it directly rather than asserting it:

```
member_cancellation_trigger? drift
  reports true from the workflow even when the installment's own copy is nil
  stays false for an ordinary new-customer workflow post
  stays false for a post with no workflow at all
3 examples, 0 failures
```

That check is committed as four examples in `spec/models/installment/installment_filters_spec.rb` (`#member_cancellation_trigger?`), green locally. `rubocop` clean on both touched files.

The rescheduling spec asserts on the queue contents (`SendWorkflowInstallmentWorker.jobs.size` plus the exact enqueued installment ids) rather than a negative `have_enqueued_sidekiq_job` matcher, per CONTRIBUTING.md.

The behaviour spec in `installment_send_installment_spec.rb` could not be exercised locally — `create(:purchase, ...)` fails in my environment with `Validation failed: We couldn't charge your card`, and an untouched neighbouring example in the same file fails identically, so it is environmental, not the change. CI has since settled it: `Test Fast 17` — the exact job that was red on this spec on the first push — is green, in a full-suite run of **74 jobs, 0 failures**.

The rescheduling spec was then re-verified locally as load-bearing rather than assumed: with `app/models/purchase.rb` reverted to `origin/main` the new example fails on the queue size (`Expected 4 to eq 3`, the cancellation installment being the 4th job), and with the guard in place it passes alongside the neighbouring abandoned-cart example (2 examples, 0 failures).

## Not in this PR

The second half of gumroad-private#1525 — the library **Generate invoice** link being scoped to the sign-up purchase rather than the charge — is untouched here. It is open separately as #6590.

