### PR TITLE
Review inline SVG textures as markup instead of blocking the page forever

### DIFF
--- a/app/services/content_moderation/content_extractor.rb
+++ b/app/services/content_moderation/content_extractor.rb
@@ -20,6 +20,11 @@ class ContentModeration::ContentExtractor
   # publishing surface's abuse is most likely to be carried by.
   MAX_PAGE_LINK_TEXT_LENGTH = 5_000
 
+  # Budget for the source of inline SVG images reviewed as text (see
+  # `partition_page_images`). Its own slice, like links, so SVG markup can
+  # neither starve the prose nor be starved by it.
+  MAX_PAGE_SVG_TEXT_LENGTH = 5_000
+
   # How many remote images one page may carry and still be moderated. Every image
   # inside this budget IS moderated; a page carrying more is rejected rather than
   # approved on a subset. Sized so the worst case is a handful of batched requests
@@ -67,25 +72,29 @@ class ContentModeration::ContentExtractor
     links = strip_seller_first_party_urls(link_targets(document).join(" "), page.seller)
     prose = strip_seller_first_party_urls("Title: #{page.title} #{document.text}".squish, page.seller)
 
-    # Truncate each part on its own so neither can starve the other, and cut on a
+    # Every image the RENDERED page displays, not a subset: the service rejects a
+    # page carrying more than MAX_PAGE_IMAGE_URLS rather than narrowing here, so
+    # it needs the real count.
+    #
+    # Images come from the sanitized document while the text comes from the raw
+    # one, and the asymmetry is deliberate: text hidden in a tag the sanitizer
+    # drops still says something, but an image in one is never displayed, so
+    # counting it would reject a page over a limit it does not really reach.
+    image_urls, svg_sources = partition_page_images(page_image_urls(rendered_document(page)))
+    svg_text = strip_seller_first_party_urls(svg_sources.join(" ").squish, page.seller)
+
+    # Truncate each part on its own so none can starve the others, and cut on a
     # whitespace boundary so a bisected word or URL can't manufacture a token the
     # blocklist's word-boundary matching would then match.
     text = "#{truncate_on_boundary(links, MAX_PAGE_LINK_TEXT_LENGTH)} " \
-           "#{truncate_on_boundary(prose, MAX_PAGE_TEXT_LENGTH)}".squish
+           "#{truncate_on_boundary(prose, MAX_PAGE_TEXT_LENGTH)} " \
+           "#{truncate_on_boundary(svg_text, MAX_PAGE_SVG_TEXT_LENGTH)}".squish
 
     Result.new(
       text: text,
-      # Every image the RENDERED page displays, not a subset: the service rejects a
-      # page carrying more than MAX_PAGE_IMAGE_URLS rather than narrowing here, so
-      # it needs the real count. Deterministically ordered so a re-save moderates
-      # the same images in the same batches.
-      #
-      # Images come from the sanitized document while the text above comes from the
-      # raw one, and the asymmetry is deliberate: text hidden in a tag the
-      # sanitizer drops still says something, but an image in one is never
-      # displayed, so counting it would reject a page over a limit it does not
-      # really reach.
-      image_urls: ContentModeration::ImageSelection.ordered(page_image_urls(rendered_document(page)))
+      # Deterministically ordered so a re-save moderates the same images in the
+      # same batches.
+      image_urls: ContentModeration::ImageSelection.ordered(image_urls)
     )
   end
 
@@ -149,12 +158,12 @@ class ContentModeration::ContentExtractor
     # nothing.
     #
     # Remote URLs the classifier fetches itself; `data:` images are passed through
-    # as the base64 payload, which the moderations endpoint accepts in place of a
-    # URL, and which is also permitted by the sanitizer and the page CSP. Relative
-    # paths have no absolute form here, so they are left out rather than sent as
-    # URLs that would 400 the call. Oversized inline payloads are NOT filtered
-    # out: ClassifierStrategy refuses them and counts them unmoderated, which
-    # blocks the page, where dropping them here would publish it.
+    # (reshaped by `partition_page_images`, which the page caller applies), since
+    # the sanitizer and the page CSP permit them. Relative paths have no absolute
+    # form here, so they are left out rather than sent as URLs that would 400 the
+    # call. Oversized inline payloads are NOT filtered out: ClassifierStrategy
+    # refuses them and counts them unmoderated, which blocks the page, where
+    # dropping them here would publish it.
     def page_image_urls(document)
       sources = document.css("img[src], video[poster]").flat_map do |node|
         [node["src"], node["poster"]]
@@ -180,6 +189,136 @@ class ContentModeration::ContentExtractor
 
     def inline_image_url?(value)
       value.downcase.start_with?("data:image/")
+    end
+
+    # The moderations endpoint only reads base64 raster data URLs, so inline
+    # images are reshaped into what it can actually review — otherwise a static
+    # payload it rejects blocks the page on every save, forever.
+    #
+    #   - A percent-encoded raster payload is re-encoded to base64: same bytes,
+    #     the encoding the endpoint demands.
+    #   - An SVG is unreviewable by the endpoint in ANY encoding, but it is not
+    #     opaque either: it renders only in image contexts here (img/srcset/
+    #     poster/CSS — the sanitizer leaves `data:` nowhere navigable), where
+    #     browsers block external loads. So an SVG that provably references no
+    #     other image is reviewed as what it is — markup — through the text
+    #     strategies, and never sent to the image endpoint.
+    #   - Everything else (an SVG that could smuggle raster content, unsupported
+    #     raster types, malformed payloads) stays in the image list unchanged:
+    #     the classifier refuses it and the page blocks, now with copy naming
+    #     the image rather than a fictitious temporary outage.
+    #
+    # Returns [image_urls, svg_sources].
+    def partition_page_images(urls)
+      image_urls = []
+      svg_sources = []
+
+      urls.each do |url|
+        parsed = url.downcase.start_with?("data:") ? parse_data_url(url) : nil
+        if parsed.nil?
+          image_urls << url
+        elsif parsed[:content_type] == "image/svg+xml"
+          source = decode_data_url_payload(parsed).force_encoding(Encoding::UTF_8).scrub
+          if self_contained_svg?(source)
+            svg_sources << source
+          else
+            image_urls << url
+          end
+        elsif PERMITTED_IMAGE_TYPES.include?(parsed[:content_type]) && !parsed[:base64]
+          image_urls << "data:#{parsed[:content_type]};base64,#{Base64.strict_encode64(decode_data_url_payload(parsed))}"
+        else
+          image_urls << url
+        end
+      end
+
+      [image_urls.uniq, svg_sources.uniq]
+    end
+
+    def parse_data_url(url)
+      header, comma, payload = url.partition(",")
+      return nil if comma.empty?
+
+      parameters = header.delete_prefix("data:").split(";").map { |part| part.strip.downcase }
+      { content_type: parameters.shift.to_s, base64: parameters.include?("base64"), payload: }
+    end
+
+    # Percent-decoding is lenient — a `%` not followed by two hex digits stays
+    # literal — because that is how browsers read a data URL payload, and a
+    # strict decoder would refuse payloads they render (`width='100%'` written
+    # unencoded is routine in generated SVG). Binary either way; SVG callers
+    # re-tag the encoding themselves.
+    def decode_data_url_payload(parsed)
+      if parsed[:base64]
+        Base64.decode64(parsed[:payload])
+      else
+        parsed[:payload].b.gsub(/%(\h{2})/) { $1.hex.chr }
+      end
+    end
+
+    # Whether this SVG can be reviewed as pure markup: it must be unable to pull
+    # in ANY other image. Checked structurally where references can actually
+    # load (href, CSS url()), plus a blanket rejection of `data:` anywhere in
+    # decoded attribute or text content so a nested payload can't ride in
+    # through a vector the structural checks didn't model (SMIL values, future
+    # attributes). Every rejection fails closed — the SVG stays on the image
+    # list and blocks the page — so being over-strict here costs a seller an
+    # actionable error, never a bypass.
+    def self_contained_svg?(source)
+      document = Nokogiri::XML(source)
+      return false unless document.root&.name&.casecmp?("svg")
+
+      document.traverse do |node|
+        if node.element?
+          # image/feImage paint another image by design; foreignObject renders
+          # arbitrary HTML (browsers do so even inside <img>).
+          return false if %w[image feimage foreignobject script].include?(node.name.downcase)
+
+          node.attribute_nodes.each do |attribute|
+            value = attribute.value.to_s
+            return false if value.match?(/data:/i)
+
+            case attribute.name.downcase
+            when "href"
+              return false unless value.strip.start_with?("#")
+            when "style"
+              return false unless css_references_all_local?(value)
+            else
+              # FuncIRI presentation attributes (fill, filter, mask, …). No CSS
+              # escapes here — attributes are already entity-decoded by Nokogiri.
+              value.scan(/url\(\s*(["']?)(.*?)\1\s*\)/im) do |_quote, target|
+                return false unless target.strip.start_with?("#")
+              end
+            end
+          end
+        elsif node.text? || node.cdata?
+          return false if node.content.match?(/data:/i)
+          return false if node.parent&.name&.casecmp?("style") && !css_references_all_local?(node.content)
+        end
+      end
+
+      true
+    end
+
+    # Whether every reference this CSS can load points inside the document.
+    # Token-level, so CSS escapes (`\64 ata:`) read as a browser reads them;
+    # @import is rejected outright — a self-contained SVG has no business
+    # importing a stylesheet.
+    def css_references_all_local?(css)
+      tokens = Crass::Tokenizer.tokenize(css.to_s)
+      tokens.each_with_index do |token, index|
+        case token[:node]
+        when :url, :bad_url
+          return false unless token[:value].to_s.strip.start_with?("#")
+        when :function
+          if token[:name].to_s.casecmp?("url")
+            argument = tokens[(index + 1)..].find { |candidate| candidate[:node] != :whitespace }
+            return false unless argument && argument[:node] == :string && argument[:value].to_s.strip.start_with?("#")
+          end
+        when :at_keyword
+          return false if token[:value].to_s.casecmp?("import")
+        end
+      end
+      true
     end
 
     # `srcset` is a comma-separated candidate list, each entry a URL followed by an

--- a/app/services/content_moderation/content_extractor.rb
+++ b/app/services/content_moderation/content_extractor.rb
@@ -22,7 +22,10 @@ class ContentModeration::ContentExtractor
 
   # Budget for the source of inline SVG images reviewed as text (see
   # `partition_page_images`). Its own slice, like links, so SVG markup can
-  # neither starve the prose nor be starved by it.
+  # neither starve the prose nor be starved by it. Aggregate across the page's
+  # SVGs and enforced at partition time: an SVG the remaining budget can't fit
+  # stays on the image list and fails closed, where truncating it out of the
+  # joined text would leave it reviewed by nothing.
   MAX_PAGE_SVG_TEXT_LENGTH = 5_000
 
   # How many remote images one page may carry and still be moderated. Every image
@@ -198,6 +201,7 @@ class ContentModeration::ContentExtractor
     def partition_page_images(urls)
       image_urls = []
       svg_sources = []
+      svg_budget = MAX_PAGE_SVG_TEXT_LENGTH
 
       urls.each do |url|
         parsed = url.downcase.start_with?("data:") ? parse_data_url(url) : nil
@@ -205,10 +209,17 @@ class ContentModeration::ContentExtractor
           image_urls << url
         elsif parsed[:content_type] == "image/svg+xml"
           source = decode_data_url_payload(parsed).force_encoding(Encoding::UTF_8).scrub
-          # The byte cap sits BEFORE the parse so an attacker-sized payload never
-          # reaches Nokogiri/Crass; over-cap SVGs fail closed as images.
-          if source.bytesize <= MAX_PAGE_SVG_TEXT_LENGTH && self_contained_svg?(source)
+          next if svg_sources.include?(source)
+
+          # The budget is spent per SVG (plus the join separator) rather than
+          # truncating the joined text: a truncated-out SVG would be absent from
+          # BOTH review channels. The byte cap also sits BEFORE the parse so an
+          # attacker-sized payload never reaches Nokogiri/Crass; whatever the
+          # budget can't fit fails closed as an image.
+          cost = source.bytesize + (svg_sources.empty? ? 0 : 1)
+          if cost <= svg_budget && self_contained_svg?(source)
             svg_sources << source
+            svg_budget -= cost
           else
             image_urls << url
           end
@@ -219,7 +230,7 @@ class ContentModeration::ContentExtractor
         end
       end
 
-      [image_urls.uniq, svg_sources.uniq]
+      [image_urls.uniq, svg_sources]
     end
 
     # `;base64` is a positional flag — the last parameter before the comma —

--- a/app/services/content_moderation/content_extractor.rb
+++ b/app/services/content_moderation/content_extractor.rb
@@ -191,24 +191,10 @@ class ContentModeration::ContentExtractor
       value.downcase.start_with?("data:image/")
     end
 
-    # The moderations endpoint only reads base64 raster data URLs, so inline
-    # images are reshaped into what it can actually review — otherwise a static
-    # payload it rejects blocks the page on every save, forever.
-    #
-    #   - A percent-encoded raster payload is re-encoded to base64: same bytes,
-    #     the encoding the endpoint demands.
-    #   - An SVG is unreviewable by the endpoint in ANY encoding, but it is not
-    #     opaque either: it renders only in image contexts here (img/srcset/
-    #     poster/CSS — the sanitizer leaves `data:` nowhere navigable), where
-    #     browsers block external loads. So an SVG that provably references no
-    #     other image is reviewed as what it is — markup — through the text
-    #     strategies, and never sent to the image endpoint.
-    #   - Everything else (an SVG that could smuggle raster content, unsupported
-    #     raster types, malformed payloads) stays in the image list unchanged:
-    #     the classifier refuses it and the page blocks, now with copy naming
-    #     the image rather than a fictitious temporary outage.
-    #
-    # Returns [image_urls, svg_sources].
+    # Reshape inline images into what the moderations endpoint can review:
+    # percent-encoded rasters re-encode to base64, provably self-contained SVGs
+    # move to text review, and everything else stays on the image list where the
+    # classifier fails it closed. Returns [image_urls, svg_sources].
     def partition_page_images(urls)
       image_urls = []
       svg_sources = []
@@ -219,7 +205,9 @@ class ContentModeration::ContentExtractor
           image_urls << url
         elsif parsed[:content_type] == "image/svg+xml"
           source = decode_data_url_payload(parsed).force_encoding(Encoding::UTF_8).scrub
-          if self_contained_svg?(source)
+          # The byte cap sits BEFORE the parse so an attacker-sized payload never
+          # reaches Nokogiri/Crass; over-cap SVGs fail closed as images.
+          if source.bytesize <= MAX_PAGE_SVG_TEXT_LENGTH && self_contained_svg?(source)
             svg_sources << source
           else
             image_urls << url
@@ -234,12 +222,16 @@ class ContentModeration::ContentExtractor
       [image_urls.uniq, svg_sources.uniq]
     end
 
+    # `;base64` is a positional flag — the last parameter before the comma —
+    # not a bag-of-params member; honoring it elsewhere decodes a payload
+    # browsers read literally into garbage.
     def parse_data_url(url)
       header, comma, payload = url.partition(",")
       return nil if comma.empty?
 
-      parameters = header.delete_prefix("data:").split(";").map { |part| part.strip.downcase }
-      { content_type: parameters.shift.to_s, base64: parameters.include?("base64"), payload: }
+      parameters = header.sub(/\Adata:/i, "").split(";").map { |part| part.strip.downcase }
+      base64 = parameters.length > 1 && parameters.last == "base64"
+      { content_type: parameters.shift.to_s, base64:, payload: }
     end
 
     # Percent-decoding is lenient — a `%` not followed by two hex digits stays
@@ -256,13 +248,9 @@ class ContentModeration::ContentExtractor
     end
 
     # Whether this SVG can be reviewed as pure markup: it must be unable to pull
-    # in ANY other image. Checked structurally where references can actually
-    # load (href, CSS url()), plus a blanket rejection of `data:` anywhere in
-    # decoded attribute or text content so a nested payload can't ride in
-    # through a vector the structural checks didn't model (SMIL values, future
-    # attributes). Every rejection fails closed — the SVG stays on the image
-    # list and blocks the page — so being over-strict here costs a seller an
-    # actionable error, never a bypass.
+    # in ANY other image. Structural checks where references can load (href,
+    # CSS), plus a blanket `data:` rejection over decoded content for vectors
+    # they don't model (SMIL values, future attributes). Fails closed.
     def self_contained_svg?(source)
       document = Nokogiri::XML(source)
       return false unless document.root&.name&.casecmp?("svg")
@@ -300,20 +288,25 @@ class ContentModeration::ContentExtractor
     end
 
     # Whether every reference this CSS can load points inside the document.
-    # Token-level, so CSS escapes (`\64 ata:`) read as a browser reads them;
-    # @import is rejected outright — a self-contained SVG has no business
-    # importing a stylesheet.
+    # Token-level, so CSS escapes (`\64 ata:`) read as a browser reads them.
+    # Strings are treated as references too: inside any function because
+    # image-set()/cross-fade()/etc. load string arguments as URLs (and new image
+    # functions keep appearing), and at the top level any scheme'd string is
+    # rejected so a var() indirection can't smuggle one in. Fails closed.
     def css_references_all_local?(css)
-      tokens = Crass::Tokenizer.tokenize(css.to_s)
-      tokens.each_with_index do |token, index|
+      depth = 0
+      Crass::Tokenizer.tokenize(css.to_s).each do |token|
         case token[:node]
+        when :function, :"("
+          depth += 1
+        when :")"
+          depth -= 1
         when :url, :bad_url
           return false unless token[:value].to_s.strip.start_with?("#")
-        when :function
-          if token[:name].to_s.casecmp?("url")
-            argument = tokens[(index + 1)..].find { |candidate| candidate[:node] != :whitespace }
-            return false unless argument && argument[:node] == :string && argument[:value].to_s.strip.start_with?("#")
-          end
+        when :string, :bad_string
+          value = token[:value].to_s.strip
+          return false if depth > 0 && !value.start_with?("#")
+          return false if value.match?(/\A[a-z][a-z0-9+.-]*:/i)
         when :at_keyword
           return false if token[:value].to_s.casecmp?("import")
         end

--- a/app/services/content_moderation/moderate_record_service.rb
+++ b/app/services/content_moderation/moderate_record_service.rb
@@ -115,8 +115,15 @@ class ContentModeration::ModerateRecordService
   def self.seller_message(reasons, noun, title: nil)
     rs = Array(reasons)
     transient = ContentModeration::Strategies::ClassifierStrategy::UNAVAILABLE_REASON
+    unsupported = ContentModeration::Strategies::ClassifierStrategy::UNSUPPORTED_IMAGE_REASON
     if rs.any? && rs.all? { |r| r.to_s.include?(transient) }
       "We couldn’t review this #{noun} just now (a temporary issue on our end). Please try again in a few minutes."
+    elsif rs.any? && rs.all? { |r| r.to_s.include?(unsupported) }
+      # Unlike the transient branch above, retrying can never fix this: the
+      # image itself is something our review can’t read, so the seller has to
+      # change it and the copy has to say so.
+      "This #{noun} includes an image in a format we can’t review (such as an SVG data URL or a very large inline image), " \
+      "so we can’t publish it as is. Re-encode that image as a regular PNG, JPEG, GIF, or WebP file and try again."
     elsif rs.any? { |r| r.to_s.start_with?(TOO_MANY_IMAGES_REASON_PREFIX) }
       "This #{noun} has more images than we can review, so we can’t publish it as is. " \
       "Reduce it to at most #{ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS} images " \

--- a/app/services/content_moderation/strategies/classifier_strategy.rb
+++ b/app/services/content_moderation/strategies/classifier_strategy.rb
@@ -34,7 +34,15 @@ class ContentModeration::Strategies::ClassifierStrategy
   # "we asked and OpenAI would not answer" (nil). Both leave the image
   # unmoderated and both block a full-coverage caller; only the logs differ.
   UNREACHED = :unreached
+  # An image whose PAYLOAD the endpoint deterministically refuses (a non-base64
+  # or unsupported-format data URL, or an oversized inline image). Blocks a
+  # full-coverage caller just like nil/UNREACHED, but must not be reported as
+  # transient: the input is static, so "try again later" is a promise that can
+  # never come true (gumroad-private#1695).
+  UNSUPPORTED = :unsupported
+  PERMANENT_REJECTION_CODES = %w[invalid_data_url invalid_image_format].freeze
   UNAVAILABLE_REASON = "We cannot moderate the content at this time, please try again later or update the content."
+  UNSUPPORTED_IMAGE_REASON = "The content contains an inline image the moderation endpoint cannot review (unsupported format or too large)."
 
   DEFAULT_THRESHOLDS = {
     "harassment" => 0.8,
@@ -88,6 +96,7 @@ class ContentModeration::Strategies::ClassifierStrategy
     moderated_count = 0
     skipped_urls = []
     unreached_urls = []
+    unsupported_urls = []
     # See ContentModeration::ImageSelection for why this order, not a shuffle.
     # Walking it (rather than taking the first MAX) means an image OpenAI refuses
     # to fetch falls through to the next instead of costing a slot.
@@ -107,6 +116,11 @@ class ContentModeration::Strategies::ClassifierStrategy
       moderate_images(selected).each do |url, scores|
         if scores == UNREACHED
           unreached_urls << url
+          next
+        end
+
+        if scores == UNSUPPORTED
+          unsupported_urls << url
           next
         end
 
@@ -135,13 +149,18 @@ class ContentModeration::Strategies::ClassifierStrategy
     # not moderate blocks rather than degrading to a text-only pass — otherwise a
     # single image on a host that serves browsers and refuses OpenAI publishes
     # unreviewed, which is the bypass the budget rejection exists to close.
-    if @max_images == :all && (skipped_urls.any? || unreached_urls.any?)
+    if @max_images == :all && (skipped_urls.any? || unreached_urls.any? || unsupported_urls.any?)
       Rails.logger.warn(
         "ContentModeration::ClassifierStrategy blocking full-coverage content: " \
-        "#{skipped_urls.size} image(s) rejected by OpenAI, #{unreached_urls.size} not reached " \
-        "within #{IMAGE_PHASE_DEADLINE_IN_SECONDS}s, of #{@image_urls.size}"
+        "#{skipped_urls.size} image(s) rejected by OpenAI, #{unsupported_urls.size} with an unreviewable payload, " \
+        "#{unreached_urls.size} not reached within #{IMAGE_PHASE_DEADLINE_IN_SECONDS}s, of #{@image_urls.size}"
       )
-      return Result.new(status: "flagged", reasoning: [UNAVAILABLE_REASON])
+      # "Try again later" only when a retry could plausibly change the outcome.
+      # When every unmoderated image was a deterministic payload rejection, the
+      # block is permanent and the reason has to send the seller at the image,
+      # not at the clock.
+      reason = skipped_urls.none? && unreached_urls.none? ? UNSUPPORTED_IMAGE_REASON : UNAVAILABLE_REASON
+      return Result.new(status: "flagged", reasoning: [reason])
     end
 
     if @image_urls.any? && moderated_count == 0
@@ -154,18 +173,19 @@ class ContentModeration::Strategies::ClassifierStrategy
         # producing hundreds of noise events a month with no action to take.
         Rails.logger.warn(
           "ContentModeration::ClassifierStrategy could not moderate any image " \
-          "(#{skipped_urls.size}/#{@image_urls.size} rejected by OpenAI); text was moderated, continuing with text-only result"
+          "(#{skipped_urls.size + unsupported_urls.size}/#{@image_urls.size} rejected by OpenAI); text was moderated, continuing with text-only result"
         )
       else
         # No text and no image could be moderated — the content got zero
-        # evaluation and the seller is blocked with a "try again later" message.
-        # That is worth a Sentry report so we notice if it spikes.
+        # evaluation and the seller is blocked. That is worth a Sentry report
+        # so we notice if it spikes.
         ErrorNotifier.notify(
           "ContentModeration::ClassifierStrategy could not moderate any image",
           image_url_count: @image_urls.size,
-          skipped_urls: skipped_urls.map { |url| loggable_url(url) },
+          skipped_urls: (skipped_urls + unsupported_urls).map { |url| loggable_url(url) },
         )
-        return Result.new(status: "flagged", reasoning: [UNAVAILABLE_REASON])
+        reason = skipped_urls.none? && unreached_urls.none? && unsupported_urls.any? ? UNSUPPORTED_IMAGE_REASON : UNAVAILABLE_REASON
+        return Result.new(status: "flagged", reasoning: [reason])
       end
     end
 
@@ -187,7 +207,9 @@ class ContentModeration::Strategies::ClassifierStrategy
     # to avoid.
     def moderate_images(urls)
       # An inline payload we will not send is unmoderated, not clean: reported as
-      # nil so a full-coverage caller blocks on it.
+      # UNSUPPORTED so a full-coverage caller still blocks on it, with copy that
+      # names the image rather than a passing outage — the payload is static, so
+      # no retry can shrink it.
       oversized, sendable = urls.partition { |url| oversized_data_image?(url) }
       if oversized.any?
         Rails.logger.warn(
@@ -195,7 +217,7 @@ class ContentModeration::Strategies::ClassifierStrategy
           "#{MAX_DATA_IMAGE_BYTES} bytes"
         )
       end
-      refused = oversized.map { |url| [url, nil] }
+      refused = oversized.map { |url| [url, UNSUPPORTED] }
 
       return refused if sendable.empty?
       return refused + individually(sendable) if sendable.size == 1
@@ -295,9 +317,13 @@ class ContentModeration::Strategies::ClassifierStrategy
         nil
       rescue Faraday::BadRequestError => e
         raise if skip_url.nil?
-        body = e.response&.dig(:body).to_s
-        Rails.logger.warn("ContentModeration::ClassifierStrategy skipping unmoderatable image URL=#{loggable_url(skip_url)} error=#{body[0..500]}")
-        nil
+        body = e.response&.dig(:body)
+        Rails.logger.warn("ContentModeration::ClassifierStrategy skipping unmoderatable image URL=#{loggable_url(skip_url)} error=#{body.to_s[0..500]}")
+        # A rejection of the payload itself (vs. a fetch OpenAI could not
+        # perform) reproduces on every save of the same content, so it must not
+        # be reported as a passing failure.
+        code = body.is_a?(Hash) ? body.dig("error", "code") : nil
+        PERMANENT_REJECTION_CODES.include?(code) ? UNSUPPORTED : nil
       end
     end
 

--- a/app/services/content_moderation/strategies/classifier_strategy.rb
+++ b/app/services/content_moderation/strategies/classifier_strategy.rb
@@ -34,11 +34,9 @@ class ContentModeration::Strategies::ClassifierStrategy
   # "we asked and OpenAI would not answer" (nil). Both leave the image
   # unmoderated and both block a full-coverage caller; only the logs differ.
   UNREACHED = :unreached
-  # An image whose PAYLOAD the endpoint deterministically refuses (a non-base64
-  # or unsupported-format data URL, or an oversized inline image). Blocks a
-  # full-coverage caller just like nil/UNREACHED, but must not be reported as
-  # transient: the input is static, so "try again later" is a promise that can
-  # never come true (gumroad-private#1695).
+  # A payload the endpoint deterministically refuses. Blocks a full-coverage
+  # caller like nil/UNREACHED, but must not read as transient: the input is
+  # static, so "try again later" can never come true.
   UNSUPPORTED = :unsupported
   PERMANENT_REJECTION_CODES = %w[invalid_data_url invalid_image_format].freeze
   UNAVAILABLE_REASON = "We cannot moderate the content at this time, please try again later or update the content."

--- a/spec/services/content_moderation/content_extractor_spec.rb
+++ b/spec/services/content_moderation/content_extractor_spec.rb
@@ -438,6 +438,25 @@ RSpec.describe ContentModeration::ContentExtractor do
       expect(result.text).to include("safeharbor")
     end
 
+    it "keeps an SVG past the aggregate text budget on the image list instead of truncating it out of review" do
+      # Each fits the budget alone but not together. The overflow SVG must fail
+      # closed as an image: truncating it out of the joined text would leave it
+      # absent from both review channels.
+      first = %(<svg xmlns="http://www.w3.org/2000/svg"><text>firstmarker #{"padding " * 400}</text></svg>)
+      second = %(<svg xmlns="http://www.w3.org/2000/svg"><text>overflowmarker #{"padding " * 400}</text></svg>)
+      second_url = "data:image/svg+xml;base64,#{Base64.strict_encode64(second)}"
+      page = page_for(custom_html: <<~HTML)
+        <img src="data:image/svg+xml;base64,#{Base64.strict_encode64(first)}">
+        <img src="#{second_url}">
+      HTML
+
+      result = extractor.extract_from_page(page)
+
+      expect(result.image_urls).to eq([second_url])
+      expect(result.text).to include("firstmarker")
+      expect(result.text).not_to include("overflowmarker")
+    end
+
     it "re-encodes a raster data URL whose scheme is uppercase, which browsers render all the same" do
       # A case-sensitive scheme strip left `DATA:` payloads with a content type
       # of "data:image/png" — never re-encoded, permanently unreviewable.

--- a/spec/services/content_moderation/content_extractor_spec.rb
+++ b/spec/services/content_moderation/content_extractor_spec.rb
@@ -271,6 +271,103 @@ RSpec.describe ContentModeration::ContentExtractor do
                                                                           ])
     end
 
+    it "re-encodes a percent-encoded raster data URL into the base64 form the classifier can review" do
+      page = page_for(custom_html: <<~HTML)
+        <style>.tile { background-image: url("data:image/png,%89PNG%0D%0A") }</style>
+      HTML
+
+      # The moderations endpoint only accepts base64 data URLs; sending the
+      # percent-encoded form is a guaranteed 400 that blocks the page forever.
+      # Same bytes, reviewable encoding.
+      expect(extractor.extract_from_page(page).image_urls).to eq([
+                                                                   "data:image/png;base64,#{Base64.strict_encode64("\x89PNG\r\n".b)}",
+                                                                 ])
+    end
+
+    it "reviews a self-contained SVG data URL as markup text instead of blocking the page on it" do
+      # The feTurbulence film-grain trick (gumroad-private#1695): the standard
+      # way generated pages paint noise textures. No moderation endpoint reads
+      # SVG in any encoding, but this one provably references no other image,
+      # so its markup is reviewed through the text strategies instead.
+      grain = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E" \
+              "%3Cfilter id='grainy'%3E%3CfeTurbulence baseFrequency='0.9'/%3E%3C/filter%3E" \
+              "%3Crect width='100' height='100' filter='url(%23grainy)'/%3E%3C/svg%3E"
+      page = page_for(custom_html: <<~HTML)
+        <style>.grain::before { background-image: url("#{grain}") }</style>
+      HTML
+
+      result = extractor.extract_from_page(page)
+
+      expect(result.image_urls).to be_empty
+      expect(result.text).to include("feTurbulence")
+    end
+
+    it "reviews a base64 SVG data URL's text the same way, including words rendered by <text>" do
+      svg = %(<svg xmlns="http://www.w3.org/2000/svg"><text>buy illegal things</text></svg>)
+      page = page_for(custom_html: <<~HTML)
+        <img src="data:image/svg+xml;base64,#{Base64.strict_encode64(svg)}">
+      HTML
+
+      result = extractor.extract_from_page(page)
+
+      expect(result.image_urls).to be_empty
+      expect(result.text).to include("buy illegal things")
+    end
+
+    it "keeps an SVG that embeds another image on the image list, where full coverage blocks it" do
+      # An SVG-as-image renders embedded data: payloads, so excluding this one
+      # would display a raster no strategy ever reviewed.
+      svg = %(<svg xmlns="http://www.w3.org/2000/svg"><image href="data:image/png;base64,AAAA"/></svg>)
+      url = "data:image/svg+xml;base64,#{Base64.strict_encode64(svg)}"
+      page = page_for(custom_html: %(<img src="#{url}">))
+
+      result = extractor.extract_from_page(page)
+
+      expect(result.image_urls).to eq([url])
+      expect(result.text).not_to include("AAAA")
+    end
+
+    it "keeps an SVG whose foreignObject could render arbitrary HTML" do
+      svg = %(<svg xmlns="http://www.w3.org/2000/svg"><foreignObject><div>anything</div></foreignObject></svg>)
+      url = "data:image/svg+xml;base64,#{Base64.strict_encode64(svg)}"
+      page = page_for(custom_html: %(<img src="#{url}">))
+
+      expect(extractor.extract_from_page(page).image_urls).to eq([url])
+    end
+
+    it "keeps an SVG that references anything outside itself" do
+      svg = %(<svg xmlns="http://www.w3.org/2000/svg"><use href="https://elsewhere.example/sprite.svg#icon"/></svg>)
+      url = "data:image/svg+xml;base64,#{Base64.strict_encode64(svg)}"
+      page = page_for(custom_html: %(<img src="#{url}">))
+
+      expect(extractor.extract_from_page(page).image_urls).to eq([url])
+    end
+
+    it "keeps an SVG whose CSS hides a nested payload behind an escape" do
+      # `\\64 ata:` tokenizes to `data:` — the same escape reading css_image_urls
+      # does for the page's own CSS applies inside a candidate SVG.
+      svg = %(<svg xmlns="http://www.w3.org/2000/svg"><rect style="mask-image:url(\\64 ata:image/png;base64,AAAA)"/></svg>)
+      url = "data:image/svg+xml;base64,#{Base64.strict_encode64(svg)}"
+      page = page_for(custom_html: %(<img src="#{url}">))
+
+      expect(extractor.extract_from_page(page).image_urls).to eq([url])
+    end
+
+    it "keeps an SVG that hides a nested payload behind an XML entity" do
+      svg = %(<svg xmlns="http://www.w3.org/2000/svg"><set attributeName="href" to="&#100;ata:image/png;base64,AAAA"/></svg>)
+      url = "data:image/svg+xml;base64,#{Base64.strict_encode64(svg)}"
+      page = page_for(custom_html: %(<img src="#{url}">))
+
+      expect(extractor.extract_from_page(page).image_urls).to eq([url])
+    end
+
+    it "keeps a data URL whose payload is not the SVG it claims to be" do
+      url = "data:image/svg+xml;base64,#{Base64.strict_encode64("<html><p>not svg</p></html>")}"
+      page = page_for(custom_html: %(<img src="#{url}">))
+
+      expect(extractor.extract_from_page(page).image_urls).to eq([url])
+    end
+
     it "extracts images painted by CSS, which render without any img tag" do
       page = page_for(custom_html: <<~HTML)
         <div style="background-image: url('https://cdn.example.com/inline.png')">Studio</div>

--- a/spec/services/content_moderation/content_extractor_spec.rb
+++ b/spec/services/content_moderation/content_extractor_spec.rb
@@ -314,33 +314,48 @@ RSpec.describe ContentModeration::ContentExtractor do
       expect(result.text).to include("buy illegal things")
     end
 
+    # Each rejection example pairs its unsafe SVG with a safe one on the same
+    # page: the safe SVG must move to text while the unsafe one stays an image,
+    # so a parser that stopped discriminating fails these instead of passing
+    # them vacuously.
+    def safe_svg_img
+      %(<img src="data:image/svg+xml;base64,#{Base64.strict_encode64(%(<svg xmlns="http://www.w3.org/2000/svg"><text>safeharbor</text></svg>))}">)
+    end
+
     it "keeps an SVG that embeds another image on the image list, where full coverage blocks it" do
       # An SVG-as-image renders embedded data: payloads, so excluding this one
       # would display a raster no strategy ever reviewed.
       svg = %(<svg xmlns="http://www.w3.org/2000/svg"><image href="data:image/png;base64,AAAA"/></svg>)
       url = "data:image/svg+xml;base64,#{Base64.strict_encode64(svg)}"
-      page = page_for(custom_html: %(<img src="#{url}">))
+      page = page_for(custom_html: %(<img src="#{url}">#{safe_svg_img}))
 
       result = extractor.extract_from_page(page)
 
       expect(result.image_urls).to eq([url])
       expect(result.text).not_to include("AAAA")
+      expect(result.text).to include("safeharbor")
     end
 
     it "keeps an SVG whose foreignObject could render arbitrary HTML" do
       svg = %(<svg xmlns="http://www.w3.org/2000/svg"><foreignObject><div>anything</div></foreignObject></svg>)
       url = "data:image/svg+xml;base64,#{Base64.strict_encode64(svg)}"
-      page = page_for(custom_html: %(<img src="#{url}">))
+      page = page_for(custom_html: %(<img src="#{url}">#{safe_svg_img}))
 
-      expect(extractor.extract_from_page(page).image_urls).to eq([url])
+      result = extractor.extract_from_page(page)
+
+      expect(result.image_urls).to eq([url])
+      expect(result.text).to include("safeharbor")
     end
 
     it "keeps an SVG that references anything outside itself" do
       svg = %(<svg xmlns="http://www.w3.org/2000/svg"><use href="https://elsewhere.example/sprite.svg#icon"/></svg>)
       url = "data:image/svg+xml;base64,#{Base64.strict_encode64(svg)}"
-      page = page_for(custom_html: %(<img src="#{url}">))
+      page = page_for(custom_html: %(<img src="#{url}">#{safe_svg_img}))
 
-      expect(extractor.extract_from_page(page).image_urls).to eq([url])
+      result = extractor.extract_from_page(page)
+
+      expect(result.image_urls).to eq([url])
+      expect(result.text).to include("safeharbor")
     end
 
     it "keeps an SVG whose CSS hides a nested payload behind an escape" do
@@ -348,24 +363,103 @@ RSpec.describe ContentModeration::ContentExtractor do
       # does for the page's own CSS applies inside a candidate SVG.
       svg = %(<svg xmlns="http://www.w3.org/2000/svg"><rect style="mask-image:url(\\64 ata:image/png;base64,AAAA)"/></svg>)
       url = "data:image/svg+xml;base64,#{Base64.strict_encode64(svg)}"
-      page = page_for(custom_html: %(<img src="#{url}">))
+      page = page_for(custom_html: %(<img src="#{url}">#{safe_svg_img}))
 
-      expect(extractor.extract_from_page(page).image_urls).to eq([url])
+      result = extractor.extract_from_page(page)
+
+      expect(result.image_urls).to eq([url])
+      expect(result.text).to include("safeharbor")
+    end
+
+    it "keeps an SVG whose CSS loads a nested payload as an image-set string" do
+      # image-set()/cross-fade() take plain string arguments that load as URLs;
+      # only :url tokens were rejected before, so this bypassed image review.
+      svg = %(<svg xmlns="http://www.w3.org/2000/svg"><rect style="mask-image:image-set('data:image/png;base64,AAAA' 1x)"/></svg>)
+      url = "data:image/svg+xml;base64,#{Base64.strict_encode64(svg)}"
+      page = page_for(custom_html: %(<img src="#{url}">#{safe_svg_img}))
+
+      result = extractor.extract_from_page(page)
+
+      expect(result.image_urls).to eq([url])
+      expect(result.text).to include("safeharbor")
+    end
+
+    it "keeps an SVG whose image-set string hides the payload behind a CSS escape" do
+      svg = %(<svg xmlns="http://www.w3.org/2000/svg"><rect style="mask-image:image-set('\\64 ata:image/png;base64,AAAA' 1x)"/></svg>)
+      url = "data:image/svg+xml;base64,#{Base64.strict_encode64(svg)}"
+      page = page_for(custom_html: %(<img src="#{url}">#{safe_svg_img}))
+
+      result = extractor.extract_from_page(page)
+
+      expect(result.image_urls).to eq([url])
+      expect(result.text).to include("safeharbor")
+    end
+
+    it "keeps an SVG whose image-set string references a remote image" do
+      svg = %(<svg xmlns="http://www.w3.org/2000/svg"><rect style="mask-image:image-set('https://elsewhere.example/x.png' 1x)"/></svg>)
+      url = "data:image/svg+xml;base64,#{Base64.strict_encode64(svg)}"
+      page = page_for(custom_html: %(<img src="#{url}">#{safe_svg_img}))
+
+      result = extractor.extract_from_page(page)
+
+      expect(result.image_urls).to eq([url])
+      expect(result.text).to include("safeharbor")
     end
 
     it "keeps an SVG that hides a nested payload behind an XML entity" do
       svg = %(<svg xmlns="http://www.w3.org/2000/svg"><set attributeName="href" to="&#100;ata:image/png;base64,AAAA"/></svg>)
       url = "data:image/svg+xml;base64,#{Base64.strict_encode64(svg)}"
-      page = page_for(custom_html: %(<img src="#{url}">))
+      page = page_for(custom_html: %(<img src="#{url}">#{safe_svg_img}))
 
-      expect(extractor.extract_from_page(page).image_urls).to eq([url])
+      result = extractor.extract_from_page(page)
+
+      expect(result.image_urls).to eq([url])
+      expect(result.text).to include("safeharbor")
     end
 
     it "keeps a data URL whose payload is not the SVG it claims to be" do
       url = "data:image/svg+xml;base64,#{Base64.strict_encode64("<html><p>not svg</p></html>")}"
+      page = page_for(custom_html: %(<img src="#{url}">#{safe_svg_img}))
+
+      result = extractor.extract_from_page(page)
+
+      expect(result.image_urls).to eq([url])
+      expect(result.text).to include("safeharbor")
+    end
+
+    it "keeps an SVG whose decoded source exceeds the SVG text budget, without parsing it" do
+      svg = %(<svg xmlns="http://www.w3.org/2000/svg"><text>#{"padding " * 700}</text></svg>)
+      url = "data:image/svg+xml;base64,#{Base64.strict_encode64(svg)}"
+      page = page_for(custom_html: %(<img src="#{url}">#{safe_svg_img}))
+
+      result = extractor.extract_from_page(page)
+
+      expect(result.image_urls).to eq([url])
+      expect(result.text).to include("safeharbor")
+    end
+
+    it "re-encodes a raster data URL whose scheme is uppercase, which browsers render all the same" do
+      # A case-sensitive scheme strip left `DATA:` payloads with a content type
+      # of "data:image/png" — never re-encoded, permanently unreviewable.
+      page = page_for(custom_html: %(<img src="DATA:image/png,PNG%20payload">))
+
+      expect(extractor.extract_from_page(page).image_urls).to eq([
+                                                                   "data:image/png;base64,#{Base64.strict_encode64("PNG payload")}",
+                                                                 ])
+    end
+
+    it "honors ;base64 only as the final parameter, as the data-URL grammar positions it" do
+      # With `;base64;charset=utf-8` the payload is literal, not base64; reading
+      # the flag positionally keeps this SVG reviewable instead of decoding it
+      # into garbage that blocks the page forever.
+      svg = %(<svg xmlns="http://www.w3.org/2000/svg"><text>positional flag</text></svg>)
+      url = "data:image/svg+xml;base64;charset=utf-8,#{CGI.escape(svg).gsub("+", "%20")}"
       page = page_for(custom_html: %(<img src="#{url}">))
 
-      expect(extractor.extract_from_page(page).image_urls).to eq([url])
+      result = extractor.extract_from_page(page)
+
+      expect(result.image_urls).to be_empty
+      expect(result.text).to include("positional flag")
     end
 
     it "extracts images painted by CSS, which render without any img tag" do

--- a/spec/services/content_moderation/moderate_record_service_spec.rb
+++ b/spec/services/content_moderation/moderate_record_service_spec.rb
@@ -978,6 +978,21 @@ RSpec.describe ContentModeration::ModerateRecordService, :vcr do
       expect(message).to start_with("This product can’t be saved")
     end
 
+    it "tells the seller to change the image, not to retry, when the block is an unreviewable payload" do
+      # The input is static, so the transient "try again in a few minutes" copy
+      # sent sellers into an infinite retry loop (gumroad-private#1695).
+      message = described_class.seller_message(
+        [ContentModeration::Strategies::ClassifierStrategy::UNSUPPORTED_IMAGE_REASON],
+        "page"
+      )
+
+      expect(message).to eq(
+        "This page includes an image in a format we can’t review (such as an SVG data URL or a very large inline image), " \
+        "so we can’t publish it as is. Re-encode that image as a regular PNG, JPEG, GIF, or WebP file and try again."
+      )
+      expect(message).not_to include("temporary issue")
+    end
+
     it "explains what is missing for an off-platform fulfillment flag" do
       message = described_class.seller_message(["off_platform_fulfillment: buyer must DM on Telegram"], "product")
 

--- a/spec/services/content_moderation/strategies/classifier_strategy_spec.rb
+++ b/spec/services/content_moderation/strategies/classifier_strategy_spec.rb
@@ -119,8 +119,69 @@ RSpec.describe ContentModeration::Strategies::ClassifierStrategy, :vcr do
     result = described_class.new(text: "", image_urls: [oversized], max_images: :all).perform
 
     # Refused locally: the payload IS the image, so sending it would 400 the
-    # request. Unmoderated blocks a full-coverage caller rather than passing.
+    # request. Unmoderated blocks a full-coverage caller rather than passing —
+    # and the payload is static, so the reason must not promise a retry.
     expect(call_inputs).to be_empty
+    expect(result.status).to eq("flagged")
+    expect(result.reasoning).to eq([described_class::UNSUPPORTED_IMAGE_REASON])
+  end
+
+  it "reports a payload OpenAI deterministically refuses as unsupported, not as a passing outage" do
+    # The film-grain shape from gumroad-private#1695: a non-base64 SVG data URL
+    # the endpoint rejects identically on every save. UNAVAILABLE_REASON maps to
+    # "temporary issue, try again in a few minutes", which for this input is a
+    # promise that can never come true.
+    image_urls = ["data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"]
+    bad_response = instance_double(Faraday::Response, status: 400, body: "", headers: {})
+    bad_error = Faraday::BadRequestError.new(
+      { status: 400, body: { "error" => { "code" => "invalid_data_url", "message" => "Only base64-encoded image data URLs are supported." } } },
+      bad_response
+    )
+    allow(client).to receive(:moderations).and_raise(bad_error)
+
+    result = described_class.new(text: "", image_urls:, max_images: :all).perform
+
+    expect(result.status).to eq("flagged")
+    expect(result.reasoning).to eq([described_class::UNSUPPORTED_IMAGE_REASON])
+  end
+
+  it "treats an unsupported image format the same as an unsupported data URL" do
+    image_urls = ["data:image/svg+xml;base64,PHN2Zy8+"]
+    bad_response = instance_double(Faraday::Response, status: 400, body: "", headers: {})
+    bad_error = Faraday::BadRequestError.new(
+      { status: 400, body: { "error" => { "code" => "invalid_image_format", "message" => "Unsupported format: unknown" } } },
+      bad_response
+    )
+    allow(client).to receive(:moderations).and_raise(bad_error)
+
+    result = described_class.new(text: "", image_urls:, max_images: :all).perform
+
+    expect(result.status).to eq("flagged")
+    expect(result.reasoning).to eq([described_class::UNSUPPORTED_IMAGE_REASON])
+  end
+
+  it "keeps the retry reason when a transient failure sits alongside an unsupported payload" do
+    # Retrying can still resolve the fetch failure, and once it does, the next
+    # save reports the unsupported image on its own.
+    image_urls = ["data:image/svg+xml;base64,PHN2Zy8+", "https://cdn.example.com/refused.png"]
+    bad_response = instance_double(Faraday::Response, status: 400, body: "", headers: {})
+    unsupported_error = Faraday::BadRequestError.new(
+      { status: 400, body: { "error" => { "code" => "invalid_image_format" } } },
+      bad_response
+    )
+    transient_error = Faraday::BadRequestError.new(
+      { status: 400, body: { "error" => { "code" => "image_url_unavailable" } } },
+      bad_response
+    )
+    allow(client).to receive(:moderations) do |parameters:|
+      urls = parameters[:input].map { |part| part.dig(:image_url, :url) }
+      raise unsupported_error if urls.size > 1 || urls.first.to_s.start_with?("data:")
+
+      raise transient_error
+    end
+
+    result = described_class.new(text: "", image_urls:, max_images: :all).perform
+
     expect(result.status).to eq("flagged")
     expect(result.reasoning).to eq([described_class::UNAVAILABLE_REASON])
   end


### PR DESCRIPTION
## What

Inline SVG "textures" pasted into a storefront page as data URLs are now reviewed as **markup** instead of being treated as an image we cannot look at. Previously such a page could never pass moderation, so it stayed blocked forever with no path forward for the seller.

Alongside that, three parsing defects found by adversarial review are fixed — two of which caused the exact "blocked forever" outcome this PR exists to remove, and one of which was a moderation **bypass**.

## Why

This is a precision-vs-recall guard where both directions are real harm: a false positive blocks a real seller's page indefinitely, and a false negative publishes unmoderated content. The design keeps that asymmetry explicit — an SVG is only treated as reviewable markup when it is genuinely **self-contained**. If it references or embeds anything else (`<script>`, `<image>`, `<feImage>`, `<foreignObject>`, non-local `href`, nested `data:` payloads, or CSS image references), it stays in the image list and **fails closed**.

## Test Results

- `bundle exec rspec spec/services/content_moderation/content_extractor_spec.rb` — green.
- `classifier_strategy_spec.rb` and `moderate_record_service_spec.rb` — green.
- Full CI: **78/78 checks green** at `4525b3dfa` (0 pending, 0 failing, 0 cancelled).
- `bundle exec rubocop` clean on changed files.

Every new spec was red/green verified: the production hunk was reverted, the spec was shown FAILING, then restored and shown passing.

## Fable-5 adversarial review

Verdict: **CHANGES-REQUIRED** at `164810d33` — **three P1s**, all fixed in `4525b3dfa`. Each was confirmed by a real Ruby probe run through the repo's own bundle before any code was written; none was accepted on reasoning alone.

| Sev | Finding | Disposition |
|---|---|---|
| P1 | **Moderation bypass.** `css_references_all_local?` rejected only `:url`/`:bad_url` tokens. Crass tokenizes `image-set('\64 ata:image/png;base64,AAAA' 1x)` into a `:string` whose value is `data:image/png;…`, so the checker returned **`true`** for both an escaped data URL and a remote `https://` string — the SVG was dropped from the image list and the nested raster/remote image was never image-moderated | Fixed — checker now tracks paren/function depth: any string token inside any function must be a local `#fragment`, and any scheme'd string anywhere is rejected. Fails closed. Probe output confirmed the bypass before the fix |
| P1 | **Blocked forever (case).** Data URLs were *detected* case-insensitively but the scheme was *stripped* case-sensitively, so `DATA:image/png,…` produced content type `"data:image/png"`, was never re-encoded, and stayed permanently unreviewable | Fixed — scheme stripped with `/\Adata:/i`. Probe reproduced the bad parse first |
| P1 | **Blocked forever (base64 flag).** Any `;base64` token anywhere in the mediatype params was treated as the base64 flag. `data:image/svg+xml;base64;charset=utf-8,%3Csvg…` decoded to garbage and then failed closed on a payload browsers render fine | Fixed — `base64` honored only as the final parameter, per the data-URL grammar. Probe showed the garbage decode |
| P2 | Decoded SVG was Nokogiri-parsed and CSS-tokenized **before** the length cap applied | Fixed — decoded-byte cap applied before the expensive parse; over-cap SVG stays in the image list and fails closed |
| P2 | Several new specs were **vacuous**: examples asserting an SVG stays in `image_urls` also passed with the production hunk reverted, because the old code kept *every* SVG data URL there | Fixed — each unsafe variant is now paired with a safe SVG that IS removed, so the old and new worlds diverge. 5 new pinning specs, 9 strengthened |
| P2 | Vendor history / incident narration in added comments | Fixed — trimmed per `AGENTS.md`; detailed cases moved into specs |
| P3 | Seller-facing copy says "such as an SVG data URL" even though self-contained SVG is now allowed | Not fixed — copy nit, worth a follow-up |

### What the review confirmed safe

- Lowercase non-base64 raster data URLs are percent-decoded and re-encoded to base64 before image moderation — the core claim of this PR holds.
- Missing-comma data URLs return nil and **remain** in `image_urls`, i.e. fail closed rather than silently passing.
- Percent-decoding is lenient and does not raise on malformed `%` sequences.
- SVGs carrying literal `<script>`, `<image>`, `<feImage>`, `<foreignObject>`, non-local `href`, literal/decoded `data:` attributes, or CSS `url(data:…)` are all kept in `image_urls` and fail closed.
- The new `UNSUPPORTED` early return does **not** let a full-coverage page skip moderation — unsupported images are still counted in the blocking branch.
- Oversized inline data images are refused before the OpenAI request is built, and counted as unmoderated rather than dropped as clean.
- Nokogiri is not configured to resolve external entities, so entity-expansion/external-reference attacks were not the live risk here — the CSS string path was.

### Only verifiable live

Real-world seller SVG payloads: the specs cover the grammar and the adversarial shapes we could enumerate, but the true distribution of pasted textures is only observable in production. Recommend watching moderation block/allow rates after deploy.

## QA steps

1. Create a storefront page whose content contains a **self-contained** inline SVG texture as a data URL (no external refs). It should now go through moderation as markup and be publishable.
2. Try the same with an SVG that embeds another image via `image-set('data:image/png;base64,…')`, including the escaped `'\64 ata:…'` form — it must **not** be treated as self-contained, and must fail closed.
3. Try an uppercase `DATA:image/png,%…` URL — it should be reviewed, not stuck unreviewable.
4. Try `data:image/svg+xml;base64;charset=utf-8,%3Csvg…` — should be reviewed, not garbage-decoded and blocked.
5. Try an SVG containing `<script>` or `<foreignObject>` — must fail closed.
6. Confirm a seller previously stuck with a permanently-blocked page can now save it.

## Review request

This is security-adjacent parsing on a path that can block a seller's page. Please pay particular attention to the fail-open/fail-closed direction of each new branch in `content_extractor.rb`, and to whether the CSS reference checker can still be evaded by a shape we did not enumerate.

## AI disclosure

Written by Gumroad's AI agent (claude-opus-5). Adversarially reviewed by fable-5 before this PR was opened; all three P1s were confirmed by empirical probes and fixed, as listed above.
