### PR TITLE
Document the guest review-reminder opt-out scope

### DIFF
--- a/app/views/help_center/articles/contents/_204-get-to-know-your-gumroad-receipt.html.erb
+++ b/app/views/help_center/articles/contents/_204-get-to-know-your-gumroad-receipt.html.erb
@@ -14,7 +14,7 @@
   <p>You can <a href="194-i-need-an-invoice">print your own invoice</a> by clicking the Generate link at the bottom of your receipt. If you need to customize your invoice, you can use the 'Additional Notes' field to add any relevant information. We are not able to customize invoices beyond that for you. </p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/65f8b3d254e485464f3dce9a/file-PEyzfH7eK6.png" %></figure>
   <h3 id="Unsubscribe-from-emails-Hqq3f">Unsubscribe from emails</h3>
-  <p>If you no longer would like to receive email updates from a seller, you can unsubscribe from future emails by clicking “Unsubscribe” at the bottom of your receipt.</p>
+  <p>If you no longer would like to receive email updates from a seller, you can unsubscribe from future emails by clicking “Unsubscribe” at the bottom of your receipt. That also stops the <a href="344-rate-and-review-your-purchase">review reminder</a> we would otherwise send for that purchase.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/65f8b3af909e484dba21070d/file-qx9PGuwNcF.png" %></figure>
   <h3 id="Cancel-memberships-ZWaRM">Cancel memberships</h3>
   <p>You can cancel a subscription to your latest membership charge by going to the receipt and click "Subscription settings" or "Manage membership":</p>

--- a/app/views/help_center/articles/contents/_344-rate-and-review-your-purchase.html.erb
+++ b/app/views/help_center/articles/contents/_344-rate-and-review-your-purchase.html.erb
@@ -11,7 +11,7 @@
   <br>
   <p>Your star rating is saved as soon as you select it, so a rating on its own counts as a review even if you don't add anything else. To share more, write your feedback in the text box and click "Post review".</p>
   <br>
-  <p>If you haven't left a review in the first 5 days after a purchase (90 days for physical products), we will send you a reminder email. You can unsubscribe from these reminders using the link at the bottom of the email. Some creators turn review reminders off, in which case you won't receive one.</p>
+  <p>If you haven't left a review in the first 5 days after a purchase (90 days for physical products), we will send you a reminder email. You can unsubscribe from these reminders using the link at the bottom of the email. If you bought without a Gumroad account, that link unsubscribes you from all of that creator's emails rather than just the review reminders, because there is no account to store a reminders-only preference on. If you have already unsubscribed from a creator's emails, we won't send you review reminders for their products. Some creators turn review reminders off, in which case you won't receive one.</p>
   <br>
   <h3>Restrictions</h3>
   <ul>


### PR DESCRIPTION
## What

Updates two help-center articles for the review-reminder opt-out changes that shipped in #6652.

`_344-rate-and-review-your-purchase` said you can "unsubscribe from these reminders using the link at the bottom of the email". That is only true for buyers with a Gumroad account: `CustomerLowPriorityMailer#review_reminder_unsubscribe_url` now falls back to the receipt footer's purchase-scoped link when `purchaser` is nil, and that link runs `Purchase#unsubscribe_buyer`, which clears `can_contact` for every purchase sharing that email and seller and unsubscribes the follower row. So a guest clicking it stops all of that creator's email, not just reminders. The article now says so, and also states that a buyer who already unsubscribed will not get reminders — `Purchase#eligible_for_review_reminder?` and the mailer's render-time guard both consult `can_contact?` as of that PR.

`_204-get-to-know-your-gumroad-receipt`'s "Unsubscribe from emails" section gains one sentence noting the receipt footer link also stops the review reminder, cross-linking the reminders article.

## Why

Triggered by merged PR #6652 (tracking issue antiwork/gumroad-private#1584). Two documented facts became wrong at that merge: the opt-out breadth for guests (56.5% of successful purchases in the trailing 30 days have no purchaser row, per the measurement in #6652), and the silence about `can_contact` gating reminders.

No policy, pricing, tax, or payout wording. No article removals. `articles.yml` untouched — no title, description, or category change, and both edits sit mid-article with anchor IDs preserved.

## Test plan

Body-only prose edit, no ERB logic, so no fable review gate.

- ERB compiles for both partials (`ERB.new(...).src`).
- Tag balance unchanged for both files (div/p/ul/li/h3/figure/a).
- Both partials render in the real view context:

```
344-rate-and-review-your-purchase: render OK (2180 bytes)
204-get-to-know-your-gumroad-receipt: render OK (3686 bytes)
```

- CI runs `spec/models/help_center` and the rest of the help-center specs, which guard slug ↔ partial integrity (unaffected here, since no slugs changed).

No UI surface beyond the rendered article text.

---

## AI disclosure

Written by claude-opus-5 (Hermes Agent) via the merged-PR → help-center doc sync automation. Instructions: check whether merged gumroad#6652 makes any help-center article inaccurate, map it to the specific articles, and ship the correction. The model read the merge commit diff and `Purchase#unsubscribe_buyer` to establish the actual opt-out scope before wording the change.
