### PR TITLE
Update instant payout eligibility in the getting-paid help article

### DIFF
--- a/app/views/help_center/articles/contents/_13-getting-paid.html.erb
+++ b/app/views/help_center/articles/contents/_13-getting-paid.html.erb
@@ -473,7 +473,7 @@
   <p>The date shown on your <a href="269-balance-page">Payouts dashboard</a> is your own payout day, so that is the day to expect the money to be sent. Bank transfers can then take a few business days to land, depending on your bank.</p>
   <p>If you have set your payouts to monthly or quarterly, they still go out on your payout day, just in the month or quarter you chose. Daily payouts are the exception: those are sent every day rather than on one weekday.</p>
   <h3 id="instant-payouts">Instant payouts</h3>
-  <p>Creators from the US can get paid within minutes for amounts up to $10K and a 3% fee. Instant payouts are available only to creators from the US who have completed four payouts.</p>
+  <p>Creators from the US can get paid within minutes for amounts up to $10K and a 3% fee. Instant payouts are available only to creators from the US who have completed at least one payout and whose Stripe account has been processing with Gumroad for at least 60 days.</p>
   <p>If you are eligible for an instant payout, you will see the option to get paid instantly on your <a href="https://gumroad.com/payouts">Payouts dashboard</a>. </p>
   <p>Not all debit cards are eligible for instant payouts. If you connect a debit card and still see a message to connect a debit card to receive instant payouts, the card you connected is not eligible. You will need to try a different card. </p>
   <h3 id="paypal-connect">Enable payments via PayPal</h3>


### PR DESCRIPTION
## What

Updates the instant payouts section of `_13-getting-paid` so it states the eligibility rule that is now live: at least one completed payout plus a Stripe account that has been processing for at least 60 days.

## Why

Triggered by #6690 (merged, on `main` as `89d43ab`), which replaced the four-completed-payouts bar with a one-payout requirement plus a 60-day account-age check. The article still said "available only to creators from the US who have completed four payouts", which now overstates the payout count and omits the age requirement entirely, so a seller with one payout would read that they are ineligible when they are not.

Both numbers verified against `origin/main`:

- `User#eligible_for_instant_payouts?` → `payments.completed.exists?` (one payout, not four)
- `User::MIN_ACCOUNT_AGE_FOR_INSTANT_PAYOUTS = 60.days`, checked in `User#stripe_account_seasoned_for_instant_payouts?` against the Stripe merchant account's `created_at`

The US-only and debit-card sentences around it are unchanged and still accurate.

## Payout wording — please sanity-check

This is payout-policy copy, which creators quote back to us, so the exact sentence is worth a second read. The age is measured on the Stripe payout account, not on Gumroad signup date; the article says "whose Stripe account has been processing with Gumroad for at least 60 days" to keep that distinction without naming internal models.

## Before / after

| | Copy |
|---|---|
| Before | Instant payouts are available only to creators from the US who have completed **four payouts**. |
| After | Instant payouts are available only to creators from the US who have completed **at least one payout** and whose **Stripe account has been processing with Gumroad for at least 60 days**. |

## Test plan

Body-only prose edit — no `articles.yml` change, no ERB logic, no anchor or TOC change, so no adversarial review gate per the help-center editing conventions.

- `bundle exec rspec spec/models/help_center` — 1 example, 0 failures (guards slug ↔ partial integrity).
- ERB syntax check on the edited partial — OK.
- Rendered the partial in the real view context: `ApplicationController.render(partial: "help_center/articles/contents/13-getting-paid")` → 22,059 bytes, contains the new sentence, no longer contains "completed four payouts".

## AI disclosure

Written by `claude-opus-5` (the `model.default` in the local Hermes config). Instruction was the standing merged-PR → help-center doc-sync job: check whether a merged gumroad PR changes anything the help center documents, map it to the affected article, and ship the correction.
