### PR TITLE
Let seller custom pages link to files that download

### DIFF
--- a/app/controllers/concerns/renders_custom_html_pages.rb
+++ b/app/controllers/concerns/renders_custom_html_pages.rb
@@ -52,24 +52,11 @@ module RendersCustomHtmlPages
     </style>
   HTML
 
-  # Every custom-page surface must sandbox identically, so they all read this one
-  # list rather than repeating the tokens: the wrapper iframes in
-  # UsersController/UserPagesController/LinksController and the CSP directive
-  # below. Adding a token here widens all four at once; that is the point.
-  #
-  # allow-downloads is required for a download to happen *at all* from seller
-  # HTML — without it the browser drops the click silently, and target="_blank"
-  # can't route around it because the escaped popup inherits the initiator's
-  # download restriction.
-  CUSTOM_HTML_SANDBOX_TOKENS = %w[
-    allow-scripts
-    allow-forms
-    allow-popups
-    allow-popups-to-escape-sandbox
-    allow-downloads
-  ].freeze
-
-  CUSTOM_HTML_SANDBOX = CUSTOM_HTML_SANDBOX_TOKENS.join(" ").freeze
+  # Without allow-downloads the browser cancels a download from seller HTML with no
+  # error anyone can see, and target="_blank" can't route around it: the escaped popup
+  # inherits the sandboxed initiator's download restriction. The editor preview iframes
+  # in app/javascript must carry the same token — attribute and CSP intersect.
+  CUSTOM_HTML_SANDBOX = "allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-downloads"
 
   CUSTOM_HTML_CSP = [
     # Sandbox the response itself, not just the wrapper's iframe attribute.

--- a/app/controllers/concerns/renders_custom_html_pages.rb
+++ b/app/controllers/concerns/renders_custom_html_pages.rb
@@ -52,13 +52,31 @@ module RendersCustomHtmlPages
     </style>
   HTML
 
+  # Every custom-page surface must sandbox identically, so they all read this one
+  # list rather than repeating the tokens: the wrapper iframes in
+  # UsersController/UserPagesController/LinksController and the CSP directive
+  # below. Adding a token here widens all four at once; that is the point.
+  #
+  # allow-downloads is required for a download to happen *at all* from seller
+  # HTML — without it the browser drops the click silently, and target="_blank"
+  # can't route around it because the escaped popup inherits the initiator's
+  # download restriction.
+  CUSTOM_HTML_SANDBOX_TOKENS = %w[
+    allow-scripts
+    allow-forms
+    allow-popups
+    allow-popups-to-escape-sandbox
+    allow-downloads
+  ].freeze
+
+  CUSTOM_HTML_SANDBOX = CUSTOM_HTML_SANDBOX_TOKENS.join(" ").freeze
+
   CUSTOM_HTML_CSP = [
     # Sandbox the response itself, not just the wrapper's iframe attribute.
     # A visitor can navigate straight to the /landing/embed endpoint (top-level,
     # not framed), where the iframe sandbox doesn't apply — without this the
-    # seller's inline scripts would run on the real subdomain origin. Matches
-    # the wrapper iframe's sandbox: scripts + forms + popups, no same-origin/top-nav.
-    "sandbox allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox",
+    # seller's inline scripts would run on the real subdomain origin.
+    "sandbox #{CUSTOM_HTML_SANDBOX}",
     "default-src 'none'",
     "script-src 'unsafe-inline' https://cdn.tailwindcss.com https://cdn.jsdelivr.net https://unpkg.com",
     "style-src 'unsafe-inline' #{PAGES_TAILWIND_ASSET_HOST} https://cdn.tailwindcss.com https://fonts.googleapis.com https://fonts.bunny.net",

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1949,7 +1949,7 @@ class LinksController < ApplicationController
               id="gumroad-landing-frame"
               src="#{iframe_src}"
               title="#{title}"
-              sandbox="allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox"
+              sandbox="#{CUSTOM_HTML_SANDBOX}"
             ></iframe>
             <script nonce="#{ERB::Util.h(nonce)}" data-cfasync="false">
               var frame = document.getElementById("gumroad-landing-frame");

--- a/app/controllers/user_pages_controller.rb
+++ b/app/controllers/user_pages_controller.rb
@@ -127,7 +127,7 @@ class UserPagesController < ApplicationController
               id="gumroad-landing-frame"
               src="#{iframe_src}"
               title="#{title}"
-              sandbox="allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox"
+              sandbox="#{CUSTOM_HTML_SANDBOX}"
             ></iframe>
             <script nonce="#{ERB::Util.h(nonce)}" data-cfasync="false">
               (function () {

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -324,7 +324,7 @@ class UsersController < ApplicationController
               id="gumroad-landing-frame"
               src="#{iframe_src}"
               title="#{title}"
-              sandbox="allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox"
+              sandbox="#{CUSTOM_HTML_SANDBOX}"
             ></iframe>
             <script nonce="#{ERB::Util.h(nonce)}" data-cfasync="false">
               (function () {

--- a/app/javascript/components/ApiDocumentation/Endpoints/Products.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/Products.tsx
@@ -115,7 +115,10 @@ gumroad products page publish <permalink> ./landing.html`}
     </CodeSnippet>
     <p>
       Your HTML is sanitized — disallowed tags and attributes are stripped — then served inside a sandboxed iframe (
-      <code>sandbox="allow-scripts allow-forms"</code>).
+      <code>
+        sandbox=&quot;allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-downloads&quot;
+      </code>
+      ).
     </p>
     <p>It can:</p>
     <ul>

--- a/app/javascript/components/ApiDocumentation/Endpoints/User.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/User.tsx
@@ -82,7 +82,7 @@ const ProfileCustomHtmlDocumentation = () => (
       </code>
       ). It can run inline JavaScript, load scripts from the Tailwind, jsDelivr, and unpkg CDNs, load fonts from Google
       Fonts and Bunny Fonts, open links in a new tab, and link to files that download. It can't read your Gumroad
-      cookies or session (it runs on an opaque origin), touch the parent page, or make <code>fetch</code>/
+      cookies or session (it runs on an opaque origin), touch or navigate the parent page, or make <code>fetch</code>/
       <code>XHR</code>/WebSocket requests (<code>connect-src 'none'</code>). Images and media may only load from
       Gumroad.
     </p>

--- a/app/javascript/components/ApiDocumentation/Endpoints/User.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/User.tsx
@@ -77,9 +77,12 @@ const ProfileCustomHtmlDocumentation = () => (
     </ul>
     <p>
       Your HTML is sanitized — disallowed tags and attributes are stripped — then served inside a sandboxed iframe (
-      <code>sandbox="allow-scripts allow-forms"</code>). It can run inline JavaScript, load scripts from the Tailwind,
-      jsDelivr, and unpkg CDNs, and load fonts from Google Fonts and Bunny Fonts. It can't read your Gumroad cookies or
-      session (it runs on an opaque origin), touch or navigate the parent page, or make <code>fetch</code>/
+      <code>
+        sandbox=&quot;allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-downloads&quot;
+      </code>
+      ). It can run inline JavaScript, load scripts from the Tailwind, jsDelivr, and unpkg CDNs, load fonts from Google
+      Fonts and Bunny Fonts, open links in a new tab, and link to files that download. It can't read your Gumroad
+      cookies or session (it runs on an opaque origin), touch the parent page, or make <code>fetch</code>/
       <code>XHR</code>/WebSocket requests (<code>connect-src 'none'</code>). Images and media may only load from
       Gumroad.
     </p>

--- a/app/javascript/components/ProductEdit/LandingPagePreview/index.tsx
+++ b/app/javascript/components/ProductEdit/LandingPagePreview/index.tsx
@@ -87,7 +87,7 @@ export const LandingPagePreview = ({
       ref={frameRef}
       title="Landing page preview"
       src={`/l/${encodeURIComponent(uniquePermalink)}/landing/embed`}
-      sandbox="allow-scripts allow-forms"
+      sandbox="allow-scripts allow-forms allow-downloads"
       referrerPolicy="no-referrer"
       className="h-[75vh] min-h-150 w-full rounded border border-border bg-white"
     />

--- a/app/javascript/components/Profile/LandingPagePreview.tsx
+++ b/app/javascript/components/Profile/LandingPagePreview.tsx
@@ -25,7 +25,7 @@ export const ProfileLandingPagePreview = ({
       ref={frameRef}
       title="Custom profile page preview"
       src={`/${encodeURIComponent(username)}/landing/embed?preview=true`}
-      sandbox="allow-scripts allow-forms allow-popups"
+      sandbox="allow-scripts allow-forms allow-popups allow-downloads"
       referrerPolicy="no-referrer"
       onLoad={postFields}
       // No border of its own: this preview renders inside the shared PreviewChrome frame,

--- a/spec/controllers/links_controller_custom_html_spec.rb
+++ b/spec/controllers/links_controller_custom_html_spec.rb
@@ -34,7 +34,7 @@ describe LinksController, :vcr, type: :controller do
 
     it "sandboxes the iframe without top-navigation and mediates checkout via postMessage" do
       get :show, params: { id: product.unique_permalink }
-      expect(response.body).to include(%(sandbox="allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox"))
+      expect(response.body).to include(%(sandbox="#{RendersCustomHtmlPages::CUSTOM_HTML_SANDBOX}"))
       expect(response.body).to include("allow-popups")
       expect(response.body).not_to include("allow-same-origin")
       expect(response.body).not_to include("allow-top-navigation")
@@ -305,7 +305,7 @@ describe LinksController, :vcr, type: :controller do
     it "applies the strict CSP and iframe-friendly response headers" do
       get :landing_iframe_content, params: { id: product.unique_permalink }
       expect(response.headers["Content-Security-Policy"]).to eq(CUSTOM_HTML_CSP)
-      expect(response.headers["Content-Security-Policy"]).to include("sandbox allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox")
+      expect(response.headers["Content-Security-Policy"]).to include("sandbox #{RendersCustomHtmlPages::CUSTOM_HTML_SANDBOX}")
       expect(response.headers["Content-Security-Policy"]).to include("frame-src https://www.youtube-nocookie.com https://www.youtube.com https://player.vimeo.com")
       # The shared Tailwind build loads from the asset host as an external
       # stylesheet, so style-src must allow it.

--- a/spec/controllers/users_controller_custom_html_spec.rb
+++ b/spec/controllers/users_controller_custom_html_spec.rb
@@ -25,7 +25,7 @@ describe UsersController, :vcr, type: :controller do
 
     it "sandboxes the iframe without same-origin or top-navigation" do
       get :show
-      expect(response.body).to include(%(sandbox="allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox"))
+      expect(response.body).to include(%(sandbox="#{RendersCustomHtmlPages::CUSTOM_HTML_SANDBOX}"))
       expect(response.body).not_to include("allow-same-origin")
       expect(response.body).not_to include("allow-top-navigation")
     end
@@ -88,7 +88,7 @@ describe UsersController, :vcr, type: :controller do
     it "applies the strict CSP and iframe-friendly response headers" do
       get :landing_iframe_content
       expect(response.headers["Content-Security-Policy"]).to eq(CUSTOM_HTML_CSP)
-      expect(response.headers["Content-Security-Policy"]).to include("sandbox allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox")
+      expect(response.headers["Content-Security-Policy"]).to include("sandbox #{RendersCustomHtmlPages::CUSTOM_HTML_SANDBOX}")
       expect(response.headers["Content-Security-Policy"]).not_to include("allow-same-origin")
       expect(response.headers["Content-Security-Policy"]).not_to include("allow-top-navigation")
       expect(response.headers["X-Frame-Options"]).to eq("SAMEORIGIN")

--- a/spec/requests/custom_html_sandbox_parity_spec.rb
+++ b/spec/requests/custom_html_sandbox_parity_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# The sandbox is spelled in four places — three wrapper iframes (profile,
+# slugged page, product landing) and the CSP directive that covers a direct
+# top-level hit on /landing/embed, where the iframe attribute doesn't apply.
+# They must stay identical: a token present on three surfaces and missing on
+# the fourth is invisible in review and reaches sellers as "this link works on
+# my product page but not my storefront". These examples hit all four for real
+# rather than asserting the constant against itself.
+describe "custom HTML sandbox parity", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:seller) { create(:user, username: "sandboxparity", name: "Jane Doe") }
+  let(:sandbox) { RendersCustomHtmlPages::CUSTOM_HTML_SANDBOX }
+
+  before { Feature.activate_user(:custom_html_pages, seller) }
+
+  it "serves the same sandbox on the profile wrapper" do
+    seller.update!(custom_html: "<section><h1>Profile</h1></section>")
+
+    get "http://#{seller.subdomain}/"
+
+    expect(response).to be_successful
+    expect(response.body).to include(%(sandbox="#{sandbox}"))
+  end
+
+  it "serves the same sandbox on a slugged page wrapper" do
+    create(:user_page, pageable: seller, slug: "studio", title: "Studio",
+                       custom_html: "<section><h1>Studio</h1></section>")
+
+    get "http://#{seller.subdomain}/studio"
+
+    expect(response).to be_successful
+    expect(response.body).to include(%(sandbox="#{sandbox}"))
+  end
+
+  it "serves the same sandbox on the product landing wrapper" do
+    product = create(:product, user: seller, custom_html: "<section><h1>Product</h1></section>")
+
+    get "http://#{seller.subdomain}/l/#{product.unique_permalink}"
+
+    expect(response).to be_successful
+    expect(response.body).to include(%(sandbox="#{sandbox}"))
+  end
+
+  it "serves the same sandbox as a CSP directive on the embed itself" do
+    product = create(:product, user: seller, custom_html: "<section><h1>Product</h1></section>")
+
+    get "http://#{seller.subdomain}/l/#{product.unique_permalink}/landing/embed"
+
+    expect(response).to be_successful
+    expect(response.headers["Content-Security-Policy"]).to include("sandbox #{sandbox}")
+  end
+
+  describe "the sandbox itself" do
+    it "permits downloads, so a seller's link to a file isn't silently dropped" do
+      # Without this token the browser cancels the download with no error the
+      # seller or we can see, and target="_blank" can't route around it: the
+      # escaped popup inherits the sandboxed initiator's download restriction.
+      expect(sandbox).to include("allow-downloads")
+    end
+
+    it "still withholds same-origin and top navigation" do
+      expect(sandbox).not_to include("allow-same-origin")
+      expect(sandbox).not_to include("allow-top-navigation")
+    end
+  end
+end

--- a/spec/requests/custom_html_sandbox_parity_spec.rb
+++ b/spec/requests/custom_html_sandbox_parity_spec.rb
@@ -2,13 +2,11 @@
 
 require "spec_helper"
 
-# The sandbox is spelled in four places — three wrapper iframes (profile,
-# slugged page, product landing) and the CSP directive that covers a direct
-# top-level hit on /landing/embed, where the iframe attribute doesn't apply.
-# They must stay identical: a token present on three surfaces and missing on
-# the fourth is invisible in review and reaches sellers as "this link works on
-# my product page but not my storefront". These examples hit all four for real
-# rather than asserting the constant against itself.
+# The sandbox is spelled on four server surfaces — three wrapper iframes (profile,
+# slugged page, product landing) and the CSP directive covering a direct top-level
+# hit on /landing/embed, where the iframe attribute doesn't apply. A token present
+# on three and missing on the fourth reaches sellers as "works on my product page
+# but not my storefront", so these examples hit all four for real.
 describe "custom HTML sandbox parity", type: :request do
   include Devise::Test::IntegrationHelpers
 
@@ -55,16 +53,32 @@ describe "custom HTML sandbox parity", type: :request do
   end
 
   describe "the sandbox itself" do
-    it "permits downloads, so a seller's link to a file isn't silently dropped" do
-      # Without this token the browser cancels the download with no error the
-      # seller or we can see, and target="_blank" can't route around it: the
-      # escaped popup inherits the sandboxed initiator's download restriction.
+    it "permits downloads" do
       expect(sandbox).to include("allow-downloads")
     end
 
     it "still withholds same-origin and top navigation" do
       expect(sandbox).not_to include("allow-same-origin")
       expect(sandbox).not_to include("allow-top-navigation")
+    end
+  end
+
+  # The editor previews frame these same /landing/embed documents from
+  # app/javascript, and a sandbox attribute intersects with the response CSP: a
+  # preview missing allow-downloads shows the seller their own download link
+  # failing on a page that works once published.
+  describe "the editor preview iframes" do
+    %w[
+      app/javascript/components/Profile/LandingPagePreview.tsx
+      app/javascript/components/ProductEdit/LandingPagePreview/index.tsx
+    ].each do |path|
+      it "grants allow-downloads in #{path}" do
+        source = Rails.root.join(path).read
+        sandbox_attr = source[/sandbox="([^"]*)"/, 1]
+
+        expect(sandbox_attr).to be_present
+        expect(sandbox_attr).to include("allow-downloads")
+      end
     end
   end
 end

--- a/spec/requests/pages_landing_embed_csp_spec.rb
+++ b/spec/requests/pages_landing_embed_csp_spec.rb
@@ -40,8 +40,9 @@ describe "GET /l/:id/landing/embed CSP", type: :request do
     csp = response.headers["Content-Security-Policy"]
     # CSP sandbox applies whether the doc is framed or loaded directly — the
     # iframe attribute alone wouldn't cover a direct navigation to this URL.
-    expect(csp).to include("sandbox allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox")
+    expect(csp).to include("sandbox #{RendersCustomHtmlPages::CUSTOM_HTML_SANDBOX}")
     expect(csp).to include("allow-popups")
+    expect(csp).to include("allow-downloads")
     expect(csp).not_to include("allow-same-origin")
     expect(csp).not_to include("allow-top-navigation")
   end

--- a/spec/requests/profile_custom_html_spec.rb
+++ b/spec/requests/profile_custom_html_spec.rb
@@ -175,7 +175,7 @@ describe "Profile custom HTML rendering", type: :request do
     it "keeps the iframe sandbox unchanged — still no allow-same-origin or allow-top-navigation" do
       get "http://seller.example.com/"
 
-      expect(response.body).to include(%(sandbox="allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox"))
+      expect(response.body).to include(%(sandbox="#{RendersCustomHtmlPages::CUSTOM_HTML_SANDBOX}"))
       expect(response.body).not_to include("allow-same-origin")
       expect(response.body).not_to include("allow-top-navigation")
     end


### PR DESCRIPTION
## What

Adds `allow-downloads` to the sandbox around seller-authored custom HTML, so a seller's link to a downloadable file actually downloads instead of being silently cancelled by the browser. Collapses the sandbox token list — previously spelled out as a literal in four places — into one shared constant, and updates the two API-docs pages that quote it.

## Why

Without `allow-downloads`, a browser cancels a download initiated from sandboxed content with no error the seller or we can see, and `target="_blank"` cannot route around it: the escaped popup inherits the initiator's download restriction. Sellers putting a "download my free sample" link on a custom page saw nothing happen.

The four hardcoded copies were a latent bug of their own — a token added to three surfaces and missed on the fourth reaches sellers as "this works on my product page but not my storefront".

## Test results

`spec/requests/custom_html_sandbox_parity_spec.rb`, `pages_landing_embed_csp_spec.rb`, `profile_custom_html_spec.rb`, `links_controller_custom_html_spec.rb`, `users_controller_custom_html_spec.rb`:

```
128 examples, 0 failures
```

Revert-proof: removing `allow-downloads` from either editor preview turns the new parity examples red (`2 examples, 2 failures`), and removing it from the constant reds the CSP example that asserts the literal token against a real HTTP response. The change cannot be reverted with a green suite.

`rubocop` clean on all touched Ruby files.

## Fable-5 adversarial review

Verdict: **CHANGES-REQUIRED → all findings addressed.** No P1.

| Finding | Disposition |
|---|---|
| P2-1 — every editor preview iframe omitted `allow-downloads`, so a download link failed in the preview and worked once published (sandbox attribute ∩ response CSP) | Fixed in 98e19aa4e — added the token to the profile and product-edit previews, plus examples that red if either loses it |
| P2-2 — the widening is not bounded by the CSP: a download can originate from any host | Documented below, no code change; see "What a reviewer should weigh" |
| P3 — the docs edit dropped the still-true "or navigate the parent page" guarantee | Fixed in 98e19aa4e |
| P3 — parity spec's "four places" framing undercounts server surfaces | Left as-is; all surfaces read the shared constant, so they cannot drift |
| SLOP — two constants where one would do; comment blocks restating the code | Fixed in 98e19aa4e — `CUSTOM_HTML_SANDBOX_TOKENS` had exactly one reader (the `.join`) and is gone |

Confirmed safe by the review:

- **Top-level vs framed parity is genuinely equivalent.** Framed = iframe attribute ∩ CSP; a direct top-level hit on `/landing/embed` = CSP only. Both now grant the same tokens, so no surface diverges.
- **The docs strings match the constant exactly, in order.** They were already stale before this PR (claiming `allow-scripts allow-forms`); this corrects a pre-existing drift.
- **The old-literal sweep is complete.** No spec still pins the four-token string.
- **Nested seller iframes are unaffected.** `Ai::PageSanitizer` forces `sandbox="allow-scripts"` on seller-embedded YouTube/Vimeo frames; only the top custom-HTML document gains `allow-downloads`.

## What a reviewer should weigh (P2-2)

`allow-downloads` is granted to arbitrary seller-authored HTML on a `*.gumroad.com` subdomain, and nothing in `CUSTOM_HTML_CSP` bounds where a downloaded file comes from — `connect-src 'none'` covers fetch/XHR/WebSocket, `img-src`/`media-src` cover resource loads, `form-action 'self'` covers form posts, and there is no `navigate-to` directive. So a hostile seller can offer a download of an arbitrary-origin file with an attacker-chosen filename while the address bar reads Gumroad.

This is incremental on a surface that already runs seller scripts and already has `allow-popups-to-escape-sandbox`, and it is the minimum needed for the feature to work at all. It is called out here so the security posture is an explicit decision rather than a side effect of a refactor.

## QA steps

1. On a seller account with custom HTML enabled, publish a custom page containing `<a href="https://…/file.pdf" download>Download</a>`.
2. Click it on the live page — the file should download (it does nothing on `main`).
3. Open the same page in the product/profile editor preview — the download should now work there too, which is the behavior this PR adds.
4. Confirm the page still cannot read cookies/session, navigate the parent, or make `fetch` calls.

## Only verifiable in a live browser

- That `allow-downloads` unblocks a real download from the live wrapper, and whether Chrome's "multiple automatic downloads" heuristic permits a gesture-free auto-download (relevant to the P2-2 discussion above).
- That no browser-side download-source enforcement silently bounds P2-2.

## AI disclosure

Written by Hermes Agent (claude-opus-5) running as gumclaw, including the adversarial review and the empirical revert proof.
