### PR TITLE
Accept an absolute FQDN in the reCAPTCHA hostname allowlist

### DIFF
--- a/app/controllers/concerns/validate_recaptcha.rb
+++ b/app/controllers/concerns/validate_recaptcha.rb
@@ -138,10 +138,11 @@ module ValidateRecaptcha
       return true unless Rails.env.production?
       return false if hostname.blank?
 
-      # This hostname comes from Google's assessment as the browser sent it, not from
-      # request.host — Rack normalizes that, so only this path sees the raw form. A trailing
-      # dot is a legal absolute FQDN that Cloudflare and Rails both serve, so a visitor on
-      # "<seller>.gumroad.com." arrives with a valid token and no way to fix the refusal.
+      # Google echoes the hostname as the browser sent it, so a legal absolute FQDN arrives
+      # with its trailing dot and in the browser's casing. Rack does not strip either
+      # (Request#host only splits the port), so a "<seller>.gumroad.com." visitor was refused
+      # with a valid token and no way to fix it — the edge normalizes the Host header Rails
+      # sees, which is why nothing but this path noticed.
       hostname = hostname.downcase.delete_suffix(".")
 
       # TODO: Refactor subdomain check. Use Subdomain module if possible

--- a/app/controllers/concerns/validate_recaptcha.rb
+++ b/app/controllers/concerns/validate_recaptcha.rb
@@ -136,6 +136,11 @@ module ValidateRecaptcha
 
     def hostname_allowed?(hostname)
       return true unless Rails.env.production?
+      # Only the top level of the verification response is guaranteed to be an object, so
+      # tokenProperties.hostname can arrive as any JSON scalar. A non-string is not a hostname
+      # we can allow, and every comparison below would raise on it — which lands on the caller's
+      # 500 rather than a clean failed verification.
+      return false unless hostname.is_a?(String)
       return false if hostname.blank?
 
       # Google echoes the hostname as the browser sent it, so a legal absolute FQDN arrives

--- a/app/controllers/concerns/validate_recaptcha.rb
+++ b/app/controllers/concerns/validate_recaptcha.rb
@@ -138,6 +138,12 @@ module ValidateRecaptcha
       return true unless Rails.env.production?
       return false if hostname.blank?
 
+      # This hostname comes from Google's assessment as the browser sent it, not from
+      # request.host — Rack normalizes that, so only this path sees the raw form. A trailing
+      # dot is a legal absolute FQDN that Cloudflare and Rails both serve, so a visitor on
+      # "<seller>.gumroad.com." arrives with a valid token and no way to fix the refusal.
+      hostname = hostname.downcase.delete_suffix(".")
+
       # TODO: Refactor subdomain check. Use Subdomain module if possible
       hostname == DOMAIN || hostname.end_with?(".#{ROOT_DOMAIN}") || CustomDomain.find_by_host(hostname).present?
     end

--- a/spec/controllers/concerns/validate_recaptcha_spec.rb
+++ b/spec/controllers/concerns/validate_recaptcha_spec.rb
@@ -269,6 +269,81 @@ describe ValidateRecaptcha, type: :controller do
         expect(response).to have_http_status(:unprocessable_entity)
         expect(parsed_body["error"]).to eq("captcha_failed")
       end
+
+      # Google reports the hostname as the browser sent it, so an absolute FQDN arrives with
+      # its trailing dot intact. gumroad-private#1634.
+      it "passes checkout on the apex written as an absolute FQDN" do
+        stub_recaptcha_response(valid: true, score: 0.7, hostname: "#{DOMAIN}.")
+
+        post :checkout_action, params: { "g-recaptcha-response" => "test_token" }
+
+        expect(response).to have_http_status(:ok)
+        expect(parsed_body["success"]).to be true
+      end
+
+      it "passes checkout on a seller subdomain written as an absolute FQDN" do
+        stub_recaptcha_response(valid: true, score: 0.7, hostname: "seller.#{ROOT_DOMAIN}.")
+
+        post :checkout_action, params: { "g-recaptcha-response" => "test_token" }
+
+        expect(response).to have_http_status(:ok)
+        expect(parsed_body["success"]).to be true
+      end
+
+      it "passes checkout on a registered custom domain written as an absolute FQDN" do
+        custom_domain = create(:custom_domain, domain: "shop.example.com")
+
+        stub_recaptcha_response(valid: true, score: 0.7, hostname: "shop.example.com.")
+
+        post :checkout_action, params: { "g-recaptcha-response" => "test_token" }
+
+        expect(CustomDomain.find_by_host("shop.example.com")).to eq(custom_domain)
+        expect(response).to have_http_status(:ok)
+        expect(parsed_body["success"]).to be true
+      end
+
+      it "passes checkout when the hostname arrives uppercased" do
+        stub_recaptcha_response(valid: true, score: 0.7, hostname: "Seller.#{ROOT_DOMAIN.upcase}")
+
+        post :checkout_action, params: { "g-recaptcha-response" => "test_token" }
+
+        expect(response).to have_http_status(:ok)
+        expect(parsed_body["success"]).to be true
+      end
+
+      # Normalizing must not widen the allowlist: an unrelated host stays refused however
+      # it is written.
+      it "still fails checkout on an unrelated host written as an absolute FQDN" do
+        allow(CustomDomain).to receive(:find_by_host).and_return(nil)
+        stub_recaptcha_response(valid: true, score: 0.7, hostname: "attacker.example.net.")
+
+        post :checkout_action, params: { "g-recaptcha-response" => "test_token" }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(parsed_body["error"]).to eq("captcha_failed")
+      end
+
+      it "still fails checkout on a lookalike host that merely ends with our domain text" do
+        allow(CustomDomain).to receive(:find_by_host).and_return(nil)
+        stub_recaptcha_response(valid: true, score: 0.7, hostname: "evil-#{ROOT_DOMAIN}.")
+
+        post :checkout_action, params: { "g-recaptcha-response" => "test_token" }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(parsed_body["error"]).to eq("captcha_failed")
+      end
+
+      # A bare "." would otherwise normalize to the empty string and fall through the blank
+      # guard, which runs before normalization.
+      it "still fails checkout when the hostname is only a dot" do
+        allow(CustomDomain).to receive(:find_by_host).and_return(nil)
+        stub_recaptcha_response(valid: true, score: 0.7, hostname: ".")
+
+        post :checkout_action, params: { "g-recaptcha-response" => "test_token" }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(parsed_body["error"]).to eq("captcha_failed")
+      end
     end
   end
 

--- a/spec/controllers/concerns/validate_recaptcha_spec.rb
+++ b/spec/controllers/concerns/validate_recaptcha_spec.rb
@@ -291,13 +291,12 @@ describe ValidateRecaptcha, type: :controller do
       end
 
       it "passes checkout on a registered custom domain written as an absolute FQDN" do
-        custom_domain = create(:custom_domain, domain: "shop.example.com")
+        create(:custom_domain, domain: "shop.example.com")
 
         stub_recaptcha_response(valid: true, score: 0.7, hostname: "shop.example.com.")
 
         post :checkout_action, params: { "g-recaptcha-response" => "test_token" }
 
-        expect(CustomDomain.find_by_host("shop.example.com")).to eq(custom_domain)
         expect(response).to have_http_status(:ok)
         expect(parsed_body["success"]).to be true
       end
@@ -311,18 +310,9 @@ describe ValidateRecaptcha, type: :controller do
         expect(parsed_body["success"]).to be true
       end
 
-      # Normalizing must not widen the allowlist: an unrelated host stays refused however
-      # it is written.
-      it "still fails checkout on an unrelated host written as an absolute FQDN" do
-        allow(CustomDomain).to receive(:find_by_host).and_return(nil)
-        stub_recaptcha_response(valid: true, score: 0.7, hostname: "attacker.example.net.")
-
-        post :checkout_action, params: { "g-recaptcha-response" => "test_token" }
-
-        expect(response).to have_http_status(:unprocessable_entity)
-        expect(parsed_body["error"]).to eq("captcha_failed")
-      end
-
+      # Normalizing must not widen the allowlist: a lookalike that merely ends with our domain
+      # text stays refused. This one would catch an end_with?(ROOT_DOMAIN) regression that drops
+      # the separating dot.
       it "still fails checkout on a lookalike host that merely ends with our domain text" do
         allow(CustomDomain).to receive(:find_by_host).and_return(nil)
         stub_recaptcha_response(valid: true, score: 0.7, hostname: "evil-#{ROOT_DOMAIN}.")
@@ -333,8 +323,8 @@ describe ValidateRecaptcha, type: :controller do
         expect(parsed_body["error"]).to eq("captcha_failed")
       end
 
-      # A bare "." would otherwise normalize to the empty string and fall through the blank
-      # guard, which runs before normalization.
+      # A bare "." is not blank, so it reaches the comparisons as the empty string. None of the
+      # three match it.
       it "still fails checkout when the hostname is only a dot" do
         allow(CustomDomain).to receive(:find_by_host).and_return(nil)
         stub_recaptcha_response(valid: true, score: 0.7, hostname: ".")
@@ -343,6 +333,23 @@ describe ValidateRecaptcha, type: :controller do
 
         expect(response).to have_http_status(:unprocessable_entity)
         expect(parsed_body["error"]).to eq("captcha_failed")
+      end
+    end
+
+    context "with the follow surface" do
+      before do
+        allow(Rails).to receive(:env).and_return(ActiveSupport::EnvironmentInquirer.new("production"))
+      end
+
+      # The surface the incident was reported on. Shares hostname_allowed? with checkout, so this
+      # pins no extra code — it ties the regression to where sellers saw it.
+      it "passes follow on a seller subdomain written as an absolute FQDN" do
+        stub_recaptcha_response(valid: true, score: 0.7, hostname: "seller.#{ROOT_DOMAIN}.")
+
+        post :follow_action, params: { "g-recaptcha-response" => "test_token" }
+
+        expect(response).to have_http_status(:ok)
+        expect(parsed_body["success"]).to be true
       end
     end
   end

--- a/spec/controllers/concerns/validate_recaptcha_spec.rb
+++ b/spec/controllers/concerns/validate_recaptcha_spec.rb
@@ -334,6 +334,20 @@ describe ValidateRecaptcha, type: :controller do
         expect(response).to have_http_status(:unprocessable_entity)
         expect(parsed_body["error"]).to eq("captcha_failed")
       end
+
+      # Only the top level of Google's response is guaranteed to be an object, so the hostname can
+      # be any JSON scalar. Without the type guard these raise instead of failing verification.
+      [true, 123].each do |malformed_hostname|
+        it "fails checkout without raising when the hostname is #{malformed_hostname.inspect}" do
+          allow(CustomDomain).to receive(:find_by_host).and_return(nil)
+          stub_recaptcha_response(valid: true, score: 0.7, hostname: malformed_hostname)
+
+          post :checkout_action, params: { "g-recaptcha-response" => "test_token" }
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(parsed_body["error"]).to eq("captcha_failed")
+        end
+      end
     end
 
     context "with the follow surface" do


### PR DESCRIPTION
## What

`hostname_allowed?` in `ValidateRecaptcha` now normalizes the reCAPTCHA assessment hostname — downcase, and strip one trailing dot — before comparing it against `DOMAIN`, `ROOT_DOMAIN` and the registered custom domains.

## Why

A visitor reaching a page via the absolute-FQDN form `<seller>.gumroad.com.` completed the CAPTCHA and was still refused: `valid=true score=1.0 hostname_ok=false`. Every `decision=fail` on the follow (subscribe) surface platform-wide on Jul 31 was this one case. The visitor has no way to fix it — retrying, disabling extensions, and incognito all produce the same refusal.

The hostname here comes from Google's assessment as the browser sent it, not from `request.host`. A trailing dot is a legal absolute FQDN, and hostnames are case-insensitive, so both forms are DNS-equivalent to hosts we already allow. Nothing else in the app noticed because the edge normalizes the Host header before Rails sees it — `Subdomain.subdomain_request?` anchors with `\z` and would not have matched a dotted host, so the page could only have served at all if Rails never saw the dot.

Closes antiwork/gumroad-private#1634.

## Test results

`spec/controllers/concerns/validate_recaptcha_spec.rb` — **34 examples, 0 failures** (local, Ruby 3.4.3). Rubocop clean on both files. CI green on the previous head (`45ce42a1d`): 76 checks, 0 pending, 0 failures, 0 cancelled; re-running on `d41ff4a15`.

Five new positive examples: apex, seller subdomain, registered custom domain, an uppercased host, and the follow surface. Two negatives pin that the allowlist did not widen (`evil-<root-domain>.` lookalike, bare `.`). Two more pin that a non-string hostname fails verification cleanly instead of raising (see the type guard below).

**Mutation-verified, not asserted:** deleting the normalization line reddens **5 of 5** positive examples (`0 → 5`); restoring it returns 34/0. The uppercase example is the unique killer of the `.downcase → no-op` mutant; the three FQDN examples kill `delete_suffix → no-op`. Deleting the `is_a?(String)` guard reddens exactly the 2 malformed-hostname examples (`0 → 2`).

## Non-string hostname type guard

`hostname_allowed?` returns `false` unless the hostname is a `String`, before normalizing (`d41ff4a15`). Only the top level of Google's verification response is guaranteed to be an object, so `tokenProperties.hostname` can arrive as any JSON scalar; a boolean or number is not blank, so it reached the comparisons and raised `NoMethodError` inside checkout and follow validation.

This is pre-existing rather than introduced here — on `main` the same inputs raise one expression later, at `true.end_with?(".<root-domain>")`. `.downcase` moved the raise earlier without changing the outcome. Fixed here because this PR owns the method.

## QA steps

Ran, not predicted — output above. Live-only items are listed in the verdict below.

## Fable-5 adversarial review

Verdict: **CHANGES-REQUIRED → all findings closed**, run against `8ac56823e` before this PR existed, per the pre-open gate. The production behavior change was found correct and safely scoped; what blocked merge was that the stated safety rationale was factually wrong in two places, on a security gate where the comments are what the next maintainer relies on.

| # | Finding | Disposition |
|---|---|---|
| P2 | Comment credited Rack with stripping the trailing dot. It does not — Rack 3.2.6 `Request#host` only splits the port off the authority. A maintainer trusting it might skip host normalization elsewhere. | Fixed in 45ce42a — re-attributed to the edge, verified against the bundled gem via `Rack::MockRequest` (returns `"seller.gumroad.com."` unchanged). |
| P2 | Commit message's ordering rationale was inverted: it claimed the blank guard must precede normalization or a bare `.` would become `""` and fall through. Backwards — `.` is not blank, so it *does* reach the comparisons as `""`, and none of the three match it. The order is not load-bearing. | Fixed in 45ce42a — corrected in the message and the spec comment. |
| P3 | The "only a dot" example is vacuous: survives revert and every mutant. | Kept, comment made non-causal — it documents the `""` edge honestly rather than implying it pins the change. |
| P3 | The `attacker.example.net.` negative is subsumed by the existing dotless negative and the sharper `evil-<root>.` lookalike. | Deleted in 45ce42a; the lookalike kept (it would catch an `end_with?` regression dropping the separating dot). |
| P3 | `expect(CustomDomain.find_by_host(...)).to eq(custom_domain)` asserts the model, not the behavior under test. | Deleted in 45ce42a. |
| P3 | Incident was on the follow surface but every example posted `:checkout_action`. | Added a follow-surface example. Pins no extra code (`follow_action` shares `hostname_allowed?`), but ties the regression to where sellers saw it. |
| P3 | In the test env `DOMAIN` (`app.test.gumroad.com:31337`) is itself a subdomain of `ROOT_DOMAIN`, so the apex example satisfies two branches; in production it satisfies only `== DOMAIN`. Pre-existing fixture shape, also true of the original line-255 example. | Not changed — out of scope for this fix, noted here for whoever next touches the branches. |

### What the review confirmed safe

- **No widening beyond DNS equivalence.** The newly-admitted set is exactly `h + "."` and case variants of already-allowed `h`. Each of `gumroad.com..`, `evil-gumroad.com.`, `gumroad.com.attacker.net.`, and whitespace variants was checked against the literal branches and stays refused. `example.com..` now passes iff `example.com` is already a registered apex custom domain — inside the equivalence closure of an allowed host, and no browser navigates to an empty-label host.
- **`find_by_host` receives a strictly narrower input than before** (downcased, no trailing dot), and `domain` is stored downcased (`stripped_fields :domain, transform: -> { _1.downcase }`), so the lookup matches storage canonical form. The `alive` scope is untouched.
- **Nothing downstream reads the hostname.** `assessment[:hostname]` is consumed once; the log line does not include it; all three call sites (`orders_controller`, `purchases_controller`, `followers_controller`) consume only the boolean. No consumer can observe normalized-vs-raw.
- **`valid_recaptcha_response?` (login) is unreachable by this change** — `require_hostname: false` short-circuits before `hostname_allowed?`.
- **Sibling-defect sweep clean.** The only other `end_with?(".` host comparison operates on save-time-normalized stored values. Every other `find_by_host`/`Subdomain` consumer takes `request.host` — different provenance, normalized before Rails. No in-scope twin.

### Verifiable only in production

- That the **edge**, not Rack, normalizes the Host header Rails sees. Rack and `Subdomain` source rule Rack out and the incident implies it, but positive attribution needs a live dotted-Host request.
- That Google's assessment hostname never carries a port (assumed from reCAPTCHA semantics).

## AI disclosure

Written by Hermes Agent (claude-opus-5) acting for @gumclaw. Reviewed adversarially by a separate headless Claude session before this PR was opened; every finding above was re-verified against this repo before being coded, and the spec claims were mutation-tested rather than asserted.

