### PR TITLE
Record when a seller's legal-entity country drifts from their Stripe account country

### DIFF
--- a/app/models/user_compliance_info.rb
+++ b/app/models/user_compliance_info.rb
@@ -54,6 +54,7 @@ class UserComplianceInfo < ApplicationRecord
 
   after_create_commit :handle_stripe_compliance_info
   after_create_commit :handle_compliance_info_request
+  after_create_commit :detect_legal_entity_country_drift
 
   scope :country, ->(country) { where(country:) }
 
@@ -264,6 +265,16 @@ class UserComplianceInfo < ApplicationRecord
 
     def handle_compliance_info_request
       UserComplianceInfoRequest.handle_new_user_compliance_info(self)
+    end
+
+    # A UserComplianceInfo is immutable, so every edit lands as a new record —
+    # that create is the moment the derived legal-entity country can change, and
+    # the only hook where drift against the Stripe account country is visible.
+    # Deferred to Sidekiq because it reads the Stripe account country off the
+    # merchant account and writes an admin note; neither belongs in the caller's
+    # save transaction. See DetectLegalEntityCountryDriftJob.
+    def detect_legal_entity_country_drift
+      DetectLegalEntityCountryDriftJob.perform_async(id)
     end
 
     def kana_fields_format

--- a/app/sidekiq/detect_legal_entity_country_drift_job.rb
+++ b/app/sidekiq/detect_legal_entity_country_drift_job.rb
@@ -54,16 +54,21 @@ class DetectLegalEntityCountryDriftJob
               "Compliance resync to Stripe will fail for this seller until the account is " \
               "recreated in the correct country; Stripe cannot change an existing account's country."
 
-    return if user.comments
+    # Near-simultaneous compliance edits enqueue jobs with distinct record ids,
+    # so the Sidekiq unique lock does not collapse them. Lock the user row to
+    # make the dedup check and the insert atomic across those jobs.
+    user.with_lock do
+      next if user.comments
                   .with_type_note
                   .where(author_name: AUTHOR_NAME, content:)
                   .where("created_at > ?", DEDUP_WINDOW.ago)
                   .exists?
 
-    user.comments.create!(
-      author_name: AUTHOR_NAME,
-      comment_type: Comment::COMMENT_TYPE_NOTE,
-      content:,
-    )
+      user.comments.create!(
+        author_name: AUTHOR_NAME,
+        comment_type: Comment::COMMENT_TYPE_NOTE,
+        content:,
+      )
+    end
   end
 end

--- a/app/sidekiq/detect_legal_entity_country_drift_job.rb
+++ b/app/sidekiq/detect_legal_entity_country_drift_job.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# Records when a seller's derived legal-entity country stops agreeing with the
+# country their Stripe account was actually created in.
+#
+# `UserComplianceInfo#legal_entity_country_code` is derived on every read as
+# `(business_country_code if is_business?) || country_code`. Nothing caches or
+# re-validates it, so a seller who opened an account as a US business and later
+# flips `is_business` to false silently starts deriving their cross-border
+# personal country instead — while the Stripe account keeps `country: "US"`
+# forever. Stripe then rejects the whole compliance payload (recipient ToS,
+# then company address country), which is the cohort in gumroad-private#1512.
+#
+# The check deliberately does not live in `legal_entity_country_code` itself:
+# that reader has 48 call sites, most of them on payout and compliance paths,
+# and a derivation that raises or writes state at read time is how a country
+# check ends up throwing inside a payout run. Detect at the point the input
+# changes instead.
+#
+# A drift cannot be self-healed. Stripe will not change an existing account's
+# country, so clearing it means opening a new account — a support decision,
+# not something to automate. This job records and stops.
+class DetectLegalEntityCountryDriftJob
+  include Sidekiq::Job
+  sidekiq_options queue: :low, retry: 3, lock: :until_executed
+
+  AUTHOR_NAME = "legal-entity-country-drift"
+  # A seller can edit compliance details repeatedly while the mismatch stands.
+  # Re-noting the same pair every time buries the first, real event.
+  DEDUP_WINDOW = 30.days
+
+  def perform(user_compliance_info_id)
+    compliance_info = UserComplianceInfo.find_by(id: user_compliance_info_id)
+    return if compliance_info.nil?
+
+    user = compliance_info.user
+    return if user.nil?
+
+    derived_country = compliance_info.legal_entity_country_code
+    return if derived_country.blank?
+
+    merchant_account = user.stripe_account
+    return if merchant_account.nil?
+    # Stripe Connect accounts are the seller's own; we do not push a legal
+    # entity onto them, so a country disagreement has no consequence there.
+    return unless merchant_account.is_a_gumroad_managed_stripe_account?
+
+    account_country = merchant_account.country
+    return if account_country.blank?
+    return if account_country == derived_country
+
+    content = "Legal-entity country #{derived_country} does not match the Stripe " \
+              "account country #{account_country} (#{merchant_account.charge_processor_merchant_id}). " \
+              "Compliance resync to Stripe will fail for this seller until the account is " \
+              "recreated in the correct country; Stripe cannot change an existing account's country."
+
+    return if user.comments
+                  .with_type_note
+                  .where(author_name: AUTHOR_NAME, content:)
+                  .where("created_at > ?", DEDUP_WINDOW.ago)
+                  .exists?
+
+    user.comments.create!(
+      author_name: AUTHOR_NAME,
+      comment_type: Comment::COMMENT_TYPE_NOTE,
+      content:,
+    )
+  end
+end

--- a/spec/sidekiq/detect_legal_entity_country_drift_job_spec.rb
+++ b/spec/sidekiq/detect_legal_entity_country_drift_job_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe DetectLegalEntityCountryDriftJob do
+  let(:seller) { create(:user) }
+
+  def stripe_account_for(country)
+    create(:merchant_account, user: seller, country:)
+  end
+
+  describe "#perform" do
+    it "notes the mismatch when the derived legal-entity country differs from the Stripe account country" do
+      stripe_account_for("US")
+      compliance_info = create(:user_compliance_info_singapore, user: seller)
+
+      expect do
+        described_class.new.perform(compliance_info.id)
+      end.to change { seller.comments.with_type_note.count }.by(1)
+
+      comment = seller.comments.with_type_note.last
+      expect(comment.author_name).to eq(described_class::AUTHOR_NAME)
+      expect(comment.content).to include("Legal-entity country SG")
+      expect(comment.content).to include("Stripe account country US")
+    end
+
+    it "does nothing when the two countries agree" do
+      stripe_account_for("US")
+      compliance_info = create(:user_compliance_info, user: seller)
+
+      expect do
+        described_class.new.perform(compliance_info.id)
+      end.not_to change { seller.comments.count }
+    end
+
+    it "uses the business country when the record is a business" do
+      stripe_account_for("US")
+      compliance_info = create(:user_compliance_info_mex_business, user: seller)
+
+      expect do
+        described_class.new.perform(compliance_info.id)
+      end.to change { seller.comments.with_type_note.count }.by(1)
+      expect(seller.comments.with_type_note.last.content).to include("Legal-entity country MX")
+    end
+
+    it "does not re-note the same mismatch inside the dedup window" do
+      stripe_account_for("US")
+      compliance_info = create(:user_compliance_info_singapore, user: seller)
+      described_class.new.perform(compliance_info.id)
+
+      expect do
+        described_class.new.perform(compliance_info.id)
+      end.not_to change { seller.comments.count }
+    end
+
+    it "notes again once the dedup window has passed" do
+      stripe_account_for("US")
+      compliance_info = create(:user_compliance_info_singapore, user: seller)
+      described_class.new.perform(compliance_info.id)
+
+      travel_to(described_class::DEDUP_WINDOW.from_now + 1.day) do
+        expect do
+          described_class.new.perform(compliance_info.id)
+        end.to change { seller.comments.with_type_note.count }.by(1)
+      end
+    end
+
+    it "ignores sellers on their own Stripe Connect account" do
+      create(:merchant_account_stripe_connect, user: seller, country: "US")
+      compliance_info = create(:user_compliance_info_singapore, user: seller)
+
+      expect do
+        described_class.new.perform(compliance_info.id)
+      end.not_to change { seller.comments.count }
+    end
+
+    it "does nothing when the seller has no Stripe account" do
+      compliance_info = create(:user_compliance_info_singapore, user: seller)
+
+      expect do
+        described_class.new.perform(compliance_info.id)
+      end.not_to change { seller.comments.count }
+    end
+
+    it "does nothing when the compliance record no longer exists" do
+      expect { described_class.new.perform(0) }.not_to raise_error
+    end
+  end
+
+  describe "enqueueing from UserComplianceInfo" do
+    it "is enqueued when a compliance record is created" do
+      expect do
+        create(:user_compliance_info, user: seller, skip_stripe_job_on_create: true)
+      end.to change { described_class.jobs.size }.by(1)
+    end
+  end
+end


### PR DESCRIPTION
Closes the generator half of [gumroad-private#1512](https://github.com/antiwork/gumroad-private/issues/1512).

## Why

`UserComplianceInfo#legal_entity_country_code` is derived on every read:

```ruby
(business_country_code if is_business?) || country_code
```

Nothing caches it and nothing re-validates it. A seller who opens an account as a US business and later flips `is_business` to false starts deriving their cross-border personal country, while the Stripe account keeps `country: "US"` forever. Stripe then rejects the compliance payload — recipient ToS first, company address country next — and no resync can ever land. That is what regrows the 28-account cohort in #1512 regardless of what we do to the current members.

## What this does

An `after_create_commit` hook on `UserComplianceInfo` enqueues `DetectLegalEntityCountryDriftJob`, which compares the newly derived legal-entity country against the live Stripe account's `country` and writes an admin note on disagreement.

**`after_create_commit`, not `after_update`:** `UserComplianceInfo` includes `Immutable`, whose `before_update` raises on any non-`attr_mutable` change. Every compliance edit goes through `dup_and_save`, so the **create** is the only hook where a changed derivation is observable. The `after_update` guard I described as the plan on the issue could never have fired — correcting that here.

**Not inside `legal_entity_country_code`:** 48 call sites across 17 files, overwhelmingly payout and compliance paths. A derivation that raises or writes state at read time is how a country check ends up throwing inside a payout run.

**Record, don't remediate:** Stripe will not change an existing account's country, so a drift can only be cleared by opening a new account. That is a support decision and deliberately not automated. Stripe Connect accounts are skipped — we don't push a legal entity onto them, so the disagreement has no consequence there.

## Notes

- 30-day dedup on identical (derived, account) country pairs, so a seller editing details repeatedly doesn't bury the first real event.
- Specs cover: mismatch noted, agreement silent, business country used, dedup inside and outside the window, Connect accounts skipped, no-Stripe-account and missing-record no-ops.
- No behaviour change for any seller whose countries already agree — the job returns before writing anything.


## Test Results

`spec/sidekiq/detect_legal_entity_country_drift_job_spec.rb` — **9 examples, 0 failures** (run locally at `f161dbfec`, 10.43s). RuboCop clean on all three changed files.

Coverage: mismatch noted; agreement stays silent; business country used when `is_business?`; dedup suppresses a repeat inside the 30-day window and allows one after it; Stripe Connect accounts skipped; no-Stripe-account no-op; deleted-compliance-record no-op; and the `after_create_commit` actually enqueues.

No QA media: this writes an internal admin note and has no rendered surface.

## AI disclosure

Written by Hermes Agent (claude-opus-5) on Sahil's behalf. The `Immutable` finding that invalidated the originally-planned `after_update` hook was verified by reading `app/modules/immutable.rb` and the two live edit paths (`UpdateUserComplianceInfo#118-123`, `Settings::PaymentsController#166`), not asserted; the specs above were run rather than claimed.
