### PR TITLE
Scope the bundle library redirect guard to the purchase's own buyer

### DIFF
--- a/app/controllers/url_redirects_controller.rb
+++ b/app/controllers/url_redirects_controller.rb
@@ -372,12 +372,18 @@ class UrlRedirectsController < ApplicationController
     end
 
     def redirect_bundle_purchase_to_library_if_needed
-      return unless @url_redirect.purchase&.is_bundle_purchase?
+      purchase = @url_redirect.purchase
+      return unless purchase&.is_bundle_purchase?
       # The library filters by `bundle_id`, which only the member purchases carry, so a bundle
       # whose members can't render there would land the buyer on an empty filtered library. Let
       # the download page render the bundle's own content instead — LibraryPresenter shows the
       # bundle row itself in exactly this case, and the two must agree (gumroad-private#1585).
-      return if @url_redirect.purchase.product_purchases.visible_in_library.none?
+      #
+      # Scoped to the parent's purchaser because `User#purchases` is keyed on `purchaser_id`: a
+      # member reassigned to (or never claimed by) that account still satisfies `visible_in_library`
+      # yet renders in a different library, or none. This runs before `check_permissions`, so anchor
+      # on the purchase rather than the signed-in user.
+      return if purchase.product_purchases.visible_in_library.where(purchaser_id: purchase.purchaser_id).none?
 
       # Build the library URL on the main app domain explicitly. This request can arrive on
       # the seller's subdomain (or custom domain), and /library requires authentication. A

--- a/spec/controllers/url_redirects_controller_spec.rb
+++ b/spec/controllers/url_redirects_controller_spec.rb
@@ -352,6 +352,39 @@ describe UrlRedirectsController, inertia: true do
             expect(response).to redirect_to(library_url({ bundles: purchase.link.external_id, host: DOMAIN, protocol: PROTOCOL }))
           end
         end
+
+        context "when the members were reassigned to another account" do
+          before do
+            buyer = create(:user, email: purchase.email)
+            purchase.update!(purchaser: buyer)
+            # Only the parent moved. The library filters on `purchaser_id`, so the members are
+            # still `visible_in_library` yet render in nobody's library here.
+            purchase.product_purchases.each { _1.update!(purchaser: create(:user)) }
+            sign_in buyer
+          end
+
+          it "renders the download page instead of redirecting to an empty filtered library" do
+            get :download_page, params: { id: purchase.url_redirect.token }
+
+            expect(response).to have_http_status(:ok)
+            expect(response).to_not be_redirect
+          end
+        end
+
+        context "when the members belong to the purchaser" do
+          before do
+            buyer = create(:user, email: purchase.email)
+            purchase.update!(purchaser: buyer)
+            purchase.product_purchases.each { _1.update!(purchaser: buyer) }
+            sign_in buyer
+          end
+
+          it "redirects to the filtered library" do
+            get :download_page, params: { id: purchase.url_redirect.token }
+
+            expect(response).to redirect_to(library_url({ bundles: purchase.link.external_id, host: DOMAIN, protocol: PROTOCOL }))
+          end
+        end
       end
     end
 


### PR DESCRIPTION
## What

Scopes the bundle download-page library redirect guard to the parent purchase's own buyer:

```ruby
return if purchase.product_purchases.visible_in_library
            .where(purchaser_id: purchase.purchaser_id).none?
```

## Why

The guard added in #6660 asked whether **any** member purchase was `visible_in_library`. The library itself is keyed on `purchaser_id` (`LibraryPresenter` loads `logged_in_user.purchases.visible_in_library`). So a bundle whose members were reassigned to a different account still satisfied the unscoped guard, and the buyer was redirected to a `?bundles=<id>` filtered library containing rows they cannot see — an empty page. Follow-up to #6660, gumroad-private#1585.

The two surfaces now agree: the controller redirects only when the members will actually render in *that* buyer's library, otherwise the download page renders the bundle's own content.

## Test Results

`spec/controllers/url_redirects_controller_spec.rb -e "bundle purchase"` on the branch head (13e7a39):

```
Finished in 1 minute 55.42 seconds (files took 47.21 seconds to load)
9 examples, 0 failures
```

Red-first proof — reverse-applying only the app hunk (`git diff origin/main...HEAD -- app | git apply -R -`):

```
1) ...when the members were reassigned to another account
   Failure/Error: expect(response).to have_http_status(:ok)
     expected the response to have status code :ok (200) but it was :found (302)
2 examples, 1 failure
```

The divergent-owner context is genuinely red-first. The same-owner context passes identically on main — it is an over-narrowing guard (it would catch a predicate keyed on the wrong side, e.g. `logged_in_user&.id`) and pins nothing new; recorded as such rather than presented as red-first.

CI: 75/75 success, 1 skipped, 0 pending/failing at 13e7a39.

## Fable-5 adversarial review

**Verdict: READY-TO-MERGE.** No P1/P2. All four questions for this change class (narrowing a parent/child visibility guard by an ownership FK) were settled from code, not reasoning:

| # | Question | Finding |
|---|---|---|
| 1 | Every writer of `purchaser_id` classified | **Safe.** Email-keyed bulk flows (`AttachPastPurchasesToUserWorker`, social/Stripe-connect signup claims, `Purchase::ReassignByEmailService`) move parent *and* members together — members share the parent's email. Single-row flows (`UrlRedirectsController#change_purchaser`, `UsersController#add_purchase_to_library`, `Admin::PurchasesController` → `attach_to_user_and_card`) are the population that flips the guard. Note `attach_to_user_and_card` cascades to `preorder` and `subscription` but **not** to `product_purchases`. |
| 2 | NULL / guest population | **Safe.** `where(purchaser_id: nil)` compiles to `IS NULL` and is a live branch. `Purchase::CreateBundleProductPurchaseService` copies both `purchaser:` and `email:` from the parent, so guests are NULL together and behave exactly as on main. No writer can NULL one side alone. |
| 3 | Agreement with the sibling surface | **Correct as written.** Anchored on `purchase.purchaser_id`, not `logged_in_user`. This guard runs *before* `check_permissions`, so `logged_in_user` is nil on every signed-out token/receipt visit — anchoring there would degenerate the predicate to `IS NULL` and wrongly suppress the redirect for a fully-claimed parent. |
| 4 | Would the query even run (ambiguous column)? | **Yes.** `product_purchases` is `has_many through:`, but `bundle_product_purchases` carries only `bundle_purchase_id` / `product_purchase_id` (no `purchaser_id`), and Rails hash-form `where` qualifies to `purchases.purchaser_id`. Every composed scope (`for_library`, `not_rental_expired`, `not_is_deleted_by_buyer`) is plain `where`/flag — no `select`/`from`/`group`/extra join. |

Behavior-change direction named explicitly: *parent claimed, members unclaimed* is the bug being fixed. The mirror case — *members claimed, parent unclaimed* — is a narrow, deliberate behavior change (no redirect; the download page renders instead), which is the conservative direction since the redirect target would not render those members for the parent's buyer anyway.

**P3 (not fixed, deliberate):** `expect(response).to_not be_redirect` alongside `have_http_status(:ok)` is redundant — a 200 is never 3xx. Kept to match the style of the sibling contexts in the same block.

AI-slop pass: the comment was reviewed against `AGENTS.md`/Sahil's newer direction. It states the non-obvious *why* (which key each surface uses, and the ordering constraint that this runs before `check_permissions`) — the one thing the code cannot say. No trim proposed; nothing in the diff is deletable without changing behavior.

## QA steps

@nyomanjyotisa — assigning you the merge call rather than self-merging, since this sits on the buyer's content-access path. What is worth a live look, both only verifiable against real data:

1. A bundle purchase whose members were reassigned to another account: the download page should render the bundle's own content instead of bouncing to an empty `?bundles=<id>` library.
2. A normal fully-claimed bundle purchase (members and parent on the same account) still redirects to the filtered library exactly as before — this is the majority population and the one to sanity-check first.
3. A signed-out receipt/token visit to a bundle download page still behaves as on main (the guard runs pre-auth; `purchaser_id` NULL on both sides).

## AI disclosure

Written by Hermes Agent (claude-opus-5) running as gumclaw, including the fable-5 adversarial review recorded above.
