### PR TITLE
Ground Store Agent replies in proposal state

### DIFF
--- a/app/controllers/api/mobile/agent_controller.rb
+++ b/app/controllers/api/mobile/agent_controller.rb
@@ -138,7 +138,7 @@ class Api::Mobile::AgentController < Api::Mobile::BaseController
         # A proposal can only be confirmed through its persisted message.
         proposed_action: assistant_message ? result[:proposed_action] : nil,
         objects: result[:objects] || [],
-        conversation_id: conversation&.external_id,
+        conversation_id: conversation&.persisted? ? conversation.external_id : nil,
       }
       response_payload[:proposal_message_id] = assistant_message.external_id if result[:proposed_action] && assistant_message
       render json: response_payload

--- a/app/controllers/concerns/agent_conversation_persistence.rb
+++ b/app/controllers/concerns/agent_conversation_persistence.rb
@@ -134,21 +134,40 @@ module AgentConversationPersistence
       end
     end
 
-    # A generated proposal cannot be confirmed unless its assistant message was stored.
+    # A generated proposal cannot be confirmed unless its assistant message was stored. The same
+    # fallback also keeps reserved proposal copy from escaping when the persistence guard rejects it.
     def replace_unpersisted_proposal_reply!(result)
-      return false if result[:proposed_action].blank?
+      if result[:proposed_action].present?
+        result[:reply] = UNPERSISTED_PROPOSAL_REPLY
+        return true
+      end
+      return false unless result[:reply].to_s.strip == Ai::StoreAgentService::PROPOSAL_READY_REPLY
 
-      result[:reply] = UNPERSISTED_PROPOSAL_REPLY
+      result[:reply] = Ai::StoreAgentService::NOTHING_STAGED_REPLY
       true
     end
 
-    # The plain role/content transcript to send to the model — rebuilt from the stored rows so a
-    # tampered or stale client-side history can't rewrite what the agent believes was said. Only
-    # the most recent HISTORY_MAX_MESSAGES are replayed: without a cap, every turn of a long-lived
-    # conversation would resend the entire transcript to the LLM (O(n²) token cost over the
-    # conversation's life) — `last` keeps the newest rows while preserving chronological order.
+    # Rebuild history from stored rows and mark assistant claims with the proposal state the server
+    # actually persisted. This keeps old card directions from being replayed as current facts.
+    # `last` bounds token cost while preserving chronological order.
     def agent_conversation_history(conversation)
-      conversation.ai_messages.last(HISTORY_MAX_MESSAGES).map { |message| { role: message.role, content: message.content } }
+      conversation.ai_messages.last(HISTORY_MAX_MESSAGES).map do |message|
+        history_message = { role: message.role, content: message.content }
+        history_message[:proposal_state] = agent_proposal_state_note(message) if message.role == "assistant"
+        history_message
+      end
+    end
+
+    def agent_proposal_state_note(message)
+      metadata = message.metadata || {}
+      return "no proposed action was recorded for this message" if metadata["proposed_action"].blank?
+
+      status = metadata["action_status"].presence
+      return "a proposed action was recorded for this message; confirmation outcome and card visibility are unknown" if status.nil?
+      return "proposal execution started; do not confirm again" if status == ACTION_STATUS_EXECUTING
+      return "the proposed action was applied and cannot be confirmed again" if status == ACTION_STATUS_APPLIED
+
+      "proposal outcome is unknown; do not confirm again"
     end
 
     def record_agent_user_message!(conversation, content)
@@ -169,6 +188,9 @@ module AgentConversationPersistence
         end
       unless result[:outcome] == expected_outcome
         raise ArgumentError, "Store agent turn outcome does not match its proposed action."
+      end
+      if result[:proposed_action].blank? && result[:reply].to_s.strip == Ai::StoreAgentService::PROPOSAL_READY_REPLY
+        raise ArgumentError, "Store agent proposal reply requires a proposed action."
       end
 
       metadata = {

--- a/app/services/ai/store_agent_service.rb
+++ b/app/services/ai/store_agent_service.rb
@@ -876,6 +876,7 @@ class Ai::StoreAgentService
 
       reply = result.text.to_s.strip
       return { status: :invalid, reason: :blank_reply } if reply.blank?
+      return { status: :invalid, reason: :staging_claim_without_proposal } if reply == PROPOSAL_READY_REPLY
       return { status: :invalid, reason: :staging_claim_without_proposal } if phantom_staged_claim?(reply:, proposed_action:)
 
       { status: :complete, reply: }
@@ -1103,7 +1104,15 @@ class Ai::StoreAgentService
         next if content.blank?
         next unless %w[user assistant].include?(role)
 
-        { role:, content: content.truncate(MAX_MESSAGE_LENGTH, omission: "...") }
+        proposal_state = msg[:proposal_state] || msg["proposal_state"]
+        state_suffix =
+          if role == "assistant" && proposal_state.present?
+            "\n\n[Server proposal state: #{proposal_state}]"
+          else
+            ""
+          end
+        content = content.truncate(MAX_MESSAGE_LENGTH - state_suffix.length, omission: "...")
+        { role:, content: "#{content}#{state_suffix}" }
       end
 
       # Anthropic's Messages API requires the conversation to START with a user message. The web chat

--- a/spec/controllers/api/internal/agent_message_streams_controller_spec.rb
+++ b/spec/controllers/api/internal/agent_message_streams_controller_spec.rb
@@ -196,6 +196,32 @@ describe Api::Internal::AgentMessageStreamsController do
         $redis.del(turn_status_key) if turn_status_key
       end
 
+      it "rejects and replaces server-owned confirmation copy without a proposal" do
+        service_double = instance_double(Ai::StoreAgentService)
+        allow(Ai::StoreAgentService).to receive(:new).and_return(service_double)
+        allow(service_double).to receive(:respond_streaming) do |on_reply_complete: nil, **_kwargs, &emit|
+          turn = store_agent_turn(reply: Ai::StoreAgentService::PROPOSAL_READY_REPLY, proposed_action: nil)
+          on_reply_complete&.call(turn)
+          emit.call(:token, { text: turn[:reply] })
+          turn.merge(suggestions: [])
+        end
+        expect(ErrorNotifier).to receive(:notify).with(
+          an_instance_of(ArgumentError).and(having_attributes(
+            message: "Store agent proposal reply requires a proposed action.",
+          )),
+        )
+
+        expect do
+          post :create, params: valid_params, format: :json
+        end.to not_change { seller.ai_conversations.count }.and not_change { AiMessage.count }
+
+        done_data = JSON.parse(response.body[/event: done\ndata: (.*)\n/, 1])
+        expect(response.body).to include("event: token")
+        expect(response.body).not_to include(Ai::StoreAgentService::PROPOSAL_READY_REPLY)
+        expect(done_data["reply"]).to eq(Ai::StoreAgentService::NOTHING_STAGED_REPLY)
+        expect(done_data["proposed_action"]).to be_nil
+      end
+
       it "persists the turn before any trailing write, so a client disconnect can't drop it" do
         # The reply is final when on_reply_complete fires; every socket write after it can raise
         # ClientDisconnected (the seller's connection died mid-stream while the server kept

--- a/spec/controllers/api/internal/agent_messages_controller_spec.rb
+++ b/spec/controllers/api/internal/agent_messages_controller_spec.rb
@@ -81,7 +81,7 @@ describe Api::Internal::AgentMessagesController do
         service_double = instance_double(Ai::StoreAgentService)
         allow(Ai::StoreAgentService).to receive(:new).and_return(service_double)
         allow(service_double).to receive(:respond).and_return(store_agent_turn(
-          reply: "Sales are up.",
+          reply: Ai::StoreAgentService::PROPOSAL_READY_REPLY,
           proposed_action: { "type" => "api_write", "summary" => "Create a discount" },
         ))
 
@@ -92,7 +92,7 @@ describe Api::Internal::AgentMessagesController do
         conversation = seller.ai_conversations.sole
         expect(conversation.title).to eq("How are my sales?")
         expect(conversation.ai_messages.map { |m| [m.role, m.content] }).to eq(
-          [["user", "How are my sales?"], ["assistant", "Sales are up."]]
+          [["user", "How are my sales?"], ["assistant", Ai::StoreAgentService::PROPOSAL_READY_REPLY]]
         )
         # The proposal rides along in metadata so reloaded history re-renders its card.
         expect(conversation.ai_messages.last.metadata["proposed_action"]).to eq(
@@ -114,7 +114,11 @@ describe Api::Internal::AgentMessagesController do
         expect(service_double).to receive(:respond).with(
           messages: [
             { role: "user", content: "Earlier question" },
-            { role: "assistant", content: "Earlier answer" },
+            {
+              role: "assistant",
+              content: "Earlier answer",
+              proposal_state: "no proposed action was recorded for this message",
+            },
             { role: "user", content: "And this month?" },
           ]
         ).and_return(store_agent_turn(reply: "Also up.", proposed_action: nil))
@@ -144,7 +148,11 @@ describe Api::Internal::AgentMessagesController do
         expect(service_double).to receive(:respond).with(
           messages: [
             { role: "user", content: "Kept question" },
-            { role: "assistant", content: "Kept answer" },
+            {
+              role: "assistant",
+              content: "Kept answer",
+              proposal_state: "no proposed action was recorded for this message",
+            },
             { role: "user", content: "And this month?" },
           ]
         ).and_return(store_agent_turn(reply: "Capped.", proposed_action: nil))
@@ -154,6 +162,32 @@ describe Api::Internal::AgentMessagesController do
              format: :json
 
         expect(response.parsed_body["success"]).to eq(true)
+      end
+
+      it "replays each assistant turn with its server-known proposal state" do
+        conversation = create(:ai_conversation, seller:)
+        proposal = { "type" => "api_write", "params" => { "endpoint" => "create_offer_code" } }
+        [
+          ["No proposal", nil],
+          ["Pending proposal", { "proposed_action" => proposal }],
+          ["Executing proposal", { "proposed_action" => proposal, "action_status" => "executing" }],
+          ["Applied proposal", { "proposed_action" => proposal, "action_status" => "applied" }],
+          ["Unknown proposal", { "proposed_action" => proposal, "action_status" => "unknown" }],
+        ].each do |content, metadata|
+          create(:ai_message, ai_conversation: conversation, role: "assistant", content:, metadata:)
+        end
+
+        history = controller.send(:agent_conversation_history, conversation)
+
+        expect(history.map { |message| message[:proposal_state] }).to eq(
+          [
+            "no proposed action was recorded for this message",
+            "a proposed action was recorded for this message; confirmation outcome and card visibility are unknown",
+            "proposal execution started; do not confirm again",
+            "the proposed action was applied and cannot be confirmed again",
+            "proposal outcome is unknown; do not confirm again",
+          ],
+        )
       end
 
       it "404s when the conversation belongs to another seller" do
@@ -248,6 +282,28 @@ describe Api::Internal::AgentMessagesController do
         )
         expect(response.parsed_body["proposed_action"]).to be_nil
         expect(response.parsed_body).not_to have_key("outcome")
+      end
+
+      it "rejects and replaces server-owned confirmation copy without a proposal" do
+        service_double = instance_double(Ai::StoreAgentService)
+        allow(Ai::StoreAgentService).to receive(:new).and_return(service_double)
+        allow(service_double).to receive(:respond).and_return(store_agent_turn(
+          reply: Ai::StoreAgentService::PROPOSAL_READY_REPLY,
+          proposed_action: nil,
+        ))
+        expect(ErrorNotifier).to receive(:notify).with(
+          an_instance_of(ArgumentError).and(having_attributes(
+            message: "Store agent proposal reply requires a proposed action.",
+          )),
+        )
+
+        expect do
+          post :create, params: valid_params, format: :json
+        end.to not_change { seller.ai_conversations.count }.and not_change { AiMessage.count }
+
+        expect(response).to be_successful
+        expect(response.parsed_body["reply"]).to eq(Ai::StoreAgentService::NOTHING_STAGED_REPLY)
+        expect(response.parsed_body["proposed_action"]).to be_nil
       end
 
       it "rejects an empty message list" do

--- a/spec/controllers/api/mobile/agent_controller_spec.rb
+++ b/spec/controllers/api/mobile/agent_controller_spec.rb
@@ -663,7 +663,11 @@ describe Api::Mobile::AgentController do
         expect(service_double).to receive(:respond).with(
           messages: [
             { role: "user", content: "Earlier question" },
-            { role: "assistant", content: "Earlier answer" },
+            {
+              role: "assistant",
+              content: "Earlier answer",
+              proposal_state: "no proposed action was recorded for this message",
+            },
             { role: "user", content: "And this month?" },
           ],
         ).and_return(store_agent_turn(reply: "Better."))
@@ -732,6 +736,25 @@ describe Api::Mobile::AgentController do
         # Persistence failure degrades to the generated reply instead of discarding it as a 500.
         expect(response).to be_successful
         expect(response.parsed_body["reply"]).to eq("You have 3 products.")
+        expect(response.parsed_body["conversation_id"]).to be_nil
+      end
+
+      it "rejects and replaces server-owned confirmation copy without a proposal" do
+        stub_agent_service(reply: Ai::StoreAgentService::PROPOSAL_READY_REPLY)
+        expect(ErrorNotifier).to receive(:notify).with(
+          an_instance_of(ArgumentError).and(having_attributes(
+            message: "Store agent proposal reply requires a proposed action.",
+          )),
+        )
+
+        expect do
+          post :create, params: valid_params
+        end.to not_change { @seller.ai_conversations.count }.and not_change { AiMessage.count }
+
+        expect(response).to be_successful
+        expect(response.parsed_body["reply"]).to eq(Ai::StoreAgentService::NOTHING_STAGED_REPLY)
+        expect(response.parsed_body["proposed_action"]).to be_nil
+        expect(response.parsed_body["conversation_id"]).to be_nil
       end
     end
 

--- a/spec/services/ai/store_agent_service_spec.rb
+++ b/spec/services/ai/store_agent_service_spec.rb
@@ -99,6 +99,30 @@ describe Ai::StoreAgentService do
       expect(captured[:messages].none? { |m| m[:role] == "system" }).to be(true)
     end
 
+    it "keeps trusted proposal state after truncating an assistant history message" do
+      captured = nil
+      allow(client).to receive(:messages) do |args|
+        captured = args
+        text_result("ok")
+      end
+      proposal_state = "the proposed action was applied and cannot be confirmed again"
+
+      service.respond(messages: [
+                        { role: "user", content: "Earlier question" },
+                        {
+                          role: "assistant",
+                          content: "x" * (described_class::MAX_MESSAGE_LENGTH + 100),
+                          proposal_state:,
+                        },
+                        { role: "user", content: "What now?" },
+                      ])
+
+      assistant_message = captured[:messages].second
+      expect(assistant_message.keys).to contain_exactly(:role, :content)
+      expect(assistant_message[:content].length).to eq(described_class::MAX_MESSAGE_LENGTH)
+      expect(assistant_message[:content]).to end_with("\n\n[Server proposal state: #{proposal_state}]")
+    end
+
     context "when the model completes a turn" do
       it "rejects an untyped staging claim that the prose backstop does not recognize" do
         false_claim = "Your edit is waiting in the action panel. Use the button there."
@@ -131,6 +155,22 @@ describe Ai::StoreAgentService do
         expect(result[:reply]).to eq("I prepared that change. Review it below, then confirm it when you're ready.")
         expect(result[:outcome]).to eq("proposal_ready")
         expect(result[:proposed_action]).to include(type: "api_write")
+      end
+
+      it "rejects server-owned confirmation copy when reply_only has no proposal" do
+        expect(described_class::STAGED_CLAIM_PATTERNS.none? { |pattern| described_class::PROPOSAL_READY_REPLY.match?(pattern) }).to be(true)
+        allow(client).to receive(:messages).and_return(
+          complete_turn_result(described_class::PROPOSAL_READY_REPLY, outcome: "reply_only"),
+        )
+
+        result = service.respond(messages: [{ role: "user", content: "fix my header" }])
+
+        expect(client).to have_received(:messages).twice
+        expect(result).to include(
+          outcome: "reply_only",
+          reply: described_class::NOTHING_STAGED_REPLY,
+          proposed_action: nil,
+        )
       end
 
       it "uses the honest no-proposal fallback when proposal_ready never has a proposal" do
@@ -1742,6 +1782,24 @@ describe Ai::StoreAgentService do
       expect(order).not_to include([:token, { text: model_reply }])
       expect(result[:reply]).to eq(described_class::PROPOSAL_READY_REPLY)
       expect(result[:outcome]).to eq("proposal_ready")
+    end
+
+    it "resets server-owned confirmation copy when no proposal backs the stream" do
+      reply = described_class::PROPOSAL_READY_REPLY
+      stub_stream_turns(
+        { stream: [reply], result: text_result(reply) },
+        { stream: [reply], result: text_result(reply) },
+      )
+      allow(client).to receive(:messages).and_return(text_result("[]"))
+
+      events, result = collect_events([{ role: "user", content: "fix my header" }])
+
+      fallback_index = events.index { |event, payload| event == :token && payload[:text] == described_class::NOTHING_STAGED_REPLY }
+      expect(events.count { |event, _| event == :reset }).to eq(2)
+      expect(events.rindex { |event, _| event == :reset }).to be < fallback_index
+      expect(result[:reply]).to eq(described_class::NOTHING_STAGED_REPLY)
+      expect(result[:proposed_action]).to be_nil
+      expect(events.any? { |event, _| event == :proposed_action }).to be(false)
     end
 
     it "enforces custom-page reads while streaming and resets them between turns" do


### PR DESCRIPTION
Ref antiwork/gumroad-private#1470

## What

- Rejects the server-owned proposal-ready reply when the turn has no proposed action, both before completion and again before persistence.
- Uses the existing retry, stream reset, and honest fallback when that invalid state occurs.
- Replays each stored assistant message with a payload-free note describing the proposal state the server actually recorded.
- Avoids returning an unusable conversation ID when a new mobile conversation rolls back.

## Why

A production audit after #6579 found four confirmed contradictions among 9,207 assistant replies: three used the exact proposal-ready reply without a proposed action, and one referred to an old applied proposal as if its confirmation card were still available.

The exact reply could be copied by the model and submitted as a `reply_only` turn because the prose matcher did not recognize the two-sentence server copy. Stored history also replayed assistant text without the proposal state that made an old card claim false.

This change closes the exact reserved-reply escape and gives the model trusted context for old proposal claims. It does not try to classify every possible phrase or claim that free-form text can make.

## Before / After

Before, the exact proposal-ready reply could persist without a proposal, and old assistant claims were replayed without their recorded proposal status.

After, that reserved reply requires a real proposal, invalid streamed text is cleared before the honest fallback, and replayed history states whether each assistant message had no proposal, a proposal with no recorded execution result, an executing proposal, an applied proposal, or an unknown outcome.

## Test results

- `bin/test-confidence --strict`: 99% confidence, 14 planned spec files passed; 100% intentionally skipped.
- Focused Store Agent service and web/mobile controller suite: 239 examples, 0 failures.
- RuboCop: 7 changed Ruby files, 0 offenses.
- Autoreview: clean, no actionable findings.

---

This PR was implemented with AI assistance using GPT-5.6 Sol and Gumclaw (for prod queries).
