### PR TITLE
Trim the save contract's comments to what a maintainer needs

### DIFF
--- a/app/services/product/save_contract.rb
+++ b/app/services/product/save_contract.rb
@@ -2,62 +2,34 @@
 
 # The product editor's save contract (gumroad-private#1379).
 #
-# ## The defect this exists to remove
+# The editor save is a full-snapshot PUT, and every collection was read as
+# `params[:thing] || []`. That collapses three different requests into one:
+# "the seller emptied this", "this request isn't about this collection", and
+# "the value was malformed, so strong parameters dropped it and it arrives
+# absent". All three read as `[]`, and `[]` meant "delete everything alive" —
+# so a client bug or a proxy that mangles a field became permanent data loss.
+# Two collections have no undo: `integrations` calls `integration.disconnect!`
+# against the provider, and `public_files` strips `<public-file-embed>` nodes
+# out of the seller's description in the same pass.
 #
-# The editor save is a full-snapshot PUT. Every collection in it was read as
-# `params[:thing] || []`, which makes three very different situations
-# indistinguishable:
+#   Rule 1  absent == [] == "no changes", uniformly across all five
+#           collections. Neither deletes anything, ever.
+#   Rule 2  deletion only through an explicit operation — a list of ids or a
+#           clear-all, both tied to the editor revision the client loaded.
+#   Rule 3  API v2 semantics unchanged; this is consulted only from the
+#           editor's save path.
 #
-#   1. "the seller emptied this collection"        -> [] on purpose
-#   2. "this request isn't about that collection"  -> key absent
-#   3. "the value was malformed"                   -> strong parameters DROPPED
-#      it, so it arrives absent — `files: "not-a-list"` never reaches the
-#      permit list's array-of-hashes shape and is silently discarded
+# Rule 1 gives up emptying a collection by sending `[]`. That is a
+# client-visible change, and it is the point.
 #
-# All three collapsed to `[]`, and `[]` meant "delete everything alive". Case 3
-# is the dangerous one: a client bug, a truncated request body, or a proxy that
-# mangles a field turns into permanent data loss with no error anywhere. Two of
-# the five collections had no deletion guard at all, and their failure modes are
-# not soft:
-#
-#   * `integrations` calls `integration.disconnect!` — a live call to the
-#     third-party provider. There is no undo.
-#   * `public_files` strips `<public-file-embed>` nodes out of the seller's
-#     description in the same pass that schedules the files, so the description
-#     is damaged immediately even though the rows survive ten days.
-#
-# ## The contract
-#
-# Per the approved ruling on gumroad-private#1379:
-#
-#   Rule 1  absent == [] == "no changes". Uniformly, across all five
-#           collections. Neither one deletes anything, ever.
-#   Rule 2  deletion happens only through an explicit operation: a list of ids
-#           to delete, or an explicit clear-all — both tied to the editor
-#           revision the client loaded.
-#   Rule 3  API v2 semantics are unchanged. This module is only consulted from
-#           the editor's save path.
-#
-# Note what Rule 1 gives up on purpose: a client can no longer empty a
-# collection by sending `[]`. That is a client-visible change, and it is the
-# point — emptying is now something you have to ask for, and asking is
-# recorded.
-#
-# ## Why this is a value object rather than a pile of `if`s in the controller
-#
-# The five collections disagree about shape (`integrations` is a hash keyed by
-# provider name; the rest are arrays), about where deletion happens (four
-# services and one inline block), and about which guard already protects them.
-# Wrapping the payload once, at the point it enters the save, means every
-# collection asks the same question — "did this request submit you?" — and
-# gets an answer that does not depend on the caller remembering to check.
+# The collections disagree about shape (`integrations` is a hash keyed by
+# provider name, the rest are arrays) and about where deletion happens, so the
+# payload is wrapped once on entry and every collection asks the same question.
 class Product::SaveContract
-  # A destructive save arrived without a current snapshot token.
-  #
-  # Distinct from StaleContentWriteGuard's conflict: that one is about
-  # overwriting an edit, this one is about removing rows the session may never
-  # have seen. They are reported separately so the editor can say something
-  # accurate, and so the two can be measured independently during rollout.
+  # A destructive save arrived without a current snapshot token. Distinct from
+  # StaleContentWriteGuard's conflict — that one is about overwriting an edit,
+  # this one about removing rows the session may never have seen — so the two
+  # are reported separately.
   class StaleDeletionConflict < StandardError
     def message
       "This page is out of date, so the items you removed were not deleted. " \
@@ -76,8 +48,8 @@ class Product::SaveContract
     end
   end
 
-  # The five collections the editor save can destroy. Named here rather than
-  # inferred so that adding a sixth is a deliberate act with a test attached.
+  # The five collections the editor save can destroy. Listed rather than
+  # inferred so adding a sixth is deliberate.
   COLLECTIONS = %i[rich_content variants files public_files integrations].freeze
 
   # `deleted_ids[:variants]` carries VERSION ids only — never VariantCategory
@@ -93,33 +65,22 @@ class Product::SaveContract
   # A grouping goes away as a consequence of losing its last version, not by being
   # named — if you add grouping-level deletion, give it its own collection.
 
-  # Kill switch. Defaults OFF: with the flag inactive every collection reports
-  # `submitted?` exactly as the old code behaved (absent/[] still reaches the
-  # existing diff-and-delete paths), so enabling and disabling this is a pure
-  # revert with no migration and no data to unwind.
+  # Kill switch, default OFF: with the flag inactive every collection reports
+  # `submitted?` exactly as the old code did (absent/[] still reaches the
+  # diff-and-delete paths), so flipping it either way is a pure revert.
   #
-  # Rolled out per-seller with `Feature.activate_user(:product_editor_save_contract, user)`
-  # and killed globally with `Feature.deactivate(:product_editor_save_contract)`.
-  #
-  # Deliberately NOT a compatibility shim: when the flag is ON, `[]` never
-  # deletes, full stop. A shim that kept "`[]` still empties, for now" would
-  # preserve the exact ambiguity this contract exists to remove, and would have
-  # to be removed later by someone who no longer remembers why it was there.
+  # Deliberately NOT a compatibility shim: with the flag ON, `[]` never deletes.
+  # Keeping "`[]` still empties, for now" would preserve the exact ambiguity
+  # this contract exists to remove.
   FEATURE_NAME = :product_editor_save_contract
 
-  # Deletion operations the client can send. Both are explicit; neither can be
-  # produced by omitting something.
-  #
-  #   deleted_ids        — remove exactly these, nothing else
-  #   cleared_collections — remove everything alive in these collections
-  #
-  # `cleared_collections` exists because "the seller really did empty this"
-  # has to remain expressible. It is deliberately noisier than sending `[]`.
+  # Deletion operations the client can send; neither can be produced by omitting
+  # something. `deleted_ids` removes exactly those; `cleared_collections`
+  # removes everything alive, deliberately noisier than sending `[]`.
   DELETION_OPERATIONS = :deletion_operations
 
-  # A save is only allowed to delete when it proves which snapshot it was built
-  # from. Absent revision means the client predates the contract; such a save
-  # may still write, but it may not delete. See `#may_delete?`.
+  # A save with no revision predates the contract: it may still write, but it
+  # may not delete. See `#may_delete?`.
   REVISION_KEY = :editor_revision
 
   attr_reader :params, :product
@@ -127,53 +88,36 @@ class Product::SaveContract
   def initialize(params:, product:)
     @params = params || ActionController::Parameters.new
     @product = product
-    # Do no revision work at all when the contract is disabled. Computing the
-    # fingerprint means five COUNT/ordering queries against the product's
-    # children, and with the flag off nothing can consume the answer — so on the
-    # default path this must cost nothing beyond one flag lookup.
+    # The fingerprint costs five COUNT/ordering queries against the product's
+    # children, and with the flag off nothing can consume the answer.
     #
-    # When enabled, answer the freshness question eagerly rather than lazily.
-    # The save mutates rows as it runs, so by the time a deletion step asks "may
-    # I delete?", the product's fingerprint has already moved and a lazy check
-    # would compare the client's token against state the request itself changed
-    # — silently dropping a legitimate deletion submitted alongside a new page.
-    # Callers construct this before any write.
+    # When enabled it must be answered eagerly, before any write: the save
+    # mutates rows as it runs, so a lazy check would compare the client's token
+    # against state this request itself changed, silently dropping a legitimate
+    # deletion submitted alongside a new page. Callers construct this first.
     may_delete? if enforced?
   end
 
-  # Is the contract enforced for this save?
+  # Read once per save and passed down, so a flag flipped mid-request cannot
+  # make one collection follow the new rules and another the old ones.
   #
-  # Read once per save and passed down rather than re-checked at each call
-  # site, so a flag flipped mid-request cannot make one collection follow the
-  # new rules and another the old ones.
-  #
-  # The flag store is Redis-backed (config/initializers/feature_toggle.rb) and
-  # this runs while the product row is locked, so a Redis outage must not raise
-  # through the seller's save.
-  #
-  # It must also not answer "disabled", which is what an earlier version of this
-  # did. "Disabled" routes the save down the legacy path, and the legacy path
-  # deletes by omission — so a Redis blip would have turned an ordinary save
-  # into a wipe of every collection the payload happened not to mention. That is
-  # the exact failure this PR exists to prevent, reintroduced through the error
-  # handler.
-  #
-  # So a failed lookup is neither enabled nor disabled: see `#degraded?`. The
-  # contract stays off (no token gating, no 409s for clients that never sent a
-  # token), but implicit deletion is suppressed for the duration of the save.
+  # The flag store is Redis-backed and this runs while the product row is
+  # locked, so a lookup failure must neither raise nor answer "disabled":
+  # "disabled" routes the save down the legacy delete-by-omission path, so a
+  # Redis blip would wipe every collection the payload didn't mention. A failed
+  # lookup is therefore neither enabled nor disabled — see `#degraded?`. The
+  # contract stays off (no token gating, no 409s for legacy clients) but
+  # implicit deletion is suppressed for the rest of the save.
   def enforced?
     return @enforced if defined?(@enforced)
 
     @enforced = resolve_enforced
   end
 
-  # Did the flag lookup itself fail?
-  #
-  # Distinct from "the flag is off". Off is a real answer and means "behave
-  # exactly as main does today". Degraded means we do not know, and the only
-  # safe reading of "we do not know" is that nothing may be deleted implicitly:
-  # the request never asked for a deletion, so not deleting cannot lose data,
-  # while deleting on a guess can and did.
+  # Did the flag lookup itself fail? Distinct from "the flag is off", which is a
+  # real answer meaning "behave exactly as main does today". Degraded means we
+  # do not know, and the only safe reading is that nothing may be deleted
+  # implicitly.
   def degraded?
     enforced? unless defined?(@enforced)
 
@@ -197,29 +141,22 @@ class Product::SaveContract
     false
   end
 
-  # Reporting must never be the thing that breaks a seller's save. The notifier
-  # reaches out over the network (Bugsnag) from inside a locked, mid-transaction
-  # save, so it gets the same treatment as the lookup it is reporting on.
+  # Bugsnag reaches over the network from inside a locked, mid-transaction save,
+  # so it gets the same treatment as the lookup it is reporting on.
   private def report_lookup_failure(error)
     ErrorNotifier.notify(error, product_id: product&.id, context: "Product::SaveContract flag lookup")
   rescue StandardError
     nil
   end
 
-  # Did this request actually submit this collection?
+  # Did this request actually submit this collection? The whole contract in one
+  # method: `false` means leave the collection exactly as the server has it —
+  # not empty it, not diff it, not touch it.
   #
-  # This is the whole contract in one method. `false` means the save must leave
-  # the collection exactly as the server has it — not empty it, not diff it,
-  # not touch it.
-  #
-  # Absent and `[]` both answer `false`, which is Rule 1. They are
-  # distinguishable at the HTTP layer (`params.key?`) and the distinction is
-  # deliberately discarded: relying on it would mean a malformed value — which
-  # strong parameters drops, making it absent — behaves differently from the
-  # same value sent correctly as `[]`, and that difference is exactly the bug.
-  #
-  # With the flag off this always answers `true`, so callers fall through to
-  # their existing behaviour unchanged.
+  # Absent and `[]` both answer `false` (Rule 1). They are distinguishable via
+  # `params.key?` and that is deliberately discarded: otherwise a malformed
+  # value, which strong parameters drops to absent, would behave differently
+  # from the same value sent correctly as `[]`.
   def submitted?(collection)
     assert_known!(collection)
     return true unless enforced?
@@ -227,11 +164,9 @@ class Product::SaveContract
     params[collection].present?
   end
 
-  # Did this save ask to remove anything at all, in any collection?
-  #
-  # Deliberately independent of whether the removal is ALLOWED: this answers
-  # "was destruction requested", so the caller can tell a stale destructive
-  # save (refuse, loudly) from a stale write-only save (let it through).
+  # Did this save ask to remove anything at all? Deliberately independent of
+  # whether the removal is ALLOWED, so the caller can tell a stale destructive
+  # save (refuse loudly) from a stale write-only save (let it through).
   def requested_deletion?
     return false unless enforced?
 
@@ -239,17 +174,13 @@ class Product::SaveContract
       requested_variant_deletion?
   end
 
-  # Ids the client explicitly asked to delete from this collection.
+  # Ids the client explicitly asked to delete. Never inferred from a diff —
+  # that inference is what let an omitted collection read as an intentional wipe.
   #
-  # Empty unless the client sent them. Never inferred from a diff — that
-  # inference is what let an omitted collection read as an intentional wipe.
-  #
-  # Every malformed shape has to degrade to "no explicit deletions" rather than
-  # raise: this runs inside the seller's save, so an exception here turns a
-  # client bug into a failed save. Verified by probe that the shapes reaching
-  # this method include a bare String, an Array, an Integer, and
-  # `{deleted_ids: "not-a-hash"}` — the last of which raised TypeError from
-  # `dig` until this was hardened, because `String#dig` does not exist.
+  # Malformed shapes degrade to "no explicit deletions" rather than raise: this
+  # runs inside the seller's save, so an exception turns a client bug into a
+  # failed save. A bare String, Array, Integer and `{deleted_ids: "not-a-hash"}`
+  # all reach here in practice, and `String#dig` does not exist.
   def deleted_ids(collection)
     return [] unless enforced?
     return [] unless may_delete?
@@ -259,14 +190,10 @@ class Product::SaveContract
     []
   end
 
-  # What the client ASKED to delete, before the freshness question is applied.
-  #
-  # Kept separate from `deleted_ids` so the two questions never get conflated:
-  # this one is "what was requested" (used to detect a destructive save that
-  # must be refused outright), while `deleted_ids` is "what may actually be
-  # deleted". Reading requested intent through the allowed-ids accessor would
-  # make a stale destructive save look identical to a save with no deletions in
-  # it, which is exactly the silent-success bug.
+  # What the client ASKED to delete, before freshness is applied. Kept separate
+  # from `deleted_ids` ("what may actually be deleted") because reading intent
+  # through the allowed-ids accessor makes a stale destructive save look
+  # identical to a save with no deletions in it.
   def raw_deleted_ids(collection)
     return [] unless enforced?
 
@@ -279,22 +206,15 @@ class Product::SaveContract
     []
   end
 
-  # Ids the client explicitly asked to delete from a collection owned by ONE
-  # version, rather than by the product.
-  #
-  # Version-level integrations are the case this exists for. They live on a
-  # join between a variant and an integration, and the editor addresses them
-  # per version, so a single flat `deleted_ids[:integrations]` list cannot say
-  # "disconnect discord from version A but leave it on version B". The payload
-  # shape mirrors the flat one, nested under the owner's external id:
+  # Ids to delete from a collection owned by ONE version rather than by the
+  # product. Version-level integrations are the case: they live on a
+  # variant/integration join, so a flat `deleted_ids[:integrations]` cannot say
+  # "disconnect discord from version A but leave it on version B". Nested under
+  # the owner's external id:
   #
   #   deletion_operations: {
   #     variant_deleted_ids: { "<variant_external_id>": { integrations: ["discord"] } }
   #   }
-  #
-  # Same rules as everywhere else: absent means no statement, malformed
-  # degrades to no deletions rather than raising, and nothing is inferred from
-  # what the payload did or didn't re-submit.
   def variant_deleted_ids(owner_external_id, collection)
     return [] unless enforced?
     return [] unless may_delete?
@@ -325,15 +245,10 @@ class Product::SaveContract
   end
 
   # External ids of the versions this save is allowed to remove something from.
-  #
-  # The save has to know which versions are named BEFORE it decides which
-  # variant groupings to visit: a version-scoped deletion names its owner
-  # directly, so it can point at a version in a grouping the editor never
-  # renders. Without this list the save would skip that grouping entirely,
+  # Needed BEFORE deciding which variant groupings to visit: a version-scoped
+  # deletion names its owner directly, so it can point at a version in a
+  # grouping the editor never renders — which the save would otherwise skip,
   # return success, and leave the integration connected.
-  #
-  # Freshness-gated like every other allowed-deletion accessor, so a stale tab
-  # cannot make the save visit a grouping it has no right to touch.
   def variant_deletion_owner_ids
     return [] unless enforced?
     return [] unless may_delete?
@@ -364,15 +279,12 @@ class Product::SaveContract
     false
   end
 
-  # Did the client explicitly ask to empty this collection?
+  # The only route to "delete everything", and a positive statement tied to a
+  # revision rather than the absence of one.
   #
-  # This is the only route to "delete everything", and it is a positive
-  # statement tied to a revision — not the absence of one.
-  #
-  # Note the deliberate strictness: a bare string ("variants" rather than
-  # ["variants"]) is NOT accepted as a clear-all. Array() would happily wrap it
-  # and turn a malformed payload into an instruction to empty the collection,
-  # which is precisely the class of accident this contract exists to prevent.
+  # Deliberately strict: a bare string ("variants" rather than ["variants"]) is
+  # NOT a clear-all, because Array() would wrap it and turn a malformed payload
+  # into an instruction to empty the collection.
   def cleared?(collection)
     return false unless enforced?
     return false unless may_delete?
@@ -395,31 +307,20 @@ class Product::SaveContract
     false
   end
 
-  # Any deletion at all requires the client to say which snapshot it was
-  # editing, AND that snapshot must still have been current when the save
-  # began. A save with no revision, or one built from a snapshot that had
-  # already moved, is treated as write-only: it can create and update, but it
-  # cannot remove anything.
+  # Deleting requires the client to name the snapshot it edited AND that
+  # snapshot to still have been current when the save began. Otherwise the save
+  # is write-only. This is the two-tabs case: tab A loads, tab B saves, tab A
+  # submits a payload describing a product that no longer exists.
   #
-  # This is what stops a stale tab from deleting rows it never knew about — the
-  # two-tabs case where tab A loads, tab B saves, and tab A then submits a
-  # payload describing a product that no longer exists.
+  # Deliberately narrower than rejecting the whole save — product-wide
+  # optimistic concurrency was tried and had to be switched off for blocking
+  # legitimate work. A stale tab fixing a typo is recoverable; one deleting a
+  # page is not, so only the deletion is refused.
   #
-  # It is deliberately narrower than rejecting the whole save. An earlier
-  # attempt (product-wide optimistic concurrency) rejected any save built on a
-  # changed product and had to be switched off for blocking legitimate work. A
-  # stale tab fixing a typo is recoverable; a stale tab deleting a page is not,
-  # so only the deletion is refused.
-  #
-  # CRITICAL: this is evaluated ONCE, against the state at construction time,
-  # and memoized. The save mutates rows as it goes — it creates content pages
-  # before it reaches the variant deletion step — and every one of those writes
-  # changes the product's fingerprint. Re-computing freshness later in the same
-  # request would therefore compare the client's token against a snapshot the
-  # request itself had already moved, and a perfectly legitimate deletion
-  # submitted alongside a new page would be silently dropped. The contract is
-  # built at the top of the save, before any mutation, precisely so this
-  # question is answered about the state the client actually edited.
+  # CRITICAL: evaluated ONCE, at construction, before any mutation, and
+  # memoized. Every write during the save moves the product's fingerprint, so
+  # re-computing later would compare the client's token against a snapshot this
+  # request itself had already moved, silently dropping a legitimate deletion.
   def may_delete?
     return @may_delete if defined?(@may_delete)
 


### PR DESCRIPTION
## What

Comments only in `app/services/product/save_contract.rb`. **No behaviour change** — not one line of code was touched, renamed, or moved. `git diff` is entirely `#` lines.

Comment lines: **257 → 158**. Net diff 103 insertions / 202 deletions.

## Why

The class was 452 lines, ~257 of them comment for ~195 lines of code. The content was right; the volume meant nobody would read it. Three patterns dominated:

- **A sectioned essay at the top** — `## The defect this exists to remove`, `## The contract`, `## Why this is a value object rather than a pile of ifs in the controller` — 51 lines walking through the reasoning that produced the design.
- **Per-method restatement.** Several comments explained what the two `return [] unless` guards directly below them already say.
- **Narration of how we got here** — "which is what an earlier version of this did", "Verified by probe that…", "that is the exact failure this PR exists to prevent, reintroduced through the error handler", plus flag-flip command lines that belong in the rollout doc, not the source.

Every fact a maintainer needs is still here, in fewer words. Per `AGENTS.md`: write for a colleague, not a student.

## Deliberately KEPT

These are the load-bearing bits, and they are why this is a trim rather than a deletion:

- **The `deleted_ids[:variants]` version-vs-grouping id collision** — untouched, verbatim. External ids have no table discriminator and the two tables have independent counters, so a grouping id silently deletes a colliding *version* and returns 200. Not re-derivable from the code.
- **The three-way ambiguity** (`[]` on purpose / key absent / strong params dropped a malformed value) and the fact that the third is the dangerous one. Compressed from ~20 lines to 6; the mechanism stays.
- **The two collections with no undo** — `integration.disconnect!` hits the provider, `public_files` strips embed nodes out of the description in the same pass.
- **Rules 1–3**, as a list. That is the contract; it stays in list form.
- **The freshness ordering constraint** on `may_delete?`, including the `CRITICAL:` marker. Evaluated once at construction, before any mutation, because every write moves the fingerprint — re-checking later silently drops a legitimate deletion submitted alongside a new page. This is the trap that bites the next editor.
- **Why a lookup failure must not answer "disabled"** — "disabled" routes to the legacy delete-by-omission path, so a Redis blip becomes a wipe. Kept because the code alone reads like ordinary defensive rescue.
- **The `Array()` strictness note** on `cleared?` — a bare `"variants"` must not become a clear-all.
- **The requested-vs-allowed split** rationale on `raw_deleted_ids`.
- **The malformed-shape list** on `deleted_ids` (`String#dig` does not exist), minus the "verified by probe" narration.

## Test Results

Local, clean env:

```
bundle exec rubocop app/services/product/save_contract.rb
1 file inspected, no offenses detected

bundle exec rspec spec/services/product/save_contract_spec.rb \
                  spec/services/product/variant_deleted_ids_kind_invariant_spec.rb
63 examples, 0 failures
```

`ruby -c` OK. Branch CI green at `f5dda4e21` — Tests (all Fast/Minitest shards, Lint Ruby, Lint JS/TS, Typecheck TS, Build images, Migration versions) and Preview app, 0 failures, 0 pending.

## Review

Needs only a skim: check that nothing in the KEPT list above reads as lost.
