### PR TITLE
Stop offering direct deposit to sellers who cannot complete bank setup

### DIFF
--- a/app/javascript/components/Settings/PaymentsPage/PayPalEmailSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/PayPalEmailSection.tsx
@@ -8,7 +8,7 @@ import { Input } from "$app/components/ui/Input";
 import { Label } from "$app/components/ui/Label";
 
 const PayPalEmailSection = ({
-  countrySupportsNativePayouts,
+  canSetupBankPayouts,
   showPayPalPayoutsFeeNote,
   isFormDisabled,
   paypalEmailAddress,
@@ -19,7 +19,7 @@ const PayPalEmailSection = ({
   errorFieldNames,
   user,
 }: {
-  countrySupportsNativePayouts: boolean;
+  canSetupBankPayouts: boolean;
   showPayPalPayoutsFeeNote: boolean;
   isFormDisabled: boolean;
   paypalEmailAddress: string | null;
@@ -40,7 +40,7 @@ const PayPalEmailSection = ({
       ) : null}
       <div className="whitespace-pre-line">{feeInfoText}</div>
       <div>
-        {countrySupportsNativePayouts && !isFormDisabled ? (
+        {canSetupBankPayouts && !isFormDisabled ? (
           <button className="cursor-pointer underline all-unset" onClick={() => updatePayoutMethod("bank")}>
             Switch to direct deposit
           </button>

--- a/app/javascript/pages/Settings/Payments/Show.tsx
+++ b/app/javascript/pages/Settings/Payments/Show.tsx
@@ -1472,7 +1472,7 @@ export default function PaymentsPage() {
               />
             ) : selectedPayoutMethod === "paypal" ? (
               <PayPalEmailSection
-                countrySupportsNativePayouts={props.user.country_supports_native_payouts}
+                canSetupBankPayouts={props.bank_account_details.show_bank_account}
                 showPayPalPayoutsFeeNote={props.user.is_charged_paypal_payout_fee}
                 isFormDisabled={props.is_form_disabled}
                 paypalEmailAddress={form.data.payment_address}

--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -936,6 +936,22 @@ describe("Payments Settings Scenario", type: :system, js: true) do
       expect(page).to_not have_field("PayPal Email")
     end
 
+    it "does not offer direct deposit to an India creator, who cannot complete bank setup" do
+      @user.update!(payment_address: "barny@paypal.com")
+      old_user_compliance_info = @user.alive_user_compliance_info
+      new_user_compliance_info = old_user_compliance_info.dup
+      new_user_compliance_info.country = "India"
+      ActiveRecord::Base.transaction do
+        old_user_compliance_info.mark_deleted!
+        new_user_compliance_info.save!
+      end
+
+      visit settings_payments_path
+
+      expect(page).to have_field("PayPal Email")
+      expect(page).to_not have_button("Switch to direct deposit")
+    end
+
     it "keeps the creator on PayPal payouts if the bank account info is not entered" do
       @user.update!(payment_address: "paypal-gr-integspecs@gumroad.com")
 


### PR DESCRIPTION
## What

Settings > Payments no longer offers "Switch to direct deposit" to sellers whose accounts can never complete bank payout setup. The link now reads the same predicate that gates the section it navigates to.

- `PayPalEmailSection` prop `countrySupportsNativePayouts` → `canSetupBankPayouts`
- `Show.tsx` passes `props.bank_account_details.show_bank_account` (`User#can_setup_bank_payouts?`) instead of `props.user.country_supports_native_payouts` (`User#native_payouts_supported?`)

Ref antiwork/gumroad-private#1687

## Why

The two predicates disagree, and the page was already using both. `native_payouts_supported?` is only "the country is in `SUPPORTED_COUNTRIES`" — India is. `can_setup_bank_payouts?` is `active_bank_account.present? || (native_payouts_supported? && !signed_up_from_india?) || signed_up_from_united_arab_emirates?`, and the Bank Account tab is gated on *that*. So for an India-signup seller with no saved bank account the page hid the bank section and simultaneously offered a link to go add one.

Following the link was not merely cosmetic: `BankAccountSection` renders on `selectedPayoutMethod === "bank"` alone without re-checking `show_bank_account` (`Show.tsx:1452`), so the seller got an uncompletable bank form. Submitting it hits `NEW_ACCOUNT_CREATION_BLOCKED_COUNTRIES = [IND]` in `StripeMerchantAccountManager`, raises `MerchantRegistrationUserNotReadyError`, and the controller bounces them back with "Bank payouts are not supported in your country yet. Please use PayPal instead."

The value was already in the payload, so this adds no prop.

**The change is not purely a narrowing** — worth stating because the commit message only described one direction:

| Direction | Population | Correct? |
|---|---|---|
| Loses the link | India-signup sellers with **no** active bank account | Yes — they cannot complete setup. India sellers *with* a saved bank account keep it via the `active_bank_account.present?` term. |
| Gains the link | UAE non-business sellers | Yes — bank-for-AE is a designed path; `updatePayoutMethod("bank")` force-sets `is_business: true` for AE (`Show.tsx:295-300`) |
| Gains the link | Sellers in now-unsupported countries holding a grandfathered active bank account | Yes — the Bank Account tab already rendered for them on this same predicate |

No seller loses a reachable path.

## Test Results

New system spec — an India creator on PayPal sees the PayPal Email field but **not** the "Switch to direct deposit" button (`spec/requests/settings/payments_spec.rb`). The fixture soft-deletes the compliance info and saves an India copy, the same pattern the neighbouring Zambia example uses.

CI at `a8d547d`: **77 success, 1 skipped, 0 pending, 0 failed.**

The positive side was already pinned — "allows US creator to switch to ACH" (`payments_spec.rb:932`) clicks the link, so it reddens if this gate over-narrows.

## QA steps for the reviewer

@nyomanjyotisa — please QA these on the preview app:

1. **India seller, no bank account, on PayPal payouts** → Settings > Payments shows the PayPal Email field and **no** "Switch to direct deposit" link.
2. **India seller WITH a saved bank account** → link still present (the `active_bank_account.present?` term must keep working; a regression here would strand an existing India bank seller on PayPal).
3. **US seller on PayPal** → link present and clicking it still opens the bank form (this is the pre-existing spec's path, worth eyeballing once).
4. **UAE individual (non-business) on PayPal** → link now present where it previously was not. This is the one behavior the review flagged as unpinned by any page-level spec (P3 below) — worth a look rather than a test.

## Pre-merge adversarial review (fable-5)

Ran the gate against `a8d547d` before opening. Verdict: **READY-TO-MERGE** — no P1s, no P2s.

| # | Finding | Disposition |
|---|---|---|
| P3 | The gained UAE-individual path has no page-level spec (the predicate side is covered at `test/modules/user/feature_status_test.rb:199`, the wiring is not) | Accepted, not fixed — head is green and this is pre-existing coverage shape, not a defect the diff introduces. Folded into QA step 4 instead. |
| P3 | Commit message described only the narrowing, not the two gained populations | Fixed here — the population table above is in this body, so a future bisect does not read the UAE change as an accident. |

**What the review confirmed safe**, each verified against the code rather than taken on the reviewer's word:

- **Both directions of the population delta enumerated.** Both predicates read the same country source (`compliance_country_code` ← `alive_user_compliance_info.legal_entity_country_code`), so there is no skew from incomplete or mid-onboarding compliance data.
- **`show_bank_account` is the right semantic object despite the display-flavoured name.** It is computed purely from `can_setup_bank_payouts?` (`settings_presenter.rb:697`) — no feature flag, no selected-payout-method state, no form state. This is not a display-value-used-as-a-gate bug: the link's only action is to navigate to the section gated by this same value, so the affordance should exist iff its destination does.
- **No sibling surface carries the same wrong gate.** "Switch to direct deposit" appears exactly once in the repo. The two remaining `country_supports_native_payouts` consumers (`Show.tsx:1039`, `AccountDetailsSection.tsx:783`) gate the business tax-ID requirement, which *should* apply to India.
- **Server-side gating is unchanged**, so this is not UI-only security: an ineligible seller who POSTs bank details directly is still bounced at `payments_controller.rb:134-144`.
- **The prop is not now dead** (still read by the two tax-ID gates) and its type is not optional, so there is no `undefined`-reads-as-false hazard. `PayPalEmailSection` has one call site, so the rename is complete.
- **The new spec is non-vacuous.** The fixture really produces the disagreement (old prop true, new prop false), `have_field("PayPal Email")` pins that the PayPal branch actually rendered, and under a one-line revert of the gate the button renders and `to_not have_button` reddens.

Not self-merging: this touches payout method setup. Assigned one human with `awaiting-human`.

## AI disclosure

Written by gumclaw, an AI agent (claude-opus-5), with a headless adversarial review pass before opening. A human owns the merge.
