### PR TITLE
Fence the undeliverable-webhook notice claim to the render that holds it

### DIFF
--- a/app/mailers/contacting_creator_mailer.rb
+++ b/app/mailers/contacting_creator_mailer.rb
@@ -379,15 +379,20 @@ class ContactingCreatorMailer < ApplicationMailer
     return do_not_send if @seller.nil?
 
     # Setting a URL or re-authorizing the app makes it deliverable again, and this email would then
-    # ask the seller to repair something already working.
+    # ask the seller to repair something already working. A disconnect in the same window soft-deletes
+    # the application, which is not deliverable either but is also not the seller's to fix, so both
+    # halves of selection's rule are re-asked here rather than only the deliverability one.
     return do_not_send if @seller.ping_notification_deliverable?(@resource_subscription)
+    return do_not_send unless @seller.ping_notification_notice_actionable?(@resource_subscription)
 
     rendered_reason = UndeliverablePingSubscriptionNotifier.reason_for(@resource_subscription)
     # Claiming rather than checking: the enqueue throttle is keyed on the reason as it was at enqueue,
     # so two jobs that resolve to the same reason here are not excluded by it and a read would let both
     # send. Nothing below can decline, so the claim marks a send this render is committed to.
-    return do_not_send unless UndeliverablePingSubscriptionNotifier.claim_send(resource_subscription_id, rendered_reason)
+    claim_token = UndeliverablePingSubscriptionNotifier.claim_send(resource_subscription_id, rendered_reason)
+    return do_not_send if claim_token.nil?
 
+    @undeliverable_ping_subscription_claim_token = claim_token
     @undeliverable_ping_subscription_reason = rendered_reason
     @application_name = @resource_subscription.oauth_application&.name
     @missing_post_url = rendered_reason == UndeliverablePingSubscriptionNotifier::MISSING_POST_URL
@@ -779,7 +784,8 @@ class ContactingCreatorMailer < ApplicationMailer
       unless @resource_subscription.nil? || @undeliverable_ping_subscription_reason.blank?
         settle = delivered ? :record_sent : :release_claim
         UndeliverablePingSubscriptionNotifier.public_send(
-          settle, @resource_subscription.id, @undeliverable_ping_subscription_reason
+          settle, @resource_subscription.id, @undeliverable_ping_subscription_reason,
+          @undeliverable_ping_subscription_claim_token
         )
       end
     end

--- a/app/modules/user/ping_notification.rb
+++ b/app/modules/user/ping_notification.rb
@@ -42,6 +42,20 @@ module User::PingNotification
     resource_subscription.post_url.present? && live_ping_notification_token?(oauth_application)
   end
 
+  # Whether an undeliverable subscription's silence is the seller's to act on. Selection below and the
+  # mailer at render time both read this one predicate: a subscription can turn terminal inside that
+  # window — the seller disconnects the application, which soft-deletes it — and an email telling them
+  # to re-authorize an integration they just removed would be wrong, as well as spending the one notice
+  # they get. Asked only of subscriptions #ping_notification_deliverable? has already rejected.
+  def ping_notification_notice_actionable?(resource_subscription)
+    oauth_application = resource_subscription.oauth_application
+    # We had a bug where we were actually deleting the application instead of setting its deleted_at. Handle those gracefully.
+    # A revoked application is also a terminal state the seller chose, so it is not undeliverable-and-worth-reporting.
+    return false if oauth_application.nil? || oauth_application.deleted?
+
+    reportable_undeliverable?(oauth_application)
+  end
+
   # Single pass, because resolving deliverability costs a token query per subscription and the read
   # paths (#urls_for_ping_notification, can_ping) run on every sale JSON.
   def ping_notification_targets(resource_name)
@@ -49,14 +63,9 @@ module User::PingNotification
     undeliverable = []
 
     resource_subscriptions.alive.where("resource_name = ?", resource_name).find_each do |resource_subscription|
-      oauth_application = resource_subscription.oauth_application
-      # We had a bug where we were actually deleting the application instead of setting its deleted_at. Handle those gracefully.
-      # A revoked application is also a terminal state the seller chose, so it is not undeliverable-and-worth-reporting.
-      next if oauth_application.nil? || oauth_application.deleted?
-
       if ping_notification_deliverable?(resource_subscription)
         deliverable << resource_subscription
-      elsif reportable_undeliverable?(oauth_application)
+      elsif ping_notification_notice_actionable?(resource_subscription)
         undeliverable << resource_subscription
       end
     end

--- a/app/services/undeliverable_ping_subscription_notifier.rb
+++ b/app/services/undeliverable_ping_subscription_notifier.rb
@@ -25,6 +25,28 @@ class UndeliverablePingSubscriptionNotifier
   # expiring is the backstop for a render that dies before it can say the send did not happen.
   SEND_CLAIM_TTL = 10.minutes
 
+  # Settle only what this render holds. A claim expires, so the key may already carry a successor's
+  # token or the permanent record of a send that successor completed; overwriting either would let a
+  # later release discard a real send, or a later event repeat one. An absent key is settled too — an
+  # expiry nobody claimed behind is still this render's send to record.
+  SETTLE_IF_HELD = <<~LUA
+    local current = redis.call('GET', KEYS[1])
+    if current == false or current == ARGV[1] then
+      return redis.call('SET', KEYS[1], ARGV[2])
+    end
+    return nil
+  LUA
+
+  # Release only what this render holds, and never an absent key: absent means the claim expired and
+  # a DEL would be a no-op anyway, while a different value means a successor's claim or a completed
+  # send that must survive.
+  RELEASE_IF_HELD = <<~LUA
+    if redis.call('GET', KEYS[1]) == ARGV[1] then
+      return redis.call('DEL', KEYS[1])
+    end
+    return 0
+  LUA
+
   def initialize(resource_subscription)
     @resource_subscription = resource_subscription
   end
@@ -44,6 +66,11 @@ class UndeliverablePingSubscriptionNotifier
     resource_subscription.post_url.present? ? REVOKED_CREDENTIAL : MISSING_POST_URL
   end
 
+  # Written into the key once a message has actually been transmitted, in place of the claiming
+  # render's token. Distinguishable from a token on purpose: settling and releasing both have to tell
+  # "the claim I took is still here" from "someone else's claim, or a send that already happened".
+  SENT = "sent"
+
   # Send once and stop, keyed on the advice actually given. The seller cannot re-authorize an app
   # holding no live token, and there is no UI or API to delete the subscription without one, so a
   # repeat is a nag they cannot act on — which is also why the record carries no expiry.
@@ -52,41 +79,57 @@ class UndeliverablePingSubscriptionNotifier
   # time would leave the gap between deciding to send and recording it, which two overlapping renders
   # both fit through. Called AFTER delivery, because a claim that expires costs at worst a repeat while
   # a permanent record written for a message that never left costs the notice itself.
-  def self.record_sent(resource_subscription_id, reason)
-    return if reason.blank?
+  #
+  # Conditional on still holding the claim, because a claim expires: a render whose token is gone has
+  # been replaced, and rewriting the key would put a permanent record under a successor's provisional
+  # claim — which that successor then releases on a failed delivery, discarding a send that did happen.
+  # Absent is claimed too, so an expiry with nobody behind it still records the send.
+  def self.record_sent(resource_subscription_id, reason, token)
+    return if reason.blank? || token.blank?
 
-    $redis.set(RedisKey.undeliverable_ping_subscription_notified(resource_subscription_id, reason), Time.current.to_i)
+    $redis.eval(
+      SETTLE_IF_HELD,
+      keys: [RedisKey.undeliverable_ping_subscription_notified(resource_subscription_id, reason)],
+      argv: [token, SENT]
+    )
   rescue => e
     report(e)
   end
 
-  # Takes the notice, or reports that someone else holds it. This is the render's decision to send, so
-  # it has to be one write rather than a read followed by one: overlapping renders both reading an
-  # absent record would both send. The claim is provisional until `record_sent` makes it permanent —
-  # a claim is not evidence the seller was told, which is why it expires and why the send path gives
-  # it back the moment it knows nothing went out.
+  # Takes the notice and returns the token proving this render holds it, or nil when someone else does.
+  # This is the render's decision to send, so it has to be one write rather than a read followed by
+  # one: overlapping renders both reading an absent record would both send. The claim is provisional
+  # until `record_sent` makes it permanent — a claim is not evidence the seller was told, which is why
+  # it expires and why the send path gives it back the moment it knows nothing went out.
   #
   # An unusable store sends. Silence is the failure this notice exists to break, and the cost of the
   # other direction is a possible repeat.
   def self.claim_send(resource_subscription_id, reason)
-    return false if reason.blank?
+    return nil if reason.blank?
 
-    !!$redis.set(
+    token = SecureRandom.hex(16)
+    claimed = $redis.set(
       RedisKey.undeliverable_ping_subscription_notified(resource_subscription_id, reason),
-      Time.current.to_i, nx: true, ex: SEND_CLAIM_TTL.to_i
+      token, nx: true, ex: SEND_CLAIM_TTL.to_i
     )
+    claimed ? token : nil
   rescue => e
     report(e)
-    true
+    token
   end
 
-  # Only ever called on a claim this process took and did not spend. Deleting unconditionally is safe
-  # for that reason: a permanent record is written after the message is handed to the delivery method,
-  # so there is nothing to delete here that another render could still be owed.
-  def self.release_claim(resource_subscription_id, reason)
-    return if reason.blank?
+  # Gives back a claim this render took and did not spend, and only that claim. Deleting the key
+  # unconditionally would let a render whose claim has already expired delete what replaced it: a
+  # successor's live claim, or the permanent record of a send that successor completed — and then the
+  # next event claims a free key and emails the seller a second time.
+  def self.release_claim(resource_subscription_id, reason, token)
+    return if reason.blank? || token.blank?
 
-    $redis.del(RedisKey.undeliverable_ping_subscription_notified(resource_subscription_id, reason))
+    $redis.eval(
+      RELEASE_IF_HELD,
+      keys: [RedisKey.undeliverable_ping_subscription_notified(resource_subscription_id, reason)],
+      argv: [token]
+    )
   rescue => e
     report(e)
   end

--- a/app/services/undeliverable_ping_subscription_notifier.rb
+++ b/app/services/undeliverable_ping_subscription_notifier.rb
@@ -27,8 +27,9 @@ class UndeliverablePingSubscriptionNotifier
 
   # Settle only what this render holds. A claim expires, so the key may already carry a successor's
   # token or the permanent record of a send that successor completed; overwriting either would let a
-  # later release discard a real send, or a later event repeat one. An absent key is settled too — an
-  # expiry nobody claimed behind is still this render's send to record.
+  # later release discard a real send, or a later event repeat one. An absent key is settled too — our
+  # own transmission happened, so whether nobody claimed behind the expiry or a successor claimed and
+  # released, this send is still the one to record.
   SETTLE_IF_HELD = <<~LUA
     local current = redis.call('GET', KEYS[1])
     if current == false or current == ARGV[1] then

--- a/spec/mailers/contacting_creator_mailer_spec.rb
+++ b/spec/mailers/contacting_creator_mailer_spec.rb
@@ -1587,6 +1587,32 @@ describe ContactingCreatorMailer do
       expect(mail.message).to be_a ActionMailer::Base::NullMail
     end
 
+    # A disconnect in the enqueue-to-render window soft-deletes the application, which is not
+    # deliverable either — so re-asking deliverability alone still renders "re-authorize" advice for an
+    # integration the seller just removed, and spends their one notice on it. Selection excludes those
+    # subscriptions; the render has to exclude them for the same reason.
+    it "sends nothing when the application was deleted by render time" do
+      oauth_application.mark_deleted!
+      # mark_deleted! soft-deletes the subscriptions too; this isolates the application's own state,
+      # which is the half the render was not re-asking.
+      ResourceSubscription.where(id: resource_subscription.id).update_all(deleted_at: nil)
+
+      mail = ContactingCreatorMailer.undeliverable_ping_subscription(resource_subscription.id)
+
+      expect(mail.message).to be_a ActionMailer::Base::NullMail
+      expect($redis.exists?(notified_key(UndeliverablePingSubscriptionNotifier::REVOKED_CREDENTIAL))).to be false
+    end
+
+    # Same shape for the agent exclusion: those subscriptions are token-less by design and their owners
+    # have no authorization flow to re-run, so a render must not email them either.
+    it "sends nothing for a Store Agent application at render time" do
+      oauth_application.update!(name: Ai::StoreAgentApiClient::AGENT_APP_NAME)
+
+      mail = ContactingCreatorMailer.undeliverable_ping_subscription(resource_subscription.id)
+
+      expect(mail.message).to be_a ActionMailer::Base::NullMail
+    end
+
     # Rendering is not sending, which is why nothing is recorded here: the record has no expiry, and
     # one written for an email nobody received would refuse the notice the seller is owed when the
     # same reason breaks again.

--- a/spec/mailers/contacting_creator_mailer_spec.rb
+++ b/spec/mailers/contacting_creator_mailer_spec.rb
@@ -1762,8 +1762,10 @@ describe ContactingCreatorMailer do
       expect(mail.message).not_to be_a ActionMailer::Base::NullMail
     end
 
+    # Recording now goes through `eval` (the claim is compare-and-set), so stub that rather than
+    # `set`: the claim must succeed and the delivery must happen for this to reach the failing write.
     it "sends the email even when recording that it sent fails" do
-      allow($redis).to receive(:set).and_raise(Redis::BaseError)
+      allow($redis).to receive(:eval).and_raise(Redis::BaseError)
       expect(ErrorNotifier).to receive(:notify).at_least(:once)
 
       expect do

--- a/spec/services/undeliverable_ping_subscription_notifier_spec.rb
+++ b/spec/services/undeliverable_ping_subscription_notifier_spec.rb
@@ -158,9 +158,9 @@ describe UndeliverablePingSubscriptionNotifier do
     # The claim is what makes the send-once decision exclusive: two overlapping renders both reading an
     # absent record would both send, so the render takes the notice with one write.
     it "gives the notice to the first caller only" do
-      expect(described_class.claim_send(resource_subscription.id, described_class::REVOKED_CREDENTIAL)).to be true
+      expect(described_class.claim_send(resource_subscription.id, described_class::REVOKED_CREDENTIAL)).to be_present
 
-      expect(described_class.claim_send(resource_subscription.id, described_class::REVOKED_CREDENTIAL)).to be false
+      expect(described_class.claim_send(resource_subscription.id, described_class::REVOKED_CREDENTIAL)).to be_nil
     end
 
     # A claim is not evidence the seller was told. It expires so a render that dies before settling
@@ -172,24 +172,74 @@ describe UndeliverablePingSubscriptionNotifier do
     end
 
     it "keeps a recorded send forever rather than letting it expire into a repeat email" do
-      described_class.claim_send(resource_subscription.id, described_class::REVOKED_CREDENTIAL)
-      described_class.record_sent(resource_subscription.id, described_class::REVOKED_CREDENTIAL)
+      token = described_class.claim_send(resource_subscription.id, described_class::REVOKED_CREDENTIAL)
+      described_class.record_sent(resource_subscription.id, described_class::REVOKED_CREDENTIAL, token)
 
       expect($redis.ttl(key_for(described_class::REVOKED_CREDENTIAL))).to eq(-1)
     end
 
     # Releasing is what keeps a render that sent nothing from spending the notice.
     it "lets a later render take a released claim" do
-      described_class.claim_send(resource_subscription.id, described_class::REVOKED_CREDENTIAL)
-      described_class.release_claim(resource_subscription.id, described_class::REVOKED_CREDENTIAL)
+      token = described_class.claim_send(resource_subscription.id, described_class::REVOKED_CREDENTIAL)
+      described_class.release_claim(resource_subscription.id, described_class::REVOKED_CREDENTIAL, token)
 
-      expect(described_class.claim_send(resource_subscription.id, described_class::REVOKED_CREDENTIAL)).to be true
+      expect(described_class.claim_send(resource_subscription.id, described_class::REVOKED_CREDENTIAL)).to be_present
+    end
+
+    # A claim expires, so a slow render can find its claim replaced. Releasing by key alone would then
+    # delete whatever replaced it: a successor's live claim, or the record of a send that completed.
+    it "leaves a replacement claim alone when a render whose claim expired releases" do
+      expired_token = described_class.claim_send(resource_subscription.id, described_class::REVOKED_CREDENTIAL)
+      $redis.del(key_for(described_class::REVOKED_CREDENTIAL))
+      successor_token = described_class.claim_send(resource_subscription.id, described_class::REVOKED_CREDENTIAL)
+
+      described_class.release_claim(resource_subscription.id, described_class::REVOKED_CREDENTIAL, expired_token)
+
+      expect($redis.get(key_for(described_class::REVOKED_CREDENTIAL))).to eq(successor_token)
+    end
+
+    # The whole point of the send-once record: a stale renderer must not delete the evidence that the
+    # seller was emailed, because the next event would then claim a free key and email them again.
+    it "leaves a completed send in place when a render whose claim expired releases" do
+      expired_token = described_class.claim_send(resource_subscription.id, described_class::REVOKED_CREDENTIAL)
+      $redis.del(key_for(described_class::REVOKED_CREDENTIAL))
+      successor_token = described_class.claim_send(resource_subscription.id, described_class::REVOKED_CREDENTIAL)
+      described_class.record_sent(resource_subscription.id, described_class::REVOKED_CREDENTIAL, successor_token)
+
+      described_class.release_claim(resource_subscription.id, described_class::REVOKED_CREDENTIAL, expired_token)
+
+      expect($redis.get(key_for(described_class::REVOKED_CREDENTIAL))).to eq(described_class::SENT)
+      expect(described_class.claim_send(resource_subscription.id, described_class::REVOKED_CREDENTIAL)).to be_nil
+    end
+
+    # The mirror image: a stale render that DID deliver must not overwrite a successor's provisional
+    # claim with a permanent record, because the successor releases that key when its own send fails.
+    it "does not record a send over a replacement claim" do
+      expired_token = described_class.claim_send(resource_subscription.id, described_class::REVOKED_CREDENTIAL)
+      $redis.del(key_for(described_class::REVOKED_CREDENTIAL))
+      successor_token = described_class.claim_send(resource_subscription.id, described_class::REVOKED_CREDENTIAL)
+
+      described_class.record_sent(resource_subscription.id, described_class::REVOKED_CREDENTIAL, expired_token)
+
+      expect($redis.get(key_for(described_class::REVOKED_CREDENTIAL))).to eq(successor_token)
+    end
+
+    # An expiry with nobody behind it is still this render's send to record — otherwise a claim that
+    # timed out mid-delivery loses the record of an email that did go out.
+    it "records a send when the claim expired and nothing replaced it" do
+      token = described_class.claim_send(resource_subscription.id, described_class::REVOKED_CREDENTIAL)
+      $redis.del(key_for(described_class::REVOKED_CREDENTIAL))
+
+      described_class.record_sent(resource_subscription.id, described_class::REVOKED_CREDENTIAL, token)
+
+      expect($redis.get(key_for(described_class::REVOKED_CREDENTIAL))).to eq(described_class::SENT)
+      expect($redis.ttl(key_for(described_class::REVOKED_CREDENTIAL))).to eq(-1)
     end
 
     it "claims each reason separately" do
       described_class.claim_send(resource_subscription.id, described_class::REVOKED_CREDENTIAL)
 
-      expect(described_class.claim_send(resource_subscription.id, described_class::MISSING_POST_URL)).to be true
+      expect(described_class.claim_send(resource_subscription.id, described_class::MISSING_POST_URL)).to be_present
     end
 
     # Silence is what this notice exists to break, so unusable bookkeeping costs a possible repeat
@@ -198,30 +248,39 @@ describe UndeliverablePingSubscriptionNotifier do
       allow($redis).to receive(:set).and_raise(Redis::BaseError)
       expect(ErrorNotifier).to receive(:notify)
 
-      expect(described_class.claim_send(resource_subscription.id, described_class::REVOKED_CREDENTIAL)).to be true
+      expect(described_class.claim_send(resource_subscription.id, described_class::REVOKED_CREDENTIAL)).to be_present
     end
 
     it "swallows a failure to record rather than failing the delivery" do
-      allow($redis).to receive(:set).and_raise(Redis::BaseError)
+      allow($redis).to receive(:eval).and_raise(Redis::BaseError)
       expect(ErrorNotifier).to receive(:notify)
 
-      expect { described_class.record_sent(resource_subscription.id, described_class::REVOKED_CREDENTIAL) }.not_to raise_error
+      expect { described_class.record_sent(resource_subscription.id, described_class::REVOKED_CREDENTIAL, "token") }.not_to raise_error
     end
 
     it "swallows a failure to release rather than failing the delivery" do
-      allow($redis).to receive(:del).and_raise(Redis::BaseError)
+      allow($redis).to receive(:eval).and_raise(Redis::BaseError)
       expect(ErrorNotifier).to receive(:notify)
 
-      expect { described_class.release_claim(resource_subscription.id, described_class::REVOKED_CREDENTIAL) }.not_to raise_error
+      expect { described_class.release_claim(resource_subscription.id, described_class::REVOKED_CREDENTIAL, "token") }.not_to raise_error
     end
 
     it "ignores a blank reason on every side" do
       expect($redis).not_to receive(:set)
-      expect($redis).not_to receive(:del)
+      expect($redis).not_to receive(:eval)
 
-      expect(described_class.claim_send(resource_subscription.id, nil)).to be false
-      described_class.record_sent(resource_subscription.id, nil)
-      described_class.release_claim(resource_subscription.id, nil)
+      expect(described_class.claim_send(resource_subscription.id, nil)).to be_nil
+      described_class.record_sent(resource_subscription.id, nil, "token")
+      described_class.release_claim(resource_subscription.id, nil, "token")
+    end
+
+    # Without a token there is nothing to compare, so settling would be an unconditional write over
+    # whatever the key holds — exactly what the token exists to prevent.
+    it "ignores a blank token on both settle paths" do
+      expect($redis).not_to receive(:eval)
+
+      described_class.record_sent(resource_subscription.id, described_class::REVOKED_CREDENTIAL, nil)
+      described_class.release_claim(resource_subscription.id, described_class::REVOKED_CREDENTIAL, nil)
     end
   end
 end


### PR DESCRIPTION
## What

Fences the send-once claim added in #6710 to the render that holds it, and re-asks the second half of the notice rule at render time. Both bugs are **live on `main`**: #6710 was squash-merged at `92968476a` on its pre-fix head, and the two fix commits were pushed seven minutes later onto a branch that was then deleted.

These are the two commits, recovered by SHA and cherry-picked onto current `main`.

## Why these shipped

Greptile filed both as P1 at 18:21Z. The fixes landed on the branch at 18:50Z. The merge happened at 18:43Z, in between — so the merge commit predates them and `main` carries the original code.

Proof rather than assertion: the new specs run against **unmodified `main`** go **11 red**. Against this branch, 52 examples, 0 failures.

```
spec/services/undeliverable_ping_subscription_notifier_spec.rb  on main: 28 examples, 11 failures
notifier + ping_notification + worker                        on branch: 52 examples,  0 failures
mailer (undeliverable_ping_subscription group)               on branch: 25 examples,  0 failures
```

## 1. A claim's own expiry was unfenced

The claim is deliberately provisional — it carries a 10-minute TTL so a render that dies before settling costs a delayed notice rather than a permanent one. But both settle paths wrote unconditionally, and a claim that can expire means the key may no longer be yours by the time you settle it:

| Interleaving | Before | After |
|---|---|---|
| Claim expires, a second render claims + sends + records, then the first render releases | bare `DEL` **erases the permanent record of a real send**, so the next event claims a free key and emails the seller again | release no-ops; the record stands |
| Claim expires, a second render claims, then the first render records | bare `SET` writes a permanent record **under the successor's provisional claim**, which that successor then releases on a failed delivery — discarding a send that did happen | record no-ops; the successor still owns the outcome |

`claim_send` now returns a per-claim token, the mailer carries it to the `around_deliver`, and both settle paths are Lua compare-and-set on it.

The two directions are deliberately asymmetric, and the asymmetry is the safety property:

- **Settle also accepts an absent key.** Our transmission happened, so whether nobody claimed behind the expiry or a successor claimed and released, this send is the one to record. A strict token match would silently fail to record it and re-arm a duplicate.
- **Release does not accept absent.** Absent means expired — `DEL` would be a no-op anyway — and any other value is a successor's claim or a completed send that has to survive.
- A claim that could not be written at all still sends (silence is the bug this feature exists to fix), and hands back a token that matches nothing, so it cannot compare-and-set against a key we never wrote.

Generalised: **a holder whose lease can expire must prove it still holds the lease before acting on it.** Unconditional cleanup of an expirable key is the same defect as an unfenced distributed lock.

## 2. Render re-asked deliverability but not reportability

`ping_notification_targets` skips subscriptions whose OAuth application is deleted or revoked — that is a terminal state the seller chose, not a fault to report. The render re-derived `ping_notification_deliverable?` and stopped there. A deleted application **is** undeliverable, so a disconnect inside the enqueue-to-render window produced an email telling the seller to re-authorize an application they had just removed — and spent their one notice doing it.

`ping_notification_notice_actionable?` is now a public predicate that selection and the render both read, in the same order, so the two cannot drift. It is asked **before** `claim_send`, so a subscription that turned terminal in the window is never claimed.

## Tests

- Both P1 interleavings pinned directly: a stale release must leave both a replacement claim and a completed `SENT` record intact; a stale record must not overwrite a replacement claim; an expiry with nothing behind it must still record.
- Blank-token guards pinned by asserting `eval` is never called.
- Deleted-application-at-render pinned at the mailer level, asserting `NullMail` **and** that no key was written.
- Each new spec kills a specific mutation of the new code (unconditional `DEL`, unconditional `SET`, dropping the `current == false` branch, dropping the blank-token guards).

## Review

Local adversarial review returned **READY TO MERGE** with no P1 and no P2, having tried to construct a losing interleaving across expiry, successor claims, Redis errors, ambiguous timeouts, same-instance redelivery and interceptor cancellation. Its three P3s: one real (a spec named for a failed *recording* stubbed `set`, which the *claim* uses — recording goes through `eval` now, so it was a near-duplicate of the spec above it; fixed in `efca3f0`), two comment-precision nits (one fixed, one deliberate and documented).

Not arming auto-merge — this is money-adjacent seller mail and the same window has now produced seven rounds of findings, so it gets a human read.
