### PR TITLE
Stop reporting a recovered missing complete_turn as an error (GUMROAD-157)

### DIFF
--- a/app/services/ai/store_agent_service.rb
+++ b/app/services/ai/store_agent_service.rb
@@ -938,9 +938,8 @@ class Ai::StoreAgentService
 
       outcome = retrying ? "retrying" : "gave up"
       message = "Store agent final turn did not match proposal state (#{reason}, #{outcome})"
-      # A model that omits the terminal marker is corrected and recovers on the retry — routine, and
-      # at roughly half of all turns it buries the phantom-staging signal it sits next to in Sentry.
-      # Only the give-up is a real failure. Every other mismatch stays error-level either way.
+      # The retry recovers this almost every time, and reporting the recoverable half buried the
+      # signals worth seeing. Only the give-up is a failure; every other reason stays error-level.
       if reason == :missing_complete_turn && retrying
         Rails.logger.info(message)
         return

--- a/app/services/ai/store_agent_service.rb
+++ b/app/services/ai/store_agent_service.rb
@@ -937,7 +937,16 @@ class Ai::StoreAgentService
       end
 
       outcome = retrying ? "retrying" : "gave up"
-      Rails.logger.warn("Store agent final turn did not match proposal state (#{reason}, #{outcome})")
+      message = "Store agent final turn did not match proposal state (#{reason}, #{outcome})"
+      # A model that omits the terminal marker is corrected and recovers on the retry — routine, and
+      # at roughly half of all turns it buries the phantom-staging signal it sits next to in Sentry.
+      # Only the give-up is a real failure. Every other mismatch stays error-level either way.
+      if reason == :missing_complete_turn && retrying
+        Rails.logger.info(message)
+        return
+      end
+
+      Rails.logger.warn(message)
       ErrorNotifier.notify(
         "Store agent final turn did not match proposal state",
         reason: reason.to_s,

--- a/spec/services/ai/store_agent_service_spec.rb
+++ b/spec/services/ai/store_agent_service_spec.rb
@@ -246,6 +246,54 @@ describe Ai::StoreAgentService do
         expect(result[:reply]).to eq(described_class::NOTHING_STAGED_REPLY)
         expect(result[:proposed_action]).to be_nil
       end
+
+      it "logs a recovered missing terminal marker at info without reporting it" do
+        allow(Rails.logger).to receive(:info)
+        expect(ErrorNotifier).not_to receive(:notify)
+        allow(client).to receive(:messages).and_return(
+          untyped_text_result("Your top seller is Cool Ebook."),
+          complete_turn_result("Your top seller is Cool Ebook.", outcome: "reply_only"),
+        )
+
+        result = service.respond(messages: [{ role: "user", content: "what sells best?" }])
+
+        expect(Rails.logger).to have_received(:info).with("Store agent final turn did not match proposal state (missing_complete_turn, retrying)")
+        expect(client).to have_received(:messages).twice
+        expect(result[:reply]).to eq("Your top seller is Cool Ebook.")
+      end
+
+      it "still reports a missing terminal marker the retry could not recover" do
+        expect(ErrorNotifier).to receive(:notify).with(
+          "Store agent final turn did not match proposal state",
+          reason: "missing_complete_turn",
+          outcome: "gave up",
+        )
+        allow(Rails.logger).to receive(:warn)
+        allow(client).to receive(:messages).and_return(untyped_text_result("Still no marker."))
+
+        result = service.respond(messages: [{ role: "user", content: "what sells best?" }])
+
+        expect(client).to have_received(:messages).twice
+        expect(result[:reply]).to eq(described_class::TURN_CONTRACT_FAILURE_REPLY)
+      end
+
+      it "still reports a non-marker proposal-state mismatch on the retry" do
+        expect(ErrorNotifier).to receive(:notify).with(
+          "Store agent final turn did not match proposal state",
+          reason: "invalid_complete_turn_outcome",
+          outcome: "retrying",
+        )
+        allow(Rails.logger).to receive(:warn)
+        allow(client).to receive(:messages).and_return(
+          complete_turn_result("Here you go.", outcome: "not_a_real_outcome"),
+          complete_turn_result("Here you go.", outcome: "reply_only"),
+        )
+
+        result = service.respond(messages: [{ role: "user", content: "what sells best?" }])
+
+        expect(client).to have_received(:messages).twice
+        expect(result[:reply]).to eq("Here you go.")
+      end
     end
 
     describe "api_read" do

--- a/spec/services/ai/store_agent_service_spec.rb
+++ b/spec/services/ai/store_agent_service_spec.rb
@@ -273,6 +273,7 @@ describe Ai::StoreAgentService do
 
         result = service.respond(messages: [{ role: "user", content: "what sells best?" }])
 
+        expect(Rails.logger).to have_received(:warn).with("Store agent final turn did not match proposal state (missing_complete_turn, gave up)")
         expect(client).to have_received(:messages).twice
         expect(result[:reply]).to eq(described_class::TURN_CONTRACT_FAILURE_REPLY)
       end


### PR DESCRIPTION
## What

In `Ai::StoreAgentService#log_turn_contract_mismatch`, a `missing_complete_turn` mismatch that is **being retried** now logs at `Rails.logger.info` and does not call `ErrorNotifier`.

Unchanged:

- the retry itself, and the whole turn contract
- the give-up path for `missing_complete_turn` — still `warn` + `ErrorNotifier`
- **every** other mismatch reason, on both the retrying and gave-up branches (`proposal_not_reported`, `proposal_ready_without_proposal`, `invalid_complete_turn_outcome`, `invalid_complete_turn_stop_reason`, `mixed_or_duplicate_complete_turn`, `blank_reply`)
- `staging_claim_without_proposal`, which returns earlier into `log_phantom_staged_claim` and is not touched

No untyped turn is accepted and the turn contract is not weakened. The model must still finish with `complete_turn`; it is still corrected and still retried when it doesn't.

## Why

Sentry `GUMROAD-157` (`Store agent final turn did not match proposal state`) is at **5,673 events across 319 sellers**, error-level, still climbing — 293 events in a single hour against ~450 turns. Every sample pulled is `reason: missing_complete_turn, outcome: retrying`: the model finishes without the terminal marker, the service corrects it, the retry recovers. It recovers at 99.8% (7 give-ups out of 3,680 on Jul 30).

Nothing is breaking. The problem is that it is **~40x the volume of the phantom-staging signal it sits beside** — the instrument gp#1470 asked for specifically so a regression would surface without a manual `ai_messages` query. At this ratio the useful signal is buried.

This is the narrow half of gp#1564's option 2, scoped to the reporting level only. It does not accept text-only final turns (that is gp#1564's option 1, a separate decision) and does not touch the prompt.

## Before / After

Sentry, error-level, for a turn the retry recovers:

**Before** — `Rails.logger.warn` + `ErrorNotifier.notify(reason: "missing_complete_turn", outcome: "retrying")`, ~1,800/day
**After** — `Rails.logger.info`, no Sentry event

For a turn the retry does not recover, before and after are identical: `warn` + `ErrorNotifier` with `outcome: "gave up"`.

## Tests

Three new examples in `spec/services/ai/store_agent_service_spec.rb`:

1. **a recovered missing marker logs at info and does not report** — drives an untyped result then a valid `complete_turn`, asserts the exact info line was received and `ErrorNotifier` was not called. The `have_received(:info).with(<exact message>)` is what proves the logging path was actually reached, so the `not_to receive(:notify)` cannot pass vacuously.
2. **a give-up still reports** — asserts `ErrorNotifier.notify` with `reason: "missing_complete_turn", outcome: "gave up"`, and pins the give-up `warn` line too.
3. **a non-marker mismatch still reports while retrying** — `invalid_complete_turn_outcome` on the first attempt asserts `outcome: "retrying"` still fires, so the guard's `reason ==` half is pinned and cannot widen to silence everything on retry.

Run on an isolated test database (`gumroad_test_gr157n`, private Redis index):

```
spec/services/ai/store_agent_service_spec.rb → 92 examples, 0 failures
```

`bundle exec rubocop app spec` — 3785 files, no offenses.

**CI on the pushed branch, before this PR existed:** run for `8acd50442` — 75 shards ran, 75 success, 0 failures, 0 cancelled.

## Review

Local adversarial pre-merge review: **no P1 or P2.** The check that mattered most — can `retrying: true` ever reach this method on a real give-up, which would silence a genuine failure — was traced through both callers: `retrying` is computed as `turn_contract_retries < MAX_TURN_CONTRACT_RETRIES` before incrementing, and every `retrying: true` path unconditionally appends the correction and re-enters the loop, so the retry always executes and the give-up branch is the only other exit. Two P3s raised and both fixed in `8acd50442`: the give-up `warn` line was stubbed but unasserted (now pinned), and the comment was trimmed.

**Round 2, at the current head `8acd50442`.** Production code changed after round 1, so the gate was re-run rather than assumed. Verdict: approve, no P1/P2, both round-1 findings RESOLVED. This round mutation-tested for real:

| mutation | result |
|---|---|
| delete the guard | exactly the info-assertion and give-up specs redden |
| widen the guard to ignore `reason` | exactly the `invalid_complete_turn_outcome` spec reddens |
| downgrade the give-up `warn` to info | exactly the give-up spec reddens |

So no example is vacuous, and the guard cannot widen to silence other reasons without a spec catching it. The reviewer also confirmed the newly-pinned `warn` string matches the production interpolation exactly rather than passing for the wrong reason, and that no other `Rails.logger.info` call in the service makes the info assertion ambiguous.

One honest note it surfaced and correctly did not raise as a finding: in `#respond_streaming` an `emit.call(:reset)` sits between the log call and the retry and could raise on a dead socket. That raise propagates out of the service rather than being swallowed, and the ordering predates this change.

The worktree was verified clean at this exact head after the mutations, so nothing leaked into the branch.

Greptile scored this 5/5 with no defects, but its runtime validation was **blocked** — its runner has Ruby 3.1.2 against the repo's required 3.4.3, so `bundle exec rspec` never ran. Treat its verdict as static review only; the executed evidence here is the local suite and the mutation table above.

## Follow-on

PR7 should retain this behaviour and add bounded telemetry, so the recovered case stays countable without being error-level.

## Notes

No screenshots or video: this changes a log level and a Sentry call on a server path with no rendered surface.

## QA steps

No preview URL and no click-path: this changes a log level and whether one `ErrorNotifier` call fires. There is no rendered surface, so the reviewable artifact is the spec diff plus the Before/After block above.

Reviewer path, if you want to see it directly:

1. `spec/services/ai/store_agent_service_spec.rb` — "a recovered missing marker logs at info and does not report". The `have_received(:info).with(<exact message>)` assertion is what stops the `not_to receive(:notify)` half passing vacuously.
2. Same file — the give-up example still pins `ErrorNotifier.notify(reason: "missing_complete_turn", outcome: "gave up")`, so the silencing cannot leak past the retry.
3. Same file — `invalid_complete_turn_outcome` while retrying still reports, pinning the `reason ==` half of the guard against widening.
4. `bundle exec rspec spec/services/ai/store_agent_service_spec.rb` → 92 examples, 0 failures.

---

Authored by Gumclaw, Gumroad's AI agent, running Hermes Agent on `claude-opus-5` (`anthropic`).

