### PR TITLE
Document that instant payout seasoning covers connected Stripe accounts

### DIFF
--- a/app/views/help_center/articles/contents/_13-getting-paid.html.erb
+++ b/app/views/help_center/articles/contents/_13-getting-paid.html.erb
@@ -437,7 +437,7 @@
   <div class="callout-red">
     <p><b>⚠️ You need a minimum balance of $100 USD to receive a payout.</b> Some countries have higher local currency minimums—see the "(min X)" values in the <a href="#bank-account">table above</a>.</p>
   </div>
-  <p>You can choose to get paid daily, weekly, monthly, or quarterly, and set your own payout threshold. Daily payouts are only available for US users with eligible bank accounts and at least 4 prior payouts. You can also pause and resume payouts anytime.</p>
+  <p>You can choose to get paid daily, weekly, monthly, or quarterly, and set your own payout threshold. Daily payouts are only available for US users with eligible bank accounts and at least 4 prior payouts. They ride the same rail as <a href="#instant-payouts">instant payouts</a>, so the 60-day account requirement described there applies to them as well. You can also pause and resume payouts anytime.</p>
   <p>Payouts include sales made through the previous Friday (UTC). All sales have a minimum 7-day holding period in your Gumroad balance before they become eligible for payout.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/63bb91fed851444a9b4d27ef/file-5kClaU1t2C.png" %></figure>
   <p>You can download a CSV report for each payout from the <a href="269-balance-page">Payouts dashboard</a>, which includes a breakdown of all <a href="66-gumroads-fees">Gumroad fees</a> and customer data. </p>
@@ -474,6 +474,7 @@
   <p>If you have set your payouts to monthly or quarterly, they still go out on your payout day, just in the month or quarter you chose. Daily payouts are the exception: those are sent every day rather than on one weekday.</p>
   <h3 id="instant-payouts">Instant payouts</h3>
   <p>Creators from the US can get paid within minutes for amounts up to $10K and a 3% fee. Instant payouts are available only to creators from the US who have completed at least one payout and whose Stripe account has been processing with Gumroad for at least 60 days.</p>
+  <p>If you also get paid through your own <a href="330-stripe-connect">connected Stripe account</a>, that account needs to have been connected for at least 60 days as well. Connecting a new Stripe account starts that 60 days again, so instant payouts are unavailable until the new account has been connected that long.</p>
   <p>If you are eligible for an instant payout, you will see the option to get paid instantly on your <a href="https://gumroad.com/payouts">Payouts dashboard</a>. </p>
   <p>Not all debit cards are eligible for instant payouts. If you connect a debit card and still see a message to connect a debit card to receive instant payouts, the card you connected is not eligible. You will need to try a different card. </p>
   <h3 id="paypal-connect">Enable payments via PayPal</h3>


### PR DESCRIPTION
## What

The "Instant payouts" section of `13-getting-paid` said eligibility depends on "your Stripe account" being 60 days old. It now says that a connected Stripe account must also have been connected for 60 days, and that connecting a new one restarts the clock. The payout-frequency paragraph gets one sentence noting that daily payouts ride the same requirement.

## Why

Triggered by #6702, which shipped `User#stripe_accounts_seasoned_for_instant_payouts?`. Eligibility now requires *every* Stripe account a payout could land on to clear `MIN_ACCOUNT_AGE_FOR_INSTANT_PAYOUTS = 60.days` — the Gumroad-managed account and, when present, the seller's own connected account. The article described a single account, so a Stripe Connect seller who just reconnected would read that they qualify while the product denies them.

The daily-payout sentence follows from `SettingsPresenter`, which gates `payout_frequency_daily_supported` on `instant_payouts_supported?`. Losing instant-payout eligibility also removes the daily frequency option, and nothing in the article said so.

Articles changed: `_13-getting-paid.html.erb` only. `articles.yml` untouched — no title, description or category change. No article removals. Anchor IDs preserved.

## QA steps

Docs-only — the diff is the reviewable artifact. No UI surface changes; the rendered article is the only output. To read it after deploy: help.gumroad.com/help/article/13-getting-paid, "Instant payouts" section.

## Test plan

Body-only prose edit, no ERB logic or YAML change, so no adversarial review gate.

- ERB compiles: `ERB.new(...).src` OK.
- Partial renders in the real view context: `ApplicationController.render(partial: "help_center/articles/contents/13-getting-paid")` → 22,746 bytes, new copy present.
- Tag-balance check across `p`, `ul`, `li`, `h3`, `table`, `tr`, `td`, `div`, `a`, `figure`, `strong`, `b`, `i`, `em`: no mismatches.
- CI runs the help-center specs.

Payout wording is creator-quotable, so the two new sentences are worth a careful read: the 60-day figure and the "connecting a new Stripe account starts that 60 days again" claim both come from the predicate, which reads `created_at` on the merchant-account row and gets a fresh row on OAuth reconnect.

---

## AI disclosure

Written by claude-opus-5 (the `model.default` in this agent's config), triggered by the merge of #6702. Instructions given: check whether the merged change makes any help-center article inaccurate, verify the behavior against `origin/main` rather than the PR body, edit only the articles that are actually wrong, and flag payout wording for human attention.
