### PR TITLE
Fix off-by-one in date-of-birth year dropdown

### DIFF
--- a/app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx
@@ -1270,7 +1270,7 @@ const AccountDetailsSection = ({
               onChange={(evt) => updateComplianceInfo({ dob_year: Number(evt.target.value) })}
             >
               <option disabled>Year</option>
-              {Array.from({ length: minDobYear - 1900 }, (_, i) => i + 1900).map((year) => (
+              {Array.from({ length: minDobYear - 1900 + 1 }, (_, i) => i + 1900).map((year) => (
                 <option key={year} value={year}>
                   {year}
                 </option>

--- a/app/javascript/components/Settings/PaymentsPage/BeneficialOwnersSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/BeneficialOwnersSection.tsx
@@ -879,7 +879,7 @@ const BeneficialOwnersSection = ({
                         <option value="" disabled>
                           Year
                         </option>
-                        {Array.from({ length: minDobYear - 1900 }, (_, i) => i + 1900).map((year) => (
+                        {Array.from({ length: minDobYear - 1900 + 1 }, (_, i) => i + 1900).map((year) => (
                           <option key={year} value={year}>
                             {year}
                           </option>


### PR DESCRIPTION
## What

The date-of-birth year dropdown in payout settings is short by one year. A user who has just turned 13 cannot select their birth year, so they cannot complete payout onboarding at all.

Reported by a user via support who said they are "at the minimum age of 13 and the date of birth page is still only for 2012, which is offset."

## Root cause

`SettingsPresenter` computes the boundary correctly:

```ruby
# app/presenters/settings_presenter.rb:243
min_dob_year: Date.today.year - UserComplianceInfo::MINIMUM_DATE_OF_BIRTH_AGE,
```

With `MINIMUM_DATE_OF_BIRTH_AGE = 13`, in 2026 that is **2013** — the newest birth year in which someone can already have turned 13.

Both consumers then build the option list with a length that drops that final year:

```tsx
Array.from({ length: minDobYear - 1900 }, (_, i) => i + 1900)
```

`length: 2013 - 1900 = 113` yields `1900..2012` inclusive. The value the presenter actually named is never rendered. Same expression in two places:

- `app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx:1273`
- `app/javascript/components/Settings/PaymentsPage/BeneficialOwnersSection.tsx:882`

The range is inclusive of both endpoints, so the length needs the `+ 1`.

## The fix

`length: minDobYear - 1900 + 1` in both components, so the list is `1900..minDobYear` inclusive.

This is a display-range fix only. Exact eligibility is still enforced server-side by `birthday_is_over_minimum_age` (`app/models/user_compliance_info.rb:253`), which compares the full date against `13.years.ago` — so someone born later in the newly-selectable year still gets "You must be 13 years old to use Gumroad." until their actual birthday. The dropdown just stops hiding the year from people who have already had it.

## Verification

- 2026, `minDobYear = 2013`: before → last option 2012; after → last option 2013.
- A user turning 13 later in 2013 can now pick their year and is correctly rejected by the server-side date check until their birthday, rather than being silently unable to describe themselves at all.
