### PR TITLE
Document what changing a membership's billing frequency does

### DIFF
--- a/app/views/help_center/articles/contents/_278-guide-to-memberships.html.erb
+++ b/app/views/help_center/articles/contents/_278-guide-to-memberships.html.erb
@@ -46,6 +46,9 @@
   <p>You will receive a receipt of this change in your email inbox and the membership renewal date will be updated to the date of the upgrade.</p>
   <br>
   <p>If you move to a less expensive tier or plan, the tier won’t be updated immediately. Instead, we will wait until the end of your billing cycle to change it.</p>
+  <br>
+  <p>Changing your billing frequency also updates your subscription to the creator’s current price for that frequency, which may not be the price you are paying today. The “Manage membership” page shows you the new price, and tells you if the change will only start at your next renewal, before you confirm it.</p>
+  <p>If the creator has stopped offering the billing frequency you are on, that frequency stays available to you only while you are still on it. Once you switch away and the change takes effect, you won’t be able to switch back to it unless the creator offers it again.</p>
   <h3 id="Adding-a-seat-cuuWa">Adding a seat</h3>
   <p>Adding a seat to a membership works the same as upgrading to a higher tier, as outlined in the above section. When you add a seat/s, you will be charged immediately with a “prorated” amount to cover the time between the original and new renewal dates.</p>
   <p>If you remove a seat from your membership, your membership price will be updated at the end of the billing cycle. </p>


### PR DESCRIPTION
## What

Adds two paragraphs to the "Changing tiers" section of `_278-guide-to-memberships` describing what happens when a buyer changes their membership's billing frequency: the subscription moves to the creator's current price for that frequency, the page says when the change only starts at the next renewal, and a frequency the creator has retired can only be left once.

Body-only edit. `articles.yml` untouched (no title/description/category change), anchor IDs preserved, TOC unchanged.

## Why

Triggered by antiwork/gumroad#6661 (merged, on `main` at `dfb6916`). That PR regated the Manage membership warning on `isRecurrenceChanged` instead of `hasPriceChanged`, added the "starting at your next renewal" phrasing on every deferring branch, and added a `current_recurrence_available` prop so the copy can say when the switch is one-way.

The article previously said only "you can change tiers or payment frequency at any time from the Manage membership area" and described deferral for tier downgrades. It said nothing about frequency changes repricing to the current catalog price, nothing about deferral for those changes, and nothing about the retired-frequency case — which is exactly the situation where a buyer cannot undo the change.

Wording checked against `origin/main`: the deferral condition mirrors `Subscription::UpdaterService#apply_plan_change_immediately?` (strict price decrease, not in free trial, not overdue, not resubscribing), and `current_recurrence_available` comes from `CheckoutPresenter`'s `current_recurrence_alive`. The docs stay qualitative ("may not be the price you are paying today", "tells you if the change will only start at your next renewal") rather than restating the predicate, so they hold if the thresholds move.

## Test plan

- ERB syntax check on the edited partial: OK
- Tag-balance check across `div`/`p`/`ul`/`li`/`h3`/`figure`/`a`: all balanced
- Help-center specs run in CI (slug ↔ partial integrity; no YAML change here)

No review gate: pure copy edit, no logic, no `articles.yml` or code change.

---

AI disclosure: written by `claude-opus-5` (the `model.default` in the Hermes config) running the merged-PR → help-center doc sync route. Instruction was the standing rule to check whether a merged `antiwork/gumroad` PR makes a help-center article wrong and to edit the affected article; no other prompt content.
