### PR TITLE
Fix the checkout-appearance FAQ answer after checkout gained seller theming

### DIFF
--- a/app/views/help_center/articles/contents/_44-build-gumroad-into-your-website.html.erb
+++ b/app/views/help_center/articles/contents/_44-build-gumroad-into-your-website.html.erb
@@ -40,7 +40,7 @@
   <p><strong>Q. Can I complete the checkout on my website, instead of redirecting customers to Gumroad?</strong></p>
   <p>A: Sorry, that’s not possible. The checkout page will allow us to add new features like upsells, cross-sells, retargeting using JS embedded on the product page itself, and more going ahead!</p>
   <p><strong>Q. Can I customize the look of the checkout page with CSS?</strong></p>
-  <p>A: Not yet, sorry!</p>
+  <p>A: You cannot add your own CSS, but checkout does follow <a href="124-your-gumroad-profile-page#theme-colors-fonts">your store's theme</a> (its background color, highlight color, and font) as long as everything on the page belongs to you. If the buyer's cart holds products from more than one creator, checkout uses Gumroad's own colors and font instead.</p>
   <p><strong>Q. Can I apply discount codes to my overlay/embed product pages?</strong></p>
   <p>A: Yes! Go to your product’s “Checkout” tab and get the discounted product’s URL by clicking the “Share” button next to the coupon’s name. Now paste this URL in your widget’s <code class="inline-code">href</code> attribute.</p>
   <p><strong>Q. Can I autofill some checkout information while sending the customer from my website to the checkout page?</strong></p>


### PR DESCRIPTION
## What

The widgets article's FAQ answer about customizing the checkout page is now correct. It said "Not yet, sorry!" to whether checkout's look can be changed, which stopped being true when #6531 merged and made checkout carry the seller's store theme.

The answer now separates the two halves of that question: custom CSS is still not available, but the store theme (background color, highlight color, font) does reach checkout when every product on the page belongs to one creator, and mixed-creator carts fall back to Gumroad's own colors and font. It links to the theme section of the profile article rather than restating the theme rules in a second place.

Triggered by antiwork/gumroad#6531 (Carry the seller's theme through checkout). Ref antiwork/gumroad-private#1493.

## Why

#6531 already updated `_124-your-gumroad-profile-page`, which is where the theme itself is documented. It did not touch `_44-build-gumroad-into-your-website`, whose FAQ carries the question a seller asking about checkout appearance is most likely to search for. Leaving "Not yet, sorry!" there means the article most directly answering "can I change how checkout looks" gives the pre-#6531 answer, and support has already fielded two sellers this month asking exactly that.

Wording checked against the shipped code rather than the PR description: `CheckoutController#sole_seller_checkout_style` requires every product on the page to resolve to the same seller before injecting `SellerProfile#custom_styles`, so "as long as everything on the page belongs to you" is the actual condition, and the mixed-cart fallback is the neutral stock theme. No feature flag gates the path, so the behavior is live for every seller as soon as #6531 deploys.

## Before / after

Not applicable as rendered media — this is a one-line copy change inside an existing FAQ answer, on a help-center article with no UI surface of its own. The diff is the evidence.

**Before:** `A: Not yet, sorry!`

**After:** `A: You cannot add your own CSS, but checkout does follow your store's theme (its background color, highlight color, and font) as long as everything on the page belongs to you. If the buyer's cart holds products from more than one creator, checkout uses Gumroad's own colors and font instead.`

## Test plan

- Partial renders in the real view context with the new copy present and the old copy gone:
  `bundle exec rails runner -e test 'ApplicationController.render(partial: "help_center/articles/contents/44-build-gumroad-into-your-website")'` → `render OK 5547 bytes`
- Tag-balance check on the edited body: every tag pair balanced (div 1/1, p 22/22, ul 2/2, li 6/6, a 10/10, strong 5/5, figure 5/5, pre 2/2, code 3/3).
- Link target verified: `#theme-colors-fonts` exists in `_124-your-gumroad-profile-page.html.erb` (line 38) and is already used by that article's own table of contents.
- `articles.yml` untouched — no title, description, or category change, so the search snippet stays accurate.

Body-only prose edit, no ERB logic and no YAML change, so no adversarial review gate per the help-center convention.

## QA steps

1. Open `help.gumroad.com/help/article/44-build-gumroad-into-your-website`.
2. Scroll to FAQs and read the "Can I customize the look of the checkout page with CSS?" answer.
3. Click "your store's theme" and confirm it lands on the "Your store's colors and font" section of the profile article.

---

## AI disclosure

Written by claude-opus-5 running as the Hermes agent. It was given the merged-PR webhook for #6531 and the standing instruction to check whether a merged product change leaves any help-center article describing the product wrong, then edit the affected article. It found the stale FAQ answer, verified the theme condition and the mixed-cart fallback against `CheckoutController#sole_seller_checkout_style` in the merged code, confirmed the anchor target exists, and rendered the partial before pushing.
