### PR TITLE
Freeze the clock around the mobile subscription-products assertion

### DIFF
--- a/spec/controllers/api/mobile/purchases_controller_spec.rb
+++ b/spec/controllers/api/mobile/purchases_controller_spec.rb
@@ -142,10 +142,15 @@ describe Api::Mobile::PurchasesController do
 
       # Both subscriptions should appear in the response
 
-      get :index, params: @params
-      expect(response.parsed_body).to include({ success: true,
-                                                products: [dead_subscription_purchase.json_data_for_mobile, subscription_purchase.json_data_for_mobile],
-                                                user_id: @purchaser.external_id }.as_json(api_scopes: ["mobile_api"]))
+      # The expectation re-renders json_data_for_mobile after the request, and the
+      # payload carries updated_at. Since prices touch their link (#6573), a write
+      # between the two renders can move it — freeze the clock so they agree.
+      freeze_time do
+        get :index, params: @params
+        expect(response.parsed_body).to include({ success: true,
+                                                 products: [dead_subscription_purchase.json_data_for_mobile, subscription_purchase.json_data_for_mobile],
+                                                 user_id: @purchaser.external_id }.as_json(api_scopes: ["mobile_api"]))
+      end
     end
 
     it "does not return unsuccessful purchases" do

--- a/spec/controllers/api/mobile/purchases_controller_spec.rb
+++ b/spec/controllers/api/mobile/purchases_controller_spec.rb
@@ -148,8 +148,8 @@ describe Api::Mobile::PurchasesController do
       freeze_time do
         get :index, params: @params
         expect(response.parsed_body).to include({ success: true,
-                                                 products: [dead_subscription_purchase.json_data_for_mobile, subscription_purchase.json_data_for_mobile],
-                                                 user_id: @purchaser.external_id }.as_json(api_scopes: ["mobile_api"]))
+                                                  products: [dead_subscription_purchase.json_data_for_mobile, subscription_purchase.json_data_for_mobile],
+                                                  user_id: @purchaser.external_id }.as_json(api_scopes: ["mobile_api"]))
       end
     end
 

--- a/spec/controllers/api/mobile/purchases_controller_spec.rb
+++ b/spec/controllers/api/mobile/purchases_controller_spec.rb
@@ -122,7 +122,10 @@ describe Api::Mobile::PurchasesController do
       expect(response.parsed_body[:products][0][:thumbnail_url]).to eq(asset_preview.url)
     end
 
-    it "displays subscription products" do
+    # The expectation re-renders json_data_for_mobile after the request, and the payload
+    # carries updated_at. Since prices touch their link (#6573), a write during setup or
+    # the request can move it — freeze the whole example so every read agrees.
+    it "displays subscription products", :freeze_time do
       # Alive Subscription
       subscription = create(:subscription, link: @subscription_product, user: @purchaser)
       subscription_purchase = create(:purchase, link: @subscription_product,
@@ -142,15 +145,10 @@ describe Api::Mobile::PurchasesController do
 
       # Both subscriptions should appear in the response
 
-      # The expectation re-renders json_data_for_mobile after the request, and the
-      # payload carries updated_at. Since prices touch their link (#6573), a write
-      # between the two renders can move it — freeze the clock so they agree.
-      freeze_time do
-        get :index, params: @params
-        expect(response.parsed_body).to include({ success: true,
-                                                  products: [dead_subscription_purchase.json_data_for_mobile, subscription_purchase.json_data_for_mobile],
-                                                  user_id: @purchaser.external_id }.as_json(api_scopes: ["mobile_api"]))
-      end
+      get :index, params: @params
+      expect(response.parsed_body).to include({ success: true,
+                                                products: [dead_subscription_purchase.json_data_for_mobile, subscription_purchase.json_data_for_mobile],
+                                                user_id: @purchaser.external_id }.as_json(api_scopes: ["mobile_api"]))
     end
 
     it "does not return unsuccessful purchases" do


### PR DESCRIPTION
## Why

`spec/controllers/api/mobile/purchases_controller_spec.rb:125` ("displays subscription products") started failing on branches that touch nothing under `api/mobile`. It is currently red on #6523 (`Test Fast 16`) and was red on #6526, on both attempts each — so not a rerun-able flake in the usual sense, but not those branches' code either.

The field-level diff is one field out of ~80: the membership product's `updated_at` is exactly one second behind the expectation, while `created_at` and `content_updated_at` match.

Cause: #6573 (merged to `main` at 05:19Z today) added `Price belongs_to :link, touch: true` and the variant-side equivalent. The spec renders the response, then rebuilds its expectation by calling `json_data_for_mobile` **again**. A price-row write between the two renders now moves `links.updated_at`, where before it could not. If the two reads straddle a second boundary, the expectation disagrees with the response.

Filed as #6607. Fixing it here rather than from either affected branch, because it belongs with the `touch:` that caused it.

## What

Tag the example `:freeze_time` so the whole example — setup included — runs under one clock. `spec/spec_helper.rb:400` already wraps `:freeze_time` examples in an `around` hook, which covers the `before` blocks too. No production code touched.

An earlier revision froze only the request and assertion; setup stayed on the real clock and the skew still reproduced.

I chose freezing over dropping `updated_at` from the comparison because the assertion's value is that it compares the *whole* mobile payload — narrowing it to dodge one field would quietly stop covering the rest of `json_data_for_mobile` in future.

## Verification

Ran locally in a worktree at this head with MySQL and Elasticsearch up:

- `spec/controllers/api/mobile/purchases_controller_spec.rb -e "displays subscription products"` — 3 consecutive runs, 0 failures
- the whole file — 64 examples, 0 failures
- `rubocop` on the file — no offenses

The failure is timing-dependent, so green runs are supporting evidence rather than proof; the argument is the mechanism (one clock across setup, request and assertion).

## Notes

Written by gumclaw (AI agent). Not armed for auto-merge — this is yours to merge.

