### PR TITLE
Stop the card-testing velocity rules blocking established buyers

### DIFF
--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -421,6 +421,7 @@ module Purchase::Blockable
         "browser_guid = ? and stripe_fingerprint is not null", browser_guid
       )
       return if unique_failed_fingerprints.count < MAX_NUMBER_OF_FAILED_FINGERPRINTS
+      return if buyer_has_clean_checkout_history?
 
       PlatformBlock.add!(object_type: PlatformBlock::TYPES[:browser_guid], object_value: browser_guid)
     end
@@ -560,8 +561,35 @@ module Purchase::Blockable
                                            .where(created_at: CARD_TESTING_WATCH_PERIOD.ago..)
 
       return if unique_failed_fingerprints.count < MAX_NUMBER_OF_FAILED_FINGERPRINTS
+      return if buyer_has_clean_checkout_history?
 
       block_buyer!
+    end
+
+    # The velocity rules' version of #buyer_has_clean_payment_history?. It needs a separate
+    # predicate because the card cannot supply provenance here: the whole trigger is several
+    # DIFFERENT cards failing, and a person hunting for a card with room on it presents cards we
+    # have never seen — in gumroad-private#1701 all six failing fingerprints were new, so the
+    # card-keyed predicate returns false for a buyer with 84 settled purchases behind him.
+    #
+    # Provenance comes from the browser instead, and only together with the email. Either alone is
+    # claimable: an unauthenticated checkout types whatever address it likes, and a browser guid is
+    # a cookie that a shared or reset device hands to the next person. Requiring settled purchases
+    # that carry BOTH means this device has paid us under this address before — which is what
+    # separates a returning customer from somebody who typed a stranger's email.
+    #
+    # Deliberately NOT `or`: on the 9 buyers who tripped these rules in the measured week, email-only
+    # history cleared a buyer with zero device history, while the both-keyed count was 5 for the
+    # established customer and 0 for all eight card testers.
+    def buyer_has_clean_checkout_history?
+      return false if email.blank? || browser_guid.blank?
+
+      Purchase.successful.non_free.not_fully_refunded.not_chargedback_or_chargedback_reversed
+              .where(created_at: ..MIN_PURCHASE_AGE_FOR_CLEAN_HISTORY.ago)
+              .where.not(id:)
+              .where(email:, browser_guid:)
+              .limit(MIN_SUCCESSFUL_PURCHASES_FOR_CLEAN_HISTORY)
+              .count >= MIN_SUCCESSFUL_PURCHASES_FOR_CLEAN_HISTORY
     end
 
     def flag_seller_based_on_recent_failures!

--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -464,7 +464,8 @@ module Purchase::Blockable
     # stop the actual human from paying with a card that is fine. Somebody spraying many stolen
     # cards at us is still caught by the card-testing velocity checks (#ban_card_testers!,
     # #ban_fraudulent_buyer_browser_guid!), which do block the browser and the email once several
-    # distinct cards have failed.
+    # distinct cards have failed — unless the sprayer has clean checkout history
+    # (#buyer_has_clean_checkout_history?), where only the per-card, IP and per-product limits apply.
     #
     # A renewal does not always carry a fingerprint of its own — a charge can fail before we ever
     # record one — so for a recurring charge we also block the card that renewal was charged on,
@@ -566,21 +567,11 @@ module Purchase::Blockable
       block_buyer!
     end
 
-    # The velocity rules' version of #buyer_has_clean_payment_history?. It needs a separate
-    # predicate because the card cannot supply provenance here: the whole trigger is several
-    # DIFFERENT cards failing, and a person hunting for a card with room on it presents cards we
-    # have never seen — in gumroad-private#1701 all six failing fingerprints were new, so the
-    # card-keyed predicate returns false for a buyer with 84 settled purchases behind him.
-    #
-    # Provenance comes from the browser instead, and only together with the email. Either alone is
-    # claimable: an unauthenticated checkout types whatever address it likes, and a browser guid is
-    # a cookie that a shared or reset device hands to the next person. Requiring settled purchases
-    # that carry BOTH means this device has paid us under this address before — which is what
-    # separates a returning customer from somebody who typed a stranger's email.
-    #
-    # Deliberately NOT `or`: on the 9 buyers who tripped these rules in the measured week, email-only
-    # history cleared a buyer with zero device history, while the both-keyed count was 5 for the
-    # established customer and 0 for all eight card testers.
+    # The velocity rules' version of #buyer_has_clean_payment_history?, which cannot be reused here:
+    # the trigger IS several never-seen cards failing, so card-keyed history is empty by
+    # construction. Provenance comes from the browser and the email together — either alone is
+    # claimable, since an unauthenticated checkout types whatever address it likes and a guid is a
+    # cookie a shared or reset device hands to the next person.
     def buyer_has_clean_checkout_history?
       return false if email.blank? || browser_guid.blank?
 

--- a/spec/models/concerns/purchase/blockable_spec.rb
+++ b/spec/models/concerns/purchase/blockable_spec.rb
@@ -921,6 +921,41 @@ describe Purchase::Blockable do
               @purchase.mark_failed!
             end.to change { PlatformBlock.count }.from(0).to(4)
           end
+
+          it "still blocks when the settled purchases were free" do
+            Purchase.successful.where(browser_guid: @guid).update_all(price_cents: 0)
+
+            expect do
+              @purchase.mark_failed!
+            end.to change { PlatformBlock.count }.from(0).to(4)
+          end
+
+          it "still blocks when the settled purchases were charged back" do
+            Purchase.successful.where(browser_guid: @guid).update_all(chargeback_date: 1.month.ago)
+
+            expect do
+              @purchase.mark_failed!
+            end.to change { PlatformBlock.count }.from(0).to(4)
+          end
+
+          it "still blocks when the buyer is one settled purchase short of the threshold" do
+            Purchase.successful.where(browser_guid: @guid).order(:id).first.destroy!
+
+            expect do
+              @purchase.mark_failed!
+            end.to change { PlatformBlock.count }.from(0).to(4)
+          end
+
+          it "still blocks when neither the failing purchase nor the history carries a browser guid" do
+            # Without the blank check, a nil guid on both sides matches, collapsing the exemption
+            # to email alone for exactly the rows where device provenance is absent.
+            Purchase.successful.where(browser_guid: @guid).update_all(browser_guid: nil)
+            @purchase.update_columns(browser_guid: nil)
+
+            expect do
+              @purchase.mark_failed!
+            end.to change { PlatformBlock.email.count }.from(0).to(1)
+          end
         end
       end
 

--- a/spec/models/concerns/purchase/blockable_spec.rb
+++ b/spec/models/concerns/purchase/blockable_spec.rb
@@ -852,6 +852,76 @@ describe Purchase::Blockable do
             end.to_not change { PlatformBlock.count }
           end
         end
+
+        context "when the buyer has settled purchases from this same email and browser" do
+          before do
+            @guid = SecureRandom.hex
+            3.times do
+              create(:purchase, purchaser: @purchaser, email: @purchaser.email, browser_guid: @guid,
+                                purchase_state: "successful", price_cents: 500,
+                                created_at: (Purchase::Blockable::MIN_PURCHASE_AGE_FOR_CLEAN_HISTORY + 1.day).ago)
+            end
+            3.times do |n|
+              create(:failed_purchase, purchaser: @purchaser, email: @purchaser.email, browser_guid: @guid,
+                                       stripe_fingerprint: SecureRandom.hex, created_at: n.days.ago)
+            end
+
+            @purchase = create(:purchase, purchaser: @purchaser, email: @purchaser.email, browser_guid: @guid,
+                                          purchase_state: "in_progress", stripe_fingerprint: SecureRandom.hex,
+                                          charge_processor_id: StripeChargeProcessor.charge_processor_id)
+          end
+
+          it "doesn't block the buyer's own identifiers" do
+            @purchase.mark_failed!
+
+            # The buyer-bound identifiers are what strand someone: email, browser guid and card
+            # blocks never expire. The IP rule is separate, shared between people, and does expire.
+            expect(PlatformBlock.pluck(:object_type)).to_not include("email", "browser_guid", "charge_processor_fingerprint")
+          end
+
+          it "doesn't block the browser guid on the lifetime-failure rule either" do
+            # #ban_fraudulent_buyer_browser_guid! counts failures with no time window at all and
+            # writes a guid block that never expires — the single row that leaves a buyer with no
+            # self-service route (gumroad-private#1701).
+            Purchase.failed.where(browser_guid: @guid).update_all(created_at: 2.years.ago)
+
+            @purchase.mark_failed!
+
+            expect(PlatformBlock.browser_guid.count).to eq 0
+          end
+
+          it "still blocks when the settled purchases are too recent to count" do
+            Purchase.successful.where(browser_guid: @guid).update_all(created_at: 1.day.ago)
+
+            expect do
+              @purchase.mark_failed!
+            end.to change { PlatformBlock.count }.from(0).to(4)
+          end
+
+          it "still blocks when the settled purchases came from a different browser" do
+            Purchase.successful.where(browser_guid: @guid).update_all(browser_guid: SecureRandom.hex)
+
+            expect do
+              @purchase.mark_failed!
+            end.to change { PlatformBlock.count }.from(0).to(4)
+          end
+
+          it "still blocks when the settled purchases were made under a different email" do
+            Purchase.successful.where(browser_guid: @guid).update_all(email: "someone-else@example.com")
+
+            expect do
+              @purchase.mark_failed!
+            end.to change { PlatformBlock.count }.from(0).to(4)
+          end
+
+          it "still blocks when the settled purchases were all refunded" do
+            Purchase.successful.where(browser_guid: @guid).find_each { _1.update!(stripe_refunded: true) }
+
+            expect do
+              @purchase.mark_failed!
+            end.to change { PlatformBlock.count }.from(0).to(4)
+          end
+        end
       end
 
       context "when purchases with different cards fail from the same IP address" do


### PR DESCRIPTION
- [x] Scope — gumroad-private#1701: established buyers platform-blocked by the card-testing velocity rules
- [x] Design — n/a: extends the existing clean-history exemption pattern to two rules that never got one
- [x] Build — bbc897561, ab97e6ea3
- [ ] Ship
- [x] Market — n/a: internal fraud-rule correctness
- [x] Sell — n/a

## What

Two card-testing velocity rules — `ban_fraudulent_buyer_browser_guid!` and
`block_buyer_based_on_recent_failures!` — block a buyer's email, browser guid, IP and card once
several distinct cards have failed. Neither had a clean-history exemption, so an established
customer working through their wallet after an insufficient-funds decline trips them and is left
platform-blocked with no self-service route: email and browser blocks never expire.

Both rules now return early for a buyer with `buyer_has_clean_checkout_history?` — at least
`MIN_SUCCESSFUL_PURCHASES_FOR_CLEAN_HISTORY` (3) settled, non-free, non-refunded, non-chargedback
purchases older than `MIN_PURCHASE_AGE_FOR_CLEAN_HISTORY` (60 days) carrying **both** the same
email **and** the same browser guid.

## Why

The existing `buyer_has_clean_payment_history?` cannot be reused: it keys on
`stripe_fingerprint`, and the velocity trigger *is* several never-seen cards failing — the buyer
in #1701 had 84 settled purchases and all six failing fingerprints were new, so the card-keyed
predicate returns false by construction.

Provenance comes from the browser and the email together. Either alone is claimable — an
unauthenticated checkout types whatever address it likes, and a guid is a cookie a shared or reset
device hands to the next person. Requiring both means this device has paid us under this address
before.

## Fable-5 adversarial review

Run against the branch before this PR was opened, at `bbc897561`. Verdict: `CHANGES-REQUIRED`,
**no P1** — guard logic, query, placement and the two core mutants were all confirmed sound. Every
finding below was verified against the repo before being coded, and every fix was mutation-verified
by running it.

| Sev | Finding | Disposition |
|-----|---------|-------------|
| P2 | **Four scope conditions in `buyer_has_clean_checkout_history?` shipped unpinned** — `non_free`, `not_chargedback_or_chargedback_reversed`, the count threshold, and the blank-guid guard each survived deletion because no fixture exercised them. `non_free` is the sharpest: three *free* downloads mint the exemption with no card at all, and the card-keyed sibling pins exactly that case (`blockable_spec.rb:228`). | Fixed in `ab97e6ea3` — four new examples, each mutation-verified (see Test results). |
| P2 | **Comment slop on the new predicate** — ~14 lines carrying ticket-investigation narration ("all six failing fingerprints were new … 84 settled purchases") and measured-week statistics that go stale and are unverifiable from the code. | Fixed in `ab97e6ea3` — compressed to the two things the code cannot say. |
| P3 | **Stale backstop comment at `blockable.rb:464`** — `block_buyer_payment_method!` justified being deliberately narrow by pointing at the velocity checks as the everything-catcher. That is now conditional, and this was the single place downstream code documented relying on it. | Fixed in `ab97e6ea3`. |
| P3 | `Onetime::ClearMistakenBuyerBlocks#velocity_protected_pairs` reproduces the rules *without* the new exemption, so it over-protects. | Accepted — fail-closed (a mistaken block survives for a human to clear, which that task explicitly accepts) and the task is a one-off. |
| P3 | Forward-only: buyers these rules already stranded stay blocked. | Accepted as scope — a cleanup keyed on the new predicate is a follow-up, tracked on gumroad-private#1701. |

### Gate-widening analysis (no finding — recorded because it is the real risk)

The newly admitted class is a buyer failing 4+ distinct fingerprints who has 3+ settled, non-free,
non-refunded, non-chargedback purchases older than 60 days under the *same* email + guid. Two
adversarial routes were traced:

- **Manufacture** — buy three cheap products with your own card, wait 60 days, then card-test from
  the same browser and email. Real and in scope.
- **Steal** — the guid is httponly but client-settable, so a shared device or kiosk hands it on.

What still catches both: `block_ip_address_based_on_recent_failures!` has **no** exemption (4
fingerprints in a day still earns a 7-day IP block), `block_purchases_on_product!` still rate-limits
per product, `ban_buyer_on_fraud_related_error_code!` still fingerprint-blocks each fraud-coded
card, and `block_buyer_based_on_chargeback_count!` still fires unconditionally. Net: a manufactured
identity buys roughly a few tested cards per IP per day instead of a permanent ban — while a
competent tester already evaded both patched rules for free by rotating the cookie and the email.

### Confirmed safe by the review

- **Guard placement** — both methods run only count queries before the new return; no write, enqueue
  or notify happens for an exempted buyer, and the new query runs only when a block was imminent.
- **Indexes** — `index_purchases_on_browser_guid` and `index_purchases_on_email_long` both exist;
  `.limit(3).count` compiles to a count over a limited subquery, so the scan is capped.
- **Email normalization** — `before_validation :downcase_email` applies to both sides of the lookup,
  so the exemption cannot silently miss on case.
- **`browser_guid` availability** — set as a 10-year cookie on first visit, hard-required at paid
  checkout, and copied onto renewals, so legitimate historical rows are matchable.
- **`where.not(id:)`** — both rules run in `after_transition any => :failed` on persisted records.
- **Rule ordering** — no earlier rule blocks the buyer's person-bound identifiers before the exempted
  ones run, so the fix is actually effective for the reported buyer (`purchase.rb:254-259`).

## Test results

Ruby 3.4.3, local, at `ab97e6ea3`:

```
bundle exec rspec spec/models/concerns/purchase/blockable_spec.rb
151 examples, 0 failures

bundle exec rubocop app/models/concerns/purchase/blockable.rb spec/models/concerns/purchase/blockable_spec.rb
2 files inspected, no offenses detected
```

Mutation verification of the four new examples — each mutation applied alone, the named example must
redden:

| Mutation | Example | Result |
|---|---|---|
| drop `.non_free` | "still blocks when the settled purchases were free" | 1 example, **1 failure** |
| drop `.not_chargedback_or_chargedback_reversed` | "still blocks when the settled purchases were charged back" | 1 example, **1 failure** |
| `>= MIN_SUCCESSFUL_PURCHASES_FOR_CLEAN_HISTORY - 1` | "still blocks when the buyer is one settled purchase short of the threshold" | 1 example, **1 failure** |
| drop `\|\| browser_guid.blank?` | "still blocks when neither the failing purchase nor the history carries a browser guid" | 1 example, **1 failure** |

The blank-guid example was **rewritten** during this round: its first version nulled the guid on the
failing purchase only, and the mutant survived (1 example, 0 failures) because the historical rows
still carried a guid and could not match either way. Nulling both sides makes the two worlds diverge
and the mutant now dies.

## QA steps for the reviewer

This touches the purchase failure path, so I am not self-merging. What I would like checked:

1. **Read the exemption as a policy call, not just as code.** The gate-widening table above is the
   real decision: is "3 settled purchases + 60 days + same email and browser" the right price for
   never platform-blocking that identity again on these two rules? That threshold is the whole PR.
2. **The IP block is deliberately left unexempted**, so a #1701-style buyer failing 4+ cards in a day
   still eats a 7-day IP block. Confirm that is acceptable — it is shared and self-expiring, which is
   why I did not exempt it.
3. Both new returns sit *after* the fingerprint-count check, so the extra query only runs when a
   block was about to be written. Worth a second read for query cost on the failure path.

## AI disclosure

Written by gumclaw (Claude Opus 4.5 via Hermes Agent). The adversarial review was a separate
headless model run against the branch; the findings were verified against the repo and the fixes run
locally before this PR was opened.

Ref gumroad-private#1701
