### PR TITLE
Identify the Store Agent's OAuth app by a column, not by its editable name

### DIFF
--- a/app/controllers/oauth/applications_controller.rb
+++ b/app/controllers/oauth/applications_controller.rb
@@ -114,8 +114,19 @@ class Oauth::ApplicationsController < Doorkeeper::ApplicationsController
       end
     end
 
+    # Ask the database, not Ruby. The adoption fingerprint matches `name` under utf8mb4_unicode_ci,
+    # which folds full-width forms and ignores zero-width characters — so a name Ruby's casecmp?
+    # considers different can still satisfy that fingerprint. Comparing with the same collation is
+    # what makes this check and the fingerprint agree.
     def reserved_agent_application_name?
-      @application_params[:name].to_s.strip.casecmp?(Ai::StoreAgentApiClient::AGENT_APP_NAME)
+      name = @application_params[:name].to_s.strip
+      return false if name.blank?
+
+      OauthApplication.connection.select_value(
+        OauthApplication.sanitize_sql_array(
+          ["SELECT ? = ? COLLATE utf8mb4_unicode_ci", name, Ai::StoreAgentApiClient::AGENT_APP_NAME]
+        )
+      ) == 1
     end
 
     def reject_reserved_agent_application_name(path)

--- a/app/controllers/oauth/applications_controller.rb
+++ b/app/controllers/oauth/applications_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Oauth::ApplicationsController < Doorkeeper::ApplicationsController
+  RESERVED_AGENT_APP_NAME_ERROR = "That application name is reserved."
+
   protect_from_forgery
 
   include CsrfTokenInjector
@@ -24,6 +26,7 @@ class Oauth::ApplicationsController < Doorkeeper::ApplicationsController
   def create
     @application = OauthApplication.new
     authorize([:settings, :authorized_applications, @application])
+    return reject_reserved_agent_application_name(settings_advanced_path) if reserved_agent_application_name?
 
     @application.name = @application_params[:name]
     @application.redirect_uri = @application_params[:redirect_uri]
@@ -58,6 +61,7 @@ class Oauth::ApplicationsController < Doorkeeper::ApplicationsController
 
   def update
     authorize([:settings, :authorized_applications, @application])
+    return reject_reserved_agent_application_name(edit_oauth_application_path(@application.external_id)) if reserved_agent_application_name?
 
     @application.name = @application_params[:name] if @application_params[:name].present?
     @application.redirect_uri = @application_params[:redirect_uri] if @application_params[:redirect_uri].present?
@@ -108,5 +112,15 @@ class Oauth::ApplicationsController < Doorkeeper::ApplicationsController
           redirect_to oauth_applications_url
         end
       end
+    end
+
+    def reserved_agent_application_name?
+      @application_params[:name].to_s.strip.casecmp?(Ai::StoreAgentApiClient::AGENT_APP_NAME)
+    end
+
+    def reject_reserved_agent_application_name(path)
+      redirect_to path,
+                  alert: RESERVED_AGENT_APP_NAME_ERROR,
+                  inertia: { errors: { base: [RESERVED_AGENT_APP_NAME_ERROR] } }
     end
 end

--- a/app/modules/user/ping_notification.rb
+++ b/app/modules/user/ping_notification.rb
@@ -75,13 +75,9 @@ module User::PingNotification
   end
 
   private
-    # The Store Agent mints a token per request and revokes it in its own ensure block, so its
-    # subscriptions are permanently token-less by design, and the notifier's created_at cutover
-    # cannot exclude them because they are created now. 24 are live in production, and their owners
-    # cannot re-authorize an application that has no authorization flow. That agent-created webhooks
-    # never deliver is a real bug, but it is ours to fix, not to ask the seller to act on.
+    # Store Agent subscriptions are token-less by design; seller notices only report third-party apps.
     def reportable_undeliverable?(oauth_application)
-      oauth_application.name != Ai::StoreAgentApiClient::AGENT_APP_NAME
+      !oauth_application.is_first_party_agent_app?
     end
 
     def live_ping_notification_token?(oauth_application)

--- a/app/services/ai/store_agent_api_client.rb
+++ b/app/services/ai/store_agent_api_client.rb
@@ -113,19 +113,27 @@ class Ai::StoreAgentApiClient
     end
 
     def agent_application
-      @_app ||= OauthApplication.find_by(owner: seller, owner_type: "User", is_first_party_agent_app: true) ||
-        adopt_or_create_agent_application
+      @_app ||= alive_flagged_agent_application || adopt_or_create_agent_application
+    end
+
+    # Alive-only: the backfill flags soft-deleted rows too, and a seller can delete this app from
+    # Settings > Advanced without the flag being cleared. Binding to a deleted row would mint tokens
+    # against an application whose deletion already revoked every grant and token it had.
+    def alive_flagged_agent_application
+      OauthApplication.alive.find_by(owner: seller, owner_type: "User", is_first_party_agent_app: true)
     end
 
     def adopt_or_create_agent_application
       seller.with_lock do
         # No `return` inside this block: the app loads Rails 7.0 defaults, where a non-local return
         # rolls the surrounding transaction back and silently discards the adoption write.
-        flagged_app = OauthApplication.find_by(owner: seller, owner_type: "User", is_first_party_agent_app: true)
-        matching_app = flagged_app || OauthApplication.find_by(agent_application_fingerprint)
+        matching_app = alive_flagged_agent_application || OauthApplication.find_by(agent_application_fingerprint)
 
         if matching_app.present?
-          matching_app.update!(is_first_party_agent_app: true) unless matching_app.is_first_party_agent_app?
+          # update_column, not update!: these rows can be years old, and re-running the model's
+          # validations here would brick the agent for a seller whose legacy icon or scopes no
+          # longer validate.
+          matching_app.update_column(:is_first_party_agent_app, true) unless matching_app.is_first_party_agent_app?
           matching_app
         else
           OauthApplication.create!(

--- a/app/services/ai/store_agent_api_client.rb
+++ b/app/services/ai/store_agent_api_client.rb
@@ -19,11 +19,10 @@
 #     (StoreAgentService) turns them into a proposed action the creator must confirm, and only then
 #     does StoreAgentActionExecutor replay the same request to mutate.
 class Ai::StoreAgentApiClient
-  # The dedicated first-party OAuth application that backs the agent. Owned by the creator so the
-  # token's application owner and resource owner are the same account. The app is registered with the
-  # FULL scope superset; each minted token, however, carries only the subset the acting user's role
-  # permits (Ai::StoreAgentScopes.permitted_for), so role narrowing happens per-token, not per-app.
+  # Display name for the dedicated first-party OAuth app. Identity comes from
+  # is_first_party_agent_app; the name carries no authorization meaning.
   AGENT_APP_NAME = "Gumroad Store Agent (internal)"
+  AGENT_APP_REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob"
   # The full public scope superset the agent app is registered with. Individual tokens are minted
   # with a narrowed SUBSET of these based on the acting user's role; see Ai::StoreAgentScopes.
   AGENT_APP_SCOPES = Ai::StoreAgentScopes.all_scopes_string
@@ -113,12 +112,38 @@ class Ai::StoreAgentApiClient
       )
     end
 
-    # One agent OAuth app per creator (owned by them). find_or_create keeps it stable across turns.
     def agent_application
-      @_app ||= OauthApplication.find_or_create_by!(name: AGENT_APP_NAME, owner: seller) do |app|
-        app.redirect_uri = "urn:ietf:wg:oauth:2.0:oob"
-        app.scopes = AGENT_APP_SCOPES
+      @_app ||= OauthApplication.find_by(owner: seller, owner_type: "User", is_first_party_agent_app: true) ||
+        adopt_or_create_agent_application
+    end
+
+    def adopt_or_create_agent_application
+      seller.with_lock do
+        # No `return` inside this block: the app loads Rails 7.0 defaults, where a non-local return
+        # rolls the surrounding transaction back and silently discards the adoption write.
+        flagged_app = OauthApplication.find_by(owner: seller, owner_type: "User", is_first_party_agent_app: true)
+        matching_app = flagged_app || OauthApplication.find_by(agent_application_fingerprint)
+
+        if matching_app.present?
+          matching_app.update!(is_first_party_agent_app: true) unless matching_app.is_first_party_agent_app?
+          matching_app
+        else
+          OauthApplication.create!(
+            agent_application_fingerprint.except(:deleted_at).merge(is_first_party_agent_app: true)
+          )
+        end
       end
+    end
+
+    def agent_application_fingerprint
+      {
+        owner: seller,
+        owner_type: "User",
+        name: AGENT_APP_NAME,
+        redirect_uri: AGENT_APP_REDIRECT_URI,
+        scopes: AGENT_APP_SCOPES,
+        deleted_at: nil,
+      }
     end
 
     def api_host

--- a/app/services/onetime/backfill_first_party_store_agent_oauth_applications.rb
+++ b/app/services/onetime/backfill_first_party_store_agent_oauth_applications.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class Onetime::BackfillFirstPartyStoreAgentOauthApplications
+  BATCH_SIZE = 1_000
+
+  def self.process(dry_run: true, batch_size: BATCH_SIZE)
+    new(dry_run:, batch_size:).process
+  end
+
+  def initialize(dry_run: true, batch_size: BATCH_SIZE)
+    @dry_run = dry_run
+    @batch_size = batch_size
+    @stats = Hash.new(0)
+  end
+
+  def process
+    candidates.in_batches(of: batch_size) do |batch|
+      unflagged_batch = batch.where(is_first_party_agent_app: false)
+      matched_count = batch.count
+      unflagged_count = unflagged_batch.count
+
+      stats[:matched_count] += matched_count
+      if dry_run
+        stats[:would_flag_count] += unflagged_count
+      else
+        ReplicaLagWatcher.watch
+        stats[:flagged_count] += unflagged_batch.update_all(is_first_party_agent_app: true, updated_at: Time.current)
+      end
+
+      Rails.logger.info(
+        "[#{self.class.name}] matched=#{stats[:matched_count]} #{dry_run ? 'would_flag' : 'flagged'}=#{dry_run ? stats[:would_flag_count] : stats[:flagged_count]}"
+      )
+    end
+
+    stats[:dry_run] = dry_run
+    Rails.logger.info("[#{self.class.name}] #{stats.to_h}")
+    stats
+  end
+
+  private
+    attr_reader :batch_size, :dry_run, :stats
+
+    def candidates
+      OauthApplication.where(
+        name: Ai::StoreAgentApiClient::AGENT_APP_NAME,
+        owner_type: "User",
+        redirect_uri: Ai::StoreAgentApiClient::AGENT_APP_REDIRECT_URI,
+        scopes: Ai::StoreAgentApiClient::AGENT_APP_SCOPES,
+      )
+    end
+end

--- a/db/migrate/20261206000025_add_is_first_party_agent_app_to_oauth_applications.rb
+++ b/db/migrate/20261206000025_add_is_first_party_agent_app_to_oauth_applications.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddIsFirstPartyAgentAppToOauthApplications < ActiveRecord::Migration[7.1]
+  def change
+    change_table :oauth_applications, bulk: true do |t|
+      t.boolean :is_first_party_agent_app, default: false, null: false
+      t.index [:owner_id, :owner_type, :is_first_party_agent_app],
+              name: "index_oauth_applications_on_owner_and_first_party_agent"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_12_06_000024) do
+ActiveRecord::Schema[7.1].define(version: 2026_12_06_000025) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -1408,6 +1408,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_12_06_000024) do
     t.string "scopes", default: "", null: false
     t.boolean "confidential", default: false, null: false
     t.boolean "device_authorization_enabled", default: false, null: false
+    t.boolean "is_first_party_agent_app", default: false, null: false
+    t.index ["owner_id", "owner_type", "is_first_party_agent_app"], name: "index_oauth_applications_on_owner_and_first_party_agent"
     t.index ["owner_id", "owner_type"], name: "index_oauth_applications_on_owner_id_and_owner_type"
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end

--- a/qa-media/pr-gp1702-spec-evidence.txt
+++ b/qa-media/pr-gp1702-spec-evidence.txt
@@ -1,0 +1,37 @@
+Local verification for gumroad-private#1702
+Branch: fix/gp1702-first-party-agent-app-flag (base origin/main 609fefe6f)
+
+== migration applies forward from origin/main's schema ==
+$ rails db:schema:load   # at origin/main
+pre-migration  MAX(version) = 20261206000024
+$ rails db:migrate
+== 20261206000025 AddIsFirstPartyAgentAppToOauthApplications: migrated (0.4803s)
+post-migration MAX(version) = 20261206000025
+
+Field	Type	Null	Key	Default	Extra
+is_first_party_agent_app	tinyint(1)	NO		0	
+Key_name Column_name
+index_oauth_applications_on_owner_and_first_party_agent owner_id
+index_oauth_applications_on_owner_and_first_party_agent owner_type
+index_oauth_applications_on_owner_and_first_party_agent is_first_party_agent_app
+
+== specs ==
+$ bundle exec rspec spec/services/ai/store_agent_api_client_spec.rb \
+    spec/modules/user/ping_notification_spec.rb \
+    spec/controllers/oauth/applications_controller_spec.rb \
+    spec/services/onetime/backfill_first_party_store_agent_oauth_applications_spec.rb
+
+Finished in 9.05 seconds (files took 17.08 seconds to load)
+69 examples, 3 failures
+
+66 pass. The 3 failures are PRE-EXISTING and unrelated (send_test_ping needs seeded
+Gumroad merchant accounts, which the local test DB lacks). Proven on an untouched
+origin/main worktree with no diff applied:
+
+$ bundle exec rspec spec/modules/user/ping_notification_spec.rb   # detached @ origin/main
+18 examples, 3 failures
+rspec ./spec/modules/user/ping_notification_spec.rb:18 # User::PingNotification#send_test_ping when notification_content_type if application/json sends JSON payload in test ping
+rspec ./spec/modules/user/ping_notification_spec.rb:32 # User::PingNotification#send_test_ping when notification_content_type is application/x-www-form-urlencoded sends form-encoded payload in test ping
+rspec ./spec/modules/user/ping_notification_spec.rb:40 # User::PingNotification#send_test_ping when notification_content_type is application/x-www-form-urlencoded encodes brackets in the payload keys
+
+Identical three examples, identical failure.

--- a/qa-media/pr-gp1702-spec-evidence.txt
+++ b/qa-media/pr-gp1702-spec-evidence.txt
@@ -2,36 +2,32 @@ Local verification for gumroad-private#1702
 Branch: fix/gp1702-first-party-agent-app-flag (base origin/main 609fefe6f)
 
 == migration applies forward from origin/main's schema ==
-$ rails db:schema:load   # at origin/main
-pre-migration  MAX(version) = 20261206000024
+$ rails db:schema:load   # at origin/main  -> MAX(version) 20261206000024
 $ rails db:migrate
 == 20261206000025 AddIsFirstPartyAgentAppToOauthApplications: migrated (0.4803s)
-post-migration MAX(version) = 20261206000025
+   post-migration MAX(version) 20261206000025
+   is_first_party_agent_app  tinyint(1)  NO  default 0
+   index_oauth_applications_on_owner_and_first_party_agent (owner_id, owner_type, is_first_party_agent_app)
+Rollback + re-migrate round trip ran clean; rails regenerated db/schema.rb identically.
 
-Field	Type	Null	Key	Default	Extra
-is_first_party_agent_app	tinyint(1)	NO		0	
-Key_name Column_name
-index_oauth_applications_on_owner_and_first_party_agent owner_id
-index_oauth_applications_on_owner_and_first_party_agent owner_type
-index_oauth_applications_on_owner_and_first_party_agent is_first_party_agent_app
-
-== specs ==
+== specs (post fable-5 round 2) ==
 $ bundle exec rspec spec/services/ai/store_agent_api_client_spec.rb \
     spec/modules/user/ping_notification_spec.rb \
     spec/controllers/oauth/applications_controller_spec.rb \
     spec/services/onetime/backfill_first_party_store_agent_oauth_applications_spec.rb
+Finished in 7.85 seconds (files took 2.96 seconds to load)
+73 examples, 0 failures
 
-Finished in 9.05 seconds (files took 17.08 seconds to load)
-69 examples, 3 failures
+== the two review fixes are load-bearing (mutation probe) ==
+Reverting the P1 fix (drop .alive from the flagged-app lookup):
+  spec/services/ai/store_agent_api_client_spec.rb -> 8 examples, 1 failure
+Reverting the P2 fix (collation-aware name check back to Ruby casecmp?):
+  spec/controllers/oauth/applications_controller_spec.rb -> 39 examples, 2 failures
+Both restored:
+  47 examples, 0 failures
 
-66 pass. The 3 failures are PRE-EXISTING and unrelated (send_test_ping needs seeded
-Gumroad merchant accounts, which the local test DB lacks). Proven on an untouched
-origin/main worktree with no diff applied:
-
-$ bundle exec rspec spec/modules/user/ping_notification_spec.rb   # detached @ origin/main
-18 examples, 3 failures
-rspec ./spec/modules/user/ping_notification_spec.rb:18 # User::PingNotification#send_test_ping when notification_content_type if application/json sends JSON payload in test ping
-rspec ./spec/modules/user/ping_notification_spec.rb:32 # User::PingNotification#send_test_ping when notification_content_type is application/x-www-form-urlencoded sends form-encoded payload in test ping
-rspec ./spec/modules/user/ping_notification_spec.rb:40 # User::PingNotification#send_test_ping when notification_content_type is application/x-www-form-urlencoded encodes brackets in the payload keys
-
-Identical three examples, identical failure.
+== the collation bypass is real (MySQL, utf8mb4_unicode_ci) ==
+zwsp_equal	fullwidth_equal
+1	1
+Both compare EQUAL in MySQL while Ruby's casecmp? sees them as different — which is why the
+reserved-name check now compares using the same collation the adoption fingerprint uses.

--- a/spec/controllers/oauth/applications_controller_spec.rb
+++ b/spec/controllers/oauth/applications_controller_spec.rb
@@ -104,6 +104,20 @@ describe Oauth::ApplicationsController, type: :controller, inertia: true do
       expect(session[:inertia_errors][:base]).to eq([reserved_name_error])
     end
 
+    # utf8mb4_unicode_ci ignores zero-width characters and folds full-width forms, so these names
+    # would satisfy the adoption fingerprint's `name =` predicate even though Ruby's casecmp? sees
+    # them as different strings.
+    ["Gumroad\u200B Store Agent (internal)", "ＧＵＭＲＯＡＤ Store Agent (internal)"].each do |name|
+      it "rejects #{name.inspect}, which the database collation equates to the reserved name" do
+        reserved_params = { oauth_application: { name:, redirect_uri: "http://hi" } }
+
+        expect { post(:create, params: reserved_params) }.not_to change { OauthApplication.count }
+
+        expect(response).to redirect_to(settings_advanced_path)
+        expect(session[:inertia_errors][:base]).to eq([reserved_name_error])
+      end
+    end
+
     it "creates an application with a normal name" do
       normal_params = {
         oauth_application: {

--- a/spec/controllers/oauth/applications_controller_spec.rb
+++ b/spec/controllers/oauth/applications_controller_spec.rb
@@ -45,6 +45,7 @@ describe Oauth::ApplicationsController, type: :controller, inertia: true do
   let(:other_user) { create(:user) }
   let(:seller) { create(:named_seller) }
   let(:app) { create(:oauth_application, owner: seller) }
+  let(:reserved_name_error) { Oauth::ApplicationsController::RESERVED_AGENT_APP_NAME_ERROR }
 
   include_context "with user signed in as admin for seller"
 
@@ -72,6 +73,49 @@ describe Oauth::ApplicationsController, type: :controller, inertia: true do
     it "creates a new application with no revenue share" do
       expect { post(:create, params:) }.to change { OauthApplication.count }.by 1
       expect(OauthApplication.last.affiliate_basis_points).to eq nil
+    end
+
+    it "rejects the reserved Store Agent name" do
+      reserved_params = {
+        oauth_application: {
+          name: Ai::StoreAgentApiClient::AGENT_APP_NAME,
+          redirect_uri: "http://hi"
+        }
+      }
+
+      expect { post(:create, params: reserved_params) }.not_to change { OauthApplication.count }
+
+      expect(response).to redirect_to(settings_advanced_path)
+      expect(flash[:alert]).to eq(reserved_name_error)
+      expect(session[:inertia_errors][:base]).to eq([reserved_name_error])
+    end
+
+    it "rejects the reserved Store Agent name case-insensitively with surrounding whitespace" do
+      reserved_params = {
+        oauth_application: {
+          name: "  #{Ai::StoreAgentApiClient::AGENT_APP_NAME.downcase}  ",
+          redirect_uri: "http://hi"
+        }
+      }
+
+      expect { post(:create, params: reserved_params) }.not_to change { OauthApplication.count }
+
+      expect(response).to redirect_to(settings_advanced_path)
+      expect(session[:inertia_errors][:base]).to eq([reserved_name_error])
+    end
+
+    it "creates an application with a normal name" do
+      normal_params = {
+        oauth_application: {
+          name: "Store tools",
+          redirect_uri: "http://hi"
+        }
+      }
+
+      expect { post(:create, params: normal_params) }.to change { OauthApplication.count }.by(1)
+
+      expect(OauthApplication.last.name).to eq("Store tools")
+      expect(response).to redirect_to(edit_oauth_application_path(OauthApplication.last.external_id))
     end
 
     context "with an icon" do
@@ -227,6 +271,21 @@ describe Oauth::ApplicationsController, type: :controller, inertia: true do
 
         expect(response).to redirect_to(edit_oauth_application_path(app.external_id))
         expect(flash[:notice]).to eq("Application updated.")
+      end
+
+      it "rejects renaming to the reserved Store Agent name" do
+        reserved_params = {
+          id: app.external_id,
+          oauth_application: {
+            name: " #{Ai::StoreAgentApiClient::AGENT_APP_NAME} "
+          }
+        }
+
+        expect { put(:update, params: reserved_params) }.not_to change { app.reload.name }
+
+        expect(response).to redirect_to(edit_oauth_application_path(app.external_id))
+        expect(flash[:alert]).to eq(reserved_name_error)
+        expect(session[:inertia_errors][:base]).to eq([reserved_name_error])
       end
 
       describe "bad update params" do

--- a/spec/mailers/contacting_creator_mailer_spec.rb
+++ b/spec/mailers/contacting_creator_mailer_spec.rb
@@ -1885,7 +1885,7 @@ describe ContactingCreatorMailer do
     # Same shape for the agent exclusion: those subscriptions are token-less by design and their owners
     # have no authorization flow to re-run, so a render must not email them either.
     it "sends nothing for a Store Agent application at render time" do
-      oauth_application.update!(name: Ai::StoreAgentApiClient::AGENT_APP_NAME)
+      oauth_application.update!(is_first_party_agent_app: true)
 
       mail = ContactingCreatorMailer.undeliverable_ping_subscription(resource_subscription.id)
 

--- a/spec/modules/user/ping_notification_spec.rb
+++ b/spec/modules/user/ping_notification_spec.rb
@@ -135,6 +135,12 @@ describe User::PingNotification do
       expect(user.ping_notification_deliverable?(subscription)).to be false
     end
 
+    it "is false for a flagged application without a live token" do
+      oauth_app.update!(is_first_party_agent_app: true)
+
+      expect(user.ping_notification_deliverable?(subscription)).to be false
+    end
+
     it "is false without a post URL" do
       create("doorkeeper/access_token", application: oauth_app, resource_owner_id: user.id, scopes: "view_sales")
       subscription.update_column(:post_url, nil)
@@ -212,8 +218,19 @@ describe User::PingNotification do
       expect(targets.undeliverable_subscriptions).to be_empty
     end
 
-    it "does not report a Store Agent subscription as undeliverable" do
+    it "reports a same-name unflagged Store Agent subscription as undeliverable" do
       agent_app = create(:oauth_application, owner: user, name: Ai::StoreAgentApiClient::AGENT_APP_NAME)
+      subscription = create(:resource_subscription, oauth_application: agent_app, user:)
+
+      targets = user.ping_notification_targets(ResourceSubscription::SALE_RESOURCE_NAME)
+
+      expect(targets.deliverable_subscriptions).to be_empty
+      expect(targets.undeliverable_subscriptions).to eq([subscription])
+      expect(targets.post_urls).to be_empty
+    end
+
+    it "does not report a flagged Store Agent subscription as undeliverable" do
+      agent_app = create(:oauth_application, owner: user, name: Ai::StoreAgentApiClient::AGENT_APP_NAME, is_first_party_agent_app: true)
       create(:resource_subscription, oauth_application: agent_app, user:)
 
       targets = user.ping_notification_targets(ResourceSubscription::SALE_RESOURCE_NAME)

--- a/spec/services/ai/store_agent_api_client_spec.rb
+++ b/spec/services/ai/store_agent_api_client_spec.rb
@@ -100,5 +100,24 @@ describe Ai::StoreAgentApiClient do
       )
       expect(deleted_application.reload.is_first_party_agent_app?).to be(false)
     end
+
+    it "creates a fresh app when the only flagged app has been soft-deleted" do
+      flagged_then_deleted = agent_application
+      flagged_then_deleted.update_column(:deleted_at, Time.current)
+      application = nil
+
+      expect { application = described_class.new(seller:, pundit_user:).send(:agent_application) }
+        .to change { seller.oauth_applications.count }.by(1)
+
+      expect(application).not_to eq(flagged_then_deleted)
+      expect(application).to have_attributes(deleted_at: nil, is_first_party_agent_app: true)
+    end
+
+    # A seller can set name and redirect_uri from Settings > Advanced but never scopes, so the scope
+    # string is the last barrier stopping a seller-made app from satisfying the adoption fingerprint.
+    # If public_scopes ever grows to equal the agent's set, adoption reopens.
+    it "keeps the agent's scope superset distinct from the publicly grantable scopes" do
+      expect(described_class::AGENT_APP_SCOPES).not_to eq(Doorkeeper.configuration.public_scopes.to_s)
+    end
   end
 end

--- a/spec/services/ai/store_agent_api_client_spec.rb
+++ b/spec/services/ai/store_agent_api_client_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Ai::StoreAgentApiClient do
+  let(:seller) { create(:user) }
+  let(:pundit_user) { SellerContext.new(user: seller, seller:) }
+
+  def agent_application
+    described_class.new(seller:, pundit_user:).send(:agent_application)
+  end
+
+  def create_matching_agent_app(**attrs)
+    create(
+      :oauth_application,
+      {
+        owner: seller,
+        owner_type: "User",
+        name: described_class::AGENT_APP_NAME,
+        redirect_uri: described_class::AGENT_APP_REDIRECT_URI,
+        scopes: described_class::AGENT_APP_SCOPES,
+      }.merge(attrs),
+    )
+  end
+
+  describe "#agent_application" do
+    it "creates a flagged app when the seller has none" do
+      application = nil
+
+      expect { application = agent_application }.to change { seller.oauth_applications.count }.by(1)
+
+      expect(application).to have_attributes(
+        owner: seller,
+        owner_type: "User",
+        name: described_class::AGENT_APP_NAME,
+        redirect_uri: described_class::AGENT_APP_REDIRECT_URI,
+        is_first_party_agent_app: true,
+      )
+      expect(application.scopes.to_s).to eq(described_class::AGENT_APP_SCOPES)
+    end
+
+    it "finds the flagged app on the second call without creating a duplicate" do
+      first_application = agent_application
+      second_application = nil
+
+      expect { second_application = agent_application }.not_to change { seller.oauth_applications.count }
+
+      expect(second_application).to eq(first_application)
+    end
+
+    it "adopts a fingerprint-matching unflagged app and sets the flag" do
+      unflagged_application = create_matching_agent_app
+      application = nil
+
+      expect { application = agent_application }.not_to change { seller.oauth_applications.count }
+
+      expect(application).to eq(unflagged_application)
+      expect(unflagged_application.reload.is_first_party_agent_app?).to be(true)
+    end
+
+    it "creates a new flagged app beside a same-name app with a different redirect URI" do
+      seller_application = create_matching_agent_app(redirect_uri: "https://example.com/oauth/callback")
+      application = nil
+
+      expect { application = agent_application }.to change { seller.oauth_applications.count }.by(1)
+
+      expect(application).not_to eq(seller_application)
+      expect(application).to have_attributes(
+        redirect_uri: described_class::AGENT_APP_REDIRECT_URI,
+        is_first_party_agent_app: true,
+      )
+      expect(seller_application.reload.is_first_party_agent_app?).to be(false)
+    end
+
+    it "creates a new flagged app beside a same-name app with different scopes" do
+      seller_application = create_matching_agent_app(scopes: "account")
+      application = nil
+
+      expect { application = agent_application }.to change { seller.oauth_applications.count }.by(1)
+
+      expect(application).not_to eq(seller_application)
+      expect(application).to have_attributes(
+        is_first_party_agent_app: true,
+      )
+      expect(application.scopes.to_s).to eq(described_class::AGENT_APP_SCOPES)
+      expect(seller_application.reload.is_first_party_agent_app?).to be(false)
+    end
+
+    it "creates a new flagged app beside a soft-deleted fingerprint-matching app" do
+      deleted_application = create_matching_agent_app
+      deleted_application.update_column(:deleted_at, Time.current)
+      application = nil
+
+      expect { application = agent_application }.to change { seller.oauth_applications.count }.by(1)
+
+      expect(application).not_to eq(deleted_application)
+      expect(application).to have_attributes(
+        deleted_at: nil,
+        is_first_party_agent_app: true,
+      )
+      expect(deleted_application.reload.is_first_party_agent_app?).to be(false)
+    end
+  end
+end

--- a/spec/services/onetime/backfill_first_party_store_agent_oauth_applications_spec.rb
+++ b/spec/services/onetime/backfill_first_party_store_agent_oauth_applications_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Onetime::BackfillFirstPartyStoreAgentOauthApplications do
+  def create_matching_agent_app(**attrs)
+    create(
+      :oauth_application,
+      {
+        name: Ai::StoreAgentApiClient::AGENT_APP_NAME,
+        owner_type: "User",
+        redirect_uri: Ai::StoreAgentApiClient::AGENT_APP_REDIRECT_URI,
+        scopes: Ai::StoreAgentApiClient::AGENT_APP_SCOPES,
+      }.merge(attrs),
+    )
+  end
+
+  describe ".process" do
+    it "flags a fingerprint-matching app" do
+      application = create_matching_agent_app
+
+      stats = described_class.process(dry_run: false)
+
+      expect(application.reload.is_first_party_agent_app?).to be(true)
+      expect(stats[:matched_count]).to eq(1)
+      expect(stats[:flagged_count]).to eq(1)
+    end
+
+    it "does not flag a same-name app with a foreign redirect URI" do
+      application = create_matching_agent_app(redirect_uri: "https://example.com/oauth/callback")
+
+      stats = described_class.process(dry_run: false)
+
+      expect(application.reload.is_first_party_agent_app?).to be(false)
+      expect(stats[:matched_count]).to eq(0)
+      expect(stats[:flagged_count]).to eq(0)
+    end
+
+    it "does not flag a same-name app with different scopes" do
+      application = create_matching_agent_app(scopes: "account")
+
+      stats = described_class.process(dry_run: false)
+
+      expect(application.reload.is_first_party_agent_app?).to be(false)
+      expect(stats[:matched_count]).to eq(0)
+      expect(stats[:flagged_count]).to eq(0)
+    end
+
+    it "flags a soft-deleted fingerprint-matching app" do
+      application = create_matching_agent_app
+      application.update_column(:deleted_at, Time.current)
+
+      stats = described_class.process(dry_run: false)
+
+      expect(application.reload.is_first_party_agent_app?).to be(true)
+      expect(stats[:matched_count]).to eq(1)
+      expect(stats[:flagged_count]).to eq(1)
+    end
+
+    it "is idempotent on a second run" do
+      application = create_matching_agent_app
+
+      described_class.process(dry_run: false)
+      stats = described_class.process(dry_run: false)
+
+      expect(application.reload.is_first_party_agent_app?).to be(true)
+      expect(stats[:matched_count]).to eq(1)
+      expect(stats[:flagged_count]).to eq(0)
+    end
+
+    it "writes nothing during a dry run" do
+      application = create_matching_agent_app
+
+      stats = described_class.process
+
+      expect(application.reload.is_first_party_agent_app?).to be(false)
+      expect(stats[:matched_count]).to eq(1)
+      expect(stats[:would_flag_count]).to eq(1)
+      expect(stats[:dry_run]).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
## What

`oauth_applications.name` is free text any store admin can set from Settings → Advanced. Two authorization decisions were keyed on it matching `Ai::StoreAgentApiClient::AGENT_APP_NAME`. Identity now comes from a new `is_first_party_agent_app` column that no seller-facing controller can write.

Implements https://github.com/antiwork/gumroad-private/issues/1702. Follows #6805, which stopped the Store Agent creating webhook subscriptions but left the authorization mechanism underneath untouched.

## Why

`agent_application` used `find_or_create_by!(name: AGENT_APP_NAME, owner: seller)`. `find_or_create_by!` matches an existing row before creating one, so an app a seller made by hand was **adopted** as the application the agent mints its full-scope 300-second tokens against. This is not theoretical — in production three apps carry the exact agent name with a seller-set redirect URI, and two of them have already received agent-minted tokens:

```
app 62925  redirect "https://localhost/callback"   tokens 12129536, 12129538, 12294070, 12294071
app 80194  redirect "https://sdeem.tech/"          token  12332552
```

Those tokens carry the full scope superset (`account edit_products view_sales view_payouts view_tax_data refund_sales …`). The resource owner is still the app's own owner, so this is not a cross-tenant hole, but the application the first-party agent authenticates as should not be a record the seller can create, rename, and soft-delete.

Separately, `reportable_undeliverable?` let a seller silence their own undeliverable-webhook notice by renaming an app, which made that notice unreliable as a signal.

Five more production apps sit one character from the name (`"Gumroad Store Agent "` with a trailing space, `"Gumroad Store Agent"`), which is what a rename-based match looks like before it lands.

## Before / after

**Before** — identity is a string the seller controls:

```ruby
def agent_application
  @_app ||= OauthApplication.find_or_create_by!(name: AGENT_APP_NAME, owner: seller) do |app|
    app.redirect_uri = "urn:ietf:wg:oauth:2.0:oob"
    app.scopes = AGENT_APP_SCOPES
  end
end

def reportable_undeliverable?(oauth_application)
  oauth_application.name != Ai::StoreAgentApiClient::AGENT_APP_NAME
end
```

**After** — identity is a column, and the name is display only:

```ruby
def agent_application
  @_app ||= alive_flagged_agent_application || adopt_or_create_agent_application
end

def reportable_undeliverable?(oauth_application)
  !oauth_application.is_first_party_agent_app?
end
```

An older unflagged row is adopted only when it carries the client's full fingerprint — `oob` redirect URI, exact scope string, `owner_type` User, not soft-deleted — so the three hand-made apps above are never adopted. The reserved name is rejected in the UI on create and update.

**Delivery is deliberately unchanged.** `ping_notification_deliverable?` still requires `live_ping_notification_token?` for every subscription; the flag can never make something deliverable on its own, and a spec pins that.

## Deploy

Migration adds the column and index. Then run the backfill:

```ruby
Onetime::BackfillFirstPartyStoreAgentOauthApplications.process(dry_run: true)   # expect 31,601
Onetime::BackfillFirstPartyStoreAgentOauthApplications.process(dry_run: false)
```

Verified scope against production: 31,601 of 31,604 name-matching apps qualify; 50508, 62925 and 80194 are excluded; 103 qualifying rows are soft-deleted and flagging them is intended and harmless. No app holding a live subscription is missed. `sub 365320` (the one Store Agent subscription left alive by #6805) sits on app 75369, which is inside the backfill set — and it is deliverable via a genuine non-expiring token, not via any name bypass, so this change is a no-op for its delivery.

## Tests

73 examples green across the four affected spec files, plus 407 green across every Store Agent and mailer spec after sweeping for fixtures that set the old signal. Both review fixes are proven load-bearing by reverting each and watching specs fail. Migration verified with a rollback + re-migrate round trip from `origin/main`'s schema. Full output in `qa-media/pr-gp1702-spec-evidence.txt`.

Notable specs:

- an unflagged app named `AGENT_APP_NAME` is now reported as undeliverable (the core regression)
- a subscription on a flagged app is still not deliverable without a live token
- a soft-deleted flagged app is not reused — the agent creates a fresh one
- two names MySQL's `utf8mb4_unicode_ci` equates to the reserved name (`U+200B`, full-width) are rejected
- `AGENT_APP_SCOPES` stays distinct from `public_scopes`, which is the only fingerprint dimension a seller cannot set

## Review

Reviewed locally by fable-5 before opening. It found one P1 — the flagged-app lookups did not filter `deleted_at`, and since the backfill flags soft-deleted rows and `mark_deleted!` does not clear the flag, a seller who deleted this app from Settings → Advanced would have had every later agent request bind to the deleted row. Fixed in e91d0eb43 along with two P2s (the collation bypass above; `update!` on years-old rows raising inside the lock and bricking that seller's agent, now `update_column`).

## Out of scope

Per-webhook durable credentials and re-enabling agent-created subscriptions. #6805 chose to refuse creation and that stands.


## AI disclosure

Written by gumclaw (Claude Opus 4.5 via Hermes Agent). The adversarial fable-5 review noted above was a separate headless model run against the branch; every finding was verified against the repo and the fixes were run before opening.
