### PR TITLE
Recommend image covers and videos in the description

### DIFF
--- a/app/views/help_center/articles/contents/_60-adding-a-cover-image.html.erb
+++ b/app/views/help_center/articles/contents/_60-adding-a-cover-image.html.erb
@@ -17,6 +17,7 @@
   <p>You can upload a cover image after adding a product file or license. Cover images can be images or videos (independent of the file you've uploaded as your product file) that advertise, help describe your product, or offer a taste of what's to come.</p>
   <p>You can upload multiple "preview" files to a product, and your customers will be able to scroll through them before purchasing.</p>
   <p>Compelling cover images (or videos) double conversion rates, contribute to your brand, and give your product its own identity.</p>
+  <p><b>We recommend using an image as your first cover</b> and putting your videos in the product description instead. The carousel controls that tell customers more covers exist — the white circles at the bottom of the frame — are hidden while a video is showing, so a video-first page gives no visible hint that anything else is there. To add a video to your description, open the description editor, click 'Insert', choose 'Insert video', and paste a YouTube or Vimeo link.</p>
   <h3 id="Filetypes-gVAzN">Filetypes</h3>
   <p>A cover image can be a PNG, JPEG, MOV, or GIF file. You can also link to a YouTube or Vimeo video.</p>
   <h3 id="Adding-cover-images-VExHp">Adding cover images</h3>
@@ -42,7 +43,7 @@
   <p>To remove a cover image, simply click the "X" at the top right of the cover thumbnail. The following image in the line will appear.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/61c1ae39dbfe5a232d667681/file-h8vZAXP0W1.png" %></figure>
   <h3 id="What-customers-see-zjqyS">What customers see</h3>
-  <p>When customers land on your product's page, they will see the image you selected to show first. White circles at the bottom of your cover image and arrows on the side of the image will indicate that there are other cover images to check out.</p>
+  <p>When customers land on your product's page, they will see the image you selected to show first. White circles at the bottom of your cover image and arrows on the side of the image will indicate that there are other cover images to check out. The circles are hidden while a video cover is showing so they do not sit on top of the video's playback controls, which is the main reason we recommend leading with an image.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/62447057c1688a6d26a7b46a/file-cF05ZzZhoJ.gif" %></figure>
   <h3 id="Thumbnails-Gx2jS">Thumbnails</h3>
   <p>Thumbnails are entirely separate from your cover images; you do not need to use them. If you choose to add one, your thumbnail will show up in customers' libraries, Gumroad Discover, and on your profile page. Make these images, as the page shows, at least 600 x 600 pixels. </p>


### PR DESCRIPTION
## What

Updates the "Adding a cover image" help-center article to recommend an image as the first cover and to keep videos in the product description. Also states plainly, in the "What customers see" section, that the carousel's dot row is hidden while a video cover is showing.

## Why

`app/javascript/components/Product/Covers/index.tsx:111` suppresses the `role="tablist"` dot row whenever the active cover is a `video` or `oembed` — the dots sit `absolute bottom-0` and would overlap the video's native control bar. The side arrows are `hidden group-hover:flex`, so they do not exist on touch devices. A product page whose first cover is a video therefore has no always-visible cue that other covers exist, and a seller wrote in convinced three of his five previews had disappeared when all five were rendering.

The product behavior is intentional and the guidance we give sellers is to lead with an image and put videos in the description (antiwork/gumroad-private#1519). The article previously described the dots as if they always appear, which is what made the seller believe something was broken. Documenting the recommendation and the actual behavior is the fix for that class of ticket.

Refs antiwork/gumroad-private#1519

## Before / After

Not applicable — help-center copy only, no rendered product surface changes.

## Test plan

Docs-only change to a static ERB partial. Tag balance verified on the edited file (all element opens equal closes); no code, spec, or config files touched.

---

## AI disclosure

Written by claude-opus-5 via Hermes Agent. Instructions given: read the linked issue and the cover-carousel component, then update the help-center article so it recommends image covers with videos in the description and describes the dot row's actual behavior on video covers.
