### PR TITLE
Never replay an old confirmation reply to the store agent's model history

### DIFF
--- a/app/controllers/concerns/agent_conversation_persistence.rb
+++ b/app/controllers/concerns/agent_conversation_persistence.rb
@@ -63,6 +63,18 @@ module AgentConversationPersistence
   MISSING_PROPOSAL_MESSAGE_ID_NOTICE = "Store agent confirmation omitted proposal message id"
   ACTION_CLAIM_RELEASE_FAILED_NOTICE = "Store agent action claim could not be released"
 
+  # What the model is told a proposal turn was, in place of the reply the creator actually saw. That
+  # reply points at a confirmation card, and by the next turn the server already knows the card's
+  # result — replaying the reply is what lets the model send the creator back to a card that can no
+  # longer be confirmed. The state notes below carry the result instead.
+  PROPOSAL_TURN_HISTORY_CONTENT = "You proposed a change on this turn."
+  NO_PROPOSAL_STATE_NOTE = "no proposed action was recorded for this message"
+  PROPOSAL_STATE_RECORDED = "a proposal was recorded, but its current result and card visibility " \
+                            "are unknown; never send the creator back to that card"
+  PROPOSAL_STATE_EXECUTING = "execution started; do not confirm again"
+  PROPOSAL_STATE_APPLIED = "the action was applied and cannot be confirmed again"
+  PROPOSAL_STATE_UNKNOWN = "the result is unknown; do not confirm again"
+
   private_constant :LEGACY_ACTION_LOOKUP_LIMIT,
                    :FORM_DECIMAL_NUMBER_PATTERN,
                    :ACTION_NUMBER_INPUT_MAX_BYTES,
@@ -147,27 +159,31 @@ module AgentConversationPersistence
       true
     end
 
-    # Rebuild history from stored rows and mark assistant claims with the proposal state the server
-    # actually persisted. This keeps old card directions from being replayed as current facts.
-    # `last` bounds token cost while preserving chronological order.
+    # Rebuild history from stored rows. A turn that carried a proposal is replayed as server-owned
+    # state only: the creator-facing confirmation copy is dropped, because the card it points at has
+    # a result the server knows and the model does not. `last` bounds token cost while preserving
+    # chronological order. Nothing here may carry proposal payloads, params, objects, or client turn
+    # ids — the model has no use for them and they are the creator's data, not conversation.
     def agent_conversation_history(conversation)
       conversation.ai_messages.last(HISTORY_MAX_MESSAGES).map do |message|
-        history_message = { role: message.role, content: message.content }
-        history_message[:proposal_state] = agent_proposal_state_note(message) if message.role == "assistant"
-        history_message
+        next { role: message.role, content: message.content } unless message.role == "assistant"
+
+        proposal_state = agent_proposal_state_note(message)
+        content = proposal_state == NO_PROPOSAL_STATE_NOTE ? message.content : PROPOSAL_TURN_HISTORY_CONTENT
+        { role: message.role, content:, proposal_state: }
       end
     end
 
     def agent_proposal_state_note(message)
       metadata = message.metadata || {}
-      return "no proposed action was recorded for this message" if metadata["proposed_action"].blank?
+      return NO_PROPOSAL_STATE_NOTE if metadata["proposed_action"].blank?
 
-      status = metadata["action_status"].presence
-      return "a proposed action was recorded for this message; confirmation outcome and card visibility are unknown" if status.nil?
-      return "proposal execution started; do not confirm again" if status == ACTION_STATUS_EXECUTING
-      return "the proposed action was applied and cannot be confirmed again" if status == ACTION_STATUS_APPLIED
-
-      "proposal outcome is unknown; do not confirm again"
+      case metadata["action_status"].presence
+      when nil then PROPOSAL_STATE_RECORDED
+      when ACTION_STATUS_EXECUTING then PROPOSAL_STATE_EXECUTING
+      when ACTION_STATUS_APPLIED then PROPOSAL_STATE_APPLIED
+      else PROPOSAL_STATE_UNKNOWN
+      end
     end
 
     def record_agent_user_message!(conversation, content)

--- a/app/controllers/concerns/agent_conversation_persistence.rb
+++ b/app/controllers/concerns/agent_conversation_persistence.rb
@@ -64,9 +64,7 @@ module AgentConversationPersistence
   ACTION_CLAIM_RELEASE_FAILED_NOTICE = "Store agent action claim could not be released"
 
   # What the model is told a proposal turn was, in place of the reply the creator actually saw. That
-  # reply points at a confirmation card, and by the next turn the server already knows the card's
-  # result — replaying the reply is what lets the model send the creator back to a card that can no
-  # longer be confirmed. The state notes below carry the result instead.
+  # reply points at a confirmation card whose result the server already knows and the model does not.
   PROPOSAL_TURN_HISTORY_CONTENT = "You proposed a change on this turn."
   NO_PROPOSAL_STATE_NOTE = "no proposed action was recorded for this message"
   PROPOSAL_STATE_RECORDED = "a proposal was recorded, but its current result and card visibility " \
@@ -89,7 +87,13 @@ module AgentConversationPersistence
                    :UNPERSISTED_PROPOSAL_REPLY,
                    :UNRESOLVED_MOBILE_ACTION_REPLY,
                    :MISSING_PROPOSAL_MESSAGE_ID_NOTICE,
-                   :ACTION_CLAIM_RELEASE_FAILED_NOTICE
+                   :ACTION_CLAIM_RELEASE_FAILED_NOTICE,
+                   :PROPOSAL_TURN_HISTORY_CONTENT,
+                   :NO_PROPOSAL_STATE_NOTE,
+                   :PROPOSAL_STATE_RECORDED,
+                   :PROPOSAL_STATE_EXECUTING,
+                   :PROPOSAL_STATE_APPLIED,
+                   :PROPOSAL_STATE_UNKNOWN
 
   private
     # Returns the seller's conversation for params[:conversation_id], or nil when the param is
@@ -160,17 +164,18 @@ module AgentConversationPersistence
     end
 
     # Rebuild history from stored rows. A turn that carried a proposal is replayed as server-owned
-    # state only: the creator-facing confirmation copy is dropped, because the card it points at has
-    # a result the server knows and the model does not. `last` bounds token cost while preserving
-    # chronological order. Nothing here may carry proposal payloads, params, objects, or client turn
-    # ids — the model has no use for them and they are the creator's data, not conversation.
+    # state only, never as the confirmation copy the creator saw. Nothing here may carry proposal
+    # payloads, params, objects, or client turn ids. `last` bounds token cost, preserving order.
     def agent_conversation_history(conversation)
       conversation.ai_messages.last(HISTORY_MAX_MESSAGES).map do |message|
         next { role: message.role, content: message.content } unless message.role == "assistant"
 
-        proposal_state = agent_proposal_state_note(message)
-        content = proposal_state == NO_PROPOSAL_STATE_NOTE ? message.content : PROPOSAL_TURN_HISTORY_CONTENT
-        { role: message.role, content:, proposal_state: }
+        proposal = (message.metadata || {})["proposed_action"].present?
+        {
+          role: message.role,
+          content: proposal ? PROPOSAL_TURN_HISTORY_CONTENT : message.content,
+          proposal_state: agent_proposal_state_note(message),
+        }
       end
     end
 

--- a/spec/controllers/api/internal/agent_message_streams_controller_spec.rb
+++ b/spec/controllers/api/internal/agent_message_streams_controller_spec.rb
@@ -150,6 +150,47 @@ describe Api::Internal::AgentMessageStreamsController do
         expect(conversation.ai_messages.reload.count).to eq(3)
       end
 
+      # The streaming path must build history the same way as the buffered one: an applied proposal
+      # turn reaches the model as server-owned state, never as its old "confirm that card" copy.
+      it "replays an applied proposal turn as server-owned state" do
+        conversation = create(:ai_conversation, seller:)
+        create(:ai_message, ai_conversation: conversation, content: "Upload the portrait")
+        create(
+          :ai_message,
+          ai_conversation: conversation,
+          role: "assistant",
+          content: "Confirm that card and the upload goes through.",
+          metadata: {
+            "proposed_action" => { "type" => "api_write", "params" => { "endpoint" => "update_user_custom_html" } },
+            "action_status" => "applied",
+            "client_turn_id" => "8f14e45f",
+          },
+        )
+
+        service_double = instance_double(Ai::StoreAgentService)
+        allow(Ai::StoreAgentService).to receive(:new).and_return(service_double)
+        expect(service_double).to receive(:respond_streaming).with(
+          messages: [
+            { role: "user", content: "Upload the portrait" },
+            {
+              role: "assistant",
+              content: "You proposed a change on this turn.",
+              proposal_state: "the action was applied and cannot be confirmed again",
+            },
+            { role: "user", content: "How are my sales?" },
+          ],
+          on_reply_complete: kind_of(Proc),
+        ) do |on_reply_complete:, **|
+          turn = store_agent_turn(reply: "Already applied.", proposed_action: nil)
+          on_reply_complete.call(turn)
+          turn.merge(suggestions: [])
+        end
+
+        post :create, params: valid_params.merge(conversation_id: conversation.external_id), format: :json
+
+        expect(response).to have_http_status(:ok)
+      end
+
       it "still emits the done event but suppresses an unpersisted proposal" do
         proposal = { "type" => "api_write", "params" => { "endpoint" => "create_offer_code" } }
         service_double = instance_double(Ai::StoreAgentService)

--- a/spec/controllers/api/internal/agent_messages_controller_spec.rb
+++ b/spec/controllers/api/internal/agent_messages_controller_spec.rb
@@ -201,9 +201,8 @@ describe Api::Internal::AgentMessagesController do
         )
       end
 
-      # The production shape from gp#1470: a proposal applied on an earlier turn, then a later turn
-      # whose persisted copy points the creator back at that card. Replaying that copy is what let
-      # the model repeat it as a live instruction.
+      # gp#1470's production shape: a proposal applied earlier, then a turn whose persisted copy
+      # points the creator back at that card. Replaying it let the model repeat it as live.
       it "replaces an applied proposal turn's confirm-that-card copy with server-owned state" do
         conversation = create(:ai_conversation, seller:)
         proposal = { "type" => "api_write", "params" => { "endpoint" => "update_user_custom_html" } }

--- a/spec/controllers/api/internal/agent_messages_controller_spec.rb
+++ b/spec/controllers/api/internal/agent_messages_controller_spec.rb
@@ -182,12 +182,54 @@ describe Api::Internal::AgentMessagesController do
         expect(history.map { |message| message[:proposal_state] }).to eq(
           [
             "no proposed action was recorded for this message",
-            "a proposed action was recorded for this message; confirmation outcome and card visibility are unknown",
-            "proposal execution started; do not confirm again",
-            "the proposed action was applied and cannot be confirmed again",
-            "proposal outcome is unknown; do not confirm again",
+            "a proposal was recorded, but its current result and card visibility are unknown; never send the creator back to that card",
+            "execution started; do not confirm again",
+            "the action was applied and cannot be confirmed again",
+            "the result is unknown; do not confirm again",
           ],
         )
+        # Every proposal turn's own creator-facing copy is gone from what the model sees; only the
+        # turn with no proposal keeps its text.
+        expect(history.map { |message| message[:content] }).to eq(
+          [
+            "No proposal",
+            "You proposed a change on this turn.",
+            "You proposed a change on this turn.",
+            "You proposed a change on this turn.",
+            "You proposed a change on this turn.",
+          ],
+        )
+      end
+
+      # The production shape from gp#1470: a proposal applied on an earlier turn, then a later turn
+      # whose persisted copy points the creator back at that card. Replaying that copy is what let
+      # the model repeat it as a live instruction.
+      it "replaces an applied proposal turn's confirm-that-card copy with server-owned state" do
+        conversation = create(:ai_conversation, seller:)
+        proposal = { "type" => "api_write", "params" => { "endpoint" => "update_user_custom_html" } }
+        create(:ai_message, ai_conversation: conversation, content: "Upload the portrait")
+        applied = create(
+          :ai_message,
+          ai_conversation: conversation,
+          role: "assistant",
+          content: "The portrait upload is the proposal already sitting in front of you from my earlier turn — confirm that card and it goes through.",
+          metadata: { "proposed_action" => proposal, "action_status" => "applied", "client_turn_id" => "8f14e45f", "objects" => [{ "id" => "prod_1" }] },
+        )
+
+        history = controller.send(:agent_conversation_history, conversation)
+
+        expect(history.last).to eq(
+          role: "assistant",
+          content: "You proposed a change on this turn.",
+          proposal_state: "the action was applied and cannot be confirmed again",
+        )
+        replayed = history.map { |message| message.values.join(" ") }.join(" ")
+        expect(replayed).not_to include("confirm that card")
+        expect(replayed).not_to include("update_user_custom_html")
+        expect(replayed).not_to include("8f14e45f")
+        expect(replayed).not_to include("prod_1")
+        # The creator's own transcript is untouched — this only changes what the model is told.
+        expect(applied.reload.content).to include("confirm that card")
       end
 
       it "404s when the conversation belongs to another seller" do

--- a/spec/controllers/api/mobile/agent_controller_spec.rb
+++ b/spec/controllers/api/mobile/agent_controller_spec.rb
@@ -681,6 +681,41 @@ describe Api::Mobile::AgentController do
         expect(conversation.ai_messages.reload.count).to eq(4)
       end
 
+      # The buffered mobile endpoint shares the history builder, so a proposal turn must reach the
+      # model as server-owned state here too.
+      it "replays an applied proposal turn as server-owned state" do
+        conversation = create(:ai_conversation, seller: @seller)
+        create(:ai_message, ai_conversation: conversation, content: "Upload the portrait")
+        create(
+          :ai_message,
+          ai_conversation: conversation,
+          role: "assistant",
+          content: "Confirm that card and the upload goes through.",
+          metadata: {
+            "proposed_action" => { "type" => "api_write", "params" => { "endpoint" => "update_user_custom_html" } },
+            "action_status" => "applied",
+          },
+        )
+
+        service_double = instance_double(Ai::StoreAgentService)
+        allow(Ai::StoreAgentService).to receive(:new).and_return(service_double)
+        expect(service_double).to receive(:respond).with(
+          messages: [
+            { role: "user", content: "Upload the portrait" },
+            {
+              role: "assistant",
+              content: "You proposed a change on this turn.",
+              proposal_state: "the action was applied and cannot be confirmed again",
+            },
+            { role: "user", content: "And this month?" },
+          ],
+        ).and_return(store_agent_turn(reply: "Already applied."))
+
+        post :create, params: @auth_params.merge(messages: [{ role: "user", content: "And this month?" }], conversation_id: conversation.external_id)
+
+        expect(response.parsed_body["conversation_id"]).to eq(conversation.external_id)
+      end
+
       it "resumes a conversation started on the web (same store, no separate mobile silo)" do
         # A conversation created through the web controllers is just a row in ai_conversations;
         # the mobile endpoint appends to it exactly the same way.

--- a/spec/controllers/api/mobile/agent_streams_controller_spec.rb
+++ b/spec/controllers/api/mobile/agent_streams_controller_spec.rb
@@ -135,6 +135,46 @@ describe Api::Mobile::AgentStreamsController do
       expect(conversation.ai_messages.reload.count).to eq(3)
     end
 
+    # Mobile streaming shares the history builder, so an applied proposal turn must reach the model
+    # as server-owned state here too.
+    it "replays an applied proposal turn as server-owned state" do
+      conversation = create(:ai_conversation, seller: @seller)
+      create(:ai_message, ai_conversation: conversation, content: "Upload the portrait")
+      create(
+        :ai_message,
+        ai_conversation: conversation,
+        role: "assistant",
+        content: "Confirm that card and the upload goes through.",
+        metadata: {
+          "proposed_action" => { "type" => "api_write", "params" => { "endpoint" => "update_user_custom_html" } },
+          "action_status" => "applied",
+        },
+      )
+
+      service_double = instance_double(Ai::StoreAgentService)
+      allow(Ai::StoreAgentService).to receive(:new).and_return(service_double)
+      expect(service_double).to receive(:respond_streaming).with(
+        messages: [
+          { role: "user", content: "Upload the portrait" },
+          {
+            role: "assistant",
+            content: "You proposed a change on this turn.",
+            proposal_state: "the action was applied and cannot be confirmed again",
+          },
+          { role: "user", content: "How are my sales?" },
+        ],
+        on_reply_complete: kind_of(Proc),
+      ) do |on_reply_complete:, **|
+        turn = store_agent_turn(reply: "Already applied.")
+        on_reply_complete.call(turn)
+        turn.merge(suggestions: [])
+      end
+
+      post :create, params: valid_params.merge(conversation_id: conversation.external_id)
+
+      expect(response).to have_http_status(:ok)
+    end
+
     it "still emits the done event but suppresses an unpersisted proposal" do
       proposal = { "type" => "api_write", "params" => { "endpoint" => "create_discount" } }
       service_double = instance_double(Ai::StoreAgentService)

--- a/spec/services/ai/store_agent_service_spec.rb
+++ b/spec/services/ai/store_agent_service_spec.rb
@@ -105,7 +105,7 @@ describe Ai::StoreAgentService do
         captured = args
         text_result("ok")
       end
-      proposal_state = "the proposed action was applied and cannot be confirmed again"
+      proposal_state = "the action was applied and cannot be confirmed again"
 
       service.respond(messages: [
                         { role: "user", content: "Earlier question" },


### PR DESCRIPTION
## What

Stop replaying a proposal turn's seller-facing confirmation reply to the model. For any assistant message whose stored metadata carries a `proposed_action`, the **entire** historical message sent to the model is replaced with server-owned state derived from `action_status`:

| `action_status` | what the model is told |
|---|---|
| `applied` | the action was applied and cannot be confirmed again |
| `executing` | execution started; do not confirm again |
| `unknown` (or any other value) | the result is unknown; do not confirm again |
| absent | a proposal was recorded, but its current result and card visibility are unknown; never send the creator back to that card |

Turns with no proposal keep their real text. The persisted seller-visible transcript is unchanged — this only changes what the model is told. No proposal payloads, params, objects, or client turn ids reach the model.

## Why

Closing gp#1470's remaining half. The reserved-reply escape shut with #6709, but the history note it added is *advice* to the model and the model can contradict it. Measured post-#6709 in production (audited read `20260731T160558Z-f3d5ca7d`), 2 hits in 735 turns, one of them a real recurrence:

> Conversation 45972. Message 369780 (15:25:38Z) carried a real proposal and was **applied** at 15:25:53Z. Two turns later, 369804 (15:26:56Z) — with `[Server proposal state: the proposed action was applied and cannot be confirmed again]` already in its replayed history — the agent answered "Yes upload the portrait now" with: *"The portrait upload is the proposal already sitting in front of you from my earlier turn — confirm that card and it goes through."* No card existed; the upload had already gone through.

The model was told the correct state **and still repeated the old copy sitting next to it**, because that copy was in the transcript as its own prior words. Removing the copy removes the thing it was copying. Advice it can override becomes state it cannot see past.

## Before / After

What the model receives for the conversation above:

**Before**
```
user:      Upload the portrait
assistant: The portrait upload is the proposal already sitting in front of you from my
           earlier turn — confirm that card and it goes through.

           [Server proposal state: the proposed action was applied and cannot be confirmed again]
```

**After**
```
user:      Upload the portrait
assistant: You proposed a change on this turn.

           [Server proposal state: the action was applied and cannot be confirmed again]
```

The seller's own chat history is byte-identical in both cases.

## Scope

Deliberately **not** in this change: no new `STAGED_CLAIM_PATTERNS`, no prose classifier, no sentence stripping, no output filtering, no prompt edits. No overlap with PR4 or PR7. Valid same-turn proposals are untouched — the rewrite applies only to stored history rows, so the current turn still proposes and the seller still gets the card.

## Tests

New coverage:

- `agent_messages_controller_spec.rb` — the exact production shape: an earlier proposal **applied**, then a turn telling the seller to confirm that old card. Asserts the model receives only the current server-owned state, and that the replayed history contains none of `confirm that card`, the endpoint name, the `client_turn_id`, or the object id. Also asserts the persisted row still contains the original copy.
- All four states (`applied` / `executing` / `unknown` / absent) pinned for both the note **and** the rewritten content.
- Web/mobile, buffered/streaming parity: `agent_message_streams_controller_spec.rb`, `agent_streams_controller_spec.rb`, `agent_controller_spec.rb` each assert the rewritten message via strict `with(messages: [...])` matching.

Runs, all on an isolated test database (`gumroad_test_gp1470h`, private Redis index):

```
spec/controllers/api/internal/agent_messages_controller_spec.rb
spec/controllers/api/internal/agent_message_streams_controller_spec.rb
spec/controllers/api/mobile/agent_controller_spec.rb
spec/controllers/api/mobile/agent_streams_controller_spec.rb
spec/services/ai/store_agent_service_spec.rb
  → 243 examples, 0 failures
```

Baseline at the merge-base in a separate worktree: 239 examples, 0 failures. One earlier run showed a single failure at `agent_streams_controller_spec.rb:262` (`expect($redis.ttl(...)).to be > 1` got `1`) — a Redis TTL timing assertion in a client-turn-id heartbeat test this diff does not touch; it passed in isolation (17/17) and on re-run of the full set.

`bundle exec rubocop app spec` — 3785 files, no offenses.

**CI on the pushed branch, before this PR existed:** run for `4244b041c` — 75 shards ran, 75 success, 0 failures, 0 cancelled.

## Review

Local adversarial pre-merge review, one P2 and three P3 raised and all fixed in `4244b041c`:

- **P2** — the first cut decided "did this turn have a proposal?" by string-comparing the state note. If that note's wording ever changed, real confirmation copy would silently be replayed again. Now branches on `metadata["proposed_action"].present?`.
- **P3** — six new constants added to the concern but not to its `private_constant` list; added.
- **P3** — the buffered mobile caller had no rewrite spec while the other three did; added.
- **P3** — comment length over the repo's ~3-line convention; trimmed.

No P1 findings.

**Round 2, at the current head `4244b041c`.** The P2 fix changed production code, so the reviewed state was stale and the gate was re-run rather than assumed. Verdict: approve, no P1/P2, all four round-1 findings confirmed RESOLVED. This round mutation-tested instead of reasoning about coverage — reverting the content rewrite reddens 5 specs across all four callers, and misrouting `applied` reddens 2. Two things it established that round 1 had not:

- The P2 fix is provably sound rather than plausible: the content branch (`:173`, `.present?`) and the state note (`:184`, `.blank?`) read the same metadata key through the same nil-guard, so they are strict complements and cannot disagree for any input.
- The rewrite is *strictly safer* than the old path in a case not previously considered — a proposal row with blank content used to vanish through `build_conversation`'s blank filter, silently losing its state note. The replacement content is always non-blank, so such a row now survives carrying state. Unhandled `action_status` values, including client-only `rejected` / `dismissed`, fail safe toward "do not confirm again".

Both reviewers temporarily mutated files; the worktree was verified clean at this exact head afterward, so nothing leaked into the branch.

Greptile scored this 5/5 with no defects, and its run is worth more than a static pass here: T-Rex executed a harness through `AgentConversationPersistence#agent_conversation_history` into a capturing service boundary and observed all four proposal states forwarding the fixed server-owned text with the correct state note, forwarding neither `Confirm that card` nor the proposal payload. That is a third independent confirmation of the behaviour, arrived at without reading these specs.

## Notes

No screenshots or video: this is a server-side change to what a model receives, with no rendered surface. The seller-visible UI is unchanged by construction, which is itself asserted in the specs.

## QA steps

No preview URL and no click-path: this changes only the message array handed to the model, a server-side path with no rendered surface. The seller-visible transcript is asserted byte-identical in `agent_messages_controller_spec.rb`, so the reviewable artifact is the spec diff plus the Before/After block above.

Reviewer path, if you want to see it directly:

1. `spec/controllers/api/internal/agent_messages_controller_spec.rb` — the production shape (proposal applied, then a turn telling the seller to confirm the old card). Asserts the replayed history contains none of `confirm that card`, the endpoint name, the `client_turn_id`, or the object id.
2. Same file — asserts the *persisted* row still contains the original copy, i.e. the seller's chat is untouched.
3. `bundle exec rspec spec/controllers/api/internal/agent_messages_controller_spec.rb spec/controllers/api/internal/agent_message_streams_controller_spec.rb spec/controllers/api/mobile/agent_controller_spec.rb spec/controllers/api/mobile/agent_streams_controller_spec.rb spec/services/ai/store_agent_service_spec.rb` → 243 examples, 0 failures.

---

Authored by Gumclaw, Gumroad's AI agent, running Hermes Agent on `claude-opus-5` (`anthropic`).

