### PR TITLE
Report a product save that applied fewer deletions than it named

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -661,6 +661,8 @@ class LinksController < ApplicationController
       end
       return render json: { error_message: }, status: :unprocessable_entity
     end
+    report_unapplied_deletions!
+
     invalid_currency_offer_codes = @product.product_and_universal_offer_codes.reject do |offer_code|
       offer_code.is_currency_valid?(@product)
     end.map(&:code)
@@ -1348,6 +1350,50 @@ class LinksController < ApplicationController
     def submitted_page_count
       count = params[:rich_content].is_a?(Array) ? params[:rich_content].size : 0
       count + (params[:variants].is_a?(Array) ? params[:variants].sum { |variant| variant[:rich_content].is_a?(Array) ? variant[:rich_content].size : 0 } : 0)
+    end
+
+    # A save that named deletions and applied fewer of them than it named is a
+    # success response the seller cannot tell apart from a real one
+    # (gumroad-private#1508). Under the save contract an unstated removal is a
+    # no-op by design, so the failure mode that used to be a wrong deletion is
+    # now a silent non-deletion: 200, nothing gone, nothing logged.
+    #
+    # Runs only on the success path, after the transaction committed, and only
+    # when the client actually stated deletions — so it costs one reload plus
+    # two id reads on the small minority of saves that delete something, and
+    # nothing at all on the rest.
+    #
+    # Never raises. This is a report, not a guard: the write already happened
+    # and failing the response here would tell the seller a committed save
+    # failed.
+    def report_unapplied_deletions!
+      contract = product_save_contract
+      return unless contract.enforced?
+      return unless contract.requested_deletion?
+
+      requested_variants = contract.deleted_ids(:variants)
+      requested_pages = contract.deleted_ids(:rich_content)
+      return if requested_variants.empty? && requested_pages.empty?
+
+      @product.reload
+      surviving_variants = requested_variants & @product.alive_variants.map(&:external_id)
+      alive_page_ids = @product.alive_rich_contents.map(&:external_id) +
+        @product.current_base_variants.flat_map { |variant| variant.alive_rich_contents.map(&:external_id) }
+      surviving_pages = requested_pages & alive_page_ids
+      return if surviving_variants.empty? && surviving_pages.empty?
+
+      ErrorNotifier.notify(
+        "Product save applied fewer deletions than it named",
+        product_id: @product.id,
+        seller_id: @product.user_id,
+        request_id: request.request_id,
+        requested_variant_ids: requested_variants,
+        surviving_variant_ids: surviving_variants,
+        requested_rich_content_ids: requested_pages,
+        surviving_rich_content_ids: surviving_pages,
+      )
+    rescue StandardError => e
+      ErrorNotifier.notify(e)
     end
 
     # Accumulates client id → canonical server id for records this save

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1376,10 +1376,8 @@ class LinksController < ApplicationController
       return if requested_variants.empty? && requested_pages.empty?
 
       @product.reload
-      surviving_variants = requested_variants & @product.alive_variants.map(&:external_id)
-      alive_page_ids = @product.alive_rich_contents.map(&:external_id) +
-        @product.current_base_variants.flat_map { |variant| variant.alive_rich_contents.map(&:external_id) }
-      surviving_pages = requested_pages & alive_page_ids
+      surviving_variants = surviving_variant_ids(requested_variants)
+      surviving_pages = surviving_rich_content_ids(requested_pages)
       return if surviving_variants.empty? && surviving_pages.empty?
 
       ErrorNotifier.notify(
@@ -1394,6 +1392,49 @@ class LinksController < ApplicationController
       )
     rescue StandardError => e
       ErrorNotifier.notify(e)
+    end
+
+    # Survivors are looked up by the requested id rather than by walking the
+    # product's live parents. Deleting a grouping does not soft-delete the
+    # versions inside it, so a version (or its page) whose grouping went away in
+    # this same save is still alive and still unapplied, while being unreachable
+    # through `current_base_variants` — exactly the rows this report exists to
+    # name.
+    def surviving_variant_ids(requested_ids)
+      return [] if requested_ids.empty?
+
+      BaseVariant.alive.by_external_ids(requested_ids)
+        .select { variant_belongs_to_product?(_1) }
+        .map(&:external_id)
+    end
+
+    # A page under a version this save DID delete is not a survivor: version
+    # deletion hands its pages to DeleteProductRichContentWorker, so the row is
+    # still alive at commit by design and reporting it would fire on every
+    # successful version removal.
+    def surviving_rich_content_ids(requested_ids)
+      return [] if requested_ids.empty?
+
+      RichContent.alive.by_external_ids(requested_ids)
+        .select { rich_content_survived?(_1) }
+        .map(&:external_id)
+    end
+
+    # A version reaches the product either directly (SKUs) or through its
+    # grouping, and the grouping may itself be soft-deleted by this save —
+    # `belongs_to` is unscoped, so the link is still readable.
+    def variant_belongs_to_product?(variant)
+      return true if variant.link_id == @product.id
+
+      variant.try(:variant_category)&.link_id == @product.id
+    end
+
+    def rich_content_survived?(page)
+      entity = page.entity
+      return entity.id == @product.id if entity.is_a?(Link)
+      return variant_belongs_to_product?(entity) && entity.alive? if entity.is_a?(BaseVariant)
+
+      false
     end
 
     # Accumulates client id → canonical server id for records this save

--- a/test/controllers/links_controller_test.rb
+++ b/test/controllers/links_controller_test.rb
@@ -8163,4 +8163,54 @@ class LinksControllerSaveContractTest < ActionController::TestCase
 
     assert_empty notified.select { |message, _| message == "Product save applied fewer deletions than it named" }
   end
+
+  test "flag on: an unapplied page deletion is reported even when its grouping is gone" do
+    enable_contract!
+    create_variant(variant_category: @category, name: "Kept")
+    # Deleting a grouping does not soft-delete the versions in it, so a page
+    # under one is alive and unreachable through the product's live versions.
+    # The grouping's state at commit is all that matters here, so deleting it
+    # up front stands in for a save that removes it and the page together.
+    other_category = create_variant_category(link: @product, title: "Formats")
+    orphaned_variant = create_variant(variant_category: other_category, name: "Under a dead grouping")
+    survivor = create_rich_content(entity: orphaned_variant, description: [])
+    other_category.mark_deleted!
+
+    notified = []
+    ErrorNotifier.stubs(:notify).with { |message, **context| notified << [message, context]; true }
+
+    post :update, params: @params.merge(
+      editor_revision: current_revision,
+      deletion_operations: { deleted_ids: { rich_content: [survivor.external_id] } },
+    ), format: :json
+    assert_response :success
+
+    assert survivor.reload.alive?, "precondition: the named page really did survive the save"
+    report = notified.find { |message, _| message == "Product save applied fewer deletions than it named" }
+    assert report, "expected the unapplied-deletion report (got: #{notified.inspect})"
+    assert_equal [survivor.external_id], report.last[:surviving_rich_content_ids]
+  end
+
+  test "flag on: a page whose version this save deleted is not reported as surviving" do
+    enable_contract!
+    kept = create_variant(variant_category: @category, name: "Kept")
+    removed = create_variant(variant_category: @category, name: "Removed")
+    # Version deletion hands the page to DeleteProductRichContentWorker, so the
+    # row is still alive when the check runs. That is the deletion working, not
+    # a discrepancy.
+    page = create_rich_content(entity: removed, description: [])
+
+    notified = []
+    ErrorNotifier.stubs(:notify).with { |message, **context| notified << [message, context]; true }
+
+    post :update, params: @params.merge(
+      variants: [{ id: kept.external_id, name: "Kept" }],
+      editor_revision: current_revision,
+      deletion_operations: { deleted_ids: { variants: [removed.external_id], rich_content: [page.external_id] } },
+    ), format: :json
+    assert_response :success
+
+    assert_not removed.reload.alive?
+    assert_empty notified.select { |message, _| message == "Product save applied fewer deletions than it named" }
+  end
 end

--- a/test/controllers/links_controller_test.rb
+++ b/test/controllers/links_controller_test.rb
@@ -8098,4 +8098,69 @@ class LinksControllerSaveContractTest < ActionController::TestCase
       end
     end
   end
+
+  # --- a 200 that applied fewer deletions than it named (gumroad-private#1508)
+  #
+  # The reported failure was a save that returned 200, deleted nothing, and
+  # left no audit row — indistinguishable from success. Under the contract that
+  # shape can only come from a payload whose stated deletions did not take
+  # effect, so the server compares what was named against what survived.
+
+  test "flag on: a save whose named variant deletion did not take effect is reported" do
+    enable_contract!
+    kept = create_variant(variant_category: @category, name: "Kept")
+    survivor = create_variant(variant_category: @category, name: "Should have gone")
+
+    # Make the deletion a no-op without changing the response: the contract
+    # still reports the id as requested, the variants updater never removes it.
+    Product::VariantCategoryUpdaterService.any_instance.stubs(:perform)
+
+    notified = []
+    ErrorNotifier.stubs(:notify).with { |message, **context| notified << [message, context]; true }
+
+    post :update, params: @params.merge(
+      variants: [{ id: kept.external_id, name: "Kept" }],
+      editor_revision: current_revision,
+      deletion_operations: { deleted_ids: { variants: [survivor.external_id] } },
+    ), format: :json
+    assert_response :success
+
+    assert survivor.reload.alive?, "precondition: the stubbed updater really did leave the version alive"
+    report = notified.find { |message, _| message == "Product save applied fewer deletions than it named" }
+    assert report, "expected the unapplied-deletion report (got: #{notified.inspect})"
+    assert_equal [survivor.external_id], report.last[:surviving_variant_ids]
+    assert_equal [survivor.external_id], report.last[:requested_variant_ids]
+  end
+
+  test "flag on: a save whose named deletions all took effect reports nothing" do
+    enable_contract!
+    kept = create_variant(variant_category: @category, name: "Kept")
+    removed = create_variant(variant_category: @category, name: "Removed")
+
+    notified = []
+    ErrorNotifier.stubs(:notify).with { |message, **context| notified << [message, context]; true }
+
+    post :update, params: @params.merge(
+      variants: [{ id: kept.external_id, name: "Kept" }],
+      editor_revision: current_revision,
+      deletion_operations: { deleted_ids: { variants: [removed.external_id] } },
+    ), format: :json
+    assert_response :success
+
+    assert_not removed.reload.alive?
+    assert_empty notified.select { |message, _| message == "Product save applied fewer deletions than it named" }
+  end
+
+  test "flag on: a save that names no deletions never runs the discrepancy check" do
+    enable_contract!
+    create_variant(variant_category: @category, name: "Kept")
+
+    notified = []
+    ErrorNotifier.stubs(:notify).with { |message, **context| notified << [message, context]; true }
+
+    post :update, params: @params, format: :json
+    assert_response :success
+
+    assert_empty notified.select { |message, _| message == "Product save applied fewer deletions than it named" }
+  end
 end


### PR DESCRIPTION
Closes the second acceptance criterion of [gumroad-private#1508](https://github.com/antiwork/gumroad-private/issues/1508).

## The failure this makes visible

Seller `ahmed4star@gmail.com` removed two versions from product 13603499, clicked Save, and got:

```
2026-07-29T09:41:40Z  POST /links/oyoubg  action=update  status=200  duration=404.27
```

All three versions still alive. No `deleted_at`. `ProductVariantDeletionAudit.where(product_id: 13603499).count == 0`. The product's `updated_at` never moved. A 200 that did nothing, with no trace anywhere.

That shape is only reachable one way under the save contract: `requested_deletion? == false` — the payload carried no deletion operations. And the contract is *right* to do nothing with a payload that names nothing. What is wrong is that the seller and we both learn nothing about it.

This is a regression in observability introduced by the contract itself. Before [#6377](https://github.com/antiwork/gumroad/pull/6377) an omission was read as a deletion, so a payload that forgot to state removals still (accidentally) did what the seller wanted. Now the same defective payload is a silent no-op that reports success.

## What this adds

`report_unapplied_deletions!` runs on the success path after the transaction commits, and only when the contract was enforced *and* the client stated at least one variant or rich-content deletion. It reloads the product, intersects the requested ids with what is still alive, and reports the difference to Sentry with the product, seller, request id, and both id sets.

Three properties that are deliberate:

- **Report, not guard.** It never raises and swallows its own errors. The write already committed; failing the response here would tell the seller a successful save failed — a worse bug than the one it detects.
- **Costs nothing on the common path.** Guarded on `requested_deletion?`, so the reload and two id reads only happen on the minority of saves that delete something. Saves that delete nothing do no extra work at all.
- **Variants and pages only.** Files, public files and integrations are deleted through paths with their own reporting; adding them here would need a per-collection survivor read for no signal we don't already have.

## Evidence

Five new tests in `LinksControllerSaveContractTest`, covering the reported failure and every direction of the guard:

| test | asserts |
|---|---|
| named variant deletion did not take effect | the report fires, and carries the surviving id — this is the seller's bug, reproduced by stubbing `VariantCategoryUpdaterService#perform` so the response stays 200 while the deletion never lands |
| named deletions all took effect | no report on a genuinely successful deletion |
| a save that names no deletions | the check never runs |
| an unapplied page deletion whose grouping is gone | the report still fires — grouping deletion does not soft-delete its versions or their pages, so the row is alive and unreachable through the product's live groupings |
| a page whose version this save deleted | no report: `DeleteProductRichContentWorker` removes those after commit, so the row being alive is the deletion working |

Run locally against this branch:

```
$ bin/rails test test/controllers/links_controller_test.rb -n "/LinksControllerSaveContractTest/"
64 runs, 261 assertions, 0 failures, 0 errors, 0 skips
```

The whole file is 477 runs with 1 failure and 17 errors, all of which I confirmed reproduce on unmodified `origin/main` in this same environment (`MerchantAccount` factory errors in `LinksControllerShowTest`, plus two stale-tier-save tests). None are in the class this touches. `rubocop` clean on both files.

## Not in scope

The other three criteria on #1508 are untouched and stay open:

- **Criterion 1** — identifying the client path that dropped `deletion_operations`. I could not reproduce the seller's session, and I am not shipping a speculative client patch. What this PR does is make the next occurrence produce a Sentry event naming the product, seller and ids, which is what turns that from unreproducible into diagnosable.
- **Criterion 3** — the `stale_deletion_conflict` retry, which is [gumroad-private#1532](https://github.com/antiwork/gumroad-private/issues/1532).
- **Criterion 4** — the audit-row regression test. Related but distinct: that asserts the happy path writes an audit row, this asserts the unhappy path is not silent.

