### PR TITLE
Resolve "Slovak Republic" to Slovakia

### DIFF
--- a/app/services/tax_remittances/quarterly_liability_calculator.rb
+++ b/app/services/tax_remittances/quarterly_liability_calculator.rb
@@ -261,9 +261,10 @@ class TaxRemittances::QuarterlyLiabilityCalculator
     # unresolved_country_names rather than quietly discarded. The report can
     # afford to bucket these as "Unknown" because a human reads the CSV; here
     # the output is a payment amount, so an unresolvable name means tax we
-    # collected and might not remit. ISO name matching is not exhaustive
-    # (e.g. "Slovak Republic" and "Holland" both fail), so this is a real
-    # possibility, not a theoretical one.
+    # collected and might not remit. ISO name matching is not exhaustive — the
+    # aliases in config/initializers/countries.rb exist because names keep
+    # arriving that the gem does not know — so this is a real possibility, not
+    # a theoretical one.
     #
     # leg_tax_cents is THIS leg's signed contribution, not the purchase's
     # gross tax: positive for a sale or a won dispute, negative for a refund

--- a/config/initializers/countries.rb
+++ b/config/initializers/countries.rb
@@ -14,6 +14,9 @@ ISO3166::Country["CG"].data["unofficial_names"] << "Congo Republic"
 ISO3166::Country["FM"].data["unofficial_names"] << "Federated States of Micronesia"
 ISO3166::Country["UM"].data["unofficial_names"] << "U.S. Outlying Islands"
 ISO3166::Country["VC"].data["unofficial_names"] << "St Vincent and Grenadines"
+# The gem knows SK only as "Slovakia" / "The Slovak Republic"; the bare long form misses. Slovakia
+# is an EU VAT state, so a purchase stored this way resolves to nil and drops out of the OSS return.
+ISO3166::Country["SK"].data["unofficial_names"] << "Slovak Republic"
 
 # Similarly, there are times when we want to query by multiple country names,
 # e.g., `WHERE purchases.country IN ()`
@@ -40,6 +43,7 @@ ISO3166::Country["PN"].data["gumroad_historical_names"] = ["Pitcairn Islands"]
 ISO3166::Country["PS"].data["gumroad_historical_names"] = ["Palestine"]
 ISO3166::Country["RU"].data["gumroad_historical_names"] = ["Russia"]
 ISO3166::Country["SH"].data["gumroad_historical_names"] = ["Saint Helena"]
+ISO3166::Country["SK"].data["gumroad_historical_names"] = ["Slovak Republic"]
 ISO3166::Country["ST"].data["gumroad_historical_names"] = ["São Tomé and Príncipe"]
 ISO3166::Country["SX"].data["gumroad_historical_names"] = ["Sint Maarten"]
 ISO3166::Country["SZ"].data["gumroad_historical_names"] = ["Swaziland"]

--- a/spec/lib/utilities/compliance_spec.rb
+++ b/spec/lib/utilities/compliance_spec.rb
@@ -54,6 +54,11 @@ describe Compliance do
         expect(Compliance::Countries.find_by_name(nil)).to be_nil
       end
 
+      it "resolves the bare long form of an EU VAT state, which the gem itself does not know" do
+        # An unresolved name here means the purchase drops out of the EU OSS return entirely.
+        expect(Compliance::Countries.find_by_name("Slovak Republic")).to eq(Compliance::Countries::SVK)
+      end
+
       it "returns nil for an empty country name" do
         expect(Compliance::Countries.find_by_name("")).to be_nil
       end

--- a/spec/services/tax_remittances/quarterly_liability_calculator_spec.rb
+++ b/spec/services/tax_remittances/quarterly_liability_calculator_spec.rb
@@ -347,15 +347,19 @@ describe TaxRemittances::QuarterlyLiabilityCalculator do
     # ISO name matching is not exhaustive, so a country name we can't resolve
     # would otherwise silently drop the tax collected against it. That must be
     # visible: here the output is money we send, not a CSV a human reads.
+    #
+    # The fixture name is fictional on purpose. Real-world misses ("Slovak
+    # Republic", "Holland") get registered as aliases as we find them, which
+    # would quietly stop these examples from exercising the gap branch at all.
     it "reports a country name that resolves to no country, with the tax at stake" do
       travel_to(in_period) do
-        create_taxed_purchase(product, country: "Slovak Republic", gumroad_tax_cents: 8_00)
+        create_taxed_purchase(product, country: "Freedonia", gumroad_tax_cents: 8_00)
         create_taxed_purchase(product, country: "Australia", gumroad_tax_cents: 10_00)
       end
 
       calculator = described_class.new(period).process
 
-      expect(calculator.unresolved_country_names).to eq({ "Slovak Republic" => 8_00 })
+      expect(calculator.unresolved_country_names).to eq({ "Freedonia" => 8_00 })
       # And it does not leak into any authority's payment.
       expect(calculator.total_usd_cents).to eq(10_00)
     end
@@ -366,7 +370,7 @@ describe TaxRemittances::QuarterlyLiabilityCalculator do
     # reviewer chasing a number that was never collected.
     it "nets a refund against the unresolved country name it belongs to" do
       travel_to(in_period) do
-        @unresolvable = create_taxed_purchase(product, country: "Slovak Republic", gumroad_tax_cents: 8_00)
+        @unresolvable = create_taxed_purchase(product, country: "Freedonia", gumroad_tax_cents: 8_00)
       end
       travel_to(in_period + 5.days) do
         create(:refund, purchase: @unresolvable, total_transaction_cents: 50_00, gumroad_tax_cents: 4_00)
@@ -374,14 +378,14 @@ describe TaxRemittances::QuarterlyLiabilityCalculator do
 
       calculator = described_class.new(period).process
 
-      expect(calculator.unresolved_country_names).to eq({ "Slovak Republic" => 4_00 })
+      expect(calculator.unresolved_country_names).to eq({ "Freedonia" => 4_00 })
     end
 
     # Fully refunded within the quarter means there is nothing left to chase,
     # so it stops being reported at all rather than showing up as a zero.
     it "drops an unresolved country name whose tax was fully refunded in the quarter" do
       travel_to(in_period) do
-        @unresolvable = create_taxed_purchase(product, country: "Slovak Republic", gumroad_tax_cents: 8_00)
+        @unresolvable = create_taxed_purchase(product, country: "Freedonia", gumroad_tax_cents: 8_00)
       end
       travel_to(in_period + 5.days) do
         create(:refund, purchase: @unresolvable, total_transaction_cents: 108_00, gumroad_tax_cents: 8_00)
@@ -398,7 +402,7 @@ describe TaxRemittances::QuarterlyLiabilityCalculator do
     # marking it as old.
     it "produces identical results when process is called again" do
       travel_to(in_period) do
-        create_taxed_purchase(product, country: "Slovak Republic", gumroad_tax_cents: 8_00)
+        create_taxed_purchase(product, country: "Freedonia", gumroad_tax_cents: 8_00)
         create_taxed_purchase(product, country: "Canada", state: "ON", gumroad_tax_cents: 13_00)
         create_taxed_purchase(product, country: nil, ip_country: nil, gumroad_tax_cents: 5_00)
         create_taxed_purchase(product, country: "Australia", gumroad_tax_cents: 10_00)
@@ -422,7 +426,7 @@ describe TaxRemittances::QuarterlyLiabilityCalculator do
           calculator.countryless_tax_cents,
         ]
       ).to eq(first_run)
-      expect(calculator.unresolved_country_names).to eq({ "Slovak Republic" => 8_00 })
+      expect(calculator.unresolved_country_names).to eq({ "Freedonia" => 8_00 })
       expect(calculator.countryless_tax_cents).to eq(5_00)
     end
   end

--- a/spec/services/tax_remittances/stage_quarterly_drafts_spec.rb
+++ b/spec/services/tax_remittances/stage_quarterly_drafts_spec.rb
@@ -481,12 +481,12 @@ describe TaxRemittances::StageQuarterlyDrafts do
 
     it "passes through country names that resolve to no country" do
       travel_to(in_period) do
-        create_taxed_purchase(product, country: "Slovak Republic", gumroad_tax_cents: 8_00)
+        create_taxed_purchase(product, country: "Freedonia", gumroad_tax_cents: 8_00)
       end
 
       service = described_class.new(period).process
 
-      expect(service.coverage_gaps[:unresolved_country_names]).to eq({ "Slovak Republic" => 8_00 })
+      expect(service.coverage_gaps[:unresolved_country_names]).to eq({ "Freedonia" => 8_00 })
     end
 
     # A purchase with no country at all can't be filed anywhere, so the amount


### PR DESCRIPTION
## Why

While computing the Q2 2026 per-authority VAT/GST totals for the July non-US filings ([gumroad-private#1183](https://github.com/antiwork/gumroad-private/issues/1183)), I found that `Compliance::Countries.find_by_name("Slovak Republic")` returns `nil`.

The gem knows SK as `Slovakia` and `The Slovak Republic`, but not the bare long form. Slovakia is an EU VAT state, so a purchase stored that way resolves to no country and drops out of the EU one-stop-shop return *and* the per-authority totals — without showing up in any coverage-gap figure, because the gap counters are themselves keyed on a resolved country.

Q2 2026 exposure is **zero** (verified: no Q2 purchase stores this form), so no filing needs restating. This closes the latent path before a row lands on it.

## What

- Register `Slovak Republic` in `unofficial_names` for SK. That is the field `find_country_by_any_name` actually reads — I confirmed that adding it only to `gumroad_historical_names` does **not** fix the lookup.
- Also add it to `gumroad_historical_names`, so name-based `WHERE country IN (...)` queries match it, consistent with the `Czech Republic` → CZ precedent directly above.

## Verification

The new example fails on `main` and passes with the initializer change:

```
# without the fix
1 example, 1 failure
# with the fix, whole file
64 examples, 0 failures
```