### PR TITLE
Anchor the product sorting spec's created_at values so slow setup cannot invert ties

### DIFF
--- a/spec/models/concerns/product/sorting_spec.rb
+++ b/spec/models/concerns/product/sorting_spec.rb
@@ -6,15 +6,15 @@ describe Product::Sorting do
   let!(:seller) { create(:recommendable_user) }
 
   describe ".sorted_by" do
-    # Every example here breaks flag/taxonomy ties on `created_at desc`, so the four products must
-    # keep a fixed relative order. Anchor them to one instant with hour-wide gaps: a per-`let!`
-    # `Time.current` with 1-2s offsets inverts p1/p4 whenever setup on a slow runner outruns the gap.
+    # These examples tie-break on `created_at desc`, so the four products must keep a fixed relative
+    # order. Derive every timestamp from one anchor with hour-wide gaps — separate `Time.current`
+    # calls let setup latency on a slow runner reorder them.
     let(:created_at_anchor) { Time.current }
     let!(:collaborator) { create(:collaborator, seller:) }
-    let!(:product1) { create(:product, :is_collab, collaborator:, user: seller, name: "p1", display_product_reviews: true, taxonomy: create(:taxonomy), purchase_disabled_at: Time.current, created_at: created_at_anchor, collaborator_cut: 45_00) }
-    let!(:product2) { create(:product, :is_collab, collaborator:, user: seller, name: "p2", display_product_reviews: false, taxonomy: create(:taxonomy), created_at: created_at_anchor + 1.hour, collaborator_cut: 35_00) }
-    let!(:product3) { create(:subscription_product, :is_collab, collaborator:, user: seller, name: "p3", display_product_reviews: false, purchase_disabled_at: Time.current, created_at: created_at_anchor - 1.hour, collaborator_cut: 15_00) }
-    let!(:product4) { create(:subscription_product, :is_collab, collaborator:, user: seller, name: "p4", display_product_reviews: true, created_at: created_at_anchor - 2.hours, collaborator_cut: 25_00) }
+    let!(:product1) { create(:product, :is_collab, collaborator:, user: seller, name: "p1", display_product_reviews: true, taxonomy: create(:taxonomy), purchase_disabled_at: Time.current, created_at: created_at_anchor - 1.hour, collaborator_cut: 45_00) }
+    let!(:product2) { create(:product, :is_collab, collaborator:, user: seller, name: "p2", display_product_reviews: false, taxonomy: create(:taxonomy), created_at: created_at_anchor, collaborator_cut: 35_00) }
+    let!(:product3) { create(:subscription_product, :is_collab, collaborator:, user: seller, name: "p3", display_product_reviews: false, purchase_disabled_at: Time.current, created_at: created_at_anchor - 2.hours, collaborator_cut: 15_00) }
+    let!(:product4) { create(:subscription_product, :is_collab, collaborator:, user: seller, name: "p4", display_product_reviews: true, created_at: created_at_anchor - 3.hours, collaborator_cut: 25_00) }
 
     before do
       create_list(:purchase, 2, link: product1)

--- a/spec/models/concerns/product/sorting_spec.rb
+++ b/spec/models/concerns/product/sorting_spec.rb
@@ -6,11 +6,15 @@ describe Product::Sorting do
   let!(:seller) { create(:recommendable_user) }
 
   describe ".sorted_by" do
+    # Every example here breaks flag/taxonomy ties on `created_at desc`, so the four products must
+    # keep a fixed relative order. Anchor them to one instant with hour-wide gaps: a per-`let!`
+    # `Time.current` with 1-2s offsets inverts p1/p4 whenever setup on a slow runner outruns the gap.
+    let(:created_at_anchor) { Time.current }
     let!(:collaborator) { create(:collaborator, seller:) }
-    let!(:product1) { create(:product, :is_collab, collaborator:, user: seller, name: "p1", display_product_reviews: true, taxonomy: create(:taxonomy), purchase_disabled_at: Time.current, created_at: Time.current, collaborator_cut: 45_00) }
-    let!(:product2) { create(:product, :is_collab, collaborator:, user: seller, name: "p2", display_product_reviews: false, taxonomy: create(:taxonomy), created_at: Time.current + 1, collaborator_cut: 35_00) }
-    let!(:product3) { create(:subscription_product, :is_collab, collaborator:, user: seller, name: "p3", display_product_reviews: false, purchase_disabled_at: Time.current, created_at: Time.current - 1, collaborator_cut: 15_00) }
-    let!(:product4) { create(:subscription_product, :is_collab, collaborator:, user: seller, name: "p4", display_product_reviews: true, created_at: Time.current - 2, collaborator_cut: 25_00) }
+    let!(:product1) { create(:product, :is_collab, collaborator:, user: seller, name: "p1", display_product_reviews: true, taxonomy: create(:taxonomy), purchase_disabled_at: Time.current, created_at: created_at_anchor, collaborator_cut: 45_00) }
+    let!(:product2) { create(:product, :is_collab, collaborator:, user: seller, name: "p2", display_product_reviews: false, taxonomy: create(:taxonomy), created_at: created_at_anchor + 1.hour, collaborator_cut: 35_00) }
+    let!(:product3) { create(:subscription_product, :is_collab, collaborator:, user: seller, name: "p3", display_product_reviews: false, purchase_disabled_at: Time.current, created_at: created_at_anchor - 1.hour, collaborator_cut: 15_00) }
+    let!(:product4) { create(:subscription_product, :is_collab, collaborator:, user: seller, name: "p4", display_product_reviews: true, created_at: created_at_anchor - 2.hours, collaborator_cut: 25_00) }
 
     before do
       create_list(:purchase, 2, link: product1)


### PR DESCRIPTION
## What

Anchors the four products in `Product::Sorting`'s `.sorted_by` spec block to a single instant with hour-wide gaps, instead of deriving each one's `created_at` from a separate `Time.current` with 1–2 **second** offsets.

## Why

Every example in that block breaks flag and taxonomy ties on `created_at desc`, so the four products must keep a fixed relative order. They didn't reliably:

- each `let!` block called its own `Time.current`, and the intended spread was only 1–2 seconds;
- Rails truncates `created_at` to whole seconds;
- so when setup between the `product1` and `product4` `let!` blocks took longer than the gap on a loaded runner, p4 landed *newer* than p1 and the `with_reviews` tie group came back `[p4, p1]` instead of `[p1, p4]`.

That is exactly what main hit on `20b7e8d6` (the #6716 merge commit), where `Test Fast 7` failed alone:

```
1) Product::Sorting.sorted_by returns products sorted by whether displaying product reviews is enabled
   expected: ["p2", "p3", "p1", "p4"]
        got: ["p2", "p3", "p4", "p1"]
```

A p1/p4 inversion, on a commit whose diff touched only `db/migrate/` and `qa-media/` — it could not have changed product sorting. The spec was reporting runner latency, not a defect.

A single memoized `created_at_anchor` makes all four timestamps derive from the same instant within an example, and hour-wide gaps are a window no amount of setup latency can close.

## Before / after

| | Before | After |
|---|---|---|
| Timestamp source | `Time.current` re-read per `let!` | one `let(:created_at_anchor)`, read once |
| Gaps between products | 1–2 seconds | 1–3 hours |
| Newest → oldest | p2, p1, p3, p4 | p2, p1, p3, p4 (unchanged) |
| Any future timestamp | yes (p2 was T+1s) | no — all offsets non-positive |
| Fails when setup is slow | yes | no |

## Tests

Isolated database (own schema + fixtures + seeds) so sibling agent suites on the same box could not contaminate the result.

- Whole file, 3 consecutive runs at final head: `10 examples, 0 failures` each time.
- Target example, 8 consecutive runs at load average 17 on 16 cores (the condition that reproduces the flake): `1 example, 0 failures` every run.
- **Mutation check — the assertion is still load-bearing.** Inverting the production sort direction in `app/models/concerns/product/sorting.rb` (the `DISPLAY_PRODUCT_REVIEWS` branch) makes the example fail on every run:

  ```
  ===== MUTATED x2 (expect 1 failure each) =====
  1 example, 1 failure
  rspec ./spec/models/concerns/product/sorting_spec.rb:78 # ... display_product_reviews ...
  1 example, 1 failure
  rspec ./spec/models/concerns/product/sorting_spec.rb:78 # ... display_product_reviews ...
  ```

  Production file restored afterwards; no app changes in this diff.

- CI on the pushed branch head `69a18da`: **70 real test shards green, 0 failing, 0 pending, 0 cancelled.** (The `SKIPPED` entries in the rollup are the known internal-PR noop gate, not the shards.)

## QA steps

No product behavior changes — spec-only diff, one file. Reviewer QA is reading the ordering argument above; nothing to click.

## Scope

Test-only: one spec file, zero production files. Swept the repo for the same seconds-scale tie-break antipattern — `spec/controllers/api/v2/links_controller_spec.rb` already uses 3600/7200-second gaps (fine); `spec/modules/product/searchable/name_field_search_spec.rb:62` has the same shape and is worth the same treatment in a **separate** PR, kept out of here to keep this diff single-purpose.

## Fable-5 adversarial review

Verdict: **READY-TO-MERGE**, no P1 or P2 findings. Three P3s, dispositions:

| Finding | Disposition |
| --- | --- |
| P3 — last clause of the new comment narrated the historical bug, which `AGENTS.md` says to cut | **Fixed** in 69a18da — trimmed to the invariant plus the trap, no archaeology. |
| P3 — p2's `created_at` sat one hour in the **future**; latent trap if a time-windowed scope or assertion is added to this block later | **Fixed** in 69a18da — all offsets shifted non-positive, relative order unchanged. |
| P3 — sibling antipattern in `name_field_search_spec.rb:62` | **Deferred** to its own PR, as recommended. |

What the review confirmed safe, with evidence:

1. **`let` memoization makes this a real fix, not just a wider window.** `created_at_anchor` is memoized per example; `let!` is `let` plus an implicit `before`. The first `let!` to reference it forces one `Time.current` and the rest read the cached value, so all four derive from the *same* instant within any example. No double-evaluation path exists.
2. **Assertions stay load-bearing** — confirmed by the mutation check above, not by argument.
3. **The unanchored `purchase_disabled_at: Time.current` calls are irrelevant** — the status sort is a `IS NULL` check, so only nil vs non-nil matters and the value is never compared.
4. **The future timestamp reached nothing** — the `elasticsearch_sorted_and_paginated_by` block defines its own products, and `ProductCachedValue` computes from purchases, not product timestamps. Fixed anyway, as defence in depth.

Greptile/T-Rex independently reproduced the old inversion with a 3-second setup delay and confirmed the revised expressions hold the intended order (5/5, no defects found).

Merging under the 2026-07-30 spec-flakiness auto-merge grant: test-only diff, named mechanism (wall-clock drift between `let!` evaluations), the fix removes the nondeterminism rather than hiding it, and coverage is proven intact by mutation.
