### PR TITLE
State that the review-reminder opt-out is account-wide

### DIFF
--- a/app/views/help_center/articles/contents/_344-rate-and-review-your-purchase.html.erb
+++ b/app/views/help_center/articles/contents/_344-rate-and-review-your-purchase.html.erb
@@ -11,7 +11,7 @@
   <br>
   <p>Your star rating is saved as soon as you select it, so a rating on its own counts as a review even if you don't add anything else. To share more, write your feedback in the text box and click "Post review".</p>
   <br>
-  <p>If you haven't left a review in the first 5 days after a purchase (90 days for physical products), we will send you a reminder email. You can unsubscribe from these reminders using the link at the bottom of the email. If you bought with a Gumroad account, that link stops review reminders only, and you keep getting the creator's other emails. If you bought without a Gumroad account, it unsubscribes you from all of that creator's emails, because there is no account to store a reminders-only preference on. If you have already unsubscribed from a creator's emails, we won't send you review reminders for their products. Some creators turn review reminders off, in which case you won't receive one.</p>
+  <p>If you haven't left a review in the first 5 days after a purchase (90 days for physical products), we will send you a reminder email. You can unsubscribe from these reminders using the link at the bottom of the email. If you bought with a Gumroad account, that link stops review reminders for every creator you buy from, not just the one whose email you clicked from, and you keep getting everyone's other emails. If you bought without a Gumroad account, it unsubscribes you from all of that creator's emails, because there is no account to store a reminders-only preference on. If you have already unsubscribed from a creator's emails, we won't send you review reminders for their products. Some creators turn review reminders off, in which case you won't receive one.</p>
   <br>
   <h3>Restrictions</h3>
   <ul>


### PR DESCRIPTION
## What

Follow-up to #6705, addressing Greptile's review on that PR. Corrects one sentence in `_344-rate-and-review-your-purchase`: an account holder who uses the unsubscribe link in a review reminder stops review reminders from every creator they buy from, not only the creator whose email carried the link.

## Why

The account-holder branch of that link is `user_unsubscribe_review_reminders_by_token_url`, which routes to `Users::ReviewRemindersController#unsubscribe_by_token` and writes a single user-level boolean:

```ruby
@user.update!(opted_out_of_review_reminders: opted_out)
```

Nothing about it is scoped to a seller. Both eligibility reads consult that same column with no creator qualifier — `Purchase#eligible_for_review_reminder?` (`!purchaser.opted_out_of_review_reminders?`) and `CustomerLowPriorityMailer#purchase_review_reminder` (`return if purchaser&.opted_out_of_review_reminders?`) — so the opt-out suppresses reminders platform-wide.

The previous wording ("stops review reminders only, and you keep getting the creator's other emails") was accurate about *which kinds* of email stop but silently implied the scope was one creator. A buyer reading it would expect to keep getting reminders from other creators, and would not.

The guest sentence is unchanged and still correct: with no `User` row there is nowhere to store a reminders-only preference, so `Purchase#unsubscribe_buyer` clears `can_contact` for that email/seller pair only.

## Before / after

Not applicable in the visual sense — the only rendered surface is the article prose in the diff.

Before: "If you bought with a Gumroad account, that link stops review reminders only, and you keep getting the creator's other emails."

After: "If you bought with a Gumroad account, that link stops review reminders for every creator you buy from, not just the one whose email you clicked from, and you keep getting everyone's other emails."

## Test plan

Body-only prose edit inside one `<p>`, no ERB logic and no tag changes.

- ERB compiles (`ERB.new(src).src` → OK).
- `articles.yml` untouched: no title, description, category, or slug change.

## QA steps

1. Open `help.gumroad.com/help/article/344-rate-and-review-your-purchase`.
2. In the reviews section, confirm the reminder paragraph now says an account holder's unsubscribe covers every creator, while the guest sentence still says it unsubscribes from that one creator's emails.

---

## AI disclosure

Written by claude-opus-5 (Hermes Agent). Instructions: Greptile's review on merged PR #6705 flagged that the help article omits the account-wide scope of an account-holder review-reminder unsubscribe; verify the claim against the implementation on `main` and ship the correction. The model read `Users::ReviewRemindersController#unsubscribe_by_token`, `Purchase#eligible_for_review_reminder?`, and `CustomerLowPriorityMailer#purchase_review_reminder` at `origin/main` before rewording, and confirmed the guest branch needed no change.
