### PR TITLE
Document that abandoned cart emails skip products the customer already owns

### DIFF
--- a/app/views/help_center/articles/contents/_131-using-workflows-to-send-automated-updates.html.erb
+++ b/app/views/help_center/articles/contents/_131-using-workflows-to-send-automated-updates.html.erb
@@ -56,6 +56,7 @@
   <p>Unlike other workflow triggers, you get a default template email for Abandoned cart workflows that goes out 24 hours after cart abandonment. You can edit the subject and email copy, but you cannot remove the embedded product list, add more emails, or change the delay from 24 hours to something else.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/664b407972987f726dc81b5e/file-zEj6Ze1xcY.jpg" %></figure>
   <p>We do not send a duplicate card abandonment email every 24 hours if the customer’s cart remains abandoned.</p>
+  <p>Abandoned cart emails also leave out any product the customer already owns, so the email only mentions what they have not bought yet. If they already own everything in the cart, no email goes out, and the cart stays eligible in case they add something else to it later.</p>
   <h3 id="Testing-your-workflow-z6ml8">Testing your workflow</h3>
   <p>You can't test a workflow as part of a <a href="62-testing-a-purchase">test purchase</a>. As a test purchase isn't a real transaction, the workflow won't be triggered.</p>
   <p>Instead, you can test the workflow by creating a 100% <a href="128-discount-codes">Discount Code</a> and purchasing using another email address.</p>


### PR DESCRIPTION
## What

`_131-using-workflows-to-send-automated-updates` now states that abandoned cart emails leave out products the customer already owns, and that a cart whose every product is owned produces no email at all and stays eligible.

Triggered by antiwork/gumroad#6720 (merge commit `30ec65b27e8b641a3f6a20035dee09b0dca5e66d`, verified an ancestor of `origin/main`), which added that filter.

## Why

The article's abandoned-cart section described sending purely in terms of staleness and the 24-hour delay — the only qualifier was that we do not re-send every 24 hours. A seller reading it would expect the reminder to name everything in the cart. As of #6720 it does not:

- `ScheduleAbandonedCartEmailsJob` skips a carted product when `Cart#purchased_product_ids` includes it, so it never enters the workflow match map; a cart with nothing left unbought produces no match, so no mail and no `SentAbandonedCartEmail` row (hence the wording that the cart stays eligible).
- `CustomerMailer#abandoned_cart` re-applies the same filter at render time and drops a workflow whose products are all owned.

The filter is per product, so the "only mentions what they have not bought yet" wording matches a mixed cart's real behavior.

Deliberately not documented: what counts as owning it (gift received vs gift sent, refunds, chargebacks, variant-specific ownership). That is send-eligibility detail no seller configures or can observe, and enumerating it in a workflows how-to would bury the one fact that matters.

Body-only prose edit — `articles.yml` untouched (title, description, category unchanged), anchor IDs preserved, no TOC change since the sentence joins an existing section.

## Test plan

Docs-only — the diff is the reviewable artifact. There is no UI surface to capture: the only file changed is a help-center article body, and its rendered output is the paragraph in the diff.

- `ERB.new(...).src` compiles the edited partial.
- Per-tag open/close balance count on the file: no mismatches.
- No logic, no yml, no ERB tags added — pure copy edit, so no adversarial review gate per the help-center editing convention.
- CI runs `spec/models/help_center` and the help-center request/presenter specs, which guard slug ↔ partial integrity.

---

## AI disclosure

Written by claude-opus-5 running as an autonomous Hermes agent.

Instructions given: on a merged antiwork/gumroad PR, check whether it changes anything the help center documents and update the affected articles to match.
