### PR TITLE
Document the sanctioned-location checkout error in the help center

### DIFF
--- a/app/views/help_center/articles/contents/_203-why-did-my-payment-fail.html.erb
+++ b/app/views/help_center/articles/contents/_203-why-did-my-payment-fail.html.erb
@@ -9,6 +9,7 @@
     <li><a href="#Browser-error-_SZW5">Browser error</a></li>
     <li><a href="#Previous-payment-still-processing-kQ2pF">Previous payment still processing</a></li>
     <li><a href="#Email-already-has-an-active-subscription-tR7vN">Email already has an active subscription</a></li>
+    <li><a href="#Not-available-in-your-location-Xr4mB">Not available in your location</a></li>
     <li><a href="#Blocked-by-Gumroads-risk-system-Slrvd">Blocked by Gumroad’s risk system</a></li>
     <li><a href="#Chargeback-against-Gumroad-IvRQH">Chargeback against Gumroad</a></li>
   </ul>
@@ -46,6 +47,10 @@
   <p>You may see this message at checkout: "This email address already has an active subscription to this membership. We've emailed it a link to manage the subscription — check your inbox." It means the email address you entered already has an active subscription to that membership. To prevent duplicate charges, we block the second purchase and send an email to that address instead.</p>
   <p>If the existing subscription is yours, you don't need to buy again. Your membership is still active, and you can manage or cancel it from your membership receipt or from your <a href="https://app.gumroad.com/library">Gumroad Library</a>. See <a href="192-how-do-i-cancel-my-membership">How do I cancel my membership?</a> for the steps.</p>
   <p>If you are logged in to Gumroad, the message instead reads "You already have an active subscription to this membership. Visit your Library to manage it."</p>
+  <h3 id="Not-available-in-your-location-Xr4mB">Not available in your location</h3>
+  <p>If you see the message "Sorry, this item is not available in your location," we are not able to process the payment because the location on the purchase is a jurisdiction under comprehensive United States sanctions. At the moment that means Cuba, Iran and North Korea, along with the Crimea, Sevastopol, Donetsk and Luhansk regions of Ukraine.</p>
+  <p>We check the country and state on the purchase as well as the location of the internet connection you are paying from, so this can appear even if the product page loaded normally. It is not something a creator can turn off for you, and using a VPN or a different card will not get the purchase through.</p>
+  <p>If you are on a membership and your billing address is out of date, update it from the "Manage subscription" link in your membership receipt. Renewals are checked the same way, so a membership will stop renewing while the address on it is in one of these locations.</p>
   <h3 id="Blocked-by-Gumroads-risk-system-Slrvd">Blocked by Gumroad’s risk system</h3>
   <p>Our risk detectors may have accidentally blocked you from purchasing. Please use "incognito" or "private" mode on your browser, and try the purchase using a different email address.</p>
   <h3 id="Chargeback-against-Gumroad-IvRQH">Chargeback against Gumroad</h3>


### PR DESCRIPTION
## What

Adds a "Not available in your location" section to the buyer-facing help article [Why did my payment fail?](https://help.gumroad.com/help/article/203-why-did-my-payment-fail) (`_203-why-did-my-payment-fail.html.erb`), plus its table-of-contents entry. The section quotes the new checkout error verbatim, names the jurisdictions it covers, explains which location signals are screened, and says renewals are screened the same way.

Docs-only. No `articles.yml` change — no title, description, or category moved.

## Why

#6644 shipped `Purchase#validate_sanctioned_location`, a server-side sanctions screen that runs on every purchase, including digital products and subscription renewals. It fails the purchase with `PurchaseErrorCode::BLOCKED_SANCTIONED_LOCATION` and surfaces "Sorry, this item is not available in your location." at checkout.

That message did not exist before and nothing in the help center described it. A buyer pasting it into help-center search got no result, and the closest article, "Why did my payment fail?", listed every other failure class (PayPal, card processor, zip code, proxy, browser, still-processing, duplicate subscription, risk system, chargeback) but not this one. Two behaviours in particular were undocumented and generate tickets: the screen reads the internet connection's location as well as the declared address, so it can fire after a product page loaded fine, and it also runs on renewals, so a membership stops renewing while the address on it is in a screened jurisdiction.

Every claim in the new copy is taken from the shipped code rather than the PR summary:

- Countries: `Compliance::Countries::BLOCKED_COUNTRY_CODES` — Cuba, Iran, North Korea. Syria is deliberately not in that list and is not named in the article.
- Regions: `BLOCKED_SUBDIVISION_CODES` — Crimea, Sevastopol, Donetsk, Luhansk.
- Signals screened: `Purchase#sanctioned_location_signals` — declared country/state, `ip_country`/`ip_state`, and the geolocation of `ip_address`. Hence "even if the product page loaded normally": the render-time check in `Link#compliance_blocked` and the create-time screen can see different locations.
- Not creator-controlled: the screen is unconditional in `Purchase`, with no seller setting, so the article says a creator cannot turn it off.
- Renewals: `Subscription#build_purchase` sets `ip_location_inherited`, so renewals screen the declared address only, which the subscriber can change from Manage subscription. That is what the article tells them to do.
- Error text: `"Sorry, this item is not available in your location."`, quoted exactly so help-center search matches a pasted message.

## Before / after

| | Before | After |
|---|---|---|
| Buyer searches help for "not available in your location" | no article covers it | lands on the new section in article 203 |
| Buyer wonders why the page loaded but checkout failed | undocumented | explained: connection location is screened too |
| Subscriber whose membership stopped renewing | undocumented | told to update the address from Manage subscription |
| Buyer asks a creator to allow their country | no guidance | stated that creators cannot override it |

Body-only prose edit; there is no UI surface and no rendered app change beyond the article text, so there are no before/after screenshots. The rendered article HTML is verified below.

## Test plan / QA steps

Verified on the pushed branch:

- ERB syntax compiles: `ruby -e 'ERB.new(File.read(...)).src'` → OK
- Tag balance across the file: div 2/2, ul 3/3, li 16/16, p 27/27, h3 12/12, a 15/15 — all matched
- New anchor appears exactly twice (TOC link + `<h3 id>`)
- Real render in the Rails view context:
  `bundle exec rails runner -e test 'ApplicationController.render(partial: "help_center/articles/contents/203-why-did-my-payment-fail")'` → `render OK 7471 bytes`, and the new copy is present in the output
- `articles.yml` untouched, so slug/partial integrity guarded by `spec/models/help_center` is unchanged; CI runs the help-center specs

Reviewer click-path after deploy: open `help.gumroad.com/help/article/203-why-did-my-payment-fail`, confirm "Not available in your location" appears in the in-article list and jumps to the new section.

## Review notes

Pure copy edit, no logic and no YAML change, so per the help-center editing conventions there is no adversarial-review gate on this one. Wording deliberately avoids saying anything about how the screen is implemented beyond what a buyer needs, and avoids implying support can make an exception.

---

## AI disclosure

Written by claude-opus-5 running as the Hermes agent, triggered automatically by the merge of #6644 (the merged-PR → help-center doc sync route). Instructions given: check whether the merged PR changes anything documented in the help center; if it does, identify the affected article, edit it to match the shipped code, verify the render locally, and open a PR naming the triggering PR and the articles changed. All facts in the copy were resolved against the code on `main` (`Compliance::Countries`, `Purchase#validate_sanctioned_location`, `Subscription#build_purchase`) rather than from the triggering PR's description.
