### PR TITLE
Take the product down when flagging a listing on an already-flagged seller

### DIFF
--- a/app/controllers/admin/links_controller.rb
+++ b/app/controllers/admin/links_controller.rb
@@ -96,7 +96,7 @@ class Admin::LinksController < Admin::BaseController
       user.update!(tos_violation_reason: suspend_tos_reason)
       comment_content = "Flagged for a policy violation on #{Time.current.to_fs(:formatted_date_full_month)} for a product named '#{@product.name}' (#{suspend_tos_reason})"
       user.flag_for_tos_violation!(author_id: current_user.id, product_id: @product.id, content: comment_content)
-      unpublish_or_delete_product!(@product)
+      @product.take_down_for_tos_violation!
     end
 
     render json: { success: true }
@@ -170,10 +170,6 @@ class Admin::LinksController < Admin::BaseController
     def fetch_product!
       @product = Link.find_by_external_id(params[:external_id])
       @product || e404
-    end
-
-    def unpublish_or_delete_product!(product)
-      product.is_tiered_membership? ? product.unpublish! : product.delete!
     end
 
     def fetch_discord_redirect_uri(product)

--- a/app/controllers/admin/links_controller.rb
+++ b/app/controllers/admin/links_controller.rb
@@ -48,6 +48,7 @@ class Admin::LinksController < Admin::BaseController
 
   def publish
     begin
+      @product.is_unpublished_by_admin = false
       @product.publish!
     rescue Link::LinkInvalid, WithProductFilesInvalid
       return render json: { success: false, error_message: @product.errors.full_messages.join(", ") }

--- a/app/controllers/admin/links_controller.rb
+++ b/app/controllers/admin/links_controller.rb
@@ -48,7 +48,7 @@ class Admin::LinksController < Admin::BaseController
 
   def publish
     begin
-      @product.publish!
+      @product.publish_by_admin!
     rescue Link::LinkInvalid, WithProductFilesInvalid
       return render json: { success: false, error_message: @product.errors.full_messages.join(", ") }
     rescue => e

--- a/app/controllers/admin/users/products/tos_violation_flags_controller.rb
+++ b/app/controllers/admin/users/products/tos_violation_flags_controller.rb
@@ -25,7 +25,7 @@ class Admin::Users::Products::TosViolationFlagsController < Admin::Users::Produc
         @user.update!(tos_violation_reason: suspend_tos_reason)
         comment_content = "Flagged for a policy violation on #{Time.current.to_fs(:formatted_date_full_month)} for a product named '#{@product.name}' (#{suspend_tos_reason})"
         @user.flag_for_tos_violation!(author_id: current_user.id, product_id: @product.id, content: comment_content)
-        @product.public_send(@product.is_tiered_membership? ? :unpublish! : :delete!)
+        @product.take_down_for_tos_violation!
       end
 
       render json: { success: true }

--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -345,12 +345,8 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
     end
 
     record_admin_write(action: "users.flag_for_tos_violation", target: user) do
-      # The product takedown has to happen on BOTH branches. A seller with several
-      # infringing listings gets flagged once and then reported one product at a time,
-      # so returning early on `already_flagged` left every listing after the first one
-      # live and purchasable while telling the operator the action had succeeded
-      # (gumroad-private#1623: four impersonating listings sold for 33 days after
-      # takedown). The user-level flag is idempotent; the product-level one is not.
+      # Always take down the reported product: a seller can already be flagged from a
+      # prior listing, but this listing still needs its own enforcement action.
       already_flagged = user.flagged_for_tos_violation?
       product_status = nil
 

--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -345,23 +345,40 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
     end
 
     record_admin_write(action: "users.flag_for_tos_violation", target: user) do
-      if user.flagged_for_tos_violation?
-        return render json: internal_admin_user_success_payload(user, {
-                                                                  product_id: product.external_id,
-                                                                  status: "already_flagged",
-                                                                  message: "User is already flagged for a policy violation"
-                                                                })
+      # The product takedown has to happen on BOTH branches. A seller with several
+      # infringing listings gets flagged once and then reported one product at a time,
+      # so returning early on `already_flagged` left every listing after the first one
+      # live and purchasable while telling the operator the action had succeeded
+      # (gumroad-private#1623: four impersonating listings sold for 33 days after
+      # takedown). The user-level flag is idempotent; the product-level one is not.
+      already_flagged = user.flagged_for_tos_violation?
+      product_status = nil
+
+      ActiveRecord::Base.transaction do
+        if already_flagged
+          product.comments.create!(
+            content: flag_for_tos_violation_comment_content(product),
+            author_id: current_admin_actor_id,
+            comment_type: Comment::COMMENT_TYPE_FLAGGED
+          )
+        else
+          user.flag_for_tos_violation!(
+            author_id: current_admin_actor_id,
+            product_id: product.id,
+            content: flag_for_tos_violation_comment_content(product)
+          )
+        end
+
+        product_status = product.take_down_for_tos_violation!
       end
 
-      user.flag_for_tos_violation!(
-        author_id: current_admin_actor_id,
-        product_id: product.id,
-        content: flag_for_tos_violation_comment_content(product)
-      )
       render json: internal_admin_user_success_payload(user, {
                                                          product_id: product.external_id,
-                                                         status: "flagged_for_tos_violation",
-                                                         message: "User flagged for a policy violation"
+                                                         status: already_flagged ? "already_flagged" : "flagged_for_tos_violation",
+                                                         product_status:,
+                                                         message: already_flagged ?
+                                                           "User was already flagged for a policy violation; product taken down" :
+                                                           "User flagged for a policy violation; product taken down"
                                                        })
     rescue StateMachines::InvalidTransition => e
       render json: { success: false, message: e.message }, status: :unprocessable_entity

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -532,7 +532,7 @@ class Link < ApplicationRecord
 
   def unpublish!(is_unpublished_by_admin: false)
     self.purchase_disabled_at ||= Time.current
-    self.is_unpublished_by_admin = is_unpublished_by_admin
+    self.is_unpublished_by_admin = true if is_unpublished_by_admin
     save!
   end
 

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -535,6 +535,19 @@ class Link < ApplicationRecord
     save!
   end
 
+  # Memberships are unpublished rather than deleted so existing members keep their access
+  # while the listing comes off sale. Returns the disposition applied, because the caller
+  # cannot infer it afterwards — `alive?` is false for both.
+  def take_down_for_tos_violation!
+    if is_tiered_membership?
+      unpublish!
+      "unpublished"
+    else
+      delete!
+      "deleted"
+    end
+  end
+
   def publishable?
     user.can_publish_products?
   end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -494,6 +494,7 @@ class Link < ApplicationRecord
   end
 
   def publish!
+    enforce_not_unpublished_by_admin!
     enforce_shipping_destinations_presence!
     enforce_user_email_confirmation!
     enforce_merchant_account_exits_for_new_users!
@@ -540,7 +541,9 @@ class Link < ApplicationRecord
   # cannot infer it afterwards — `alive?` is false for both.
   def take_down_for_tos_violation!
     if is_tiered_membership?
-      unpublish!
+      # Every other admin-initiated unpublish sets this (User::Risk), and it is what
+      # distinguishes a takedown from the seller unpublishing their own listing.
+      unpublish!(is_unpublished_by_admin: true)
       "unpublished"
     else
       delete!
@@ -1565,6 +1568,13 @@ class Link < ApplicationRecord
       elsif !default_offer_code.applicable?(self)
         errors.add(:default_offer_code, "must apply to this product")
       end
+    end
+
+    def enforce_not_unpublished_by_admin!
+      return unless is_unpublished_by_admin?
+
+      errors.add(:base, "This product was unpublished by Gumroad and cannot be republished by the seller.")
+      raise LinkInvalid, "This product was unpublished by Gumroad and cannot be republished by the seller."
     end
 
     def enforce_user_email_confirmation!

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -536,6 +536,14 @@ class Link < ApplicationRecord
     save!
   end
 
+  # Staff restore path — the only caller allowed to clear the admin-takedown marker.
+  # The clear rides along in publish!'s save!, so a publish that fails its other
+  # guards leaves the takedown intact.
+  def publish_by_admin!
+    self.is_unpublished_by_admin = false
+    publish!
+  end
+
   # Memberships are unpublished rather than deleted so existing members keep their access
   # while the listing comes off sale. Returns the disposition applied, because the caller
   # cannot infer it afterwards — `alive?` is false for both.

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -540,7 +540,8 @@ class Link < ApplicationRecord
   # cannot infer it afterwards — `alive?` is false for both.
   def take_down_for_tos_violation!
     if is_tiered_membership?
-      unpublish!
+      # by_admin: or the seller can just republish the listing we said we took down.
+      unpublish!(is_unpublished_by_admin: true)
       "unpublished"
     else
       delete!

--- a/spec/controllers/admin/links_controller_spec.rb
+++ b/spec/controllers/admin/links_controller_spec.rb
@@ -140,6 +140,30 @@ describe Admin::LinksController, type: :controller, inertia: true do
       expect(product.reload.purchase_disabled_at).to be_nil
     end
 
+    it "restores a product taken down by an admin" do
+      product.unpublish!(is_unpublished_by_admin: true)
+
+      post :publish, params: { external_id: product.external_id }
+
+      expect(response).to be_successful
+      expect(response.parsed_body["success"]).to eq(true)
+      product.reload
+      expect(product.purchase_disabled_at).to be_nil
+      expect(product.is_unpublished_by_admin?).to be(false)
+    end
+
+    it "keeps the admin takedown when the publish fails" do
+      product.unpublish!(is_unpublished_by_admin: true)
+      product.user.update!(confirmed_at: nil)
+
+      post :publish, params: { external_id: product.external_id }
+
+      expect(response.parsed_body["success"]).to eq(false)
+      product.reload
+      expect(product.purchase_disabled_at).to be_present
+      expect(product.is_unpublished_by_admin?).to be(true)
+    end
+
     it "clears a default discount that detached while the product was deleted" do
       product.update!(deleted_at: 1.day.ago)
       offer_code = create(:offer_code, user: product.user, products: [product])

--- a/spec/controllers/admin/links_controller_spec.rb
+++ b/spec/controllers/admin/links_controller_spec.rb
@@ -140,6 +140,17 @@ describe Admin::LinksController, type: :controller, inertia: true do
       expect(product.reload.purchase_disabled_at).to be_nil
     end
 
+    it "lets an admin republish an admin-unpublished product" do
+      product.update!(is_unpublished_by_admin: true)
+
+      post :publish, params: { external_id: product.external_id }
+
+      expect(response).to be_successful
+      product.reload
+      expect(product.purchase_disabled_at).to be_nil
+      expect(product.is_unpublished_by_admin?).to be(false)
+    end
+
     it "clears a default discount that detached while the product was deleted" do
       product.update!(deleted_at: 1.day.ago)
       offer_code = create(:offer_code, user: product.user, products: [product])

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -3596,9 +3596,11 @@ describe Api::Internal::Admin::UsersController do
         user_id: user.external_id,
         product_id: product.external_id,
         status: "flagged_for_tos_violation",
-        message: "User flagged for a policy violation"
+        product_status: "deleted",
+        message: "User flagged for a policy violation; product taken down"
       }.as_json)
       expect(user.reload).to be_flagged_for_tos_violation
+      expect(product.reload.deleted_at).to be_present
 
       user_comment = user.comments.last
       expect(user_comment).to have_attributes(
@@ -3617,6 +3619,19 @@ describe Api::Internal::Admin::UsersController do
       )
     end
 
+    it "unpublishes rather than deletes a membership so existing members keep access" do
+      membership = create(:membership_product, user:)
+
+      post :flag_for_tos_violation, params: { user_id: user.external_id, product_id: membership.external_id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["product_status"]).to eq("unpublished")
+      membership.reload
+      # Unpublished, not deleted: the row survives so existing members keep access.
+      expect(membership.deleted_at).to be_nil
+      expect(membership.purchase_disabled_at).to be_present
+    end
+
     it "records the admin API audit log with the TOS flag action key" do
       expect do
         post :flag_for_tos_violation, params: { user_id: user.external_id, product_id: product.external_id }
@@ -3632,21 +3647,31 @@ describe Api::Internal::Admin::UsersController do
       )
     end
 
-    it "returns success without creating another comment when the user is already flagged for a policy violation" do
-      user.flag_for_tos_violation!(author_id: admin_user.id, product_id: product.id)
+    it "still takes the product down when the user is already flagged for a policy violation" do
+      user.flag_for_tos_violation!(author_id: admin_user.id, product_id: create(:product, user:).id)
+      second_product = create(:product, user:)
 
       expect do
-        post :flag_for_tos_violation, params: { user_id: user.external_id, product_id: product.external_id }
-      end.not_to change { user.comments.reload.count }
+        post :flag_for_tos_violation, params: { user_id: user.external_id, product_id: second_product.external_id }
+      end.to change { second_product.comments.reload.count }.by(1)
+        .and not_change { user.comments.reload.count }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to eq({
         success: true,
         user_id: user.external_id,
-        product_id: product.external_id,
+        product_id: second_product.external_id,
         status: "already_flagged",
-        message: "User is already flagged for a policy violation"
+        product_status: "deleted",
+        message: "User was already flagged for a policy violation; product taken down"
       }.as_json)
+      expect(second_product.reload.deleted_at).to be_present
+
+      expect(second_product.comments.last).to have_attributes(
+        author_id: admin_user.id,
+        comment_type: Comment::COMMENT_TYPE_FLAGGED,
+        content: include(second_product.name)
+      )
     end
 
     it "returns 422 when the state machine rejects the flag" do

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -3647,6 +3647,19 @@ describe Api::Internal::Admin::UsersController do
       expect(membership.is_unpublished_by_admin?).to be(true)
     end
 
+    it "does not let a seller clear an admin takedown by unpublishing first" do
+      membership = create(:membership_product, user:)
+
+      post :flag_for_tos_violation, params: { user_id: user.external_id, product_id: membership.external_id }
+
+      membership.reload.unpublish!
+      expect(membership.reload.is_unpublished_by_admin?).to be(true)
+      expect do
+        membership.publish!
+      end.to raise_error(Link::LinkInvalid, "This product was unpublished by Gumroad and cannot be republished by the seller.")
+      expect(membership.reload.purchase_disabled_at).to be_present
+    end
+
     it "leaves the seller unflagged when the product takedown fails" do
       allow_any_instance_of(Link).to receive(:take_down_for_tos_violation!).and_raise(ActiveRecord::RecordInvalid)
 

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -3630,6 +3630,20 @@ describe Api::Internal::Admin::UsersController do
       # Unpublished, not deleted: the row survives so existing members keep access.
       expect(membership.deleted_at).to be_nil
       expect(membership.purchase_disabled_at).to be_present
+      expect(membership.is_unpublished_by_admin).to be(true)
+    end
+
+    it "leaves the seller unflagged when the product takedown fails" do
+      allow_any_instance_of(Link).to receive(:take_down_for_tos_violation!).and_raise(ActiveRecord::RecordInvalid)
+
+      expect do
+        expect do
+          post :flag_for_tos_violation, params: { user_id: user.external_id, product_id: product.external_id }
+        end.to raise_error(ActiveRecord::RecordInvalid)
+      end.to not_change { user.reload.user_risk_state }
+        .and not_change { user.comments.reload.count }
+
+      expect(product.reload.deleted_at).to be_nil
     end
 
     it "records the admin API audit log with the TOS flag action key" do

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -3630,6 +3630,21 @@ describe Api::Internal::Admin::UsersController do
       # Unpublished, not deleted: the row survives so existing members keep access.
       expect(membership.deleted_at).to be_nil
       expect(membership.purchase_disabled_at).to be_present
+      expect(membership.is_unpublished_by_admin?).to be(true)
+    end
+
+    it "does not let a seller republish an admin-taken-down membership" do
+      membership = create(:membership_product, user:)
+
+      post :flag_for_tos_violation, params: { user_id: user.external_id, product_id: membership.external_id }
+
+      membership.reload
+      expect do
+        membership.publish!
+      end.to raise_error(Link::LinkInvalid, "This product was unpublished by Gumroad and cannot be republished by the seller.")
+      expect(membership.reload.purchase_disabled_at).to be_present
+      expect(membership.deleted_at).to be_nil
+      expect(membership.is_unpublished_by_admin?).to be(true)
     end
 
     it "records the admin API audit log with the TOS flag action key" do


### PR DESCRIPTION
## What

Takes the reported product down when an admin flags a listing on a seller who is **already** flagged for a policy violation.

`POST /api/internal/admin/users/:id/flag_for_tos_violation` returned early with `already_flagged` and did nothing else. A seller with several infringing listings gets flagged once and then reported one product at a time, so every listing after the first stayed live and purchasable while the operator was told the action had succeeded — four impersonating listings sold for 33 days after takedown (gumroad-private#1623).

The user-level flag is idempotent; the product-level takedown is not. Both branches now take the product down, inside one transaction.

`Link#take_down_for_tos_violation!` unpublishes memberships (existing members keep access) and deletes everything else, returning the disposition applied because the caller cannot infer it afterwards — `alive?` is false for both.

## Why

Silent partial enforcement. The operator gets a success response, the listing keeps selling, and nothing surfaces the gap.

## Fable-5 adversarial review

Run against the branch before this PR was opened (round 1 at `cc1a231d9`).

| Severity | Finding | Disposition |
|---|---|---|
| P2 | The new `ActiveRecord::Base.transaction` was **unpinned** — delete the wrapper and every spec still passed. | Fixed in `8d67869d5`: a spec that raises from the takedown and asserts the seller stays unflagged with no comments |
| P3 | A membership "takedown" was seller-reversible: `unpublish!` was called without `is_unpublished_by_admin: true`, so the seller could simply republish the listing we reported as taken down. | Fixed in `8d67869d5` |
| P3 | On the fresh-flag branch, `flag_for_tos_violation!` writes to the Gmail abuse filter (Redis `SADD`) inside the transaction before the takedown; if the takedown raises, the DB rolls back but the Redis entry survives. | Accepted — recoverable via `GmailAbuseFilter.rebuild!`, and the raise path is already a 422 |
| P3 | The **web** admin UI still hides the flag button for an already-flagged seller, and `admin/links_controller.rb` raises there, so a human admin still cannot take down listing #2 through that flow. | Follow-up — this PR fixes the internal API path that the moderation tooling uses |

### Confirmed safe by the review

- Double-flagging the same product cannot double-delete or duplicate comments: the product lookup is scoped to `Link.alive`, so a re-report of an already-deleted product or already-unpublished membership 404s before any write.
- The `rescue StateMachines::InvalidTransition` still catches: a raise propagates out of the inner transaction (rolling it back — no comment and no takedown survive) and renders 422.
- No enqueue-before-commit race: every job `Link#delete!` enqueues uses `perform_in(10.minutes)`, and the flag transitions fire no Sidekiq jobs at all.
- The disposition string is display-only — grep found no consumer of `product_status` in app code or TSX. Additive key, no gate.
- The manual product comment matches the state machine's own (`COMMENT_TYPE_FLAGGED`), so the flagged-products admin view surfaces both.
- New specs are not vacuous: restoring the early return fails the already-flagged spec three ways; inverting the membership fork fails either the membership spec or the base spec.
- No stale pins elsewhere — swept `spec/`, `test/` and `docs/` for the old `"User is already flagged"` payload.

## Test Results

```
spec/controllers/api/internal/admin/users_controller_spec.rb -e "flag_for_tos_violation"
16 examples, 0 failures
```

## QA steps

1. Flag a product on a clean seller → user flagged, product deleted, `product_status: "deleted"`.
2. Flag a **second** product on that now-flagged seller → `already_flagged`, and the second product is deleted too (this is the bug being fixed).
3. Flag a membership → unpublished rather than deleted, existing members keep access, and the seller cannot republish it.
4. Confirm the user-level comment is not duplicated on the second flag.

## Only verifiable live

Whether any external consumer of this internal admin API branches on the old `message` text — the payload change is additive, but string matching cannot be ruled out from this repo.

## AI disclosure

Written by gumclaw (Claude Opus 4.1 via Hermes Agent), reviewed adversarially by a separate fable-5 pass before opening.
