### PR TITLE
Correct the review-reminder opt-out wording to match main

### DIFF
--- a/app/views/help_center/articles/contents/_204-get-to-know-your-gumroad-receipt.html.erb
+++ b/app/views/help_center/articles/contents/_204-get-to-know-your-gumroad-receipt.html.erb
@@ -14,7 +14,7 @@
   <p>You can <a href="194-i-need-an-invoice">print your own invoice</a> by clicking the Generate link at the bottom of your receipt. If you need to customize your invoice, you can use the 'Additional Notes' field to add any relevant information. We are not able to customize invoices beyond that for you. </p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/65f8b3d254e485464f3dce9a/file-PEyzfH7eK6.png" %></figure>
   <h3 id="Unsubscribe-from-emails-Hqq3f">Unsubscribe from emails</h3>
-  <p>If you no longer would like to receive email updates from a seller, you can unsubscribe from future emails by clicking “Unsubscribe” at the bottom of your receipt. That also stops the <a href="344-rate-and-review-your-purchase">review reminder</a> we would otherwise send for that purchase.</p>
+  <p>If you no longer would like to receive email updates from a seller, you can unsubscribe from future emails by clicking “Unsubscribe” at the bottom of your receipt.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/65f8b3af909e484dba21070d/file-qx9PGuwNcF.png" %></figure>
   <h3 id="Cancel-memberships-ZWaRM">Cancel memberships</h3>
   <p>You can cancel a subscription to your latest membership charge by going to the receipt and click "Subscription settings" or "Manage membership":</p>

--- a/app/views/help_center/articles/contents/_344-rate-and-review-your-purchase.html.erb
+++ b/app/views/help_center/articles/contents/_344-rate-and-review-your-purchase.html.erb
@@ -11,7 +11,7 @@
   <br>
   <p>Your star rating is saved as soon as you select it, so a rating on its own counts as a review even if you don't add anything else. To share more, write your feedback in the text box and click "Post review".</p>
   <br>
-  <p>If you haven't left a review in the first 5 days after a purchase (90 days for physical products), we will send you a reminder email. You can unsubscribe from these reminders using the link at the bottom of the email. If you bought without a Gumroad account, that link unsubscribes you from all of that creator's emails rather than just the review reminders, because there is no account to store a reminders-only preference on. If you have already unsubscribed from a creator's emails, we won't send you review reminders for their products. Some creators turn review reminders off, in which case you won't receive one.</p>
+  <p>If you haven't left a review in the first 5 days after a purchase (90 days for physical products), we will send you a reminder email. If you bought with a Gumroad account, you can unsubscribe from these reminders using the link at the bottom of the email, and that stops review reminders only — you keep getting the creator's other emails. Some creators turn review reminders off, in which case you won't receive one.</p>
   <br>
   <h3>Restrictions</h3>
   <ul>


### PR DESCRIPTION
## What

Reverts the review-reminder opt-out wording added in #6667, and tightens the surviving sentence in `_344-rate-and-review-your-purchase` to describe only what main actually does today.

`_344-rate-and-review-your-purchase` now says the unsubscribe link in a review reminder is for buyers with a Gumroad account, and that it stops review reminders only. `_204-get-to-know-your-gumroad-receipt` loses the sentence claiming the receipt footer's unsubscribe also stops review reminders.

## Why

#6667 documented behavior that is not on main. It was written against #6652, but #6652's base branch was `fix/tokenized-review-reminder-unsubscribe`, not `main` — that work sits in #6643, which is still open and assigned for review. `git merge-base --is-ancestor f062eb8 origin/main` fails.

What main does today, in `CustomerLowPriorityMailer`:

- `@unsub_link = user_unsubscribe_review_reminders_url if @purchase.purchaser` — a guest reminder renders no unsubscribe control at all, because `app/views/layouts/email.html.erb` only emits the footer link when `@unsub_link` is present.
- `purchase_review_reminder` returns early on `product_review.present? || purchaser&.opted_out_of_review_reminders?`. No `can_contact?` check.
- `Purchase#eligible_for_review_reminder?` gates on `allows_review_to_be_counted?`, `product_review.blank?`, `seller.disable_review_reminders?`, and the purchaser opt-out. No `can_contact?` check either.

So both added claims were wrong in the same direction, which is the harmful one: a guest who unsubscribes from a creator's emails via the receipt would still be told they had opted out of review reminders, and would still receive them. For an account holder the link exists and is reminders-scoped, so that sentence stays — narrowed to say who it applies to.

Found by Greptile's P1 on #6667. The finding is correct on the mailer behavior; the underlying cause is the base-branch mismatch, not the wording.

The docs are worth re-landing once #6643 merges — same text, verified against main at that point.

## Test plan

Body-only prose edit, no ERB logic.

- ERB compiles for both partials (`ERB.new(...).src`).
- Tag balance unchanged for both files (div/p/ul/li/h3/figure/a all net zero).
- No `articles.yml` change: no slug, title, description, or category moved, and both edits sit mid-article with anchor IDs intact.
- CI runs the help-center specs, which guard slug ↔ partial integrity.

No UI surface beyond the rendered article text.

---

## AI disclosure

Written by claude-opus-5 (Hermes Agent), responding to Greptile's P1 review on #6667. Instructions: read the bot finding, verify it against the code on main rather than the PR's stated premise, and correct the articles. The model read `CustomerLowPriorityMailer#purchase_review_reminder`, `Purchase#eligible_for_review_reminder?`, and `layouts/email.html.erb` on `origin/main`, and checked #6652's merge commit ancestry, before concluding the documented behavior had not shipped.
