### PR TITLE
Reject Colombian ID numbers Stripe will refuse, with an actionable message

### DIFF
--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_beneficial_owners_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_beneficial_owners_manager.rb
@@ -70,6 +70,7 @@ module StripeBeneficialOwnersManager
     stripe_account = ensure_eligible!(user)
     validate_required_fields!(params, action: :create, user: user)
     validate_jp_kana_address_format!(params, user)
+    validate_colombia_id_number!(params, user)
     person_params = build_person_params(params, user, action: :create)
     person = Stripe::Account.create_person(stripe_account.charge_processor_merchant_id, person_params)
     serialize(person)
@@ -84,6 +85,7 @@ module StripeBeneficialOwnersManager
     else
       validate_required_fields!(params, action: :update, user: user)
       validate_jp_kana_address_format!(params, user)
+      validate_colombia_id_number!(params, user)
       person_params = build_person_params(params, user, action: :update)
     end
 
@@ -213,6 +215,19 @@ module StripeBeneficialOwnersManager
     raise InvalidFieldError, "#{label} may only contain #{allowed_description}."
   end
   private_class_method :validate_kana_param!
+
+  # The form's maxLength counts characters so a pasted "1.123.456.789" fits, which means a value can
+  # satisfy the input and still carry too few digits. Checking digits here — and normalizing in
+  # build_person_params — keeps this path from handing Stripe a number it will refuse, which is the
+  # rolled-back-create failure that left one seller with eight silent attempts.
+  def self.validate_colombia_id_number!(params, user)
+    return unless user.alive_user_compliance_info&.legal_entity_country_code == Compliance::Countries::COL.alpha2
+    id_number = params[:id_number].to_s
+    return if id_number.strip.blank?
+    return if Compliance::ColombiaIdNumber.valid?(id_number)
+    raise InvalidFieldError, Compliance::ColombiaIdNumber::ERROR_MESSAGE
+  end
+  private_class_method :validate_colombia_id_number!
 
   def self.representative?(person)
     relationship = person.is_a?(Hash) ? person[:relationship] || person["relationship"] : person[:relationship]
@@ -356,6 +371,9 @@ module StripeBeneficialOwnersManager
     end
 
     id_number = params[:id_number].to_s.strip
+    # Send the digits the guard counted, not the separators the seller typed — Stripe refuses a CO
+    # id_number that is not digits-only.
+    id_number = Compliance::ColombiaIdNumber.normalize(id_number) if country_code == Compliance::Countries::COL.alpha2
     if id_number.present?
       if country_code == Compliance::Countries::USA.alpha2 && id_number.length == 4
         hash[:ssn_last_4] = id_number

--- a/app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import typia from "typia";
 
 import type { ComplianceInfo, FormFieldName, User } from "$app/types/payments";
+import { COLOMBIA_ID_MAX_INPUT_LENGTH, COLOMBIA_ID_MIN_DIGITS } from "$app/utils/colombiaIdNumbers";
 import { countryRequiresPostalCode } from "$app/utils/postalCodes";
 
 import { Button } from "$app/components/Button";
@@ -209,13 +210,8 @@ const AccountDetailsSection = ({
         // resident reads "Cédula de Ciudadanía" and concludes their ID cannot be used.
         label: "Cédula de Ciudadanía (CC) or Cédula de Extranjería (CE)",
         placeholder: "1234567890",
-        // Colombian ID numbers vary in length: Cédula de Extranjería numbers are commonly six or
-        // seven digits, citizen numbers eight to ten. A single exact length would block most of that
-        // range, so only a loose range is enforced here (the upper bound leaves room for a number
-        // pasted with thousands separators, e.g. "1.123.123.123"). Stripe does the authoritative
-        // validation on individual.id_number.
-        minLength: 6,
-        maxLength: 13,
+        minLength: COLOMBIA_ID_MIN_DIGITS,
+        maxLength: COLOMBIA_ID_MAX_INPUT_LENGTH,
         idSuffix: "colombia-id-number",
       },
       UY: {

--- a/app/javascript/components/Settings/PaymentsPage/BeneficialOwnersSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/BeneficialOwnersSection.tsx
@@ -1,7 +1,12 @@
 import * as React from "react";
 import typia from "typia";
 
-import { COLOMBIA_ID_MAX_INPUT_LENGTH, COLOMBIA_ID_MIN_DIGITS } from "$app/utils/colombiaIdNumbers";
+import {
+  COLOMBIA_ID_MAX_INPUT_LENGTH,
+  COLOMBIA_ID_MIN_DIGITS,
+  COLOMBIA_ID_NUMBER_ERROR_MESSAGE,
+  isValidColombiaIdNumber,
+} from "$app/utils/colombiaIdNumbers";
 import { countryRequiresPostalCode } from "$app/utils/postalCodes";
 import { request, ResponseError } from "$app/utils/request";
 
@@ -518,12 +523,25 @@ const BeneficialOwnersSection = ({
     return null;
   };
 
+  const validateColombiaIdNumber = (): string | null => {
+    if (defaultCountry !== "CO") return null;
+    if (editState?.mode === "edit" && editState.owner.relationship.representative) return null;
+    // An edit that leaves the stored ID untouched submits a blank field; only judge what was typed.
+    if (!formState.id_number.trim()) return null;
+    return isValidColombiaIdNumber(formState.id_number) ? null : COLOMBIA_ID_NUMBER_ERROR_MESSAGE;
+  };
+
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!editState) return;
     const kanaError = validateJpKanaFields();
     if (kanaError) {
       setFormError(kanaError);
+      return;
+    }
+    const colombiaIdError = validateColombiaIdNumber();
+    if (colombiaIdError) {
+      setFormError(colombiaIdError);
       return;
     }
     setIsSaving(true);

--- a/app/javascript/components/Settings/PaymentsPage/BeneficialOwnersSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/BeneficialOwnersSection.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import typia from "typia";
 
+import { COLOMBIA_ID_MAX_INPUT_LENGTH, COLOMBIA_ID_MIN_DIGITS } from "$app/utils/colombiaIdNumbers";
 import { countryRequiresPostalCode } from "$app/utils/postalCodes";
 import { request, ResponseError } from "$app/utils/request";
 
@@ -217,13 +218,12 @@ const TAX_ID_CONFIGS: Record<string, TaxIdConfig> = {
   },
   CO: {
     // Colombia issues two personal IDs: the Cédula de Ciudadanía to citizens and the Cédula de
-    // Extranjería to foreign residents. Both are valid here, and their numbers range from about six
-    // to ten digits, so the field accepts a loose range rather than one exact length. Kept in sync
-    // with the same entry in AccountDetailsSection.tsx.
+    // Extranjería to foreign residents. Both are valid here. Bounds and copy are shared with
+    // AccountDetailsSection via the colombiaIdNumbers helper.
     label: "Cédula de Ciudadanía (CC) or Cédula de Extranjería (CE)",
     placeholder: "1234567890",
-    minLength: 6,
-    maxLength: 13,
+    minLength: COLOMBIA_ID_MIN_DIGITS,
+    maxLength: COLOMBIA_ID_MAX_INPUT_LENGTH,
     idSuffix: "colombia-id-number",
   },
   UY: {

--- a/app/javascript/pages/Settings/Payments/Show.tsx
+++ b/app/javascript/pages/Settings/Payments/Show.tsx
@@ -8,6 +8,7 @@ import { CardPayoutError, prepareCardTokenForPayouts, type CardPayoutToken } fro
 import { SavedCreditCard } from "$app/parsers/card";
 import { SettingPage } from "$app/parsers/settings";
 import type { ComplianceInfo, PayoutMethod, FormFieldName, User, PayoutDebitCardData } from "$app/types/payments";
+import { COLOMBIA_ID_NUMBER_ERROR_MESSAGE, isValidColombiaIdNumber } from "$app/utils/colombiaIdNumbers";
 import { formatPriceCentsWithCurrencySymbol, formatPriceCentsWithoutCurrencySymbol } from "$app/utils/currency";
 import { countryRequiresPostalCode } from "$app/utils/postalCodes";
 import { asyncVoid } from "$app/utils/promise";
@@ -873,6 +874,17 @@ export default function PaymentsPage() {
         message:
           "Your NRIC/FIN must start with S, T, F, G or M and end with a letter (for example, S1234567A). Please enter it exactly as it appears on your ID.",
       });
+    }
+    const colombiaIdRequired = form.data.user.is_business
+      ? form.data.user.business_country === "CO"
+      : form.data.user.country === "CO";
+    if (
+      colombiaIdRequired &&
+      form.data.user.individual_tax_id &&
+      !isValidColombiaIdNumber(form.data.user.individual_tax_id)
+    ) {
+      markFieldInvalid("individual_tax_id");
+      setClientErrorMessage({ message: COLOMBIA_ID_NUMBER_ERROR_MESSAGE });
     }
     if (form.data.user.is_business) {
       if (!form.data.user.business_type) {

--- a/app/javascript/utils/colombiaIdNumbers.test.ts
+++ b/app/javascript/utils/colombiaIdNumbers.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  COLOMBIA_ID_MAX_DIGITS,
+  COLOMBIA_ID_MIN_DIGITS,
+  COLOMBIA_ID_NUMBER_ERROR_MESSAGE,
+  isValidColombiaIdNumber,
+} from "$app/utils/colombiaIdNumbers";
+
+describe("isValidColombiaIdNumber", () => {
+  it("accepts the digit lengths Stripe accepts for CO", () => {
+    expect(isValidColombiaIdNumber("1234567")).toBe(true);
+    expect(isValidColombiaIdNumber("12345678")).toBe(true);
+    expect(isValidColombiaIdNumber("1234567890")).toBe(true);
+  });
+
+  it("rejects a six-digit Cédula de Extranjería, which Stripe refuses", () => {
+    expect(isValidColombiaIdNumber("482913")).toBe(false);
+  });
+
+  it("rejects numbers longer than Stripe's upper bound", () => {
+    expect(isValidColombiaIdNumber("12345678901")).toBe(false);
+  });
+
+  it("ignores thousands separators and spaces", () => {
+    expect(isValidColombiaIdNumber("1.123.456")).toBe(true);
+    expect(isValidColombiaIdNumber("1 123 456")).toBe(true);
+    // 13 characters but only 6 digits — the character count must not stand in for the digit count.
+    expect(isValidColombiaIdNumber("4.8.2.9.1.3")).toBe(false);
+  });
+
+  it("rejects an empty value rather than treating it as valid", () => {
+    expect(isValidColombiaIdNumber("")).toBe(false);
+    expect(isValidColombiaIdNumber("...")).toBe(false);
+  });
+
+  it("names both documents and the bounds in the error message", () => {
+    expect(COLOMBIA_ID_NUMBER_ERROR_MESSAGE).toContain("Cédula de Ciudadanía");
+    expect(COLOMBIA_ID_NUMBER_ERROR_MESSAGE).toContain("Cédula de Extranjería");
+    expect(COLOMBIA_ID_NUMBER_ERROR_MESSAGE).toContain(`${COLOMBIA_ID_MIN_DIGITS}-${COLOMBIA_ID_MAX_DIGITS} digits`);
+    expect(COLOMBIA_ID_NUMBER_ERROR_MESSAGE).toContain("leading zeros");
+  });
+});

--- a/app/javascript/utils/colombiaIdNumbers.ts
+++ b/app/javascript/utils/colombiaIdNumbers.ts
@@ -1,0 +1,29 @@
+// Colombia issues two personal IDs: the Cédula de Ciudadanía to citizens and the Cédula de
+// Extranjería to foreign residents. Both are sent to Stripe as individual.id_number, and Stripe
+// enforces 7-10 digits on that field for CO — confirmed by Stripe support on case
+// sco_UyXAayCkurHzCd after their validator refused a real 6-digit Cédula de Extranjería.
+//
+// Colombia's own document spec (Anexo Técnico 1, Resolución 2011) allows 6-digit numbers, so
+// Stripe's floor excludes IDs that legitimately exist. Until they widen it, matching their bounds
+// here is the honest thing to do: the alternative is accepting input we know the processor will
+// refuse, which is how one seller reached eight silent rolled-back attempts.
+export const COLOMBIA_ID_MIN_DIGITS = 7;
+export const COLOMBIA_ID_MAX_DIGITS = 10;
+
+// The input's maxLength counts characters, so it has to leave room for a number pasted with
+// thousands separators ("1.123.456.789"). The digit-count check below is the real bound.
+export const COLOMBIA_ID_MAX_INPUT_LENGTH = 13;
+
+// Sellers paste numbers with dots or spaces ("1.123.456"), which are cosmetic here.
+const digitsOnly = (value: string) => value.replace(/\D/gu, "");
+
+export const isValidColombiaIdNumber = (value: string) => {
+  const digits = digitsOnly(value);
+  return digits.length >= COLOMBIA_ID_MIN_DIGITS && digits.length <= COLOMBIA_ID_MAX_DIGITS;
+};
+
+// Named for the two documents rather than "your ID", so a foreign resident can tell the message is
+// about the document they actually hold. Zero-padding a short number is called out because it is
+// the workaround sellers reach for on their own, and it trades today's block for an
+// id_number_match verification failure later, once they have a balance.
+export const COLOMBIA_ID_NUMBER_ERROR_MESSAGE = `Your Cédula de Ciudadanía or Cédula de Extranjería must be ${COLOMBIA_ID_MIN_DIGITS}-${COLOMBIA_ID_MAX_DIGITS} digits. Enter it exactly as it appears on your document — do not add leading zeros, as the number has to match the document you may later be asked to upload.`;

--- a/app/javascript/utils/colombiaIdNumbers.ts
+++ b/app/javascript/utils/colombiaIdNumbers.ts
@@ -2,6 +2,8 @@
 // Extranjería to foreign residents. Both are sent to Stripe as individual.id_number, and Stripe
 // enforces 7-10 digits on that field for CO — confirmed by Stripe support on case
 // sco_UyXAayCkurHzCd after their validator refused a real 6-digit Cédula de Extranjería.
+// Test-mode Stripe does NOT enforce this, so a local probe accepts any length and cannot be used
+// to re-derive these bounds.
 //
 // Colombia's own document spec (Anexo Técnico 1, Resolución 2011) allows 6-digit numbers, so
 // Stripe's floor excludes IDs that legitimately exist. Until they widen it, matching their bounds

--- a/app/services/update_user_compliance_info.rb
+++ b/app/services/update_user_compliance_info.rb
@@ -39,6 +39,13 @@ class UpdateUserComplianceInfo
   # seller gets an actionable error at save time instead. Case-insensitive: Stripe accepts
   # lowercase, so we don't reject it.
   SINGAPORE_NRIC_FIN_PATTERN = /\A[STFGM]\d{7}[A-Z]\z/i
+  # Stripe enforces 7-10 digits on individual.id_number for Colombia — confirmed by Stripe support
+  # on case sco_UyXAayCkurHzCd. Colombia's own document spec (Anexo Técnico 1, Resolución 2011)
+  # allows 6-digit numbers, so the floor excludes Cédula de Extranjería numbers that legitimately
+  # exist; Stripe has that with their product team. Until it moves, reject here rather than let the
+  # save through: a rejected create rolls back with nothing the seller can act on, which is how one
+  # seller reached eight silent failed attempts.
+  COLOMBIA_ID_DIGIT_RANGE = (7..10)
   ENCRYPTED_FIELD_LABELS = {
     individual_tax_id: "Individual tax id",
     ssn_last_four: "Individual tax id",
@@ -110,6 +117,9 @@ class UpdateUserComplianceInfo
 
       singapore_nric_error = singapore_individual_nric_error(old_compliance_info)
       return { success: false, error_message: singapore_nric_error } if singapore_nric_error
+
+      colombia_id_error = colombia_individual_id_error(old_compliance_info)
+      return { success: false, error_message: colombia_id_error } if colombia_id_error
 
       saved, new_compliance_info = if encrypted_compliance_info_params_present?
         dup_and_save_compliance_info(old_compliance_info)
@@ -328,6 +338,14 @@ class UpdateUserComplianceInfo
       # matching what the browser-side check accepts.
       return if submitted.gsub(/[[:space:]-]/, "").match?(SINGAPORE_NRIC_FIN_PATTERN)
       "Your NRIC/FIN must start with S, T, F, G or M and end with a letter (for example, S1234567A). Please enter it exactly as it appears on your ID."
+    end
+
+    def colombia_individual_id_error(old_compliance_info)
+      submitted = submitted_tax_id_for(:individual_tax_id)
+      return if submitted.blank?
+      return unless effective_legal_entity_country_code(old_compliance_info) == Compliance::Countries::COL.alpha2
+      return if COLOMBIA_ID_DIGIT_RANGE.cover?(submitted.gsub(/\D/, "").length)
+      "Your Cédula de Ciudadanía or Cédula de Extranjería must be #{COLOMBIA_ID_DIGIT_RANGE.first}-#{COLOMBIA_ID_DIGIT_RANGE.last} digits. Enter it exactly as it appears on your document — do not add leading zeros, as the number has to match the document you may later be asked to upload."
     end
 
     def effective_legal_entity_country_code(old_compliance_info)

--- a/app/services/update_user_compliance_info.rb
+++ b/app/services/update_user_compliance_info.rb
@@ -276,10 +276,15 @@ class UpdateUserComplianceInfo
     end
 
     def encrypted_compliance_info_changed?(old_compliance_info)
+      raw_individual_tax_id = submitted_tax_id_for(:individual_tax_id).presence || submitted_tax_id_for(:ssn_last_four).presence
       submitted_individual_tax_id = normalize_individual_tax_id(
-        submitted_tax_id_for(:individual_tax_id).presence || submitted_tax_id_for(:ssn_last_four).presence,
+        raw_individual_tax_id,
         country_code: old_compliance_info.legal_entity_country_code,
       )
+      # A value the seller typed that normalizes away entirely ("n/a", "-") counts as a change so
+      # the country guards below get to reject it. Treating it as "nothing changed" would return
+      # success for a save that stored nothing.
+      return true if raw_individual_tax_id.present? && submitted_individual_tax_id.blank?
       return true if submitted_individual_tax_id.present? && encrypted_compliance_info_value(old_compliance_info, :individual_tax_id) != submitted_individual_tax_id
 
       submitted_business_tax_id = normalize_business_tax_id(

--- a/app/services/update_user_compliance_info.rb
+++ b/app/services/update_user_compliance_info.rb
@@ -39,12 +39,6 @@ class UpdateUserComplianceInfo
   # seller gets an actionable error at save time instead. Case-insensitive: Stripe accepts
   # lowercase, so we don't reject it.
   SINGAPORE_NRIC_FIN_PATTERN = /\A[STFGM]\d{7}[A-Z]\z/i
-  # Stripe enforces 7-10 digits on individual.id_number for Colombia (support case
-  # sco_UyXAayCkurHzCd). Colombia's own document spec allows 6 digits, so the floor excludes
-  # Cédula de Extranjería numbers that legitimately exist — Stripe have raised that with their
-  # product team, and this bound should be widened if they change it. Rationale and the
-  # test-mode caveat: app/javascript/utils/colombiaIdNumbers.ts.
-  COLOMBIA_ID_DIGIT_RANGE = (7..10)
   ENCRYPTED_FIELD_LABELS = {
     individual_tax_id: "Individual tax id",
     ssn_last_four: "Individual tax id",
@@ -325,7 +319,7 @@ class UpdateUserComplianceInfo
       # Colombia is the exception: the number is digits-only, sellers paste it with thousands
       # separators, and the length guard counts digits. Storing the separators would send Stripe a
       # longer string than the guard measured, so strip them and keep the two in agreement.
-      return stripped.gsub(/\D/, "") if country_code == Compliance::Countries::COL.alpha2
+      return Compliance::ColombiaIdNumber.normalize(stripped) if country_code == Compliance::Countries::COL.alpha2
       stripped
     end
 
@@ -354,8 +348,8 @@ class UpdateUserComplianceInfo
       submitted = submitted_tax_id_for(:individual_tax_id)
       return if submitted.blank?
       return unless effective_legal_entity_country_code(old_compliance_info) == Compliance::Countries::COL.alpha2
-      return if COLOMBIA_ID_DIGIT_RANGE.cover?(submitted.gsub(/\D/, "").length)
-      "Your Cédula de Ciudadanía or Cédula de Extranjería must be #{COLOMBIA_ID_DIGIT_RANGE.first}-#{COLOMBIA_ID_DIGIT_RANGE.last} digits. Enter it exactly as it appears on your document — do not add leading zeros, as the number has to match the document you may later be asked to upload."
+      return if Compliance::ColombiaIdNumber.valid?(submitted)
+      Compliance::ColombiaIdNumber::ERROR_MESSAGE
     end
 
     def effective_legal_entity_country_code(old_compliance_info)

--- a/app/services/update_user_compliance_info.rb
+++ b/app/services/update_user_compliance_info.rb
@@ -39,12 +39,11 @@ class UpdateUserComplianceInfo
   # seller gets an actionable error at save time instead. Case-insensitive: Stripe accepts
   # lowercase, so we don't reject it.
   SINGAPORE_NRIC_FIN_PATTERN = /\A[STFGM]\d{7}[A-Z]\z/i
-  # Stripe enforces 7-10 digits on individual.id_number for Colombia — confirmed by Stripe support
-  # on case sco_UyXAayCkurHzCd. Colombia's own document spec (Anexo Técnico 1, Resolución 2011)
-  # allows 6-digit numbers, so the floor excludes Cédula de Extranjería numbers that legitimately
-  # exist; Stripe has that with their product team. Until it moves, reject here rather than let the
-  # save through: a rejected create rolls back with nothing the seller can act on, which is how one
-  # seller reached eight silent failed attempts.
+  # Stripe enforces 7-10 digits on individual.id_number for Colombia (support case
+  # sco_UyXAayCkurHzCd). Colombia's own document spec allows 6 digits, so the floor excludes
+  # Cédula de Extranjería numbers that legitimately exist — Stripe have raised that with their
+  # product team, and this bound should be widened if they change it. Rationale and the
+  # test-mode caveat: app/javascript/utils/colombiaIdNumbers.ts.
   COLOMBIA_ID_DIGIT_RANGE = (7..10)
   ENCRYPTED_FIELD_LABELS = {
     individual_tax_id: "Individual tax id",
@@ -193,8 +192,8 @@ class UpdateUserComplianceInfo
       new_compliance_info.business_zip_code =       compliance_params[:business_zip_code]       if compliance_params[:business_zip_code].present?
       new_compliance_info.business_type =           compliance_params[:business_type]           if compliance_params[:business_type].present?
       new_compliance_info.is_business =             compliance_params[:is_business]             unless compliance_params[:is_business].nil?
-      new_compliance_info.individual_tax_id =       normalize_individual_tax_id(submitted_tax_id_for(:ssn_last_four))     if submitted_tax_id_for(:ssn_last_four).present?
-      new_compliance_info.individual_tax_id =       normalize_individual_tax_id(submitted_tax_id_for(:individual_tax_id)) if submitted_tax_id_for(:individual_tax_id).present?
+      new_compliance_info.individual_tax_id =       normalize_individual_tax_id(submitted_tax_id_for(:ssn_last_four), country_code: new_compliance_info.legal_entity_country_code)     if submitted_tax_id_for(:ssn_last_four).present?
+      new_compliance_info.individual_tax_id =       normalize_individual_tax_id(submitted_tax_id_for(:individual_tax_id), country_code: new_compliance_info.legal_entity_country_code) if submitted_tax_id_for(:individual_tax_id).present?
       if submitted_tax_id_for(:business_tax_id).present?
         new_compliance_info.business_tax_id = normalize_business_tax_id(
           submitted_tax_id_for(:business_tax_id),
@@ -278,7 +277,8 @@ class UpdateUserComplianceInfo
 
     def encrypted_compliance_info_changed?(old_compliance_info)
       submitted_individual_tax_id = normalize_individual_tax_id(
-        submitted_tax_id_for(:individual_tax_id).presence || submitted_tax_id_for(:ssn_last_four).presence
+        submitted_tax_id_for(:individual_tax_id).presence || submitted_tax_id_for(:ssn_last_four).presence,
+        country_code: old_compliance_info.legal_entity_country_code,
       )
       return true if submitted_individual_tax_id.present? && encrypted_compliance_info_value(old_compliance_info, :individual_tax_id) != submitted_individual_tax_id
 
@@ -311,12 +311,17 @@ class UpdateUserComplianceInfo
       value.gsub(/[[:space:]-]+/, "")
     end
 
-    def normalize_individual_tax_id(value)
+    def normalize_individual_tax_id(value, country_code: nil)
       return nil if value.blank?
       # Same Unicode-whitespace hazard as normalize_business_tax_id above. Only strip
       # whitespace here — dashes can be a meaningful part of individual IDs (for example
       # Peru DNIs are entered with the verification digit as "12345678-9").
-      value.gsub(/[[:space:]]+/, "")
+      stripped = value.gsub(/[[:space:]]+/, "")
+      # Colombia is the exception: the number is digits-only, sellers paste it with thousands
+      # separators, and the length guard counts digits. Storing the separators would send Stripe a
+      # longer string than the guard measured, so strip them and keep the two in agreement.
+      return stripped.gsub(/\D/, "") if country_code == Compliance::Countries::COL.alpha2
+      stripped
     end
 
     def peru_individual_dni_error(old_compliance_info)

--- a/lib/utilities/compliance/colombia_id_number.rb
+++ b/lib/utilities/compliance/colombia_id_number.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Stripe enforces 7-10 digits on individual.id_number for Colombia (support case
+# sco_UyXAayCkurHzCd). Colombia's own document spec allows 6 digits, so the floor excludes Cédula
+# de Extranjería numbers that legitimately exist — Stripe have raised that with their product team,
+# and this range should be widened if they change it. Test-mode Stripe does NOT enforce the rule, so
+# a local probe cannot re-derive these bounds. Browser copy: app/javascript/utils/colombiaIdNumbers.ts.
+module Compliance
+  module ColombiaIdNumber
+    DIGIT_RANGE = (7..10)
+
+    # Sellers paste the number with the thousands separators printed on the document. Stripe refuses
+    # those, and the length check counts digits, so callers must send what was counted — otherwise a
+    # value that passes the guard reaches Stripe longer than the guard measured.
+    def self.normalize(value)
+      value.to_s.gsub(/\D/, "")
+    end
+
+    def self.valid?(value)
+      DIGIT_RANGE.cover?(normalize(value).length)
+    end
+
+    # Names both documents rather than "your ID", so a foreign resident can tell the message is about
+    # the document they actually hold. Zero-padding is called out because it is the workaround sellers
+    # reach for on their own, and it trades today's block for an id_number_match verification failure
+    # later, once they have a balance.
+    ERROR_MESSAGE = "Your Cédula de Ciudadanía or Cédula de Extranjería must be " \
+                    "#{DIGIT_RANGE.first}-#{DIGIT_RANGE.last} digits. Enter it exactly as it appears " \
+                    "on your document — do not add leading zeros, as the number has to match the " \
+                    "document you may later be asked to upload."
+  end
+end

--- a/spec/business/payments/merchant_registration/stripe/stripe_beneficial_owners_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_beneficial_owners_manager_spec.rb
@@ -182,6 +182,48 @@ describe StripeBeneficialOwnersManager do
       expect { described_class.create(user, params) }.to raise_error(Stripe::InvalidRequestError, /exceed 100/)
     end
 
+    context "when the seller's legal entity is in Colombia" do
+      let(:colombia_params) { params.deep_dup.tap { |p| p[:address] = { line1: "Cra 7 #71", city: "Bogotá", state: "DC", postal_code: "110231", country: "CO" } } }
+
+      before do
+        # alive_user_compliance_info reads the newest alive row, so this supersedes the UK one the
+        # outer before block created without touching the shared merchant account.
+        user.alive_user_compliance_info.mark_deleted!
+        create(:user_compliance_info_business, user:, business_country: "Colombia", country: "Colombia")
+      end
+
+      it "rejects an ID whose digit count is outside Stripe's range even though it fits the input's character limit" do
+        # 11 characters, so the form's maxLength of 13 accepts it, but only 6 digits.
+        separated_six_digits = colombia_params.deep_dup.tap { |p| p[:id_number] = "4.8.2.9.1.3" }
+        expect(Stripe::Account).not_to receive(:create_person)
+        expect { described_class.create(user, separated_six_digits) }
+          .to raise_error(StripeBeneficialOwnersManager::InvalidFieldError, /Cédula de Ciudadanía or Cédula de Extranjería must be 7-10 digits/)
+      end
+
+      it "rejects a bare 6-digit Cédula de Extranjería and an 11-digit number" do
+        %w[482913 12345678901].each do |value|
+          out_of_range = colombia_params.deep_dup.tap { |p| p[:id_number] = value }
+          expect { described_class.create(user, out_of_range) }
+            .to raise_error(StripeBeneficialOwnersManager::InvalidFieldError)
+        end
+      end
+
+      it "sends Stripe the digits it counted, not the separators the seller typed" do
+        pasted = colombia_params.deep_dup.tap { |p| p[:id_number] = "1.123.456.789" }
+        expect(Stripe::Account).to receive(:create_person) do |_account_id, attrs|
+          expect(attrs[:id_number]).to eq("1123456789")
+          other_owner_person
+        end
+        described_class.create(user, pasted)
+      end
+
+      it "accepts an in-range ID" do
+        valid = colombia_params.deep_dup.tap { |p| p[:id_number] = "1020304050" }
+        expect(Stripe::Account).to receive(:create_person).and_return(other_owner_person)
+        expect { described_class.create(user, valid) }.not_to raise_error
+      end
+    end
+
     it "raises NotEligibleError for ineligible users" do
       allow(user).to receive(:stripe_account).and_return(nil)
       expect { described_class.create(user, params) }.to raise_error(StripeBeneficialOwnersManager::NotEligibleError)

--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -2406,8 +2406,8 @@ describe("Payments Settings Scenario", type: :system, js: true) do
         fill_in("Bank Code", with: "060")
         fill_in("Account #", with: "000123456789")
         fill_in("Confirm account #", with: "000123456789")
-        # A seven-digit value: the shape of a Cédula de Extranjería, the ID issued to foreign
-        # residents of Colombia. It used to be rejected by the field's exact 13-character length.
+        # Seven digits: the shortest Cédula de Ciudadanía or Cédula de Extranjería number Stripe
+        # accepts for Colombia. Shorter numbers exist and are refused by Stripe, not by us.
         fill_in("Cédula de Ciudadanía (CC) or Cédula de Extranjería (CE)", with: "1234567")
 
         expect(page).to have_content("Must exactly match the name on your bank account")

--- a/spec/services/update_user_compliance_info_spec.rb
+++ b/spec/services/update_user_compliance_info_spec.rb
@@ -724,19 +724,21 @@ describe UpdateUserComplianceInfo do
         expect(user.reload.alive_user_compliance_info.id).to eq(original.id)
       end
 
-      it "warns against zero-padding, which is the workaround sellers reach for" do
+      it "cannot detect a zero-padded number, so the message is what warns against it" do
         user = create_colombian_individual_user(individual_tax_id: "1234567")
 
-        params = ActionController::Parameters.new(is_business: false, individual_tax_id: "482913")
+        # Padding a 6-digit number to seven satisfies Stripe's length rule, so no guard can catch
+        # it: the number simply stops matching the document and fails id_number_match verification
+        # later, once the seller has a balance. Pinned as passing so the limitation is visible
+        # rather than assumed, and so the warning in the message stays load-bearing.
+        params = ActionController::Parameters.new(is_business: false, individual_tax_id: "0482913")
+
+        expect(StripeMerchantAccountManager).to receive(:handle_new_user_compliance_info)
 
         result = described_class.new(compliance_params: params, user:).process
 
-        expect(result[:success]).to be false
-        # Padding a short number to seven digits does satisfy Stripe's length rule, so we cannot
-        # detect it here — the stored number would simply stop matching the document, and the
-        # account would fail id_number_match verification later, after the seller has a balance.
-        # The message is the only place we can head that off.
-        expect(result[:error_message]).to include("do not add leading zeros")
+        expect(result[:success]).to be true
+        expect(expected_error).to include("do not add leading zeros")
       end
 
       it "rejects a number longer than Stripe's upper bound" do
@@ -775,6 +777,22 @@ describe UpdateUserComplianceInfo do
         result = described_class.new(compliance_params: params, user:).process
 
         expect(result[:success]).to be true
+      end
+
+      it "stores a separator-formatted number as digits only, matching what the guard counted" do
+        user = create_colombian_individual_user(individual_tax_id: "1234567")
+
+        params = ActionController::Parameters.new(is_business: false, individual_tax_id: "1.123.456.789")
+
+        expect(StripeMerchantAccountManager).to receive(:handle_new_user_compliance_info)
+
+        described_class.new(compliance_params: params, user:).process
+
+        # The guard measures digits, and StripeMerchantAccountManager sends this value to Stripe
+        # verbatim. Storing "1.123.456.789" would hand Stripe a 13-character string the guard had
+        # judged as 10 digits, so what is stored has to be what was counted.
+        stored = user.reload.alive_user_compliance_info.individual_tax_id.decrypt("1234")
+        expect(stored).to eq("1123456789")
       end
 
       it "leaves other countries' individual tax IDs alone" do

--- a/spec/services/update_user_compliance_info_spec.rb
+++ b/spec/services/update_user_compliance_info_spec.rb
@@ -847,8 +847,8 @@ describe UpdateUserComplianceInfo do
         # value this service then refuses, or refuse one it would accept.
         helper = Rails.root.join("app/javascript/utils/colombiaIdNumbers.ts").read
 
-        expect(helper).to include("COLOMBIA_ID_MIN_DIGITS = #{described_class::COLOMBIA_ID_DIGIT_RANGE.first}")
-        expect(helper).to include("COLOMBIA_ID_MAX_DIGITS = #{described_class::COLOMBIA_ID_DIGIT_RANGE.last}")
+        expect(helper).to include("COLOMBIA_ID_MIN_DIGITS = #{Compliance::ColombiaIdNumber::DIGIT_RANGE.first}")
+        expect(helper).to include("COLOMBIA_ID_MAX_DIGITS = #{Compliance::ColombiaIdNumber::DIGIT_RANGE.last}")
 
         # The browser builds its copy by interpolating those two constants, so comparing the
         # invariant part of the sentence is what catches a reworded message on one side only.

--- a/spec/services/update_user_compliance_info_spec.rb
+++ b/spec/services/update_user_compliance_info_spec.rb
@@ -687,6 +687,126 @@ describe UpdateUserComplianceInfo do
       end
     end
 
+    context "with a Colombian individual" do
+      def create_colombian_individual_user(individual_tax_id:)
+        create(:user).tap do |u|
+          create(
+            :user_compliance_info,
+            user: u,
+            country: "Colombia",
+            state: nil,
+            city: "Medellin",
+            zip_code: "050022",
+            individual_tax_id:,
+          )
+        end
+      end
+
+      let(:expected_error) do
+        "Your Cédula de Ciudadanía or Cédula de Extranjería must be 7-10 digits. Enter it exactly as it appears on your document — do not add leading zeros, as the number has to match the document you may later be asked to upload."
+      end
+
+      it "rejects a six-digit Cédula de Extranjería, which Stripe refuses" do
+        user = create_colombian_individual_user(individual_tax_id: "1234567")
+        original = user.alive_user_compliance_info
+
+        params = ActionController::Parameters.new(is_business: false, individual_tax_id: "482913")
+
+        expect(StripeMerchantAccountManager).not_to receive(:handle_new_user_compliance_info)
+
+        result = nil
+        expect do
+          result = described_class.new(compliance_params: params, user:).process
+        end.not_to change { UserComplianceInfo.count }
+
+        expect(result[:success]).to be false
+        expect(result[:error_message]).to eq(expected_error)
+        expect(user.reload.alive_user_compliance_info.id).to eq(original.id)
+      end
+
+      it "warns against zero-padding, which is the workaround sellers reach for" do
+        user = create_colombian_individual_user(individual_tax_id: "1234567")
+
+        params = ActionController::Parameters.new(is_business: false, individual_tax_id: "482913")
+
+        result = described_class.new(compliance_params: params, user:).process
+
+        expect(result[:success]).to be false
+        # Padding a short number to seven digits does satisfy Stripe's length rule, so we cannot
+        # detect it here — the stored number would simply stop matching the document, and the
+        # account would fail id_number_match verification later, after the seller has a balance.
+        # The message is the only place we can head that off.
+        expect(result[:error_message]).to include("do not add leading zeros")
+      end
+
+      it "rejects a number longer than Stripe's upper bound" do
+        user = create_colombian_individual_user(individual_tax_id: "1234567")
+
+        params = ActionController::Parameters.new(is_business: false, individual_tax_id: "12345678901")
+
+        expect(StripeMerchantAccountManager).not_to receive(:handle_new_user_compliance_info)
+
+        result = described_class.new(compliance_params: params, user:).process
+
+        expect(result[:success]).to be false
+        expect(result[:error_message]).to eq(expected_error)
+      end
+
+      it "accepts a seven-digit number and stores it exactly as entered" do
+        user = create_colombian_individual_user(individual_tax_id: "1234567")
+
+        params = ActionController::Parameters.new(is_business: false, individual_tax_id: "4829137")
+
+        expect(StripeMerchantAccountManager).to receive(:handle_new_user_compliance_info)
+
+        result = described_class.new(compliance_params: params, user:).process
+
+        expect(result[:success]).to be true
+        expect(user.reload.alive_user_compliance_info.individual_tax_id.decrypt("1234")).to eq("4829137")
+      end
+
+      it "accepts a ten-digit number entered with thousands separators" do
+        user = create_colombian_individual_user(individual_tax_id: "1234567")
+
+        params = ActionController::Parameters.new(is_business: false, individual_tax_id: "1.123.456.789")
+
+        expect(StripeMerchantAccountManager).to receive(:handle_new_user_compliance_info)
+
+        result = described_class.new(compliance_params: params, user:).process
+
+        expect(result[:success]).to be true
+      end
+
+      it "leaves other countries' individual tax IDs alone" do
+        user = create(:user).tap do |u|
+          create(:user_compliance_info, user: u, country: "Uruguay", individual_tax_id: "482913")
+        end
+
+        params = ActionController::Parameters.new(is_business: false, individual_tax_id: "482914", city: "Montevideo")
+
+        result = described_class.new(compliance_params: params, user:).process
+
+        expect(result[:success]).to be true
+      end
+
+      it "ignores a masked resubmission while saving other edited fields" do
+        user = create_colombian_individual_user(individual_tax_id: "4829137")
+
+        # The city differs from the stored record so the save path actually runs — otherwise the
+        # service early-returns "nothing changed" before the guard executes.
+        params = ActionController::Parameters.new(
+          is_business: false,
+          individual_tax_id: "•••9137",
+          city: "Bogotá",
+        )
+
+        result = described_class.new(compliance_params: params, user:).process
+
+        expect(result[:success]).to be true
+        expect(user.reload.alive_user_compliance_info.city).to eq("Bogotá")
+      end
+    end
+
     context "with a non-US business" do
       def create_ie_business_user(business_tax_id:)
         create(:user).tap do |u|
@@ -854,7 +974,9 @@ describe UpdateUserComplianceInfo do
 
     context "when Stripe rejects the account" do
       let(:user) { create(:user) }
-      let(:params) { ActionController::Parameters.new(is_business: false, individual_tax_id: "123456") }
+      # Seven digits so the submission clears our own Colombia length guard and actually reaches
+      # Stripe — these examples are about what we keep when Stripe rejects, not about the length.
+      let(:params) { ActionController::Parameters.new(is_business: false, individual_tax_id: "1234567") }
 
       before do
         create(:user_compliance_info, user:, country: "Colombia", individual_tax_id: "0000000000000")

--- a/spec/services/update_user_compliance_info_spec.rb
+++ b/spec/services/update_user_compliance_info_spec.rb
@@ -805,6 +805,21 @@ describe UpdateUserComplianceInfo do
         expect(result[:success]).to be true
         expect(user.reload.alive_user_compliance_info.city).to eq("Bogotá")
       end
+
+      it "keeps the browser's bounds and message identical to this guard's" do
+        # The same rule is enforced in the browser so the seller gets the error before a round
+        # trip. Two copies can drift silently, and the drift is invisible: the form would accept a
+        # value this service then refuses, or refuse one it would accept.
+        helper = Rails.root.join("app/javascript/utils/colombiaIdNumbers.ts").read
+
+        expect(helper).to include("COLOMBIA_ID_MIN_DIGITS = #{described_class::COLOMBIA_ID_DIGIT_RANGE.first}")
+        expect(helper).to include("COLOMBIA_ID_MAX_DIGITS = #{described_class::COLOMBIA_ID_DIGIT_RANGE.last}")
+
+        # The browser builds its copy by interpolating those two constants, so comparing the
+        # invariant part of the sentence is what catches a reworded message on one side only.
+        expect(helper).to include("digits. Enter it exactly as it appears on your document")
+        expect(helper).to include("do not add leading zeros")
+      end
     end
 
     context "with a non-US business" do

--- a/spec/services/update_user_compliance_info_spec.rb
+++ b/spec/services/update_user_compliance_info_spec.rb
@@ -795,6 +795,23 @@ describe UpdateUserComplianceInfo do
         expect(stored).to eq("1123456789")
       end
 
+      it "refuses a value that is not a number at all, rather than reporting success" do
+        user = create_colombian_individual_user(individual_tax_id: "1234567")
+        original = user.alive_user_compliance_info
+
+        # "n/a" normalizes to an empty string, which would otherwise read as "nothing changed" and
+        # early-return success for a save that stored nothing.
+        params = ActionController::Parameters.new(is_business: false, individual_tax_id: "n/a")
+
+        expect(StripeMerchantAccountManager).not_to receive(:handle_new_user_compliance_info)
+
+        result = described_class.new(compliance_params: params, user:).process
+
+        expect(result[:success]).to be false
+        expect(result[:error_message]).to eq(expected_error)
+        expect(user.reload.alive_user_compliance_info.id).to eq(original.id)
+      end
+
       it "leaves other countries' individual tax IDs alone" do
         user = create(:user).tap do |u|
           create(:user_compliance_info, user: u, country: "Uruguay", individual_tax_id: "482913")


### PR DESCRIPTION
## What

Stops the Colombian personal-ID field on Settings → Payments from accepting numbers Stripe will refuse.

Stripe enforces 7-10 digits on `individual.id_number` for Colombia. Our form advertised `minLength: 6, maxLength: 13`, so a seller could enter a value we already knew the processor would reject — and the rejection surfaced only as a merchant-account create that rolled back, leaving nothing they could act on.

- New `Compliance::ColombiaIdNumber` (`lib/utilities/compliance/colombia_id_number.rb`) and `app/javascript/utils/colombiaIdNumbers.ts` hold the bounds, the digit-count check, the normalizer, and the error copy — one rule per language rather than a copy per call site, pinned against each other by a spec.
- `UpdateUserComplianceInfo` gains `colombia_individual_id_error`, alongside the existing Peru and Singapore guards. This is the load-bearing one for the seller's own ID: the settings controller is the only writer of `individual_tax_id`, and browser-side length attributes are bypassable.
- `StripeBeneficialOwnersManager` gains the same guard on `create` and `update`, next to the existing JP kana checks. Beneficial owners are a separate writer that reaches Stripe without going through `UpdateUserComplianceInfo` at all.
- Colombian values are normalized to digits before storage and before being sent. The guard counts digits after stripping separators, but both `StripeMerchantAccountManager.person_hash` and `StripeBeneficialOwnersManager.build_person_params` sent the string verbatim — so `1.123.456.789` used to pass as ten digits and reach Stripe as thirteen characters. Storing and sending what was counted removes the assumption rather than relying on Stripe to strip separators. Peru's dash stays meaningful, so the branch is Colombia-only.
- `AccountDetailsSection.tsx` and `BeneficialOwnersSection.tsx` read the shared constants; `Settings/Payments/Show.tsx` and the beneficial-owner form both run the client-side check so the seller sees the error before a round trip.


The message names both documents rather than "your ID", so a foreign resident can tell it is about the document they hold, and it tells them not to zero-pad a short number.

## Why

A Colombian seller (foreign resident, 6-digit Cédula de Extranjería) made eight merchant-account attempts over three days. Every one was created and soft-deleted in the same second with `charge_processor_merchant_id` nil, and until #6476 shipped we discarded the Stripe error, so nothing on his account said which field was at fault. Once the breadcrumb landed, two fresh attempts both recorded `param=individual[id_number] — That ID number does not appear to be valid`.

Stripe support confirmed the 7-10 rule on case `sco_UyXAayCkurHzCd` and have raised it with their product team, because Colombia's own document spec (Anexo Técnico 1, Resolución 2011) permits 6-digit numbers — so their floor excludes IDs that legitimately exist. Until that moves, refusing the value up front with a message beats a silent rollback.

Two notes on scope, because this raises our floor from 6 to 7 and that deserves to be explicit:

- It does **not** unblock the seller who prompted it. Stripe separately state they cannot pay individual accounts verified with Cédula de Extranjería at all; that question is still open with them. This PR stops the next CE holder from burning eight attempts to discover the problem, and nothing more.
- It should not outlive Stripe's fix. The bound lives in one named constant with the reasoning attached, so widening it later is a one-line change.

Tracking issue: antiwork/gumroad-private#1429

## Before / After

Not applicable — no rendered surface changes. The diff adds a validation guard and swaps two hardcoded numbers for named constants; the field, its label, and its placeholder render identically. The user-visible change is an error message that appears on a value which previously produced a silent rollback, and that path needs live Stripe to reach.

## Test plan

Server-side, `spec/services/update_user_compliance_info_spec.rb` — **55 examples, 0 failures**, 10 of them new:

- 6-digit CE refused, no new `UserComplianceInfo` row, `StripeMerchantAccountManager` never called, existing row untouched
- 11-digit value refused
- 7-digit and dotted 10-digit values accepted and stored as entered
- a dotted value stored as digits only, so Stripe receives what the guard measured
- a value that is not a number at all refused, rather than reported as a successful save
- a zero-padded number pinned as **passing**, documenting that no guard can catch it and the message is the only defence
- another country's ID of the same length unaffected
- a masked resubmission still saves unrelated edits
- the browser's constants and message pinned against the server's

Browser-side, `app/javascript/utils/colombiaIdNumbers.test.ts` — 6 examples covering the accepted lengths, the 6-digit rejection, the upper bound, separator handling, a 13-character-but-6-digit value, and empty input.

Beneficial-owner path, `spec/business/payments/merchant_registration/stripe/stripe_beneficial_owners_manager_spec.rb` — 4 new examples: the 11-character/6-digit value asserting `create_person` is never reached, a bare 6-digit and an 11-digit refusal, the payload assertion that Stripe receives `1123456789` rather than `1.123.456.789`, and an in-range control.

Every guard is proven load-bearing, not just green:

| mutation | result |
|---|---|
| remove the `colombia_individual_id_error` call from `#process` | 3 examples fail |
| revert `COLOMBIA_ID_MIN_DIGITS` to 6 | 2 unit tests fail |
| drift the browser constant away from the server's | the parity example fails, naming the expected value |
| neuter the digits-only normalization for CO | the storage example fails, and only that one |
| remove the normalizes-away guard | the non-numeric example fails, and only that one |
| make the CO branch fire for every country | Peru's dash and Singapore's NRIC examples fail |
| remove `validate_colombia_id_number!` and the CO normalization from the beneficial-owner path | 3 of the 4 new examples fail; the in-range control stays green |

Local caveat, stated rather than rounded off: `spec/requests/settings/payments_spec.rb` has 6 failing examples in my worktree and `stripe_beneficial_owners_manager_spec.rb` has 1. I ran the same 7 example IDs on the untouched branch head and got an identical failing list, 7 for 7 — pre-existing local harness state (a leftover `MerchantAccount` row and Capybara `visit` timeouts), not this diff. CI is the authority; those shards were green on the previous head.


## Review

Two rounds of local adversarial review ran on the branch before this PR opened; the second returned READY-TO-MERGE.

Round 1's substantive finding was the separator issue: the guard counted digits while storage kept the separators, and my own spec asserted success with Stripe mocked — codifying exactly the kind of unverified processor assumption this PR exists to remove. Fixing it meant touching the shared `normalize_individual_tax_id`, which is the highest-blast-radius edit here, so round 2 reviewed that specifically. It confirmed Peru's dash and Singapore's alphanumeric NRIC survive (by mutation, not inspection) and that US sellers are byte-identical.

Round 2 then found a regression the separator fix had introduced: a typed value of only non-digits normalized to empty, read as "nothing changed", and returned success before any guard ran. Fixed in the last commit with a spec that fails if the guard is removed.

Round 3 came from Greptile, after the PR opened, and it found a real bug of the same class: `BeneficialOwnersSection` read the shared constants but nothing ran the digit check on that path, and `StripeBeneficialOwnersManager.build_person_params` forwarded `id_number` to Stripe with only whitespace stripped. So a Colombian business seller adding a beneficial owner could send `4.8.2.9.1.3` — 11 characters, inside the field's limits, six digits — and get the same rolled-back create with nothing actionable. I had updated that component's bounds two commits earlier and did not check whether it had a validator behind it. Fixed in `b703a3eaa` with the guard, the normalization, the browser check, and four examples; disposition in the thread.

Two findings I declined, deliberately. The length check accepts letters (`abc1234567` is seven digits) — Peru's guard has the identical hole, so tightening it here is a separate change rather than a quiet deviation from convention, and the digits-only normalization already stops letters reaching Stripe. And legacy Colombian rows stored with separators are not migrated: they self-heal when the seller next retypes the number, and sizing a one-off cleanup needs a production count I would rather take from a real query than guess at.


Two honest caveats:

- `spec/requests/settings/payments_spec.rb -e "CO creator"` times out on `visit` in my worktree — and does so identically on unmodified main (107s vs 109s), so it is environmental here, not this diff. CI covers it.
- I probed test-mode Stripe to try to re-derive the bounds and it **accepted every length**, including 6 and 11 digits. Test mode does not run the ID validator, so it cannot confirm or refute the rule; the 7-10 range rests on live-mode probes and Stripe's own confirmation. That caveat is now a comment in the helper so the next person does not repeat the probe and draw the wrong conclusion.

## QA steps

Colombia has no preview-app path that reaches the real validator (test-mode Stripe accepts anything), so this is the console check:

1. On a seller whose compliance country is Colombia, submit `individual_tax_id: "482913"` through `UpdateUserComplianceInfo`. Expect `success: false` and the 7-10 digit message, with no new `UserComplianceInfo` row.
2. Submit `"4829137"`. Expect `success: true` and the value stored verbatim.
3. Submit `"1.123.456.789"`. Expect `success: true` — separators are cosmetic, the digit count is the bound.
4. On a non-Colombian seller, submit a 6-digit ID and confirm it is unaffected.
5. On a Colombian **business** seller, call `StripeBeneficialOwnersManager.create` with `id_number: "4.8.2.9.1.3"`. Expect `InvalidFieldError` with the 7-10 digit message and no Stripe call. Repeat with `"1.123.456.789"` and expect Stripe to receive `1123456789`.


## Blast radius

Colombia only, and only on the input path. `submitted_tax_id_for` returns nil for blank and masked values, and `compliance_info_details` never sends the raw tax ID to the client — so an existing Colombian seller with a now-invalid stored number can still save unrelated settings, because the form does not echo the value back. `UserComplianceInfo`'s own completeness check tests `present?` only, so it is indifferent to digit count.

There are two writers that reach Stripe with a Colombian ID, not one. `grep -rn "individual_tax_id" app lib --include=*.rb` confirms the settings controller is the only writer of the *stored* `individual_tax_id` — but `StripeBeneficialOwnersManager` sends a caller-supplied `id_number` straight to `Stripe::Account.create_person`/`update_person` without storing it, so that grep never surfaced it. An earlier revision of this section claimed a single writer on the strength of that grep; Greptile found the second path, and both are now guarded. The lesson worth carrying: "who writes the column" and "who sends the field to the processor" are different questions, and the second is the one that matters for a processor-validation guard.

The guard keys off `effective_legal_entity_country_code`, so it also covers a Colombian business account's representative. That is correct rather than incidental: `StripeMerchantAccountManager.person_hash` sends the same `personal_tax_id` as `id_number` for any non-US legal entity, and its own comment records that Stripe validates the field against the account country. The representative branch of the beneficial-owner `update` is deliberately exempt — `build_representative_update_params` sends only relationship fields and never touches `id_number`.


Scope boundary worth stating: the same config map holds 18 other countries, and I have **not** verified their advertised bounds against Stripe — doing so needs a live-mode probe per country, since test mode does not run the validator. Colombia is the one with confirmed evidence (a support case and two recorded rejections), so it is the one this PR changes. Two things I did check across the map: no country's frontend floor is stricter than its server rule, and Peru's `minLength: 10` against a 9-digit server rule is the same character-versus-digit distinction handled here, not a bug.

---

## AI disclosure

Written by `claude-opus-5` (`model.default` in `~/.hermes/config.yaml`) running as Gumclaw.

Instructions given: a maintainer replied "1 and 2." on antiwork/gumroad-private#1429, selecting two items from a decision list I had put to him — take the Colombia ID validation gap to Stripe, and fix our own advertised bounds. Item 1 was already done (Stripe case `sco_UyXAayCkurHzCd`); this PR is item 2. No further direction was given on approach; the choice to enforce server-side beside the existing Peru and Singapore guards, to share the bounds through one helper, and to pin the two copies against each other was mine, as was the decision to state plainly that this does not unblock the originating seller.

