### PR TITLE
Widen CardData.zipCode to fix the typecheck failure on main

### DIFF
--- a/app/javascript/data/card_payment_method_data.ts
+++ b/app/javascript/data/card_payment_method_data.ts
@@ -25,7 +25,7 @@ type ReusableCCVariation<CardParams extends CardPaymentMethodParams | PaymentReq
 type CardData = {
   cardElement: StripeCardElement | { token: string };
   email: string;
-  zipCode?: string | null;
+  zipCode?: string | null | undefined;
 };
 export const prepareCardPaymentMethodData = async (
   cardData: CardData,


### PR DESCRIPTION
## What

Widens `CardData.zipCode` in `app/javascript/data/card_payment_method_data.ts` to `string | null | undefined`, fixing the one error `npm run typecheck` reports on `main`.

## Why

The AVS spec added in #6594 passes `zipCode: undefined` on purpose, to verify that an undefined ZIP reaches Stripe as `null`. The project compiles with `exactOptionalPropertyTypes`, and under that flag the declaration `zipCode?: string | null` rejects an explicit `undefined`, so `tsc` fails on the spec file.

At runtime the function already coerces the value with `|| null`, so the widened union matches the actual contract, and it follows the pattern other optional fields use (`buyerCurrency` in `utils/currency.ts`, `mountCurrency` in `PaymentElementInput.tsx`). The one production caller is unaffected.

With #6626 gating CI on `npm run typecheck`, every branch cut from `main` inherits this error and fails the new job until this lands.

## Before/After

Type-level change only; app behavior is unchanged.

Before, on `main`:

```
app/javascript/data/card_payment_method_data.test.ts(404,40): error TS2379:
Argument of type '{ cardElement: { token: string; }; email: string;
zipCode: string | null | undefined; }' is not assignable to parameter of
type 'CardData' with 'exactOptionalPropertyTypes: true'.
```

After: `npm run typecheck` completes with zero errors.

## Test Results

```
$ npm run typecheck
> tsc --noEmit
(zero errors)

$ npm run test -- app/javascript/data/card_payment_method_data.test.ts
Test Files  1 passed (1)
     Tests  22 passed (22)
```

`eslint` on the changed file is clean.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) using Claude Fable 5.
