### PR TITLE
Stop the payout schedule specs from inverting every Saturday

### DIFF
--- a/spec/business/payments/payouts/payouts_spec.rb
+++ b/spec/business/payments/payouts/payouts_spec.rb
@@ -835,13 +835,26 @@ describe Payouts do
       let(:seller) { create(:compliant_user, payment_address: "seller@example.com") }
       let(:payout_date) { Date.today - 1 }
 
+      # Pinned to a Wednesday, because `Date.today - 1` is only a *past* payout period on six
+      # days out of seven. The gate in .create_payments_for_balances_up_to_date_for_users
+      # compares `date + PAYOUT_DELAY_DAYS` against the seller's cycle, and cycles are Fridays:
+      # run this on a Saturday and `payout_date` IS the Friday just gone, so the balance
+      # created 3 days earlier falls inside that cycle's period (cycle - PAYOUT_DELAY_DAYS)
+      # instead of before it. The cycle then stops advancing for being under the minimum, and
+      # `date + PAYOUT_DELAY_DAYS` lands exactly ON it — `>=` accepts, and all three examples
+      # here invert. On any other weekday the balance sits outside the period, the cycle
+      # advances a week, and the gate rejects as these examples assume.
       before do
+        travel_to(Time.utc(2026, 8, 5, 12))
         create(:balance, user: seller, date: payout_date - 3, amount_cents: 1000_00)
         create(:user_compliance_info, user: seller)
       end
 
-      it "does not create payments if next_payout_date does not match payout date" do
-        allow(seller).to receive(:next_payout_date).and_return(payout_date + 1.week)
+      it "does not create payments if the seller's payout cycle is past this payout date" do
+        # #next_payout_cycle_date, not #next_payout_date: the cycle is what the gate in
+        # .create_payments_for_balances_up_to_date_for_users actually reads, so stubbing the
+        # seller's own rail day left this example asserting nothing about the branch it names.
+        allow(seller).to receive(:next_payout_cycle_date).and_return(payout_date + 2.weeks)
 
         expect do
           described_class.create_payments_for_balances_up_to_date_for_users(payout_date, PayoutProcessorType::PAYPAL, [seller])


### PR DESCRIPTION
## Problem

Every open PR in this repo went red shortly after 00:00 UTC today (Saturday 2026-08-01) on `Test Fast`, with three failures in `spec/business/payments/payouts/payouts_spec.rb`. `main` itself was green at 23:42Z — nothing was merged in between. The trigger was the calendar rolling over to Saturday.

## Cause

The `payout schedule` block uses:

```ruby
let(:payout_date) { Date.today - 1 }
create(:balance, user: seller, date: payout_date - 3, amount_cents: 1000_00)
```

which the examples read as "a payout period already in the past". Payout **cycles** are Fridays. On a Saturday, `Date.today - 1` *is* the Friday just gone, so:

- the balance (`payout_date - 3`) falls **inside** that cycle's period (`cycle - PAYOUT_DELAY_DAYS`) instead of before it;
- `payout_amount_for_cycle` is therefore over the minimum, so `#next_payout_cycle_date` stops advancing and returns that same Friday;
- the gate in `Payouts.create_payments_for_balances_up_to_date_for_users` compares `date + PAYOUT_DELAY_DAYS >= user.next_payout_cycle_date` — which lands **exactly on** it, and `>=` accepts.

So the seller is paid when the examples assume they are skipped, and all three invert. On the other six weekdays the balance sits outside the period, the cycle advances a week, and the gate rejects. The two requeue examples landed 2026-07-30 (#6620) and 2026-07-31 (#6526), so this is their first Saturday.

## Fix

Pin the block to a Wednesday with `travel_to`. `spec_helper.rb` already calls `travel_back` after every example, so nothing leaks.

Second, smaller correction in the same block: the first example stubbed `#next_payout_date`, but the gate reads `#next_payout_cycle_date`. The stub never influenced the branch the example claims to cover — it passed because of the unstubbed cycle value. Switched to stubbing the cycle, and renamed the example to say what it actually pins.

## Test results

Verified by simulating `get_initial_payout_date` / `advance_payout_date` / `payout_amount_for_cycle` and the gate against both dates:

| | today | `payout_date` | balance in period? | cycle | gate |
|---|---|---|---|---|---|
| broken | Sat 2026-08-01 | Fri 07-31 | **yes** | 2026-07-31 | `08-07 >= 07-31` → **accepts** ❌ |
| pinned | Wed 2026-08-05 | Tue 08-04 | no | 2026-08-14 | `08-11 >= 08-14` → rejects ✅ |

Full suite runs in CI on this PR. Note this branch's own CI is the honest check — I could not run RSpec locally (the Gemfile pins a Ruby this host does not have).

## Scope

Spec-only. No production code changes — the payout gate behaviour is not being altered, only the date the examples run on.

## Impact

This unblocks every open PR in the repo; each will need a rerun once this lands.

---

🤖 Written by gumclaw (Claude Opus 5). Diagnosed from the CI logs of #6754/#6718/#6755 during the PR momentum sweep.