### PR TITLE
Pin the clock in the payout CSV affiliate-fee spec

### DIFF
--- a/spec/services/exports/payouts/csv_spec.rb
+++ b/spec/services/exports/payouts/csv_spec.rb
@@ -141,6 +141,11 @@ describe Exports::Payouts::Csv, :vcr do
 
   describe "affiliate fees from Stripe Connect sales" do
     it "correctly adds the affiliate fee entries from Stripe Connect sales" do
+      # The refund is created inside `travel_to(10.days.ago)` while the expected CSV row
+      # re-reads `10.days.ago.to_date` at assertion time; crossing midnight between the two
+      # skews the expected date by a day.
+      travel_to(Time.current.midday)
+
       seller = create :user
       direct_affiliate = create(:direct_affiliate, affiliate_user: create(:user), seller:)
       stripe_connect_account = create(:merchant_account_stripe_connect, user: seller, charge_processor_merchant_id: "acct_1SOb0DEwFhlcVS6d")


### PR DESCRIPTION
## What

Freeze the clock at the top of the payout CSV affiliate-fee spec so it cannot fail as a function of the time of day it runs.

## Why

`spec/services/exports/payouts/csv_spec.rb:143` creates the Stripe Connect refund inside `travel_to(10.days.ago)`, but the expected CSV rows re-read `10.days.ago.to_date` at *assertion* time (lines 171-172, 176-177). Those are two separate reads of the real clock. When setup straddles midnight UTC the second read resolves to a different day, so the expected date string is a day off the one the exporter actually rendered and the example goes red for no reason connected to the code.

This is the last live sibling of the class fixed in #6663 (`Pin the clock in the time-dependent stats specs`). That PR covered the two `User::Stats` payout-window groups and `#last_weeks_sales`; this one closes the same shape in the CSV exporter spec. The pattern is identical: a date-bearing value produced under one clock read and asserted against another.

I swept the rest of the class before opening this. Five spec files mix `days.ago.to_date` with `travel_to`; the other three (`balance_transaction_spec`, `analytics_controller_spec`, `caching_proxy_spec`) either anchor on an absolute `travel_to(Time.utc(...))` or have no cross-instant window, so no other instance is live.

## Test Results

`bundle exec rspec spec/services/exports/payouts/csv_spec.rb` — **7 examples, 0 failures** (2m13s, local, ActiveSupport 7.1.6 / Ruby 3.4.3).
`bundle exec rubocop spec/services/exports/payouts/csv_spec.rb` — 1 file inspected, no offenses.

## QA steps

Spec-only; no runtime code path changes. Nothing to QA in the app.

## Fable-5 adversarial review

This change *is* a finding from the fable-5 review of `fix/paypal-stats-spec-midnight-flake` (the branch that became #6663). That review returned **READY-TO-MERGE** for the branch and listed this csv_spec instance as a P3 to be filed separately, having sized the whole class from the code. Findings from that round:

| Finding | Disposition |
| --- | --- |
| P2 — comment restated the `travel_to` on the next line | Trimmed; landed in #6663 |
| P3 — `#last_weeks_sales` shares the hazard (`Date.today` re-read at query time) | Fixed in #6663 |
| P3 — `csv_spec:158` vs `171-172` shares the hazard | **This PR** |
| P1 | None |

What the review confirmed safe, with the load-bearing check first:

- **Nested block-form `travel_to` does not wipe the outer freeze.** This was the attack that could have made the whole approach useless. ActiveSupport 7.1.6 `time_helpers.rb:177` captures the already-stubbed `Time.now` before re-stubbing, and the block's `ensure` (`:196-203`) does `travel_to stubbed_time` rather than `travel_back` — so each nested block returns to the outer frozen instant, not the real clock. On older Rails, where the `ensure` unconditionally called `travel_back`, this fix shape would have been incomplete. Verified against the Gemfile.lock-resolved gem, not the docs.
- **`midday` is a sound anchor.** `config.time_zone` is commented out (`config/application.rb:48`) so the app zone is UTC; 12:00 UTC is 12h from both midnights and UTC has no DST.
- **The freeze breaks nothing.** No elapsed-time, TTL, or timestamp-uniqueness assertion exists in the affected examples, and no assertion's truth value changes under a frozen clock.
- **No production bug is being papered over.** The exporter's date rendering is a pure function of the row timestamps; the skew was entirely spec-side.
- **The leaked-freeze risk is covered** by the global `travel_back` at `spec/spec_helper.rb:416`.

Revert-detectability, stated honestly: by construction there is no test that fails on revert — reproducing it requires setup to straddle a real midnight. The comment is the pin, which is the right weight for a one-line spec change.

## AI disclosure

Written by Hermes Agent (claude-opus-5) running as gumclaw, including the fable-5 adversarial review that produced this finding.
