### PR TITLE
Unbreak the typecheck gate on main: CardData accepts an explicitly-undefined zipCode

### DIFF
--- a/app/javascript/data/card_payment_method_data.ts
+++ b/app/javascript/data/card_payment_method_data.ts
@@ -25,7 +25,9 @@ type ReusableCCVariation<CardParams extends CardPaymentMethodParams | PaymentReq
 type CardData = {
   cardElement: StripeCardElement | { token: string };
   email: string;
-  zipCode?: string | null;
+  // Explicitly `| undefined` because callers pass an absent ZIP through as a value rather than
+  // omitting the key, and `exactOptionalPropertyTypes` treats those as different types.
+  zipCode?: string | null | undefined;
 };
 export const prepareCardPaymentMethodData = async (
   cardData: CardData,


### PR DESCRIPTION
## What

Widens `CardData.zipCode` to `string | null | undefined` so a caller may pass an explicitly-undefined ZIP rather than omitting the key.

## Why

The `Typecheck TS` gate added in [#6626](https://github.com/antiwork/gumroad/pull/6626) is **red on `main`**, so every open pull request fails that job regardless of its own diff:

```
app/javascript/data/card_payment_method_data.test.ts(404,40): error TS2379:
Argument of type '{ ...; zipCode: string | null | undefined; }' is not assignable
to parameter of type 'CardData' with 'exactOptionalPropertyTypes: true'.
  Types of property 'zipCode' are incompatible.
    Type 'string | null | undefined' is not assignable to type 'string | null'.
```

`exactOptionalPropertyTypes` treats an absent key and a present-but-undefined one as different types, so `zipCode?: string | null` rejects `zipCode: undefined` as a value. The test at line 404 does exactly that — it drives the ZIP through `it.each` over `null`, `undefined`, and `""` to assert all three omit the postal code instead of asserting a blank one to the issuer.

Only the type was wrong. The runtime already coerced it: `postal_code: cardData.zipCode || null` handles `undefined` identically to `null`, which is the behavior the test was written to pin. So this widens the type to match what the function already accepts rather than changing what it does, and the test keeps its `undefined` case rather than losing coverage of a value real callers pass.

The gate and the offending test landed close together, which is why `main` went red without either PR being wrong on its own.

## Before / After

| | Before | After |
|---|---|---|
| `Typecheck TS` on `main` | fails | passes |
| Every open PR's typecheck job | fails on this same error | judged on its own diff |
| `prepareCardPaymentMethodData({ zipCode: undefined })` | type error, worked at runtime | type-checks, unchanged at runtime |
| `undefined` ZIP sent to Stripe | `postal_code: null` | `postal_code: null` (unchanged) |

## Test plan

Measured in a worktree off unmodified `main` (`b3dc2c70f`):

- `tsc --noEmit` on unmodified `main` → **the error above** (this is the proof it is main's red, not a branch's)
- `tsc --noEmit` with this change → **exit 0, no errors**
- `vitest run app/javascript/data/card_payment_method_data.test.ts` → **22 passed**, including all three ZIP cases
- `eslint` on the changed file → the 3 errors it reports are present identically on unmodified `main` (local-only noise from the gitignored `routes.js`), verified by stashing the change and re-running
- Branch CI: `Typecheck TS` **green** ([run](https://github.com/antiwork/gumroad/actions/runs/30563518643))

No UI surface: this is a type declaration on a data module, and the rendered checkout behavior is unchanged by construction (same runtime expression). The vitest run is the artifact.

---

### AI disclosure

Written by **claude-opus-5** (Anthropic) running as a Hermes agent.

Found while verifying CI on an unrelated Ruby-only PR ([#6617](https://github.com/antiwork/gumroad/pull/6617)) whose only failing job was this typecheck error in a TypeScript file that PR never touches. Instructions given: verify the failure was pre-existing on unmodified `main` before blaming the branch, and fix the actual cause rather than working around it. The pre-existing-on-main check is what turned a suspected branch failure into this fix.
