### PR TITLE
Cap the cover frame's height only when the cover is portrait

### DIFF
--- a/app/javascript/components/Product/Covers/index.test.tsx
+++ b/app/javascript/components/Product/Covers/index.test.tsx
@@ -62,6 +62,30 @@ describe("Covers", () => {
     expect(frame(container)?.style.aspectRatio).toBe("1920 / 1080");
   });
 
+  // The cap on a LANDSCAPE frame is what shrank every cover on afetop.gumroad.com: the
+  // derived height of a 16:9 cover in the product column exceeds 80svh in any window
+  // shorter than ~800px, the frame goes shorter than its ratio, and `object-contain`
+  // then shrinks the cover in both axes — measured 142px of empty background either
+  // side of a 1280x720 cover at 1440x700. Nothing needs capping here: a landscape
+  // frame's height never exceeds the column width.
+  // See https://github.com/antiwork/gumroad-private/issues/1570
+  it("does not cap the height of a landscape frame, which would pillarbox the cover", () => {
+    const { container } = renderCovers([cover({ native_width: 1280, native_height: 720 })]);
+
+    expect(frame(container)?.style.aspectRatio).toBe("1280 / 720");
+    expect(frame(container)?.style.maxHeight).toBe("");
+  });
+
+  // A square cover derives a height equal to the column width, so it has the same
+  // no-runaway property as landscape and must not be capped either. It is called out
+  // separately because `height > width` is the boundary the cap turns on.
+  it("does not cap the height of a square frame", () => {
+    const { container } = renderCovers([cover({ native_width: 1000, native_height: 1000 })]);
+
+    expect(frame(container)?.style.aspectRatio).toBe("1000 / 1000");
+    expect(frame(container)?.style.maxHeight).toBe("");
+  });
+
   it("shapes the frame to a portrait cover and caps its height so the buy box stays in view", () => {
     const { container } = renderCovers([portrait()]);
 

--- a/app/javascript/components/Product/Covers/index.test.tsx
+++ b/app/javascript/components/Product/Covers/index.test.tsx
@@ -62,13 +62,9 @@ describe("Covers", () => {
     expect(frame(container)?.style.aspectRatio).toBe("1920 / 1080");
   });
 
-  // The cap on a LANDSCAPE frame is what shrank every cover on afetop.gumroad.com: the
-  // derived height of a 16:9 cover in the product column exceeds 80svh in any window
-  // shorter than ~800px, the frame goes shorter than its ratio, and `object-contain`
-  // then shrinks the cover in both axes — measured 142px of empty background either
-  // side of a 1280x720 cover at 1440x700. Nothing needs capping here: a landscape
-  // frame's height never exceeds the column width.
-  // See https://github.com/antiwork/gumroad-private/issues/1570
+  // Capping a landscape frame is what shrank every cover on the storefront in #1570: the
+  // cap cannot narrow the frame, so once it is shorter than the ratio `object-contain`
+  // shrinks the cover in both axes and leaves side bars. Landscape needs no cap.
   it("does not cap the height of a landscape frame, which would pillarbox the cover", () => {
     const { container } = renderCovers([cover({ native_width: 1280, native_height: 720 })]);
 
@@ -76,9 +72,8 @@ describe("Covers", () => {
     expect(frame(container)?.style.maxHeight).toBe("");
   });
 
-  // A square cover derives a height equal to the column width, so it has the same
-  // no-runaway property as landscape and must not be capped either. It is called out
-  // separately because `height > width` is the boundary the cap turns on.
+  // Square is the boundary the `height > width` test turns on, and it belongs on the
+  // uncapped side: its derived height is the column width, not a runaway.
   it("does not cap the height of a square frame", () => {
     const { container } = renderCovers([cover({ native_width: 1000, native_height: 1000 })]);
 

--- a/app/javascript/components/Product/Covers/index.tsx
+++ b/app/javascript/components/Product/Covers/index.tsx
@@ -54,16 +54,12 @@ export const Covers = ({
   // frame that changed width with the active cover would move the panels out from under
   // that calculation and bounce a two-cover carousel back to the first cover.
   //
-  // The cap is portrait-only, and that restriction is the whole point of it. Applied to
-  // every shaped frame it fires on covers it was never meant for: a 16:9 cover in the
-  // 1138px product column derives a 640px frame, which exceeds 80svh in any window
-  // shorter than about 800px, so the frame goes shorter than the ratio and the
-  // `object-contain` below shrinks the cover in BOTH axes to fit — 142px of empty
-  // background either side of a 1280x720 cover at 1440x700. That is a regression against
-  // the pre-#6451 `w-full` behaviour for a shape that never had the problem the cap
-  // exists to solve. A landscape cover's derived height is at most the column width, so
-  // it cannot run away the way a 9:16 frame (~1.8x its width) does.
-  // See https://github.com/antiwork/gumroad-private/issues/1570
+  // Only portrait gets the cap, and the exclusion is load-bearing: because the frame
+  // cannot narrow, a cap shorter than the ratio makes `object-contain` shrink the cover
+  // in BOTH axes, so capping a shape that does not need it buys empty side bars and
+  // nothing else. Only portrait needs it — a cover no taller than it is wide derives a
+  // frame at most the column's width, which is not the runaway a 9:16 frame (~1.8x its
+  // width) is.
   //
   // Covers with no recorded dimensions still get no ratio at all and fall back to the
   // CSS box exactly as before.
@@ -87,10 +83,10 @@ export const Covers = ({
   // in which case the cover narrows and whatever is behind it becomes visible for the
   // first time. The decorative tiled artwork is meant for products with no cover at
   // all, and tiling it either side of a cover reads as a rendering glitch, so a shaped
-  // frame uses the plain page background instead. Keying on "the frame is shaped"
-  // rather than "the cover is portrait" matters because the cap can bite on a square
-  // or 4:3 cover in a short window too; behind a cover that does fill the frame the
-  // backdrop is invisible either way, so this is a no-op there.
+  // frame uses the plain page background instead. Keyed on "the frame is shaped" rather
+  // than "the cap bit" because behind a cover that does fill its frame the backdrop is
+  // invisible either way, so the broader condition is a no-op there and stays correct if
+  // the cap's shape test changes.
   const frameIsShaped = frameStyle !== undefined;
 
   const { itemsRef, handleScroll } = useScrollableCarousel(activeCoverIndex, (index) =>

--- a/app/javascript/components/Product/Covers/index.tsx
+++ b/app/javascript/components/Product/Covers/index.tsx
@@ -54,6 +54,17 @@ export const Covers = ({
   // frame that changed width with the active cover would move the panels out from under
   // that calculation and bounce a two-cover carousel back to the first cover.
   //
+  // The cap is portrait-only, and that restriction is the whole point of it. Applied to
+  // every shaped frame it fires on covers it was never meant for: a 16:9 cover in the
+  // 1138px product column derives a 640px frame, which exceeds 80svh in any window
+  // shorter than about 800px, so the frame goes shorter than the ratio and the
+  // `object-contain` below shrinks the cover in BOTH axes to fit — 142px of empty
+  // background either side of a 1280x720 cover at 1440x700. That is a regression against
+  // the pre-#6451 `w-full` behaviour for a shape that never had the problem the cap
+  // exists to solve. A landscape cover's derived height is at most the column width, so
+  // it cannot run away the way a 9:16 frame (~1.8x its width) does.
+  // See https://github.com/antiwork/gumroad-private/issues/1570
+  //
   // Covers with no recorded dimensions still get no ratio at all and fall back to the
   // CSS box exactly as before.
   // See https://github.com/antiwork/gumroad-private/issues/1437
@@ -67,7 +78,7 @@ export const Covers = ({
           // position the active-cover calculation reads.
           width: "100%",
           aspectRatio: `${activeCover.native_width} / ${activeCover.native_height}`,
-          maxHeight: MAX_PORTRAIT_FRAME_HEIGHT,
+          ...(activeCover.native_height > activeCover.native_width ? { maxHeight: MAX_PORTRAIT_FRAME_HEIGHT } : {}),
         };
   const prevCover = covers[activeCoverIndex - 1];
   const nextCover = covers[activeCoverIndex + 1];


### PR DESCRIPTION
Fixes gumroad-private#1570 — a seller (AFETOP.COM) reported every product cover on their storefront rendering inside a smaller box with empty space either side on desktop, after re-uploading all covers at 1280×720 and 1920×1080.

## The cause

#6451 gave the cover frame a height cap (`MAX_PORTRAIT_FRAME_HEIGHT = "80svh"`) and gave the cover `object-contain`. The cap is applied to **every** shaped frame, not just the portrait frames it exists for.

A 16:9 cover in the ~1138px product column derives a 640px frame. That exceeds 80svh in any window shorter than about 800px. The frame then becomes shorter than its own aspect ratio implies, and `object-contain` shrinks the cover in **both** axes to fit the shorter box — leaving visible background left and right. That is exactly the reported symptom, on a perfectly ordinary landscape cover.

## Measured on the reporter's live storefront

Rendered geometry read out of the real DOM on `afetop.gumroad.com/l/programme-financier-structure` (cover is 1280×720, `object-fit: contain`), sweeping desktop viewport heights:

| viewport | frame | painted cover | empty space |
|---|---|---|---|
| 1512×950 | 1138×640 | 1138×640 | 0px — fills |
| 1440×900 | 1138×640 | 1138×640 | 0px — fills |
| 1920×1080 | 1138×640 | 1138×640 | 0px — fills |
| 1680×780 | 1138×**624** (capped) | 1109×624 | **29px** |
| 1440×700 | 1138×**560** (capped) | 996×560 | **142px** |

The `max-height` the browser resolved at 1440×700 is `560px` against a ratio-derived 640px — the cap biting, on a landscape cover. Both of the seller's products reproduce identically, which matches their report that it affects every product on the account.

This also explains why the seller could not fix it by re-uploading: nothing is wrong with their covers. The trigger is window height, not the image.

## The fix

Apply the cap only when `native_height > native_width`.

Only a portrait frame can run away: a 9:16 box at full column width is ~1.8× its width, taller than a laptop window, which is the problem #6451's cap was added to solve (and it still solves it — that path is untouched). A landscape or square frame's height is at most the column width, so capping it can only ever render the cover smaller than the space it was already given. Square is included on the safe side of the boundary deliberately: its derived height equals the column width, same no-runaway property as landscape.

`object-contain` on the cover stays. It is correct and load-bearing for the portrait path; it was only ever visible here because the frame was being capped when it should not have been.

## Tests

Two new regression examples in `Covers/index.test.tsx`, both verified to redden when only this fix is reverted (put `maxHeight` back unconditionally → 2 failures, everything else still green):

- `does not cap the height of a landscape frame, which would pillarbox the cover`
- `does not cap the height of a square frame`

Full file: 21 passed. The pre-existing portrait examples (`shapes the frame to a portrait cover and caps its height so the buy box stays in view`, the capped-frame image/embed/video sizing examples) all still pass unchanged, so the #6451 behaviour is pinned intact.

`tsc --noEmit` clean, `prettier --write` applied.

## What is not covered

A square cover can still push the buy box below the fold in a short window: at 1440×700 a 1000×1000 cover derives a 1140px-tall frame. That is unchanged by this PR and predates #6451 — a square cover has always had `aspectRatio: 1` and no cap. Capping it is not the fix, because the frame cannot narrow (the carousel reads panel offsets), so a cap would shrink the cover to 560×560 with 290px of empty background either side, which is the #1570 complaint at a different ratio. The real fix is letting the frame narrow the way `videoFrameStyle` does on the content page, which needs the carousel's scroll maths reworked first — filed as gumroad-private#1580 rather than folded in here.

The seller's own viewport height is not recorded in the ticket, so I cannot state that 1440×700 is literally their window — only that the defect reproduces on their live covers at ordinary desktop sizes and is impossible on the pre-#6451 `w-full` behaviour. Once this is live the check is one screenshot from them at their own window size.

