### PR TITLE
Report resource subscriptions that can never deliver

### DIFF
--- a/app/modules/user/ping_notification.rb
+++ b/app/modules/user/ping_notification.rb
@@ -32,13 +32,34 @@ module User::PingNotification
       can_view_sales = Doorkeeper::AccessToken.active_for(self).where(application_id: oauth_application.id).find do |token|
         token.includes_scope?(:view_sales) || token.includes_scope?(:account)
       end
-      post_urls << [resource_subscription.post_url, resource_subscription.content_type] if oauth_application && resource_subscription.post_url.present? && can_view_sales
+      if resource_subscription.post_url.present? && can_view_sales
+        post_urls << [resource_subscription.post_url, resource_subscription.content_type]
+      else
+        report_undeliverable(resource_subscription, resource_name, can_view_sales:)
+      end
     end
     post_urls << [notification_endpoint, notification_content_type] if notification_endpoint.present? && resource_name == ResourceSubscription::SALE_RESOURCE_NAME
     post_urls
   end
 
   private
+    # A live resource subscription that produces no post URL delivers nothing, forever, with no
+    # trace on either side: PostToPingEndpointsWorker returns early on an empty list, so there is
+    # no attempt to retry and no failure for the seller to see. The subscription keeps reading as
+    # active in the API. Report it so the silence is visible while the delivery contract for
+    # agent-created subscriptions is decided (gumroad-private#1545).
+    def report_undeliverable(resource_subscription, resource_name, can_view_sales:)
+      ErrorNotifier.notify(
+        "Resource subscription is undeliverable: no post URL resolved for an alive subscription",
+        resource_subscription_id: resource_subscription.id,
+        resource_name:,
+        seller_id: id,
+        oauth_application_id: resource_subscription.oauth_application_id,
+        post_url_present: resource_subscription.post_url.present?,
+        live_view_sales_token: can_view_sales.present?
+      )
+    end
+
     def encode_brackets(key)
       key.to_s.gsub(/[\[\]]/) { |char| URI.encode_www_form_component(char) }
     end

--- a/spec/modules/user/ping_notification_spec.rb
+++ b/spec/modules/user/ping_notification_spec.rb
@@ -107,5 +107,48 @@ describe User::PingNotification do
       sale_post_urls = user.urls_for_ping_notification(ResourceSubscription::SALE_RESOURCE_NAME)
       expect(sale_post_urls).to match_array([])
     end
+
+    it "does not report a subscription that resolves to a post URL" do
+      user = create(:user)
+      oauth_app = create(:oauth_application, owner: user)
+      create("doorkeeper/access_token", application: oauth_app, resource_owner_id: user.id, scopes: "view_sales")
+      create(:resource_subscription, oauth_application: oauth_app, user:)
+
+      expect(ErrorNotifier).not_to receive(:notify)
+      expect(user.urls_for_ping_notification(ResourceSubscription::SALE_RESOURCE_NAME).size).to eq(1)
+    end
+
+    it "reports an alive resource subscription that resolves to no post URL" do
+      user = create(:user)
+      oauth_app = create(:oauth_application, owner: user)
+      token = create("doorkeeper/access_token", application: oauth_app, resource_owner_id: user.id, scopes: "view_sales")
+      subscription = create(:resource_subscription, oauth_application: oauth_app, user:)
+      # The Store Agent revokes its own token in the same request that created the subscription, so
+      # the subscription outlives every credential that could satisfy the gate.
+      token.update!(revoked_at: Time.current)
+
+      expect(ErrorNotifier).to receive(:notify).with(
+        "Resource subscription is undeliverable: no post URL resolved for an alive subscription",
+        hash_including(
+          resource_subscription_id: subscription.id,
+          resource_name: ResourceSubscription::SALE_RESOURCE_NAME,
+          seller_id: user.id,
+          oauth_application_id: oauth_app.id,
+          post_url_present: true,
+          live_view_sales_token: false
+        )
+      )
+      expect(user.urls_for_ping_notification(ResourceSubscription::SALE_RESOURCE_NAME)).to match_array([])
+    end
+
+    it "does not report a subscription whose application was deleted" do
+      user = create(:user)
+      oauth_app = create(:oauth_application, owner: user)
+      create(:resource_subscription, oauth_application: oauth_app, user:)
+      oauth_app.mark_deleted!
+
+      expect(ErrorNotifier).not_to receive(:notify)
+      expect(user.urls_for_ping_notification(ResourceSubscription::SALE_RESOURCE_NAME)).to match_array([])
+    end
   end
 end


### PR DESCRIPTION
## What

Report a resource subscription that resolves to no post URL, instead of silently skipping it.

`User#urls_for_ping_notification` only appends a subscription's `post_url` when the owning OAuth application has an active `view_sales`/`account` token. When it does not, the subscription is skipped with no trace. `PostToPingEndpointsWorker` then hits `return if post_urls.empty?` before enqueuing anything, so there is no POST attempt, no retry, and no delivery error — while the subscription keeps reading as `active` in the API forever.

## Why

From [gumroad-private#1545](https://github.com/antiwork/gumroad-private/issues/1545): a seller's `sale` subscription (id `365319`) received nothing across four test sales. The subscription was healthy, the purchases were all in a webhook-firing state, and the endpoint was fine. The cause was that the Gumroad Store Agent creates subscriptions against an ephemeral OAuth token that it revokes in its own `ensure` block, so `Doorkeeper::AccessToken.active_for(user).where(application_id: 78479).count` is `0` at delivery time and the gate can never be satisfied again.

**This PR deliberately does not decide the delivery contract.** Item 1 of that issue's "what's needed from a human" is a product/security call between three options (exempt the first-party app, mint a durable credential, or refuse agent-created subscriptions), and that call is not mine to make. Item 2 — *"make the silent failure loud regardless of which option wins"* — is design-agnostic: whichever option lands, a subscription that cannot deliver should not be invisible. That is what this ships, so the observability is in place before and independent of the decision.

The seller in #1545 spent hours debugging his own endpoint (he created and deleted two subscriptions against a different URL first) for a platform-side gate that produced no signal on either side. This report is what would have pointed at the real cause immediately.

## Before / After

| | Before | After |
|---|---|---|
| Alive subscription, no live token | skipped silently; worker returns early; nothing anywhere | `ErrorNotifier` report with the subscription id, resource name, seller, app id, and which half of the gate failed |
| Alive subscription with a live token | post URL appended | unchanged, no report |
| Subscription whose app was deleted | skipped | still skipped, **no** report — a revoked app is a legitimate terminal state, not a fault |

The reported context distinguishes the two failing halves (`post_url_present`, `live_view_sales_token`) so a missing URL and a dead credential are not one undifferentiated alert.

`oauth_application &&` was dropped from the append condition: the `next if oauth_application.nil?` guard three lines above already makes it unreachable-false.

## QA steps

No user-visible surface changes, so there is nothing to screenshot — this adds an error report on an internal delivery path. It is covered by tests that assert both the firing and the non-firing cases:

```
bundle exec rspec spec/modules/user/ping_notification_spec.rb -e "urls_for_ping_notification"
```

## Test results

Run locally on `360d6f822` (ruby 3.4.3):

```
......  [0.41s]
Finished in 4.15 seconds (files took 3.23 seconds to load)
6 examples, 0 failures
```

Three `#send_test_ping` examples in the same file fail on this branch. They **also fail on unmodified `origin/main`** (verified by stashing the diff and re-running: `6 examples, 3 failures`, same three), so they are pre-existing and unrelated to this change.

Three new/changed examples:
- reports an alive subscription that resolves to no post URL (token revoked after creation — the Store Agent's exact shape)
- does **not** report when the subscription resolves to a post URL
- does **not** report when the owning application was deleted

---

## AI disclosure

Written by Gumclaw (claude-opus-5).
