### PR TITLE
Document the default discount detachment guards in the help center

### DIFF
--- a/app/views/help_center/articles/contents/_128-discount-codes.html.erb
+++ b/app/views/help_center/articles/contents/_128-discount-codes.html.erb
@@ -31,7 +31,7 @@
   <ul>
     <li>If a customer arrives with a different discount from a <a href="270-url-parameters">discount link or URL parameter</a>, Gumroad applies whichever discount is larger. Discounts never stack.</li>
     <li>If the automatically applied code's validity period ends, customers simply pay full price until you pick a different code or turn the setting off.</li>
-    <li>You can't delete a discount code while it's set as the automatic discount on a product. Remove it from the product first.</li>
+    <li>While a code is set as the automatic discount on a product, Gumroad blocks any edit to that code that would stop it applying there. You can't delete it, remove the product from the code's list of products, exclude the product from an all-products code, or move a fixed-amount all-products code to a currency the product doesn't use. Turn the setting off on the product first, then make the change.</li>
   </ul>
   <h3 id="Discounts-for-memberships-_Pxb_">Discounts for memberships</h3>
   <p>When a discount code applies to a membership, choose how long it lasts under <b>Discount duration for memberships</b>:</p>


### PR DESCRIPTION
## What

Updates the "Automatically apply a discount code" section of `_128-discount-codes` so the caveat list describes all four ways an edit to a default discount code is now blocked, not just deletion.

Triggered by #6640 (merged), which added `OfferCode#validate_default_discount_remains_applicable`. The existing bullet only covered the older delete guard (`validate_not_used_as_default_discount`).

## Why

Before #6640, the only edit blocked on a code set as a product's default discount was deleting it, and that is what the article said. Sellers now also get a validation error when they remove the product from a product-specific code's product list, exclude the product from an all-products code (`validate_excluded_products`), or move a fixed-amount all-products code to a currency the product doesn't use. A seller hitting any of those three sees an error the help center does not explain.

The wording is scoped to what the code actually enforces:

- Removals are checked per-edit against the products that edit removed (`removed_product_ids`), and only for visible products (`Link.visible`).
- The currency guard only fires for universal codes with a non-nil `currency_type`, which is the fixed-amount case — percentage codes have `currency_type` nil and are unaffected, hence "fixed-amount all-products code".

Both the old and new guards resolve the same way for the seller: turn the setting off on the product, then edit the code. The bullet keeps that instruction and generalizes it.

Articles changed: `_128-discount-codes.html.erb` (body only). No `articles.yml` change — the title, description, and category are unchanged, and the edited bullet sits mid-article so the search snippet is unaffected. No article removals. No pricing, tax, payout, or refund wording touched.

## Before/After

Body-only copy edit inside an existing bullet list, no rendering change. Before and after, from the rendered partial:

Before:

> You can't delete a discount code while it's set as the automatic discount on a product. Remove it from the product first.

After:

> While a code is set as the automatic discount on a product, Gumroad blocks any edit to that code that would stop it applying there. You can't delete it, remove the product from the code's list of products, exclude the product from an all-products code, or move a fixed-amount all-products code to a currency the product doesn't use. Turn the setting off on the product first, then make the change.

## Test plan

Verified locally on the pushed branch:

- ERB syntax compiles (`ERB.new(...).src`).
- Partial renders in the real view context and contains the new copy: `ApplicationController.render(partial: "help_center/articles/contents/128-discount-codes")` → `render OK 13591 bytes`.
- Tag balance unchanged across `div/ul/li/p/h3/figure` (2/2, 8/8, 29/29, 47/47, 10/10, 12/12).
- Diff scope is one line in one file.

CI runs the help-center specs (`spec/models/help_center`, `spec/presenters/help_center_presenter_spec.rb`), which guard the slug ↔ partial integrity this change does not alter.

Pure copy edit inside an existing article body: no logic, no YAML, no ERB control flow, so no adversarial review gate.

---

AI disclosure: written by claude-opus-5 running as the Hermes help-center doc-sync automation. Instructions: on a merged `antiwork/gumroad` PR, decide whether it changes externally documented behavior, map it to the affected help-center article(s), and ship the correction. The wording above was derived from `OfferCode#validate_default_discount_remains_applicable`, `#validate_excluded_products`, `#validate_not_used_as_default_discount`, and `Link#default_offer_code_must_be_valid` on `origin/main`.
