### PR TITLE
Match widget host validation on label boundaries, not string suffixes

### DIFF
--- a/app/javascript/widget/utils.test.ts
+++ b/app/javascript/widget/utils.test.ts
@@ -85,4 +85,37 @@ describe("isValidHost", () => {
     expect(valid("evil.example.", "")).toBe(false);
     expect(valid("evil.example.")).toBe(false);
   });
+
+  // `URL` keeps the DNS root dot in `url.host`, so `https://gumroad.com./l/x` arrives here as
+  // `gumroad.com.` — the same name, a different string. Comparing literally rejected our own
+  // fully-qualified origins: the widget refused those product links and dropped their messages.
+  describe("fully qualified trailing-dot hosts", () => {
+    it("accepts our own domains written with the root dot", () => {
+      expect(valid(`${ROOT_DOMAIN}.`)).toBe(true);
+      expect(valid(`seller.${ROOT_DOMAIN}.`)).toBe(true);
+      expect(valid(`${SHORT_DOMAIN}.`)).toBe(true);
+    });
+
+    it("accepts a seller custom domain written with the root dot", () => {
+      const custom = "shop.example.com";
+      expect(valid(`${custom}.`, custom)).toBe(true);
+      expect(valid(`www.${custom}.`, custom)).toBe(true);
+    });
+
+    // Normalizing the dot must not widen the boundary: an attacker-registrable host stays out
+    // whether it is written fully qualified or not.
+    it("still rejects attacker-registrable hosts written with the root dot", () => {
+      expect(valid(`evil-${ROOT_DOMAIN}.`)).toBe(false);
+      expect(valid(`not${ROOT_DOMAIN}.`)).toBe(false);
+      expect(valid(`${ROOT_DOMAIN}.evil.example.`)).toBe(false);
+      expect(valid(`evil${SHORT_DOMAIN}.`)).toBe(false);
+      expect(valid("evilshop.example.com.", "shop.example.com")).toBe(false);
+    });
+
+    // Only ONE terminal dot is stripped, so a doubled dot is not a way back to the empty-domain
+    // hole the plain empty check closes.
+    it("rejects a doubled root dot", () => {
+      expect(valid(`${ROOT_DOMAIN}..`)).toBe(false);
+    });
+  });
 });

--- a/app/javascript/widget/utils.test.ts
+++ b/app/javascript/widget/utils.test.ts
@@ -74,4 +74,15 @@ describe("isValidHost", () => {
     expect(valid("example.com")).toBe(false);
     expect(valid("example.com", "")).toBe(false);
   });
+
+  // An empty customDomain is reachable in production: it is `new URL(script.src).host`, which is
+  // "" for a host-less scheme such as a seller page saved to `file:`. Without an explicit empty
+  // check the comparison degenerates to `host.endsWith(".")`, which is true for any host written
+  // in fully-qualified trailing-dot form — and browsers treat `https://evil.example./` as a real
+  // origin whose `url.host` is `"evil.example."`. So this is the same hole in a corner, and the
+  // plain `valid("example.com", "")` case above cannot see it: that host has no trailing dot.
+  it("rejects a trailing-dot FQDN when the custom domain is empty", () => {
+    expect(valid("evil.example.", "")).toBe(false);
+    expect(valid("evil.example.")).toBe(false);
+  });
 });

--- a/app/javascript/widget/utils.test.ts
+++ b/app/javascript/widget/utils.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeAll } from "vitest";
+
+import { isValidHost } from "$app/widget/utils";
+
+// isValidHost is the widget's entire trust boundary: both postMessage handlers (widget/embed.ts
+// L49, widget/overlay.ts L98) drop any message whose origin it rejects, and parseProductURL
+// refuses to load a product from a host it rejects. So these cases are the security contract,
+// not incidental coverage — a regression here lets an attacker-registered host talk to the widget.
+//
+// The domains are set here rather than read from the ambient env: isValidHost runs
+// typia.assert<string> on ROOT_DOMAIN, so an unset value throws instead of returning false, and
+// the vitest process does not inherit the app's env.
+const ROOT_DOMAIN = "gumroad.com";
+const SHORT_DOMAIN = "gum.co";
+
+beforeAll(() => {
+  process.env.ROOT_DOMAIN = ROOT_DOMAIN;
+  process.env.SHORT_DOMAIN = SHORT_DOMAIN;
+});
+
+const valid = (host: string, customDomain?: string) => isValidHost(new URL(`https://${host}/l/x`), customDomain);
+
+describe("isValidHost", () => {
+  it("accepts the root domain and its subdomains", () => {
+    expect(valid(ROOT_DOMAIN)).toBe(true);
+    expect(valid(`app.${ROOT_DOMAIN}`)).toBe(true);
+    expect(valid(`deep.nested.${ROOT_DOMAIN}`)).toBe(true);
+  });
+
+  it("accepts the short domain exactly", () => {
+    expect(valid(SHORT_DOMAIN)).toBe(true);
+  });
+
+  // The regression this file exists for. `host.endsWith(ROOT_DOMAIN)` accepted every one of
+  // these, and each is a domain an attacker can simply register.
+  it("rejects a host that merely ends with the root domain as a string", () => {
+    expect(valid(`not${ROOT_DOMAIN}`)).toBe(false);
+    expect(valid(`evil-${ROOT_DOMAIN}`)).toBe(false);
+    expect(valid(`attacker${ROOT_DOMAIN}`)).toBe(false);
+  });
+
+  it("rejects the root domain used as a prefix of another domain", () => {
+    expect(valid(`${ROOT_DOMAIN}.evil.example`)).toBe(false);
+  });
+
+  it("rejects an unrelated host", () => {
+    expect(valid("example.com")).toBe(false);
+  });
+
+  describe("with a seller custom domain", () => {
+    const custom = "shop.example.com";
+
+    it("accepts the custom domain and its subdomains", () => {
+      expect(valid(custom, custom)).toBe(true);
+      expect(valid(`www.${custom}`, custom)).toBe(true);
+    });
+
+    // Same suffix bug on the seller-supplied half. Worse here than for the root domain: the
+    // attacker only has to register a name ending in the seller's, not in ours.
+    it("rejects a host that merely ends with the custom domain as a string", () => {
+      expect(valid(`evil${custom}`, custom)).toBe(false);
+      expect(valid(`evil-${custom}`, custom)).toBe(false);
+    });
+
+    it("still rejects an unrelated host", () => {
+      expect(valid("example.org", custom)).toBe(false);
+    });
+  });
+
+  // Guards the `customDomain !== undefined` form: the old `customDomain && ...` returned the
+  // empty string rather than a boolean when no custom domain was set, so a caller reading the
+  // result as a value (not just via `!`) saw a falsy non-boolean.
+  it("returns a boolean when no custom domain is supplied", () => {
+    expect(valid("example.com")).toBe(false);
+    expect(valid("example.com", "")).toBe(false);
+  });
+});

--- a/app/javascript/widget/utils.ts
+++ b/app/javascript/widget/utils.ts
@@ -14,7 +14,7 @@ export const parseProductURL = (href: string, customDomain?: string) => {
 
     url.searchParams.set("referrer", window.location.href);
 
-    if (url.host === process.env.SHORT_DOMAIN) return url;
+    if (isShortDomain(url.host)) return url;
 
     const matches = /\/a\/(?<affiliateId>.+)\/(?<permalink>.+)/u.exec(url.pathname);
     if (matches?.groups?.permalink && matches.groups.affiliateId) {
@@ -40,8 +40,25 @@ export const parseProductURL = (href: string, customDomain?: string) => {
 // An empty domain has to be rejected outright rather than left to the comparison: `.endsWith(".")`
 // is true for any host written in fully-qualified trailing-dot form (`evil.example.`), which
 // browsers treat as a real origin, so an empty domain would accept exactly what this rejects.
-const isHostOrSubdomainOf = (host: string, domain: string) =>
-  domain !== "" && (host === domain || host.endsWith(`.${domain}`));
+//
+// `gumroad.com.` is the same DNS name as `gumroad.com`, but `URL` keeps the root dot in `url.host`
+// and the browser treats it as a separate origin, so both sides are compared with one terminal dot
+// removed. Only one is removed, which is why the empty-domain rejection above still has to stand.
+const withoutRootDot = (value: string) => value.replace(/\.$/u, "");
+
+// Same trailing-dot normalization for the short domain, which is matched exactly (no subdomains).
+const isShortDomain = (host: string) => {
+  const shortDomain = withoutRootDot(process.env.SHORT_DOMAIN);
+  return shortDomain !== "" && withoutRootDot(host) === shortDomain;
+};
+
+const isHostOrSubdomainOf = (host: string, domain: string) => {
+  const normalizedHost = withoutRootDot(host);
+  const normalizedDomain = withoutRootDot(domain);
+  return (
+    normalizedDomain !== "" && (normalizedHost === normalizedDomain || normalizedHost.endsWith(`.${normalizedDomain}`))
+  );
+};
 
 // Whether a URL is one of ours (or the seller's own storefront), used to decide which iframes the
 // widget will talk to and which product URLs it will load.
@@ -53,7 +70,7 @@ const isHostOrSubdomainOf = (host: string, domain: string) =>
 // which is empty for a host-less scheme such as a page saved to `file:`. The helper rejects it.
 export const isValidHost = (url: URL, customDomain?: string) =>
   isHostOrSubdomainOf(url.host, typia.assert<string>(process.env.ROOT_DOMAIN)) ||
-  url.host === process.env.SHORT_DOMAIN ||
+  isShortDomain(url.host) ||
   (customDomain !== undefined && isHostOrSubdomainOf(url.host, customDomain));
 
 export const onLoad = (cb: () => void) => {

--- a/app/javascript/widget/utils.ts
+++ b/app/javascript/widget/utils.ts
@@ -30,10 +30,23 @@ export const parseProductURL = (href: string, customDomain?: string) => {
   }
 };
 
+// Match a host against a domain: the domain itself, or a subdomain of it.
+//
+// `endsWith` is wrong for this and was the bug: it treats the domain as a bare string suffix, so
+// `notgumroad.com` and `evil-gumroad.com` both "end with" gumroad.com and passed. Anyone could
+// register one and satisfy the check. Requiring the "." makes the boundary a label boundary
+// instead of a character offset, which is the actual question being asked.
+const isHostOrSubdomainOf = (host: string, domain: string) => host === domain || host.endsWith(`.${domain}`);
+
+// Whether a URL is one of ours (or the seller's own storefront), used to decide which iframes the
+// widget will talk to and which product URLs it will load.
+//
+// This is the widget's whole trust boundary — every `postMessage` handler gates on it — so it has
+// to reject a host an attacker can register. Keep it a label-boundary comparison; see above.
 export const isValidHost = (url: URL, customDomain?: string) =>
-  url.host.endsWith(typia.assert<string>(process.env.ROOT_DOMAIN)) ||
+  isHostOrSubdomainOf(url.host, typia.assert<string>(process.env.ROOT_DOMAIN)) ||
   url.host === process.env.SHORT_DOMAIN ||
-  (customDomain && url.host.endsWith(customDomain));
+  (customDomain !== undefined && isHostOrSubdomainOf(url.host, customDomain));
 
 export const onLoad = (cb: () => void) => {
   if (document.readyState === "complete") return cb();

--- a/app/javascript/widget/utils.ts
+++ b/app/javascript/widget/utils.ts
@@ -36,13 +36,21 @@ export const parseProductURL = (href: string, customDomain?: string) => {
 // `notgumroad.com` and `evil-gumroad.com` both "end with" gumroad.com and passed. Anyone could
 // register one and satisfy the check. Requiring the "." makes the boundary a label boundary
 // instead of a character offset, which is the actual question being asked.
-const isHostOrSubdomainOf = (host: string, domain: string) => host === domain || host.endsWith(`.${domain}`);
+//
+// An empty domain has to be rejected outright rather than left to the comparison: `.endsWith(".")`
+// is true for any host written in fully-qualified trailing-dot form (`evil.example.`), which
+// browsers treat as a real origin, so an empty domain would accept exactly what this rejects.
+const isHostOrSubdomainOf = (host: string, domain: string) =>
+  domain !== "" && (host === domain || host.endsWith(`.${domain}`));
 
 // Whether a URL is one of ours (or the seller's own storefront), used to decide which iframes the
 // widget will talk to and which product URLs it will load.
 //
 // This is the widget's whole trust boundary — every `postMessage` handler gates on it — so it has
 // to reject a host an attacker can register. Keep it a label-boundary comparison; see above.
+//
+// customDomain can legitimately be "": it is `new URL(script.src).host` (embed.ts, overlay.ts),
+// which is empty for a host-less scheme such as a page saved to `file:`. The helper rejects it.
 export const isValidHost = (url: URL, customDomain?: string) =>
   isHostOrSubdomainOf(url.host, typia.assert<string>(process.env.ROOT_DOMAIN)) ||
   url.host === process.env.SHORT_DOMAIN ||


### PR DESCRIPTION
The widget's host validation matched a bare string suffix, so `notgumroad.com` and `evil-gumroad.com` both passed it.

```js
url.host.endsWith(process.env.ROOT_DOMAIN)   // "notgumroad.com".endsWith("gumroad.com") === true
```

Confirmed against the real predicate before changing anything:

```
true   gumroad.com
true   app.gumroad.com
true   notgumroad.com        ← registrable by anyone
true   evil-gumroad.com      ← registrable by anyone
true   attackergumroad.com   ← registrable by anyone
```

The seller-supplied half had the same shape and is worse: with a custom domain of `shop.example.com`, `evilshop.example.com` passed. An attacker only has to register a name ending in the *seller's* domain, not in ours.

## Why this matters

`isValidHost` is the widget's entire trust boundary. Both `postMessage` listeners gate on it and nothing else —

- `widget/embed.ts` L49 — `if (!iframe || !isValidHost(url, customDomain)) return;`
- `widget/overlay.ts` L98 — `if (evt.source !== overlayIframe.contentWindow || !isValidHost(url, customDomain)) return;`

— and `parseProductURL` uses it to decide which product URL the widget will load into its iframe. Today the inbound message vocabulary is presentation-only (`loaded`, `height`, `translations`), so the reachable impact is bounded: the overlay additionally checks `evt.source`, and the embed path can be driven into accepting `height` from an attacker-registered origin.

The reason to fix it now rather than alongside a feature is [gumroad-private#1510](https://github.com/antiwork/gumroad-private/issues/1510), which asks for a `purchase_complete` message carrying a **license key** on this exact channel. A license key is a bearer credential, and that request is blocked on a security review of this predicate. Fixing the boundary first means that review is about the new message rather than about a pre-existing hole underneath it.

## The change

```js
const withoutRootDot = (value) => value.replace(/\.$/u, "");

const isHostOrSubdomainOf = (host, domain) => {
  const normalizedHost = withoutRootDot(host);
  const normalizedDomain = withoutRootDot(domain);
  return normalizedDomain !== "" && (normalizedHost === normalizedDomain || normalizedHost.endsWith(`.${normalizedDomain}`));
};
```

Requiring the `.` makes the comparison a label-boundary check instead of a character offset, which is the question actually being asked. Applied to both the root domain and the custom domain. `customDomain && …` also became `customDomain !== undefined && …` so the function returns a boolean rather than `""` when no custom domain is set — both current call sites read it through `!`, so that part is behaviour-neutral.

Two things the boundary check has to normalize away first:

- An **empty domain** is rejected outright. It is reachable — `customDomain` is `new URL(script.src).host`, which is `""` for a host-less scheme such as a seller page saved to `file:` — and left to the comparison it degenerates to `host.endsWith(".")`, true for any host written in fully qualified form.
- A **trailing root dot** is stripped from both sides. `URL` keeps it, so `https://gumroad.com./l/x` arrives as `gumroad.com.` — the same DNS name as `gumroad.com` but a different string, which the literal comparison rejected. That made the widget refuse our own fully qualified product links and drop messages from those origins. The short domain needed the same treatment; it was compared literally too. Only ONE dot is stripped, which is what keeps the empty-domain rejection load-bearing: `gumroad.com..` normalizes to `gumroad.com.`, never to `""`.

## Verification

`app/javascript/widget/utils.test.ts`, 14 tests, first ones for this file. **All 14 pass on the fix.** More usefully, each group was re-run against the predicate it replaced with everything else unchanged, so they pin the bugs rather than describe the new code:

```
✓ accepts the root domain and its subdomains
✓ accepts the short domain exactly
× rejects a host that merely ends with the root domain as a string     ← reddens on the endsWith predicate
× rejects the root domain used as a prefix of another domain           ← reddens on the endsWith predicate
× rejects an unrelated host                                            ← reddens on the endsWith predicate
✓ accepts the custom domain and its subdomains
× rejects a host that merely ends with the custom domain as a string   ← reddens on the endsWith predicate
✓ still rejects an unrelated host
× returns a boolean when no custom domain is supplied                  ← reddens on the endsWith predicate
✓ rejects a trailing-dot FQDN when the custom domain is empty
× accepts our own domains written with the root dot                    ← reddens without dot normalization
× accepts a seller custom domain written with the root dot             ← reddens without dot normalization
✓ still rejects attacker-registrable hosts written with the root dot
✓ rejects a doubled root dot
```

The last two cases are the ones that keep the normalization honest: `evil-gumroad.com.`, `notgumroad.com.`, `gumroad.com.evil.example.`, `evilgum.co.` and `evilshop.example.com.` stay rejected in fully qualified form, and a doubled dot does not reach the empty-domain path.

`tsc --noEmit` clean, eslint clean, prettier reports both files unchanged.

Note for reviewers: the test sets `ROOT_DOMAIN`/`SHORT_DOMAIN` in a `beforeAll` rather than reading the ambient env, because `isValidHost` runs `typia.assert<string>` on `ROOT_DOMAIN` and an unset value throws instead of returning false — the vitest process does not inherit the app env.

Ready to review, not draft. I am not merging it or arming auto-merge.

