### PR TITLE
Render a profile's saved sections when its only tab references none

### DIFF
--- a/app/presenters/profile_presenter.rb
+++ b/app/presenters/profile_presenter.rb
@@ -94,9 +94,20 @@ class ProfilePresenter
       # the virtual default products section (only possible when the creator has no saved
       # sections), replace the tabs with a single tab that points at it. Any leftover saved tabs
       # can't reference real sections here - there are none.
-      if include_default_products_section &&
-         sections_props[:sections].any? { _1[:id] == ProfileSectionsPresenter::DEFAULT_PRODUCTS_SECTION_ID }
-        tabs = [{ name: ProfileSectionsPresenter::DEFAULT_PRODUCTS_TAB_NAME, sections: [ProfileSectionsPresenter::DEFAULT_PRODUCTS_SECTION_ID] }]
+      if include_default_products_section
+        if sections_props[:sections].any? { _1[:id] == ProfileSectionsPresenter::DEFAULT_PRODUCTS_SECTION_ID }
+          tabs = [{ name: ProfileSectionsPresenter::DEFAULT_PRODUCTS_TAB_NAME, sections: [ProfileSectionsPresenter::DEFAULT_PRODUCTS_SECTION_ID] }]
+        else
+          # A saved layout can also be unrenderable: sections exist but no tab references any of
+          # them (the editor can persist an empty tab while its sections survive), which left the
+          # public page showing only the follow form. Serve one tab pointing at every saved
+          # section. A deliberately empty tab next to a working one is left alone — this only
+          # triggers when no tab would render anything.
+          section_ids = sections_props[:sections].map { _1[:id] }
+          if section_ids.any? && tabs.none? { |tab| tab[:sections].intersect?(section_ids) }
+            tabs = [{ name: tabs.first&.dig(:name) || ProfileSectionsPresenter::DEFAULT_PRODUCTS_TAB_NAME, sections: section_ids }]
+          end
+        end
       end
       {
         **sections_props,

--- a/app/presenters/profile_presenter.rb
+++ b/app/presenters/profile_presenter.rb
@@ -98,12 +98,10 @@ class ProfilePresenter
         if sections_props[:sections].any? { _1[:id] == ProfileSectionsPresenter::DEFAULT_PRODUCTS_SECTION_ID }
           tabs = [{ name: ProfileSectionsPresenter::DEFAULT_PRODUCTS_TAB_NAME, sections: [ProfileSectionsPresenter::DEFAULT_PRODUCTS_SECTION_ID] }]
         else
-          # A saved layout can also be unrenderable: sections exist but no tab references any of
-          # them (the editor can persist an empty tab while its sections survive), which left the
-          # public page showing only the follow form. Serve one tab pointing at every saved
-          # section. A deliberately empty tab next to a working one is left alone — this only
-          # triggers when no tab would render anything.
-          section_ids = sections_props[:sections].map { _1[:id] }
+          # Sections can also exist while no tab references any of them (the editor can persist an
+          # empty tab); serve one tab pointing at every saved section. Fires only when no tab would
+          # render anything, and sorts by id because the query has no ORDER BY and this is user-visible.
+          section_ids = sections_props[:sections].map { _1[:id] }.sort_by { ObfuscateIds.decrypt(_1) }
           if section_ids.any? && tabs.none? { |tab| tab[:sections].intersect?(section_ids) }
             tabs = [{ name: tabs.first&.dig(:name) || ProfileSectionsPresenter::DEFAULT_PRODUCTS_TAB_NAME, sections: section_ids }]
           end

--- a/spec/presenters/profile_presenter_spec.rb
+++ b/spec/presenters/profile_presenter_spec.rb
@@ -167,6 +167,54 @@ describe ProfilePresenter do
       end
     end
 
+    context "when the seller's tabs reference none of their saved sections" do
+      let(:broken_seller) { create(:user, name: "Broken Seller") }
+      let!(:broken_seller_product) { create(:product, user: broken_seller) }
+      let!(:text_section) { create(:seller_profile_rich_text_section, seller: broken_seller) }
+      let!(:products_section) { create(:seller_profile_products_section, seller: broken_seller, header: "Products") }
+      let(:visitor_pundit_user) { SellerContext.new(user: logged_in_user, seller: logged_in_user) }
+
+      before do
+        broken_seller.seller_profile.update!(json_data: { tabs: [{ name: "New page", sections: [] }] })
+        Link.import(force: true, refresh: true)
+      end
+
+      it "serves a single tab pointing at every saved section instead of the empty saved tab" do
+        props = described_class.new(pundit_user: visitor_pundit_user, seller: broken_seller).profile_props(seller_custom_domain_url: nil, request:)
+
+        expect(props[:sections].map { _1[:id] }).to match_array([text_section.external_id, products_section.external_id])
+        expect(props[:tabs]).to eq([{ name: "New page", sections: [text_section.external_id, products_section.external_id] }])
+      end
+
+      it "repairs tabs whose only references point at sections that no longer exist" do
+        broken_seller.seller_profile.update!(json_data: { tabs: [{ name: "New page", sections: [products_section.id + 100] }] })
+
+        props = described_class.new(pundit_user: visitor_pundit_user, seller: broken_seller).profile_props(seller_custom_domain_url: nil, request:)
+
+        expect(props[:tabs]).to eq([{ name: "New page", sections: [text_section.external_id, products_section.external_id] }])
+      end
+
+      it "leaves the saved tabs alone when any tab references a saved section" do
+        broken_seller.seller_profile.update!(json_data: { tabs: [{ name: "Empty page", sections: [] }, { name: "Store", sections: [products_section.id] }] })
+
+        props = described_class.new(pundit_user: visitor_pundit_user, seller: broken_seller).profile_props(seller_custom_domain_url: nil, request:)
+
+        expect(props[:tabs]).to eq(
+          [
+            { name: "Empty page", sections: [] },
+            { name: "Store", sections: [products_section.external_id] },
+          ]
+        )
+      end
+
+      it "does not repair the profile editor payload" do
+        pundit_user = SellerContext.new(user: broken_seller, seller: broken_seller)
+        props = described_class.new(pundit_user:, seller: broken_seller).profile_settings_props(request:)
+
+        expect(props[:editable_profile][:tabs]).to eq([{ name: "New page", sections: [] }])
+      end
+    end
+
     context "when the seller has no products and no profile sections" do
       it "keeps the empty-sections shape so the email signup fallback still renders" do
         new_seller = create(:user, name: "New Seller")

--- a/spec/presenters/profile_presenter_spec.rb
+++ b/spec/presenters/profile_presenter_spec.rb
@@ -186,6 +186,18 @@ describe ProfilePresenter do
         expect(props[:tabs]).to eq([{ name: "New page", sections: [text_section.external_id, products_section.external_id] }])
       end
 
+      it "orders the fallback tab's sections by id regardless of the query's return order" do
+        # The sections query has no ORDER BY; simulate the database returning rows in a
+        # different plan-dependent order.
+        allow_any_instance_of(ProfileSectionsPresenter).to receive(:props).and_wrap_original do |original, **kwargs|
+          original.call(**kwargs).tap { _1[:sections] = _1[:sections].reverse }
+        end
+
+        props = described_class.new(pundit_user: visitor_pundit_user, seller: broken_seller).profile_props(seller_custom_domain_url: nil, request:)
+
+        expect(props[:tabs]).to eq([{ name: "New page", sections: [text_section.external_id, products_section.external_id] }])
+      end
+
       it "repairs tabs whose only references point at sections that no longer exist" do
         broken_seller.seller_profile.update!(json_data: { tabs: [{ name: "New page", sections: [products_section.id + 100] }] })
 

--- a/spec/requests/user/profile_spec.rb
+++ b/spec/requests/user/profile_spec.rb
@@ -189,6 +189,25 @@ describe "User profile page", type: :system, js: true do
         expect_product_cards_in_order([@product4, @product3, @product2, @product1])
       end
 
+      it "renders the saved sections when the only tab references none of them" do
+        Link.import(force: true, refresh: true)
+        create(:seller_profile_rich_text_section, seller:, header: "About", text: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "Welcome to my store" }] }] })
+        create(:seller_profile_products_section, seller:, header: "My products", shown_products: [@product1.id, @product2.id, @product3.id, @product4.id], add_new_products: false)
+        # The editor can persist a tab that references no sections while the section rows
+        # survive; the storefront must still render them instead of only the follow form.
+        create(:seller_profile, seller:, json_data: { tabs: [{ name: "New page", sections: [] }] })
+
+        visit seller.subdomain_with_protocol
+
+        expect(page).to_not have_text "Subscribe to receive email updates from #{seller.name}"
+        within_section "About", section_element: :section do
+          expect(page).to have_text "Welcome to my store"
+        end
+        within_section "My products", section_element: :section do
+          expect_product_cards_in_order([@product1, @product2, @product3, @product4])
+        end
+      end
+
       it "shows the subscribe block when there are no sections and no products" do
         # The subscribe form only takes a follow with no challenge for a seller we
         # have reviewed and marked compliant (see FollowRecaptcha); a headless


### PR DESCRIPTION
## What

When a seller's profile has exactly one tab and that tab references no sections that still exist, the public profile page now renders the profile's saved sections instead of rendering nothing.

## Why

The editor can leave a profile in this state: `Settings::ProfileController#update` skips orphan pruning when any tab section GUID fails to decrypt, so the section rows survive while the saved tabs carry dropped references. The public page then showed only the follow form — the seller's actual content was invisible even though every section row was still there.

The repair is deliberately narrow:

- It fires only when **no** tab would render anything. A tab left empty *beside* a working tab is a real editorial choice and is left alone.
- It is gated to the **public page only** (`include_default_products_section`), so the profile editor still shows the seller the true saved state rather than silently hiding the problem from them.
- Sellers with no sections at all are untouched — they keep the follow-form empty state.

## Test Results

- `bundle exec rspec spec/presenters/profile_presenter_spec.rb` — **26 examples, 0 failures**.
- Full CI: **78/78 checks green** at `ace5cc864` (0 pending, 0 failing, 0 cancelled).

Red/green verified: the production hunk was reverted, the new ordering spec was shown FAILING (`1 example, 1 failure`), then restored and shown passing.

## Fable-5 adversarial review

Verdict: **CHANGES-REQUIRED** at `9cfe25d80` → findings addressed in `ace5cc864`.

| Sev | Finding | Disposition |
|---|---|---|
| P2 | The fallback made **raw DB order user-visible**. `seller_profile_sections.on_profile` is a bare `where(product_id: nil)` with no `ORDER BY`, no `default_scope`, no association order. Normally order comes from the tab's saved array, so this never mattered — the fallback exposed it. MySQL returns PK-ish order today but that is plan-dependent, and this repo already documents the same trap in `visible_posts`. It also made two order-sensitive `eq` assertions latently flaky | Fixed in `ace5cc864` — fallback ids sorted explicitly. Chose sorting the fallback array over `.order(:id)` on the query because the query also feeds the cache key and the non-fallback path; this guarantees zero behavior change elsewhere. New spec wraps the presenter to return sections in reversed order and asserts the tab is still sorted |
| P3 | New comment ran to 5 lines and narrated the bug | Fixed in `ace5cc864` — trimmed to 3 lines (the why + the scope guarantee) |
| P3 | `Api::V2::UsersController#profile_layout` returns unrepaired tabs, so for a broken seller the store agent describes a layout the public page no longer shows | **Not fixed — deliberate.** Agreed it is a real but minor divergence; out of scope for this fix. Worth a follow-up |

### What the review confirmed safe

- **No forcibly-unhidden content.** The reviewer specifically hunted for a seller who *deliberately* emptied a tab now having hidden sections re-shown. That state is not reachable: the editor's prune loop **destroys** any unreferenced on-profile section whenever all references resolve, so "saved but deliberately hidden" is not a supported state. The one deliberate case that does survive — an empty tab beside a working tab — is excluded by the guard and pinned by a spec.
- **Editor payload untouched**: both `profile_settings_props` call sites default the flag to false; spec-pinned.
- **Genuinely-empty sellers keep the follow-form** empty state (guarded and pinned by a pre-existing spec).
- **No N+1 and no added queries**: the fallback is pure in-memory work over already-computed props.
- **Nil/empty branch matrix** all handled; `sections: nil` is structurally impossible (enforced by the JSON schema).
- All commit-message claims were verified against the code rather than accepted.

### Only verifiable live

Whether MySQL's row order was in fact stable for affected sellers before this fix — moot now that the order is explicit.

## QA steps

1. Find (or construct) a seller whose profile has one tab whose section references no longer resolve, with section rows still alive.
2. Load the public profile page — the saved sections should render, in a stable order, instead of only the follow form.
3. Reload a few times: the order must not change.
4. Open the profile **editor** for that seller — it should still show the true saved state (the repair is public-page-only, by design).
5. Check a seller with an empty tab **beside** a working tab — that empty tab must stay empty.
6. Check a brand-new seller with no sections — should still see the follow-form empty state.

## AI disclosure

Written by Gumroad's AI agent (claude-opus-5). Adversarially reviewed by fable-5 before this PR was opened; findings and their fixes are listed above.
