### PR TITLE
Document the review-reminder opt-out scope now that it is on main

### DIFF
--- a/app/views/help_center/articles/contents/_204-get-to-know-your-gumroad-receipt.html.erb
+++ b/app/views/help_center/articles/contents/_204-get-to-know-your-gumroad-receipt.html.erb
@@ -14,7 +14,7 @@
   <p>You can <a href="194-i-need-an-invoice">print your own invoice</a> by clicking the Generate link at the bottom of your receipt. If you need to customize your invoice, you can use the 'Additional Notes' field to add any relevant information. We are not able to customize invoices beyond that for you. </p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/65f8b3d254e485464f3dce9a/file-PEyzfH7eK6.png" %></figure>
   <h3 id="Unsubscribe-from-emails-Hqq3f">Unsubscribe from emails</h3>
-  <p>If you no longer would like to receive email updates from a seller, you can unsubscribe from future emails by clicking “Unsubscribe” at the bottom of your receipt.</p>
+  <p>If you no longer would like to receive email updates from a seller, you can unsubscribe from future emails by clicking “Unsubscribe” at the bottom of your receipt. That also stops the <a href="344-rate-and-review-your-purchase">review reminder</a> we would otherwise send for that purchase.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/65f8b3af909e484dba21070d/file-qx9PGuwNcF.png" %></figure>
   <h3 id="Cancel-memberships-ZWaRM">Cancel memberships</h3>
   <p>You can cancel a subscription to your latest membership charge by going to the receipt and click "Subscription settings" or "Manage membership":</p>

--- a/app/views/help_center/articles/contents/_344-rate-and-review-your-purchase.html.erb
+++ b/app/views/help_center/articles/contents/_344-rate-and-review-your-purchase.html.erb
@@ -11,7 +11,7 @@
   <br>
   <p>Your star rating is saved as soon as you select it, so a rating on its own counts as a review even if you don't add anything else. To share more, write your feedback in the text box and click "Post review".</p>
   <br>
-  <p>If you haven't left a review in the first 5 days after a purchase (90 days for physical products), we will send you a reminder email. If you bought with a Gumroad account, you can unsubscribe from these reminders using the link at the bottom of the email, and that stops review reminders only — you keep getting the creator's other emails. Some creators turn review reminders off, in which case you won't receive one.</p>
+  <p>If you haven't left a review in the first 5 days after a purchase (90 days for physical products), we will send you a reminder email. You can unsubscribe from these reminders using the link at the bottom of the email. If you bought with a Gumroad account, that link stops review reminders only, and you keep getting the creator's other emails. If you bought without a Gumroad account, it unsubscribes you from all of that creator's emails, because there is no account to store a reminders-only preference on. If you have already unsubscribed from a creator's emails, we won't send you review reminders for their products. Some creators turn review reminders off, in which case you won't receive one.</p>
   <br>
   <h3>Restrictions</h3>
   <ul>


### PR DESCRIPTION
## What

Re-lands the review-reminder opt-out wording in two help-center articles, now that the behavior it describes is actually on `main`.

`_344-rate-and-review-your-purchase` now says the reminder's unsubscribe link exists for every recipient, that it stops review reminders only for buyers with a Gumroad account, that it unsubscribes a guest from all of that creator's emails (there is no account row to hold a reminders-only preference), and that a buyer who already unsubscribed will not be sent reminders at all.

`_204-get-to-know-your-gumroad-receipt`'s "Unsubscribe from emails" section regains one sentence noting the receipt footer link also stops the review reminder for that purchase, cross-linking the reminders article.

## Why

Triggered by merged PR #6643 (tracking issue antiwork/gumroad-private#1578), which carried the stacked #6652 (antiwork/gumroad-private#1584) with it. Verified on `main` at `751e06f7`:

- `CustomerLowPriorityMailer#review_reminder_unsubscribe_url` returns the receipt footer's purchase-scoped `unsubscribe_purchase_url` when `purchaser` is nil, so a guest reminder now renders an Unsubscribe link where it previously rendered none.
- That link runs `Purchase#unsubscribe_buyer`, which clears `can_contact` on every purchase sharing that email and seller and unsubscribes the follower row — broader than reminders-only, which is what the article now states.
- For an account holder the link is `user_unsubscribe_review_reminders_by_token_url`, which flips `opted_out_of_review_reminders` only.
- `Purchase#eligible_for_review_reminder?` and `CustomerLowPriorityMailer#purchase_review_reminder` both consult `can_contact?`, so an existing unsubscribe suppresses the reminder.

This text first shipped in #6667 and was reverted by #6674, because #6652's base branch was `fix/tokenized-review-reminder-unsubscribe` rather than `main` — the docs were ahead of the code. That is no longer true: `git merge-base --is-ancestor 751e06f71eee6a42e945e904deb2d6632a5fc1a8 origin/main` passes.

No policy, pricing, tax, or payout wording. No article removals. `articles.yml` untouched — no title, description, or category change, and both edits sit mid-article with anchor IDs preserved.

## Before / after

Not applicable in the visual sense — the only rendered surface is the article prose in the diff. Both partials were rendered in the real view context to confirm they compile and the new copy lands (byte counts below).

## Test plan

Body-only prose edit, no ERB logic, so no fable review gate.

- ERB compiles for both partials (`ERB.new(...).src`).
- Tag balance: `_344` net zero across div/p/ul/li/h3/figure/a/br; `_204` gains exactly the one intended `<a>` pair.
- Both partials render in the real view context:

```
344-rate-and-review-your-purchase: render OK (2261 bytes)
204-get-to-know-your-gumroad-receipt: render OK (3686 bytes)
344 has guest wording: true
```

- `bundle exec rspec spec/models/help_center` — **1 example, 0 failures** (guards slug ↔ partial integrity). CI runs the remaining help-center specs.

No UI surface beyond the rendered article text.

## QA steps

1. Open `help.gumroad.com/help/article/344-rate-and-review-your-purchase`.
2. In the reviews section, confirm the reminder paragraph distinguishes account holders (reminders-only unsubscribe) from guests (unsubscribes from all of that creator's emails), and states that an existing unsubscribe suppresses reminders.
3. Open `help.gumroad.com/help/article/204-get-to-know-your-gumroad-receipt`, "Unsubscribe from emails", and confirm the sentence about the review reminder links to article 344.

---

## AI disclosure

Written by claude-opus-5 (Hermes Agent) via the merged-PR → help-center doc sync automation. Instructions: check whether merged gumroad#6643 makes any help-center article inaccurate, map it to the specific articles, and ship the correction. The model verified the merge commit is an ancestor of `origin/main`, then read `CustomerLowPriorityMailer#review_reminder_unsubscribe_url`, `Purchase#unsubscribe_buyer`, `Purchase#eligible_for_review_reminder?`, and `layouts/email.html.erb` at `origin/main` before wording the change, rather than trusting the triggering PR's prose.

Co-authored-by: Hermes Agent <gumclaw@users.noreply.github.com>
