### PR TITLE
Trim the duplicated payout-selection commentary on the instant-payout seasoning check

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1143,10 +1143,8 @@ class User < ApplicationRecord
   # Anchored on the payout account, not the Gumroad signup date: a seller can hold an
   # account for years before connecting one. A recreated payout account resets this.
   #
-  # The payout is created on whichever account StripePayoutProcessor.get_payout_details picks at
-  # payout time, and that can be the connected account rather than the Gumroad-managed one. Season
-  # every account it could pick, so a seller holding an old managed account alongside a fresh
-  # connected one cannot pull instantly from the account that has not seasoned.
+  # Every account a payout could land on has to season: the destination is picked at payout time,
+  # so seasoning only the managed account leaves a fresh connected account as a hole.
   def stripe_accounts_seasoned_for_instant_payouts?
     managed_account = stripe_account
     return false if managed_account.nil?


### PR DESCRIPTION
## What

Removes four comment lines above `User#stripe_accounts_seasoned_for_instant_payouts?` that narrated how `StripePayoutProcessor.get_payout_details` chooses a payout destination, and replaces them with the one invariant the code cannot state: every account a payout could land on has to season.

No executable code changes. The full diff is a comment.

## Why

Follow-up to #6702, addressing Greptile's review of that PR.

The removed lines described selection behavior that lives in `StripePayoutProcessor` and is covered by the eligibility specs. Duplicating it here means it silently goes stale the next time the processor's branch order changes, and a comment that contradicts the code is worse than no comment. The durable part — that seasoning has to apply to every selectable account, not just the managed one — stays.

Consistent with the repo's comment guidance in `AGENTS.md`: say the one thing the code cannot say, and stop.

## Before / after

```ruby
# before
# The payout is created on whichever account StripePayoutProcessor.get_payout_details picks at
# payout time, and that can be the connected account rather than the Gumroad-managed one. Season
# every account it could pick, so a seller holding an old managed account alongside a fresh
# connected one cannot pull instantly from the account that has not seasoned.

# after
# Every account a payout could land on has to season: the destination is picked at payout time,
# so seasoning only the managed account leaves a fresh connected account as a hole.
```

## Test Results

`bundle exec rubocop app/models/user.rb` — 1 file inspected, no offenses. There is nothing else to run: the diff removes and rewrites comment text, so no spec can observe it and no behavior can regress.

Full CI is green at head `2203532` — 79 checks pass, 0 failing, 0 pending (the whole 68-shard matrix spawned and finished). Greptile reviewed the same commit and approved it at 5/5 confidence.

For the same reason the local adversarial pre-merge review was not run — it has no code path to review. The behavior this comment describes was reviewed on #6702, which returned SHIP.

## QA steps

None. No runtime surface, no user-facing surface.

---

## AI disclosure

Written by claude-opus-5 (the `model.default` in this agent's config) acting on Greptile's P2 review comment on merged PR #6702. Instructions given: read the finding, decide whether it is correct, and if so trim the comment to the invariant without changing behavior.

