### PR TITLE
Gate CI on npm run typecheck

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,33 @@ jobs:
           LANG: en_US.UTF-8
           LC_ALL: en_US.UTF-8
 
+  typecheck:
+    name: Typecheck TS
+    runs-on: ubicloud-standard-4
+    needs: ci_gate
+    if: ${{ github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name != github.repository }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: npm
+      - run: npm ci
+      # tsc needs the gitignored js:export output (app/javascript/utils/routes.*
+      # and app/javascript/json_schemas/*). The export boots Rails off the
+      # committed .env.test but tolerates every backing service being down, so
+      # no MySQL/Redis/etc. containers are needed here.
+      - run: bundle exec rails js:export
+        env:
+          RAILS_ENV: test
+      - run: npm run typecheck
+
   lint_ruby:
     name: Lint Ruby
     runs-on: ubicloud-standard-4


### PR DESCRIPTION
## What

Adds a `Typecheck TS` job to the Tests workflow. It runs `npm ci`, generates the gitignored `js:export` modules (`app/javascript/utils/routes.*`, `app/javascript/json_schemas/*`), and runs `npm run typecheck` with the same triggers and fork-PR gating as the existing lint jobs, so a failing typecheck now blocks `ci/green`.

## Why

CI never ran `tsc`, and that let a config-level breakage go unnoticed: the Vite migration (#5067) added `"vite/client"` to tsconfig's `types` while the custom `typeRoots` entry blocked its resolution. tsc reported that single TS2688 error and skipped semantic checking of every file, so about 56 type errors accumulated over 2.5 months until #6622 cleaned them up. With this job in place, any typecheck failure surfaces on the PR that introduces it.

The job needs no database containers: `rails js:export` boots Rails off the committed `.env.test` and completes with every backing service down, which keeps the job at roughly the cost of the existing lint jobs.

## Test Results

Ran the job's exact step sequence locally against current `main` (`4559f0697`):

- `npm ci` → `RAILS_ENV=test bundle exec rails js:export` with MySQL/Redis/Mongo/Elasticsearch all unreachable → routes and JSON-schema modules generated in ~8s.
- `npm run typecheck` → exit 0 in ~14s.
- Reverting #6622's tsconfig fix reproduces the TS2688 failure, so the job fails when typecheck is broken.
- `actionlint` reports no new findings for the workflow change and the YAML parses.

Per discussion, no video: the change is CI configuration only and the diff plus the job's own run on this PR are the reviewable evidence.

---

AI disclosure: written with Claude Fable 5.
