### PR TITLE
Let the payout requirements list mention business registration

### DIFF
--- a/app/views/help_center/articles/contents/_13-getting-paid.html.erb
+++ b/app/views/help_center/articles/contents/_13-getting-paid.html.erb
@@ -402,10 +402,10 @@
   </div>
   <p><b>Note:</b> Countries showing "(min X)" have a higher minimum payout threshold than the standard $100 USD requirement.</p>
   <p>We can only pay out to a local bank account and in your local currency. We cannot pay you out in USD if it is not listed above as your country's payout currency. All currency conversions happen based on the exchange rates at the time of sale, not at the time of the payout. These are typically mid-market rates that you can estimate <a href="https://dashboard.stripe.com/currency_conversion">here</a>.</p>
-  <p>For prompt payouts, please ensure that you have the following for your country of residence: </p>
+  <p>For prompt payouts, please ensure that you have the following for the country you select: </p>
   <ul>
     <li>A valid, government-issued photo ID</li>
-    <li>Proof of residence within the country</li>
+    <li>Proof of residence in that country, or a business registered there</li>
   </ul>
   <p>If you sell as a business, your bank account must be in the country where your business is registered. For example, a US LLC needs a US bank account. You can live in another country and use your real home address.</p>
   <p>Depending on your country, bank payouts can take 2-7 business days to process, and can be delayed around bank holidays.</p>


### PR DESCRIPTION
## What

Updates the payout-requirements list in `_13-getting-paid` (help.gumroad.com/help/article/13-getting-paid) so it no longer reads as residence-only.

Before: "For prompt payouts, please ensure that you have the following for your country of residence: ... Proof of residence within the country".

After: "For prompt payouts, please ensure that you have the following for the country you select: ... Proof of residence in that country, or a business registered there".

## Why

Triggered by merged PR #6541, which changed the country-selection modal's attestation from two lines requiring both proof of residence *and* an individual/registered-business statement, to a single line: "I can provide proof of residence in the country above, or my business is registered there".

The product now lets a non-resident owner of a registered business get past the country screen — business registration is an accepted alternative tie to the selected country. The article still told sellers they needed proof of residence in that country, full stop, which is now wrong for exactly the sellers PR #6541 unblocked.

The second sentence in that same section already said "If you sell as a business, your bank account must be in the country where your business is registered ... You can live in another country and use your real home address" — so the article was internally inconsistent even before this change. This edit makes the requirements list agree with it and with the shipped modal copy.

Only the requirements list changed. `articles.yml` is untouched (no title, description, or category change), and no anchor IDs were affected.

## Test plan

- ERB syntax check on the edited partial: OK.
- Tag-balance count across all tags in the file: balanced (no pre-existing or new mismatches).
- Rendered the partial in the real view context (`ApplicationController.render`, `RAILS_ENV=test`): renders, contains the new wording, no longer contains the stale wording.
- Repo-wide grep for the old residence wording across all article bodies: no remaining occurrences.
- Body-only prose change: no ERB logic, no YAML, no code, so no fable review gate applies.
- CI runs the help-center specs.

---

## AI disclosure

Written by **claude-opus-5** (Anthropic) running as Hermes Agent, on the standing instruction to keep help-center articles accurate when a merged PR changes user-facing behavior. The model read the merged diff of #6541, mapped the changed attestation copy to the affected article, verified no other article carried the residence-only wording, and made the edit.
