### PR TITLE
Pin the payout schedule specs' clock so they do not depend on the weekday

### DIFF
--- a/spec/business/payments/payouts/payouts_spec.rb
+++ b/spec/business/payments/payouts/payouts_spec.rb
@@ -832,6 +832,13 @@ describe Payouts do
     end
 
     describe "payout schedule" do
+      # These examples need a payout_date whose cycle has already been spent, which only holds
+      # when payout_date falls midweek: the cycle is anchored on the platform's Friday, so a
+      # payout_date of Fri-Mon still advances to the very next Friday and lands exactly on
+      # payout_date + PAYOUT_DELAY_DAYS rather than past it. Pin the clock so the scenario does
+      # not depend on the day the suite happens to run.
+      before { travel_to Date.new(2026, 8, 6).in_time_zone("UTC").change(hour: 12) }
+
       let(:seller) { create(:compliant_user, payment_address: "seller@example.com") }
       let(:payout_date) { Date.today - 1 }
 

--- a/spec/business/payments/payouts/payouts_spec.rb
+++ b/spec/business/payments/payouts/payouts_spec.rb
@@ -832,12 +832,10 @@ describe Payouts do
     end
 
     describe "payout schedule" do
-      # These examples need a payout_date whose cycle has already been spent, which only holds
-      # when payout_date falls midweek: the cycle is anchored on the platform's Friday, so a
-      # payout_date of Fri-Mon still advances to the very next Friday and lands exactly on
-      # payout_date + PAYOUT_DELAY_DAYS rather than past it. Pin the clock so the scenario does
-      # not depend on the day the suite happens to run.
-      before { travel_to Date.new(2026, 8, 6).in_time_zone("UTC").change(hour: 12) }
+      # These examples need next_payout_cycle_date past payout_date + PAYOUT_DELAY_DAYS. With the
+      # balance below dated payout_date - 3, that only holds when today is Wed-Fri: the balance is
+      # then too new for the coming Friday's period, so the cycle advances a week.
+      before { travel_to Time.local(2026, 8, 6, 12) } # Thursday
 
       let(:seller) { create(:compliant_user, payment_address: "seller@example.com") }
       let(:payout_date) { Date.today - 1 }


### PR DESCRIPTION
Main went red overnight on `Test Fast 15` with three failures in `spec/business/payments/payouts/payouts_spec.rb`, all of the shape:

```
expected: ([], "2026-07-31")
     got: ([1355], "2026-07-31")
```

Nothing was merged that touches payouts. The specs broke because the run crossed midnight UTC into Saturday.

## What actually makes them weekday-dependent

The three `payout schedule` examples need `next_payout_cycle_date` to sit strictly past `payout_date + PAYOUT_DELAY_DAYS`, so that the cycle gate in `Payouts.create_payments_for_balances_up_to_date_for_users` has something to reject. That state is not produced by the payment row the examples create — it comes from the balance being dated `payout_date - 3`. On Wed–Fri that balance is too new for the coming Friday's period, so the low-balance advance in `User::PayoutSchedule#next_payout_cycle_date` pushes the cycle out a week. On Sat–Tue it does not, the cycle stays on the coming Friday, and the precondition is unconstructible.

So this pins the clock to a Thursday. Test-only change, no production code touched.

## Verification

All runs on this branch, `TZ=UTC` (the box is EDT, so the flake does not reproduce without it — under local time `Date.today` was still Friday and the group passed):

**Reproduces the CI failure.** Pin removed, `TZ=UTC` (Sat 2026-08-01): 3 examples, 3 failures, including the identical `expected: ([], "2026-07-31") / got: ([1008392069], "2026-07-31")`. Pin restored: 3 examples, 0 failures.

**The mechanism is the balance date, not the payment row.** With the pin in place but the balance aged from `payout_date - 3` to `payout_date - 10`, all three fail again — confirming the coupling the comment now names.

**Coverage is preserved (mutation checks, pin in place).** Breaking the production code these specs cover turns them red:

| Mutation in `app/business/payments/payouts/payouts.rb` | Result |
|---|---|
| `retrying ||` → `false ||` (kill the requeue bypass) | 1 failure — retry spec red |
| cycle gate → `true` (never skip) | 2 failures — skip spec red |

**No product bug is being hidden.** The only production requeue path (`RequeueTransientlyFailedPayoutsJob`) passes `retrying: true`, which short-circuits the cycle gate entirely, so a genuine requeue cannot be skipped by it on any weekday. The Saturday shape — a payment created today whose `payout_period_end_date` is yesterday — does not occur in production.

`rubocop` clean. Branch CI was green on the previous head (run 30674807182); re-running on the current one.

Merging under the 2026-07-30 spec-flakiness auto-merge grant: test-only diff, mechanism demonstrated and reproduced, coverage proven by mutation.
