### PR TITLE
Lock the invariant that deleted_ids[:variants] holds version ids only

### DIFF
--- a/app/services/product/save_contract.rb
+++ b/app/services/product/save_contract.rb
@@ -80,6 +80,19 @@ class Product::SaveContract
   # inferred so that adding a sixth is a deliberate act with a test attached.
   COLLECTIONS = %i[rich_content variants files public_files integrations].freeze
 
+  # `deleted_ids[:variants]` carries VERSION ids only — never VariantCategory
+  # (grouping) ids. An external id is `ObfuscateIds.encrypt(primary_key)` with no
+  # table discriminator, and `variants`/`variant_categories` have independent
+  # auto-increment counters, so a version and a grouping can share one id string.
+  # The deletion paths in Product::VariantCategoryUpdaterService resolve these ids
+  # against versions with no collision check, which is correct only while this
+  # holds. Put a grouping id in here and that grouping's colliding VERSION is what
+  # disappears, while the grouping survives and the save reports 200.
+  #
+  # Enforced by spec/services/product/variant_deleted_ids_kind_invariant_spec.rb.
+  # A grouping goes away as a consequence of losing its last version, not by being
+  # named — if you add grouping-level deletion, give it its own collection.
+
   # Kill switch. Defaults OFF: with the flag inactive every collection reports
   # `submitted?` exactly as the old code behaved (absent/[] still reaches the
   # existing diff-and-delete paths), so enabling and disabling this is a pure

--- a/spec/services/product/variant_deleted_ids_kind_invariant_spec.rb
+++ b/spec/services/product/variant_deleted_ids_kind_invariant_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# `deleted_ids[:variants]` carries version ids only, never grouping ids
+# (gumroad-private#1503).
+#
+# External ids are `ObfuscateIds.encrypt(primary_key)` with no table
+# discriminator, and `base_variants`/`variant_categories` have independent
+# auto-increment counters — so one id string can name both a version and a
+# grouping. The deletion paths in Product::VariantCategoryUpdaterService resolve
+# every id in `deleted_ids(:variants)` against VERSION external ids with no
+# collision check. That is correct today only because no client can put a
+# grouping id in that array; it is not a tie-break the server wins on merit.
+#
+# The first example pins what the collision actually costs, so nobody has to
+# re-derive it. The rest are the tripwire: they fail the moment the editor grows
+# a way to name a grouping in that collection.
+describe "deleted_ids[:variants] kind invariant" do
+  let(:seller) { create(:user) }
+  let(:product) { create(:product, user: seller) }
+
+  before { Feature.activate_user(Product::SaveContract::FEATURE_NAME, seller) }
+  after { Feature.deactivate_user(Product::SaveContract::FEATURE_NAME, seller) }
+
+  describe "the damage a grouping id would do if one ever reached the server" do
+    it "deletes the colliding version, leaves the named grouping alive, and reports success" do
+      category = create(:variant_category, link: product, title: "Groupings")
+      version = create(:variant, variant_category: category, name: "V1")
+
+      # Force the collision the id scheme permits: a SECOND grouping whose
+      # primary key equals the version's, so both encrypt to the same string.
+      colliding_category = create(:variant_category, link: product, title: "Collides")
+      VariantCategory.where(id: colliding_category.id).update_all(id: version.id)
+      colliding_category = VariantCategory.find(version.id)
+
+      expect(colliding_category.external_id).to eq(version.external_id)
+
+      contract = Product::SaveContract.new(
+        params: {
+          editor_revision: Product::EditorRevision.current(product.reload),
+          deletion_operations: { deleted_ids: { variants: [colliding_category.external_id] } },
+        },
+        product: product.reload
+      )
+
+      # The seller means "remove that grouping". The server has no way to know.
+      Product::VariantCategoryUpdaterService.new(
+        product: product,
+        category_params: { id: category.external_id, name: "Groupings", options: nil },
+        confirmed_removed_variant_ids: [colliding_category.external_id],
+        contract: contract
+      ).perform
+
+      expect(version.reload.alive?).to eq(false), "the unrelated VERSION was deleted"
+      expect(colliding_category.reload.alive?).to eq(true), "the grouping the seller named survived"
+    end
+  end
+
+  describe "the client cannot construct that request" do
+    javascript_root = Rails.root.join("app", "javascript")
+
+    # Every file that APPENDS to confirmed_removed_variant_ids — the sole
+    # upstream of deleted_ids[:variants]. Each of these four is a per-row
+    # deletion modal for one kind of version row (versions, durations, tiers,
+    # suggested amounts); none of them can hold a grouping.
+    permitted_producers = %w[
+      components/ProductEdit/ProductTab/VersionsEditor.tsx
+      components/ProductEdit/ProductTab/DurationsEditor.tsx
+      components/ProductEdit/ProductTab/TiersEditor.tsx
+      components/ProductEdit/ProductTab/SuggestedAmountsEditor.tsx
+    ]
+
+    it "has no producer of confirmed_removed_variant_ids outside the version-row editors" do
+      producers = Dir.glob(javascript_root.join("**", "*.{ts,tsx}")).select do |path|
+        next false if path.end_with?(".test.ts", ".test.tsx")
+
+        File.read(path).match?(/product\.confirmed_removed_variant_ids\s*=/)
+      end.map { |path| Pathname.new(path).relative_path_from(javascript_root).to_s }
+
+      expect(producers.sort).to eq(permitted_producers.sort),
+                                "A new writer of confirmed_removed_variant_ids appeared. If it can name a " \
+                                "VariantCategory (grouping), it will delete a colliding VERSION instead — see " \
+                                "gumroad-private#1503. Give grouping deletion its own collection."
+    end
+
+    it "gives deleted_ids.variants exactly one producer, fed only by confirmed_removed_variant_ids" do
+      contract_source = File.read(javascript_root.join("data", "product_save_contract.ts"))
+
+      assignments = contract_source.scan(/deletedIds\.variants\s*=\s*(.+)/).flatten
+      expect(assignments.size).to eq(1)
+      expect(assignments.first).to include("removedVariants")
+      expect(contract_source).to include("const removedVariants = product.confirmed_removed_variant_ids ?? [];")
+    end
+
+    it "exposes no grouping as a deletable object in the product editor" do
+      editor_sources = Dir.glob(javascript_root.join("components", "ProductEdit", "**", "*.{ts,tsx}")) +
+                       [javascript_root.join("data", "product_edit.ts").to_s]
+
+      naming_groupings = editor_sources.select do |path|
+        File.read(path).match?(/variant_categor|variantCategor/i)
+      end.map { |path| Pathname.new(path).relative_path_from(javascript_root).to_s }
+
+      expect(naming_groupings).to be_empty,
+                                  "The editor now references variant categories. A grouping still cannot be " \
+                                  "named in deleted_ids[:variants] — see gumroad-private#1503."
+    end
+  end
+end

--- a/spec/services/product/variant_deleted_ids_kind_invariant_spec.rb
+++ b/spec/services/product/variant_deleted_ids_kind_invariant_spec.rb
@@ -28,11 +28,19 @@ describe "deleted_ids[:variants] kind invariant" do
       category = create(:variant_category, link: product, title: "Groupings")
       version = create(:variant, variant_category: category, name: "V1")
 
-      # Force the collision the id scheme permits: a SECOND grouping whose
-      # primary key equals the version's, so both encrypt to the same string.
-      colliding_category = create(:variant_category, link: product, title: "Collides")
-      VariantCategory.where(id: colliding_category.id).update_all(id: version.id)
-      colliding_category = VariantCategory.find(version.id)
+      # Force the collision the id scheme permits: a grouping whose primary key
+      # equals the version's, so both encrypt to the same string. `base_variants`
+      # and `variant_categories` have independent counters, so whether that row
+      # already exists is incidental — take it if it does, move one onto that id
+      # if it does not. Never `update_all(id:)` blindly: when the id is already
+      # taken (which it is whenever the counters happen to line up) that violates
+      # the primary key, and the failure looks like a flake rather than a clash.
+      colliding_category = VariantCategory.find_by(id: version.id)
+      if colliding_category.nil?
+        spare = create(:variant_category, link: product, title: "Collides")
+        VariantCategory.where(id: spare.id).update_all(id: version.id)
+        colliding_category = VariantCategory.find(version.id)
+      end
 
       expect(colliding_category.external_id).to eq(version.external_id)
 
@@ -72,11 +80,13 @@ describe "deleted_ids[:variants] kind invariant" do
     ]
 
     it "has no producer of confirmed_removed_variant_ids outside the version-row editors" do
-      producers = Dir.glob(javascript_root.join("**", "*.{ts,tsx}")).select do |path|
-        next false if path.end_with?(".test.ts", ".test.tsx")
+      producers = Dir.glob(javascript_root.join("**", "*.{ts,tsx}")).filter_map do |path|
+        next if path.end_with?(".test.ts", ".test.tsx")
 
-        File.read(path).match?(/product\.confirmed_removed_variant_ids\s*=/)
-      end.map { |path| Pathname.new(path).relative_path_from(javascript_root).to_s }
+        next unless File.read(path).match?(/product\.confirmed_removed_variant_ids\s*=/)
+
+        Pathname.new(path).relative_path_from(javascript_root).to_s
+      end
 
       expect(producers.sort).to eq(permitted_producers.sort),
                                 "A new writer of confirmed_removed_variant_ids appeared. If it can name a " \
@@ -97,9 +107,11 @@ describe "deleted_ids[:variants] kind invariant" do
       editor_sources = Dir.glob(javascript_root.join("components", "ProductEdit", "**", "*.{ts,tsx}")) +
                        [javascript_root.join("data", "product_edit.ts").to_s]
 
-      naming_groupings = editor_sources.select do |path|
-        File.read(path).match?(/variant_categor|variantCategor/i)
-      end.map { |path| Pathname.new(path).relative_path_from(javascript_root).to_s }
+      naming_groupings = editor_sources.filter_map do |path|
+        next unless File.read(path).match?(/variant_categor|variantCategor/i)
+
+        Pathname.new(path).relative_path_from(javascript_root).to_s
+      end
 
       expect(naming_groupings).to be_empty,
                                   "The editor now references variant categories. A grouping still cannot be " \

--- a/spec/services/product/variant_deleted_ids_kind_invariant_spec.rb
+++ b/spec/services/product/variant_deleted_ids_kind_invariant_spec.rb
@@ -29,18 +29,17 @@ describe "deleted_ids[:variants] kind invariant" do
       version = create(:variant, variant_category: category, name: "V1")
 
       # Force the collision the id scheme permits: a grouping whose primary key
-      # equals the version's, so both encrypt to the same string. `base_variants`
-      # and `variant_categories` have independent counters, so whether that row
-      # already exists is incidental — take it if it does, move one onto that id
-      # if it does not. Never `update_all(id:)` blindly: when the id is already
-      # taken (which it is whenever the counters happen to line up) that violates
-      # the primary key, and the failure looks like a flake rather than a clash.
-      colliding_category = VariantCategory.find_by(id: version.id)
-      if colliding_category.nil?
-        spare = create(:variant_category, link: product, title: "Collides")
-        VariantCategory.where(id: spare.id).update_all(id: version.id)
-        colliding_category = VariantCategory.find(version.id)
-      end
+      # equals the version's, so both encrypt to the same string. Move BOTH rows
+      # onto an id free in both tables rather than reusing whatever grouping
+      # already sits at the version's id — when the two counters line up that row
+      # is `category` itself, and the example then asserts the grouping under
+      # test both survives and gets swept.
+      collision_id = [BaseVariant.maximum(:id), VariantCategory.maximum(:id)].compact.max + 1
+      BaseVariant.where(id: version.id).update_all(id: collision_id)
+      version = Variant.find(collision_id)
+      spare = create(:variant_category, link: product, title: "Collides")
+      VariantCategory.where(id: spare.id).update_all(id: collision_id)
+      colliding_category = VariantCategory.find(collision_id)
 
       expect(colliding_category.external_id).to eq(version.external_id)
 


### PR DESCRIPTION
Closes the open half of [gumroad-private#1503](https://github.com/antiwork/gumroad-private/issues/1503) — but not the way that issue proposed. See the trace in [my comment there](https://github.com/antiwork/gumroad-private/issues/1503#issuecomment-latest): the scenario it describes ("the seller names a grouping for deletion") has no client path that produces it, so neither of the two options on the table — (a) a third tie-break in `VariantCategoryUpdaterService`, (b) kind-prefixed external ids across the frontend and `SaveContract` — is fixing a reachable bug.

What is real is that the invariant making the current code correct is undocumented and unenforced.

## The invariant

`deleted_ids[:variants]` carries **version** ids only, never `VariantCategory` (grouping) ids.

`contract_scoped_category_deletions` and `contract_scoped_variant_deletions` match every id in that array against version external ids with no collision awareness. An external id is `ObfuscateIds.encrypt(primary_key)` with no table discriminator, and `base_variants`/`variant_categories` have independent auto-increment counters, so one string can name both kinds of row. Matching against versions is correct **because that is the only kind of row that can be in there** — not because the server wins a tie on merit.

## Why this needs a lock

Nothing states it. `confirmed_removed_variant_ids` has exactly four producers, all per-row version deletion modals (`VersionsEditor`, `DurationsEditor`, `TiersEditor`, `SuggestedAmountsEditor`), and the editor has no grouping-deletion UI — a grouping goes away only as a server-side consequence of losing its last version. The next person to add grouping-level deletion to the editor would naturally reuse this collection and silently resurrect exactly the data-loss bug #1503 describes.

## What is here

`spec/services/product/variant_deleted_ids_kind_invariant_spec.rb`:

1. **Pins the cost.** Forces the id collision (a `VariantCategory` whose primary key equals a live version's, so both encrypt to the same string), sends that id as a deletion, and asserts what happens: **the unrelated version is soft-deleted, the grouping the seller named survives, the save reports success.** This is measured, not argued — it is the concrete damage, recorded so nobody re-derives it.
2. **Three tripwires** that fail if a fifth writer of `confirmed_removed_variant_ids` appears, if `deletedIds.variants` gains a second producer, or if the product editor starts referencing variant categories at all.

Plus a comment on `SaveContract::COLLECTIONS` stating the invariant and pointing at the spec.

## Not covered

A **hand-crafted** request (curl, or a tab predating the contract) can still put a grouping id in that array and the server will read it as a version. That is an unauthorized-payload question, not the seller-facing bug #1503 is filed as. This PR makes closing that deliberate rather than accidental.

## Test plan

```
bundle exec rspec spec/services/product/variant_deleted_ids_kind_invariant_spec.rb
4 examples, 0 failures
```
