### PR TITLE
Require page reads before Store Agent writes

### DIFF
--- a/app/services/ai/store_agent_api_catalog.rb
+++ b/app/services/ai/store_agent_api_catalog.rb
@@ -17,7 +17,8 @@
 #
 # Path templates use :name placeholders filled from the tool call's `path_params`. `params` lists the
 # query (reads) or body (writes) keys the endpoint accepts. `forced_params` holds catalog-owned values
-# applied to a read regardless of model input. For writes, `params` is load-bearing: a proposed body
+# applied to a read regardless of model input. `requires_read` names the full-read endpoint a write
+# must follow for the same target and turn. For writes, `params` is load-bearing: a proposed body
 # carrying a key not listed here is refused (see StoreAgentService and StoreAgentActionExecutor),
 # because the v2 API silently ignores unknown body keys — a misnamed key (e.g. `price_cents` instead
 # of `price`) would otherwise drop the value the model meant to send and fail downstream with a
@@ -25,7 +26,7 @@
 # is exactly what the system-prompt manifest teaches the model, so the agent only drives the surface
 # it was told about.
 module Ai::StoreAgentApiCatalog
-  Endpoint = Struct.new(:id, :method, :path, :read, :scope, :admin_only, :summary, :path_params, :params, :forced_params, keyword_init: true) do
+  Endpoint = Struct.new(:id, :method, :path, :read, :scope, :admin_only, :summary, :path_params, :params, :forced_params, :requires_read, keyword_init: true) do
     def read? = read == true
     def write? = !read?
 
@@ -69,7 +70,7 @@ module Ai::StoreAgentApiCatalog
     # then fails downstream with a confusing validation error. Both the propose path (service) and
     # the confirm path (executor) refuse such bodies up front using this list.
     def unknown_param_keys(body)
-      (body || {}).keys.map(&:to_s) - params
+      (body || {}).keys.map(&:to_s) - params - forced_params.keys
     end
 
     # The corrective message for a body carrying undeclared keys, or nil when the body is fine.
@@ -80,14 +81,27 @@ module Ai::StoreAgentApiCatalog
       unknown = unknown_param_keys(body)
       return nil if unknown.empty?
 
-      accepted = params.any? ? "this endpoint accepts: #{params.join(', ')}" : "this endpoint accepts no params"
+      accepted_params = (params + forced_params.keys).uniq
+      accepted = accepted_params.any? ? "this endpoint accepts: #{accepted_params.join(', ')}" : "this endpoint accepts no params"
       "Unknown param#{"s" if unknown.size > 1} #{unknown.join(', ')} for #{id}; #{accepted}."
     end
   end
 
   # Build one endpoint row. read defaults to false (i.e. a write that must be confirmed).
-  def self.ep(id, method, path, summary, read: false, scope: nil, admin_only: false, path_params: [], params: [], forced_params: {})
-    Endpoint.new(id:, method:, path:, read:, scope:, admin_only:, summary:, path_params:, params:, forced_params: forced_params.transform_keys(&:to_s).freeze)
+  def self.ep(id, method, path, summary, read: false, scope: nil, admin_only: false, path_params: [], params: [], forced_params: {}, requires_read: nil)
+    Endpoint.new(
+      id:,
+      method:,
+      path:,
+      read:,
+      scope:,
+      admin_only:,
+      summary:,
+      path_params:,
+      params:,
+      forced_params: forced_params.transform_keys(&:to_s).freeze,
+      requires_read:,
+    )
   end
 
   ENDPOINTS = [
@@ -108,8 +122,8 @@ module Ai::StoreAgentApiCatalog
     # his own live page was not there, was "actually Products, not Albums", and was his browser cache
     # (gumroad-private#1466). The heading was his own section header all along.
     ep("get_user_profile_layout", :get, "/user/profile_layout", "Get the layout of the creator's DEFAULT storefront profile: their tabs, the sections in each tab, and each section's heading (the <h2> the visitor sees above it). Use this for questions about the default profile's tabs, sections, or headings. A standalone page is a different surface; use list_pages and get_page for that. On a store with no custom HTML this layout is still creator-owned, and get_user_custom_html returning nothing does NOT mean the profile is Gumroad's untouched default. rendering says which surface the visitor actually sees (custom_html takes over the whole storefront when published). tab_bar_visible is false when there is only one tab, because the public profile hides the tab bar until there are two — that is why a creator's single named tab appears to have vanished. The creator edits all of this in the dashboard; you have no endpoint to change it.", read: true, scope: "view_profile"),
-    ep("update_user_custom_html", :patch, "/user/custom_html", "Replace the creator's ENTIRE profile custom HTML with a new page. Destructive: anything not included in custom_html is lost, and the page becomes the whole storefront — so it must show everything the store shows: render all products (with working links) dynamically from the gumroad-data JSON injected into every served page — and when products_total exceeds the products array's length, or posts_total exceeds the posts array's length, that list is capped, so the page must show the count for that section rather than silently omitting the rest — plus the creator's name and bio via data-gumroad-field elements the server fills at render time (they are NOT in the JSON). Only use this to author a brand-new page; to change part of an existing page, use edit_user_custom_html.", scope: "edit_profile", params: %w[custom_html]),
-    ep("edit_user_custom_html", :post, "/user/custom_html/edit", "Make a targeted edit to the creator's existing profile custom HTML: replaces one exact snippet (find) with new HTML (replace) and leaves the rest of the page untouched. find must match the current HTML exactly once — include enough surrounding context. Always prefer this over update_user_custom_html when a page already exists.", scope: "edit_profile", params: %w[find replace]),
+    ep("update_user_custom_html", :patch, "/user/custom_html", "Replace the creator's ENTIRE profile custom HTML with a new page. Destructive: anything not included in custom_html is lost, and the page becomes the whole storefront — so it must show everything the store shows: render all products (with working links) dynamically from the gumroad-data JSON injected into every served page — and when products_total exceeds the products array's length, or posts_total exceeds the posts array's length, that list is capped, so the page must show the count for that section rather than silently omitting the rest — plus the creator's name and bio via data-gumroad-field elements the server fills at render time (they are NOT in the JSON). Only use this to author a brand-new page; to change part of an existing page, use edit_user_custom_html.", scope: "edit_profile", params: %w[custom_html], requires_read: "get_user_custom_html"),
+    ep("edit_user_custom_html", :post, "/user/custom_html/edit", "Make a targeted edit to the creator's existing profile custom HTML: replaces one exact snippet (find) with new HTML (replace) and leaves the rest of the page untouched. find must match the current HTML exactly once — include enough surrounding context. Always prefer this over update_user_custom_html when a page already exists.", scope: "edit_profile", params: %w[find replace], requires_read: "get_user_custom_html"),
 
     # ---- Standalone storefront pages (first-class Pages, addressed by slug) ----
     # A separate surface from the profile root above: additional pages a creator publishes under
@@ -167,8 +181,8 @@ module Ai::StoreAgentApiCatalog
     # deliberately does NOT accept custom_html, so every full-page write flows through the id whose
     # summary carries that warning.
     ep("get_product_custom_html", :get, "/products/:id/custom_html", "Get a product's custom landing page HTML (the /l/ page buyers see). has_landing_page says whether a custom page is currently published; when it is false the product serves its native Gumroad page.", read: true, scope: "view_sales", path_params: %w[id]),
-    ep("update_product_custom_html", :put, "/products/:id", "Replace a product's ENTIRE custom landing page with a new page (or clear it by sending blank custom_html, restoring the native product page). Destructive: anything not included in custom_html is lost. A published page REPLACES the product's native page — price and buy button included — so the page MUST contain a buy element like <a data-gumroad-action=\"buy\">Buy now</a>; publishing HTML without one makes the product unpurchasable. The server fills elements marked data-gumroad-field=\"name\", \"price\", or \"description\" with live product values on every render. Product pages do NOT receive the gumroad-data JSON (that exists only on profile pages). Only use this to author a brand-new page; to change part of an existing page, use edit_product_custom_html.", scope: "edit_products", path_params: %w[id], params: %w[custom_html]),
-    ep("edit_product_custom_html", :post, "/products/:id/custom_html/edit", "Make a targeted edit to a product's existing custom landing page: replaces one exact snippet (find) with new HTML (replace) and leaves the rest of the page untouched. find must match the current HTML exactly once — include enough surrounding context. Always prefer this over update_product_custom_html when a page already exists. Keep the page's buy element intact — a page without one makes the product unpurchasable.", scope: "edit_products", path_params: %w[id], params: %w[find replace]),
+    ep("update_product_custom_html", :put, "/products/:id", "Replace a product's ENTIRE custom landing page with a new page (or clear it by sending blank custom_html, restoring the native product page). Destructive: anything not included in custom_html is lost. A published page REPLACES the product's native page — price and buy button included — so the page MUST contain a buy element like <a data-gumroad-action=\"buy\">Buy now</a>; publishing HTML without one makes the product unpurchasable. The server fills elements marked data-gumroad-field=\"name\", \"price\", or \"description\" with live product values on every render. Product pages do NOT receive the gumroad-data JSON (that exists only on profile pages). Only use this to author a brand-new page; to change part of an existing page, use edit_product_custom_html.", scope: "edit_products", path_params: %w[id], params: %w[custom_html], requires_read: "get_product_custom_html"),
+    ep("edit_product_custom_html", :post, "/products/:id/custom_html/edit", "Make a targeted edit to a product's existing custom landing page: replaces one exact snippet (find) with new HTML (replace) and leaves the rest of the page untouched. find must match the current HTML exactly once — include enough surrounding context. Always prefer this over update_product_custom_html when a page already exists. Keep the page's buy element intact — a page without one makes the product unpurchasable.", scope: "edit_products", path_params: %w[id], params: %w[find replace], requires_read: "get_product_custom_html"),
 
     # ---- Custom fields (per product) ----
     ep("list_custom_fields", :get, "/products/:link_id/custom_fields", "List a product's custom fields.", read: true, scope: "view_sales", path_params: %w[link_id]),
@@ -289,7 +303,8 @@ module Ai::StoreAgentApiCatalog
     list.map do |e|
       pp = e.path_params.any? ? " (path: #{e.path_params.join(', ')})" : ""
       bp = e.params.any? ? " (params: #{e.params.join(', ')})" : ""
-      "- #{e.id}#{pp}#{bp}: #{e.summary}"
+      precondition = e.requires_read.present? ? " (requires a successful #{e.requires_read} for the same target in this turn)" : ""
+      "- #{e.id}#{pp}#{bp}#{precondition}: #{e.summary}"
     end.join("\n")
   end
 end

--- a/app/services/ai/store_agent_service.rb
+++ b/app/services/ai/store_agent_service.rb
@@ -40,6 +40,7 @@ class Ai::StoreAgentService
   # below when the normal budget no longer has room for them.
   MAX_TOOL_ITERATIONS = 25
   MAX_MESSAGE_LENGTH = 2_000
+  MISSING_REQUIRED_READ_MESSAGE = "Store agent write proposal blocked by missing required full read"
   # Anthropic requires max_tokens on every request. This cap has to fit more than a brief chat
   # reply: when the agent edits a product, the model must emit the ENTIRE new value (for example a
   # long description's full HTML) inside the tool call's JSON arguments. A cap sized only for text
@@ -641,6 +642,8 @@ class Ai::StoreAgentService
     proposed_action = nil
     # Display objects collected from the read calls this turn, rendered inline as cards in the chat.
     @objects = []
+    @completed_read_targets = {}
+    @reads_completed_in_tool_batch = nil
     turn_contract_retries = 0
 
     remaining_iterations = MAX_TOOL_ITERATIONS
@@ -705,6 +708,8 @@ class Ai::StoreAgentService
     last_user_message = conversation.reverse.find { |m| m[:role] == "user" }&.dig(:content).to_s
     proposed_action = nil
     @objects = []
+    @completed_read_targets = {}
+    @reads_completed_in_tool_batch = nil
     turn_contract_retries = 0
 
     remaining_iterations = MAX_TOOL_ITERATIONS
@@ -925,6 +930,10 @@ class Ai::StoreAgentService
       end
       conversation << { role: "assistant", content: assistant_content }
 
+      # A read only satisfies a write precondition after its result has gone back to the model.
+      # Otherwise the model could request a read and a speculative write in the same tool-use batch,
+      # before it had seen the page it was supposed to preserve.
+      @reads_completed_in_tool_batch = {}
       tool_results = tool_uses.map do |tool_use|
         arguments = sanitize_param_hash(tool_use[:input])
         result, action = run_tool(name: tool_use[:name], arguments:)
@@ -940,6 +949,8 @@ class Ai::StoreAgentService
         end
         { type: "tool_result", tool_use_id: tool_use[:id], content: result.to_json }
       end
+      @completed_read_targets.merge!(@reads_completed_in_tool_batch)
+      @reads_completed_in_tool_batch = nil
       conversation << { role: "user", content: tool_results }
 
       proposed_action
@@ -1118,10 +1129,16 @@ class Ai::StoreAgentService
       end
 
       path = endpoint.expand_path(arguments["path_params"])
+      params = sanitize_param_hash(arguments["params"])
+      if (error = endpoint.unknown_param_keys_error(params))
+        return [{ error: }, nil]
+      end
+
       # Catalog-owned values win over model input, so a specialized read can share a controller
       # route without exposing its fixed query contract to the model or adding endpoint-id branches.
-      params = sanitize_param_hash(arguments["params"]).merge(endpoint.forced_params)
+      params.merge!(endpoint.forced_params)
       result = api_client.get(path, params)
+      record_successful_read(endpoint:, expanded_path: path, result:)
       # Collect any renderable objects from the response so the chat can show them inline as cards.
       @objects.concat(Ai::StoreAgentObjectFormatter.from_response(endpoint, result)) if @objects
       [result, nil]
@@ -1158,6 +1175,42 @@ class Ai::StoreAgentService
         return [{ error: e.message }, nil]
       end
 
+      if endpoint.requires_read.present?
+        required_read = Ai::StoreAgentApiCatalog.find(endpoint.requires_read)
+        unless required_read&.read?
+          raise Error, "Catalog endpoint #{endpoint.id} requires invalid read endpoint #{endpoint.requires_read}"
+        end
+
+        required_path = required_read.expand_path(path_params)
+        required_target = [required_read.id, required_path]
+        unless @completed_read_targets&.key?(required_target)
+          log_missing_required_read(endpoint:, required_read:)
+          return [
+            {
+              error: "#{endpoint.id} requires a successful full read of this exact target first. Only if the seller explicitly requested this custom-page work, call #{required_read.id} with api_read, wait for its result, then retry #{endpoint.id} in this turn. Otherwise, do not read the page body and do not retry the write. Status or metadata-only reads do not count.",
+              corrective_action: {
+                condition: "The seller explicitly requested this custom-page work.",
+                if_requested: {
+                  tool: "api_read",
+                  endpoint: required_read.id,
+                  path_params: path_params.slice(*required_read.path_params),
+                  after_success: {
+                    action: "retry_write",
+                    endpoint: endpoint.id,
+                    timing: "this_turn",
+                  },
+                },
+                otherwise: {
+                  action: "do_not_read_or_retry",
+                  instruction: "Do not read the page body and do not retry the write.",
+                },
+              },
+            },
+            nil,
+          ]
+        end
+      end
+
       # Refuse to stage a body carrying keys the endpoint doesn't declare. The v2 API silently
       # ignores unknown body keys, so without this check a write like create_product with
       # "price_cents" (instead of the declared "price") sails through to the API missing its real
@@ -1180,6 +1233,38 @@ class Ai::StoreAgentService
         fields: write_fields(endpoint, path_params, body),
       )
       [{ proposed: true, summary: }, action]
+    end
+
+    # A read precondition is satisfied only by a successful response from the exact catalog endpoint
+    # and expanded target path the write names. A status endpoint may share the same HTTP route, but
+    # its distinct catalog id cannot unlock a body-changing write.
+    def record_successful_read(endpoint:, expanded_path:, result:)
+      return unless successful_api_read?(result)
+
+      (@reads_completed_in_tool_batch || @completed_read_targets)[[endpoint.id, expanded_path]] = true
+    end
+
+    def successful_api_read?(result)
+      return false unless result.is_a?(Hash)
+      return false if result["success"] == false || result[:success] == false
+
+      status = result["http_status"] || result[:http_status]
+      status.blank? || status.to_i.between?(200, 299)
+    end
+
+    # Keep the message fixed in both logs and Sentry so every blocked proposal groups together.
+    # Endpoint ids and the catalog path template are safe structured context. Never report the
+    # expanded path because its model-supplied target id could contain seller text. The notifier
+    # also strips ambient request data from this event.
+    def log_missing_required_read(endpoint:, required_read:)
+      Rails.logger.warn(MISSING_REQUIRED_READ_MESSAGE)
+      ErrorNotifier.notify(
+        MISSING_REQUIRED_READ_MESSAGE,
+        exclude_request_context: true,
+        write_endpoint: endpoint.id,
+        required_read_endpoint: required_read.id,
+        required_read_path: required_read.path,
+      )
     end
 
     # A human-readable description of the pending change for the confirmation card. Built from the

--- a/spec/services/ai/store_agent_api_catalog_spec.rb
+++ b/spec/services/ai/store_agent_api_catalog_spec.rb
@@ -177,6 +177,12 @@ describe Ai::StoreAgentApiCatalog do
   end
 
   describe "profile custom HTML endpoints" do
+    it "requires the full profile-page read before either profile-page write" do
+      %w[update_user_custom_html edit_user_custom_html].each do |id|
+        expect(described_class.find(id).requires_read).to eq("get_user_custom_html")
+      end
+    end
+
     it "exposes a targeted-edit write so an existing page never has to be fully regenerated" do
       endpoint = described_class.find("edit_user_custom_html")
 
@@ -224,6 +230,12 @@ describe Ai::StoreAgentApiCatalog do
   end
 
   describe "product custom HTML endpoints" do
+    it "requires the full targeted product-page read before either product-page write" do
+      %w[update_product_custom_html edit_product_custom_html].each do |id|
+        expect(described_class.find(id).requires_read).to eq("get_product_custom_html")
+      end
+    end
+
     it "exposes a read so the agent can inspect a product's current landing page" do
       endpoint = described_class.find("get_product_custom_html")
 
@@ -285,6 +297,13 @@ describe Ai::StoreAgentApiCatalog do
     # offer a second, warning-free path to the same write.
     it "keeps custom_html out of the generic update_product params" do
       expect(described_class.find("update_product").params).not_to include("custom_html")
+    end
+
+    it "includes the declared read precondition in the generated write manifest" do
+      manifest = described_class.manifest(:write)
+
+      expect(manifest).to include("update_product_custom_html")
+      expect(manifest).to include("requires a successful get_product_custom_html for the same target in this turn")
     end
   end
 

--- a/spec/services/ai/store_agent_service_spec.rb
+++ b/spec/services/ai/store_agent_service_spec.rb
@@ -744,6 +744,467 @@ describe Ai::StoreAgentService do
         )
         expect(result[:proposed_action][:fields]).to include({ label: "Price currency type", value: "zar" })
       end
+
+      describe "custom-page read preconditions" do
+        page_write_cases = [
+          {
+            write_endpoint: "update_user_custom_html",
+            read_endpoint: "get_user_custom_html",
+            path_params: {},
+            read_path: "/user/custom_html",
+            observable_read_path: "/user/custom_html",
+            params: { "custom_html" => "<main>New profile</main>" },
+          },
+          {
+            write_endpoint: "edit_user_custom_html",
+            read_endpoint: "get_user_custom_html",
+            path_params: {},
+            read_path: "/user/custom_html",
+            observable_read_path: "/user/custom_html",
+            params: { "find" => "<h1>Old</h1>", "replace" => "<h1>New</h1>" },
+          },
+          {
+            write_endpoint: "update_product_custom_html",
+            read_endpoint: "get_product_custom_html",
+            path_params: { "id" => "product-a" },
+            read_path: "/products/product-a/custom_html",
+            observable_read_path: "/products/:id/custom_html",
+            params: { "custom_html" => %(<main><a data-gumroad-action="buy">Buy</a></main>) },
+          },
+          {
+            write_endpoint: "edit_product_custom_html",
+            read_endpoint: "get_product_custom_html",
+            path_params: { "id" => "product-a" },
+            read_path: "/products/product-a/custom_html",
+            observable_read_path: "/products/:id/custom_html",
+            params: { "find" => "<h1>Old</h1>", "replace" => "<h1>New</h1>" },
+          },
+        ].freeze
+
+        page_write_cases.each do |page_case|
+          it "blocks #{page_case[:write_endpoint]} until its declared full read succeeds" do
+            captured = nil
+            first = true
+            expect(Rails.logger).to receive(:warn).with(described_class::MISSING_REQUIRED_READ_MESSAGE)
+            expect(ErrorNotifier).to receive(:notify).with(
+              described_class::MISSING_REQUIRED_READ_MESSAGE,
+              exclude_request_context: true,
+              write_endpoint: page_case[:write_endpoint],
+              required_read_endpoint: page_case[:read_endpoint],
+              required_read_path: page_case[:observable_read_path],
+            )
+            allow(client).to receive(:messages) do |args|
+              if first
+                first = false
+                tool_result("api_write", {
+                              "endpoint" => page_case[:write_endpoint],
+                              "path_params" => page_case[:path_params],
+                              "params" => page_case[:params],
+                            })
+              else
+                captured = captured_tool_result(args)
+                text_result("I need to read the current page first.")
+              end
+            end
+
+            result = service.respond(messages: [{ role: "user", content: "Change my custom page" }])
+
+            expect(result[:proposed_action]).to be_nil
+            expect(captured["error"]).to include(
+              "successful full read",
+              "Only if the seller explicitly requested this custom-page work",
+              "Otherwise, do not read the page body and do not retry the write",
+              "Status or metadata-only reads do not count",
+            )
+            expect(captured["corrective_action"]).to eq(
+              "condition" => "The seller explicitly requested this custom-page work.",
+              "if_requested" => {
+                "tool" => "api_read",
+                "endpoint" => page_case[:read_endpoint],
+                "path_params" => page_case[:path_params],
+                "after_success" => {
+                  "action" => "retry_write",
+                  "endpoint" => page_case[:write_endpoint],
+                  "timing" => "this_turn",
+                },
+              },
+              "otherwise" => {
+                "action" => "do_not_read_or_retry",
+                "instruction" => "Do not read the page body and do not retry the write.",
+              },
+            )
+          end
+
+          it "allows #{page_case[:write_endpoint]} after its declared full read succeeds for the same target" do
+            expect(api_client).to receive(:get).with(page_case[:read_path], {}).and_return(
+              { "success" => true, "custom_html" => "<h1>Current</h1>", "http_status" => 200 },
+            )
+            allow(client).to receive(:messages).and_return(
+              tool_result("api_read", {
+                            "endpoint" => page_case[:read_endpoint],
+                            "path_params" => page_case[:path_params],
+                          }),
+              tool_result("api_write", {
+                            "endpoint" => page_case[:write_endpoint],
+                            "path_params" => page_case[:path_params],
+                            "params" => page_case[:params],
+                          }),
+              text_result("I read the current page and prepared the change.", outcome: "proposal_ready"),
+            )
+
+            result = service.respond(messages: [{ role: "user", content: "Change my custom page" }])
+
+            expect(result[:proposed_action]).to include(
+              type: "api_write",
+              params: include(
+                "endpoint" => page_case[:write_endpoint],
+                "path_params" => page_case[:path_params],
+              ),
+            )
+          end
+        end
+
+        it "does not let a full read of product A unlock a write to product B" do
+          captured = nil
+          expect(api_client).to receive(:get).with("/products/product-a/custom_html", {}).and_return(
+            { "success" => true, "custom_html" => "<h1>A</h1>", "http_status" => 200 },
+          )
+          expect(ErrorNotifier).to receive(:notify).with(
+            described_class::MISSING_REQUIRED_READ_MESSAGE,
+            exclude_request_context: true,
+            write_endpoint: "update_product_custom_html",
+            required_read_endpoint: "get_product_custom_html",
+            required_read_path: "/products/:id/custom_html",
+          )
+          allow(Rails.logger).to receive(:warn)
+          replies = [
+            tool_result("api_read", {
+                          "endpoint" => "get_product_custom_html",
+                          "path_params" => { "id" => "product-a" },
+                        }),
+            tool_result("api_write", {
+                          "endpoint" => "update_product_custom_html",
+                          "path_params" => { "id" => "product-b" },
+                          "params" => { "custom_html" => "<main>Product B</main>" },
+                        }),
+            text_result("I need to read product B first."),
+          ]
+          allow(client).to receive(:messages) do |args|
+            captured = captured_tool_result(args) if replies.one?
+            replies.shift
+          end
+
+          result = service.respond(messages: [{ role: "user", content: "Replace product B's page" }])
+
+          expect(result[:proposed_action]).to be_nil
+          expect(captured.dig("corrective_action", "if_requested", "path_params")).to eq("id" => "product-b")
+        end
+
+        it "does not let a full read from a prior turn unlock the current turn" do
+          captured_results = []
+          expect(api_client).to receive(:get).with("/products/product-a/custom_html", {}).and_return(
+            { "success" => true, "custom_html" => "<h1>A</h1>", "http_status" => 200 },
+          )
+          expect(ErrorNotifier).to receive(:notify).with(
+            described_class::MISSING_REQUIRED_READ_MESSAGE,
+            exclude_request_context: true,
+            write_endpoint: "edit_product_custom_html",
+            required_read_endpoint: "get_product_custom_html",
+            required_read_path: "/products/:id/custom_html",
+          )
+          allow(Rails.logger).to receive(:warn)
+          replies = [
+            tool_result("api_read", {
+                          "endpoint" => "get_product_custom_html",
+                          "path_params" => { "id" => "product-a" },
+                        }),
+            text_result("I found the current page."),
+            tool_result("api_write", {
+                          "endpoint" => "edit_product_custom_html",
+                          "path_params" => { "id" => "product-a" },
+                          "params" => { "find" => "<h1>A</h1>", "replace" => "<h1>Updated</h1>" },
+                        }),
+            text_result("I need to read it again in this turn."),
+          ]
+          allow(client).to receive(:messages) do |args|
+            captured = captured_tool_result(args)
+            captured_results << captured if captured
+            replies.shift
+          end
+
+          service.respond(messages: [{ role: "user", content: "What is on product A's page?" }])
+          second_turn = service.respond(messages: [{ role: "user", content: "Change its heading" }])
+
+          expect(second_turn[:proposed_action]).to be_nil
+          expect(captured_results.last["error"]).to include("in this turn")
+        end
+
+        it "does not let a product metadata read unlock a custom-page write" do
+          captured = nil
+          expect(api_client).to receive(:get).with("/products/product-a", {}).and_return(
+            { "success" => true, "product" => { "id" => "product-a", "name" => "Product A" }, "http_status" => 200 },
+          )
+          expect(ErrorNotifier).to receive(:notify).with(
+            described_class::MISSING_REQUIRED_READ_MESSAGE,
+            exclude_request_context: true,
+            write_endpoint: "update_product_custom_html",
+            required_read_endpoint: "get_product_custom_html",
+            required_read_path: "/products/:id/custom_html",
+          )
+          allow(Rails.logger).to receive(:warn)
+          replies = [
+            tool_result("api_read", {
+                          "endpoint" => "get_product",
+                          "path_params" => { "id" => "product-a" },
+                        }),
+            tool_result("api_write", {
+                          "endpoint" => "update_product_custom_html",
+                          "path_params" => { "id" => "product-a" },
+                          "params" => { "custom_html" => "<main>Replacement</main>" },
+                        }),
+            text_result("I need the full page, not its metadata."),
+          ]
+          allow(client).to receive(:messages) do |args|
+            captured = captured_tool_result(args) if replies.one?
+            replies.shift
+          end
+
+          result = service.respond(messages: [{ role: "user", content: "Replace product A's page" }])
+
+          expect(result[:proposed_action]).to be_nil
+          expect(captured["error"]).to include("metadata-only reads do not count")
+        end
+
+        it "does not turn an unsolicited custom-page write into unconditional read and retry instructions" do
+          captured = nil
+          expect(api_client).not_to receive(:get)
+          allow(ErrorNotifier).to receive(:notify)
+          allow(Rails.logger).to receive(:warn)
+          replies = [
+            tool_result("api_write", {
+                          "endpoint" => "update_product_custom_html",
+                          "path_params" => { "id" => "product-a" },
+                          "params" => { "custom_html" => "<main>Blue theme</main>" },
+                        }),
+            text_result("That was not requested, so I will not inspect or change the custom page."),
+          ]
+          allow(client).to receive(:messages) do |args|
+            captured = captured_tool_result(args) if replies.one?
+            replies.shift
+          end
+
+          result = service.respond(messages: [{ role: "user", content: "Why is my product page blue?" }])
+
+          expect(result[:proposed_action]).to be_nil
+          expect(captured["error"]).to include(
+            "Only if the seller explicitly requested this custom-page work",
+            "Otherwise, do not read the page body and do not retry the write",
+          )
+          expect(captured["corrective_action"]).not_to have_key("tool")
+          expect(captured.dig("corrective_action", "condition")).to eq(
+            "The seller explicitly requested this custom-page work.",
+          )
+          expect(captured.dig("corrective_action", "otherwise")).to eq(
+            "action" => "do_not_read_or_retry",
+            "instruction" => "Do not read the page body and do not retry the write.",
+          )
+        end
+
+        it "gives explicitly requested page work the exact read target and allows a retry after the read succeeds" do
+          captured_results = []
+          expect(api_client).to receive(:get).with("/products/product-a/custom_html", {}).and_return(
+            { "success" => true, "custom_html" => "<h1>Current</h1>", "http_status" => 200 },
+          )
+          allow(ErrorNotifier).to receive(:notify)
+          allow(Rails.logger).to receive(:warn)
+          replies = [
+            tool_result("api_write", {
+                          "endpoint" => "edit_product_custom_html",
+                          "path_params" => { "id" => "product-a" },
+                          "params" => { "find" => "<h1>Current</h1>", "replace" => "<h1>Updated</h1>" },
+                        }),
+            tool_result("api_read", {
+                          "endpoint" => "get_product_custom_html",
+                          "path_params" => { "id" => "product-a" },
+                        }),
+            tool_result("api_write", {
+                          "endpoint" => "edit_product_custom_html",
+                          "path_params" => { "id" => "product-a" },
+                          "params" => { "find" => "<h1>Current</h1>", "replace" => "<h1>Updated</h1>" },
+                        }),
+            text_result("I read the current page and prepared the requested heading change.", outcome: "proposal_ready"),
+          ]
+          allow(client).to receive(:messages) do |args|
+            captured = captured_tool_result(args)
+            captured_results << captured if captured
+            replies.shift
+          end
+
+          result = service.respond(messages: [{ role: "user", content: "On product A's custom page, change the heading to Updated" }])
+
+          correction = captured_results.first.fetch("corrective_action")
+          expect(correction.dig("if_requested", "endpoint")).to eq("get_product_custom_html")
+          expect(correction.dig("if_requested", "path_params")).to eq("id" => "product-a")
+          expect(correction.dig("if_requested", "after_success")).to eq(
+            "action" => "retry_write",
+            "endpoint" => "edit_product_custom_html",
+            "timing" => "this_turn",
+          )
+          expect(result[:proposed_action]).to include(
+            type: "api_write",
+            params: include(
+              "endpoint" => "edit_product_custom_html",
+              "path_params" => { "id" => "product-a" },
+            ),
+          )
+        end
+
+        it "does not send a model-supplied target id to guard observability" do
+          sentinel = "raw-seller-chat-DO-NOT-SEND"
+          expect(Rails.logger).to receive(:warn).with(described_class::MISSING_REQUIRED_READ_MESSAGE)
+          expect(ErrorNotifier).to receive(:notify).with(
+            described_class::MISSING_REQUIRED_READ_MESSAGE,
+            exclude_request_context: true,
+            write_endpoint: "update_product_custom_html",
+            required_read_endpoint: "get_product_custom_html",
+            required_read_path: "/products/:id/custom_html",
+          )
+          allow(client).to receive(:messages).and_return(
+            tool_result("api_write", {
+                          "endpoint" => "update_product_custom_html",
+                          "path_params" => { "id" => sentinel },
+                          "params" => { "custom_html" => "<main>Replacement</main>" },
+                        }),
+            text_result("I need to read the current page first."),
+          )
+
+          result = service.respond(messages: [{ role: "user", content: sentinel }])
+
+          expect(result[:proposed_action]).to be_nil
+        end
+
+        it "rejects a metadata-only param on the full-read endpoint and keeps the write locked" do
+          captured_results = []
+          expect(api_client).not_to receive(:get)
+          allow(ErrorNotifier).to receive(:notify)
+          allow(Rails.logger).to receive(:warn)
+          replies = [
+            tool_result("api_read", {
+                          "endpoint" => "get_product_custom_html",
+                          "path_params" => { "id" => "product-a" },
+                          "params" => { "metadata_only" => true },
+                        }),
+            tool_result("api_write", {
+                          "endpoint" => "update_product_custom_html",
+                          "path_params" => { "id" => "product-a" },
+                          "params" => { "custom_html" => "<main>Replacement</main>" },
+                        }),
+            text_result("I still need the declared full read."),
+          ]
+          allow(client).to receive(:messages) do |args|
+            captured = captured_tool_result(args)
+            captured_results << captured if captured
+            replies.shift
+          end
+
+          result = service.respond(messages: [{ role: "user", content: "Replace product A's page" }])
+
+          expect(result[:proposed_action]).to be_nil
+          expect(captured_results.first["error"]).to include("metadata_only")
+          expect(captured_results.last["error"]).to include("successful full read")
+        end
+
+        it "does not let a failed full read unlock a custom-page write" do
+          captured = nil
+          expect(api_client).to receive(:get).with("/user/custom_html", {}).and_return(
+            { "success" => false, "message" => "Unavailable", "http_status" => 200 },
+          )
+          allow(ErrorNotifier).to receive(:notify)
+          allow(Rails.logger).to receive(:warn)
+          replies = [
+            tool_result("api_read", { "endpoint" => "get_user_custom_html" }),
+            tool_result("api_write", {
+                          "endpoint" => "update_user_custom_html",
+                          "params" => { "custom_html" => "<main>Replacement</main>" },
+                        }),
+            text_result("The read failed, so I cannot prepare this yet."),
+          ]
+          allow(client).to receive(:messages) do |args|
+            captured = captured_tool_result(args) if replies.one?
+            replies.shift
+          end
+
+          result = service.respond(messages: [{ role: "user", content: "Replace my profile page" }])
+
+          expect(result[:proposed_action]).to be_nil
+          expect(captured["error"]).to include("successful full read")
+        end
+
+        it "does not let a non-2xx full read unlock a custom-page write when success is omitted" do
+          captured = nil
+          expect(api_client).to receive(:get).with("/user/custom_html", {}).and_return(
+            { "message" => "Unavailable", "http_status" => 503 },
+          )
+          allow(ErrorNotifier).to receive(:notify)
+          allow(Rails.logger).to receive(:warn)
+          replies = [
+            tool_result("api_read", { "endpoint" => "get_user_custom_html" }),
+            tool_result("api_write", {
+                          "endpoint" => "update_user_custom_html",
+                          "params" => { "custom_html" => "<main>Replacement</main>" },
+                        }),
+            text_result("The read failed, so I cannot prepare this yet."),
+          ]
+          allow(client).to receive(:messages) do |args|
+            captured = captured_tool_result(args) if replies.one?
+            replies.shift
+          end
+
+          result = service.respond(messages: [{ role: "user", content: "Replace my profile page" }])
+
+          expect(result[:proposed_action]).to be_nil
+          expect(captured["error"]).to include("successful full read")
+        end
+
+        it "requires the model to receive the full-read result before it can propose the write" do
+          simultaneous_read_and_write = Ai::AnthropicClient::Result.new(
+            text: "",
+            tool_uses: [
+              {
+                id: "toolu_read",
+                name: "api_read",
+                input: {
+                  "endpoint" => "get_product_custom_html",
+                  "path_params" => { "id" => "product-a" },
+                },
+              },
+              {
+                id: "toolu_write",
+                name: "api_write",
+                input: {
+                  "endpoint" => "update_product_custom_html",
+                  "path_params" => { "id" => "product-a" },
+                  "params" => { "custom_html" => "<main>Speculative replacement</main>" },
+                },
+              },
+            ],
+            stop_reason: "tool_use",
+          )
+          expect(api_client).to receive(:get).with("/products/product-a/custom_html", {}).and_return(
+            { "success" => true, "custom_html" => "<h1>Current</h1>", "http_status" => 200 },
+          )
+          allow(ErrorNotifier).to receive(:notify)
+          allow(Rails.logger).to receive(:warn)
+          allow(client).to receive(:messages).and_return(
+            simultaneous_read_and_write,
+            text_result("I read the page, but I need to prepare the write in a new tool step."),
+          )
+
+          result = service.respond(messages: [{ role: "user", content: "Replace product A's page" }])
+
+          expect(result[:proposed_action]).to be_nil
+        end
+      end
     end
 
     context "when the model proposes more than one write in a single turn" do
@@ -1279,6 +1740,46 @@ describe Ai::StoreAgentService do
       expect(order).not_to include([:token, { text: model_reply }])
       expect(result[:reply]).to eq(described_class::PROPOSAL_READY_REPLY)
       expect(result[:outcome]).to eq("proposal_ready")
+    end
+
+    it "enforces custom-page reads while streaming and resets them between turns" do
+      turns = [
+        { result: tool_result("api_read", { "endpoint" => "get_product_custom_html", "path_params" => { "id" => "product-a" } }, id: "toolu_read") },
+        { result: tool_result("api_write", {
+                                "endpoint" => "update_product_custom_html",
+                                "path_params" => { "id" => "product-a" },
+                                "params" => { "custom_html" => "<main>First change</main>" },
+                              }, id: "toolu_first_write") },
+        { stream: ["The first change is ready."], result: text_result("The first change is ready.", outcome: "proposal_ready") },
+        { result: tool_result("api_write", {
+                                "endpoint" => "update_product_custom_html",
+                                "path_params" => { "id" => "product-a" },
+                                "params" => { "custom_html" => "<main>Second change</main>" },
+                              }, id: "toolu_second_write") },
+        { stream: ["I need to read it again."], result: text_result("I need to read it again.") },
+      ]
+      captured_results = []
+      allow(client).to receive(:stream_messages) do |args, &on_text|
+        captured = captured_tool_result(args)
+        captured_results << captured if captured
+        turn = turns.shift
+        Array(turn[:stream]).each { |piece| on_text&.call(piece) }
+        turn[:result]
+      end
+      allow(client).to receive(:messages).and_return(text_result("[]"))
+      allow(ErrorNotifier).to receive(:notify)
+      allow(Rails.logger).to receive(:warn)
+      expect(api_client).to receive(:get).with("/products/product-a/custom_html", {}).once.and_return(
+        { "success" => true, "custom_html" => "<main>Current</main>", "http_status" => 200 },
+      )
+
+      _first_events, first_turn = collect_events([{ role: "user", content: "Make the first change" }])
+      _second_events, second_turn = collect_events([{ role: "user", content: "Make another change" }])
+
+      expect(first_turn[:proposed_action]).to include(type: "api_write")
+      expect(second_turn[:proposed_action]).to be_nil
+      expect(captured_results.last["error"]).to include("successful full read", "in this turn")
+      expect(turns).to be_empty
     end
 
     it "still returns a reply when the follow-up suggestion call fails" do


### PR DESCRIPTION
## What

Requires the Store Agent to successfully read the exact profile or product custom page in the current turn before it can stage a replacement or targeted edit.

The catalog declares each write’s required full-read endpoint. Shared tool dispatch tracks successful expanded targets, while failed, metadata-only, prior-turn, different-target, and same-batch reads cannot unlock a write. Missing reads return conditional guidance so an unsolicited write does not trigger a page-body read or retry.

## Why

Custom-page writes can replace seller HTML with no version history. A prompt can ask the model to read first, but it cannot enforce that rule. This guard moves the invariant to the proposal boundary without adding endpoint-specific service branches or changing the existing confirmation contract.

## Before/After

Before, the model could stage a destructive custom-page write without reading the page it needed to preserve.

After, no confirmation card can be created until the declared full read succeeds for that exact target in the same turn.

This is a non-visual server-side safety guard; no video is included.

## Test Results

- Focused service, catalog, and privacy specs: 133 examples, 0 failures
- RuboCop: 4 files inspected, no offenses
- `bin/test-confidence`: 99% confidence, 13 planned test files passed; one unrelated failure was reproduced on the merge base

---

This PR was implemented with AI assistance using GPT‑5.6 Sol and Fable 5.