### PR TITLE
Make the cover "X" remove button tappable on touch devices

### DIFF
--- a/app/javascript/components/ProductEdit/ProductTab/CoverEditor.test.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/CoverEditor.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment happy-dom
+import { cleanup, render, screen } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AssetPreview } from "$app/parsers/product";
+
+import { CoverEditor } from "$app/components/ProductEdit/ProductTab/CoverEditor";
+
+// The real ReactSortable installs SortableJS on the DOM node, which needs layout happy-dom
+// does not provide. Stub it to a plain wrapper that records the options it was handed: the
+// bug here is entirely about which options reach SortableJS, so those options ARE the
+// contract worth pinning.
+type StubbedSortableProps = {
+  children?: React.ReactNode;
+  tag?: React.ElementType;
+  list?: unknown;
+  setList?: unknown;
+  filter?: string;
+  preventOnFilter?: boolean;
+};
+const sortableProps = vi.hoisted(() => {
+  const box: { current: StubbedSortableProps | null } = { current: null };
+  return box;
+});
+vi.mock("react-sortablejs", () => ({
+  ReactSortable: ({ children, tag, list: _list, setList: _setList, ...options }: StubbedSortableProps) => {
+    sortableProps.current = options;
+    const Wrapper = tag ?? "div";
+    return <Wrapper>{children}</Wrapper>;
+  },
+}));
+
+// The remove button is hover-gated on desktop and always shown below `lg`. Report a small
+// viewport so it renders unconditionally, which is the touch case this fix is about.
+vi.mock("$app/components/useIsAboveBreakpoint", () => ({ useIsAboveBreakpoint: () => false }));
+
+// Radix's popover pulls in its own React copy under vitest's resolution and dies on
+// `useMemo`. It is the "add cover" menu, unrelated to the drag surface under test, so stub
+// it to plain wrappers rather than fighting the module graph.
+vi.mock("$app/components/Popover", () => {
+  const Passthrough = ({ children }: { children?: React.ReactNode }) => <div>{children}</div>;
+  return {
+    Popover: Passthrough,
+    PopoverAnchor: Passthrough,
+    PopoverContent: Passthrough,
+    PopoverTrigger: Passthrough,
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  sortableProps.current = null;
+});
+
+const cover = (overrides: Partial<AssetPreview> = {}): AssetPreview => ({
+  type: "image",
+  filetype: "png",
+  id: "cover-1",
+  url: "https://example.test/cover.png",
+  original_url: "https://example.test/cover-original.png",
+  thumbnail: null,
+  width: 1280,
+  height: 720,
+  native_width: 1280,
+  native_height: 720,
+  ...overrides,
+});
+
+const renderEditor = (covers: AssetPreview[]) =>
+  render(<CoverEditor covers={covers} setCovers={() => {}} permalink="abc" />);
+
+describe("CoverEditor cover removal on touch devices", () => {
+  // Four separate support tickets and four manual prod-console soft-deletes came from this:
+  // the whole cover tab is a drag surface, so SortableJS claimed the `touchstart` on the
+  // remove button and the tap never became a click.
+  // See https://github.com/antiwork/gumroad-private/issues/1524
+  it("excludes the remove button from the drag surface", () => {
+    renderEditor([cover()]);
+
+    expect(sortableProps.current?.filter).toBe("[data-remove-cover]");
+  });
+
+  // The half that actually makes the tap work. SortableJS's `preventOnFilter` defaults to
+  // true and calls `preventDefault()` on the filtered `touchstart` (sortable.esm.js: the
+  // `preventOnFilter && evt.cancelable && evt.preventDefault()` on the filter path), which
+  // cancels the synthetic click the browser would otherwise emit. `filter` alone stops the
+  // tap being read as a drag but still leaves the button dead on touch.
+  it("lets the filtered touch through so it still becomes a click", () => {
+    renderEditor([cover()]);
+
+    expect(sortableProps.current?.preventOnFilter).toBe(false);
+  });
+
+  // The filter selector has to actually match the button, or both options above are inert.
+  it("marks the remove button with the attribute the filter selects on", () => {
+    renderEditor([cover()]);
+
+    const button = screen.getByLabelText("Remove cover");
+    const filter = String(sortableProps.current?.filter);
+
+    expect(button.matches(filter)).toBe(true);
+  });
+});

--- a/app/javascript/components/ProductEdit/ProductTab/CoverEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/CoverEditor.tsx
@@ -33,6 +33,12 @@ const IMAGE_EXTENSIONS = ["jpeg", "jpg", "png", "gif"];
 const MEGABYTE = 1024 * 1024;
 const MAX_IMAGE_FILE_SIZE = 50 * MEGABYTE;
 
+// Marks the remove button so the Sortable below can exclude it from the drag surface.
+// A data attribute rather than a class: Tailwind classes on this button are styling the
+// seller can reasonably expect to change, and a `filter` selector pointed at one of them
+// would silently stop working the next time the button is restyled.
+const REMOVE_COVER_ATTRIBUTE = "data-remove-cover";
+
 export const CoverEditor = ({
   covers,
   setCovers,
@@ -82,7 +88,21 @@ export const CoverEditor = ({
           <div
             style={{ display: "grid", gridTemplateColumns: "1fr auto", alignItems: "start", gap: "var(--spacer-4)" }}
           >
-            <Sortable animation={150} tag={CoversTabList} list={covers} setList={setCovers}>
+            {/* `filter` keeps the remove button out of the drag surface, and
+                `preventOnFilter: false` is the half that actually fixes touch: SortableJS's
+                default is to `preventDefault()` the filtered `touchstart`, which cancels the
+                synthetic click the browser would otherwise emit — so on a phone the button
+                rendered, highlighted, and did nothing. Both are needed; `filter` alone only
+                stops the tap being read as a drag.
+                See https://github.com/antiwork/gumroad-private/issues/1524 */}
+            <Sortable
+              animation={150}
+              tag={CoversTabList}
+              list={covers}
+              setList={setCovers}
+              filter={`[${REMOVE_COVER_ATTRIBUTE}]`}
+              preventOnFilter={false}
+            >
               {covers.map((cover) => (
                 <CoverTab
                   key={cover.id}
@@ -327,6 +347,7 @@ const CoverTab = ({
 
       {showDelete || !isDesktop ? (
         <RemoveButton
+          {...{ [REMOVE_COVER_ATTRIBUTE]: "" }}
           onClick={(evt) => {
             evt.stopPropagation();
             onRemove();


### PR DESCRIPTION
Fixes gumroad-private#1524 — the cover "X" remove button is unclickable on touch devices. Four support tickets, and four manual production-console soft-deletes of the same seller's `AssetPreview` rows, all trace to this one missing option.

## The cause

`CoverEditor.tsx` renders the cover tab strip inside `<Sortable>` with **no `handle` and no `filter`**:

```tsx
<Sortable animation={150} tag={CoversTabList} list={covers} setList={setCovers}>
```

So the entire tab — including the absolutely-positioned remove button on top of it — is drag surface. SortableJS claims the `touchstart`, and the tap never becomes a click. `evt.stopPropagation()` in the button's `onClick` cannot help, because `onClick` is never reached.

Every other `Sortable` call site in the app already constrains its drag surface (`SortableList.tsx` defaults to `handle="[aria-grabbed]"`, `Profile/EditSections.tsx` passes it explicitly). This one is the outlier.

## The fix: two options, and the second one is the one that matters

```tsx
filter={`[${REMOVE_COVER_ATTRIBUTE}]`}
preventOnFilter={false}
```

`filter` alone is the obvious fix and it is **not sufficient**. SortableJS defaults `preventOnFilter` to `true`, and on the filter path it does this (`sortablejs/modular/sortable.esm.js`, verified in the vendored copy at lines 1235 and 1257):

```js
preventOnFilter && evt.cancelable && evt.preventDefault();
return; // cancel dnd
```

`preventDefault()` on a `touchstart` cancels the synthetic click the browser would otherwise synthesise. So with `filter` alone the tap stops being read as a drag — and still produces no click. The button stays dead on touch, which is exactly the reported symptom. Both options are required, and the tests below pin them separately for that reason.

The selector is a data attribute (`data-remove-cover`) rather than a Tailwind class, so restyling the button cannot silently un-fix this.

Desktop is unaffected: mouse `mousedown` was already reaching the button (the bug is touch-specific), and excluding the button from the drag surface is correct there too — dragging a cover by its delete affordance was never intended.

## Tests

New `CoverEditor.test.tsx`, 3 examples, each verified to redden when only its own half of the fix is reverted:

| mutation | result |
|---|---|
| baseline (fix in place) | 3 passed |
| drop the `filter` prop | **2 failed**, 1 passed |
| `preventOnFilter` back to its default | **1 failed**, 2 passed |
| drop the attribute on the button | **1 failed**, 2 passed |

That third row is the one worth noting: without it the `filter` selector could stop matching the button and both other options would go inert while still reading as configured.

The test stubs `ReactSortable` and records the options handed to it — the defect is entirely about which options reach SortableJS, so those options are the contract. It also stubs `$app/components/Popover` (Radix resolves a second React copy under vitest and dies on `useMemo`; it is the unrelated "add cover" menu).

`tsc --noEmit` clean, `eslint` clean, `prettier` applied.

## What is not covered

No real-device confirmation — happy-dom cannot dispatch a genuine touch sequence with the synthetic-click behaviour, so the `preventOnFilter` reasoning is grounded in the SortableJS source rather than a device test. One tap on the deployed preview by someone holding a phone closes that out.
