### PR TITLE
Document what happens to payouts during the new-account review

### DIFF
--- a/app/views/help_center/articles/contents/_281-payout-delays.html.erb
+++ b/app/views/help_center/articles/contents/_281-payout-delays.html.erb
@@ -22,6 +22,10 @@
     </strong>If you go to <a href="http://www.gumroad.com/balance">your balance page</a> and see a message that your account is under review (see above), that means your account is still under review.  </p>
   <p><strong>What to do: <br>
     </strong>We kindly ask that you wait until you've made 2-3 more sales, then email us for clarification. We cannot speed up the review for you, and we cannot provide everyone with <em>specific</em> information about why their account hasn't been reviewed, but we can at least answer the questions that you have. </p>
+  <p><strong>What happens to your payouts while you wait: <br>
+    </strong>Every payout day that comes around before your account has been reviewed is skipped, and we do not send you an email for each skipped payout. That can mean several payout days pass without a payment.</p>
+  <p>None of the money is lost. Your earnings stay on your account as your balance, and they are paid out on your first payout day after your account is marked compliant, including the earnings from the payouts that were skipped in the meantime.</p>
+  <p>Your <a href="https://gumroad.com/payouts">payouts</a> page is where you can check on this. If your balance has reached your minimum payout amount, the page shows a note about the most recent skipped payout. If your balance is still under that amount, the page shows your balance and the minimum instead, because at that point the balance is what is holding up your payout rather than the review.</p>
   <h3> Reason 2: There's an issue with your bank or PayPal account </h3>
   <p> It's also possible that we <em>have</em> been attempting to send money to your bank, or your PayPal account, but they are blocking the money. You may have entered incorrect information in your <a href="http://gumroad.com/settings/payments">Payment Settings</a>, or there may be a lock on your PayPal account. </p>
   <p>When our payment partner will not accept a bank account you saved, we email you, and the email tells you which of these applies:</p>


### PR DESCRIPTION
## What

Adds three paragraphs to the "Reason 1: You haven't been reviewed yet" section of the payout delays help center article (`_281-payout-delays`), covering what happens to payouts while a new account's review is open: payout days are skipped, no email is sent per skip, the balance is not lost and pays out on the first payout day after the account is marked compliant, and where on the Payouts page to check.

Body-only change. `articles.yml` is untouched (no title, description, or category change), and the section's existing anchors and copy are preserved.

## Why

The article already explained *why* a new account is reviewed and what the seller can do about it, but said nothing about the payouts themselves. A new seller whose weekly payouts were skipped repeatedly while their review sat open had no documented way to distinguish a routine review that resolves itself from something being wrong with their account, and nothing telling them the money was still theirs. That is the documentation gap in antiwork/gumroad-private#1588.

Refs antiwork/gumroad-private#1588.

## What the copy is based on

Every claim was checked against the code rather than the report, and two claims from the issue's own discussion turned out to be wrong and are deliberately **not** in the article:

- **"The skip note is suppressed, so this population has no surface at all"** — not true in general. `PayoutsHelper#current_payout_period_data` only blanks the note when `status == "not_payable"` **and** `user.not_reviewed?` **and** the note matches `UNDER_REVIEW_PAYOUT_NOTE_REGEX`. `not_payable` is set only when `unpaid_balance_cents < minimum_payout_amount_cents`. A not-reviewed seller **at or above** their minimum keeps `status == "payable"`, so the note renders in the Payouts banner (`pages/Payouts/Index.tsx`). The article therefore splits the two cases by balance instead of claiming there is no surface.
- **"Each skip is silent — no email per skip"** — the no-email half is right (no mailer sends on a skip; `git grep` across `app/mailers` finds none), but "silent" overall is not, per the point above. The article says only the accurate, narrower thing: we do not email you for each skipped payout.

Other claims verified:

| Claim in the copy | Source |
|---|---|
| Payout days before review completion are skipped | `Payouts.is_user_payable` returns `false` unless `user.compliant?`, writing the "under review" note when `not_reviewed?` |
| Balance is retained and pays out after the review clears | Skip returns `false` before any `Payment` is created; balances stay unpaid and are picked up by the next eligible payout |
| "marked compliant" is the state that unblocks it | The `user.compliant?` guard in the same method; wording mirrors the article's existing "we mark your account as \"compliant\"" sentence |
| Below-minimum sellers see balance and minimum instead | The `not_payable` branch in `PayoutsHelper`, rendered by the balance notice in `Index.tsx` |

Deliberately omitted: any expected review duration (the code sets no deadline, so any number would be invented), and the internal `payout_note` wording itself.

## Test plan

- `bundle exec rspec spec/models/help_center` — 1 example, 0 failures. These guard slug/partial integrity.
- Partial renders in the real view context via `ApplicationController.render(partial: "help_center/articles/contents/281-payout-delays")` — render OK, 12037 bytes, all three new paragraphs present.
- ERB syntax check passes; HTML tag-balance count across `div/p/ul/li/h3/strong/em/a/figure/ol` is even on every tag.
- No UI surface: this is prose inside an existing help center article, with no layout, component, or logic change. The rendered-partial check above is the artifact.

## Review notes

This is payout wording, which creators quote back to us, so the balance-dependent split in the third paragraph is the part worth a second pair of eyes: it is the difference between what a seller above their payout minimum sees and what a seller below it sees.

---

## AI disclosure

Written by claude-opus-5 running as the Hermes agent. Instructions given: a GitHub webhook delivered Sahil's comment on antiwork/gumroad-private#1588 ("Document in help center but nothing else to do imo"), and the agent was directed to follow its `github-pr-workflow` and `gumroad-help-center-editing` skills. The agent read the issue thread, verified each factual claim against `Payouts.is_user_payable`, `PayoutsHelper`, `PayoutNoteVisibility`, and `pages/Payouts/Index.tsx` on `origin/main`, rejected two inaccurate claims from the issue discussion, wrote the copy, and ran the checks listed above.
