### PR TITLE
Honor the seller's gifting setting in the checkout preview

### DIFF
--- a/app/javascript/components/CheckoutDashboard/CheckoutPreview.test.tsx
+++ b/app/javascript/components/CheckoutDashboard/CheckoutPreview.test.tsx
@@ -1,0 +1,40 @@
+// @vitest-environment happy-dom
+import { cleanup, render } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { PLACEHOLDER_CART_ITEM } from "$app/utils/cart";
+
+import { CheckoutPreview } from "$app/components/CheckoutDashboard/CheckoutPreview";
+
+vi.stubGlobal("Routes", new Proxy({}, { get: () => () => "#" }));
+
+vi.mock("$app/components/Checkout/PaymentForm", () => ({ PaymentForm: () => null }));
+vi.mock("$app/components/server-components/Alert", () => ({ showAlert: vi.fn() }));
+vi.mock("$app/utils/user_analytics", () => ({ trackUserProductAction: vi.fn(), startTrackingForSeller: vi.fn() }));
+vi.mock("$app/components/Product/Thumbnail", () => ({ Thumbnail: () => null }));
+vi.mock("$app/components/useIsAboveBreakpoint", () => ({ useIsAboveBreakpoint: () => true }));
+vi.mock("$app/components/useOriginalLocation", () => ({
+  useOriginalLocation: () => "https://gumroad.com/checkout",
+}));
+
+const renderPreview = (canGift: boolean) =>
+  render(
+    <CheckoutPreview
+      cartItem={{ ...PLACEHOLDER_CART_ITEM, product: { ...PLACEHOLDER_CART_ITEM.product, can_gift: canGift } }}
+    />,
+  );
+
+describe("CheckoutPreview gifting", () => {
+  afterEach(cleanup);
+
+  it("shows the gift section when the seller allows gifting", () => {
+    const { queryByText } = renderPreview(true);
+    expect(queryByText("Give as a gift?")).not.toBeNull();
+  });
+
+  it("hides the gift section when the seller has disabled gifting", () => {
+    const { queryByText } = renderPreview(false);
+    expect(queryByText("Give as a gift?")).toBeNull();
+  });
+});

--- a/app/javascript/components/CheckoutDashboard/CheckoutPreview.tsx
+++ b/app/javascript/components/CheckoutDashboard/CheckoutPreview.tsx
@@ -77,7 +77,7 @@ export const CheckoutPreview = ({
             isPreorder: false,
             nativeType: "digital",
             recurrence: null,
-            canGift: true,
+            canGift: cartItem.product.can_gift,
           },
         ],
         paypalClientId: "",

--- a/app/javascript/components/CheckoutDashboard/FormPage.test.tsx
+++ b/app/javascript/components/CheckoutDashboard/FormPage.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { PLACEHOLDER_CART_ITEM } from "$app/utils/cart";
+
+import FormPage, { FormPageProps } from "$app/components/CheckoutDashboard/FormPage";
+
+vi.stubGlobal("Routes", new Proxy({}, { get: () => () => "#" }));
+
+vi.mock("@inertiajs/react", () => ({
+  useForm: <T,>(initial: T) => {
+    const [data, setData] = React.useState(initial);
+    return {
+      data,
+      setData: (key: keyof T, value: T[keyof T]) => setData((prev) => ({ ...prev, [key]: value })),
+      processing: false,
+      errors: {},
+      put: vi.fn(),
+      post: vi.fn(),
+    };
+  },
+}));
+
+vi.mock("$app/components/Checkout/PaymentForm", () => ({ PaymentForm: () => null }));
+vi.mock("$app/components/server-components/Alert", () => ({ showAlert: vi.fn() }));
+vi.mock("$app/utils/user_analytics", () => ({ trackUserProductAction: vi.fn(), startTrackingForSeller: vi.fn() }));
+vi.mock("$app/components/Product/Thumbnail", () => ({ Thumbnail: () => null }));
+vi.mock("$app/components/useIsAboveBreakpoint", () => ({ useIsAboveBreakpoint: () => true }));
+vi.mock("$app/components/useOriginalLocation", () => ({
+  useOriginalLocation: () => "https://gumroad.com/checkout",
+}));
+vi.mock("$app/components/LoggedInUser", () => ({
+  useLoggedInUser: () => ({ policies: { checkout_form: { update: true } } }),
+}));
+vi.mock("$app/components/CheckoutDashboard/PayPalConnectSection", () => ({ default: () => null }));
+
+const props = (giftingDisabled: boolean): FormPageProps => ({
+  pages: [],
+  user: {
+    display_offer_code_field: false,
+    recommendation_type: "no_recommendations",
+    tipping_enabled: false,
+    ach_payments_enabled: false,
+    gifting_disabled: giftingDisabled,
+  },
+  cart_item: PLACEHOLDER_CART_ITEM,
+  card_product: null,
+  custom_fields: [],
+  products: [],
+  paypal_connect: {
+    email: null,
+    charge_processor_merchant_id: null,
+    charge_processor_verified: false,
+    needs_email_confirmation: false,
+    unsupported_countries: [],
+    show_paypal_connect: false,
+    allow_paypal_connect: false,
+    paypal_disconnect_allowed: false,
+    paypal_disconnect_removes_payout_rail: false,
+    paypal_disconnect_blocks_publishing: false,
+    payout_setup_method: "bank_account",
+  },
+  connect_account_fee_info_text: "",
+});
+
+describe("FormPage gifting preview", () => {
+  afterEach(cleanup);
+
+  it("shows the gift section in the preview when gifting is enabled", () => {
+    render(<FormPage {...props(false)} />);
+    expect(screen.queryByText("Give as a gift?")).not.toBeNull();
+  });
+
+  it("hides the gift section in the preview when gifting is disabled", () => {
+    render(<FormPage {...props(true)} />);
+    expect(screen.queryByText("Give as a gift?")).toBeNull();
+  });
+
+  // The reported bug: the preview kept the gift section until the page was saved and reloaded.
+  it("updates the preview as soon as the toggle changes, before any save", () => {
+    render(<FormPage {...props(false)} />);
+    expect(screen.queryByText("Give as a gift?")).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("switch", { name: /purchase your products as gifts/u }));
+
+    expect(screen.queryByText("Give as a gift?")).toBeNull();
+  });
+});

--- a/app/javascript/components/CheckoutDashboard/FormPage.tsx
+++ b/app/javascript/components/CheckoutDashboard/FormPage.tsx
@@ -456,6 +456,7 @@ const FormPage = ({
               has_offer_codes: displayOfferCodeField,
               custom_fields: customFields.map(({ key, ...field }) => ({ ...field, id: key })),
               has_tipping_enabled: tippingEnabled,
+              can_gift: !giftingDisabled,
             },
           }}
           recommendedProduct={recommendationType !== "no_recommendations" ? cardProduct : undefined}


### PR DESCRIPTION
## What

The Checkout → Form page preview kept showing the "Give as a gift?" section after a seller turned gifting off. `CheckoutPreview` hardcoded `canGift: true` when building its synthetic sample cart, so the preview contradicted the real checkout, which was already correct.

Threads the value through the way `has_tipping_enabled` already is: `CheckoutPreview` reads `cartItem.product.can_gift`, and `FormPage` supplies `can_gift: !giftingDisabled` in the same override block that already carries the other live form values.

Fixes antiwork/gumroad-private#1658.

## Why

The gifting toggle shipped in #6068 and works — `Link#can_gift?` gates the real checkout correctly. Only the seller-facing preview was wrong, which is the surface a seller uses to confirm the setting took effect. The preview is the feedback loop for the feature, so it disagreeing with production is the whole bug.

Because `giftingDisabled` comes from Inertia form state rather than the persisted user, the preview now reacts to the toggle **immediately**, before any save — which is what the report was actually about.

## Test results

`npx vitest run app/javascript/components/CheckoutDashboard/` — 9 passed (3 files):

```
 ✓ app/javascript/components/CheckoutDashboard/DiscountsPage.test.ts (4 tests)
 ✓ app/javascript/components/CheckoutDashboard/CheckoutPreview.test.tsx (2 tests)
 ✓ app/javascript/components/CheckoutDashboard/FormPage.test.tsx (3 tests)

 Test Files  3 passed (3)
      Tests  9 passed (9)
```

`npx tsc --noEmit` clean for these files; eslint and prettier clean. CI green at `16299c448` — **76 checks, 0 pending, 0 failing, 0 cancelled**.

**Mutation-verified, both halves.** Each production line was deleted and the suite re-run:

| Mutation | Result |
|---|---|
| `canGift: cartItem.product.can_gift` → `canGift: true` | 1 failed — `expected <h4></h4> to be null` |
| delete `can_gift: !giftingDisabled` from FormPage | 2 failed (both FormPage examples) |

The second row is the point of the second commit — see the review section.

## QA steps

1. Go to Checkout → Form as a seller with gifting enabled. The preview on the right shows "Give as a gift?".
2. Toggle **Allow customers to purchase your products as gifts** off. The gift section disappears from the preview immediately, with no save and no reload.
3. Toggle it back on — the section returns.
4. Save, reload, and confirm the preview still matches the saved setting.
5. Real checkout is unchanged in both states (it was already correct).

## Fable-5 adversarial review

Verdict: **READY-TO-MERGE** at `d943b6fd6`, with one P2 and two P3s. Full round run locally against the branch before this PR was opened.

| Sev | Finding | Disposition |
|---|---|---|
| P2 | The FormPage half of the fix was unpinned — deleting `can_gift: !giftingDisabled` left the entire suite green while the reported bug returned. The two original tests rendered `CheckoutPreview` directly, so they pinned only the component half. | **Fixed in `16299c448`.** New `FormPage.test.tsx` renders the real component and clicks the toggle. Independently confirmed by mutation before and after: 0 tests red before, 2 red after. |
| P3 | `UpsellsPage`'s placeholder lane still feeds `PLACEHOLDER_CART_ITEM` with hardcoded `can_gift: true`, so a gifting-disabled seller sees the gift section in the transient state before a product is selected. | **Not fixed — pre-existing and unchanged-wrong**, not a regression (that lane was wrong on *every* upsell preview before this change; the real-product lane is now correct via `CheckoutPresenter`). Out of scope for a 2-line fix; worth its own change. |
| P3 | `!giftingDisabled` drops the `!is_in_preorder_state` conjunct of `Link#can_gift?`. | **Accepted deliberately.** `CheckoutPreview` already normalizes the synthetic product (`isPreorder: false`, `nativeType: "digital"`, `hasFreeTrial: false`), and the neighbouring `has_tipping_enabled` override drops its own server-side conjuncts identically. The preview demonstrates the *setting*, not the quirks of whichever product is newest. For non-preorder products `!giftingDisabled` equals `product.can_gift?` exactly. |

**What the review confirmed safe** (each independently verified against the code, not assumed):

- **The fix is live, not save-gated.** `giftingDisabled` reads `form.data.user.gifting_disabled`; the Switch's `onChange` calls `updateUserData` → Inertia `form.setData`, a React state update. The new `cartItem` identity invalidates `CheckoutPreview`'s `useMemo([cartItem])`. This is the same plumbing as the working `tipping_enabled` toggle three lines up. Now also pinned by a test.
- **`canGift` genuinely and solely gates the section.** Single consumer is `Checkout/index.tsx:335` → `GiftForm`. No `||`, no cart-level flag. The preview always has exactly one product and `pay_in_installments` is false for the sample cart.
- **No lane regresses from the override.** The `UpsellsPage` real-product lane is now *more* correct than before (server truth via `CheckoutPresenter#checkout_product`).
- **Type plumbing.** `can_gift` is a required `boolean` on `Product`, and the override sits in a fresh object literal, so a typoed key fails typecheck. Deleting the override still typechecks — which is exactly why the P2 test matters.
- **No slop.** No comments added to production code; the diff carries no narration or dead defensiveness. Nothing to trim.

**Only verifiable live:** the visual result in a real browser at the preview's 0.4 scale factor — covered by QA step 2 above.

## AI disclosure

Written by Hermes Agent (claude-opus-5) on gumclaw's behalf. Adversarial review by fable-5; the P2 it raised was independently reproduced by mutation before being fixed.
