### PR TITLE
Pin the payout-schedule specs off the Friday cycle boundary

### DIFF
--- a/spec/business/payments/payouts/payouts_spec.rb
+++ b/spec/business/payments/payouts/payouts_spec.rb
@@ -835,7 +835,10 @@ describe Payouts do
       let(:seller) { create(:compliant_user, payment_address: "seller@example.com") }
       let(:payout_date) { Date.today - 1 }
 
+      # The cycle is Friday-anchored, so on a Saturday `Date.today - 1` IS the current
+      # payout date and "the cycle has moved past it" stops being true. Pin a Wednesday.
       before do
+        travel_to Time.utc(2026, 7, 29, 12, 0, 0)
         create(:balance, user: seller, date: payout_date - 3, amount_cents: 1000_00)
         create(:user_compliance_info, user: seller)
       end


### PR DESCRIPTION
Three examples in `spec/business/payments/payouts/payouts_spec.rb` fail on `main` for the whole of every Saturday (UTC). They are red right now, on every open PR whose shards run after 00:00 UTC.

## What happens

The `payout schedule` block derives its date from the wall clock:

```ruby
let(:payout_date) { Date.today - 1 }
```

The payout cycle is Friday-anchored — `User::PayoutSchedule.next_scheduled_payout_date` returns today if today is a Friday, otherwise the next Friday. So on a **Saturday**, `Date.today - 1` *is* the current Friday payout date, and "the cycle has moved past this payout date" — the premise all three examples assert — stops being true. The specs are correct Sunday through Friday and wrong on Saturday.

This is a calendar bug, not a flake: it fails deterministically for a 24-hour window each week, then passes for six days.

```
1) …does not create payments if next_payout_date does not match payout date
2) …creates payments when retrying even though the cycle has moved past this payout date
   expected: < Fri, 07 Aug 2026
        got:   Fri, 07 Aug 2026
3) …skips the seller when not retrying and the cycle has moved past this payout date
   #<PaypalPayoutProcessor (class)> received :enqueue_payments with unexpected arguments
     expected: ([], "2026-07-31")
          got: ([668], "2026-07-31")
```

Failure 2 is the clearest tell — the assertion wants the cycle date strictly greater, and gets exactly equal.

## The fix

One `travel_to` pinning the block to a Wednesday, so `payout_date` lands on a Tuesday and the cycle genuinely has moved past it. No production code changes, and no change to what the three examples actually verify.

Anchoring to a fixed weekday rather than an offset from the wall clock is what makes it durable; the offset is exactly what rots.

## Measured

Clean `main` (`6608e2a24`) in its own worktree with a private test DB and Redis index, forcing CI's timezone with `TZ=UTC` (my box is EDT, where it is still Friday and everything passes — that timezone gap is why this reached `main`):

| | before | after |
|---|---|---|
| `-e "payout schedule"` | **3 examples, 3 failures** | **3 examples, 0 failures** |
| whole file | **87 examples, 3 failures** | **87 examples, 0 failures** |

The whole-file run is what rules out `travel_to` leaking into the other 84 examples.

## How it surfaced

`Test Fast 4` went red on antiwork/gumroad#6721, a PR touching only `app/models/link.rb` and two test files. The failing spec is absent from that diff, and the same job had passed on that PR's previous head 30 minutes earlier with an identical code diff — the only delta between the two commits was `qa-media/` files. The clock had crossed midnight UTC in between.

## AI disclosure

Written by `claude-opus-5` (Anthropic) via Hermes Agent, working on antiwork/gumroad#6721. The agent noticed the red shard named a file outside its own diff, checked the job start times against the run that had passed, reproduced the failure on unmodified `main` under `TZ=UTC`, traced the cause to the Friday anchor in `User::PayoutSchedule`, and verified the fix moved the file from 3 failures to 0 both scoped and whole-file.
