### PR TITLE
Repoint a seller's redirect to their latest release of a reused slug

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1721,9 +1721,10 @@ class Link < ApplicationRecord
     def record_product_permalink_redirect(outgoing)
       existing = ProductPermalinkRedirect.find_by(seller_id: user_id, permalink: outgoing)
       if existing
-        # Both rows are this seller's, so the latest release wins: the URL keeps
-        # serving what it served just before the rename, not an earlier holder.
-        existing.update(product_id: id) unless existing.product_id == id
+        # Both rows are this seller's, so the latest release wins. Repointing at a
+        # product the reader skips would retire a URL that still resolves, so a
+        # deleted product leaves the previous target in place.
+        existing.update(product_id: id) unless existing.product_id == id || deleted_at.present?
         return
       end
       return if LegacyPermalink.joins(:product).where(permalink: outgoing, links: { user_id: }).exists?

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1721,9 +1721,10 @@ class Link < ApplicationRecord
     def record_product_permalink_redirect(outgoing)
       existing = ProductPermalinkRedirect.find_by(seller_id: user_id, permalink: outgoing)
       if existing
-        # Both rows are this seller's, so the latest release wins. Repointing at a
-        # product the reader skips would retire a URL that still resolves, so a
-        # deleted product leaves the previous target in place.
+        # Both rows are this seller's, so the latest release wins. A seller-owned
+        # legacy mapping still outranks this row in fetch_leniently, so the
+        # repoint only reaches readers where no such mapping exists. Repointing at
+        # a product the reader skips would retire a URL that still resolves.
         existing.update(product_id: id) unless existing.product_id == id || deleted_at.present?
         return
       end
@@ -1732,8 +1733,7 @@ class Link < ApplicationRecord
       redirect = ProductPermalinkRedirect.create(permalink: outgoing, product_id: id, seller_id: user_id)
       Rails.logger.warn("ProductPermalinkRedirect not recorded for #{outgoing.inspect}: #{redirect.errors.full_messages.to_sentence}") unless redirect.persisted?
     rescue ActiveRecord::RecordNotUnique
-      # A concurrent rename by this seller created the row between the lookup
-      # and the insert; both targets are this seller's, either one is fine.
+      # A concurrent rename by this seller won the insert; both targets are hers.
       nil
     end
 

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1719,13 +1719,20 @@ class Link < ApplicationRecord
     end
 
     def record_product_permalink_redirect(outgoing)
-      return if ProductPermalinkRedirect.exists?(seller_id: user_id, permalink: outgoing)
+      existing = ProductPermalinkRedirect.find_by(seller_id: user_id, permalink: outgoing)
+      if existing
+        # Both rows are this seller's, so the latest release wins: the URL keeps
+        # serving what it served just before the rename, not an earlier holder.
+        existing.update(product_id: id) unless existing.product_id == id
+        return
+      end
       return if LegacyPermalink.joins(:product).where(permalink: outgoing, links: { user_id: }).exists?
 
       redirect = ProductPermalinkRedirect.create(permalink: outgoing, product_id: id, seller_id: user_id)
       Rails.logger.warn("ProductPermalinkRedirect not recorded for #{outgoing.inspect}: #{redirect.errors.full_messages.to_sentence}") unless redirect.persisted?
     rescue ActiveRecord::RecordNotUnique
-      # A concurrent rename by this seller won the row; first writer keeps it.
+      # A concurrent rename by this seller created the row between the lookup
+      # and the insert; both targets are this seller's, either one is fine.
       nil
     end
 

--- a/test/models/link_test.rb
+++ b/test/models/link_test.rb
@@ -1600,6 +1600,25 @@ class LinkTest < ActiveSupport::TestCase
     assert_equal claimant, Link.fetch_leniently("shared")
   end
 
+  test "reusing a released slug for a second product repoints the seller's redirect when that product releases it" do
+    # Another seller holds the slug live throughout, so no legacy mapping is
+    # recorded and the seller-scoped redirect alone answers the retired slug.
+    create_product(unique_permalink: "zzz", custom_permalink: "slug")
+    seller = create_user
+    first = create_product(user: seller, unique_permalink: "aaa", custom_permalink: "slug")
+    first.update!(custom_permalink: "first-new")
+    assert_nil LegacyPermalink.find_by(permalink: "slug")
+    assert_equal first.id, ProductPermalinkRedirect.find_by(seller_id: seller.id, permalink: "slug").product_id
+
+    second = create_product(user: seller, unique_permalink: "bbb", custom_permalink: "slug")
+    second.update!(custom_permalink: "second-new")
+
+    # The redirect follows the seller's latest release, so the old URL keeps
+    # serving what it served just before the rename, not an earlier holder.
+    assert_equal second.id, ProductPermalinkRedirect.find_by(seller_id: seller.id, permalink: "slug").product_id
+    assert_equal second, Link.fetch_leniently("slug", user: seller)
+  end
+
   test "the first writer keeps a legacy mapping when a second product claims and releases the same slug" do
     first = create_product(unique_permalink: "aaa", custom_permalink: "slug")
     first.update!(custom_permalink: "first-new")

--- a/test/models/link_test.rb
+++ b/test/models/link_test.rb
@@ -1619,6 +1619,23 @@ class LinkTest < ActiveSupport::TestCase
     assert_equal second, Link.fetch_leniently("slug", user: seller)
   end
 
+  test "a rename that deletes the product leaves the seller's redirect on the target that still resolves" do
+    create_product(unique_permalink: "zzz", custom_permalink: "slug")
+    seller = create_user
+    first = create_product(user: seller, unique_permalink: "aaa", custom_permalink: "slug")
+    first.update!(custom_permalink: "first-new")
+    assert_equal first.id, ProductPermalinkRedirect.find_by(seller_id: seller.id, permalink: "slug").product_id
+
+    second = create_product(user: seller, unique_permalink: "bbb", custom_permalink: "slug")
+    second.update!(deleted_at: Time.current)
+    second.update!(custom_permalink: "second-new")
+
+    # fetch_leniently skips deleted products, so repointing here would retire a
+    # URL that still resolves.
+    assert_equal first.id, ProductPermalinkRedirect.find_by(seller_id: seller.id, permalink: "slug").product_id
+    assert_equal first, Link.fetch_leniently("slug", user: seller)
+  end
+
   test "the first writer keeps a legacy mapping when a second product claims and releases the same slug" do
     first = create_product(unique_permalink: "aaa", custom_permalink: "slug")
     first.update!(custom_permalink: "first-new")

--- a/test/models/link_test.rb
+++ b/test/models/link_test.rb
@@ -1613,8 +1613,6 @@ class LinkTest < ActiveSupport::TestCase
     second = create_product(user: seller, unique_permalink: "bbb", custom_permalink: "slug")
     second.update!(custom_permalink: "second-new")
 
-    # The redirect follows the seller's latest release, so the old URL keeps
-    # serving what it served just before the rename, not an earlier holder.
     assert_equal second.id, ProductPermalinkRedirect.find_by(seller_id: seller.id, permalink: "slug").product_id
     assert_equal second, Link.fetch_leniently("slug", user: seller)
   end


### PR DESCRIPTION
## What

When a seller renames product A off a custom slug, reuses that slug for product B, and later renames B too, the seller-scoped `ProductPermalinkRedirect` row still pointed at **A** — so B's previously shared URL opened a different product. This repoints the row to the seller's latest release of the slug.

Follow-up to #6721, which introduced the table. That PR's writer used first-writer-wins (`return if ProductPermalinkRedirect.exists?`); the row could never move once created.

## Why

Both candidate rows belong to the same seller, and `custom_permalink` uniqueness is scoped per seller, so the product releasing the slug is genuinely its latest holder. Cross-seller policy and the global `LegacyPermalink` table's first-writer-wins policy are unchanged — deliberately, since deletion is reversible there and the table spans sellers.

## Fable-5 adversarial review

Run against the branch before this PR was opened (`CHANGES-REQUIRED`, two P1s). Both P1s were reproduced with throwaway probe tests before being fixed — neither was taken on the reviewer's word.

| Sev | Finding | Disposition |
|-----|---------|-------------|
| P1 | **Repoint could target a deleted product and kill a live URL.** `fetch_leniently` filters `.visible` (`deleted_at: nil`), so repointing at a product deleted in the same save retired a URL that had kept working. Probe confirmed: main served the first product, the branch returned `nil`. | Fixed in `7120178` — repoint skips when `deleted_at.present?`, matching the two sibling guards already in this method. Pinned by a new test; mutation-verified (removing the guard reddens it at the intended assertion). |
| P1 | **Repoint is a no-op wherever the seller owns a legacy mapping.** `fetch_leniently` consults `LegacyPermalink` *before* the scoped row, and in the ordinary no-collision case A's first rename writes **both** rows — so the URL still opens A and the original comment's promise ("the URL keeps serving what it served just before the rename") was false for that population. Probe confirmed: `PPR -> B, Legacy -> A, fetch_leniently => A`. | Comment corrected in `e23b384` to name the limit. **Not** fixed by reversing legacy precedence: that is a deliberate cross-seller policy from #6721 and changing it is a design decision, not a review fix. The repoint remains correct and effective in the cross-seller-collision population the tests cover. Flagged below for QA. |
| P2 | Comment slop — the test comment restated the test name and repeated the false claim; the rescue comment had grown to two lines of race narration. | Fixed in `e23b384`. |
| P3 | `RecordNotUnique` rescue keeps the earlier writer, mildly contradicting latest-wins. | Accepted — genuine concurrency makes ordering fuzzy, and this predates the change. |
| P3 | `existing.update(...)` return value dropped while the `create` path logs failures. | Accepted — verified the update cannot fail today (only `product_id` changes, points at persisted `self`, uniqueness excludes the row's own id). |

**Confirmed safe by the review:** cross-seller isolation (both the `find_by` and the uniqueness validation stay scoped to `seller_id`); the new test is non-vacuous and its "no legacy mapping" premise is asserted and load-bearing; no pre-existing test silently lost its pin (every neighbouring takeover test uses *different* sellers, so none exercises the changed branch); latest-release-wins ordering holds in serial flows.

## Test results

```
bundle exec ruby -Itest test/models/link_test.rb
440 runs, 1000 assertions, 0 failures, 0 errors, 0 skips

bundle exec ruby -Itest test/controllers/links_controller_test.rb -n "/permalink|slug|redirect/"
33 runs, 82 assertions, 0 failures, 0 errors, 0 skips

bundle exec rubocop app/models/link.rb test/models/link_test.rb
2 files inspected, no offenses detected
```

Both new tests were mutation-verified: reverting the code under test reddens each at its intended assertion, not earlier and not for an unrelated reason.

## QA steps

1. As one seller, create product A with custom permalink `slug`; have a **second** seller also hold `slug` live (this is the population where the scoped row is what answers).
2. Rename A to `a-new`. Visit the first seller's `/slug` — it serves A.
3. Create product B under the first seller with permalink `slug`, then rename it to `b-new`.
4. Visit the first seller's `/slug` again — **it should now serve B**, not A. On main it serves A.
5. Regression check: repeat with B **deleted** before its rename. The URL must still serve A rather than 404.

Worth a look during QA: the second P1 above means this only changes reader behavior where the seller has no legacy mapping for that slug. If you'd prefer the scoped row to outrank a same-seller legacy row, say so and I'll open that as a separate change.

## AI disclosure

Written by Claude Opus 4.1 (`claude-opus-5`) running as gumclaw. Adversarially reviewed by a separate headless Claude instance; both P1s independently reproduced with probe tests before fixing.
