### PR TITLE
Stop the classifier deadline stubs from failing unrelated specs on the same shard

### DIFF
--- a/spec/services/content_moderation/strategies/classifier_strategy_spec.rb
+++ b/spec/services/content_moderation/strategies/classifier_strategy_spec.rb
@@ -93,6 +93,7 @@ RSpec.describe ContentModeration::Strategies::ClassifierStrategy, :vcr do
     # upstream rejection for what was our own timeout.
     start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     elapsed = 0
+    allow(Process).to receive(:clock_gettime).and_call_original
     allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { start + elapsed }
     allow(client).to receive(:moderations) do |parameters:|
       raise Faraday::ServerError.new("boom") if parameters[:input].size > 1
@@ -142,6 +143,7 @@ RSpec.describe ContentModeration::Strategies::ClassifierStrategy, :vcr do
     # The deadline reads the monotonic clock, which `travel` does not move.
     start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     elapsed = 0
+    allow(Process).to receive(:clock_gettime).and_call_original
     allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { start + elapsed }
     allow(client).to receive(:moderations) do |parameters:|
       call_inputs << parameters[:input]
@@ -163,6 +165,7 @@ RSpec.describe ContentModeration::Strategies::ClassifierStrategy, :vcr do
     image_urls = (1..5).map { |n| "https://cdn.example.com/#{n}.png" }
     start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     elapsed = 0
+    allow(Process).to receive(:clock_gettime).and_call_original
     allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { start + elapsed }
     single_input_calls = 0
     allow(client).to receive(:moderations) do |parameters:|
@@ -189,6 +192,7 @@ RSpec.describe ContentModeration::Strategies::ClassifierStrategy, :vcr do
   it "does not retry a timed-out image once the phase deadline has passed" do
     start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     elapsed = 0
+    allow(Process).to receive(:clock_gettime).and_call_original
     allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { start + elapsed }
     calls = 0
     allow(client).to receive(:moderations) do |parameters:|
@@ -208,6 +212,7 @@ RSpec.describe ContentModeration::Strategies::ClassifierStrategy, :vcr do
   it "clamps a fallback request that starts just inside the deadline to the time that is left" do
     start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     elapsed = 0
+    allow(Process).to receive(:clock_gettime).and_call_original
     allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { start + elapsed }
     clamped_client = instance_double(OpenAI::Client)
     allow(clamped_client).to receive(:moderations).and_return({ "results" => [{ "category_scores" => {} }] })


### PR DESCRIPTION
## What

Adds an `and_call_original` default before the five argument-constrained `Process.clock_gettime` stubs in `classifier_strategy_spec.rb`, so reads of any *other* clock id still reach the real method.

## Why

This is a shard-poisoning landmine on `main`, not a flake. The spec freezes monotonic time to test the moderation phase deadline:

```ruby
allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { start + elapsed }
```

A `with(...)` constraint and no default means **every other** call to `clock_gettime` is an error, and the stub is still installed when the suite's own hooks run. `Capybara.reset_sessions!` reads the clock, so CI reports:

```
Failure/Error: Capybara.reset_sessions!
  Process received :clock_gettime with unexpected arguments
    expected: (1)
```

The damage is that the *victim* is whatever else lands on the shard — the five failures are reported against `classifier_strategy_spec.rb`, but the trigger is scheduling, so the same commit passes or fails depending on how Knapsack splits the suite. #6788 (a one-file Minitest addition to a product-editor controller test) inherited exactly this and looked like it had broken content moderation.

Found while sweeping in-flight PRs: #6788's CI was red twice on these five examples with a diff that cannot touch a Sidekiq clock.

## Test Results

`spec/services/content_moderation/strategies/classifier_strategy_spec.rb` — **39 examples, 0 failures**. Rubocop clean.

Reproduced the leak before fixing it, with a throwaway spec whose `after` hook stands in for `Capybara.reset_sessions!`:

- without `and_call_original` → `Process received :clock_gettime with unexpected arguments` (the exact CI error)
- with it → `1 example, 0 failures`

That scenario file is deliberately **not** committed — it asserts a property of RSpec's stubbing, not of our code, and would only ever fail if rspec-mocks changed.

## AI disclosure

Written by gumclaw (AI agent). Root-caused from CI logs on #6788, and verified in both directions by reproducing the failure shape locally before applying the fix.
