### PR TITLE
Document the editor's refusal of a stale deletion

### DIFF
--- a/app/views/help_center/articles/contents/_126-setting-up-versions-on-a-digital-product.html.erb
+++ b/app/views/help_center/articles/contents/_126-setting-up-versions-on-a-digital-product.html.erb
@@ -31,6 +31,7 @@
   <h3 id="delete">Delete a version</h3>
   <p>Click the trash icon next to the version’s name to delete it.</p>
   <p>When you save, if the deleted version still has content pages or files, Gumroad shows a summary of what the save will permanently delete and asks you to confirm before anything is removed.</p>
+  <p>If the product changed somewhere else after you opened the editor (a second tab, or a team member saving while your tab sat open), Gumroad refuses the save and tells you your deletion was not applied. Nothing is saved in that case, including the version you removed. Reload the page to get the current content, then delete again. Reloading discards unsaved edits in that tab, so copy anything you still need first.</p>
   <p>If you delete a version, its associated content will be removed as well. Your existing customers who purchased it will see the content from the current cheapest version as a fallback. If no version exists, they will see the product-level content.</p>
   <p>To avoid any confusion, we recommend that you reassign the customer to another version that will remain alive before deleting a version.</p>
   <h3 id="reassign">Reassign a customer to a different version</h3>

--- a/app/views/help_center/articles/contents/_82-membership-products.html.erb
+++ b/app/views/help_center/articles/contents/_82-membership-products.html.erb
@@ -87,6 +87,7 @@
   <h3 id="What-happens-if-you-delete-an-active-tier-0nSPc">What happens if you delete an active tier?</h3>
   <p>If you delete a tier, its associated content will be removed as well. Your existing customers who purchased it will see the content from the current cheapest tier as a fallback. If no tier exists, they will see the product-level content.</p>
   <p>When you save, if the deleted tier still has content pages or files, Gumroad shows a summary of what the save will permanently delete and asks you to confirm before anything is removed.</p>
+  <p>If the product changed somewhere else after you opened the editor (a second tab, or a team member saving while your tab sat open), Gumroad refuses the save and tells you your deletion was not applied. Nothing is saved in that case, including the tier you removed. Reload the page to get the current content, then delete again. Reloading discards unsaved edits in that tab, so copy anything you still need first.</p>
   <p>Also, deleting the tier does not stop customers' subscriptions. They will keep paying their recurring charge until the membership is canceled. The <a href="https://gumroad.com/api#licenses" target="_self">Licenses API</a> will also keep returning the deleted tier in the variants field.</p>
   <p>To avoid any confusion, we recommend that you reassign the customer to another tier that will remain live before deleting a tier.</p>
   <h3 id="Restrictions-for-memberships-0_yOY">Restrictions for memberships</h3>


### PR DESCRIPTION
## What

Adds a paragraph to the version-deletion and tier-deletion sections of the help center saying what happens when a save that deletes something is refused because the product changed elsewhere: nothing is saved, the removal did not happen, and the recovery is a reload.

## Why

#6559 (merged) gave the product editor a modal for the save contract's `stale_deletion_conflict` — "Your deletion was not applied", stating that nothing was saved including the removals, with a reload as the way out. Both articles already documented the neighbouring save-time behaviour (the confirmation summary listing what a save will permanently delete) but stopped there, so a seller who hit the refusal had nothing to read.

Articles changed:

- `_126-setting-up-versions-on-a-digital-product` — "Delete a version"
- `_82-membership-products` — "What happens if you delete an active tier?"

Both sentences are additive, placed after the existing confirmation-summary line, and mirror the modal's wording rather than paraphrasing it. Anchors and TOC entries are untouched; no `articles.yml` change (no title/description/category change).

Two facts checked against code rather than the PR body:

- The refusal is live for every seller: `Product::SaveContract::FEATURE_NAME` (`:product_editor_save_contract`) reads `boolean=true` in production with no per-actor or percentage gating, so the copy is unconditional rather than hedged.
- The trigger is any concurrent change to the product, not specifically a second tab of your own — `LinksController#update` compares the payload's `editor_revision` against the current one, so a collaborator or team member saving while your tab sat open produces it too. Both are named in the copy.

Scope kept deliberately narrow: durations (call products) have no delete section in the help center to extend, and the buyer-facing articles do not describe seller-side saving at all.

## Test plan

- `bundle exec rspec spec/models/help_center` — 1 example, 0 failures.
- Both partials rendered through `ApplicationController.render` and asserted to contain the new copy: 5007 and 14401 bytes.
- ERB compiles (`ERB.new(...).src`) and per-tag open/close balance unchanged in both files.

Not applicable — before/after media: the diff is help-center prose with no rendered UI change beyond the paragraph text itself.

---

## AI disclosure

Written by Claude Opus 5 (`model.default` in the agent's config) acting as gumclaw.

Prompts and instructions given:

1. A GitHub webhook delivered the merge of #6559, which routes merged `antiwork/gumroad` PRs through a help-center relevance check: decide whether the merged change makes any help-center article wrong, and if so edit and ship it.
2. Standing instruction to verify copy facts against the code the article describes rather than the triggering PR's description, and to keep the edit to the articles that actually describe the changed surface.
