### PR TITLE
State that the gambling clause does not reach trackers or education

### DIFF
--- a/app/views/home/prohibited.html.erb
+++ b/app/views/home/prohibited.html.erb
@@ -1,7 +1,7 @@
 <%= render "home/shared/header",
   bg_color: "pink",
   title: "Prohibited Products and Activities",
-  description: "Last revised: July 6, 2026" %>
+  description: "Last revised: July 31, 2026" %>
 
 <div class="max-w-6xl px-8 lg:px-[4vw] py-12 md:py-20 mx-auto space-y-8 text-lg">
   <p>The following products and activities are not allowed on Gumroad. This is almost always because they violate U.S. federal law, they are prohibited by card network rules, or they are restricted by our payment processing partners. If you are unsure whether your content is prohibited on Gumroad, please contact us at support@gumroad.com with a description or example of the content.</p>
@@ -34,7 +34,7 @@
     <li>flea markets</li>
     <li>food products and ingredients (including consumer packaged goods, livestock, plants, and seeds)</li>
     <li>fortune tellers</li>
-    <li>gambling (including legal gambling where the cardholder is not present when the bet is made, lotteries, illegal gambling, internet gambling, sports forecasting and odds making)</li>
+    <li>gambling (including legal gambling where the cardholder is not present when the bet is made, lotteries, illegal gambling, internet gambling, sports forecasting and odds making). See the note on gambling below.</li>
     <li>government IDs or documents which includes fake IDs, passports, diplomas, and noble titles</li>
     <li>hacking and cracking materials which includes manuals, how-to guides, information, or equipment enabling illegal access to software, servers, website, or other protected property</li>
     <li>illegal products or services</li>
@@ -62,6 +62,9 @@
     <li>wire transfers or money orders</li>
     <li>eSIMs</li>
   </ol>
+  <p><strong>A note on gambling.</strong> The gambling entry above covers wagering itself and the things that drive a wager: picks, predictions, tips or "signals", live odds feeds, sportsbook affiliate and promo-code funnels, lotteries, and any claim of guaranteed or expected profit. It also covers storefronts that present themselves as a casino, sportsbook or betting brand.</p>
+  <p>It does not cover material that only informs or records. Educational writing and courses about strategy, discipline, house edge or bankroll math are allowed. So are bet logs, bankroll and session trackers, profit-and-loss spreadsheets, odds and expected-value calculators that work on numbers the buyer supplies, and statistical research datasets. A tracker records bets that have already been placed, which is not forecasting.</p>
+  <p>The test is what the product does with the wager, not whether it mentions betting. If a product decides the wager for the buyer, promises a profit, or routes them to an operator, it is prohibited. If it teaches or keeps records, it is allowed. Naming a sportsbook to describe compatibility or audience is not by itself promotion.</p>
   <p>This list is maintained separately from Gumroad's <%= link_to "Terms of Service", terms_path %>. Gumroad makes every effort to keep this list as current as possible. However, because of the unpredictable nature of card network rules, legislation and payment processor relationships, this list may change abruptly and without notice. Changes to this list take effect immediately.</p>
 </div>
 


### PR DESCRIPTION
## What

Adds a scope note to the gambling entry on gumroad.com/prohibited, stating what the clause does and does not reach. The enumerated entry is unchanged; the note sits directly below the list and the entry now points at it. Bumps the page's "Last revised" date.

Prohibited, per the note: wagering itself, picks, predictions, tips or "signals", live odds feeds, sportsbook affiliate and promo-code funnels, lotteries, profit claims, and storefronts branded as a casino or sportsbook.

Not prohibited: educational writing on strategy, discipline, house edge and bankroll math; bet logs, bankroll and session trackers, profit-and-loss spreadsheets; odds and expected-value calculators operating on buyer-supplied numbers; statistical research datasets.

The stated test is what the product does with the wager, not whether it mentions betting.

## Why

The entry reads "gambling (including ... sports forecasting and odds making)", which has been applied as though any betting-adjacent product is banned. Under that reading the daily content scan auto-suspended sellers whose products were bet trackers, bankroll spreadsheets and educational ebooks. **Nine such accounts were suspended and all nine were reinstated** on review; the same wrong suspension recurred roughly weekly through July.

Each reinstatement was handled as an individual false positive, so the written policy never moved and the scan kept firing on the same class. This PR closes that loop by making the boundary explicit in the policy itself.

The boundary here is not new. It restates rulings already made on three separate escalations: gumroad-private#1005 (educational bankroll-discipline content is allowed), gumroad-private#1140 (allowed where genuinely useful rather than "signals"), and gumroad-private#1600, where the direction was to update the policy and enforce it here too.

The most recent case is the clearest illustration: the suspension note cited "sports forecasting and odds making" for a six-page printable form whose only prose was responsible-gambling advice about not chasing losses. The title carried the suspension; the file was never read.

Tracking issue: gumroad-private#1600. Refs gumroad-private#1005, gumroad-private#1140.

## Before / after

Only the gambling list entry changes, plus three new paragraphs after the list. Rendered text of the changed region:

**Before**

> gambling (including legal gambling where the cardholder is not present when the bet is made, lotteries, illegal gambling, internet gambling, sports forecasting and odds making)

**After**

> gambling (including legal gambling where the cardholder is not present when the bet is made, lotteries, illegal gambling, internet gambling, sports forecasting and odds making). See the note on gambling below.
>
> **A note on gambling.** The gambling entry above covers wagering itself and the things that drive a wager: picks, predictions, tips or "signals", live odds feeds, sportsbook affiliate and promo-code funnels, lotteries, and any claim of guaranteed or expected profit. It also covers storefronts that present themselves as a casino, sportsbook or betting brand.
>
> It does not cover material that only informs or records. Educational writing and courses about strategy, discipline, house edge or bankroll math are allowed. So are bet logs, bankroll and session trackers, profit-and-loss spreadsheets, odds and expected-value calculators that work on numbers the buyer supplies, and statistical research datasets. A tracker records bets that have already been placed, which is not forecasting.
>
> The test is what the product does with the wager, not whether it mentions betting. If a product decides the wager for the buyer, promises a profit, or routes them to an operator, it is prohibited. If it teaches or keeps records, it is allowed. Naming a sportsbook to describe compatibility or audience is not by itself promotion.

## Test results

The diff is a single static view with no logic, so there is no behavior to unit-test. Verification run:

- ERB parses: `ERB.new(src).src` succeeds.
- Tag balance on the file: `p` 5/5, `li` 55/55, `ol` 1/1, `strong` 1/1, `div` 1/1.
- Rendered text of the changed region extracted and read back (quoted above) to confirm no markup leaked into copy.
- Route and caching specs covering this page (`spec/services/home_page_link_service_spec.rb`, `spec/requests/home_pages_caching_spec.rb`) are the ones that exercise `/prohibited`. Local boot was blocked in my worktree by missing MySQL credentials, so I did not run them locally. CI runs both on this branch; at time of writing the branch run shows zero failures.

Consistency sweep for contradicting copy elsewhere, since a policy statement can conflict with untouched text:

- `app/views/home/pricing.html.erb` summarises prohibited categories as "gambling & lotteries" and links here for the full list. Still accurate, no edit needed.
- Help-center article 155 ("Things you can't sell") lists common prohibited products and links here; it makes no gambling claim, so nothing contradicts the note.
- No other view, model or locale file references the gambling clause.

## QA steps

1. Open `/prohibited`.
2. Item 29 in the list reads "... sports forecasting and odds making). See the note on gambling below."
3. Below the list, before the closing "maintained separately" paragraph, three paragraphs appear starting with bolded "A note on gambling."
4. Header reads "Last revised: July 31, 2026".
5. The rest of the list is unchanged (55 entries).

## Notes for the reviewer

Not arming auto-merge, deliberately. This is public policy wording on a page whose preamble attributes restrictions to card-network and payment-processor rules, so the exact phrasing is worth your read even though the substance is your own prior ruling. Two things I'd specifically like checked:

- Whether "any claim of guaranteed or expected profit" is the line you want. "Expected profit" also catches expected-value framing, which is standard vocabulary in the educational material we're explicitly allowing, so it may be stricter than intended.
- Whether stating the allowed list this concretely on a public page is desirable, versus keeping it internal to the review process. It helps honest sellers and it also tells someone exactly how to dress up a picks product.

Enforcement for the case that prompted this is already done: the account is reinstated, its products are live, it's on the scan allowlist, and the seller has been told.

---

Written by claude-opus-5 (Anthropic) via Hermes Agent. Prompt: a GitHub webhook delivered gumroad-private#1600, where the instruction on the issue was "Sounds good. Update policy and enforce here too." I read the issue and its two cited precedents, verified the account state and the reinstatement, replied to the seller, then wrote this policy change. The count of nine affected accounts was derived from the keyword-scan allowlist entries rather than taken from an existing note; a figure of "ten" in the commit message is that unverified earlier number and is corrected here.
