### PR TITLE
Pin the clock in the Apple Pay end-date specs

### DIFF
--- a/app/javascript/components/Checkout/applePayRecurringPaymentRequest.test.ts
+++ b/app/javascript/components/Checkout/applePayRecurringPaymentRequest.test.ts
@@ -32,6 +32,19 @@ const membership = (overrides: Partial<Product> = {}) =>
   product({ nativeType: "membership", recurrence: "monthly", ...overrides });
 
 describe("getApplePayRecurringPaymentRequest", () => {
+  // End dates are derived from the current date, so every example that asserts one runs against a
+  // pinned clock. Left on the real clock they only pass on days whose target month is long enough
+  // to hold the same day-of-month, so they go red on the 31st of a month 11 or 9 months ahead of a
+  // 30-day one. Examples below that pin their own date override this.
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 15)); // March 15, 2026
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("returns null for a one-time cart", () => {
     expect(getApplePayRecurringPaymentRequest([product()], MANAGEMENT_URL)).toBeNull();
   });
@@ -77,24 +90,25 @@ describe("getApplePayRecurringPaymentRequest", () => {
 
   it("bounds the agreement with an end date for a fixed-duration membership", () => {
     // A 12-month membership billed monthly makes 12 payments; the first is charged today, so the
-    // agreement ends 11 months out.
+    // agreement ends 11 months out — February 15, 2027 from the pinned March 15, 2026.
     const request = getApplePayRecurringPaymentRequest([membership({ durationInMonths: 12 })], MANAGEMENT_URL);
-    const expectedEnd = new Date();
-    expectedEnd.setMonth(expectedEnd.getMonth() + 11);
-    expect(request?.regularBilling.recurringPaymentEndDate?.getMonth()).toBe(expectedEnd.getMonth());
-    expect(request?.regularBilling.recurringPaymentEndDate?.getFullYear()).toBe(expectedEnd.getFullYear());
+    const endDate = request?.regularBilling.recurringPaymentEndDate;
+    expect(endDate?.getFullYear()).toBe(2027);
+    expect(endDate?.getMonth()).toBe(1); // February
+    expect(endDate?.getDate()).toBe(15);
     expect(request?.billingAgreement).toBe("$10 a month for 12 payments. Manage anytime from your Gumroad library.");
   });
 
   it("computes billing cycles from the recurrence interval for fixed-duration memberships", () => {
-    // 12 months billed quarterly = 4 payments, ending 9 months out.
+    // 12 months billed quarterly = 4 payments, ending 9 months out — December 15, 2026.
     const request = getApplePayRecurringPaymentRequest(
       [membership({ recurrence: "quarterly", durationInMonths: 12 })],
       MANAGEMENT_URL,
     );
-    const expectedEnd = new Date();
-    expectedEnd.setMonth(expectedEnd.getMonth() + 9);
-    expect(request?.regularBilling.recurringPaymentEndDate?.getMonth()).toBe(expectedEnd.getMonth());
+    const endDate = request?.regularBilling.recurringPaymentEndDate;
+    expect(endDate?.getFullYear()).toBe(2026);
+    expect(endDate?.getMonth()).toBe(11); // December
+    expect(endDate?.getDate()).toBe(15);
     expect(request?.billingAgreement).toContain("for 4 payments");
   });
 


### PR DESCRIPTION
Every open pull request in this repository is red on `Lint JS/TS` right now, and none of them broke anything. Two examples in `applePayRecurringPaymentRequest.test.ts` computed their expected end date on the real clock:

```ts
const expectedEnd = new Date();
expectedEnd.setMonth(expectedEnd.getMonth() + 11);
```

A raw `setMonth()` overflows when the target month is shorter than the starting day-of-month. Production deliberately does *not* do that — `addMonthsClamped` clamps to the target month's last day, because billing anniversaries clamp. So the two disagree on exactly the days when overflow happens.

Today is **July 31**. July 31 + 11 months = June 31, which `setMonth()` rolls into July, so the spec expected month 6 and got 5. July 31 + 9 months = April 31, rolled into May, so it expected 4 and got 3. Both assertions that failed in CI are precisely these:

```
AssertionError: expected 5 to be 6   applePayRecurringPaymentRequest.test.ts:84
AssertionError: expected 3 to be 4   applePayRecurringPaymentRequest.test.ts:97
```

The production clamp is correct and is **not** touched here. Only the two examples move onto a pinned clock (March 15, 2026), matching what the rest of the describe block already does for the two overflow-specific examples further down, and they now assert the full date rather than just month and year — the day-of-month is the part that was silently unchecked.

## Test Results

`npx vitest run app/javascript/components/Checkout/applePayRecurringPaymentRequest.test.ts`

```
 ✓ app/javascript/components/Checkout/applePayRecurringPaymentRequest.test.ts (24 tests) 23ms

 Test Files  1 passed (1)
      Tests  24 passed (24)
```

24/24 green, including the two Jan-31 and Oct-31 clamping examples that prove the production behaviour this change leaves alone is still exercised.

Mutation check: the failure is self-proving in the other direction — the *unfixed* spec is red in CI on every open PR today (e.g. run 30592277423 on #6558) and was green yesterday with no code change between, which is only explicable by the date dependency.

## QA media

Not applicable: no user-visible surface changes. This is a spec-only change to two assertions; the CI logs linked above are the evidence.

## AI disclosure

Written by an AI agent (gumclaw). The diagnosis, the fix and the local verification above are mine. Worth a human eye on one judgement call: a partially-written change on this branch had also *deleted* the `addMonthsClamped` clamping logic from the production module, which would have made the specs pass by reintroducing the January-31 overflow bug. I discarded that and fixed only the expectations, on the grounds that the clamp is the intended behaviour and the specs were the thing that was wrong.
