### PR TITLE
Explain the three bank-account rejection emails in the payout delays article

### DIFF
--- a/app/views/help_center/articles/contents/_281-payout-delays.html.erb
+++ b/app/views/help_center/articles/contents/_281-payout-delays.html.erb
@@ -24,8 +24,15 @@
     </strong>We kindly ask that you wait until you've made 2-3 more sales, then email us for clarification. We cannot speed up the review for you, and we cannot provide everyone with <em>specific</em> information about why their account hasn't been reviewed, but we can at least answer the questions that you have. </p>
   <h3> Reason 2: There's an issue with your bank or PayPal account </h3>
   <p> It's also possible that we <em>have</em> been attempting to send money to your bank, or your PayPal account, but they are blocking the money. You may have entered incorrect information in your <a href="http://gumroad.com/settings/payments">Payment Settings</a>, or there may be a lock on your PayPal account. </p>
+  <p>When our payment partner will not accept a bank account you saved, we email you, and the email tells you which of these applies:</p>
+  <ul>
+    <li><strong>The details don't match the format banks in your country use.</strong> Correct them in your <a href="https://gumroad.com/settings/payments">payment settings</a>. Waiting will not clear this one, because we keep getting the same answer until the details change.</li>
+    <li><strong>Your bank or branch isn't in our payment partner's records yet.</strong> This is common for a newly opened account or a recently added bank. If your details are correct, you don't need to do anything: we re-check once a week for up to <%= RetryStripeRejectedPayoutSetupsJob::RETRY_WINDOW_WEEKS %> weeks, and we only email you again if we still can't verify it.</li>
+    <li><strong>Our payment partner won't accept that particular account.</strong> Nothing is wrong with the details you entered, so re-entering them or waiting will not help. Add a different account you hold in your <a href="https://gumroad.com/settings/payments">payment settings</a>. A different account at the same bank is fine. If that account is the only one you have, reply to the email we sent and we'll look into it with you.</li>
+  </ul>
+  <p>Clearing a bank account problem does not on its own mean your next payout goes out: your payment settings page will tell you if anything else, such as verification or your payout threshold, is still outstanding.</p>
   <p><strong>What to do:</strong><br>
-    Email us and we can look into it for you.</p>
+    For PayPal, or if you did not receive an email about your bank account, email us and we can look into it for you.</p>
   <h3>Reason 3: There is an issue with your account </h3>
   <p> If this is the case, you may have received an email from us telling you that we were unable to pay you. You would have received this email because your account was skipped during payouts due to a security issue, a compliance issue, or a problem with your payout settings. It's usually nothing to worry about, but the email can be a little scary sometimes.  </p>
   <p><strong>What to do:</strong><br>


### PR DESCRIPTION
## What

`_281-payout-delays.html.erb`, Reason 2 ("There's an issue with your bank or PayPal account"), now describes what a seller is actually told when our payment partner refuses a saved bank account. It lists the three rejection outcomes the `invalid_bank_account` email distinguishes, what each one asks the seller to do, and says plainly that clearing the bank problem does not by itself release a payout.

The old copy said only "email us and we can look into it for you". That "email us" line is now scoped to PayPal and to sellers who did not receive an email.

## Why

Triggered by #6523, which added a third branch to the `invalid_bank_account` email. The three branches now give three different and mutually contradictory instructions:

- **format rejection** (`BANK_REJECTION_KIND_FORMAT`) — correct the details; waiting will not help.
- **directory miss** (generic branch) — details may be fine; do nothing, we re-check weekly for `RetryStripeRejectedPayoutSetupsJob::RETRY_WINDOW_WEEKS` weeks.
- **block-listed account** (`BANK_REJECTION_KIND_BLOCKED`, new in #6523) — details are correct, re-entering or waiting is guaranteed to fail, add a *different* account.

A seller reading the article got none of this and was pointed at support for all three. The third case is the one that cost real money: a seller re-saved the same valid account three times over three months. The article now matches the emails, so a seller who received one can tell which instruction applies to them.

The article body reads the constant (`<%= RetryStripeRejectedPayoutSetupsJob::RETRY_WINDOW_WEEKS %>`) rather than hardcoding 8 weeks, matching the mailer, the settings banner, and the payments controller.

## Test plan

Body-only edit to one article partial. `articles.yml` untouched (no title, description, slug, or category change), all anchor IDs preserved, no section removed.

- Rendered the partial in the real view context: `ApplicationController.render(partial: "help_center/articles/contents/281-payout-delays")` — 9556 bytes, new copy present, the constant interpolates to "up to 8 weeks".
- Tag-balance check on the file: all of `div p ul ol li strong em h3 a figure` balanced.
- CI runs the help-center specs.

No fable review gate: pure prose edit, no yml, no ERB logic beyond the existing constant read.

---

## AI disclosure

Written by claude-opus-5. Instruction: after #6523 merged, check whether any help center article now describes bank-account rejection wrongly, and update it.
