### PR TITLE
Fail fast in patch-verification tests when node_modules is stale

### DIFF
--- a/app/javascript/inertia/prefetch_rejection.test.ts
+++ b/app/javascript/inertia/prefetch_rejection.test.ts
@@ -14,7 +14,10 @@
 // module (Vitest leaves dependencies inside node_modules unmocked) we install a
 // custom axios adapter on the shared axios instance the router itself imports.
 import axios, { type AxiosAdapter } from "axios";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Loading and initialising the real router costs seconds on a cold Vitest
 // environment, so the default one-second waitFor budget is not enough to be
@@ -64,6 +67,18 @@ const adapter: AxiosAdapter = (config) => {
 };
 
 describe("inertia prefetch rejection", () => {
+  // When node_modules predates the patch (a git pull without npm install), every
+  // test below fails as an unhelpful 5s timeout, so name the fix up front. The
+  // ESM build is the one vitest resolves the router import to.
+  beforeAll(() => {
+    const distDir = dirname(createRequire(import.meta.url).resolve("@inertiajs/core"));
+    if (!readFileSync(join(distDir, "index.esm.js"), "utf8").includes("abandonCurrentUse")) {
+      throw new Error(
+        "@inertiajs/core in node_modules is missing patches/@inertiajs+core+2.3.13.patch — your install is stale; run npm install (or npx patch-package).",
+      );
+    }
+  });
+
   beforeEach(() => {
     requests.length = 0;
     pendingPrefetchReject = null;

--- a/app/javascript/pages/UrlRedirects/epubjs-patch.test.ts
+++ b/app/javascript/pages/UrlRedirects/epubjs-patch.test.ts
@@ -7,7 +7,21 @@ import Rendition from "epubjs/src/rendition";
 import Resources from "epubjs/src/resources";
 import Queue from "epubjs/src/utils/queue";
 import JSZip from "jszip";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+// When node_modules predates the patch (a git pull without npm install), the
+// constants above import as undefined and every suite below fails as a wall of
+// unhelpful timeouts, so name the fix up front.
+beforeAll(() => {
+  const archiveSource = readFileSync(createRequire(import.meta.url).resolve("epubjs/src/archive"), "utf8");
+  if (!archiveSource.includes("MAX_EPUB_ENTRY_COUNT")) {
+    throw new Error(
+      "epubjs in node_modules is missing patches/epubjs+0.3.93.patch — your install is stale; run npm install (or npx patch-package).",
+    );
+  }
+});
 
 describe("epub.js resource cleanup patch", () => {
   afterEach(() => vi.unstubAllGlobals());


### PR DESCRIPTION
## What

Adds a fail-fast guard to the two test suites that verify our patch-package patches:

- `app/javascript/inertia/prefetch_rejection.test.ts` (verifies `patches/@inertiajs+core+2.3.13.patch`)
- `app/javascript/pages/UrlRedirects/epubjs-patch.test.ts` (verifies `patches/epubjs+0.3.93.patch`)

Each suite now reads the installed package source in a `beforeAll` and throws a clear error when the marker its patch introduces is missing.

## Why

These suites exercise patched dependency code, so they only pass when the patches are applied to `node_modules`. After a `git pull` without `npm install`, they fail as ~19 five-second timeouts and unhandled promise rejections, with nothing pointing at the real cause. The guard turns that into a sub-second failure that names the fix: run `npm install` (or `npx patch-package`).

The guards follow the existing pattern in `app/javascript/utils/inertia_partial_reload.test.ts`, which already pins header names against the installed Inertia source. They check for a string only the patch introduces, so they have no effect when the install is current.

## Before/After

This is a test-only change, so the before/after is terminal output.

Before: with a stale `node_modules`, both suites failed as a wall of 5-second timeouts and unhandled rejections.

After, same stale install (simulated with `npx patch-package --reverse`):

```
Error: @inertiajs/core in node_modules is missing patches/@inertiajs+core+2.3.13.patch — your install is stale; run npm install (or npx patch-package).
Error: epubjs in node_modules is missing patches/epubjs+0.3.93.patch — your install is stale; run npm install (or npx patch-package).

 Test Files  2 failed (2)
      Tests  23 skipped (23)
   Duration  299ms
```

After, with a current install, both suites pass unchanged:

```
 Test Files  2 passed (2)
      Tests  23 passed (23)
   Duration  1.97s
```

## QA steps

1. `npx patch-package --reverse`
2. `npx vitest run app/javascript/inertia/prefetch_rejection.test.ts app/javascript/pages/UrlRedirects/epubjs-patch.test.ts` — both files fail immediately with the stale-install message.
3. `npx patch-package`
4. Rerun the same command — 23 tests pass.

## Test results

```
 Test Files  2 passed (2)
      Tests  23 passed (23)
   Duration  1.97s
```

ESLint passes on both changed files.

---

AI disclosure: written with Claude Fable 5 (Claude Code).
