### PR TITLE
Correct what the payout schedule pin's comments say the mechanism is

### DIFF
--- a/spec/business/payments/payouts/payouts_spec.rb
+++ b/spec/business/payments/payouts/payouts_spec.rb
@@ -835,15 +835,10 @@ describe Payouts do
       let(:seller) { create(:compliant_user, payment_address: "seller@example.com") }
       let(:payout_date) { Date.today - 1 }
 
-      # Pinned to a Wednesday, because `Date.today - 1` is only a *past* payout period on six
-      # days out of seven. The gate in .create_payments_for_balances_up_to_date_for_users
-      # compares `date + PAYOUT_DELAY_DAYS` against the seller's cycle, and cycles are Fridays:
-      # run this on a Saturday and `payout_date` IS the Friday just gone, so the balance
-      # created 3 days earlier falls inside that cycle's period (cycle - PAYOUT_DELAY_DAYS)
-      # instead of before it. The cycle then stops advancing for being under the minimum, and
-      # `date + PAYOUT_DELAY_DAYS` lands exactly ON it — `>=` accepts, and all three examples
-      # here invert. On any other weekday the balance sits outside the period, the cycle
-      # advances a week, and the gate rejects as these examples assume.
+      # Pinned because these examples only hold Wed-Fri. From Saturday through Tuesday the
+      # balance below lands inside the upcoming Friday cycle's period, so it clears the minimum,
+      # the cycle stays put, and the gate in .create_payments_for_balances_up_to_date_for_users
+      # accepts where these examples expect a reject.
       before do
         travel_to(Time.utc(2026, 8, 5, 12))
         create(:balance, user: seller, date: payout_date - 3, amount_cents: 1000_00)
@@ -851,9 +846,7 @@ describe Payouts do
       end
 
       it "does not create payments if the seller's payout cycle is past this payout date" do
-        # #next_payout_cycle_date, not #next_payout_date: the cycle is what the gate in
-        # .create_payments_for_balances_up_to_date_for_users actually reads, so stubbing the
-        # seller's own rail day left this example asserting nothing about the branch it names.
+        # The gate reads #next_payout_cycle_date, not the seller's own rail day.
         allow(seller).to receive(:next_payout_cycle_date).and_return(payout_date + 2.weeks)
 
         expect do
@@ -862,8 +855,9 @@ describe Payouts do
       end
 
       it "creates payments when retrying even though the cycle has moved past this payout date" do
-        # The real requeue shape: a payment row already exists for today, which advances
-        # #next_payout_cycle_date whether or not that payment succeeded.
+        # The real requeue shape: a payment row already exists for the period, failed or not.
+        # What puts the cycle past this payout date here is the balance being too new for the
+        # coming Friday's period, not this row — the row's own advance needs cycle == today.
         create(:payment, user: seller, payout_period_end_date: payout_date, state: "processing")
                 .mark_failed!(Payment::FailureReason::PROCESSOR_RATE_LIMITED)
         expect(payout_date + User::PayoutSchedule::PAYOUT_DELAY_DAYS).to be < seller.reload.next_payout_cycle_date


### PR DESCRIPTION
#6757 fixed the weekend flake correctly, but the comments it left behind describe a mechanism that is not the one at work. Three corrections, each settled by running the specs rather than by arithmetic.

**The group inverts Saturday through Tuesday, not only on Saturday.** Pinning the block to each day of one week, everything else unchanged:

| pinned day | result |
|---|---|
| Sat 2026-08-01 | 3 examples, 2 failures |
| Sun 2026-08-02 | 3 examples, 2 failures |
| Mon 2026-08-03 | 3 examples, 2 failures |
| Tue 2026-08-04 | 3 examples, 2 failures |
| Wed 2026-08-05 | 0 failures |
| Thu 2026-08-06 | 0 failures |
| Fri 2026-08-07 | 0 failures |

The safe band is Wed–Fri. The old comment's "six days out of seven" would send the next person looking for a Saturday-only edge case.

**The cycle stays put because the amount clears the minimum, not because it falls under it.** The old comment said "the cycle then stops advancing for being under the minimum" — backwards. Deleting the under-minimum advance in `User::PayoutSchedule#next_payout_cycle_date` turns the pinned group red (2 failures), which is what identifies it as the branch doing the work.

**The payment row is not what advances the cycle.** The retry example's comment claimed it was. Deleting that branch entirely (`payout_cycle_date == Date.today && payments.where(...)`) leaves the group green — it never fires here, because the cycle is already a week out and the branch needs `cycle == Date.today`. What actually puts the cycle past the payout date is the balance being dated `payout_date - 3`, too new for the coming Friday's period. Aging it to `payout_date - 10` breaks the group even pinned to Wednesday.

Also trimmed the group comment from nine lines to four and the stub comment from three to one, per the repo's comment guidance.

No behaviour change: comments and nothing else. Group green under `TZ=UTC` on a real Saturday, `rubocop` clean.
