### PR TITLE
Stop returning an unusable editor_revision on the stale-deletion 409

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -623,12 +623,21 @@ class LinksController < ApplicationController
       # must NOT clear its pending-removal state on this response — the whole
       # point is that the seller's deletion has not happened yet.
       #
-      # A fresh token rides along so the editor can reconcile and retry after
-      # showing the seller what changed, rather than forcing a full page reload.
+      # Deliberately NO fresh `editor_revision` here, unlike the success
+      # response. Adopting a token on this path can only authorise the session's
+      # NEXT save — which is the same stale full snapshot — so the deletion
+      # would land while every field a co-editor changed in between was reverted
+      # to this session's values (proved in LinksControllerSaveContractTest,
+      # "resending a stale snapshot with the 409's fresh token deletes as asked
+      # AND reverts the other session's edit"). It was emitted here for a
+      # reconcile-and-retry affordance that does not exist and cannot be built
+      # client-side; the client threw it away (see saveProductError). Both
+      # candidate retries in gumroad-private#1532 — a deletion-only write, or
+      # re-fetch-then-reconcile — get a current token from the reload they
+      # already have to do, so neither needs one on the refusal.
       return render json: {
         error_message: e.message,
         error_code: "stale_deletion_conflict",
-        editor_revision: Product::EditorRevision.current(@product.reload),
       }, status: :conflict
     rescue Product::RichContentDeletionGuard::HiddenVariantContentConflict => e
       # The fail-closed inconsistent-content case: hidden version-level pages

--- a/app/javascript/data/product_edit.test.ts
+++ b/app/javascript/data/product_edit.test.ts
@@ -420,7 +420,6 @@ describe("save contract conflict responses", () => {
     const error = saveProductError({
       error_message: "This product changed since you opened it.",
       error_code: "stale_deletion_conflict",
-      editor_revision: "revision-issued-with-the-409",
     });
 
     expect(error).toBeInstanceOf(StaleDeletionConflictError);
@@ -428,17 +427,23 @@ describe("save contract conflict responses", () => {
     expect(error.message).toBe("This product changed since you opened it.");
   });
 
-  // The 409's fresh token must not reach the editor. Adopting it would let the
+  // A fresh token must never reach the editor: adopting it would let the
   // session's next save — still the full stale snapshot — delete AND revert
   // every field another session changed in between (gumroad-private#1532).
-  it("does not carry the fresh revision onto the error", () => {
+  // The server no longer sends one, and the payload type no longer has a field
+  // to receive it, so this pins the defence in depth: even a server that
+  // regressed and emitted the token could not get it onto the error.
+  it("does not carry a fresh revision onto the error", () => {
     const error = saveProductError({
       error_message: "Stale.",
       error_code: "stale_deletion_conflict",
+      // @ts-expect-error -- not part of SaveProductErrorPayload; a server that
+      // regressed and sent it anyway must still not have it reach the editor.
       editor_revision: "revision-issued-with-the-409",
     });
 
-    expect(Object.values({ ...error })).not.toContain("revision-issued-with-the-409");
+    expect(error).toBeInstanceOf(StaleDeletionConflictError);
+    expect(JSON.stringify({ ...error, message: error.message })).not.toContain("revision-issued-with-the-409");
   });
 
   // Pins the discrimination to error_code, not to HTTP status. stale-content and

--- a/app/javascript/data/product_edit.ts
+++ b/app/javascript/data/product_edit.ts
@@ -77,14 +77,14 @@ export class StaleContentConflictError extends Error {
 // any mutation, so nothing was written and the removals are still pending in
 // this editor session.
 //
-// The 409 carries a fresh `editor_revision`, and this error deliberately does
-// NOT expose it. Adopting that token would authorise the session's next save —
-// which is still the full stale snapshot — to delete, so the deletion would go
-// through while every field another session changed in the meantime got
-// reverted to this session's values. The seller confirmed a deletion, not an
-// overwrite. Retrying safely means reconciling against current stored state, or
-// a payload that can only delete; neither exists client-side yet
-// (gumroad-private#1532), so the recovery here is a reload.
+// The 409 carries NO fresh `editor_revision`, and must not: adopting one would
+// authorise the session's next save — still the full stale snapshot — to delete,
+// so the deletion would go through while every field another session changed in
+// the meantime got reverted to this session's values. The seller confirmed a
+// deletion, not an overwrite. Retrying safely means reconciling against current
+// stored state, or a payload that can only delete; neither exists yet
+// (gumroad-private#1532), so the recovery here is a reload — which issues a
+// current token of its own.
 export class StaleDeletionConflictError extends Error {}
 
 // The server's error payload for a rejected save. Every conflict the editor can
@@ -94,9 +94,6 @@ export class StaleDeletionConflictError extends Error {}
 export type SaveProductErrorPayload = {
   error_message: string;
   error_code?: string;
-  // Sent with a stale_deletion_conflict. Read by nothing here on purpose — see
-  // StaleDeletionConflictError for why the editor must not adopt it.
-  editor_revision?: string | null;
   hidden_variant_pages?: { id: string; title: string | null; variant_name: string | null }[];
   stale_records?: { type: "page" | "variant"; id: string; name: string | null }[];
 };

--- a/test/controllers/links_controller_test.rb
+++ b/test/controllers/links_controller_test.rb
@@ -7189,9 +7189,11 @@ class LinksControllerSaveContractTest < ActionController::TestCase
 
     body = response.parsed_body
     assert_equal "stale_deletion_conflict", body["error_code"]
-    # The response carries the token for the CURRENT state, so the editor can
-    # reconcile and retry without a full reload.
-    assert_equal Product::EditorRevision.current(@product.reload), body["editor_revision"]
+    # And NO token: one here could only authorise the session's next save, which
+    # is the same stale snapshot, so the retry it enabled would delete AND revert
+    # a co-editor's changes (gumroad-private#1532). Recovery is a reload, which
+    # issues a current token of its own.
+    assert_not body.key?("editor_revision")
 
     # Nothing was written: the deletion did not happen AND the ordinary field
     # updates in the same payload were rolled back with it.
@@ -7442,9 +7444,11 @@ class LinksControllerSaveContractTest < ActionController::TestCase
 
     body = response.parsed_body
     assert_equal "stale_deletion_conflict", body["error_code"]
-    # The 409 carries a token for the state as it stands NOW, so the editor
-    # can reconcile and retry without forcing a full reload.
-    assert_equal Product::EditorRevision.current(@product.reload), body["editor_revision"]
+    # And NO token. See gumroad-private#1532: the only thing a token here could
+    # authorise is the session's next save, which is the same stale snapshot, so
+    # it would delete as asked AND revert a co-editor's edits. Recovery is a
+    # reload, which issues a current token of its own.
+    assert_not body.key?("editor_revision")
 
     # Refused BEFORE any mutation: the rows survive and the ordinary field
     # updates in the same payload were rolled back with the transaction.
@@ -7481,7 +7485,7 @@ class LinksControllerSaveContractTest < ActionController::TestCase
   # Driven end to end here rather than asserted in the client, because it is the
   # SERVER's acceptance of the retry that makes the overwrite happen; a client
   # test can only show which request was sent.
-  test "flag on: resending a stale snapshot with the 409's fresh token deletes as asked AND reverts the other session's edit" do
+  test "flag on: the 409 refusing a stale deletion carries no fresh revision token" do
     enable_contract!
     doomed = create_variant(variant_category: @category, name: "Version Y, to delete")
     edited = create_variant(variant_category: @category, name: "Version X, as this session loaded it")
@@ -7501,13 +7505,52 @@ class LinksControllerSaveContractTest < ActionController::TestCase
       deletion_operations: { deleted_ids: { variants: [doomed.external_id] } },
     ), format: :json
     assert_response :conflict
-    fresh_token = response.parsed_body["editor_revision"]
+
+    # The refusal must not hand back a token. It could only authorise the next
+    # save, which is the same stale snapshot — so the deletion would land AND
+    # revert the other session's rename (gumroad-private#1532). The client
+    # discards it, and the recovery is a reload, which issues its own current
+    # token from ProductPresenter.
+    assert_equal "stale_deletion_conflict", response.parsed_body["error_code"]
+    assert_not response.parsed_body.key?("editor_revision"),
+               "the 409 must not carry a token that can only authorise a stale overwrite"
+    assert response.parsed_body["error_message"].present?
+
+    # Nothing was written: the deletion is still pending and the co-editor's
+    # rename survives.
+    assert doomed.reload.alive?
+    assert_equal "Version X, renamed by the other session", edited.reload.name
+  end
+
+  test "flag on: resending a stale snapshot with a separately-obtained fresh token deletes as asked AND reverts the other session's edit" do
+    enable_contract!
+    doomed = create_variant(variant_category: @category, name: "Version Y, to delete")
+    edited = create_variant(variant_category: @category, name: "Version X, as this session loaded it")
+    stale_token = current_revision
+    session_snapshot = @params.merge(
+      variants: [
+        { id: doomed.external_id, name: doomed.name },
+        { id: edited.external_id, name: edited.name },
+      ],
+    )
+
+    # The other session renames X. That moves the fingerprint, so this session's
+    # deletion of Y is refused.
+    edited.update!(name: "Version X, renamed by the other session")
+    post :update, params: session_snapshot.merge(
+      editor_revision: stale_token,
+      deletion_operations: { deleted_ids: { variants: [doomed.external_id] } },
+    ), format: :json
+    assert_response :conflict
     assert_equal "Version X, renamed by the other session", edited.reload.name
 
-    # The retry the removed "Save again" button used to send: same in-memory
-    # snapshot, only the token swapped.
+    # The 409 no longer supplies a token, so compute the current one directly —
+    # this is what any client-side "adopt a fresh token and resend" retry
+    # amounts to, however the token is obtained. The point of this test is that
+    # the DANGER is in resending the stale snapshot, not in where the token came
+    # from: that is why no safe retry can be built by swapping tokens alone.
     post :update, params: session_snapshot.merge(
-      editor_revision: fresh_token,
+      editor_revision: current_revision,
       deletion_operations: { deleted_ids: { variants: [doomed.external_id] } },
     ), format: :json
     assert_response :success


### PR DESCRIPTION
Settles the third of the three options in antiwork/gumroad-private#1532, the only one that did not need a design decision first.

## What was wrong

The save contract answers a stale-token deletion with 409 + a fresh `editor_revision`, and the comment on that response said the token rode along "so the editor can reconcile and retry after showing the seller what changed, rather than forcing a full page reload."

That affordance was never built, and antiwork/gumroad#6559 established it **cannot** be built by adopting the token. Deletions are gated on the token; ordinary writes are not, and the editor save is a full snapshot. So swapping the token and resending applies the deletion *and* reverts every field another session changed in between. That is proved end to end through the real endpoint in `LinksControllerSaveContractTest`.

Since #6559 the client has thrown the token away — `saveProductError` maps the 409 to `StaleDeletionConflictError` and deliberately does not expose it. So the field is a documented invitation to do the one unsafe thing, consumed by nothing. `git grep editor_revision -- app/javascript` confirms the only reader is the *success* path in `ProductEditPage`.

## Why removing it costs the remaining work nothing

Both routes still open in #1532 obtain a current token without this one:

- **a deletion-only write** — a fresh request built from a read of current state;
- **re-fetch and reconcile** — a read of current state by definition.

`ProductPresenter` issues `Product::EditorRevision.current` on every product-edit load, so the reload that both routes start from already hands out a live token. The 409's copy is redundant to both.

## What changed

- `LinksController` no longer emits `editor_revision` on `stale_deletion_conflict`, with the reasoning at the raise site instead of the old comment promising a retry that cannot exist.
- `SaveProductErrorPayload` drops the field, so there is no longer a typed slot for it.
- The two tests asserting the token's presence now assert its absence.
- The end-to-end "resending a stale snapshot deletes as asked AND reverts the other session's edit" proof is **kept**, obtaining the token directly rather than from the 409. That was the point all along: the danger is the stale snapshot, not where the token came from. Keeping it means the trap stays documented for whoever builds the real retry.
- One client test now asserts defence in depth — a server that regressed and sent the token still could not get it onto the error.

## Verified by running

- `LinksControllerSaveContractTest`: **59 runs, 241 assertions, 0 failures**.
- `product_edit.test.ts`: **18 passed**.
- rubocop clean on both Ruby files; eslint clean; `tsc --noEmit` reports nothing for either changed TS file.

One note from actually running it rather than assuming: my first draft of the client test asserted `typia.assert` would *reject* the extra key. It does not — typia permits excess properties — so that test passed vacuously and I rewrote it to assert the reachable property instead.

No behaviour change for sellers: the reload path from #6559 is untouched, and the only thing removed is a field nothing read.
