### PR TITLE
Let a forced-currency renewal with a stored amount charge off-session

### DIFF
--- a/app/services/checkout/buyer_currency_eligibility.rb
+++ b/app/services/checkout/buyer_currency_eligibility.rb
@@ -462,7 +462,14 @@ class Checkout::BuyerCurrencyEligibility
     # any currency is written for these charges — there is nothing for a non-USD settlement
     # currency to corrupt. Payouts for such sellers are made by Stripe itself, not by us.
     return fallback(:future_charge_setup) if setup_future_charges
-    return fallback(:off_session) if off_session
+    # Same carve-out as the general-mode exit above, and for the same reason: a renewal that
+    # stored a fixed amount at signup charges that stored amount, so no live FX quote is
+    # involved and going off-session is safe. The asymmetry was not deliberate — the general
+    # exit gained the carve-out and this one was missed, silently making every forced-currency
+    # renewal charge canonical USD. For a mandate denominated in a local currency that is not a
+    # degraded fallback but an unchargeable request: an INR UPI Autopay mandate can only ever be
+    # debited in INR (gumroad-private#1434).
+    return fallback(:off_session) if off_session && !subscription_renewal_with_stored_amount?
     return fallback(:no_purchases) if purchases.empty?
 
     product_currencies = []

--- a/spec/services/checkout/buyer_currency_eligibility_spec.rb
+++ b/spec/services/checkout/buyer_currency_eligibility_spec.rb
@@ -876,6 +876,50 @@ describe Checkout::BuyerCurrencyEligibility do
       expect(off_session_decision.fallback_reason).to eq(:off_session)
     end
 
+    # The forced path is the one a local-currency mandate renews on, and a mandate denominated in
+    # that currency cannot be debited in dollars at all — so unlike the general mode, falling back
+    # here produces an unchargeable request rather than a merely degraded one (gumroad-private#1434).
+    it "allows an off-session renewal that has a stored fixed amount, matching the general mode" do
+      product = create(:membership_product, user: seller, price_currency_type: Currency::INR, price_cents: 7300)
+      subscription = create(:membership_purchase, link: product, seller:).subscription
+      renewal = create(:purchase, link: product, seller:, subscription:, is_original_subscription_purchase: false)
+      create(:later_charge_presentment,
+             owner: subscription,
+             presentment_currency: Currency::INR,
+             presentment_price_cents: 7300,
+             canonical_price_cents: 100)
+
+      renewal_decision = described_class.new(order:,
+                                             seller:,
+                                             merchant_account:,
+                                             chargeable:,
+                                             purchases: [renewal],
+                                             params:,
+                                             setup_future_charges:,
+                                             off_session: true).method_forced_decision(payment_method: "upi")
+
+      expect(renewal_decision).to be_eligible
+      expect(renewal_decision.currency).to eq(Currency::INR)
+    end
+
+    it "still withholds an off-session renewal that stored no amount, so it bills canonical dollars" do
+      product = create(:membership_product, user: seller, price_currency_type: Currency::INR, price_cents: 7300)
+      subscription = create(:membership_purchase, link: product, seller:).subscription
+      renewal = create(:purchase, link: product, seller:, subscription:, is_original_subscription_purchase: false)
+
+      renewal_decision = described_class.new(order:,
+                                             seller:,
+                                             merchant_account:,
+                                             chargeable:,
+                                             purchases: [renewal],
+                                             params:,
+                                             setup_future_charges:,
+                                             off_session: true).method_forced_decision(payment_method: "upi")
+
+      expect(renewal_decision).not_to be_eligible
+      expect(renewal_decision.fallback_reason).to eq(:off_session)
+    end
+
     it "allows the direct listed-amount path for multi-item carts uniformly priced in the forced currency" do
       purchase.update!(link: create(:product, user: seller, price_currency_type: Currency::INR, price_cents: 7300))
       purchases << create(:purchase,


### PR DESCRIPTION
Relates to gumroad-private#1434 (UPI Autopay), scope bullet 2.

> **Status: the premise below did not survive review — this is not ready to merge, and may not be worth merging at all.** CI is green, but a pre-merge adversarial review found the branch this adds is unreachable in production. See "What review found" and the [full verdict](https://github.com/antiwork/gumroad/pull/6796#issuecomment-5152272991). The open question is a product/routing call, not a code fix. @rmarescu — your call, and nothing here needs a patch from you.

## What

`Checkout::BuyerCurrencyEligibility` has two off-session exits:

- **general mode** (`:370`) — `return fallback(:off_session) if off_session && !multi_seller_order? && !subscription_renewal_with_stored_amount?`
- **forced-currency mode**, inside `method_forced_decision` (`:465`) — `return fallback(:off_session) if off_session`, unconditional

The general exit gained its renewal carve-out in #6495; this one did not. This PR makes the forced-currency exit symmetric, reusing the existing `subscription_renewal_with_stored_amount?` predicate.

## Why (as originally reasoned — see the correction below)

Every `fallback(...)` in `method_forced_decision` means "charge canonical USD". A mandate is denominated in the buyer's currency, and an INR UPI Autopay mandate can only ever be debited in INR — so a USD renewal against it is unchargeable rather than merely suboptimal. The intent was to stop forced-currency renewals falling back to USD.

## What review found

Two P1s, both verified against the code rather than taken on the reviewer's word. Greptile reached the same core conclusion independently.

**The added branch is unreachable, so the change is inert.** `method_forced_decision` has exactly one production caller, and it hardcodes the flag this change keys on:

```ruby
# app/services/charge/method_forced_presentment.rb:120-129
Checkout::BuyerCurrencyEligibility.new(
  ...
  off_session: false
).method_forced_decision(payment_method: payment_method_type, forced_currency:)
```

`git grep -n "method_forced_decision" origin/main -- app lib` returns that call site and the definition, nothing else. Off-session renewals bill via `Purchase#create_charge_intent` → `Purchase::LaterChargePresentmentService`, which never consults `method_forced_decision`. The new condition can only be exercised by the tests added alongside it.

**If a caller ever did pass `off_session: true`, the carve-out would be unsafe.** This lane charges the purchase's *current* `displayed_price_cents` (`method_forced_presentment.rb:184`) and the USD-priced leg mints a fresh quote at today's rate — precisely the re-derived off-session amount the gate exists to block. The claimed symmetry with `:370` does not hold: on the general path a stored-amount renewal is intercepted *before* `.decision` by `Charge::CreateService#subscription_renewal_presentment_processor_args` (`create_service.rb:273`), which charges the fixing and carries the `:stale_fixing` guard and settlement-currency match this lane has no counterpart for. Line 370's carve-out is safe *because* of that interception, not because the exit itself is harmless.

## Test results

`spec/services/checkout/buyer_currency_eligibility_spec.rb` — **84 examples, 0 failures**, run three consecutive times locally (82 on `main`; the 2 new ones are here). Both directions covered: a renewal *with* a stored amount stays eligible and presents INR, one *without* still falls back with `:off_session`.

Full CI is **green** at `2a2c313`: 79 checks passed, 10 internal-PR noops, 0 failures, 0 pending.

Caveat on what that green proves: the positive spec does fail with the production change reverted, so it is load-bearing. The negative spec ("still withholds an off-session renewal that stored no amount") passes on revert — with no stored amount the helper returns false either way, so it is a boundary guard rather than a pin on this diff.

## Before / after

No user-visible surface. The change is one condition in an eligibility service on a branch that, per the finding above, no production request reaches — so there is no rendered state to capture, and a screenshot would assert a behaviour change that review says does not occur. The spec run is the artifact.

## What is actually being asked

Not a patch. The question is whether gumroad-private#1434's renewal is mis-billing today **on the real path** (`Purchase::LaterChargePresentmentService`), measured before deciding whether anything in this file should change. Routing stored-amount renewals through the fixing *here* would re-implement what `Charge::CreateService` already does correctly, so an edge-patch on this branch is probably the wrong shape.

Three ways this can go, all yours to pick:

1. **Close it** — the forced-currency exit is dead code for renewals, and the asymmetry with `:370` is cosmetic.
2. **Keep it as a guard** — harmless and correct-in-principle if a future caller passes `off_session: true`, but then P1 (b) needs answering first: the carve-out would be unsafe on this lane as written.
3. **Measure first** — I can take the measurement on the real renewal path and report back before anything merges.

Auto-merge is **not** armed and will not be: this touches renewal billing.

---

*AI disclosure — written by Claude Opus 5 (`model.default: claude-opus-5` in `~/.hermes/config.yaml`). Instructions given: fix the off-session asymmetry in `Checkout::BuyerCurrencyEligibility` blocking gumroad-private#1434 scope bullet 2; then, on a later pass, run a pre-merge adversarial review, verify its findings independently against the code, and correct this description to match what that review established.*
