### PR TITLE
Note EU VAT-exempt territories in the VAT refund article

### DIFF
--- a/app/views/help_center/articles/contents/_200-i-need-a-vat-refund.html.erb
+++ b/app/views/help_center/articles/contents/_200-i-need-a-vat-refund.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <p>We are required by the EU and UK law to collect and remit VAT on the transactions we are responsible for: every digital purchase in the EU and the UK, and physical items shipped to the UK. Physical items shipped into an EU country are imports, so no VAT is charged at checkout on those — see below.</p>
+  <p>We are required by the EU and UK law to collect and remit VAT on the transactions we are responsible for: every digital purchase in the EU and the UK, and physical items shipped to the UK. A few EU territories sit outside the EU VAT area — the Canary Islands, for example — and purchases made from there are not charged VAT at checkout. Physical items shipped into an EU country are imports, so no VAT is charged at checkout on those — see below.</p>
   <p>If you are a business with a valid VAT number, please enter it at the time of checkout and you won’t be charged VAT on the purchase.</p>
   <h3>Physical items shipped into the EU</h3>
   <p>If you bought a physical item that ships to you in an EU country, you will not see VAT on your Gumroad receipt. The parcel is an import, so your own customs authority assesses the import VAT when it arrives and you pay it there rather than at checkout. That charge comes from customs or the carrier, not from Gumroad, and there is nothing to refund on our side.</p>


### PR DESCRIPTION
## What

The "I need a VAT refund" help center article opens by saying VAT is collected on "every digital purchase in the EU and the UK". That is not what checkout does for a handful of EU territories that sit outside the EU VAT area: `SalesTaxCalculator#is_vat_exempt?` returns early and applies zero tax when the buyer's IP geocodes to a region in `Compliance::VAT_EXEMPT_REGIONS` (currently `["Canarias", "Canary Islands"]`). This adds that carve-out to the opening paragraph.

## Why

Follow-up to #6599, addressing Greptile's review on that PR (it landed after the merge). A buyer in the Canary Islands reading the old wording would expect VAT on their receipt, not find it, and write in — or, worse, request a "VAT refund" for VAT that was never charged. The article should describe the outcome checkout actually produces.

Only the Canary Islands are named because that is the only territory the calculator currently implements; the wording ("a few EU territories… the Canary Islands, for example") stays correct if the list is expanded.

## Before / After

**Before:** "…every digital purchase in the EU and the UK, and physical items shipped to the UK. Physical items shipped into an EU country are imports…"

**After:** "…every digital purchase in the EU and the UK, and physical items shipped to the UK. A few EU territories sit outside the EU VAT area — the Canary Islands, for example — and purchases made from there are not charged VAT at checkout. Physical items shipped into an EU country are imports…"

## Test plan

Docs-only change to a static ERB help-center partial — one paragraph of copy, no code, no logic, no tests to affect. Verified tag balance on the edited file (7 `<p>`/7 `</p>`, 2 `<div>`/2 `</div>`) and verified the claim against source: `app/business/sales_tax/sales_tax_calculator.rb:213,221-230` and `lib/utilities/compliance.rb:21`.

---

## AI disclosure

Written by Hermes Agent running `claude-opus-5`. Instructions given: triage the Greptile review that landed on merged PR #6599, verify the finding against the sales-tax calculator source, and if real, ship the correction as a follow-up PR from fresh `main`.
