### PR TITLE
Pin the bundle library guard's anchor to the purchase's own buyer

### DIFF
--- a/app/controllers/url_redirects_controller.rb
+++ b/app/controllers/url_redirects_controller.rb
@@ -380,9 +380,8 @@ class UrlRedirectsController < ApplicationController
       # bundle row itself in exactly this case, and the two must agree (gumroad-private#1585).
       #
       # Scoped to the parent's purchaser because `User#purchases` is keyed on `purchaser_id`: a
-      # member reassigned to (or never claimed by) that account still satisfies `visible_in_library`
-      # yet renders in a different library, or none. This runs before `check_permissions`, so anchor
-      # on the purchase rather than the signed-in user.
+      # member reassigned to (or never claimed by) that account still satisfies `visible_in_library`.
+      # This runs before `check_permissions`, so anchor on the purchase, not the signed-in user.
       return if purchase.product_purchases.visible_in_library.where(purchaser_id: purchase.purchaser_id).none?
 
       # Build the library URL on the main app domain explicitly. This request can arrive on

--- a/spec/controllers/url_redirects_controller_spec.rb
+++ b/spec/controllers/url_redirects_controller_spec.rb
@@ -385,6 +385,24 @@ describe UrlRedirectsController, inertia: true do
             expect(response).to redirect_to(library_url({ bundles: purchase.link.external_id, host: DOMAIN, protocol: PROTOCOL }))
           end
         end
+
+        context "when a team member views a purchase belonging to someone else" do
+          before do
+            buyer = create(:user, email: purchase.email)
+            purchase.update!(purchaser: buyer)
+            purchase.product_purchases.each { _1.update!(purchaser: buyer) }
+            # Pins the anchor: the guard asks whose library the MEMBERS render in, which is the
+            # purchaser's, not the viewer's. Keying on `logged_in_user` would render the bundle's
+            # own page here and silently disagree with the library it is supposed to mirror.
+            sign_in create(:user, is_team_member: true)
+          end
+
+          it "still redirects to the purchaser's filtered library" do
+            get :download_page, params: { id: purchase.url_redirect.token }
+
+            expect(response).to redirect_to(library_url({ bundles: purchase.link.external_id, host: DOMAIN, protocol: PROTOCOL }))
+          end
+        end
       end
     end
 


### PR DESCRIPTION
## What

Adds the one spec example that #6668's guard was missing, and trims the guard's comment to the non-obvious why.

#6668 scoped the bundle library redirect guard to `purchase.purchaser_id`. The scoping was right, but nothing in the suite failed if you swapped the anchor for the signed-in viewer: every existing example had `logged_in_user` agreeing with `purchase.purchaser_id`, or both reads returning nil. The mutation `where(purchaser_id: purchase.purchaser_id)` -> `where(purchaser_id: logged_in_user.id)` survived the whole file.

## Why

The guard decides which library a bundle's members render in. Anchoring it on the viewer instead of the purchase would silently disagree with the library it exists to mirror — an access-control-adjacent behaviour with no test holding it in place. This is the pin, not a behaviour change.

## Test Results

`spec/controllers/url_redirects_controller_spec.rb` — 208 examples, 2 failures. The new example passes:

```
UrlRedirectsController GET 'download_page' posts with a bundle purchase
  when a team member views a purchase belonging to someone else
    still redirects to the purchaser's filtered library      0.66849 seconds
```

Both failures are pre-existing on `origin/main` and unrelated to this diff — verified by running the same two examples in a clean worktree at `origin/main` (2 examples, 2 failures there too):

- `for a fully refunded product purchase does not return posts` — missing local `audiencemember-test` Elasticsearch index.
- `reading Product when user is signed in gets current product file if replaced`.

## QA steps

Behaviour is unchanged, so there is nothing to click. To confirm the spec is load-bearing, flip `purchase.purchaser_id` to `logged_in_user.id` on `app/controllers/url_redirects_controller.rb:385` and re-run the file — the new example goes red.

## Fable-5 adversarial review

`READY-TO-MERGE`, no P1 or P2.

The review's job was to decide one question: is the new example vacuous? It traced the fixture line by line and confirmed the mutation is killed — under the mutant the team member owns no member purchases, so `.none?` is true, the guard falls through, `check_permissions` waves a team member past its non-purchaser bounce, and `download_page` renders 200 instead of the asserted redirect.

| Finding | Disposition |
|---|---|
| P3 — the comment does not explain the one non-obvious fixture choice, `is_team_member: true` | Not taken; the example name and the guard comment already carry the intent, and the reviewer's own analysis notes a plain non-team user would kill the mutation too |
| SLOP/TRIM — the 3-line spec comment partly restates the context description | Not taken; it names the mutation being pinned, which is the reason the example exists |

Confirmed safe by the review, with evidence:

- **The comment trim drops nothing load-bearing** — the removed clause stated a consequence already carried by the first paragraph of the same comment; the surviving text keeps the whole why-chain (library keyed on `purchaser_id`, `visible_in_library` insufficient alone, runs before `check_permissions`).
- **Guard ordering verified from code** — `redirect_bundle_purchase_to_library_if_needed` is registered before `check_permissions`, as both comments claim.
- **The guard's other mutations are already pinned** — dropping `visible_in_library`, dropping the `where`, `.none?` -> `.any?`, and a hardcoded nil purchaser each redden an existing example. No unpinned access-control mutation remains.
- **No sibling reddening** — the new context adds no `let`s, shadows nothing, and its description is unique in the block.
- **The assertion cannot pass for the wrong cause** — it is an exact-URL `redirect_to`, so a 200 render, a `check_purchaser_path` bounce and a confirm-page redirect all fail it.

Only live-verifiable: nothing meaningful. The spec was run.

## AI disclosure

Written by Hermes Agent (claude-opus-5) as gumclaw, including the fable-5 adversarial review.
