### PR TITLE
Unblock the buyer, not one purchase row

### DIFF
--- a/app/controllers/admin/purchases_controller.rb
+++ b/app/controllers/admin/purchases_controller.rb
@@ -91,7 +91,7 @@ class Admin::PurchasesController < Admin::BaseController
 
   def unblock_buyer
     if @purchase.buyer_blocked?
-      @purchase.unblock_buyer!
+      surviving = @purchase.unblock_buyer!
 
       comment_content = "Buyer unblocked by Admin (#{current_user.email})"
       @purchase.comments.create!(content: comment_content, comment_type: "note", author_id: current_user.id)
@@ -101,6 +101,18 @@ class Admin::PurchasesController < Admin::BaseController
                                              comment_type: "note",
                                              author: current_user,
                                              purchase: @purchase)
+      end
+
+      if surviving.any?
+        # Same disclosure the internal API makes: the alert this message feeds is the only thing
+        # the agent sees, and a bare "Buyer unblocked!" over a surviving row is the silence that
+        # hid gumroad-private#1648.
+        return render json: {
+          success: true,
+          status: "partially_unblocked",
+          message: "Unblocked buyer, but #{surviving.size} block(s) still hold this buyer: " \
+                   "#{surviving.map { |block| "#{block.object_type} #{block.object_value}" }.join(", ")}"
+        }
       end
     end
 

--- a/app/controllers/api/internal/admin/purchases_controller.rb
+++ b/app/controllers/api/internal/admin/purchases_controller.rb
@@ -314,8 +314,21 @@ class Api::Internal::Admin::PurchasesController < Api::Internal::Admin::BaseCont
         }
       end
 
-      purchase.unblock_buyer!
+      surviving = purchase.unblock_buyer!
       create_unblock_buyer_comments!(purchase)
+
+      if surviving.any?
+        # Say so rather than reporting a bare success. Three years of "Buyer unblocked" notes were
+        # written over unblocks that left a row behind, and the silence is what hid it
+        # (gumroad-private#1648).
+        return render json: {
+          success: true,
+          status: "partially_unblocked",
+          surviving_blocks: surviving.map { |block| { object_type: block.object_type, object_value: block.object_value } },
+          message: "Unblocked buyer for purchase number #{purchase.external_id_numeric}, but #{surviving.size} block(s) still hold this buyer: " \
+                   "#{surviving.map { |block| "#{block.object_type} #{block.object_value}" }.join(", ")}"
+        }
+      end
 
       render json: {
         success: true,

--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -169,6 +169,11 @@ module Purchase::Blockable
   #
   # Guids and card fingerprints ARE widened from siblings, for the reason #unblock_buyer! gives:
   # they name a browser and a physical card, not a string somebody typed.
+  #
+  # A browser can still be shared, so clearing a sibling guid can lift a block a co-user of that
+  # browser earned. Accepted deliberately: the co-user's person-bound blocks (email, card) stay
+  # put, renewed abuse re-earns the guid block via the velocity checks, and withholding sibling
+  # guids is exactly the never-expiring stranded-block problem this widening exists to fix.
   private def blockable_values_for(purchases, extra_fingerprints: [], widened_emails: true)
     guids = Set.new
     emails = Set.new

--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -131,60 +131,90 @@ module Purchase::Blockable
   # Every active block that still holds this buyer after an unblock. Same identifier set
   # `buyer_blocked?` asks about, but resolved across the buyer's purchases and returning the rows
   # rather than a boolean, so the caller can name what survived.
+  #
+  # Also reports blocks on same-email guest rows that failed the corroboration bar in
+  # #corroborated_guest_purchases. Those are blocks the unblock refused to clear because the row
+  # may be somebody else's; reporting them keeps the refusal visible, so the agent sees the
+  # surviving row and judges it instead of the response reading as a full success while the buyer
+  # may still be held — the silence gumroad-private#1648 is about.
   def surviving_buyer_blocks
     scopes = buyer_blockable_values.map { |object_type, values| PlatformBlock.active.where(object_type:, object_value: values) }
     scopes << PlatformBlock.active.ip_address.where(object_value: ip_address) if ip_address.present?
+    blockable_values_for(same_email_guest_purchases - sibling_buyer_purchases).each do |object_type, values|
+      scopes << PlatformBlock.active.where(object_type:, object_value: values)
+    end
     return PlatformBlock.none if scopes.empty?
 
     scopes.reduce { |combined, scope| combined.or(scope) }
   end
 
   private def buyer_blockable_values
-    @_buyer_blockable_values ||= begin
-      guids = Set.new
-      emails = Set.new
-      fingerprints = Set.new
-
-      [self, *sibling_buyer_purchases].each do |purchase|
-        guids << purchase.browser_guid
-        emails.merge([purchase.email, purchase.paypal_email, purchase.gifter_email, purchase.purchaser_email])
-        fingerprints << purchase.charge_processor_fingerprint
-      end
-      fingerprints << recent_stripe_fingerprint
-
-      {
-        PlatformBlock::TYPES[:browser_guid] => guids.compact_blank.to_a,
-        PlatformBlock::TYPES[:email] => emails.compact_blank.to_a,
-        PlatformBlock::TYPES[:charge_processor_fingerprint] => fingerprints.compact_blank.to_a,
-      }.reject { |_, values| values.empty? }
-    end
+    @_buyer_blockable_values ||= blockable_values_for([self, *sibling_buyer_purchases], extra_fingerprints: [recent_stripe_fingerprint])
   end
 
-  # The buyer's other purchases. Newest first and capped — a buyer with thousands of rows
-  # contributes no new identifiers past the first few hundred, and an admin click must not turn
-  # into an unbounded scan.
+  private def blockable_values_for(purchases, extra_fingerprints: [])
+    guids = Set.new
+    emails = Set.new
+    fingerprints = Set.new
+
+    purchases.each do |purchase|
+      guids << purchase.browser_guid
+      emails.merge([purchase.email, purchase.paypal_email, purchase.gifter_email, purchase.purchaser_email])
+      fingerprints << purchase.charge_processor_fingerprint
+    end
+    fingerprints.merge(extra_fingerprints)
+
+    {
+      PlatformBlock::TYPES[:browser_guid] => guids.compact_blank.to_a,
+      PlatformBlock::TYPES[:email] => emails.compact_blank.to_a,
+      PlatformBlock::TYPES[:charge_processor_fingerprint] => fingerprints.compact_blank.to_a,
+    }.reject { |_, values| values.empty? }
+  end
+
+  # The buyer's other purchases, this one excluded: rows that resolved to the same account, plus
+  # guest rows a second identifier ties to the buyer (see #corroborated_guest_purchases). Newest
+  # first and capped per branch — a buyer with thousands of rows contributes no new identifiers
+  # past the first few hundred, and an admin click must not turn into an unbounded scan.
+  # Deliberately not memoized: #block_buyer! reads #recent_stripe_fingerprint through the
+  # attr-blockable machinery, so a memo taken then would still be live at unblock time and hide
+  # any purchase the buyer made in between.
   private def sibling_buyer_purchases
-    same_buyer_purchases.where.not(id:).order(id: :desc).limit(MAX_SIBLING_PURCHASES_FOR_UNBLOCK)
+    account_purchases =
+      if purchaser_id.present?
+        Purchase.where(purchaser_id:).where.not(id:).order(id: :desc).limit(MAX_SIBLING_PURCHASES_FOR_UNBLOCK).to_a
+      else
+        []
+      end
+
+    account_purchases + corroborated_guest_purchases(account_purchases)
   end
 
-  # Every purchase carrying this buyer's identity, this one included: rows that resolved to the
-  # same account, plus rows made under the same email that resolved to no account at all (the
-  # buyer's guest checkouts).
+  # The buyer's guest checkouts: same-email rows that resolved to no account at all. A checkout
+  # email is unauthenticated — anyone can type anyone's address, and card testers do exactly that —
+  # so sharing the email is NOT enough to call a guest row this buyer's: a tester who checked out
+  # under this buyer's address would otherwise get their own browser and card unblocked whenever
+  # an admin unblocks the buyer. A guest row only counts when a second, buyer-bound identifier
+  # ties it to a row we already trust (this one, or an account-bound sibling): its browser guid or
+  # its card fingerprint. One hop only — a corroborated guest row does not corroborate further
+  # rows. Rows that fail the bar contribute nothing here; their blocks are surfaced by
+  # #surviving_buyer_blocks for a human to judge.
   #
-  # An email match alone must NOT pull in rows that resolved to a DIFFERENT account. A checkout
-  # email is unauthenticated and gets reassigned, so a same-email row owned by another account can
-  # be another person's entirely — collecting its browser guid and card fingerprint here would let
-  # blocking or unblocking this buyer touch blocks that other account earned.
-  private def same_buyer_purchases
-    if purchaser_id.present? && email.present?
-      Purchase.where("purchaser_id = ? OR (email = ? AND purchaser_id IS NULL)", purchaser_id, email)
-    elsif purchaser_id.present?
-      Purchase.where(purchaser_id:)
-    elsif email.present?
-      Purchase.where(email:, purchaser_id: nil)
-    else
-      Purchase.none
+  # Same-email rows that resolved to a DIFFERENT account are excluded outright, corroborated or
+  # not — those identifiers belong to that account's blocks, not this buyer's.
+  private def corroborated_guest_purchases(account_purchases)
+    trusted = [self, *account_purchases]
+    trusted_guids = trusted.map(&:browser_guid).compact_blank.to_set
+    trusted_fingerprints = trusted.map(&:charge_processor_fingerprint).compact_blank.to_set
+
+    same_email_guest_purchases.select do |candidate|
+      trusted_guids.include?(candidate.browser_guid) || trusted_fingerprints.include?(candidate.charge_processor_fingerprint)
     end
+  end
+
+  private def same_email_guest_purchases
+    return [] if email.blank?
+
+    Purchase.where(email:, purchaser_id: nil).where.not(id:).order(id: :desc).limit(MAX_SIBLING_PURCHASES_FOR_UNBLOCK).to_a
   end
 
   def charge_processor_fingerprint
@@ -338,7 +368,7 @@ module Purchase::Blockable
 
   private
     def recent_stripe_fingerprint
-      same_buyer_purchases.with_stripe_fingerprint.last&.stripe_fingerprint
+      [self, *sibling_buyer_purchases].select { |purchase| purchase.stripe_fingerprint.present? }.max_by(&:id)&.stripe_fingerprint
     end
 
     def blockable_emails_if_fraudulent_transaction

--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -143,23 +143,46 @@ module Purchase::Blockable
     blockable_values_for(same_email_guest_purchases - sibling_buyer_purchases).each do |object_type, values|
       scopes << PlatformBlock.active.where(object_type:, object_value: values)
     end
+    # The typed-in addresses on sibling rows, which the unblock deliberately does not clear (see
+    # #blockable_values_for). Reported for the same reason as the uncorroborated guest rows: a
+    # refusal the caller cannot see reads as a successful unblock while the buyer is still held.
+    withheld_sibling_emails = blockable_values_for(sibling_buyer_purchases)[PlatformBlock::TYPES[:email]].to_a -
+                              buyer_blockable_values[PlatformBlock::TYPES[:email]].to_a
+    scopes << PlatformBlock.active.email.where(object_value: withheld_sibling_emails) if withheld_sibling_emails.any?
     return PlatformBlock.none if scopes.empty?
 
     scopes.reduce { |combined, scope| combined.or(scope) }
   end
 
   private def buyer_blockable_values
-    @_buyer_blockable_values ||= blockable_values_for([self, *sibling_buyer_purchases], extra_fingerprints: [recent_stripe_fingerprint])
+    @_buyer_blockable_values ||= blockable_values_for([self, *sibling_buyer_purchases], extra_fingerprints: [recent_stripe_fingerprint], widened_emails: false)
   end
 
-  private def blockable_values_for(purchases, extra_fingerprints: [])
+  # `widened_emails: false` keeps a sibling row's typed-in addresses out of the unblock set, and
+  # is the default for anything that CLEARS blocks. A checkout, PayPal or gifter email is
+  # unauthenticated text on a row — the buyer can put anyone's address there, and a gift row
+  # legitimately carries the recipient's. Siblings are selected by `purchaser_id`, so widening
+  # those would let an unblock of this buyer deactivate a PlatformBlock earned by a different
+  # person whose address happens to sit on one of the buyer's rows. Only `purchaser_email` is
+  # account-owned (it is delegated to the purchaser record), so that is the one a sibling
+  # contributes; the acting row's own addresses stay in scope because the admin is acting on it.
+  #
+  # Guids and card fingerprints ARE widened from siblings, for the reason #unblock_buyer! gives:
+  # they name a browser and a physical card, not a string somebody typed.
+  private def blockable_values_for(purchases, extra_fingerprints: [], widened_emails: true)
     guids = Set.new
     emails = Set.new
     fingerprints = Set.new
 
     purchases.each do |purchase|
       guids << purchase.browser_guid
-      emails.merge([purchase.email, purchase.paypal_email, purchase.gifter_email, purchase.purchaser_email])
+      emails.merge(
+        if widened_emails || purchase == self
+          [purchase.email, purchase.paypal_email, purchase.gifter_email, purchase.purchaser_email]
+        else
+          [purchase.purchaser_email]
+        end
+      )
       fingerprints << purchase.charge_processor_fingerprint
     end
     fingerprints.merge(extra_fingerprints)

--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -193,21 +193,22 @@ module Purchase::Blockable
   # email is unauthenticated — anyone can type anyone's address, and card testers do exactly that —
   # so sharing the email is NOT enough to call a guest row this buyer's: a tester who checked out
   # under this buyer's address would otherwise get their own browser and card unblocked whenever
-  # an admin unblocks the buyer. A guest row only counts when a second, buyer-bound identifier
-  # ties it to a row we already trust (this one, or an account-bound sibling): its browser guid or
-  # its card fingerprint. One hop only — a corroborated guest row does not corroborate further
-  # rows. Rows that fail the bar contribute nothing here; their blocks are surfaced by
-  # #surviving_buyer_blocks for a human to judge.
+  # an admin unblocks the buyer. A guest row only counts when its card fingerprint matches a row
+  # we already trust (this one, or an account-bound sibling) — the fingerprint is derived from a
+  # physical card in the buyer's hands, so it is the one corroborating identifier that is itself
+  # buyer-bound. A browser guid match deliberately does NOT corroborate: a guid names a browser,
+  # and browsers are shared, so another person's guest checkout under the buyer's email on the
+  # buyer's machine would match on guid and get their own card unblocked. One hop only — a
+  # corroborated guest row does not corroborate further rows. Rows that fail the bar contribute
+  # nothing here; their blocks are surfaced by #surviving_buyer_blocks for a human to judge.
   #
   # Same-email rows that resolved to a DIFFERENT account are excluded outright, corroborated or
   # not — those identifiers belong to that account's blocks, not this buyer's.
   private def corroborated_guest_purchases(account_purchases)
-    trusted = [self, *account_purchases]
-    trusted_guids = trusted.map(&:browser_guid).compact_blank.to_set
-    trusted_fingerprints = trusted.map(&:charge_processor_fingerprint).compact_blank.to_set
+    trusted_fingerprints = [self, *account_purchases].map(&:charge_processor_fingerprint).compact_blank.to_set
 
     same_email_guest_purchases.select do |candidate|
-      trusted_guids.include?(candidate.browser_guid) || trusted_fingerprints.include?(candidate.charge_processor_fingerprint)
+      trusted_fingerprints.include?(candidate.charge_processor_fingerprint)
     end
   end
 

--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -160,20 +160,31 @@ module Purchase::Blockable
     end
   end
 
-  # The buyer's other purchases, found by the two identities a purchase carries: the email it was
-  # made under and the account it resolved to. Newest first and capped — a buyer with thousands of
-  # rows contributes no new identifiers past the first few hundred, and an admin click must not
-  # turn into an unbounded scan.
+  # The buyer's other purchases. Newest first and capped — a buyer with thousands of rows
+  # contributes no new identifiers past the first few hundred, and an admin click must not turn
+  # into an unbounded scan.
   private def sibling_buyer_purchases
-    scope = if purchaser_id.present?
-      Purchase.where("purchaser_id = ? OR email = ?", purchaser_id, email)
-    elsif email.present?
-      Purchase.where(email:)
-    else
-      return Purchase.none
-    end
+    same_buyer_purchases.where.not(id:).order(id: :desc).limit(MAX_SIBLING_PURCHASES_FOR_UNBLOCK)
+  end
 
-    scope.where.not(id:).order(id: :desc).limit(MAX_SIBLING_PURCHASES_FOR_UNBLOCK)
+  # Every purchase carrying this buyer's identity, this one included: rows that resolved to the
+  # same account, plus rows made under the same email that resolved to no account at all (the
+  # buyer's guest checkouts).
+  #
+  # An email match alone must NOT pull in rows that resolved to a DIFFERENT account. A checkout
+  # email is unauthenticated and gets reassigned, so a same-email row owned by another account can
+  # be another person's entirely — collecting its browser guid and card fingerprint here would let
+  # blocking or unblocking this buyer touch blocks that other account earned.
+  private def same_buyer_purchases
+    if purchaser_id.present? && email.present?
+      Purchase.where("purchaser_id = ? OR (email = ? AND purchaser_id IS NULL)", purchaser_id, email)
+    elsif purchaser_id.present?
+      Purchase.where(purchaser_id:)
+    elsif email.present?
+      Purchase.where(email:, purchaser_id: nil)
+    else
+      Purchase.none
+    end
   end
 
   def charge_processor_fingerprint
@@ -327,9 +338,7 @@ module Purchase::Blockable
 
   private
     def recent_stripe_fingerprint
-      Purchase.with_stripe_fingerprint
-              .where("purchaser_id = ? or email = ?", purchaser_id, email)
-              .last&.stripe_fingerprint
+      same_buyer_purchases.with_stripe_fingerprint.last&.stripe_fingerprint
     end
 
     def blockable_emails_if_fraudulent_transaction

--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -47,6 +47,12 @@ module Purchase::Blockable
 
   MAX_BUYER_CHARGEBACKS_BEFORE_BLOCK = 5
 
+  # How many of the buyer's other purchases #unblock_buyer! collects identifiers from. An admin
+  # click has to stay bounded, and past a few hundred rows a buyer stops contributing new browser
+  # guids, addresses or cards — the largest stranded buyer in gumroad-private#1648 had 231
+  # purchases and 85 distinct guids.
+  MAX_SIBLING_PURCHASES_FOR_UNBLOCK = 500
+
   # How many settled purchases a buyer needs behind them before a fraud-flavoured decline from
   # their card issuer stops being treated as a fraud signal about the person. Three is well above
   # what a card tester accumulates and well below what an ordinary repeat customer or a membership
@@ -89,17 +95,85 @@ module Purchase::Blockable
     create_blocked_buyer_comments!(blocking_user:, comment_content:)
   end
 
+  # Unblocking is scoped to the BUYER, not to this one purchase row. The purchase an agent opens
+  # to press Unblock is almost never the purchase the block was written from — a buyer browses
+  # from several devices over the years, so unblocking from purchase A cleared guid A while the
+  # block sat on guid B and kept rejecting them. #block_buyer! is symmetric with the old
+  # single-row unblock, so the round trip looked fine on the acting row and nothing anywhere said
+  # a row had been left behind: `buyer_blocked?` is an OR, the controller still wrote "Buyer
+  # unblocked", and the response was still `success: true`. Browser-guid blocks are the worst ones
+  # to strand, because PlatformBlock.add! only accepts an `expires_in` for ip_address and so a guid
+  # block never lapses (gumroad-private#1648: 71% of hand-unblocked buyers were still blocked, one
+  # of them for 2.5 years).
+  #
+  # IP addresses are deliberately NOT widened across rows. An IP is not buyer-bound — it is shared
+  # by everyone behind a NAT or a carrier pool and gets reallocated — so clearing every IP this
+  # buyer has ever checked out from would lift blocks earned by other people. It also expires on
+  # its own. The identifiers widened here are the ones that identify this buyer specifically:
+  # their browser, their email addresses and their cards.
+  #
+  # Returns the PlatformBlocks that are STILL active afterwards, so a caller can tell the agent the
+  # truth instead of reporting an unqualified success. Non-empty means something outside this
+  # buyer's identifiers is holding them (an email-domain block, a shared IP).
   def unblock_buyer!
-    unblock_by_browser_guid!
-    unblock_by_email!
-    unblock_by_paypal_email!
-    unblock_by_gifter_email!
-    unblock_by_purchaser_email!
     unblock_by_ip_address!
-    unblock_by_charge_processor_fingerprint!
-    unblock_by_recent_stripe_fingerprint!
+
+    buyer_blockable_values.each do |object_type, values|
+      PlatformBlock.where(object_type:, object_value: values).find_each(&:unblock!)
+    end
+    @blocked_by_attributes = nil
 
     update!(is_buyer_blocked_by_admin: false) if is_buyer_blocked_by_admin?
+
+    surviving_buyer_blocks
+  end
+
+  # Every active block that still holds this buyer after an unblock. Same identifier set
+  # `buyer_blocked?` asks about, but resolved across the buyer's purchases and returning the rows
+  # rather than a boolean, so the caller can name what survived.
+  def surviving_buyer_blocks
+    scopes = buyer_blockable_values.map { |object_type, values| PlatformBlock.active.where(object_type:, object_value: values) }
+    scopes << PlatformBlock.active.ip_address.where(object_value: ip_address) if ip_address.present?
+    return PlatformBlock.none if scopes.empty?
+
+    scopes.reduce { |combined, scope| combined.or(scope) }
+  end
+
+  private def buyer_blockable_values
+    @_buyer_blockable_values ||= begin
+      guids = Set.new
+      emails = Set.new
+      fingerprints = Set.new
+
+      [self, *sibling_buyer_purchases].each do |purchase|
+        guids << purchase.browser_guid
+        emails.merge([purchase.email, purchase.paypal_email, purchase.gifter_email, purchase.purchaser_email])
+        fingerprints << purchase.charge_processor_fingerprint
+      end
+      fingerprints << recent_stripe_fingerprint
+
+      {
+        PlatformBlock::TYPES[:browser_guid] => guids.compact_blank.to_a,
+        PlatformBlock::TYPES[:email] => emails.compact_blank.to_a,
+        PlatformBlock::TYPES[:charge_processor_fingerprint] => fingerprints.compact_blank.to_a,
+      }.reject { |_, values| values.empty? }
+    end
+  end
+
+  # The buyer's other purchases, found by the two identities a purchase carries: the email it was
+  # made under and the account it resolved to. Newest first and capped — a buyer with thousands of
+  # rows contributes no new identifiers past the first few hundred, and an admin click must not
+  # turn into an unbounded scan.
+  private def sibling_buyer_purchases
+    scope = if purchaser_id.present?
+      Purchase.where("purchaser_id = ? OR email = ?", purchaser_id, email)
+    elsif email.present?
+      Purchase.where(email:)
+    else
+      return Purchase.none
+    end
+
+    scope.where.not(id:).order(id: :desc).limit(MAX_SIBLING_PURCHASES_FOR_UNBLOCK)
   end
 
   def charge_processor_fingerprint

--- a/spec/controllers/admin/purchases_controller_spec.rb
+++ b/spec/controllers/admin/purchases_controller_spec.rb
@@ -106,6 +106,31 @@ describe Admin::PurchasesController, :vcr, inertia: true do
     end
   end
 
+  describe "POST unblock_buyer" do
+    before do
+      @purchase = create(:purchase, purchaser: create(:user))
+      @purchase.block_buyer!(blocking_user_id: @admin_user.id)
+    end
+
+    it "unblocks the buyer and reports a plain success when nothing survives" do
+      post :unblock_buyer, params: { external_id: @purchase.external_id }
+
+      expect(response.parsed_body).to eq("success" => true)
+      expect(@purchase.reload.buyer_blocked?).to eq(false)
+    end
+
+    it "reports the blocks that survive the unblock" do
+      PlatformBlock.add!(object_type: PlatformBlock::TYPES[:browser_guid], object_value: "surviving-guid")
+      surviving = PlatformBlock.active.where(object_value: "surviving-guid")
+      allow_any_instance_of(Purchase).to receive(:unblock_buyer!).and_return(surviving)
+
+      post :unblock_buyer, params: { external_id: @purchase.external_id }
+
+      expect(response.parsed_body).to include("success" => true, "status" => "partially_unblocked")
+      expect(response.parsed_body["message"]).to include("1 block(s) still hold this buyer: browser_guid surviving-guid")
+    end
+  end
+
   describe "POST refund_taxes_only" do
     before do
       @purchase = create(:purchase_in_progress, chargeable: create(:chargeable), purchaser: create(:user))

--- a/spec/controllers/api/internal/admin/purchases_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/purchases_controller_spec.rb
@@ -1546,6 +1546,20 @@ describe Api::Internal::Admin::PurchasesController do
       expect(purchase.reload.is_buyer_blocked_by_admin?).to be(false)
     end
 
+    it "reports partially_unblocked with the surviving blocks when the unblock leaves rows behind" do
+      purchase.block_buyer!(blocking_user_id: admin_user.id)
+      PlatformBlock.add!(object_type: PlatformBlock::TYPES[:browser_guid], object_value: "surviving-guid")
+      surviving = PlatformBlock.active.where(object_value: "surviving-guid")
+      allow_any_instance_of(Purchase).to receive(:unblock_buyer!).and_return(surviving)
+
+      post :unblock_buyer, params: params
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include("success" => true, "status" => "partially_unblocked")
+      expect(response.parsed_body["surviving_blocks"]).to eq([{ "object_type" => PlatformBlock::TYPES[:browser_guid], "object_value" => "surviving-guid" }])
+      expect(response.parsed_body["message"]).to include("1 block(s) still hold this buyer")
+    end
+
     it "creates an unblock comment on the purchaser when present" do
       buyer = create(:user, email: "buyer@example.com")
       purchase.update!(purchaser: buyer)

--- a/spec/models/concerns/purchase/blockable_spec.rb
+++ b/spec/models/concerns/purchase/blockable_spec.rb
@@ -597,6 +597,78 @@ describe Purchase::Blockable do
       purchase.unblock_buyer!
       expect(purchase.is_buyer_blocked_by_admin).to eq(false)
     end
+
+    context "when the block was written from a different purchase of the same buyer" do
+      it "clears a browser_guid block belonging to another purchase" do
+        other_purchase = create(:purchase, link: product, email: purchase.email, purchaser: buyer, browser_guid: "other-device-guid")
+        other_purchase.block_buyer!
+
+        expect(other_purchase.reload.buyer_blocked?).to eq(true)
+
+        purchase.unblock_buyer!
+
+        expect(PlatformBlock.active.find_by(object_value: "other-device-guid")).to be_nil
+        expect(other_purchase.reload.buyer_blocked?).to eq(false)
+      end
+
+      it "clears a card fingerprint block belonging to another purchase" do
+        other_purchase = create(:purchase, link: product, email: purchase.email, purchaser: buyer, stripe_fingerprint: "other-card-fingerprint")
+        PlatformBlock.add!(object_type: PlatformBlock::TYPES[:charge_processor_fingerprint], object_value: other_purchase.charge_processor_fingerprint)
+
+        purchase.unblock_buyer!
+
+        expect(PlatformBlock.active.find_by(object_value: "other-card-fingerprint")).to be_nil
+      end
+
+      it "finds the sibling purchase by email when the acting purchase has no purchaser" do
+        guest_purchase = create(:purchase, link: product, email: "guest@example.com", purchaser: nil, browser_guid: "guest-acting-guid")
+        sibling = create(:purchase, link: product, email: "guest@example.com", purchaser: nil, browser_guid: "guest-other-guid")
+        sibling.block_buyer!
+
+        guest_purchase.unblock_buyer!
+
+        expect(PlatformBlock.active.find_by(object_value: "guest-other-guid")).to be_nil
+      end
+
+      it "does not touch another buyer's blocks" do
+        stranger = create(:purchase, link: product, email: "stranger@example.com", browser_guid: "stranger-guid")
+        stranger.block_buyer!
+
+        purchase.unblock_buyer!
+
+        expect(PlatformBlock.active.find_by(object_value: "stranger-guid")).to be_present
+      end
+
+      it "leaves IP blocks on the buyer's other purchases alone" do
+        other_purchase = create(:purchase, link: product, email: purchase.email, purchaser: buyer, ip_address: "203.0.113.9")
+        PlatformBlock.add!(object_type: PlatformBlock::TYPES[:ip_address], object_value: "203.0.113.9", expires_in: 1.day)
+
+        purchase.unblock_buyer!
+
+        expect(PlatformBlock.active.find_by(object_value: "203.0.113.9")).to be_present
+        expect(other_purchase).to be_present
+      end
+    end
+
+    describe "the return value" do
+      it "is empty when nothing is left holding the buyer" do
+        purchase.block_buyer!
+
+        expect(purchase.unblock_buyer!).to be_empty
+      end
+
+      it "reports a block that survives because it is not one of the buyer's own identifiers" do
+        purchase.block_buyer!
+        PlatformBlock.add!(object_type: PlatformBlock::TYPES[:ip_address], object_value: purchase.ip_address, expires_in: 1.day)
+        # unblock_by_ip_address! clears the acting row's IP, so re-block it from elsewhere to stand
+        # in for a shared-IP block the buyer did not earn.
+        allow(purchase).to receive(:unblock_by_ip_address!)
+
+        surviving = purchase.unblock_buyer!
+
+        expect(surviving.map(&:object_value)).to eq([purchase.ip_address])
+      end
+    end
   end
 
   describe "#mark_failed" do

--- a/spec/models/concerns/purchase/blockable_spec.rb
+++ b/spec/models/concerns/purchase/blockable_spec.rb
@@ -674,6 +674,52 @@ describe Purchase::Blockable do
         expect(housemate_row).to be_present
       end
 
+      # gumroad-private#1648 widened the unblock across sibling rows, but siblings are selected by
+      # purchaser_id and a checkout/PayPal/gifter address is unauthenticated text anyone can type.
+      # Widening those would let an unblock of this buyer deactivate a block a DIFFERENT person
+      # earned, whose address happens to sit on one of the buyer's rows.
+      it "does not unblock a third party whose address was typed into a sibling row's checkout email" do
+        create(:purchase, link: product, email: "victim@example.com", purchaser: buyer, browser_guid: "sibling-guid")
+        PlatformBlock.add!(object_type: PlatformBlock::TYPES[:email], object_value: "victim@example.com")
+
+        surviving = purchase.unblock_buyer!
+
+        expect(PlatformBlock.active.find_by(object_value: "victim@example.com")).to be_present
+        # ...and the refusal is visible, so an agent judges the surviving row rather than reading
+        # an unqualified success while the buyer may still be held.
+        expect(surviving.map(&:object_value)).to include("victim@example.com")
+      end
+
+      it "does not unblock a third party whose PayPal address sits on a sibling row" do
+        create(:purchase, link: product, purchaser: buyer, browser_guid: "sibling-paypal-guid",
+                          charge_processor_id: PaypalChargeProcessor.charge_processor_id, card_visual: "someone-else@paypal.example")
+        PlatformBlock.add!(object_type: PlatformBlock::TYPES[:email], object_value: "someone-else@paypal.example")
+
+        purchase.unblock_buyer!
+
+        expect(PlatformBlock.active.find_by(object_value: "someone-else@paypal.example")).to be_present
+      end
+
+      # The account-owned address is the one identifier on a sibling that is not typed in — it is
+      # delegated to the purchaser record — so widening it is the whole point of the change and
+      # must not be lost to the narrowing above.
+      it "still clears a block on the buyer's own account email reached through a sibling row" do
+        create(:purchase, link: product, email: "checkout-alias@example.com", purchaser: buyer, browser_guid: "sibling-guid-2")
+        PlatformBlock.add!(object_type: PlatformBlock::TYPES[:email], object_value: buyer.email)
+
+        purchase.unblock_buyer!
+
+        expect(PlatformBlock.active.find_by(object_value: buyer.email)).to be_nil
+      end
+
+      it "still clears a block on the acting row's own checkout email" do
+        PlatformBlock.add!(object_type: PlatformBlock::TYPES[:email], object_value: purchase.email)
+
+        purchase.unblock_buyer!
+
+        expect(PlatformBlock.active.find_by(object_value: purchase.email)).to be_nil
+      end
+
       it "does not touch another buyer's blocks" do
         stranger = create(:purchase, link: product, email: "stranger@example.com", browser_guid: "stranger-guid")
         stranger.block_buyer!

--- a/spec/models/concerns/purchase/blockable_spec.rb
+++ b/spec/models/concerns/purchase/blockable_spec.rb
@@ -622,14 +622,41 @@ describe Purchase::Blockable do
         expect(PlatformBlock.active.find_by(object_value: "other-card-fingerprint")).to be_nil
       end
 
-      it "finds the sibling purchase by email when the acting purchase has no purchaser" do
-        guest_purchase = create(:purchase, link: product, email: "guest@example.com", purchaser: nil, browser_guid: "guest-acting-guid")
-        sibling = create(:purchase, link: product, email: "guest@example.com", purchaser: nil, browser_guid: "guest-other-guid")
+      it "finds the sibling purchase by email when the acting purchase has no purchaser and a shared card ties the rows together" do
+        guest_purchase = create(:purchase, link: product, email: "guest@example.com", purchaser: nil, browser_guid: "guest-acting-guid", stripe_fingerprint: "guest-shared-card")
+        sibling = create(:purchase, link: product, email: "guest@example.com", purchaser: nil, browser_guid: "guest-other-guid", stripe_fingerprint: "guest-shared-card")
         sibling.block_buyer!
 
         guest_purchase.unblock_buyer!
 
         expect(PlatformBlock.active.find_by(object_value: "guest-other-guid")).to be_nil
+      end
+
+      it "leaves alone a guest row that shares nothing but the checkout email, and reports its blocks as surviving" do
+        # A card tester checking out under this buyer's address produces exactly this row: same
+        # email, no account, its own browser and its own card.
+        tester_row = create(:purchase, link: product, email: purchase.email, purchaser: nil,
+                                       browser_guid: "tester-guid", stripe_fingerprint: "tester-card")
+        PlatformBlock.add!(object_type: PlatformBlock::TYPES[:browser_guid], object_value: "tester-guid")
+        PlatformBlock.add!(object_type: PlatformBlock::TYPES[:charge_processor_fingerprint], object_value: "tester-card")
+
+        surviving = purchase.unblock_buyer!
+
+        expect(PlatformBlock.active.find_by(object_value: "tester-guid")).to be_present
+        expect(PlatformBlock.active.find_by(object_value: "tester-card")).to be_present
+        expect(surviving.map(&:object_value)).to match_array(["tester-guid", "tester-card"])
+        expect(tester_row).to be_present
+      end
+
+      it "clears a guest row's browser block when a shared card corroborates the email match" do
+        guest_row = create(:purchase, link: product, email: purchase.email, purchaser: nil,
+                                      browser_guid: "corroborated-guest-guid", stripe_fingerprint: purchase.stripe_fingerprint)
+        PlatformBlock.add!(object_type: PlatformBlock::TYPES[:browser_guid], object_value: "corroborated-guest-guid")
+
+        purchase.unblock_buyer!
+
+        expect(PlatformBlock.active.find_by(object_value: "corroborated-guest-guid")).to be_nil
+        expect(guest_row).to be_present
       end
 
       it "does not touch another buyer's blocks" do

--- a/spec/models/concerns/purchase/blockable_spec.rb
+++ b/spec/models/concerns/purchase/blockable_spec.rb
@@ -659,6 +659,21 @@ describe Purchase::Blockable do
         expect(guest_row).to be_present
       end
 
+      it "does not let a shared browser corroborate a guest row: its own card stays blocked and is reported" do
+        # Another person guest-checking-out under the buyer's email on the buyer's machine (a shared
+        # household browser) matches on guid, but the card is theirs. A guid names a browser, not a
+        # buyer, so it must not pull the row's card into the unblock.
+        housemate_row = create(:purchase, link: product, email: purchase.email, purchaser: nil,
+                                          browser_guid: purchase.browser_guid, stripe_fingerprint: "housemate-card")
+        PlatformBlock.add!(object_type: PlatformBlock::TYPES[:charge_processor_fingerprint], object_value: "housemate-card")
+
+        surviving = purchase.unblock_buyer!
+
+        expect(PlatformBlock.active.find_by(object_value: "housemate-card")).to be_present
+        expect(surviving.map(&:object_value)).to include("housemate-card")
+        expect(housemate_row).to be_present
+      end
+
       it "does not touch another buyer's blocks" do
         stranger = create(:purchase, link: product, email: "stranger@example.com", browser_guid: "stranger-guid")
         stranger.block_buyer!

--- a/spec/models/concerns/purchase/blockable_spec.rb
+++ b/spec/models/concerns/purchase/blockable_spec.rb
@@ -608,7 +608,9 @@ describe Purchase::Blockable do
         purchase.unblock_buyer!
 
         expect(PlatformBlock.active.find_by(object_value: "other-device-guid")).to be_nil
-        expect(other_purchase.reload.buyer_blocked?).to eq(false)
+        # The sibling row still reads blocked overall: block_buyer! blocked its IP too, and IP
+        # blocks deliberately stay row-scoped, so only the browser assertion belongs here.
+        expect(other_purchase.reload.blocked_by_browser_guid?).to eq(false)
       end
 
       it "clears a card fingerprint block belonging to another purchase" do
@@ -637,6 +639,18 @@ describe Purchase::Blockable do
         purchase.unblock_buyer!
 
         expect(PlatformBlock.active.find_by(object_value: "stranger-guid")).to be_present
+      end
+
+      it "leaves alone the blocks of a different account that shares the checkout email" do
+        former_account_purchase = create(:purchase, link: product, email: purchase.email, purchaser: create(:user),
+                                                    browser_guid: "former-account-guid", stripe_fingerprint: "former-account-fingerprint")
+        PlatformBlock.add!(object_type: PlatformBlock::TYPES[:browser_guid], object_value: former_account_purchase.browser_guid)
+        PlatformBlock.add!(object_type: PlatformBlock::TYPES[:charge_processor_fingerprint], object_value: former_account_purchase.stripe_fingerprint)
+
+        purchase.unblock_buyer!
+
+        expect(PlatformBlock.active.find_by(object_value: "former-account-guid")).to be_present
+        expect(PlatformBlock.active.find_by(object_value: "former-account-fingerprint")).to be_present
       end
 
       it "leaves IP blocks on the buyer's other purchases alone" do


### PR DESCRIPTION
## What

`Purchase#unblock_buyer!` now clears the buyer's blocked identifiers across **all** of their purchases, not just the one row the unblock was called from, and reports what it could not clear.

- **Model.** `unblock_buyer!` resolves browser guids, email addresses (`email`, `paypal_email`, `gifter_email`, `purchaser_email`) and card fingerprints across the buyer's purchases — newest first, capped at `MAX_SIBLING_PURCHASES_FOR_UNBLOCK = 500` so an admin click stays bounded — and unblocks the union.
- **Only rows that are actually the buyer's.** Siblings are rows that resolved to the same account, plus guest rows (no account) whose card fingerprint matches the acting purchase or an account-bound sibling — the one corroborating identifier that is itself buyer-bound. A checkout email is unauthenticated, so an email match alone proves nothing — a same-email row owned by a *different* account can be somebody else's (Greptile P1 round one, reproduced with a harness), and so can a purchaser-less one: a card tester who typed the buyer's address at a guest checkout would otherwise get their own browser and card unblocked whenever an admin unblocks the buyer (Greptile P1 round two). A browser guid match deliberately does not corroborate either: a guid names a browser and browsers are shared, so another person's guest checkout under the buyer's email on the buyer's machine would match on guid and get its own card unblocked (Greptile P1 round three). Uncorroborated same-email guest rows contribute nothing to the clear, but their blocks come back from `#surviving_buyer_blocks` so they surface as `partially_unblocked` instead of being stranded silently. `recent_stripe_fingerprint` resolves over the same sibling set, both because its old `purchaser_id OR email` lookup had the same leak and so `block_buyer!`/`buyer_blocked?`/`unblock_buyer!` stay symmetric on one identifier set.
- **IP addresses stay row-scoped.** An IP is not buyer-bound: it is shared behind a NAT or a carrier pool and gets reallocated, so clearing every IP this buyer has ever checked out from would lift blocks other people earned. It also expires on its own (6 months). The widened identifiers are the ones that identify *this buyer*.
- **`unblock_buyer!` returns the blocks that survive.** New `#surviving_buyer_blocks` re-asks the same identifier question after the write and returns the rows rather than a boolean.
- **Controllers.** `api/internal/admin/purchases#unblock_buyer` renders `status: "partially_unblocked"` with a `surviving_blocks` list when anything is left holding the buyer, instead of an unqualified `success: true`. The rendered `Admin::PurchasesController#unblock_buyer` does the same via its `message`, which `AdminActionButton` shows in place of the static "Buyer unblocked!" alert.

## Why

Fixes [gumroad-private#1648](https://github.com/antiwork/gumroad-private/issues/1648). Opened at @slavingia's request on that thread ("Open fixes PRs").

The old implementation was scoped to one purchase's attribute values:

```ruby
def unblock_buyer!
  unblock_by_browser_guid!   # THIS purchase's browser_guid
  unblock_by_email!
  ...
end
```

`block_buyer!` is symmetric, so on the same row it round-trips fine. The asymmetry is across rows: the purchase an agent opens to press Unblock is almost never the purchase the block was written from. A buyer browses from several devices over the years, so unblocking from purchase A cleared guid A while the block sat on guid B and kept rejecting them.

Nothing said so. `buyer_blocked?` is an OR across identifiers, so it stayed true, the controller still wrote its "Buyer unblocked" comment, and the response was still `success: true`. Browser-guid rows are the worst ones to strand: `PlatformBlock.add!` only accepts an `expires_in` for `ip_address`, so a guid block never lapses.

Measured on the issue: sampling the 600 most recent "Buyer unblocked" comments carrying a `purchase_id` (277 resolvable buyers), **196 (71%) still carry an active automated block**, and for **183** of those the surviving row *predates* the unblock — i.e. the unblock missed it, rather than the buyer earning a second block (only 13 were genuine later re-blocks). **135** are stranded with clean history (≥3 aged paid purchases, 0 chargebacks) behind **7,243** paid purchases. One buyer had been unable to check out for **2.5 years** across two hand-unblocks that both left the same guid row active.

The two historical unblocks on that buyer, both of which reported success:

| Unblock | Acting purchase | Rows cleared | Rows left active |
|---|---|---|---|
| 2023-05-11 | `183093839` | `405428` fingerprint | `426098` browser_guid |
| 2024-01-24 | `221490801` | `471948` email, `471949` fingerprint | `426098` browser_guid |

Sequencing note from the issue: this fix has to land before the cohort clear, otherwise the next hand-unblock re-creates the cohort.

## Test results

Eleven new examples in `spec/models/concerns/purchase/blockable_spec.rb`, covering: a guid block written from a sibling purchase; a fingerprint block written from a sibling purchase; sibling resolution by email when the acting purchase has no `purchaser`; that a *different* buyer's block is left alone; that a *different account's* blocks are left alone even when it shares the checkout email (fails without the scoping fix); that a guest row sharing only the checkout email keeps its blocks and has them reported as surviving (fails without the corroboration fix); that a shared card still corroborates a guest sibling's cross-device guid clear; that a guest row sharing the buyer's browser but not their card keeps its card block and has it reported as surviving (fails without the fingerprint-only corroboration fix); that IP blocks on the buyer's other purchases are left alone; and both branches of the return value. Controller examples cover the `partially_unblocked` response in both admin controllers.

Verified locally: `spec/models/concerns/purchase/blockable_spec.rb` is green in full (137 examples), as are `spec/controllers/admin/purchases_controller_spec.rb` (21) and the `POST unblock_buyer` examples of the internal API controller spec (9). The earlier "cannot create a `:purchase` locally" blocker was an unseeded test database — `Purchase#financial_transaction_validation` fails when `MerchantAccount.gumroad` is missing, and the error message is the generic card-decline copy — fixed with `RAILS_ENV=test bin/rails db:seed`, not a Stripe problem.

The first CI run's `Test Fast 8` failure was a bad assertion in one of this PR's own new examples: it expected the sibling row to flip fully unblocked, but the sibling's IP block survives by design (IPs stay row-scoped). The example now asserts the browser guid specifically.

`bundle exec rubocop` is clean on all five files.

## Not in scope

The cohort clear itself — the 135 stranded clean-history buyers — is item 3 on the issue and is not in this PR.

---
🤖 Authored by gumclaw (AI agent), at @slavingia's request on gumroad-private#1648.




