### PR TITLE
Quote refused bank codes only when we know which account Stripe saw

### DIFF
--- a/app/mailers/contacting_creator_mailer.rb
+++ b/app/mailers/contacting_creator_mailer.rb
@@ -667,11 +667,12 @@ class ContactingCreatorMailer < ApplicationMailer
     # sentence we're after either, so drop it rather than pasting a wall of text into the email.
     MAX_FORMAT_HINT_LENGTH = 200
 
-    # The row Stripe refused, or the current one when the caller could not name it (legacy calls
-    # and the debit-card path). A missing id must not fall back silently to nothing: without a row
-    # there is nothing to quote, which is the correct outcome, not an error.
+    # The row Stripe refused, and only that row. An unnamed id (a job enqueued before this
+    # argument existed) resolves to nothing rather than to the active account: the seller may have
+    # saved a replacement since, and quoting those values as "the details we sent" points them at
+    # a row Stripe never saw. No row means no quoted values, which is the pre-existing copy.
     def rejected_bank_account(bank_account_id)
-      return @seller.active_bank_account if bank_account_id.blank?
+      return if bank_account_id.blank?
 
       @seller.bank_accounts.find_by(id: bank_account_id)
     end

--- a/app/presenters/settings_presenter.rb
+++ b/app/presenters/settings_presenter.rb
@@ -517,7 +517,14 @@ class SettingsPresenter
           "We've been re-checking the bank account you added, but our payment partner still hasn't been able to verify it. Please double-check your details and re-save them. If everything looks correct, contact support and we'll look into it." if abandoned_reason.blank?
         else
           # Cadence wording must match ContactingCreatorMailer#invalid_bank_account.
-          directory_detail = StripeMerchantAccountManager.bank_directory_miss_detail(seller.active_bank_account) if StripeMerchantAccountManager.bank_details_directory_miss_note?(bank_note)
+          # Quote the row the note names, not the active one. A legacy note with no
+          # bank_account_id reaches here through the selector's timestamp fallback and may
+          # describe a row the seller has already replaced, so it quotes nothing and keeps the
+          # generic sentence. Mirrors ContactingCreatorMailer#rejected_bank_account.
+          if StripeMerchantAccountManager.bank_details_directory_miss_note?(bank_note)
+            refused_bank_account = seller.bank_accounts.find_by(id: bank_note.json_data["bank_account_id"])
+            directory_detail = StripeMerchantAccountManager.bank_directory_miss_detail(refused_bank_account)
+          end
           ["Our payment partner couldn't verify the bank account you entered.",
            directory_detail,
            "Please double-check your details and re-save them. If you're sure they're correct (for example, a newly opened account), you don't need to do anything — we'll automatically re-check it once a week for up to #{RetryStripeRejectedPayoutSetupsJob::RETRY_WINDOW_WEEKS} weeks."].compact.join(" ")

--- a/spec/mailers/contacting_creator_mailer_spec.rb
+++ b/spec/mailers/contacting_creator_mailer_spec.rb
@@ -2382,7 +2382,7 @@ describe ContactingCreatorMailer do
         # Decoded, not .encoded: quoted-printable soft-wraps can split a quoted value across a
         # line break and make a negative assertion pass for the wrong reason.
         body = mail.html_part&.decoded || mail.body.decoded
-        # Positive anchor from static template text — @subject interpolations are HTML-escaped
+        # Positive anchor from static template text — the header copy's apostrophes HTML-escape
         # ("couldn&#39;t"), so anchoring on those makes the negatives below vacuous.
         expect(body).to include("double-check your details")
         expect(body).not_to include("JSCLUZ22XXX")

--- a/spec/mailers/contacting_creator_mailer_spec.rb
+++ b/spec/mailers/contacting_creator_mailer_spec.rb
@@ -2372,6 +2372,23 @@ describe ContactingCreatorMailer do
         expect(mail.body.encoded).not_to include("check both")
       end
 
+      it "quotes nothing when the caller could not name the refused row" do
+        # A job enqueued before the id argument existed. The seller may have re-saved since, so
+        # naming the active row would attribute values Stripe never saw.
+        create(:uzbekistan_bank_account, user: seller, bank_code: "JSCLUZ22XXX", branch_code: "00401")
+
+        mail = ContactingCreatorMailer.invalid_bank_account(seller.id, nil, directory_miss_message)
+
+        # Decoded, not .encoded: quoted-printable soft-wraps can split a quoted value across a
+        # line break and make a negative assertion pass for the wrong reason.
+        body = mail.html_part&.decoded || mail.body.decoded
+        # Positive anchor from static template text — @subject interpolations are HTML-escaped
+        # ("couldn&#39;t"), so anchoring on those makes the negatives below vacuous.
+        expect(body).to include("double-check your details")
+        expect(body).not_to include("JSCLUZ22XXX")
+        expect(body).not_to include("The details we sent were")
+      end
+
       it "quotes the row Stripe refused, not whatever the seller has saved since" do
         # The mail renders asynchronously, and the #1550 seller re-saved six times in eleven
         # minutes. Re-saving soft-deletes the old row and makes the newest one active, so reading

--- a/spec/presenters/settings_presenter_spec.rb
+++ b/spec/presenters/settings_presenter_spec.rb
@@ -898,15 +898,34 @@ describe SettingsPresenter do
         end
 
         it "quotes back the refused values on a directory miss so the seller knows what to check" do
-          create(:uzbekistan_bank_account, user: seller, bank_code: "JSCLUZ22XXX", branch_code: "00401")
+          rejected = create(:uzbekistan_bank_account, user: seller, bank_code: "JSCLUZ22XXX", branch_code: "00401")
           note = seller.add_payout_note(content: bank_note_content)
           note.json_data["stripe_error_message"] = "We couldn't find the bank for that bank/branch code"
+          note.json_data["bank_account_id"] = rejected.id
           note.save!
 
           message = presenter.payments_props[:account_status][:compliance_actions].first[:message]
           expect(message).to include("bank code JSCLUZ22XXX and branch code 00401")
           expect(message).to include("check both")
           expect(message).not_to include("branch code is the half")
+        end
+
+        it "does not quote values for an unstamped note that may describe a replaced row" do
+          # A note written before we stamped bank_account_id reaches the banner through the
+          # selector's timestamp fallback, so it can outlive the row it was about. Nothing here can
+          # tell whether the active codes are the ones Stripe refused, so quote neither.
+          rejected = create(:uzbekistan_bank_account, user: seller, bank_code: "JSCLUZ22XXX", branch_code: "00401")
+          rejected.mark_deleted!
+          create(:uzbekistan_bank_account, user: seller, bank_code: "KACHUZ22XXX", branch_code: "01158")
+          note = seller.add_payout_note(content: bank_note_content)
+          note.json_data["stripe_error_message"] = "We couldn't find the bank for that bank/branch code"
+          note.save!
+
+          message = presenter.payments_props[:account_status][:compliance_actions].first[:message]
+          expect(message).to include("couldn't verify the bank account you entered")
+          expect(message).not_to include("KACHUZ22XXX")
+          expect(message).not_to include("JSCLUZ22XXX")
+          expect(message).not_to include("check both")
         end
 
         it "does not quote values for a rejection that is not a directory miss" do


### PR DESCRIPTION
## What

When our payment partner can't find a seller's bank, we now quote the bank/branch codes from the account it actually refused — or quote nothing at all when we can't tell which account that was.

Follow-up to #6651, fixing two review findings on it after it merged.

## Why

#6651 started naming the values we sent, so a seller could see which code to check. Both surfaces that show that copy read the seller's **currently active** bank account, which isn't necessarily the one that was refused:

- `ContactingCreatorMailer#invalid_bank_account` fell back to the active account whenever the caller passed no account id — which is every job enqueued before that argument existed.
- The settings-page compliance banner formatted `seller.active_bank_account` rather than the account named on the rejection note.

A rejection is recorded by a background sync that makes network calls, and re-saving soft-deletes the old row and promotes the new one. So a seller who re-saves after being rejected could be shown **their new codes** as "the details we sent" — values our payment partner never saw. That sends them to check a field that was never the problem, which is the exact failure #6651 existed to stop.

## Before / After

For a seller whose Uzbekistan account was refused on `JSCLUZ22XXX` / `00401`, who then saved a replacement (`KACHUZ22XXX` / `01158`):

| | Banner copy |
|---|---|
| **Before** | Our payment partner couldn't verify the bank account you entered. **The details we sent were bank code KACHUZ22XXX and branch code 01158.** Our payment partner doesn't tell us which of the two it couldn't match, so please check both… |
| **After** | Our payment partner couldn't verify the bank account you entered. Please double-check your details and re-save them. If you're sure they're correct… |

The "After" row is the copy that shipped before #6651 — when we can't attribute the values, we say nothing rather than something false. When the note does name the refused row (every rejection recorded since #6647), the quoted values are unchanged and now provably come from that row even after the seller replaces it.

## How

Both surfaces resolve the account by the id recorded on the rejection, and `find_by` returns nil when there's no id, so the quoted sentence drops out and the generic copy remains:

- `rejected_bank_account` no longer falls back to the active account.
- The banner loads `seller.bank_accounts.find_by(id: bank_note.json_data["bank_account_id"])`. `bank_accounts` is unscoped, so this still resolves a row the seller has since soft-deleted — which is the whole point.

## Tests

`spec/presenters/settings_presenter_spec.rb`, `spec/mailers/contacting_creator_mailer_spec.rb`

- "does not quote values for an unstamped note that may describe a replaced row" — a legacy note reaching the banner through the selector's timestamp fallback quotes neither the old nor the replacement codes.
- "quotes nothing when the caller could not name the refused row" — the mailer's unnamed-id path. Asserted against the decoded body, since quoted-printable soft-wraps can make a `not_to include` pass for the wrong reason.
- The pre-existing positive example now stamps `bank_account_id`, so it exercises the lookup rather than relying on the active row happening to match.

Both new examples were verified to bite: reverting each fix independently turns 0 failures into exactly those 2, each failing the guard it pins. Both files were also run whole against a clean `origin/main` baseline in a separate worktree — the 74 mailer failures and the one `advanced_props` failure are identical before and after, and are the known local-only merchant-account factory/fixture id collision (they don't reproduce on CI).
