### PR TITLE
Document the shortened dispute evidence window

### DIFF
--- a/app/views/help_center/articles/contents/_134-how-does-gumroad-handle-chargebacks.html.erb
+++ b/app/views/help_center/articles/contents/_134-how-does-gumroad-handle-chargebacks.html.erb
@@ -32,6 +32,7 @@
   <p>If the dispute is filed for a <a href="330-stripe-connect">Stripe Connect</a> or <a href="275-paypal-connect">PayPal Connect</a> purchase, you will need to fight this dispute through your respective Stripe or PayPal accounts. </p>
   <p>We also email your customer, asking them to cancel the dispute. In our email, we tell them what they bought and what email address was used for the purchase.  It is very helpful to us if you also email them and ask them to cancel the dispute, or at least ask them (nicely) why they canceled the payment.</p>
   <p>To provide additional information, click the Submit Additional Information button within the email. You have 72 hours to submit any additional information using the form below; after that, we will auto-submit on your behalf. You can only submit additional information once. </p>
+  <p>Occasionally we contact you later than usual about a dispute, and by then the card provider's own deadline is closer than 72 hours away. In that case the email tells you how many hours you actually have, and we submit at the end of that shorter window so it still reaches the card provider in time. If there is no time left to ask you at all, we submit what we have without a statement from you, so the dispute is still contested.</p>
   <h3 id="Understanding-the-dispute-form-wy_30">Understanding the dispute form</h3>
   <ul>
     <li>You can find the dispute reason (explanation) displayed at the top of the form.  </li>


### PR DESCRIPTION
## What

Adds one paragraph to the chargeback help-center article (`_134-how-does-gumroad-handle-chargebacks`) covering the case where the seller's evidence window is shorter than 72 hours, or has already elapsed by the time we can contact them.

## Why

Triggered by merged PR #6534 (`Sweep for disputes left with no evidence record`), which is now on main.

The article stated a flat promise: "You have 72 hours to submit any additional information... after that, we will auto-submit on your behalf." Two changes in #6534 make that conditionally wrong for a seller:

- `CreateMissingDisputeEvidenceJob#seller_window_start` backdates the window so it ends `DEADLINE_BUFFER = 6.hours` before Stripe's `evidence_details.due_by`, whenever a full `DisputeEvidence::SUBMIT_EVIDENCE_WINDOW_DURATION_IN_HOURS = 72` window would overrun that cutoff. A seller swept late is quoted the hours they really have, not 72.
- `ContactingCreatorMailer#chargeback_notice` now drops the "in the next N hours" ask when `hours_left_to_submit_evidence` is not positive, and the job submits the evidence without a seller statement in that case.

Both are creator-visible: the number in the email no longer matches the number in the docs, and a seller can now receive a chargeback notice with no submission ask at all. The new paragraph explains both outcomes and why the shorter window exists (so the submission still reaches the card provider in time).

## Articles changed

| Article | Change |
|---|---|
| `_134-how-does-gumroad-handle-chargebacks.html.erb` | +1 paragraph after the existing 72-hour paragraph |

No removals. `articles.yml` untouched — body-only edit, no title/description/category change, and the existing anchor IDs and TOC entries are unchanged.

The wording deliberately does not publish the 6-hour buffer constant or the 60-day sweep lookback; a seller only needs to know the window may be shorter and that the email carries the real number.

## Test plan

Body-only prose edit, no logic — no adversarial review gate per the help-center editing conventions.

- ERB syntax: `ERB.new(...).src` compiles.
- Tag balance across the whole file: `div 2/2, p 45/45, ul 7/7, li 27/27, h3 10/10, h4 1/1, figure 1/1, b 16/16, a 25/25` — all balanced.
- Real render in the view context: `ApplicationController.render(partial: "help_center/articles/contents/134-how-does-gumroad-handle-chargebacks")` → `render OK 14900 bytes`, and the new copy is present in the output.
- CI runs the help-center specs (`spec/models/help_center`, `spec/presenters/help_center_presenter_spec.rb`), which guard slug ↔ partial integrity.

## Before / after

Not applicable as a screenshot pair — the change is one added paragraph of body copy in a help-center article, rendered as plain text inside the existing section. Verified instead by rendering the partial and asserting the new copy is in the output (above).

---

## AI disclosure

Written by claude-opus-5 running as the Hermes agent. It was given the merge webhook for PR #6534 and asked to run the standing merged-PR → help-center sync: judge whether the merged change makes any help-center article wrong, and if so identify the exact article and ship the edit. It read the job, the mailer, and `DisputeEvidence` on main to establish the real constants and the real conditional behaviour before wording the paragraph, rather than working from the PR description.
