### PR TITLE
Send abandoned-cart emails per day-window so a kill costs one chunk

### DIFF
--- a/app/sidekiq/schedule_abandoned_cart_emails_job.rb
+++ b/app/sidekiq/schedule_abandoned_cart_emails_job.rb
@@ -21,6 +21,10 @@ class ScheduleAbandonedCartEmailsJob
   # (see PerformPayoutsUpToDelayDaysAgoWorker).
   SCAN_TIME_BUDGET = 2.hours
 
+  # Bound on SQL IN-list length. Past roughly 10k ids MySQL's range optimizer exhausts
+  # range_optimizer_max_mem_size and silently falls back to a full table scan.
+  IN_LIST_BATCH_SIZE = 5_000
+
   # A SIGKILL (OOM, deploy pod reap) skips the `ensure` that releases an `until_executed`
   # lock, and this job's digest is constant because it takes no arguments — so a stranded
   # lock silently dropped every subsequent daily enqueue (gumroad-private#1576). Kept under
@@ -43,17 +47,29 @@ class ScheduleAbandonedCartEmailsJob
     )
   end
 
+  # One day's window is scanned, matched, and delivered before the next begins: a mid-run
+  # kill costs only the window in flight, not the whole run. The previous version
+  # accumulated all 30 days in memory and sent nothing until the very end, so it needed
+  # hours of uninterrupted runtime and rarely survived a weekday's deploys — sends
+  # flatlined platform-wide (gumroad-private#1576). Re-scanning finished windows after a
+  # restart is safe and cheap: delivered carts are excluded by Cart.abandoned, and a cart
+  # whose mail is enqueued but undelivered re-enqueues into the mailer's unique-indexed
+  # insert, which drops the duplicate.
   def perform
-    # cart_product_ids_with_cart_ids is a hash of { product_id => { cart_id => [variant_ids] } }
-    cart_product_ids_with_cart_ids = {}
-
     days_to_process = (Cart::ABANDONED_IF_UPDATED_AFTER_AGO.to_i / 1.day.to_i)
     (1..days_to_process).each do |day|
       day_start = day.days.ago.beginning_of_day
       day_end = day == 1 ? Cart::ABANDONED_IF_UPDATED_BEFORE_AGO.ago : (day - 1).days.ago.beginning_of_day
+      schedule_emails_for_window(day_start..day_end)
+    end
+  end
 
+  private
+    def schedule_emails_for_window(window)
       start_time = Time.current
-      cart_ids = abandoned_cart_ids(day_start..day_end)
+      # { product_id => { cart_id => [variant_ids] } }
+      cart_product_ids_with_cart_ids = {}
+      cart_ids = abandoned_cart_ids(window)
       cart_ids.each_slice(BATCH_SIZE) do |batch_ids|
         Cart.includes(:alive_cart_products).where(id: batch_ids).each do |cart|
           next if cart.user_id.blank? && cart.email.blank?
@@ -67,38 +83,50 @@ class ScheduleAbandonedCartEmailsJob
           end
         end
       end
-      Rails.logger.info "Fetched #{cart_ids.count} carts for #{day_start} to #{day_end} in #{(Time.current - start_time).round(2)} seconds"
+      Rails.logger.info "Fetched #{cart_ids.count} carts for #{window.begin} to #{window.end} in #{(Time.current - start_time).round(2)} seconds"
+
+      start_time = Time.current
+      cart_ids_with_matched_workflow_ids_and_product_ids = matched_workflow_ids_and_product_ids_by_cart_id(cart_product_ids_with_cart_ids)
+
+      cart_ids_with_matched_workflow_ids_and_product_ids.each do |cart_id, workflow_ids_with_product_ids|
+        CustomerMailer.abandoned_cart(cart_id, workflow_ids_with_product_ids.stringify_keys).deliver_later(queue: "low")
+      end
+      Rails.logger.info "Scheduled abandoned cart emails for #{cart_ids_with_matched_workflow_ids_and_product_ids.count} carts for #{window.begin} to #{window.end} in #{(Time.current - start_time).round(2)} seconds"
     end
 
-    # cart_ids_with_matched_workflow_ids_and_product_ids is a hash of { cart_id => { workflow_id => [product_ids] } }
-    cart_ids_with_matched_workflow_ids_and_product_ids = {}
+    # Returns { cart_id => { workflow_id => [product_ids] } } for the given
+    # { product_id => { cart_id => [variant_ids] } } map. Candidate workflows are looked up
+    # through the carted products' sellers rather than by walking every published
+    # abandoned-cart workflow — the full walk dominated the old single-pass runtime
+    # (gumroad-private#1576) and would have run once per window here.
+    def matched_workflow_ids_and_product_ids_by_cart_id(cart_product_ids_with_cart_ids)
+      matches = {}
+      seller_ids = []
+      cart_product_ids_with_cart_ids.keys.each_slice(IN_LIST_BATCH_SIZE) do |product_ids|
+        seller_ids |= Link.visible_and_not_archived.where(id: product_ids).distinct.pluck(:user_id)
+      end
 
-    start_time = Time.current
-    Workflow.distinct.alive.abandoned_cart_type.published.joins(seller: :links).merge(User.alive.not_suspended).merge(Link.visible_and_not_archived).includes(:seller).find_each do |workflow|
-      next unless workflow.seller&.eligible_for_abandoned_cart_workflows?
+      seller_ids.each_slice(IN_LIST_BATCH_SIZE) do |batch_seller_ids|
+        Workflow.alive.abandoned_cart_type.published.where(seller_id: batch_seller_ids).joins(:seller).merge(User.alive.not_suspended).includes(:seller).find_each do |workflow|
+          next unless workflow.seller&.eligible_for_abandoned_cart_workflows?
 
-      workflow.abandoned_cart_products(only_product_and_variant_ids: true).each do |product_id, variant_ids|
-        next unless cart_product_ids_with_cart_ids.key?(product_id)
+          workflow.abandoned_cart_products(only_product_and_variant_ids: true).each do |product_id, variant_ids|
+            next unless cart_product_ids_with_cart_ids.key?(product_id)
 
-        cart_product_ids_with_cart_ids[product_id].each do |cart_id, cart_variant_ids|
-          has_matching_variants = variant_ids.empty? || (variant_ids & cart_variant_ids).any?
-          next unless has_matching_variants
+            cart_product_ids_with_cart_ids[product_id].each do |cart_id, cart_variant_ids|
+              has_matching_variants = variant_ids.empty? || (variant_ids & cart_variant_ids).any?
+              next unless has_matching_variants
 
-          cart_ids_with_matched_workflow_ids_and_product_ids[cart_id] ||= {}
-          cart_ids_with_matched_workflow_ids_and_product_ids[cart_id][workflow.id] ||= []
-          cart_ids_with_matched_workflow_ids_and_product_ids[cart_id][workflow.id] << product_id
+              matches[cart_id] ||= {}
+              matches[cart_id][workflow.id] ||= []
+              matches[cart_id][workflow.id] << product_id
+            end
+          end
         end
       end
+      matches
     end
 
-    Rails.logger.info "Fetched #{cart_ids_with_matched_workflow_ids_and_product_ids.count} cart ids with matched workflow ids and product ids in #{(Time.current - start_time).round(2)} seconds"
-
-    cart_ids_with_matched_workflow_ids_and_product_ids.each do |cart_id, workflow_ids_with_product_ids|
-      CustomerMailer.abandoned_cart(cart_id, workflow_ids_with_product_ids.stringify_keys).deliver_later(queue: "low")
-    end
-  end
-
-  private
     # Returns the ids of all abandoned carts in the given updated_at window, equivalent to
     # `Cart.abandoned(updated_at: window).pluck(:id)` but walked in id-ordered keyset batches
     # so no single statement has to materialize the whole window. The cursor advances past

--- a/spec/sidekiq/schedule_abandoned_cart_emails_job_spec.rb
+++ b/spec/sidekiq/schedule_abandoned_cart_emails_job_spec.rb
@@ -88,6 +88,57 @@ describe ScheduleAbandonedCartEmailsJob do
             .and have_enqueued_mail(CustomerMailer, :abandoned_cart).with(cart2.id, { seller2_abandoned_cart_workflow.id => [seller2_product1.id] }.stringify_keys)
             .and have_enqueued_mail(CustomerMailer, :abandoned_cart).with(guest_cart1.id, { seller1_abandoned_cart_workflow.id => [seller1_product1.id, seller1_product2.id] }.stringify_keys)
         end
+
+        it "does not walk workflows of sellers with no products in the abandoned carts" do
+          # Workflow matching drives off the carted products' sellers; walking every
+          # published workflow was the bulk of the runtime that kept the job from
+          # finishing inside a deploy window (gumroad-private#1576).
+          uncarted_seller = create(:user)
+          create(:payment_completed, user: uncarted_seller)
+          uncarted_product = create(:product, user: uncarted_seller)
+          uncarted_workflow = create(:abandoned_cart_workflow, seller: uncarted_seller, published_at: 1.day.ago, bought_products: [uncarted_product.unique_permalink])
+
+          walked_workflow_ids = []
+          allow_any_instance_of(Workflow).to receive(:abandoned_cart_products).and_wrap_original do |original, **kwargs|
+            walked_workflow_ids << original.receiver.id
+            original.call(**kwargs)
+          end
+
+          described_class.new.perform
+
+          expect(walked_workflow_ids).to include(seller1_abandoned_cart_workflow.id, seller2_abandoned_cart_workflow.id)
+          expect(walked_workflow_ids).not_to include(uncarted_workflow.id)
+        end
+      end
+
+      context "when the run is killed partway through the day windows" do
+        it "has already scheduled emails for the days scanned before the kill" do
+          # Each day's window is matched and delivered before the next is scanned, so a
+          # deploy-window kill costs one day's chunk instead of the whole run
+          # (gumroad-private#1576): a death on day 2 must not take day 1's sends with it.
+          travel_to Time.current.noon do
+            day1_cart = create(:cart)
+            create(:cart_product, cart: day1_cart, product: seller1_product1)
+            day1_cart.update!(updated_at: 25.hours.ago)
+
+            day2_cart = create(:cart)
+            create(:cart_product, cart: day2_cart, product: seller1_product1)
+            day2_cart.update!(updated_at: 2.days.ago)
+
+            job = described_class.new
+            scanned_windows = 0
+            allow(job).to receive(:abandoned_cart_ids).and_wrap_original do |original, window|
+              scanned_windows += 1
+              raise Sidekiq::Shutdown if scanned_windows > 1
+              original.call(window)
+            end
+
+            expect do
+              expect { job.perform }.to raise_error(Sidekiq::Shutdown)
+            end.to have_enqueued_mail(CustomerMailer, :abandoned_cart)
+              .with(day1_cart.id, { seller1_abandoned_cart_workflow.id => [seller1_product1.id] }.stringify_keys)
+          end
+        end
       end
 
       context "when there are multiple matching abandoned cart workflows for a cart" do


### PR DESCRIPTION
## What

`ScheduleAbandonedCartEmailsJob` now processes one day-window at a time: each day is scanned, workflow-matched, and its `CustomerMailer.abandoned_cart` mails enqueued before the next day begins. Previously the job accumulated the entire 30-day window in memory and enqueued nothing until the very end of `#perform`.

Workflow matching is also inverted: candidate workflows are looked up through the day's carted products' sellers (`links.user_id` → `workflows.seller_id`, both indexed) instead of walking every published abandoned-cart workflow. The new SQL IN lists are sliced (`IN_LIST_BATCH_SIZE`) to stay under MySQL's range-optimizer memory limit, past which it silently falls back to a full table scan.

## Why

Fixes the remaining half of antiwork/gumroad-private#1576. Because the old shape sent nothing until the final loop, any worker death before that point sent zero — and deploys recycle Sidekiq pods far more often than the job's hours-long runtime could dodge, so `super_fetch` kept restarting it from the top and abandoned-cart sends flatlined platform-wide. #6654 (lock TTL + unique index on `sent_abandoned_cart_emails`) stopped a killed run from muting the job forever, but could not make it finish; this PR is the part that does.

- A mid-run kill now costs at most the day-window in flight instead of the whole run.
- A restarted run re-covers finished windows safely and cheaply: delivered carts drop out of the `Cart.abandoned` scope, and a cart whose mail is enqueued but not yet delivered re-enqueues into the mailer's unique-indexed insert, which drops the duplicate. #6654's index is the precondition that makes incremental sending safe, which is why the changes shipped in this order.
- The matching inversion is required by the chunking, not an optional optimization: the full workflow walk dominated the runtime and would now run once per window. It is semantically identical because `Workflow#abandoned_cart_products` can only ever match the seller's own visible products, so a workflow whose seller has no product among the day's carts could never have matched anyway.

## Before/After

No user-visible change: same emails, same recipients, same mailer arguments — pinned by the existing specs, which pass unchanged. The behavioral difference is failure cost: before, a mid-run kill silently zeroed the entire daily run; after, every completed day-window has already sent.

## Test Results

Two new specs, both verified to fail with the job change reverted (spec kept, code stashed):

- a `Sidekiq::Shutdown` raised while scanning day 2 no longer takes day 1's already-scheduled email with it — old code enqueued nothing
- workflows of sellers with no products in any abandoned cart are not walked — old code walked all of them

```
$ bundle exec rspec spec/sidekiq/schedule_abandoned_cart_emails_job_spec.rb
10 examples, 0 failures

$ git stash push app/sidekiq/schedule_abandoned_cart_emails_job.rb && \
  bundle exec rspec spec/sidekiq/schedule_abandoned_cart_emails_job_spec.rb \
    -e "does not walk workflows" -e "killed partway"
2 examples, 2 failures
```

Rubocop clean on both files.

---

**AI disclosure:** Written with Claude Fable 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
