### PR TITLE
Scope the VAT collection statement in the VAT refund article

### DIFF
--- a/app/views/help_center/articles/contents/_200-i-need-a-vat-refund.html.erb
+++ b/app/views/help_center/articles/contents/_200-i-need-a-vat-refund.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <p>We are required by the EU and UK law to collect and remit VAT on all transactions made in the EU and UK respectively.</p>
+  <p>We are required by the EU and UK law to collect and remit VAT on the transactions we are responsible for: every digital purchase in the EU and the UK, and physical items shipped to the UK. Physical items shipped into an EU country are imports, so no VAT is charged at checkout on those — see below.</p>
   <p>If you are a business with a valid VAT number, please enter it at the time of checkout and you won’t be charged VAT on the purchase.</p>
   <h3>Physical items shipped into the EU</h3>
   <p>If you bought a physical item that ships to you in an EU country, you will not see VAT on your Gumroad receipt. The parcel is an import, so your own customs authority assesses the import VAT when it arrives and you pay it there rather than at checkout. That charge comes from customs or the carrier, not from Gumroad, and there is nothing to refund on our side.</p>


### PR DESCRIPTION
## What

The "I need a VAT refund" help center article opened with "We are required by the EU and UK law to collect and remit VAT on all transactions made in the EU and UK respectively." That line now scopes VAT collection to the cases we actually collect on: digital purchases in the EU and the UK, and physical items shipped to the UK, with a pointer to the physical-import section directly below it.

## Why

antiwork/gumroad#6593 stopped charging EU VAT at checkout on physical products shipped into the EU-27, and antiwork/gumroad#6598 added a "Physical items shipped into the EU" section to this article explaining that. The unchanged opening line contradicted that new section, so a buyer reading top to bottom got two different answers about whether their EU physical order should have had VAT on it. Follow-up to #6598, addressing Greptile's P2 review finding on that PR (posted after it merged).

The other three articles touched by #6598 do not have this problem: `_10-dealing-with-vat` already scopes its statement to digital products, and `_121-sales-tax-on-gumroad` / `_282-how-do-purchases-work-for-my-customers` carry the exception inline.

## Before / after

| | Before | After |
|---|---|---|
| Opening line | "…collect and remit VAT on all transactions made in the EU and UK respectively." | "…on the transactions we are responsible for: every digital purchase in the EU and the UK, and physical items shipped to the UK. Physical items shipped into an EU country are imports, so no VAT is charged at checkout on those — see below." |
| Reader's takeaway | Contradicts the physical-import section below | Consistent with it |

## Test plan

Help center specs pass locally on the branch:

```
bundle exec rspec spec/services/help_center/article_text_spec.rb \
  spec/controllers/help_center/articles_controller_spec.rb
32 examples, 0 failures
```

ERB tag balance verified identical to `origin/main` for the edited file (22 open / 19 close both sides).

No UI surface changes beyond the article copy itself — the page renders the same markup structure with one paragraph reworded.

---

## AI disclosure

Written by claude-opus-5 running as the Hermes agent. Instructions given: triage the Greptile review that arrived on antiwork/gumroad#6598 after it merged, verify the finding against the merged code, and if real, fix it in a follow-up PR and reply on the original review thread.
