### PR TITLE
Route the purchase-healthcheck job's lock TTL through RecurringLockTtl

### DIFF
--- a/app/sidekiq/update_purchase_healthcheck_threshold_job.rb
+++ b/app/sidekiq/update_purchase_healthcheck_threshold_job.rb
@@ -17,17 +17,20 @@ class UpdatePurchaseHealthcheckThresholdJob
   # Survives ~6 missed runs, then the endpoint fails closed on the absent key.
   THRESHOLD_TTL = 1.hour
 
+  sidekiq_options retry: 0, queue: :critical, lock: :until_executed
+
   # A SIGKILL (OOM, deploy pod reap) skips the `ensure` that releases an
   # `until_executed` lock, and this job's digest is constant because it takes no
   # arguments — so one stranded lock silently drops every subsequent enqueue
   # (gumroad-private#1576). That failure is worse here than elsewhere: the
   # threshold key then expires and the healthcheck it feeds goes quiet in exactly
-  # the conditions that kill workers. Bounded above a slow run (seven windowed
-  # COUNTs on purchases) and far below THRESHOLD_TTL, so a strand costs a couple
-  # of refreshes rather than the page.
-  LOCK_TTL = 2.minutes
-
-  sidekiq_options retry: 0, queue: :critical, lock: :until_executed, lock_ttl: LOCK_TTL.to_i
+  # the conditions that kill workers. A minute covers a slow run (seven windowed
+  # COUNTs on purchases); the resulting TTL still sits far below THRESHOLD_TTL, so
+  # a strand costs a few refreshes rather than the page. Like the other per-minute
+  # job here, the interval is below any survivable attempt, so no TTL clears both
+  # bounds and safety wins.
+  include RecurringLockTtl
+  recurring_lock_ttl max_attempt: 1.minute
 
   def perform
     now = Time.current


### PR DESCRIPTION
`main` is red on `Test Fast 1`:

```
RecurringLockTtl every scheduled until_executed job
  UpdatePurchaseHealthcheckThresholdJob keeps the ttl above its declared worst-case attempt

  UpdatePurchaseHealthcheckThresholdJob sets lock_ttl without going through
  RecurringLockTtl, so nothing relates its TTL to a declared worst-case attempt.
```

Nobody wrote a bug. Two PRs crossed:

- #6711 added the guard asserting that every scheduled `until_executed` job declares its worst-case attempt through `RecurringLockTtl`.
- #6700 added `UpdatePurchaseHealthcheckThresholdJob` with a hand-set `lock_ttl: LOCK_TTL.to_i`.

Each was green against the `main` it was tested on. The second to merge broke the first — the guard reads the schedule and `sidekiq_options` at runtime, so a new job qualifies the moment it lands, and no diff overlaps.

## The fix

Drop the `LOCK_TTL = 2.minutes` literal and declare `max_attempt: 1.minute` through the concern instead.

The derived TTL is 360s (`max_attempt + SAFETY_MARGIN`) rather than the previous 120s. That is still far below the 1h `THRESHOLD_TTL`, so the original reasoning holds: a stranded lock costs a few refreshes, not the page.

Like `DispatchPendingFailedRefundExceptionsJob`, this job's per-minute interval is below any survivable attempt, so no TTL clears both bounds at once. Safety wins and the two interval examples skip, which is the same accommodation that job already gets.

## Verification

`spec/models/concerns/recurring_lock_ttl_spec.rb` locally: 138 examples, 0 failures, 4 pending (the pre-existing interval skips). Full `Tests` suite green on this branch before opening.

`spec/sidekiq/update_purchase_healthcheck_threshold_job_spec.rb:65` fails on my machine, but it fails identically on unmodified `main` — a local env artifact, unrelated, and green in CI.
