### PR TITLE
Document that EU physical shipments are not charged VAT at checkout

### DIFF
--- a/app/models/help_center/articles.yml
+++ b/app/models/help_center/articles.yml
@@ -322,7 +322,7 @@
 - id: 200
   slug: "200-i-need-a-vat-refund"
   title: "I need a VAT refund"
-  description: "We are required by the EU and UK law to collect and remit VAT on all transactions made in the EU and UK respectively. If you are a business with a valid VAT num"
+  description: "We are required by EU and UK law to collect and remit VAT on transactions made in the EU and UK respectively. The one exception is physical products shipped to"
   category_id: <%= HelpCenter::Category::RECEIPTS_AND_REFUNDS.id %>
 - id: 203
   slug: "203-why-did-my-payment-fail"

--- a/app/views/help_center/articles/contents/_10-dealing-with-vat.html.erb
+++ b/app/views/help_center/articles/contents/_10-dealing-with-vat.html.erb
@@ -21,9 +21,10 @@
   <p>This will also reduce e-publications in the UK down to 0%.</p>
   <p>If you are unsure if your product qualifies as an e-publication for reduced VAT rates, please contact a local tax accountant. </p>
   <h3>Physical products shipped to the EU</h3>
-  <p>Gumroad does not charge VAT at checkout on physical products shipped to a buyer in an EU country. A parcel arriving from outside the EU is an import, so the customs authority in the destination country collects import VAT when it arrives. Charging VAT at checkout as well would mean the buyer paid the same VAT twice.</p>
-  <p>The buyer pays that import VAT to customs or to the carrier delivering the parcel, not to Gumroad, and the carrier is who provides any paperwork for it. Nothing changes in how you set up or price a physical product.</p>
-  <p>Physical products shipped to the UK are not affected. Gumroad still collects UK VAT at checkout on those orders.</p>
+  <p>Gumroad does not charge VAT at checkout on physical products shipped to a buyer in an EU country. What happens after that depends on where the parcel ships from.</p>
+  <p>If it ships from outside the EU, its arrival is an import, so the customs authority in the destination country collects import VAT then. The buyer pays that to customs or to the carrier delivering the parcel, not to Gumroad, and the carrier is who provides any paperwork for it. Charging VAT at checkout as well would mean the buyer paid the same VAT twice.</p>
+  <p>If it ships from one EU country to another, there is no import and no customs charge, so nothing is added to the order at checkout or on arrival. Whether the sale itself carries a VAT obligation for you depends on your own registration and on your country's rules for selling goods to buyers in other EU countries, so speak to a local tax accountant if you ship physical products within the EU.</p>
+  <p>Nothing changes in how you set up or price a physical product. Physical products shipped to the UK are not affected either — Gumroad still collects UK VAT at checkout on those orders.</p>
   <h3>Frequently asked questions</h3>
   <p><strong>I am registered for VAT in my EU country or in the UK - why do you have to charge VAT to my customers? </strong></p>
   <ul>

--- a/app/views/help_center/articles/contents/_10-dealing-with-vat.html.erb
+++ b/app/views/help_center/articles/contents/_10-dealing-with-vat.html.erb
@@ -20,6 +20,10 @@
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/63b6b228bfe3f971fb093bd0/file-0xO68phTOC.png" %></figure>
   <p>This will also reduce e-publications in the UK down to 0%.</p>
   <p>If you are unsure if your product qualifies as an e-publication for reduced VAT rates, please contact a local tax accountant. </p>
+  <h3>Physical products shipped to the EU</h3>
+  <p>Gumroad does not charge VAT at checkout on physical products shipped to a buyer in an EU country. A parcel arriving from outside the EU is an import, so the customs authority in the destination country collects import VAT when it arrives. Charging VAT at checkout as well would mean the buyer paid the same VAT twice.</p>
+  <p>The buyer pays that import VAT to customs or to the carrier delivering the parcel, not to Gumroad, and the carrier is who provides any paperwork for it. Nothing changes in how you set up or price a physical product.</p>
+  <p>Physical products shipped to the UK are not affected. Gumroad still collects UK VAT at checkout on those orders.</p>
   <h3>Frequently asked questions</h3>
   <p><strong>I am registered for VAT in my EU country or in the UK - why do you have to charge VAT to my customers? </strong></p>
   <ul>

--- a/app/views/help_center/articles/contents/_121-sales-tax-on-gumroad.html.erb
+++ b/app/views/help_center/articles/contents/_121-sales-tax-on-gumroad.html.erb
@@ -2,7 +2,7 @@
   <p><em><strong>Disclaimer:</strong></em><em> This article is neither legal advice nor tax advice. We recommend that you speak to your tax advisor with any questions or concerns about tax reporting.</em></p>
   <h3>Gumroad as Merchant of Record</h3>
   <p>Gumroad now acts as the Merchant of Record for all sales. This means we automatically handle all sales tax collection and remittance worldwide. You don't need to manage any tax settings or applications - we take care of everything.</p>
-  <p>One exception: we do not charge VAT at checkout on physical products shipped to a buyer in an EU country. Those parcels are imports, so customs in the destination country collects import VAT on arrival instead. See <a href="10-dealing-with-vat">EU &amp; UK VAT on Gumroad</a>.</p>
+  <p>Physical products are treated differently in some countries. One case is the EU: we do not charge VAT at checkout on physical products shipped to a buyer in an EU country. Those parcels are imports, so customs in the destination country collects import VAT on arrival instead. See <a href="10-dealing-with-vat">EU &amp; UK VAT on Gumroad</a>.</p>
   <h3>Reseller Certificate</h3>
   <p>Some creators may have an obligation to file sales tax (or other indirect tax) returns already, and will need to report their sales on Gumroad as "sales to other retailers for purposes of resale", which are not taxable. To justify this treatment to your tax authority, you will need to download and save <a href="/Gumroad-CA-Resale%20Certificate-01JAN25.pdf">this Reseller Certificate</a>.</p>
 </div>

--- a/app/views/help_center/articles/contents/_121-sales-tax-on-gumroad.html.erb
+++ b/app/views/help_center/articles/contents/_121-sales-tax-on-gumroad.html.erb
@@ -2,9 +2,7 @@
   <p><em><strong>Disclaimer:</strong></em><em> This article is neither legal advice nor tax advice. We recommend that you speak to your tax advisor with any questions or concerns about tax reporting.</em></p>
   <h3>Gumroad as Merchant of Record</h3>
   <p>Gumroad now acts as the Merchant of Record for all sales. This means we automatically handle all sales tax collection and remittance worldwide. You don't need to manage any tax settings or applications - we take care of everything.</p>
-  <h3>Physical products shipped into the EU</h3>
-  <p>There is one exception. When a physical product ships to a buyer in an EU country, we do not charge VAT at checkout. A parcel arriving from outside the EU is an import, and the destination country's customs authority assesses the import VAT itself when the parcel arrives, so the buyer pays it there. Collecting it at checkout as well would mean the buyer pays the same VAT twice.</p>
-  <p>This applies to the 27 EU member states. Physical shipments to the United Kingdom, Norway, Australia, and Singapore still have VAT or GST collected at checkout, because those countries allow the marketplace to collect it on lower-value consignments. Higher-value shipments to any country can still be assessed at the border, so check the import rules for the destination country. Digital products are unaffected and still have VAT collected at checkout everywhere it applies.</p>
+  <p>One exception: we do not charge VAT at checkout on physical products shipped to a buyer in an EU country. Those parcels are imports, so customs in the destination country collects import VAT on arrival instead. See <a href="10-dealing-with-vat">EU &amp; UK VAT on Gumroad</a>.</p>
   <h3>Reseller Certificate</h3>
   <p>Some creators may have an obligation to file sales tax (or other indirect tax) returns already, and will need to report their sales on Gumroad as "sales to other retailers for purposes of resale", which are not taxable. To justify this treatment to your tax authority, you will need to download and save <a href="/Gumroad-CA-Resale%20Certificate-01JAN25.pdf">this Reseller Certificate</a>.</p>
 </div>

--- a/app/views/help_center/articles/contents/_121-sales-tax-on-gumroad.html.erb
+++ b/app/views/help_center/articles/contents/_121-sales-tax-on-gumroad.html.erb
@@ -2,7 +2,7 @@
   <p><em><strong>Disclaimer:</strong></em><em> This article is neither legal advice nor tax advice. We recommend that you speak to your tax advisor with any questions or concerns about tax reporting.</em></p>
   <h3>Gumroad as Merchant of Record</h3>
   <p>Gumroad now acts as the Merchant of Record for all sales. This means we automatically handle all sales tax collection and remittance worldwide. You don't need to manage any tax settings or applications - we take care of everything.</p>
-  <p>Physical products are treated differently in some countries. One case is the EU: we do not charge VAT at checkout on physical products shipped to a buyer in an EU country. Those parcels are imports, so customs in the destination country collects import VAT on arrival instead. See <a href="10-dealing-with-vat">EU &amp; UK VAT on Gumroad</a>.</p>
+  <p>Physical products are treated differently in some countries. One case is the EU: we do not charge VAT at checkout on physical products shipped to a buyer in an EU country. If the parcel ships from outside the EU, customs in the destination country collects import VAT on arrival instead; if it ships from one EU country to another there is no import, so nothing is collected on arrival either. See <a href="10-dealing-with-vat">EU &amp; UK VAT on Gumroad</a>.</p>
   <h3>Reseller Certificate</h3>
   <p>Some creators may have an obligation to file sales tax (or other indirect tax) returns already, and will need to report their sales on Gumroad as "sales to other retailers for purposes of resale", which are not taxable. To justify this treatment to your tax authority, you will need to download and save <a href="/Gumroad-CA-Resale%20Certificate-01JAN25.pdf">this Reseller Certificate</a>.</p>
 </div>

--- a/app/views/help_center/articles/contents/_200-i-need-a-vat-refund.html.erb
+++ b/app/views/help_center/articles/contents/_200-i-need-a-vat-refund.html.erb
@@ -7,7 +7,8 @@
   <p>If you need anything else on your invoice, please write it in the "Additional notes" box before you generate your invoice. Gumroad cannot change or adjust invoices, so be sure to add anything your tax office might need there.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/64b8b7a5a9d61472afe090d1/file-6vYr2YX72h.png" %></figure>
   <h3>Physical products shipped to the EU</h3>
-  <p>Gumroad does not charge VAT at checkout on a physical product shipped to you in an EU country, so there is no VAT on that order for us to refund. Import VAT on the parcel is collected by customs in your country, or by the carrier delivering it, when the parcel arrives.</p>
+  <p>Gumroad does not charge VAT at checkout on a physical product shipped to you in an EU country, so there is no VAT on that order for us to refund.</p>
+  <p>If the parcel is coming from outside the EU, its arrival is an import: customs in your country, or the carrier delivering it, collects import VAT at that point and provides the paperwork for it. If it is shipping to you from inside the EU there is no import, so nothing is collected on arrival either.</p>
   <p>If you were charged VAT at checkout on a physical order shipped to the EU and customs also charged you import VAT on the same parcel, <a href="20-how-do-i-contact-gumroad">contact us</a> with your receipt and we will refund the VAT we collected.</p>
 </div>
 <div>

--- a/app/views/help_center/articles/contents/_200-i-need-a-vat-refund.html.erb
+++ b/app/views/help_center/articles/contents/_200-i-need-a-vat-refund.html.erb
@@ -1,15 +1,14 @@
 <div>
-  <p>We are required by the EU and UK law to collect and remit VAT on the transactions we are responsible for: every digital purchase in the EU and the UK, and physical items shipped to the UK. Physical items shipped into an EU country are imports, so no VAT is charged at checkout on those — see below.</p>
+  <p>We are required by EU and UK law to collect and remit VAT on transactions made in the EU and UK respectively. The one exception is physical products shipped to the EU, covered at the bottom of this article.</p>
   <p>If you are a business with a valid VAT number, please enter it at the time of checkout and you won’t be charged VAT on the purchase.</p>
-  <h3>Physical items shipped into the EU</h3>
-  <p>If you bought a physical item that ships to you in an EU country, you will not see VAT on your Gumroad receipt. The parcel is an import, so your own customs authority assesses the import VAT when it arrives and you pay it there rather than at checkout. That charge comes from customs or the carrier, not from Gumroad, and there is nothing to refund on our side.</p>
-  <p>If you were charged VAT at checkout on a physical item shipped into the EU and customs also charged you import VAT on the same parcel, <a href="/help/article/196-contact-gumroad" target="_blank">contact us</a> with your receipt and the customs paperwork and we will refund the VAT we collected.</p>
-  <h3>Requesting a refund with your VAT ID</h3>
   <p>If you’ve already made your purchase without giving your VAT ID, you can request a refund by generating an invoice from your emailed receipt.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/65b0e4b487e88924b5fa2015/file-5q7QumzVdW.png" %></figure>
   <p>Enter your VAT ID there and we will automatically initiate a refund for the VAT you paid. The refund will take 2-3 days to show on your statement and the invoice will be displayed without VAT.</p>
   <p>If you need anything else on your invoice, please write it in the "Additional notes" box before you generate your invoice. Gumroad cannot change or adjust invoices, so be sure to add anything your tax office might need there.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/64b8b7a5a9d61472afe090d1/file-6vYr2YX72h.png" %></figure>
+  <h3>Physical products shipped to the EU</h3>
+  <p>Gumroad does not charge VAT at checkout on a physical product shipped to you in an EU country, so there is no VAT on that order for us to refund. Import VAT on the parcel is collected by customs in your country, or by the carrier delivering it, when the parcel arrives.</p>
+  <p>If you were charged VAT at checkout on a physical order shipped to the EU and customs also charged you import VAT on the same parcel, <a href="20-how-do-i-contact-gumroad">contact us</a> with your receipt and we will refund the VAT we collected.</p>
 </div>
 <div>
   <h3>Related Articles</h3>


### PR DESCRIPTION
## What

Documents the checkout behavior shipped in #6593: Gumroad no longer charges VAT at checkout on physical products shipped to a buyer in an EU member state. Three articles change.

- `10-dealing-with-vat` (creator-facing) gains a "Physical products shipped to the EU" section: no VAT at checkout regardless of origin, then the two cases split. Shipped from outside the EU, the arrival is an import and customs collects import VAT, paid to customs or the carrier rather than to Gumroad. Shipped from one EU country to another, there is no import and nothing is collected on arrival — whether that sale carries a VAT obligation for the creator depends on their own registration and their country's rules, so it points at a local tax accountant rather than asserting an answer. Nothing changes in product setup, and the UK is explicitly unaffected.
- `200-i-need-a-vat-refund` (buyer-facing) gains the same section scoped to a refund request, plus a corrected opening line. The article opened with "we collect and remit VAT on all transactions made in the EU and UK", which is no longer true. It also tells a buyer who WAS charged VAT at checkout on an EU physical order and then charged import VAT at the border to contact support for a refund, which is the path support already follows.
- `121-sales-tax-on-gumroad` says Gumroad handles tax collection "worldwide" with no exceptions. One sentence names physical products as the exception and links to article 10. It avoids calling the EU rule the *only* exception, because `336-singaporean-gst` already exempts physical products from Singaporean GST.

`articles.yml` changes only article 200's `description`, because that snippet quoted the now-wrong opening sentence verbatim.

## Why

#6593 changed what buyers are charged, so the help center now describes checkout wrongly in three places. Article 200 is the sharpest: a buyer looking for a VAT refund on a physical EU order was being told VAT is always collected, when as of that deploy it is not, and the refund they may actually be owed comes from customs paperwork or from support for historical orders rather than from the VAT-ID flow the article walks through.

The UK carve-out is stated explicitly because the UK sits inside `EU_VAT_APPLICABLE_COUNTRY_CODES` and #6593 excluded it deliberately: Gumroad holds `GUMROAD_UK_VAT_REGISTRATION`, and for consignments at or under £135 the marketplace collects at checkout with the border not charging again. A doc that said "the EU" without naming the UK would read as a change to UK orders that did not happen. Norway, Australia and Singapore fall outside the EU membership check on their own and their articles were checked: `336-singaporean-gst` already says physical products are exempt from Singaporean GST, so it needs no edit.

Wording is scoped to what the code does. `eu_import_vat_unremittable?` short-circuits only when the product is physical, the rate is Gumroad's rather than a seller-supplied one, and the destination is in `EU_VAT_APPLICABLE_COUNTRY_CODES` other than the UK — so the docs say nothing about digital products, about seller-supplied rates, or about US and Canadian orders, none of which changed.

The suppression keys on the **buyer's** country only: `SalesTaxCalculator` is handed no creator or dispatch country, and `tax_rate` comes from `buyer_location[:country]` in `calculate_with_lookup_table`. An EU creator shipping to an EU buyer therefore takes the same path with no import and no customs event, so the copy splits the imported-parcel case from the intra-EU case rather than promising every EU buyer a customs charge. For the intra-EU case it states only what the platform does (nothing is added at checkout or on arrival) and refers the creator to a local tax accountant for their own obligation, which the code does not determine.

Deliberately omitted: the £135 UK, NOK 3,000 Norwegian, A$1,000 Australian and S$400 Singaporean consignment thresholds are not implemented in the code, so above those values the border charges regardless of what happened at checkout. That is pre-existing and out of scope in #6593, and documenting a threshold the product does not enforce would be wrong.

Triggering PR: antiwork/gumroad#6593. Tracking issue: antiwork/gumroad-private#1513.

## Before / After

Not applicable — help-center article body copy, no rendered application surface changes. The three edited partials render correctly (verified below).

## Test Results

Ran from a throwaway worktree off `origin/main`:

```
$ bundle exec rspec spec/models/help_center
1 example, 0 failures

$ bundle exec rails runner -e test '... ApplicationController.render(partial: ...)'
10-dealing-with-vat: render OK (4565 bytes)
121-sales-tax-on-gumroad: render OK (1589 bytes)
200-i-need-a-vat-refund: render OK (2285 bytes)
```

Also checked: `articles.yml` parses with ERB stripped (128 articles, slug `200-i-need-a-vat-refund` present), all three partials compile as ERB, and HTML tag balance holds per tag in each edited file.

## QA steps

1. Visit `help.gumroad.com/help/article/10-dealing-with-vat` and confirm the new "Physical products shipped to the EU" section renders between the e-publications section and the FAQ.
2. Visit `help.gumroad.com/help/article/200-i-need-a-vat-refund` and confirm the opening sentence names the physical-EU exception and the new section appears after the invoice screenshot.
3. Visit `help.gumroad.com/help/article/121-sales-tax-on-gumroad` and confirm the exception sentence renders under "Gumroad as Merchant of Record", and that its link to `10-dealing-with-vat` resolves.
4. Search the help center for "physical VAT" and confirm article 200's preview snippet shows the updated description.

## Review notes

This is tax wording that gets quoted back to us, so the sentences worth a second read are article 200's "there is no VAT on that order for us to refund", article 10's split between "the buyer pays that to customs or to the carrier delivering the parcel, not to Gumroad" for imports and "there is no import and no customs charge" for intra-EU shipments, and article 10's referral to a local tax accountant for an intra-EU creator's own VAT obligation. All describe the post-#6593 state, not the historical one — buyers with pre-deploy orders were charged, which is why article 200 keeps a contact-support path.

---

## AI disclosure

Written by claude-opus-5 running as the Hermes agent, triggered automatically by the merge of #6593 via the merged-PR help-center sync route. Instructions given: check whether the merged PR changes anything documented in the help center, map it to the specific affected articles, and edit them to match the shipped behavior without guessing at facts — reading `sales_tax_calculator.rb` and the #6593 diff for every claim rather than the PR prose. No human authored or reviewed the copy before this PR was opened.

