### PR TITLE
Fix red main: resolve checkout-time shipping against the whole second the purchase landed in

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -2085,8 +2085,14 @@ class Purchase < ApplicationRecord
   # evidence, most of all — must read the product as it stood at purchase time. Falls back to the
   # live product when no version covers the purchase, or when the purchase is mid-checkout and
   # has no created_at yet — the live product IS its checkout state.
+  #
+  # `purchases.created_at` has no sub-second precision, so the real checkout instant is somewhere
+  # in [created_at, created_at + 1s). Resolve at the END of that window: a product saved a few
+  # milliseconds after its own creation row otherwise reifies at its pre-save state and reads as
+  # digital. The widened window cannot admit a seller flipping shipping post-checkout — that never
+  # lands inside the same second as the sale.
   def required_delivery_at_checkout?
-    product = (link.paper_trail.version_at(created_at) if created_at) || link
+    product = (link.paper_trail.version_at(created_at + 1.second) if created_at) || link
     product.is_physical? || product.require_shipping?
   end
 

--- a/spec/models/shipment_spec.rb
+++ b/spec/models/shipment_spec.rb
@@ -40,6 +40,20 @@ describe Shipment do
       expect(Shipment.new(purchase:)).to be_valid
     end
 
+    it "allows a shipment when the product was saved physical moments after its creation row", :versioning do
+      # purchases.created_at is second-precision, so a product whose create and update versions
+      # straddle a whole second reifies at its pre-physical state without the window widening.
+      product = create(:physical_product)
+      purchase = create(:physical_purchase, link: product)
+      boundary = purchase.created_at.change(usec: 0) + 5.seconds
+      versions = product.versions.reload.to_a
+      versions.first.update_column(:created_at, boundary - 0.05.seconds)
+      versions[1..].each_with_index { |v, i| v.update_column(:created_at, boundary + (0.01 * (i + 1)).seconds) }
+      purchase.update_column(:created_at, boundary)
+
+      expect(Shipment.new(purchase: purchase.reload)).to be_valid
+    end
+
     it "still allows updates to a pre-existing shipment on a non-shipping product" do
       shipment = create(:shipment)
       shipment.purchase.link.update_columns(flags: 0, require_shipping: false)


### PR DESCRIPTION
Main went red on 609fefe6f with `ActiveRecord::RecordInvalid: Validation failed: Purchase does not require shipping` in `PurchaseTest#test_#json_data_for_mobile_uses_the_cached_resolved_discount_amount_for_offer_code_display` (Test Minitest 1, run 30722785030). The Store Agent commit it landed on is unrelated — the latent bug came from #6798.

`purchases.created_at` has no sub-second precision, so `version_at(created_at)` floors to the start of the second the sale landed in. `create_physical_product` writes a `create` version for a plain digital product and then an `update` version turning on `is_physical`/`require_shipping` a few milliseconds later. When those two rows straddle a whole second, the floored purchase timestamp resolves to the `create` version, the product reifies as digital, and the create-only shipment guard rejects a shipment on a genuinely physical order. That timing is why it only reddened now and why a rerun could hide it — the fault is real, not a flake.

The fix resolves at the end of the second the purchase is known to fall in. A seller flipping shipping after checkout still cannot authorize a false shipment: that edit never lands inside the same second as the sale, and the two existing post-checkout specs still pass.

Proof: the new spec fails against main's `purchase.rb` and passes with the change; `spec/models/shipment_spec.rb` is 42/42; and `bin/rails test test/models/purchase_test.rb:5615` — the exact test that broke main — goes from error to pass locally. CI on this branch is green across all 76 jobs, including Test Minitest 1.
