### PR TITLE
Correct the payout-spec failure window to the measured four days

### DIFF
--- a/spec/business/payments/payouts/payouts_spec.rb
+++ b/spec/business/payments/payouts/payouts_spec.rb
@@ -835,15 +835,15 @@ describe Payouts do
       let(:seller) { create(:compliant_user, payment_address: "seller@example.com") }
       let(:payout_date) { Date.today - 1 }
 
-      # Pinned to a Wednesday, because `Date.today - 1` is only a *past* payout period on six
-      # days out of seven. The gate in .create_payments_for_balances_up_to_date_for_users
+      # Pinned to a Wednesday, because `Date.today - 1` is only a *past* payout period on
+      # Wednesday through Friday. The gate in .create_payments_for_balances_up_to_date_for_users
       # compares `date + PAYOUT_DELAY_DAYS` against the seller's cycle, and cycles are Fridays:
-      # run this on a Saturday and `payout_date` IS the Friday just gone, so the balance
-      # created 3 days earlier falls inside that cycle's period (cycle - PAYOUT_DELAY_DAYS)
-      # instead of before it. The cycle then stops advancing for being under the minimum, and
-      # `date + PAYOUT_DELAY_DAYS` lands exactly ON it — `>=` accepts, and all three examples
-      # here invert. On any other weekday the balance sits outside the period, the cycle
-      # advances a week, and the gate rejects as these examples assume.
+      # from Saturday through Tuesday `payout_date` has not fallen behind the cycle yet, so the
+      # balance created 3 days earlier falls inside that cycle's period
+      # (cycle - PAYOUT_DELAY_DAYS) instead of before it. The cycle then stops advancing for
+      # being under the minimum, `date + PAYOUT_DELAY_DAYS` lands on or before it, `>=` accepts,
+      # and these examples invert. Measured: Sat/Sun/Mon/Tue all fail, Wednesday is the first
+      # clean day.
       before do
         travel_to(Time.utc(2026, 8, 5, 12))
         create(:balance, user: seller, date: payout_date - 3, amount_cents: 1000_00)


### PR DESCRIPTION
Follow-up to #6757. Comment-only; no behaviour change.

#6757 correctly pinned the `payout schedule` group to a Wednesday, but its comment says the premise holds "six days out of seven". Measured against the merged code, it holds on **three** days out of seven — the group inverts from Saturday through Tuesday.

I swept every weekday by moving the `travel_to` anchor and re-running the group, against `main` at `2946e5387`, `TZ=UTC`, private test DB and Redis index:

| anchor | weekday | result |
|---|---|---|
| 2026-08-01 | Sat | 3 examples, **2 failures** |
| 2026-08-02 | Sun | 3 examples, **2 failures** |
| 2026-08-03 | Mon | 3 examples, **2 failures** |
| 2026-08-04 | Tue | 3 examples, **2 failures** |
| 2026-08-05 | Wed | 3 examples, 0 failures |

The cycle is Friday-anchored, so `Date.today - 1` has not fallen behind the cycle until Wednesday. Saturday is the equality case the original comment describes, but Sun/Mon/Tue fail too on strict inequality. The pinned Wednesday is correct and unchanged — only the explanation of *why* was too narrow.

Worth correcting because the comment is the thing that orients whoever touches this next: "Saturday" sends them looking for a weekend-only cause, when CI would in fact have stayed red into the working week.

Verified after the edit: `87 examples, 0 failures` on the whole file under `TZ=UTC`.

## AI disclosure

Written by `claude-opus-5` (Anthropic) via Hermes Agent. The narrower window originated in my own earlier PR #6758 (closed in favour of #6757, which was a superset — it also fixed an inert stub). An adversarial review of that PR argued the window was wider than one day; I executed the weekday sweep to check rather than accepting the derivation, found the reviewer right, and am correcting the merged comment to match measurement.
