### PR TITLE
Deploy a preview app for every branch, not just labeled PRs

### DIFF
--- a/.buildkite/scripts/preview_gate.sh
+++ b/.buildkite/scripts/preview_gate.sh
@@ -7,35 +7,52 @@ logger() {
   echo -e "${GREEN}$(date "+%Y/%m/%d %H:%M:%S") preview_gate.sh: $1${NC}"
 }
 
-PREVIEW_LABEL="preview"
+# Every branch build gets a preview app. There is no opt-in.
+#
+# This used to require a `preview` label on an open PR, which meant the app only
+# existed once someone remembered to ask for it — so the branches most worth
+# looking at (pushed, green, no PR yet) had no environment at all, and reviewing
+# a change meant reading a diff. Standing order (Sahil, 2026-08-01): "Don't use
+# preview label anymore. Instead, generate a preview app for every deployment.
+# It's totally fine to have 50+ even in parallel."
+#
+# Two consequences that follow, and are deliberate:
+#   * No PR is required. A pushed branch is enough — the PR-less green branch is
+#     exactly the case the old gate left uncovered.
+#   * Concurrency is not capped here. Preview environments are per-branch and
+#     independent, so 50+ in parallel is a supported state, not something to
+#     defend against.
+#
+# `main` and `comp-assets-*` are excluded in pipeline.yml (`branches:`), not here:
+# main deploys to production and comp-assets-* is the asset-cache builder.
 PREVIEW_GITHUB_REPO="${PREVIEW_GITHUB_REPO:-antiwork/gumroad}"
 
-if [ -z "${GITHUB_TOKEN:-}" ]; then
-  logger "Error: GITHUB_TOKEN is not set"
-  exit 1
-fi
-export GH_TOKEN="$GITHUB_TOKEN"
-
-source .buildkite/scripts/ensure_gh.sh
-ensure_gh
-
+# The PR number is looked up only to label the Buildkite annotation with
+# something a human can click. It is NOT a gate — a missing PR must never stop
+# the preview from deploying.
 pr_number="${BUILDKITE_PULL_REQUEST:-false}"
 if [ "$pr_number" = "false" ] || [ -z "$pr_number" ]; then
-  pr_number=$(gh pr list --repo "$PREVIEW_GITHUB_REPO" --head "$BUILDKITE_BRANCH" --state open --json number --jq '.[0].number // empty')
+  pr_number=""
+  if [ -n "${GITHUB_TOKEN:-}" ]; then
+    export GH_TOKEN="$GITHUB_TOKEN"
+    source .buildkite/scripts/ensure_gh.sh
+    ensure_gh
+    # Never let a gh failure (rate limit, token scope, API blip) block the deploy.
+    pr_number=$(gh pr list --repo "$PREVIEW_GITHUB_REPO" --head "$BUILDKITE_BRANCH" \
+      --state open --json number --jq '.[0].number // empty' 2>/dev/null || true)
+  fi
 fi
 
-if [ -z "$pr_number" ]; then
-  logger "No open PR for ${BUILDKITE_BRANCH}; skipping preview app"
-  buildkite-agent annotate "No open PR for \`${BUILDKITE_BRANCH}\`. Open a PR and add the \`${PREVIEW_LABEL}\` label to deploy a preview app." --style "info" --context "preview" || true
-  exit 0
+if [ -n "$pr_number" ]; then
+  logger "Deploying preview app for ${BUILDKITE_BRANCH} (PR #${pr_number})"
+  buildkite-agent annotate \
+    "Preview app deploying for PR #${pr_number} (\`${BUILDKITE_BRANCH}\`)." \
+    --style "info" --context "preview" || true
+else
+  logger "Deploying preview app for ${BUILDKITE_BRANCH} (no open PR)"
+  buildkite-agent annotate \
+    "Preview app deploying for \`${BUILDKITE_BRANCH}\` (no open PR — every branch gets one)." \
+    --style "info" --context "preview" || true
 fi
 
-has_label=$(gh pr view "$pr_number" --repo "$PREVIEW_GITHUB_REPO" --json labels --jq "any(.labels[]; .name == \"${PREVIEW_LABEL}\")")
-if [ "$has_label" != "true" ]; then
-  logger "PR #${pr_number} is not labeled '${PREVIEW_LABEL}'; skipping preview app"
-  buildkite-agent annotate "Add the \`${PREVIEW_LABEL}\` label to PR #${pr_number} to deploy a preview app." --style "info" --context "preview" || true
-  exit 0
-fi
-
-logger "PR #${pr_number} is labeled '${PREVIEW_LABEL}'; provisioning preview app"
 buildkite-agent pipeline upload .buildkite/preview.yml

--- a/.github/workflows/preview-app.yml
+++ b/.github/workflows/preview-app.yml
@@ -1,12 +1,34 @@
 name: Preview app
 
+# Every push to a branch gets a preview app — no label, no opt-in
+# (Sahil, 2026-08-01: "Don't use preview label anymore. Instead, generate a preview
+# app for every deployment. It's totally fine to have 50+ even in parallel.")
+#
+# This previously ran on `pull_request: [labeled]` and checked for a `preview` label,
+# so a branch had no environment until someone remembered to ask — and a pushed,
+# green, PR-less branch never got one at all.
+#
+# Note this workflow is a convenience trigger, not the gate: Buildkite's own
+# preview_gate.sh runs on every branch build and uploads the preview pipeline
+# regardless of how the build was started. If this job is skipped (or its
+# credentials are absent) the push still produces a preview app.
 on:
-  pull_request:
-    types: [labeled]
+  push:
+    branches-ignore:
+      # main deploys to production; comp-assets-* is the asset-cache builder.
+      - main
+      - 'comp-assets-*'
+
+# One preview build per branch. A newer push supersedes an in-flight build of the
+# same branch (nothing is gained by finishing a deploy of superseded code), while
+# DIFFERENT branches never queue behind each other — 50+ concurrent previews is a
+# supported state, so the group key must be the branch, never a global constant.
+concurrency:
+  group: preview-app-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   deploy:
-    if: github.event.label.name == 'preview'
     runs-on: ubuntu-latest
     steps:
       - name: Trigger preview app build on Buildkite
@@ -14,12 +36,11 @@ jobs:
           BUILDKITE_API_TOKEN: ${{ secrets.BUILDKITE_API_TOKEN }}
           BUILDKITE_ORG: ${{ vars.BUILDKITE_ORG }}
           BUILDKITE_PIPELINE: ${{ vars.BUILDKITE_PIPELINE }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.sha }}
+          HEAD_REF: ${{ github.ref_name }}
         run: |
           if [ -z "$BUILDKITE_API_TOKEN" ] || [ -z "$BUILDKITE_ORG" ] || [ -z "$BUILDKITE_PIPELINE" ]; then
-            echo "Buildkite credentials are not configured; skipping. A push to the branch will still deploy the preview app."
+            echo "Buildkite credentials are not configured; skipping. The branch push still deploys the preview app."
             exit 0
           fi
 
@@ -31,7 +52,7 @@ jobs:
           {
             "commit": "${HEAD_SHA}",
             "branch": "${HEAD_REF}",
-            "message": "Preview app for #${PR_NUMBER}",
+            "message": "Preview app for ${HEAD_REF}",
             "ignore_pipeline_branch_filters": true
           }
           JSON


### PR DESCRIPTION
## What

Every branch push now deploys a preview app. The `preview` label is retired.

## Why

A preview app only existed once someone remembered to add a `preview` label to an open PR, so the branches most worth looking at were the ones that missed out: a pushed, green, PR-less branch got no environment at all, and reviewing it meant reading a diff instead of clicking through the change.

Standing order (2026-08-01): *"Don't use preview label anymore. Instead, generate a preview app for every deployment. It's totally fine to have 50+ even in parallel."*

## Before / after

| | Before | After |
|---|---|---|
| Trigger | `pull_request: [labeled]` + `preview` label | any branch `push` |
| Open PR required | yes | no |
| `gh` / token failure | blocks the preview (exit 1) | cannot block it |
| Concurrency | effectively serialized by hand | per-branch, many in parallel |

Three gates removed:

- `preview_gate.sh` no longer reads the label, and no longer requires an open PR. The PR number is still looked up, but only to make the Buildkite annotation clickable — a missing PR, an unset `GITHUB_TOKEN`, or a failing `gh` call can no longer stop the deploy.
- The GitHub workflow triggers on `push` instead of `pull_request: [labeled]`.
- Concurrency is keyed on `github.ref`, so a newer push supersedes an in-flight build of the **same** branch while different branches never queue behind each other. Many simultaneous previews is the expected state, not something to defend against.

`main` and `comp-assets-*` keep their existing exclusions: main deploys to production, `comp-assets-*` is the asset-cache builder.

## Tests

No unit tests — this is CI pipeline config. Verified two ways instead.

**1. Gate logic, with `buildkite-agent` and `gh` stubbed, across five cases.** The old gate deployed a preview in **none** of them; this one deploys in all five:

| Case | Old | New |
|---|---|---|
| PR number supplied by Buildkite | no preview | deploys |
| No PR env, `gh` finds a PR | no preview | deploys |
| No PR at all (PR-less branch) | no preview | deploys |
| `gh` fails (rate limit) | **exit 1** | deploys |
| No `GITHUB_TOKEN` | **exit 1** | deploys |

**2. This branch is its own test case.** Pushing it fired the `Preview app` workflow on the `push` event with no label present, and Buildkite build [#18956](https://buildkite.com/gumroad-inc/gumroad/builds/18956) was scheduled for `chore/preview-app-every-branch` — an unlabelled branch getting a preview, which is the whole change.

## Progress

- [x] Scope — retire the label, deploy per push
- [x] Design — remove the gate rather than widen it; per-branch concurrency
- [x] Build — 1 script + 1 workflow
- [x] Ship — pending merge
- [ ] Market — n/a, internal CI change
- [ ] Sell — n/a, internal CI change

## Note for the reviewer

`BUILDKITE_PIPELINE` is not currently set as a repo variable, so the GitHub workflow takes its documented skip path and Buildkite's own branch build is what produces the preview. That is the designed fallback and is why the workflow is a convenience trigger rather than the gate — but it does mean the `curl` path in this workflow is not exercised today.
