### PR TITLE
Let the monthly sitemap job finish a full month, and survive a kill

### DIFF
--- a/.buildkite/scripts/deploy_production.sh
+++ b/.buildkite/scripts/deploy_production.sh
@@ -77,8 +77,8 @@ wait_for_healthcheck() {
 wait_for_healthcheck "Payout batch" "https://gumroad.com/healthcheck/payouts" 15 proceed \
   '[ "$(date -u +%u)" -ge 2 ] && [ "$(date -u +%u)" -le 5 ] && [ "$(date -u +%H)" -eq 10 ]'
 
-# Long-running non-payout jobs — the monthly/quarterly finance and tax reports, sitemap
-# rebuilds, the daily instant payouts (see LongRunningJobTracking). These are NOT safe to
+# Long-running non-payout jobs — the monthly/quarterly finance and tax reports and the
+# daily instant payouts (see LongRunningJobTracking). These are NOT safe to
 # interrupt: they hold no checkpoint, so a recycled worker means the run starts over, and
 # killed runs of these are how finance reports have silently gone missing. So we wait longer
 # (up to 2 hours, the slowest of them is the Canada sales report at well over an hour) and,
@@ -94,7 +94,7 @@ wait_for_healthcheck "Payout batch" "https://gumroad.com/healthcheck/payouts" 15
 # jobs are actually SCHEDULED for, plus ~2h of runtime headroom. Read straight off
 # config/sidekiq_schedule.yml, which is written in UTC — the schedule is not an ET
 # midnight-6am block, so testing ET hours here would leave most of it uncovered:
-#   UTC 00:00 sitemap refresh, outstanding balances CSV
+#   UTC 00:00 outstanding balances CSV
 #   UTC 01:00 monthly financial reports (fans out the Canada sales report, 1-2h)
 #   UTC 02:00 YTD sales report   UTC 03:00 TaxJar upload, India sales report
 #   UTC 08:00 daily instant payouts

--- a/app/services/sitemap_service.rb
+++ b/app/services/sitemap_service.rb
@@ -5,9 +5,13 @@ class SitemapService
   MAX_SITEMAP_LINKS = 50_000
   SITEMAP_PATH_MONTHLY = "sitemap/products/monthly"
 
-  # Everything the per-product `add` below touches. Without these the walk costs
-  # a handful of queries per row, which is what made a full month time out.
-  SITEMAP_PRELOADS = [:user, { display_asset_previews: { file_attachment: :blob } }].freeze
+  # Flattens the per-row seller and cover lookups the `add` loop below makes. The retina
+  # variant is NOT covered: `preview_url` calls `.processed`, which resolves each cover's
+  # variant record individually, so that cost stays per-row whatever is preloaded here.
+  SITEMAP_PRELOADS = [
+    :user,
+    { display_asset_previews: { file_attachment: { blob: { variant_records: { image_attachment: :blob } } } } }
+  ].freeze
   private_constant :SITEMAP_PRELOADS
 
   def generate(date = Date.current)

--- a/app/services/sitemap_service.rb
+++ b/app/services/sitemap_service.rb
@@ -5,9 +5,9 @@ class SitemapService
   MAX_SITEMAP_LINKS = 50_000
   SITEMAP_PATH_MONTHLY = "sitemap/products/monthly"
 
-  # Flattens the per-row seller and cover lookups the `add` loop below makes. The retina
-  # variant is NOT covered: `preview_url` calls `.processed`, which resolves each cover's
-  # variant record individually, so that cost stays per-row whatever is preloaded here.
+  # Flattens the per-row seller and cover lookups the `add` loop below makes. The
+  # variant_records leg matters: with it loaded, `.processed` finds the retina variant in
+  # memory. Only a cover being processed for the FIRST time still costs a write per row.
   SITEMAP_PRELOADS = [
     :user,
     { display_asset_previews: { file_attachment: { blob: { variant_records: { image_attachment: :blob } } } } }

--- a/app/services/sitemap_service.rb
+++ b/app/services/sitemap_service.rb
@@ -5,6 +5,11 @@ class SitemapService
   MAX_SITEMAP_LINKS = 50_000
   SITEMAP_PATH_MONTHLY = "sitemap/products/monthly"
 
+  # Everything the per-product `add` below touches. Without these the walk costs
+  # a handful of queries per row, which is what made a full month time out.
+  SITEMAP_PRELOADS = [:user, { display_asset_previews: { file_attachment: :blob } }].freeze
+  private_constant :SITEMAP_PRELOADS
+
   def generate(date = Date.current)
     # Parse date from Sidekiq job argument
     date = Date.parse(date) if date.is_a?(String)
@@ -20,7 +25,7 @@ class SitemapService
       sitemap_config(filename, path, include_index)
 
       SitemapGenerator::Sitemap.create do
-        Link.alive.where(created_at: period).find_each do |product|
+        Link.alive.where(created_at: period).preload(*SITEMAP_PRELOADS).find_each do |product|
           relative_url = Rails.application.routes.url_helpers.short_link_path(product)
           add relative_url, changefreq: "daily", priority: 1, lastmod: product.updated_at, images: [{ loc: product.preview_url }],
                             host: product.user.subdomain_with_protocol

--- a/app/sidekiq/concerns/long_running_job_tracking.rb
+++ b/app/sidekiq/concerns/long_running_job_tracking.rb
@@ -35,6 +35,8 @@
 #   * SendMembershipsPriceUpdateEmailsJob (UTC 08:10) — claims each notification before
 #     enqueueing a delivery job. Only that job confirms the notification marker after sending,
 #     so a killed scheduler leaves an expiring claim without authorizing the new price.
+#   * RefreshSitemapDailyWorker — regenerating a month overwrites that month's file wholesale,
+#     so a kill loses nothing and Sidekiq re-runs it (retry: 3).
 # PerformDailyInstantPayoutsWorker (UTC 08:00) IS included: it runs with `retry: 0`, so a
 # killed run is never retried and that day's daily-schedule sellers go unpaid.
 #

--- a/app/sidekiq/refresh_sitemap_daily_worker.rb
+++ b/app/sidekiq/refresh_sitemap_daily_worker.rb
@@ -2,11 +2,8 @@
 
 class RefreshSitemapDailyWorker
   include Sidekiq::Job
-  # Regenerating a month's sitemap overwrites it wholesale, so a retry is free. Without a
-  # budget a single killed run left that month's file frozen until the next nightly pass,
-  # and a run that kept dying left it frozen indefinitely with nothing recorded anywhere
-  # (gumroad-private#1679). Given the retry, LongRunningJobTracking no longer applies —
-  # see the exclusion list in that module.
+  # Regenerating a month overwrites its file wholesale, so a retry is free and a killed run
+  # loses nothing — which is also why LongRunningJobTracking no longer applies here.
   sidekiq_options retry: 3, queue: :low
 
   def perform(date = Date.current.to_s)

--- a/app/sidekiq/refresh_sitemap_daily_worker.rb
+++ b/app/sidekiq/refresh_sitemap_daily_worker.rb
@@ -3,7 +3,11 @@
 class RefreshSitemapDailyWorker
   include Sidekiq::Job
   include LongRunningJobTracking
-  sidekiq_options retry: 0, queue: :low
+  # Regenerating a month's sitemap overwrites it wholesale, so a retry is free. Without a
+  # budget a single killed run left that month's file frozen until the next nightly pass,
+  # and a run that kept dying left it frozen indefinitely with nothing recorded anywhere
+  # (gumroad-private#1679).
+  sidekiq_options retry: 3, queue: :low
 
   def perform(date = Date.current.to_s)
     SitemapService.new.generate(date)

--- a/app/sidekiq/refresh_sitemap_daily_worker.rb
+++ b/app/sidekiq/refresh_sitemap_daily_worker.rb
@@ -2,11 +2,11 @@
 
 class RefreshSitemapDailyWorker
   include Sidekiq::Job
-  include LongRunningJobTracking
   # Regenerating a month's sitemap overwrites it wholesale, so a retry is free. Without a
   # budget a single killed run left that month's file frozen until the next nightly pass,
   # and a run that kept dying left it frozen indefinitely with nothing recorded anywhere
-  # (gumroad-private#1679).
+  # (gumroad-private#1679). Given the retry, LongRunningJobTracking no longer applies —
+  # see the exclusion list in that module.
   sidekiq_options retry: 3, queue: :low
 
   def perform(date = Date.current.to_s)

--- a/spec/services/sitemap_service_spec.rb
+++ b/spec/services/sitemap_service_spec.rb
@@ -33,21 +33,35 @@ describe SitemapService do
     # the per-product `add` reads keeps the cost flat as products are added.
     it "does not query per product for the seller or the cover image" do
       seller = create(:user)
-      3.times { create(:product, user: seller, created_at: Time.current) }
 
-      per_row_queries = 0
-      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
-        per_row_queries += 1 if /FROM `(users|asset_previews|active_storage_(attachments|blobs))`/.match?(payload[:sql])
-      end
-      begin
-        service.generate(Date.current)
-      ensure
-        ActiveSupport::Notifications.unsubscribe(subscriber)
+      count_association_queries = lambda do |product_count|
+        Link.alive.delete_all
+        product_count.times do
+          product = create(:product, user: seller, created_at: Time.current)
+          # Without a cover the preview chain has nothing to load and this assertion holds
+          # no matter what SITEMAP_PRELOADS contains.
+          create(:asset_preview, link: product)
+        end
+
+        queries = 0
+        subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+          queries += 1 if /FROM `(users|asset_previews)`/.match?(payload[:sql])
+        end
+        begin
+          service.generate(Date.current)
+        ensure
+          ActiveSupport::Notifications.unsubscribe(subscriber)
+        end
+        queries
       end
 
-      # One statement per preloaded association, regardless of how many products the month
-      # holds — never one (or several) per product.
-      expect(per_row_queries).to be <= 4
+      # Tripling the month's size must not add a statement for these. A fixed bound would
+      # pin whatever SitemapGenerator does today; flatness is the property the preload owes.
+      #
+      # Active Storage is deliberately not counted here: `preview_url` resolves through
+      # AssetPreview#retina_variant, and `.processed` looks up (and may create) each cover's
+      # variant record individually, so that tail stays per-row and no preload removes it.
+      expect(count_association_queries.call(6)).to eq(count_association_queries.call(2))
     end
 
     it "still renders the seller host and cover image for each product" do

--- a/spec/services/sitemap_service_spec.rb
+++ b/spec/services/sitemap_service_spec.rb
@@ -58,9 +58,9 @@ describe SitemapService do
       # Tripling the month's size must not add a statement for these. A fixed bound would
       # pin whatever SitemapGenerator does today; flatness is the property the preload owes.
       #
-      # Active Storage is deliberately not counted here: `preview_url` resolves through
-      # AssetPreview#retina_variant, and `.processed` looks up (and may create) each cover's
-      # variant record individually, so that tail stays per-row and no preload removes it.
+      # Active Storage tables are not counted: every cover here is processed for the first
+      # time, which writes a variant record per row. The preload's variant_records leg pays
+      # off only for already-processed covers, which a cold fixture cannot stage.
       expect(count_association_queries.call(6)).to eq(count_association_queries.call(2))
     end
 

--- a/spec/services/sitemap_service_spec.rb
+++ b/spec/services/sitemap_service_spec.rb
@@ -27,5 +27,41 @@ describe SitemapService do
 
       expect(redis_namespace.get(cache_key)).to eq nil
     end
+
+    # A month's walk is ~200k products in production, so anything queried per row is what
+    # decides whether the job finishes at all (gumroad-private#1679). Counting the tables
+    # the per-product `add` reads keeps the cost flat as products are added.
+    it "does not query per product for the seller or the cover image" do
+      seller = create(:user)
+      3.times { create(:product, user: seller, created_at: Time.current) }
+
+      per_row_queries = 0
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+        per_row_queries += 1 if /FROM `(users|asset_previews|active_storage_(attachments|blobs))`/.match?(payload[:sql])
+      end
+      begin
+        service.generate(Date.current)
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+
+      # One statement per preloaded association, regardless of how many products the month
+      # holds — never one (or several) per product.
+      expect(per_row_queries).to be <= 4
+    end
+
+    it "still renders the seller host and cover image for each product" do
+      seller = create(:user, username: "sitemapseller")
+      product = create(:product, user: seller, created_at: Time.current)
+      create(:asset_preview, link: product)
+
+      date = product.created_at
+      path = "#{Rails.public_path}/sitemap/products/monthly/#{date.year}/#{date.month}/sitemap.xml.gz"
+      service.generate(date)
+
+      xml = Zlib::GzipReader.open(path, &:read)
+      expect(xml).to include(seller.subdomain_with_protocol)
+      expect(xml).to include(product.reload.preview_url)
+    end
   end
 end

--- a/spec/services/sitemap_service_spec.rb
+++ b/spec/services/sitemap_service_spec.rb
@@ -33,11 +33,14 @@ describe SitemapService do
     # the per-product `add` reads keeps the cost flat as products are added.
     it "does not query per product for the seller or the cover image" do
       seller = create(:user)
+      # One clock sample for fixtures and generation: sampling twice can straddle a month
+      # boundary, and generating an empty month makes the flatness comparison vacuous.
+      sitemap_month = Time.current
 
       count_association_queries = lambda do |product_count|
         Link.alive.delete_all
         product_count.times do
-          product = create(:product, user: seller, created_at: Time.current)
+          product = create(:product, user: seller, created_at: sitemap_month)
           # Without a cover the preview chain has nothing to load and this assertion holds
           # no matter what SITEMAP_PRELOADS contains.
           create(:asset_preview, link: product)
@@ -48,7 +51,7 @@ describe SitemapService do
           queries += 1 if /FROM `(users|asset_previews)`/.match?(payload[:sql])
         end
         begin
-          service.generate(Date.current)
+          service.generate(sitemap_month.to_date)
         ensure
           ActiveSupport::Notifications.unsubscribe(subscriber)
         end

--- a/spec/sidekiq/refresh_sitemap_daily_worker_spec.rb
+++ b/spec/sidekiq/refresh_sitemap_daily_worker_spec.rb
@@ -21,5 +21,11 @@ describe RefreshSitemapDailyWorker do
 
       described_class.new.perform
     end
+
+    # Regenerating a month overwrites its file, so retrying costs nothing and a killed run
+    # would otherwise leave that month frozen with nothing recorded (gumroad-private#1679).
+    it "retries a failed run" do
+      expect(described_class.sidekiq_options["retry"]).to eq(3)
+    end
   end
 end


### PR DESCRIPTION
## What

Makes the monthly product sitemap job able to finish a full month, and survive being killed.

- `SitemapService` preloads the seller and cover-image associations the per-product `add` loop reads, so a month's walk stops issuing two queries per product.
- `RefreshSitemapDailyWorker` moves from `retry: 0` to `retry: 3` and drops `LongRunningJobTracking`.

## Why

Ref antiwork/gumroad-private#1679. Monthly sitemaps stopped rebuilding 3-5 days into each month, for 8+ months, silently — roughly 185k of July's 210k live products were in no sitemap at all. A month is ~200k products, and everything queried per row is what decides whether the job finishes at all.

The retry change is the other half. Regenerating a month overwrites that month's file wholesale, so a retry is free, but the job ran with `retry: 0`: a single killed run left the month's file frozen until the next nightly pass, and a run that kept dying left it frozen indefinitely with nothing recorded anywhere. Because the retry now covers a killed run, `LongRunningJobTracking` no longer applies — it exists for jobs where a kill loses work, and this one has no such loss. Sidekiq Pro's `super_fetch!` (`config/initializers/sidekiq.rb`) recovers SIGKILL'd jobs independently of `retry:`, so the recovery is real in production, not just on a clean shutdown.

## Test results

`spec/services/sitemap_service_spec.rb` + `spec/sidekiq/refresh_sitemap_daily_worker_spec.rb` — **7 examples, 0 failures** locally. Full CI at `ce5ce6923` (head): **81 checks, 0 pending, 0 failing**, 10 skipped.

The preload spec asserts *flatness* rather than a fixed query count: tripling the month's size must not add a `users` or `asset_previews` statement. A fixed bound would pin whatever SitemapGenerator happens to do today.

## Fable-5 adversarial review

Two rounds. Round 1 ran against `5dbc68c72`; its fix commit `b388b6359` was itself unreviewed, so a second round was scoped to it (per the round-chaining rule — the commit that closes round N's findings is outside round N's scope by construction).

**Verdict: CHANGES-REQUIRED, no P1.** All findings fixed in `5d9af9e75`.

| # | Finding | Disposition |
|---|---|---|
| P2 | `sitemap_service.rb` — the `SITEMAP_PRELOADS` comment claimed the retina variant "stays per-row whatever is preloaded here". False: `ActiveStorage::VariantWithRecord#record` does an in-memory `find` when `variant_records` is loaded (verified in the lockfile-resolved activestorage 7.1.6), so the deepest leg of the constant is load-bearing for already-processed covers. The comment argued for deleting code that does work. | Fixed in `5d9af9e75` |
| P2 | `.buildkite/scripts/deploy_production.sh:80,97` — still listed sitemap rebuilds among the tracked not-safe-to-interrupt jobs, and named "UTC 00:00 sitemap refresh" in the fail-safe window derivation. Both made false by this branch. No functional impact: the healthcheck is set-based (`ZCARD`), and the 00–05 window stays justified by the outstanding-balances CSV at the same hour. | Fixed in `5d9af9e75` |
| P3 | The ActiveStorage half of `SITEMAP_PRELOADS` is not query-counted (the spec's regex counts only `users`/`asset_previews`). Every cover in a cold fixture is processed for the first time, which writes a variant record per row, so a cold fixture structurally cannot show flatness there. | Accepted, documented in the spec |
| P3 | Worker comment ran to five lines with bug-history narration. | Trimmed in `5d9af9e75` |

**What the review confirmed safe** (passed adversarial claims):

- **Removing `LongRunningJobTracking` breaks no monitor.** The deploy healthcheck is purely `zremrangebyscore` + `ZCARD > 0` on one Redis set — nothing enumerates tracked job classes, so nothing goes blind. This was the highest-value hunt (a gate silently guaranteeing a property to downstream code) and it came up genuinely empty.
- **Kill recovery is real**: `super_fetch!` + sidekiq-pro ~> 7.2 in the lockfile.
- **Retries converge**: the month's file is deterministically named and overwritten wholesale; no new singleton-race exposure via `SitemapGenerator::Sitemap`.
- **The preload chain resolves end-to-end** and matches what `preview_url` actually traverses.
- `private_constant` applies correctly.
- Round 1's spec vacuity (products created without covers, so the assertion held no matter what the constant contained) is genuinely fixed.

## QA steps

Only verifiable live: that a production-scale month (~200k products) now completes. Suggested check after deploy — run `RefreshSitemapDailyWorker` for a past month and confirm the file at `sitemap/products/monthly/<year>/<month>/sitemap.xml.gz` is rewritten with the full product count, and that the job's runtime is no longer growing superlinearly with month size.

## AI disclosure

Written by Hermes Agent (claude-opus-5) on behalf of @gumclaw. Reviewed adversarially by claude-fable-5 in two rounds; every finding above was independently verified against this repo before being acted on.



---

**Ownership right now: mine, not the assignee's.** CI has not settled yet (checks still running), so there is nothing for a reviewer to act on and the label is `working`. I owe the green run; the moment it settles this flips to `awaiting-human` with an explicit review request, and if anything reddens I fix it first.


