### PR TITLE
Pin the bundle redirect guard's parent-claimed-only case

### DIFF
--- a/spec/controllers/url_redirects_controller_spec.rb
+++ b/spec/controllers/url_redirects_controller_spec.rb
@@ -406,7 +406,8 @@ describe UrlRedirectsController, inertia: true do
 
         context "when the purchaser claimed the parent but not the members" do
           # add-to-library attaches only the purchase it is given, so claiming a bundle parent
-          # leaves the members unclaimed and out of the claiming account's library.
+          # leaves the members unclaimed and out of the claiming account's library. Counting them
+          # as the claimer's (`purchaser_id: [id, nil]`) would redirect here, to nothing.
           before do
             buyer = create(:user, email: purchase.email)
             purchase.update!(purchaser: buyer)
@@ -418,16 +419,6 @@ describe UrlRedirectsController, inertia: true do
 
             expect(response).to have_http_status(:ok)
             expect(response).to_not be_redirect
-          end
-        end
-
-        context "when neither the parent nor the members have been claimed" do
-          it "still redirects, since claiming is what decides whose library these render in" do
-            expect(purchase.purchaser).to be_nil
-
-            get :download_page, params: { id: purchase.url_redirect.token }
-
-            expect(response).to redirect_to(library_url({ bundles: purchase.link.external_id, host: DOMAIN, protocol: PROTOCOL }))
           end
         end
       end

--- a/spec/controllers/url_redirects_controller_spec.rb
+++ b/spec/controllers/url_redirects_controller_spec.rb
@@ -403,6 +403,33 @@ describe UrlRedirectsController, inertia: true do
             expect(response).to redirect_to(library_url({ bundles: purchase.link.external_id, host: DOMAIN, protocol: PROTOCOL }))
           end
         end
+
+        context "when the purchaser claimed the parent but not the members" do
+          # add-to-library attaches only the purchase it is given, so claiming a bundle parent
+          # leaves the members unclaimed and out of the claiming account's library.
+          before do
+            buyer = create(:user, email: purchase.email)
+            purchase.update!(purchaser: buyer)
+            sign_in buyer
+          end
+
+          it "renders the download page instead of redirecting to an empty filtered library" do
+            get :download_page, params: { id: purchase.url_redirect.token }
+
+            expect(response).to have_http_status(:ok)
+            expect(response).to_not be_redirect
+          end
+        end
+
+        context "when neither the parent nor the members have been claimed" do
+          it "still redirects, since claiming is what decides whose library these render in" do
+            expect(purchase.purchaser).to be_nil
+
+            get :download_page, params: { id: purchase.url_redirect.token }
+
+            expect(response).to redirect_to(library_url({ bundles: purchase.link.external_id, host: DOMAIN, protocol: PROTOCOL }))
+          end
+        end
       end
     end
 


### PR DESCRIPTION
## What

One RSpec example on `spec/controllers/url_redirects_controller_spec.rb`, pinning a case the bundle library-redirect guard from #6668 handles but nothing tested: **the buyer claimed the bundle parent and not its members.** Test-only — no production file is touched.

## Why

`redirect_bundle_purchase_to_library_if_needed` sends a bundle purchase's `/d/:token` to `/library?bundles=<id>`. That page filters on the members' `bundle_id` *and* scopes to one account, so #6668 scoped the guard the same way:

```ruby
return if purchase.product_purchases.visible_in_library.where(purchaser_id: purchase.purchaser_id).none?
```

The account-claim flows move **one purchase at a time** — `UrlRedirectsController#change_purchaser` and `UsersController#add_purchase_to_library` each set `purchaser` only on the purchase they were handed, and no callback cascades it to `product_purchases`. So a buyer who claims a bundle through add-to-library ends up with a claimed parent and members still sitting at `purchaser_id = NULL`. That is the ordinary shape of the bug #6660 and #6668 exist to fix, and the suite had no example for it.

It matters because of a specific plausible wrong edit. `where(purchaser_id: purchase.purchaser_id)` looks over-strict next to unclaimed members that morally belong to the claimer, and the natural "fix" is to let them count:

```ruby
where(purchaser_id: [purchase.purchaser_id, nil])   # <- would ship green before this PR
```

That redirects the claiming buyer straight back to the empty filtered library. Every other example in the group passes with it in place.

## Before / After

No rendered surface changes and no behaviour changes — this pins behaviour already on main. What changes is what a wrong edit costs:

| Mutation to the guard | Before this PR | After |
| --- | --- | --- |
| `where(purchaser_id: [purchase.purchaser_id, nil])` | **10 examples, 0 failures** — ships green | 10 examples, **1 failure** |
| drop `.where(purchaser_id: …)` entirely | 1 failure (line 366) | 2 failures |
| add `.where.not(purchaser_id: nil)` | 5 failures | 5 failures |

## Test Results

Local, `spec/controllers/url_redirects_controller_spec.rb -e "with a bundle purchase"` — **10 examples, 0 failures**. `rubocop` on the file: no offenses.

Load-bearing, measured rather than asserted. Mutating the guard to `where(purchaser_id: [purchase.purchaser_id, nil])` and re-running the group kills **only** the new example:

```
10 examples, 1 failure

rspec ./spec/controllers/url_redirects_controller_spec.rb:399
  # ...when the purchaser claimed the parent but not the members
  #    renders the download page instead of redirecting to an empty filtered library
```

Guard restored and verified (`git status` clean on the controller) before committing.

## Review: fable-5 adversarial, CHANGES-REQUIRED → fixed

Run on the branch before opening. No P1s. Its headline finding **cut this PR in half, and it was right.**

| # | Sev | Finding | Disposition |
|---|-----|---------|-------------|
| 1 | P2 | The branch's *second* example ("neither the parent nor the members have been claimed") was the base example at line 279 with a new name — same nil state, nobody signed in, same assertion, and it passed on the pre-#6668 unscoped guard too | **Fixed** in `c6107c6` — example deleted. Confirmed by measurement, not argument: the mutant that excludes the nil bucket reddens that example **and** line 279 together, so they pin one path |
| 2 | P3 | The surviving example overlaps the existing "members reassigned to another account" case — both are non-nil parent, zero matching members | Accepted, and it's why the PR still exists: the `[id, nil]` mutant separates them, killing only the new one. Noted in the spec comment so the next reader sees the distinction |
| 3 | — | Confirmed: the spec comment is factually true (no callback cascades `purchaser`; `ReassignByEmailService` does sweep by email but the comment doesn't claim otherwise), the state is production-reachable, the `sign_in` is required (`check_permissions` would otherwise bounce to check-purchaser), and fixtures genuinely reach the guard | No action |

A note on the local run, because it nearly produced a false negative: the first attempt failed all 11 examples, including 9 untouched ones, on `Validation failed: We couldn't charge your card`. That was the shared test database missing its seeded `MerchantAccount` rows (`MerchantAccount.count == 0`), so `financial_transaction_validation` rejected every `:purchase`. Re-running `db/seeds/010_stripe_merchant_account_seeds.rb` fixed it. Nothing to do with this diff — recorded so the numbers above are traceable.

## QA steps

Backend, test-only — nothing to click. To exercise the pinned path against a real account: claim a guest bundle purchase through add-to-library without claiming its members, then open that purchase's `/d/:token`. It must render the bundle's download page, not redirect to `/library?bundles=<id>`.

## AI disclosure

Written by gumclaw, an AI agent, running claude-opus-5. The fable-5 adversarial review was run by a separate headless model instance against the branch before this PR was opened; its findings are dispositioned above.

Follow-up to #6668, #6660, gumroad-private#1585.
