### PR TITLE
Document what Gumroad Ping actually promises

### DIFF
--- a/app/javascript/pages/Public/Ping.tsx
+++ b/app/javascript/pages/Public/Ping.tsx
@@ -51,6 +51,8 @@ const PING_PARAMETERS: PingParameter[] = [
   { name: "referrer", description: "-" },
   { name: "gumroad_fee", description: "Gumroad's fee, in USD cents" },
   { name: "card", description: "Payment instrument details" },
+  { name: "resource_name", description: <>What the ping is about. <Code>sale</Code> for a purchase, <Code>refund</Code> when the same purchase is later refunded</> },
+  { name: "retry_count", description: "Only present on a retried delivery: 1, 2 or 3" },
 ];
 
 const PublicPing = () => (
@@ -76,7 +78,30 @@ const PublicPing = () => (
             <p>
               The ping comes in the form of an HTTP POST request to the URL that you specify in your{" "}
               <Link href={Routes.settings_advanced_path()}>account settings</Link>.
-              The payload is x-www-form-urlencoded. If your endpoint does not return a 200 HTTP status code, the POST is retried once an hour for up to 3 hours.
+              The payload is x-www-form-urlencoded. Return any 2xx status to acknowledge it; nothing in your response body is read.
+            </p>
+
+            <div>
+              <p>Delivery works like this, and it is worth building against rather than inferring:</p>
+              <ul className="ml-6 mt-2 list-disc space-y-1">
+                <li>Delivery is at least once. The same ping can arrive more than once, so deduplicate.</li>
+                <li>Ordering is not guaranteed. A refund ping can reach you before the sale ping it refers to.</li>
+                <li>
+                  Deduplicate on <Code>sale_id</Code> together with <Code>resource_name</Code>, not on <Code>sale_id</Code> alone.
+                  A refund carries the same <Code>sale_id</Code> as the sale it reverses.
+                </li>
+                <li>
+                  A failed delivery is retried after 1 minute, 3 minutes, 10 minutes and 1 hour, then stops. Only 499, 500, 502,
+                  503 and 504 are retried. Any other non-2xx response is not, and neither is a connection error or a timeout.
+                </li>
+                <li>Your endpoint has 5 seconds to respond. Acknowledge first and do your work afterwards.</li>
+              </ul>
+            </div>
+
+            <p>
+              Because the payload is unsigned and deliveries can be dropped once the retries run out, treat a ping as a trigger
+              rather than as data: take <Code>sale_id</Code>, read the sale back through the API, and reconcile periodically
+              against your own records.
             </p>
 
             <p>In each request, Gumroad sends the parameters in the table below.</p>


### PR DESCRIPTION
## What

Rewrites the delivery-semantics paragraph on the public Gumroad Ping page (`/ping`) so it matches what `PostToIndividualPingEndpointWorker` actually does, and documents the parts an integrator currently has to reverse-engineer.

## Why

The page said:

> If your endpoint does not return a 200 HTTP status code, the POST is retried once an hour for up to 3 hours.

Both halves are wrong, in the direction that costs sellers money:

| Page said | Code does (`app/sidekiq/post_to_individual_ping_endpoint_worker.rb`) |
|---|---|
| retried once an hour, up to 3 hours | `BACKOFF_STRATEGY = [60, 180, 600, 3600]` — 1m / 3m / 10m / 1h, then stops |
| any non-200 is retried | `ERROR_CODES_TO_RETRY = [499, 500, 502, 503, 504]` only |
| (silent) | a connection error or timeout is rescued and never retried at all |
| (silent) | the request `timeout: 5` — a slow endpoint is a dead delivery, and unlike a 500 it does not even get the retry schedule |

So an integrator who builds to the published contract expects an hour of slack before their first retry lands (it is 60 seconds), expects a 502-returning endpoint to keep being retried for 3 hours (it stops after four attempts), and expects a 4xx or a timeout to be retried (neither ever is). Each of those is a dropped sale notification the seller never learns about.

Also added, because integrators have to infer it today and one of them gets it wrong in a way that silently loses refunds:

- Delivery is at least once (two independent retry layers: `PostToPingEndpointsWorker` has `retry: 20`, and per-endpoint delivery has its own backoff).
- Ordering is not guaranteed — refunds go out via `PostToPingEndpointsWorker.perform_in(5.seconds, ...)` while a sale delivery can be retried up to an hour later, so a refund ping really can land first.
- **Deduplicate on `sale_id` + `resource_name`, not `sale_id` alone.** A refund ping carries the *same* `sale_id` as the sale it reverses (`payload[:resource_name] = resource_name`), so the obvious dedupe key throws the refund away as a duplicate.
- Any 2xx acknowledges; only `response.success?` is inspected, nothing in the body is read.
- Treat the ping as a trigger, not as data: it is unsigned and droppable, so read the sale back through the API.

Two payload fields the table never listed are now in it: `resource_name` and `retry_count` (absent on the first attempt, then 1/2/3).

No behaviour change — copy and one table only. `/ping` is the single source for this; the API docs' Resource Subscriptions section already links here rather than restating it.

## Before / After

**Before** — the one sentence on retries, both halves wrong:

> The payload is x-www-form-urlencoded. If your endpoint does not return a 200 HTTP status code, the POST is retried once an hour for up to 3 hours.

**After** — accurate acknowledgment rule, plus the contract as a list:

> The payload is x-www-form-urlencoded. Return any 2xx status to acknowledge it; nothing in your response body is read.
>
> Delivery works like this, and it is worth building against rather than inferring:
> - Delivery is at least once. The same ping can arrive more than once, so deduplicate.
> - Ordering is not guaranteed. A refund ping can reach you before the sale ping it refers to.
> - Deduplicate on `sale_id` together with `resource_name`, not on `sale_id` alone. A refund carries the same `sale_id` as the sale it reverses.
> - A failed delivery is retried after 1 minute, 3 minutes, 10 minutes and 1 hour, then stops. Only 499, 500, 502, 503 and 504 are retried. Any other non-2xx response is not, and neither is a connection error or a timeout.
> - Your endpoint has 5 seconds to respond. Acknowledge first and do your work afterwards.
>
> Because the payload is unsigned and deliveries can be dropped once the retries run out, treat a ping as a trigger rather than as data: take `sale_id`, read the sale back through the API, and reconcile periodically against your own records.

## Tests

Copy-only change to one Inertia page; there is no spec asserting this prose. Verified instead that every claim traces to code:

- retry codes + schedule: `ERROR_CODES_TO_RETRY` / `BACKOFF_STRATEGY`, and `spec/sidekiq/post_to_individual_ping_endpoint_worker_spec.rb` ("retries 50x status codes the right number of times" expects exactly 4 posts; "does not retry other status codes" expects exactly 1 for a 417).
- timeout + connection-error drop: `HTTParty.post(..., timeout: 5)` and the `rescue *INTERNET_EXCEPTIONS` that logs and returns.
- acknowledgment: `unless response.success?`.
- shared `sale_id` across sale and refund: `payload[:sale_id] = ObfuscateIds.encrypt(id)` with `payload[:resource_name] = resource_name`, and `send_refunded_notification_webhook` re-pinging the same purchase with `REFUNDED_RESOURCE_NAME`.
- `retry_count`: `params["retry_count"]`, merged as `retry_count => retry_count + 1` on each requeue.

Ran prettier and eslint on the file — the 5 remaining eslint errors are the pre-existing `Routes` global typing complaints, identical before and after the change (confirmed by stashing the diff and re-running).

Prompted by a developer on a support thread who asked us to publish exactly these semantics.
