### PR TITLE
Make the payout-schedule block's third example assert its own premise

### DIFF
--- a/spec/business/payments/payouts/payouts_spec.rb
+++ b/spec/business/payments/payouts/payouts_spec.rb
@@ -835,7 +835,10 @@ describe Payouts do
       let(:seller) { create(:compliant_user, payment_address: "seller@example.com") }
       let(:payout_date) { Date.today - 1 }
 
+      # The cycle is Friday-anchored, so on a Saturday `Date.today - 1` IS the current
+      # payout date and "the cycle has moved past it" stops being true. Pin a Wednesday.
       before do
+        travel_to Time.utc(2026, 7, 29, 12, 0, 0)
         create(:balance, user: seller, date: payout_date - 3, amount_cents: 1000_00)
         create(:user_compliance_info, user: seller)
       end

--- a/spec/business/payments/payouts/payouts_spec.rb
+++ b/spec/business/payments/payouts/payouts_spec.rb
@@ -835,8 +835,9 @@ describe Payouts do
       let(:seller) { create(:compliant_user, payment_address: "seller@example.com") }
       let(:payout_date) { Date.today - 1 }
 
-      # The cycle is Friday-anchored, so on a Saturday `Date.today - 1` IS the current
-      # payout date and "the cycle has moved past it" stops being true. Pin a Wednesday.
+      # The premise "the cycle has moved past payout_date" only holds Wed-Fri: earlier in the
+      # week the next-Friday cycle still covers the balance dated payout_date - 3, so the gate
+      # pays instead of skipping. Pin a Wednesday.
       before do
         travel_to Time.utc(2026, 7, 29, 12, 0, 0)
         create(:balance, user: seller, date: payout_date - 3, amount_cents: 1000_00)
@@ -866,6 +867,7 @@ describe Payouts do
       it "skips the seller when not retrying and the cycle has moved past this payout date" do
         create(:payment, user: seller, payout_period_end_date: payout_date, state: "processing")
                 .mark_failed!(Payment::FailureReason::PROCESSOR_RATE_LIMITED)
+        expect(payout_date + User::PayoutSchedule::PAYOUT_DELAY_DAYS).to be < seller.reload.next_payout_cycle_date
 
         expect(PaypalPayoutProcessor).to receive(:enqueue_payments).with([], payout_date.to_s)
 


### PR DESCRIPTION
## What

One line, on top of `main`: the third example in the `payout schedule` block now asserts its own premise, as the second already does.

```ruby
expect(payout_date + User::PayoutSchedule::PAYOUT_DELAY_DAYS).to be < seller.reload.next_payout_cycle_date
```

Spec-only. No production code is touched.

**This PR has shrunk twice.** It originally also corrected the block comment, but #6757 landed the `travel_to` pin and #6761 landed the comment correction, so both are on `main` already and the comment half is now dropped in favour of main's wording — which is shorter and, as measured below, correct. What survives is the assertion, which nothing else has shipped.

## Why

All three examples in the block depend on one premise: the payout **cycle has moved past** `payout_date`. That premise is weekday-dependent, which is what made the block redden CI as a function of which weekday the shard ran on.

Examples one and two state the premise (one stubs the cycle outright, two asserts it). The third states nothing, so on the days where the premise is false it fails at the *mock* rather than at the thing that is actually wrong. Measured, pinned to Saturday 2026-08-01:

**Without the assertion (main as merged):**
```
Failure/Error: payout_processor.enqueue_payments(user_ids_to_pay, date_string)
  #<PaypalPayoutProcessor (class)> received :enqueue_payments with unexpected arguments
    expected: ([], "2026-07-31")
         got: ([2591], "2026-07-31")
```

**With it:**
```
Failure/Error: expect(payout_date + User::PayoutSchedule::PAYOUT_DELAY_DAYS).to be < seller.reload.next_payout_cycle_date
  Expected #<Date 2026-08-07> to be < #<Date 2026-08-07>.
```

The first message sends a maintainer into `PaypalPayoutProcessor` looking for a seller-selection bug. The second names the calendar premise and prints the two dates that collided. Same failing set either way — this buys diagnosis, not coverage, and it makes the pin non-revertible: delete `travel_to` and the block says why it broke.

## Verification

Real captured output, run at this branch's tree on Ruby 3.4.3, private test DB (`gumroad_test_pspec`, `MerchantAccount.count == 3`) and private Redis index, `TZ=UTC`.

**Weekday walk** — the block pinned to each of seven consecutive days, nothing else changed:

| pinned day | result |
|---|---|
| Sat 2026-08-01 | 3 examples, 2 failures |
| Sun 2026-08-02 | 3 examples, 2 failures |
| Mon 2026-08-03 | 3 examples, 2 failures |
| Tue 2026-08-04 | 3 examples, 2 failures |
| Wed 2026-08-05 | 3 examples, 0 failures |
| Thu 2026-08-06 | 3 examples, 0 failures |
| Fri 2026-08-07 | 3 examples, 0 failures |

Wed–Fri is the safe band, matching what main's comment now says.

**Mechanism check** — a throwaway probe printed the schedule internals for the block's own setup across the same seven days, which confirms main's comment names the right branch:

```
Sat 08-01  delayed=2026-08-07  cycle=2026-08-07  amount=100000  min=10000  clears_min=true   final=2026-08-07  premise=false
Wed 08-05  delayed=2026-08-11  cycle=2026-08-07  amount=0       min=10000  clears_min=false  final=2026-08-14  premise=true
```

Sat–Tue the balance dated `payout_date - 3` is inside the coming Friday's period, so `payout_amount_for_cycle` clears the minimum, `#next_payout_cycle_date` does **not** advance, and the gate pays. Wed–Fri the balance is outside the period, the amount is 0, the cycle advances a week, and the gate skips. Probe deleted afterwards.

**Mutation kills** — each mutant reverted individually, pinned Wednesday:

| mutation | result |
|---|---|
| *(baseline, unmutated)* | 3 examples, 0 failures |
| under-minimum advance deleted from `#next_payout_cycle_date` | **3 examples, 2 failures** |
| already-paid-today payment-row branch deleted | 3 examples, 0 failures |
| balance aged from `payout_date - 3` to `payout_date - 10` | **3 examples, 2 failures** |

The under-minimum advance and the balance's recency are load-bearing; the payment-row branch never fires here, because it needs `cycle == Date.today` and the cycle is already a week out. Both facts are what main's comments now say.

**Suite and lint** — whole file `87 examples, 0 failures`; `rubocop` on the file clean.

## QA steps

None beyond CI — one line in one spec file, no production behaviour. To see the assertion do its job, repin `travel_to` to any of Sat–Tue and read the failure message.

## AI disclosure

Written by Gumclaw (claude-opus-5). All numbers above are real captured output, not predicted.
