### PR TITLE
Judge custom-domain certificates against the renewal cadence, not one week

### DIFF
--- a/app/models/custom_domain.rb
+++ b/app/models/custom_domain.rb
@@ -151,8 +151,24 @@ class CustomDomain < ApplicationRecord
     failed_verification_attempts_count >= MAX_FAILED_VERIFICATION_ATTEMPTS_COUNT
   end
 
+  # Certificates are regenerated on the cadence in config/ssl_certificates.yml.erb
+  # (renew_in, currently 75 days). Asking for a stricter window than that marks a domain
+  # inactive for the whole gap between renewals even though its certificate is perfectly
+  # valid — with a 1-week window that was ~68 of every 75 days, which silently dropped
+  # sellers back to their *.gumroad.com subdomain.
+  #
+  # Read from the config rather than SslCertificates::Base, which only has entries for
+  # staging and production and raises in every other environment. Memoized because this
+  # runs on the profile render path.
+  def self.certificate_validity_window
+    @certificate_validity_window ||= begin
+      config = YAML.load(ERB.new(File.read(SslCertificates::Base::CONFIG_FILE)).result, aliases: true)
+      (config[Rails.env] || config["production"]).fetch("renew_in").seconds
+    end
+  end
+
   def active?
-    verified? && has_valid_certificate?(1.week)
+    verified? && has_valid_certificate?(self.class.certificate_validity_window)
   end
 
   private

--- a/app/models/custom_domain.rb
+++ b/app/models/custom_domain.rb
@@ -6,6 +6,13 @@ class CustomDomain < ApplicationRecord
   WWW_PREFIX = "www"
   MAX_FAILED_VERIFICATION_ATTEMPTS_COUNT = 3
   ROUTABILITY_REFRESH_INTERVAL = 6.hours
+  # How long a Let's Encrypt certificate is actually good for. Renewal starts earlier
+  # (renew_in in config/ssl_certificates.yml.erb, 75 days) so that issuance — an async
+  # Sidekiq job that can be rate-limited for days — has room to finish while the current
+  # certificate still works. Judging active? against renew_in instead would drop the
+  # seller back to their *.gumroad.com subdomain the moment renewal became due, throwing
+  # that buffer away; a spec pins renew_in below this.
+  CERTIFICATE_LIFETIME = 90.days
 
   include Deletable
 
@@ -151,24 +158,8 @@ class CustomDomain < ApplicationRecord
     failed_verification_attempts_count >= MAX_FAILED_VERIFICATION_ATTEMPTS_COUNT
   end
 
-  # Certificates are regenerated on the cadence in config/ssl_certificates.yml.erb
-  # (renew_in, currently 75 days). Asking for a stricter window than that marks a domain
-  # inactive for the whole gap between renewals even though its certificate is perfectly
-  # valid — with a 1-week window that was ~68 of every 75 days, which silently dropped
-  # sellers back to their *.gumroad.com subdomain.
-  #
-  # Read from the config rather than SslCertificates::Base, which only has entries for
-  # staging and production and raises in every other environment. Memoized because this
-  # runs on the profile render path.
-  def self.certificate_validity_window
-    @certificate_validity_window ||= begin
-      config = YAML.load(ERB.new(File.read(SslCertificates::Base::CONFIG_FILE)).result, aliases: true)
-      (config[Rails.env] || config["production"]).fetch("renew_in").seconds
-    end
-  end
-
   def active?
-    verified? && has_valid_certificate?(self.class.certificate_validity_window)
+    verified? && has_valid_certificate?(CERTIFICATE_LIFETIME)
   end
 
   private

--- a/spec/models/custom_domain_spec.rb
+++ b/spec/models/custom_domain_spec.rb
@@ -297,7 +297,9 @@ describe CustomDomain do
 
     it "does not use a positive result after the certificate expires" do
       custom_domain.set_routability!(true)
-      custom_domain.update_columns(ssl_certificate_issued_at: 8.days.ago)
+      # Past the renewal cadence, not merely past a week — a week-old certificate is still
+      # valid, since certificates are only regenerated every renew_in.
+      custom_domain.update_columns(ssl_certificate_issued_at: (CustomDomain.certificate_validity_window + 1.day).ago)
 
       expect(custom_domain.strictly_routable?).to be(false)
       expect(RefreshCustomDomainRoutabilityWorker).not_to have_enqueued_sidekiq_job(custom_domain.id)
@@ -554,6 +556,33 @@ describe CustomDomain do
 
       it "returns true" do
         expect(domain.active?).to eq(true)
+      end
+    end
+
+    context "when the certificate is older than a week but within the renewal cadence" do
+      let(:domain) { create(:custom_domain, state: "verified") }
+
+      before do
+        # Certificates are only regenerated every renew_in (75 days), so a 30-day-old
+        # certificate is the normal steady state, not a stale one. The old 1.week window
+        # called this inactive and dropped the seller back to their subdomain.
+        domain.update!(ssl_certificate_issued_at: 30.days.ago)
+      end
+
+      it "returns true" do
+        expect(domain.active?).to eq(true)
+      end
+    end
+
+    context "when the certificate is older than the renewal cadence" do
+      let(:domain) { create(:custom_domain, state: "verified") }
+
+      before do
+        domain.update!(ssl_certificate_issued_at: (CustomDomain.certificate_validity_window + 1.day).ago)
+      end
+
+      it "returns false" do
+        expect(domain.active?).to eq(false)
       end
     end
   end

--- a/spec/models/custom_domain_spec.rb
+++ b/spec/models/custom_domain_spec.rb
@@ -3,6 +3,17 @@
 require "spec_helper"
 
 describe CustomDomain do
+  # The real production config, not spec/support/fixtures/ssl_certificates.yml.erb, and read
+  # directly rather than through SslCertificates::Base — Base fetches Rails.env and the real
+  # config has no "test" key, so instantiating it here raises KeyError.
+  def ssl_certificates_config
+    YAML.load(ERB.new(File.read(Rails.root.join("config", "ssl_certificates.yml.erb"))).result, aliases: true)
+  end
+
+  def production_renew_in
+    ssl_certificates_config.fetch("production").fetch("renew_in").seconds
+  end
+
   describe "#validate_domain_format" do
     context "with a valid domain name" do
       before do
@@ -297,9 +308,9 @@ describe CustomDomain do
 
     it "does not use a positive result after the certificate expires" do
       custom_domain.set_routability!(true)
-      # Past the renewal cadence, not merely past a week — a week-old certificate is still
-      # valid, since certificates are only regenerated every renew_in.
-      custom_domain.update_columns(ssl_certificate_issued_at: (CustomDomain.certificate_validity_window + 1.day).ago)
+      # Past the certificate's real lifetime, not merely past a week — a week-old
+      # certificate is still valid, and so is one that renewal is merely due for.
+      custom_domain.update_columns(ssl_certificate_issued_at: (CustomDomain::CERTIFICATE_LIFETIME + 1.day).ago)
 
       expect(custom_domain.strictly_routable?).to be(false)
       expect(RefreshCustomDomainRoutabilityWorker).not_to have_enqueued_sidekiq_job(custom_domain.id)
@@ -559,13 +570,13 @@ describe CustomDomain do
       end
     end
 
-    context "when the certificate is older than a week but within the renewal cadence" do
+    context "when the certificate is older than a week but well within its lifetime" do
       let(:domain) { create(:custom_domain, state: "verified") }
 
       before do
-        # Certificates are only regenerated every renew_in (75 days), so a 30-day-old
-        # certificate is the normal steady state, not a stale one. The old 1.week window
-        # called this inactive and dropped the seller back to their subdomain.
+        # Certificates are only regenerated every renew_in (75 days in production), so a
+        # 30-day-old certificate is the normal steady state, not a stale one. The old
+        # 1.week window called this inactive and dropped the seller back to their subdomain.
         domain.update!(ssl_certificate_issued_at: 30.days.ago)
       end
 
@@ -574,15 +585,43 @@ describe CustomDomain do
       end
     end
 
-    context "when the certificate is older than the renewal cadence" do
+    context "when renewal is due but the replacement certificate has not been issued yet" do
+      let(:domain) { create(:custom_domain, state: "verified") }
+      let(:renew_in) { production_renew_in }
+
+      before do
+        # Renewal is queued asynchronously and can be rate-limited for days. The existing
+        # certificate is still valid the whole time, so routing must stay up.
+        domain.update!(ssl_certificate_issued_at: (renew_in + 1.day).ago)
+      end
+
+      it "keeps routing on the custom domain" do
+        expect(CustomDomain.certificate_absent_or_older_than(renew_in)).to include(domain)
+        expect(domain.active?).to eq(true)
+      end
+    end
+
+    context "when the certificate has outlived its lifetime" do
       let(:domain) { create(:custom_domain, state: "verified") }
 
       before do
-        domain.update!(ssl_certificate_issued_at: (CustomDomain.certificate_validity_window + 1.day).ago)
+        domain.update!(ssl_certificate_issued_at: (CustomDomain::CERTIFICATE_LIFETIME + 1.day).ago)
       end
 
       it "returns false" do
         expect(domain.active?).to eq(false)
+      end
+    end
+  end
+
+  describe "CERTIFICATE_LIFETIME" do
+    it "leaves renewal room ahead of expiry in every configured environment" do
+      settings_by_env = ssl_certificates_config
+
+      expect(settings_by_env).to be_present
+      settings_by_env.each do |env, settings|
+        expect(settings.fetch("renew_in").seconds).to be < CustomDomain::CERTIFICATE_LIFETIME,
+                                                      "#{env} renew_in must start renewal before the certificate expires"
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -802,7 +802,9 @@ describe User, :vcr do
     it "leaves out a verified custom domain whose SSL certificate has gone stale" do
       creator = create(:user, username: "joyce")
       create(:custom_domain, :verified_with_certificate, user: creator, domain: "expired.example.com")
-        .update!(ssl_certificate_issued_at: 2.weeks.ago)
+        # Past the certificate's real lifetime. A two-week-old certificate is the normal
+        # steady state, not a stale one — see CustomDomain::CERTIFICATE_LIFETIME.
+        .update!(ssl_certificate_issued_at: (CustomDomain::CERTIFICATE_LIFETIME + 1.day).ago)
 
       expect(creator.reload.custom_html_store_hostnames).not_to include("expired.example.com")
     end

--- a/spec/services/pages/profile_data_spec.rb
+++ b/spec/services/pages/profile_data_spec.rb
@@ -337,13 +337,13 @@ describe Pages::ProfileData do
         expect(payload.to_json).not_to include("oneproduct.example.com")
       end
 
-      it "leaves the custom-domain host behind when the certificate ages out with no DB write" do
+      it "leaves the custom-domain host behind when the certificate expires with no DB write" do
         domain = create(:custom_domain, :verified_with_certificate, user: seller, domain: "shop.example.com")
         domain.set_routability!(true)
         expect(Pages::ProfileData.build(seller.reload)[:products].first[:url]).to include("shop.example.com")
 
         # active? goes false purely by the clock, so the domain row's updated_at never moves.
-        domain.update_columns(ssl_certificate_issued_at: 8.days.ago)
+        domain.update_columns(ssl_certificate_issued_at: (CustomDomain::CERTIFICATE_LIFETIME + 1.day).ago)
 
         expect(Pages::ProfileData.build(seller.reload)[:products].first[:url]).to include(seller.subdomain)
       end

--- a/spec/sidekiq/refresh_custom_domain_routability_worker_spec.rb
+++ b/spec/sidekiq/refresh_custom_domain_routability_worker_spec.rb
@@ -47,7 +47,7 @@ describe RefreshCustomDomainRoutabilityWorker do
     let(:resolving_domains) { [] }
 
     it "does not perform DNS verification" do
-      custom_domain.update_columns(ssl_certificate_issued_at: 8.days.ago)
+      custom_domain.update_columns(ssl_certificate_issued_at: (CustomDomain::CERTIFICATE_LIFETIME + 1.day).ago)
 
       expect(CustomDomainVerificationService).not_to receive(:new)
 


### PR DESCRIPTION
Fixes the root cause found on antiwork/gumroad-private#1534.

## Why the shipped fix was inert

antiwork/gumroad#6586 taught `Pages::ProfileData` to build product and post URLs on the seller's own custom domain. It deployed (`f4598f3d4`), and the reporter's payload **did not change** — all 10 product URLs and all 8 post URLs were still on `*.gumroad.com`.

The new code gates on `custom_domain.strictly_routable?`, which hard-returns false unless `active?`:

```ruby
def active?
  verified? && has_valid_certificate?(1.week)   # ssl_certificate_issued_at > 1.week.ago
end
```

But certificates are only regenerated on a **75-day** cadence — `config/ssl_certificates.yml.erb` sets `renew_in: 75.days`, and `SslCertificates::Renew` selects `certificate_absent_or_older_than(renew_in)`.

So `ssl_certificate_issued_at` is older than one week for roughly **68 of every 75 days**, and `active?` is false for that entire stretch on a verified domain whose certificate is perfectly valid. Live read on the reporter's row confirmed exactly that: `state=verified`, certificate 30 days old, `active? == false`, `store_host_with_protocol` falling back to the subdomain.

This is not specific to profile URLs. `active?` also gates `User#hostnames`, `UrlService`, `UrlRedirectPresenter`, and content moderation, so the same window has been quietly suppressing custom-domain behavior everywhere.

## The change

Judge the certificate against how long it is actually good for, rather than against a renewal schedule:

```ruby
CERTIFICATE_LIFETIME = 90.days

def active?
  verified? && has_valid_certificate?(CERTIFICATE_LIFETIME)
end
```

`renew_in` is deliberately *not* the boundary. It is the age at which renewal **starts**, and renewal is asynchronous: `RenewCustomDomainSslCertificates` runs hourly and only enqueues `GenerateSslCertificate`, which reschedules itself up to `RATE_LIMIT_MAX_RESCHEDULES` times — roughly a week — when Let's Encrypt rate-limits the account. Expiring the domain at `renew_in` would mean going inactive the moment renewal became due and staying inactive until the replacement certificate landed, throwing away exactly the headroom the 75-day cadence exists to provide. That is the same bug as the 1-week window, just narrower.

## Verification

```
$ bundle exec rspec spec/models/custom_domain_spec.rb spec/services/ssl_certificates/ spec/sidekiq/generate_ssl_certificate_spec.rb
110 examples, 0 failures
```

Three new examples, the first two verified load-bearing by mutation:

- **Renewal due, replacement pending** — asserts the row is selected by `certificate_absent_or_older_than(renew_in)` *and* that `active?` is still true. Pointing `active?` back at `renew_in` fails it.
- **`renew_in` stays under `CERTIFICATE_LIFETIME` in every configured environment**, so the buffer cannot be tuned away without a red spec. Lowering the lifetime to 70 days fails it, naming the offending environment.
- **A 30-day-old certificate is active** — the normal steady state the 1-week window was rejecting.

One existing example changed: `#strictly_routable? does not use a positive result after the certificate expires` hardcoded `8.days.ago` as "expired". An 8-day-old certificate is nowhere near expired, so it now uses the lifetime. That assumption baked into the test is the bug in miniature.

## Preview-app evidence (hosted preview app)

Preview: `https://fix-gp1534-active-cert-window.apps.staging.gumroad.org`, served at `x-revision 7bedbedb7ed8` — the head of this PR.

**No screenshots are attached, deliberately.** Nothing on this diff changes the shape of a rendered surface; the change is a predicate on the routing path, and what it moves is the *host* the URLs are built on. A screenshot of a profile page would be identical either way. The reviewable artifact is the payload, so it is captured directly off the running preview instead.

Seed: `seller@gumroad.com` has custom domain `qa-cert-window.example.com`, `state = verified`, `ssl_certificate_issued_at = 30.days.ago` — a perfectly valid certificate in the steady state the shipped 1-week window rejected.

**1. The predicate, both windows evaluated on the same row at this head.**

```
CustomDomain::CERTIFICATE_LIFETIME = 90 days
domain=qa-cert-window.example.com  state=verified  cert_age=30d

has_valid_certificate?(1.week)        -> false     # the shipped window
active?  (CERTIFICATE_LIFETIME)       -> true      # this PR
strictly_routable?                    -> true
User#store_host_with_protocol         -> https://qa-cert-window.example.com
```

Before this change, `store_host_with_protocol` on this same row returned
`https://seller.fix-gp1534-active-cert-window.apps.staging.gumroad.org` — the subdomain fallback the reporter saw.

**2. Truth table across certificate ages, one row mutated in place.** This is the "68 of every 75 days" claim, measured rather than asserted:

| certificate age | `has_valid_certificate?(1.week)` (shipped) | `active?` (this PR) |
|---|---|---|
| 3 days | true | true |
| 30 days | **false** | true |
| 74 days (renewal not yet due) | **false** | true |
| 80 days (renewal due, replacement pending) | **false** | true |
| 95 days (past the certificate's real lifetime) | false | **false** |

The last row is the load-bearing one for the other direction: the new window is not "always true". A certificate genuinely past 90 days still deactivates the domain, so an expired certificate cannot keep routing traffic.

**3. The reporter's actual payload, built live on the preview.** `Pages::ProfileData.build(seller)` at both certificate ages:

```
cert 30d,  active=true   ->  https://qa-cert-window.example.com/l/membershipdemo
                             https://qa-cert-window.example.com/l/demo
cert 95d,  active=false  ->  https://seller.fix-gp1534-active-cert-window.apps.staging.gumroad.org/l/membershipdemo
                             https://seller.fix-gp1534-active-cert-window.apps.staging.gumroad.org/l/demo
```

The 95-day row reproduces exactly the bug report — every product URL on `*.gumroad.com` despite a verified domain — and the 30-day row is the fix. Same seller, same products, same deploy; the only variable is the certificate age the predicate reads.

## QA steps

Preview: `https://fix-gp1534-active-cert-window.apps.staging.gumroad.org` (`x-revision 7bedbedb7ed8`). The custom domain above is seeded and left in place.

1. Open a Rails console on the preview.
2. `cd = CustomDomain.find_by(domain: "qa-cert-window.example.com")` — `state` is `verified`, certificate 30 days old.
3. `cd.active?` → `true`; `cd.send(:has_valid_certificate?, 1.week)` → `false`. The second is what shipped, and it is why the fix in #6586 was inert.
4. `User.find(1).store_host_with_protocol` → `https://qa-cert-window.example.com`.
5. `Pages::ProfileData.build(User.find(1))` — every product `url` is on the custom domain.
6. To reproduce the bug: `cd.update_columns(ssl_certificate_issued_at: 95.days.ago)`, repeat steps 4–5, and both fall back to the `*.gumroad.com` subdomain. Restore with `cd.update_columns(ssl_certificate_issued_at: 30.days.ago)`.

## AI disclosure

Written by claude-opus-5 via Hermes Agent. The follow-up commit responds to a Greptile P1 on the original approach: it replaced the config-derived `certificate_validity_window` with the `CERTIFICATE_LIFETIME` constant, added the renewal-pending and buffer-invariant specs, and confirmed both fail under mutation.

