### PR TITLE
Let the deploy step outlive its own healthcheck waits

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -55,7 +55,14 @@ steps:
       - require-approval
     branches: "main"
     command: ".buildkite/scripts/deploy_production.sh"
-    timeout_in_minutes: 120
+    # Must exceed the script's OWN waits plus a deploy, or the script can never reach its
+    # own decision. deploy_production.sh waits up to 45 min on the payout healthcheck and
+    # up to 120 min on the long-running-job one before it gives up and skips; a deploy then
+    # takes ~23 min more. At 120 the long-running wait alone consumed the whole step, so a
+    # deploy that waited it out was killed as `timed_out` (exit 255) instead of exiting 0 on
+    # the skip path — turning a designed "let the report finish, ship on the next push" into
+    # a red main. 240 leaves ~50 min of headroom over the 190-min worst case.
+    timeout_in_minutes: 240
     # Serialize production deploys. A deploy holds a Consul lock for its whole run
     # (median 23 minutes), and deploy_production.sh exits 1 immediately if the lock is
     # already held. Without this, two commits merged inside one deploy window race: the

--- a/spec/buildkite/production_deploy_timeout_spec.rb
+++ b/spec/buildkite/production_deploy_timeout_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "yaml"
+
+# The deploy step's timeout and the waits inside deploy_production.sh are two numbers in two
+# files that have to agree. On 2026-08-01 they did not: the long-running-job wait alone was
+# budgeted the entire step timeout, so build #18755 sat through all 40 attempts and was killed
+# 5 seconds before the script would have exited 0 on its own skip path. The step is designed to
+# give up gracefully; it can only do that if it is allowed to outlive its own waiting.
+RSpec.describe "Production deploy step timeout" do
+  PIPELINE = Rails.root.join(".buildkite/pipeline.yml")
+  DEPLOY_SCRIPT = Rails.root.join(".buildkite/scripts/deploy_production.sh")
+
+  # median deploy runtime, per the concurrency_group comment on the same step
+  DEPLOY_RUNTIME_MINUTES = 23
+
+  let(:step) do
+    YAML.safe_load_file(PIPELINE).fetch("steps")
+      .find { _1.is_a?(Hash) && _1["key"] == "production-deployment" }
+  end
+
+  # Each wait_for_healthcheck call polls every 3 minutes, so its budget is attempts * 3.
+  let(:wait_budget_minutes) do
+    DEPLOY_SCRIPT.read.scan(/wait_for_healthcheck\s+"[^"]+"\s+\S+\s+(\d+)\s+\w+/)
+      .sum { |(attempts)| attempts.to_i * 3 }
+  end
+
+  it "parses the deploy step out of the pipeline" do
+    expect(step).to be_present
+    expect(step["command"]).to eq(".buildkite/scripts/deploy_production.sh")
+  end
+
+  it "finds every healthcheck wait in the deploy script" do
+    # 15 attempts (payouts) + 40 attempts (long-running jobs), 3 minutes apart
+    expect(wait_budget_minutes).to eq(165)
+  end
+
+  it "allows the script to finish waiting AND still deploy" do
+    expect(step["timeout_in_minutes"]).to be > wait_budget_minutes + DEPLOY_RUNTIME_MINUTES
+  end
+
+  it "would have rejected the timeout that killed build #18755" do
+    # The regression itself: 120 was less than the 165 minutes of waiting the script can do,
+    # so the skip path was unreachable and a waited-out deploy always died red.
+    expect(120).to be < wait_budget_minutes
+  end
+end

--- a/spec/buildkite/production_deploy_timeout_spec.rb
+++ b/spec/buildkite/production_deploy_timeout_spec.rb
@@ -20,15 +20,28 @@ RSpec.describe "Production deploy step timeout" do
       .find { _1.is_a?(Hash) && _1["key"] == "production-deployment" }
   end
 
-  # Each wait_for_healthcheck call polls every 3 minutes, so its budget is attempts * 3.
+  # Read the polling interval out of the script rather than restating it: hard-coding 3 minutes
+  # here would let someone widen `sleep` in wait_for_healthcheck and leave this spec green while
+  # the real wait budget silently outgrew the step timeout again — the exact drift this file exists
+  # to catch, one level up.
+  let(:poll_interval_minutes) do
+    sleeps = DEPLOY_SCRIPT.read[/wait_for_healthcheck\(\).*?\n}/m].to_s.scan(/^\s*sleep\s+(\d+)\s*$/).flatten.map(&:to_i).uniq
+    expect(sleeps.size).to eq(1), "expected one polling sleep inside wait_for_healthcheck, found #{sleeps.inspect}"
+    sleeps.first / 60.0
+  end
+
   let(:wait_budget_minutes) do
     DEPLOY_SCRIPT.read.scan(/wait_for_healthcheck\s+"[^"]+"\s+\S+\s+(\d+)\s+\w+/)
-      .sum { |(attempts)| attempts.to_i * 3 }
+      .sum { |(attempts)| attempts.to_i * poll_interval_minutes }
   end
 
   it "parses the deploy step out of the pipeline" do
     expect(step).to be_present
     expect(step["command"]).to eq(".buildkite/scripts/deploy_production.sh")
+  end
+
+  it "reads the polling interval from the script instead of assuming it" do
+    expect(poll_interval_minutes).to eq(3)
   end
 
   it "finds every healthcheck wait in the deploy script" do


### PR DESCRIPTION
Main went red on `buildkite/gumroad` build [#18755](https://buildkite.com/gumroad-inc/gumroad/builds/18755) (commit 2946e53876). No test failed — GitHub Actions was green on that commit. The `:rocket: Deploy to Production` step timed out with exit 255.

## What happened

`deploy_production.sh` waits on two healthchecks before deploying, and can spend **165 minutes** doing it: 45 on `/healthcheck/payouts` (15 attempts) and 120 on `/healthcheck/long_running_jobs` (40 attempts, 3 minutes apart). When the long-running check is still 503 at the end, the script deliberately logs "skipping deployment" and **exits 0** — never kill a finance report; the change ships with the next push.

The step around it was capped at `timeout_in_minutes: 120`, so that skip path was unreachable. The long-running wait alone consumed the entire step budget:

```
payout healthcheck       15 × 3min =  45 min
long-running healthcheck 40 × 3min = 120 min
                           waiting = 165 min
                         + deploy  ≈  23 min  (median, per the concurrency_group comment)
                        worst case = 188 min   vs a 120 min cap
```

The job logged `attempt 40/40` at 03:24:07 and then slept 180s, so it would have exited 0 at 03:27:07. The agent killed it at **03:27:01.310** — it missed its own graceful skip by **5.7 seconds** and reported `timed_out` instead.

This is deterministic, not a flake. The blocker was legitimate: Aug 1 is month-start, so the UTC 01:00 monthly financial reports (which fan out the 1–2h Canada sales report) were correctly holding deploys. Every ingredient behaved as designed except the cap.

## The fix

Raise the step timeout to 240, leaving ~50 minutes of headroom over the 188-minute worst case. No behaviour change to the deploy or the guards — this only lets the script reach the decision it already knows how to make.

The two numbers live in two files, which is how they drifted. `spec/buildkite/production_deploy_timeout_spec.rb` now parses the attempt counts out of the shell script and the timeout out of the pipeline YAML and asserts the step outlasts its own waiting, so this cannot silently return.

## Evidence

- Spec green locally: `4 examples, 0 failures`. Reverting the timeout to 120 reddens it on the intended assertion (`expect(step["timeout_in_minutes"]).to be > wait_budget_minutes + DEPLOY_RUNTIME_MINUTES`) — it is not vacuous.
- Skip path proven directly: running the guard with a stubbed always-503 curl exits **0** with "skipping deployment".
- CI green on this branch before opening: run [30683047226](https://github.com/antiwork/gumroad/actions/runs/30683047226), 75 success / 1 skipped / 0 failures. The new spec ran on `Test Fast 10`.

## Note for whoever merges

Builds 18789, 18804 and 18807 are queued on main behind the same `concurrency: 1` deploy group with the healthcheck still 503. 18789's deploy started at 03:27:03 and hits the identical 120-minute wall around 05:27 UTC. They will keep going red the same way until this lands — production itself is healthy and serving (`x-revision: 6608e2a24`), it is only the deploy step that is red.
