### PR TITLE
Make product-editor file attachment saves idempotent

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -539,7 +539,8 @@ class LinksController < ApplicationController
         product_permitted_params[:variants].each { rich_content_params.push(*_1[:rich_content]) } if product_permitted_params[:variants].present?
         rich_content_params = rich_content_params.flat_map { _1[:description] = _1.dig(:description, :content) }
         rich_contents_to_keep = []
-        SaveFilesService.perform(@product, product_permitted_params, rich_content_params, contract: product_save_contract)
+        file_id_mappings = SaveFilesService.perform(@product, product_permitted_params, rich_content_params, contract: product_save_contract)
+        save_id_mappings[:files].merge!(file_id_mappings) if file_id_mappings.present?
         existing_rich_contents = @product.alive_rich_contents.to_a
         rich_content.each.with_index do |product_rich_content, index|
           rich_content = existing_rich_contents.find { |c| c.external_id === product_rich_content[:id] } || @product.alive_rich_contents.build
@@ -689,10 +690,10 @@ class LinksController < ApplicationController
       }
     end
 
-    # The editor needs the canonical ids of records this save created (pages
-    # and variants submitted under client-generated ids) so its next save
+    # The editor needs the canonical ids of records this save created (pages,
+    # variants, and files submitted under client-generated ids) so its next save
     # addresses them instead of re-creating them — without this, saving twice
-    # without a reload trips the content deletion guard.
+    # without a reload trips the content deletion guard or re-attaches files.
     render json: save_id_mappings_response
   end
 
@@ -1438,11 +1439,11 @@ class LinksController < ApplicationController
     end
 
     # Accumulates client id → canonical server id for records this save
-    # creates (pages and variants submitted under client-generated ids).
+    # creates (pages, variants, and files submitted under client-generated ids).
     # Returned to the editor so its next save addresses the created records
     # instead of re-creating them (which would trip the deletion guards).
     def save_id_mappings
-      @_save_id_mappings ||= { variants: {}, rich_content: {}, removed_file_embeds: {} }
+      @_save_id_mappings ||= { variants: {}, rich_content: {}, files: {}, removed_file_embeds: {} }
     end
 
     # Snapshot stored move/copy provenance before this save can repair or
@@ -1635,6 +1636,7 @@ class LinksController < ApplicationController
       {
         variant_id_mappings: save_id_mappings[:variants],
         rich_content_id_mappings: save_id_mappings[:rich_content],
+        file_id_mappings: save_id_mappings[:files],
         rich_content_removed_file_embed_ids: save_id_mappings[:removed_file_embeds],
         **content_updated_at_response,
         # The revision token for the state this save just committed

--- a/app/javascript/components/ProductEdit/ContentTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.tsx
@@ -35,6 +35,7 @@ import { fetchDropboxFiles, ResponseDropboxFile, uploadDropboxFile } from "$app/
 import {
   copyRichContentPages,
   prepareRichContentPagesForMove,
+  reconcileMountedEditorFileEmbedIds,
   reconcileMountedEditorFileEmbeds,
   removedFileEmbedIdsForPage,
   resolveServerIdMapping,
@@ -184,6 +185,7 @@ const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: string | 
     uniquePermalink,
     filesById,
     richContentIdMappings,
+    fileIdMappings,
     richContentRemovedFileEmbedIds,
   } = useProductEditContext();
   const uid = React.useId();
@@ -343,6 +345,9 @@ const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: string | 
     onInputNonImageFiles: (files) => uploadFilesRef.current(files),
   });
   const removedFileEmbedIds = removedFileEmbedIdsForPage(selectedPage, richContentRemovedFileEmbedIds);
+  React.useEffect(() => {
+    if (editor) reconcileMountedEditorFileEmbedIds(editor, fileIdMappings);
+  }, [editor, fileIdMappings]);
   React.useEffect(() => {
     if (editor && removedFileEmbedIds?.length) {
       // A save can remove a legacy file node from product state while this

--- a/app/javascript/components/ProductEdit/ContentTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.tsx
@@ -661,8 +661,17 @@ const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: string | 
                         <Button
                           color="primary"
                           onClick={() => {
-                            updateProduct({ files: [...product.files, ...selectingExistingFiles.selected] });
-                            onSelectFiles(selectingExistingFiles.selected.map((file) => file.id));
+                            // A picked file already attached to this product is a deliberate
+                            // re-attach (e.g. embedding it on another version), so submit it
+                            // under a fresh client id: resending the row's canonical id would
+                            // resolve to the existing row on the server and no second row —
+                            // and no second embed target — would ever be created.
+                            const existingIds = new Set(product.files.map((file) => file.id));
+                            const selected = selectingExistingFiles.selected.map((file) =>
+                              existingIds.has(file.id) ? { ...file, id: FileUtils.generateGuid() } : file,
+                            );
+                            updateProduct({ files: [...product.files, ...selected] });
+                            onSelectFiles(selected.map((file) => file.id));
                             setSelectingExistingFiles(null);
                           }}
                         >

--- a/app/javascript/components/ProductEdit/state.ts
+++ b/app/javascript/components/ProductEdit/state.ts
@@ -275,6 +275,7 @@ export const ProductEditContext = React.createContext<{
   // a numeric database id, so a shared map cannot safely follow mapping chains.
   variantIdMappings: Record<string, string>;
   richContentIdMappings: Record<string, string>;
+  fileIdMappings: Record<string, string>;
   // Canonical page id → file ids removed by the last successful save. The
   // content tab uses this one-shot response signal to reconcile its mounted
   // TipTap document; changing product state alone does not update that editor.

--- a/app/javascript/components/server-components/ProductEditPage.tsx
+++ b/app/javascript/components/server-components/ProductEditPage.tsx
@@ -133,6 +133,7 @@ const createContextValue = (props: Props) => ({
   save: () => Promise.resolve(false),
   variantIdMappings: {},
   richContentIdMappings: {},
+  fileIdMappings: {},
   richContentRemovedFileEmbedIds: {},
   googleClientId: props.google_client_id,
   seller_refund_policy_enabled: props.seller_refund_policy_enabled,
@@ -245,6 +246,7 @@ const applyCanonicalIds = (
   sentPagesById: ReadonlyMap<string, ScopedPage> = new Map(),
 ) => {
   const variantMappings = response.variant_id_mappings ?? {};
+  const fileMappings = response.file_id_mappings ?? {};
   const variantTimestamps = response.variant_updated_at ?? {};
   const variantBaselines = response.variant_loaded_integrations ?? {};
   // Adopt the revision token for the state this save committed. The token the
@@ -259,6 +261,10 @@ const applyCanonicalIds = (
   // connect -> save -> disconnect -> save (no reload) emits no deletion,
   // because the stale baseline still says the integration was never on.
   if (response.loaded_integrations) product.loaded_integrations = response.loaded_integrations;
+  for (const file of product.files) {
+    const canonicalId = fileMappings[file.id];
+    if (canonicalId) file.id = canonicalId;
+  }
   for (const variant of product.variants) {
     const canonicalId = variantMappings[variant.id];
     if (canonicalId) {
@@ -364,6 +370,7 @@ const ProductEditPage = (props: Props) => {
   // variant and page external ids are not distinct namespaces.
   const [variantIdMappings, setVariantIdMappings] = React.useState<Record<string, string>>({});
   const [richContentIdMappings, setRichContentIdMappings] = React.useState<Record<string, string>>({});
+  const [fileIdMappings, setFileIdMappings] = React.useState<Record<string, string>>({});
   const [richContentRemovedFileEmbedIds, setRichContentRemovedFileEmbedIds] = React.useState<Record<string, string[]>>(
     {},
   );
@@ -451,6 +458,7 @@ const ProductEditPage = (props: Props) => {
       lastSavedProductRef.current = reconciled;
       setVariantIdMappings((previous) => ({ ...previous, ...response.variant_id_mappings }));
       setRichContentIdMappings((previous) => ({ ...previous, ...response.rich_content_id_mappings }));
+      setFileIdMappings((previous) => ({ ...previous, ...response.file_id_mappings }));
       setRichContentRemovedFileEmbedIds(response.rich_content_removed_file_embed_ids ?? {});
       updateProduct((current) => {
         applyCanonicalIds(current, response, sentPagesById);
@@ -551,6 +559,7 @@ const ProductEditPage = (props: Props) => {
       saving,
       variantIdMappings,
       richContentIdMappings,
+      fileIdMappings,
       richContentRemovedFileEmbedIds,
       contentUpdates,
       setContentUpdates,
@@ -564,6 +573,7 @@ const ProductEditPage = (props: Props) => {
       filesById,
       variantIdMappings,
       richContentIdMappings,
+      fileIdMappings,
       richContentRemovedFileEmbedIds,
     ],
   );

--- a/app/javascript/components/server-components/ProductEditPage.tsx
+++ b/app/javascript/components/server-components/ProductEditPage.tsx
@@ -261,10 +261,14 @@ const applyCanonicalIds = (
   // connect -> save -> disconnect -> save (no reload) emits no deletion,
   // because the stale baseline still says the integration was never on.
   if (response.loaded_integrations) product.loaded_integrations = response.loaded_integrations;
-  for (const file of product.files) {
+  // Replace the array, don't mutate entries: `filesById` memoizes on
+  // `product.files` identity, and the mounted editor's node ids are remapped to
+  // the canonical ids in the same commit. A stale Map misses every lookup and
+  // the embed renders blank.
+  product.files = product.files.map((file) => {
     const canonicalId = fileMappings[file.id];
-    if (canonicalId) file.id = canonicalId;
-  }
+    return canonicalId ? { ...file, id: canonicalId } : file;
+  });
   for (const variant of product.variants) {
     const canonicalId = variantMappings[variant.id];
     if (canonicalId) {

--- a/app/javascript/data/product_edit.test.ts
+++ b/app/javascript/data/product_edit.test.ts
@@ -4,7 +4,9 @@ import { EditorState, TextSelection } from "@tiptap/pm/state";
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  applyFileIdMappingsToRichContent,
   applyRichContentPageSaveResponse,
+  buildRichContentFileIdMappingTransaction,
   buildRichContentReconciliationTransaction,
   HiddenVariantContentConflictError,
   canonicalRichContentScope,
@@ -309,6 +311,46 @@ describe("overlapping save reconciliation", () => {
 });
 
 describe("removeFileEmbedsFromRichContent", () => {
+  it("rewrites mapped file embed ids throughout rich content", () => {
+    const page = {
+      id: "page",
+      title: "Files",
+      updated_at: "before",
+      description: {
+        type: "doc",
+        content: [
+          { type: "fileEmbed", attrs: { id: "temporary-file", uid: "file-uid" } },
+          {
+            type: "fileEmbedGroup",
+            attrs: { uid: "group-uid" },
+            content: [
+              { type: "fileEmbed", attrs: { id: "temporary-file", uid: "group-file-uid" } },
+              { type: "fileEmbed", attrs: { id: "keep-file", uid: "keep-uid" } },
+            ],
+          },
+        ],
+      },
+    };
+
+    applyRichContentPageSaveResponse(page, { file_id_mappings: { "temporary-file": "canonical-file" } });
+    expect(page.description).toEqual({
+      type: "doc",
+      content: [
+        { type: "fileEmbed", attrs: { id: "canonical-file", uid: "file-uid" } },
+        {
+          type: "fileEmbedGroup",
+          attrs: { uid: "group-uid" },
+          content: [
+            { type: "fileEmbed", attrs: { id: "canonical-file", uid: "group-file-uid" } },
+            { type: "fileEmbed", attrs: { id: "keep-file", uid: "keep-uid" } },
+          ],
+        },
+      ],
+    });
+
+    expect(applyFileIdMappingsToRichContent(page.description, { missing: "unused" })).toEqual(page.description);
+  });
+
   it("removes reported embeds, prunes empty groups, and preserves other content", () => {
     const description = {
       type: "doc",
@@ -406,6 +448,64 @@ describe("removeFileEmbedsFromRichContent", () => {
     expect(undoneState.doc.toJSON()).toEqual({
       type: "doc",
       content: [{ type: "paragraph", content: [{ type: "text", text: "First edit" }] }],
+    });
+  });
+
+  it("keeps mounted-editor file id remapping out of undo history", () => {
+    const schema = new Schema({
+      nodes: {
+        doc: { content: "block+" },
+        paragraph: { group: "block", content: "text*" },
+        text: {},
+        fileEmbed: {
+          group: "block",
+          atom: true,
+          attrs: { id: { default: null }, uid: { default: null } },
+        },
+      },
+    });
+    const originalDocument = schema.nodeFromJSON({
+      type: "doc",
+      content: [
+        { type: "fileEmbed", attrs: { id: "temporary-file", uid: "file-uid" } },
+        { type: "paragraph", content: [{ type: "text", text: "Saved text" }] },
+      ],
+    });
+    let state = EditorState.create({
+      doc: originalDocument,
+      plugins: [history()],
+    });
+    const editTransaction = state.tr.insertText(
+      " still editing",
+      originalDocument.child(0).nodeSize + "Saved".length + 1,
+    );
+    state = state.apply(editTransaction);
+    const transaction = buildRichContentFileIdMappingTransaction(state, { "temporary-file": "canonical-file" });
+
+    expect(transaction.getMeta("addToHistory")).toBe(false);
+    expect(transaction.getMeta("preventUpdate")).toBe(true);
+
+    const reconciledState = state.apply(transaction);
+    expect(reconciledState.doc.toJSON()).toEqual({
+      type: "doc",
+      content: [
+        { type: "fileEmbed", attrs: { id: "canonical-file", uid: "file-uid" } },
+        { type: "paragraph", content: [{ type: "text", text: "Saved still editing text" }] },
+      ],
+    });
+
+    let undoneState = reconciledState;
+    expect(
+      undo(reconciledState, (undoTransaction) => {
+        undoneState = reconciledState.apply(undoTransaction);
+      }),
+    ).toBe(true);
+    expect(undoneState.doc.toJSON()).toEqual({
+      type: "doc",
+      content: [
+        { type: "fileEmbed", attrs: { id: "canonical-file", uid: "file-uid" } },
+        { type: "paragraph", content: [{ type: "text", text: "Saved text" }] },
+      ],
     });
   });
 });

--- a/app/javascript/data/product_edit.ts
+++ b/app/javascript/data/product_edit.ts
@@ -1,4 +1,5 @@
 import { Editor, findChildren } from "@tiptap/core";
+import { type Mark } from "@tiptap/pm/model";
 import { EditorState, Transaction } from "@tiptap/pm/state";
 import typia from "typia";
 
@@ -13,12 +14,13 @@ import { baseEditorOptions } from "$app/components/RichTextEditor";
 
 export type SaveProductResponse = {
   warning_message?: string;
-  // Client-generated id → canonical server id for variants/pages this save
+  // Client-generated id → canonical server id for variants/pages/files this save
   // created. The editor swaps its ids for these so the next save updates the
   // created records instead of re-creating them (re-creation trips the
-  // server's content deletion guard and duplicates variants).
+  // server's content deletion guard, duplicates variants, or re-attaches files).
   variant_id_mappings?: Record<string, string>;
   rich_content_id_mappings?: Record<string, string>;
+  file_id_mappings?: Record<string, string>;
   // Canonical page id → file external ids removed while repairing legacy
   // content. The editor removes the same invisible nodes from its live state,
   // otherwise its next save would resubmit them as newly introduced embeds.
@@ -285,12 +287,40 @@ export const applyRichContentPageSaveResponse = (
     }
   }
 
+  if (response.file_id_mappings && Object.keys(response.file_id_mappings).length > 0) {
+    page.description = applyFileIdMappingsToRichContent(page.description, response.file_id_mappings);
+  }
   const removedIds = removedFileEmbedIdsForPage(page, response.rich_content_removed_file_embed_ids ?? {});
   if (removedIds?.length) {
     page.description = removeFileEmbedsFromRichContent(page.description, new Set(removedIds));
   }
   const timestamp = response.rich_content_updated_at?.[page.id];
   if (timestamp) page.updated_at = timestamp;
+};
+
+const applyFileIdMappings = (value: unknown, fileIdMappings: Record<string, string>): unknown => {
+  if (Array.isArray(value)) return value.map((child) => applyFileIdMappings(child, fileIdMappings));
+  if (!isRecord(value)) return value;
+
+  const mapped = { ...value };
+  if (
+    mapped.type === "fileEmbed" &&
+    isRecord(mapped.attrs) &&
+    typeof mapped.attrs.id === "string" &&
+    fileIdMappings[mapped.attrs.id]
+  ) {
+    mapped.attrs = { ...mapped.attrs, id: fileIdMappings[mapped.attrs.id] };
+  }
+  if ("content" in mapped) mapped.content = applyFileIdMappings(mapped.content, fileIdMappings);
+  return mapped;
+};
+
+export const applyFileIdMappingsToRichContent = (
+  description: object,
+  fileIdMappings: Record<string, string>,
+): object => {
+  const mapped = applyFileIdMappings(description, fileIdMappings);
+  return isRecord(mapped) ? mapped : description;
 };
 
 const removeFileEmbeds = (value: unknown, fileIds: Set<string>): unknown => {
@@ -356,8 +386,35 @@ export const buildRichContentReconciliationTransaction = (
   return transaction;
 };
 
+export const buildRichContentFileIdMappingTransaction = (
+  state: EditorState,
+  fileIdMappings: Record<string, string>,
+): Transaction => {
+  const updates: { pos: number; attrs: Record<string, unknown>; marks: readonly Mark[] }[] = [];
+  state.doc.descendants((node, pos) => {
+    if (node.type.name === FileEmbed.name && typeof node.attrs.id === "string") {
+      const canonicalId = fileIdMappings[node.attrs.id];
+      if (canonicalId) updates.push({ pos, attrs: { ...node.attrs, id: canonicalId }, marks: node.marks });
+    }
+    return true;
+  });
+
+  const transaction = state.tr;
+  for (const update of updates) {
+    transaction.setNodeMarkup(update.pos, undefined, update.attrs, update.marks);
+  }
+  transaction.setMeta("addToHistory", false);
+  transaction.setMeta("preventUpdate", true);
+  return transaction;
+};
+
 export const reconcileMountedEditorFileEmbeds = (editor: Editor, removedFileIds: string[]): void => {
   const transaction = buildRichContentReconciliationTransaction(editor.state, new Set(removedFileIds));
+  if (transaction.docChanged) editor.view.dispatch(transaction);
+};
+
+export const reconcileMountedEditorFileEmbedIds = (editor: Editor, fileIdMappings: Record<string, string>): void => {
+  const transaction = buildRichContentFileIdMappingTransaction(editor.state, fileIdMappings);
   if (transaction.docChanged) editor.view.dispatch(transaction);
 };
 

--- a/app/modules/with_product_files.rb
+++ b/app/modules/with_product_files.rb
@@ -43,8 +43,12 @@ module WithProductFiles
   def save_files!(files_params, rich_content_params = [], delete_missing: true)
     files_to_keep = []
     new_product_files = []
-    existing_files = alive_product_files
+    # dup: rows created below are appended to this list, and `alive_product_files`
+    # is memoized — mutating it in place grows callers' own snapshots of what was
+    # alive before the save (SaveFilesService's clear-all target).
+    existing_files = alive_product_files.dup
     existing_files_by_external_id = existing_files.index_by(&:external_id)
+    directly_addressed_files = files_params.filter_map { existing_files_by_external_id[_1[:external_id] || _1[:id]] }
     should_check_pdf_stampability = false
     file_id_mappings = {}
 
@@ -53,7 +57,7 @@ module WithProductFiles
 
       begin
         external_id = file_params.delete(:external_id) || file_params.delete(:id)
-        product_file = existing_files_by_external_id[external_id] || reusable_product_file_for(file_params, existing_files) || product_files.build(url: file_params[:url])
+        product_file = existing_files_by_external_id[external_id] || reusable_product_file_for(file_params, existing_files - directly_addressed_files) || product_files.build(url: file_params[:url])
         files_to_keep << product_file
 
         # Defaults to true so that usage sites of this function continue

--- a/app/modules/with_product_files.rb
+++ b/app/modules/with_product_files.rb
@@ -48,7 +48,6 @@ module WithProductFiles
     # alive before the save (SaveFilesService's clear-all target).
     existing_files = alive_product_files.dup
     existing_files_by_external_id = existing_files.index_by(&:external_id)
-    directly_addressed_files = files_params.filter_map { existing_files_by_external_id[_1[:external_id] || _1[:id]] }
     should_check_pdf_stampability = false
     file_id_mappings = {}
 
@@ -57,7 +56,7 @@ module WithProductFiles
 
       begin
         external_id = file_params.delete(:external_id) || file_params.delete(:id)
-        product_file = existing_files_by_external_id[external_id] || reusable_product_file_for(file_params, existing_files - directly_addressed_files) || product_files.build(url: file_params[:url])
+        product_file = existing_files_by_external_id[external_id] || reusable_product_file_for(file_params, existing_files) || product_files.build(url: file_params[:url])
         files_to_keep << product_file
 
         # Defaults to true so that usage sites of this function continue

--- a/app/modules/with_product_files.rb
+++ b/app/modules/with_product_files.rb
@@ -46,14 +46,14 @@ module WithProductFiles
     existing_files = alive_product_files
     existing_files_by_external_id = existing_files.index_by(&:external_id)
     should_check_pdf_stampability = false
-    rich_content_id_mappings = {}
+    file_id_mappings = {}
 
     files_params.each do |file_params|
       next unless file_params[:url].present?
 
       begin
         external_id = file_params.delete(:external_id) || file_params.delete(:id)
-        product_file = existing_files_by_external_id[external_id] || product_files.build(url: file_params[:url])
+        product_file = existing_files_by_external_id[external_id] || reusable_product_file_for(file_params, existing_files) || product_files.build(url: file_params[:url])
         files_to_keep << product_file
 
         # Defaults to true so that usage sites of this function continue
@@ -75,7 +75,14 @@ module WithProductFiles
 
         should_check_pdf_stampability = true if product_file.saved_change_to_pdf_stamp_enabled? && product_file.pdf_stamp_enabled?
 
-        rich_content_id_mappings[external_id] = product_file.external_id if external_id != product_file.external_id
+        if external_id.present? && external_id != product_file.external_id
+          file_id_mappings[external_id] = product_file.external_id
+          existing_files_by_external_id[external_id] = product_file
+        end
+        unless existing_files_by_external_id.key?(product_file.external_id)
+          existing_files << product_file
+          existing_files_by_external_id[product_file.external_id] = product_file
+        end
         save_subtitle_files(product_file, subtitle_files_params)
         product_file.thumbnail.attach thumbnail_signed_id if thumbnail_signed_id.present?
       rescue ActiveRecord::RecordInvalid => e
@@ -86,8 +93,8 @@ module WithProductFiles
       end
     end
 
-    if rich_content_id_mappings.any?
-      rich_content_params.each { apply_rich_content_id_mappings(_1, rich_content_id_mappings) }
+    if file_id_mappings.any?
+      rich_content_params.each { apply_rich_content_id_mappings(_1, file_id_mappings) }
     end
 
     (existing_files - files_to_keep).each(&:mark_deleted) if delete_missing
@@ -97,6 +104,7 @@ module WithProductFiles
     link.content_updated_at = Time.current if new_product_files.any?(&:link_id?)
     PdfUnstampableNotifierJob.perform_in(5.seconds, link.id) if is_a?(Link) && should_check_pdf_stampability
     link&.enqueue_index_update_for(["filetypes"])
+    file_id_mappings
   end
 
   def transcode_videos!(queue: TranscodeVideoForStreamingWorker.sidekiq_options["queue"], first_batch_size: 30, additional_delay_after_first_batch: 5.minutes)
@@ -251,6 +259,58 @@ module WithProductFiles
     rescue ActiveRecord::RecordInvalid => e
       errors.add(:base, e.message)
       raise e
+    end
+
+    def reusable_product_file_for(file_params, existing_files)
+      matching_url_files = existing_files.select { _1.url == file_params[:url] }
+      return preferred_product_file(matching_url_files, existing_files) if matching_url_files.any?
+
+      matching_fingerprint_product_file_for(file_params, existing_files)
+    end
+
+    def matching_fingerprint_product_file_for(file_params, existing_files)
+      size = ActiveModel::Type::Integer.new.cast(file_params[:size])
+      return if size.nil?
+
+      submitted_file = ProductFile.new(url: file_params[:url])
+      return unless submitted_file.s3?
+
+      submitted_etag = s3_etag_for(submitted_file)
+      return if submitted_etag.blank?
+
+      candidates = existing_files.select { _1.s3? && _1.size == size }
+      preferred_product_files(candidates, existing_files).detect { s3_etag_for(_1) == submitted_etag }
+    end
+
+    def preferred_product_file(candidates, existing_files)
+      preferred_product_files(candidates, existing_files).first
+    end
+
+    def preferred_product_files(candidates, existing_files)
+      return candidates if candidates.size <= 1
+
+      referenced_external_ids = referenced_product_file_external_ids(existing_files)
+      candidates.sort_by do |file|
+        [
+          referenced_external_ids.include?(file.external_id) ? 0 : 1,
+          file.created_at || Time.zone.at(0),
+          file.id || 0,
+        ]
+      end
+    end
+
+    def referenced_product_file_external_ids(existing_files)
+      file_ids = []
+      file_ids.concat(alive_rich_contents.flat_map(&:embedded_product_file_ids_in_order)) if respond_to?(:alive_rich_contents)
+      file_ids.concat(alive_variants.flat_map { _1.alive_rich_contents.flat_map(&:embedded_product_file_ids_in_order) }) if respond_to?(:alive_variants)
+
+      existing_files.select { file_ids.include?(_1.id) }.map(&:external_id).to_set
+    end
+
+    def s3_etag_for(product_file)
+      product_file.s3_object.etag
+    rescue Aws::S3::Errors::ServiceError, Seahorse::Client::NetworkingError
+      nil
     end
 
     # Private: associate_dropbox_file_and_product_file

--- a/app/modules/with_product_files.rb
+++ b/app/modules/with_product_files.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 module WithProductFiles
+  # Each fingerprint comparison is a synchronous S3 HEAD on the save request, so
+  # the scan is capped. A true match past the cap re-creates a row — the rare
+  # pre-existing duplicate — which beats an unbounded save stalling or timing out.
+  FINGERPRINT_MATCH_MAX_CANDIDATES = 5
+
   def self.included(base)
     base.class_eval do
       has_many :product_files
@@ -291,7 +296,9 @@ module WithProductFiles
       submitted_etag = s3_etag_for(submitted_file)
       return if submitted_etag.blank?
 
-      preferred_product_files(candidates, existing_files).detect { s3_etag_for(_1) == submitted_etag }
+      preferred_product_files(candidates, existing_files)
+        .first(FINGERPRINT_MATCH_MAX_CANDIDATES)
+        .detect { s3_etag_for(_1) == submitted_etag }
     end
 
     def preferred_product_file(candidates, existing_files)

--- a/app/modules/with_product_files.rb
+++ b/app/modules/with_product_files.rb
@@ -48,6 +48,11 @@ module WithProductFiles
     # alive before the save (SaveFilesService's clear-all target).
     existing_files = alive_product_files.dup
     existing_files_by_external_id = existing_files.index_by(&:external_id)
+    # Rows the payload names by their canonical id are off-limits as dedupe
+    # targets: a retry can't name an id the client never received, so a named
+    # row means the client wants BOTH — the picker re-embedding a file already
+    # on the product, or a sibling version attaching it.
+    directly_addressed_files = files_params.filter_map { existing_files_by_external_id[_1[:external_id] || _1[:id]] }
     should_check_pdf_stampability = false
     file_id_mappings = {}
 
@@ -56,7 +61,7 @@ module WithProductFiles
 
       begin
         external_id = file_params.delete(:external_id) || file_params.delete(:id)
-        product_file = existing_files_by_external_id[external_id] || reusable_product_file_for(file_params, existing_files) || product_files.build(url: file_params[:url])
+        product_file = existing_files_by_external_id[external_id] || reusable_product_file_for(file_params, existing_files - directly_addressed_files) || product_files.build(url: file_params[:url])
         files_to_keep << product_file
 
         # Defaults to true so that usage sites of this function continue
@@ -278,10 +283,14 @@ module WithProductFiles
       submitted_file = ProductFile.new(url: file_params[:url])
       return unless submitted_file.s3?
 
+      # Candidate check first: a genuinely new attach almost never has one, and
+      # every S3 HEAD below is a synchronous round trip on the save request.
+      candidates = existing_files.select { _1.s3? && _1.size == size }
+      return if candidates.empty?
+
       submitted_etag = s3_etag_for(submitted_file)
       return if submitted_etag.blank?
 
-      candidates = existing_files.select { _1.s3? && _1.size == size }
       preferred_product_files(candidates, existing_files).detect { s3_etag_for(_1) == submitted_etag }
     end
 

--- a/app/services/save_files_service.rb
+++ b/app/services/save_files_service.rb
@@ -78,11 +78,12 @@ class SaveFilesService
       # can never be swept up by a clear-all sent alongside them.
       preexisting_files = owner.alive_product_files.to_a
 
+      file_id_mappings = {}
       if contract.submitted?(:files)
         # The collection was actually submitted: apply creates/updates as
         # before, but `delete_missing: false` — under the contract, a file
         # missing from the payload is "no statement", not "delete me".
-        owner.save_files!(updated_file_params(params[:files]), rich_content_params, delete_missing: false)
+        file_id_mappings = owner.save_files!(updated_file_params(params[:files]), rich_content_params, delete_missing: false)
       end
       # else: absent or [] means "this request isn't about files" (Rule 1) —
       # there is nothing to create or update, and nothing gets deleted.
@@ -94,7 +95,7 @@ class SaveFilesService
           ids = contract.deleted_ids(:files)
           ids.any? ? preexisting_files.select { ids.include?(_1.external_id) } : []
         end
-      return if files_to_delete.empty?
+      return file_id_mappings if files_to_delete.empty?
 
       # An id that is both kept in the payload and listed in deleted_ids is
       # contradictory; the explicit, revision-gated deletion wins — it is the
@@ -102,6 +103,7 @@ class SaveFilesService
       files_to_delete.each { _1.mark_deleted unless _1.deleted? }
       owner.cached_alive_product_files = nil
       owner.link&.enqueue_index_update_for(["filetypes"])
+      file_id_mappings
     end
 
     def updated_file_params(all_file_params)

--- a/spec/modules/with_product_files_spec.rb
+++ b/spec/modules/with_product_files_spec.rb
@@ -380,6 +380,23 @@ describe WithProductFiles do
         expect(requested_keys).to include(s3_key_for(original_url), s3_key_for(new_url))
       end
 
+      it "caps S3 fingerprint lookups when many same-size files share no matching ETag" do
+        product = create(:product)
+        cap = WithProductFiles::FINGERPRINT_MATCH_MAX_CANDIDATES
+        new_url = "#{S3_BASE_URL}attachments/fingerprint-capped/original/guide.pdf"
+        candidate_urls = (1..cap + 2).map { "#{S3_BASE_URL}attachments/fingerprint-candidate-#{_1}/original/guide.pdf" }
+        candidate_urls.each { create(:product_file, link: product, url: _1, size: 123) }
+        requested_keys = stub_s3_etags(
+          candidate_urls.each_with_index.to_h { |url, i| [s3_key_for(url), "\"candidate-etag-#{i}\""] }
+            .merge(s3_key_for(new_url) => "\"submitted-etag\""),
+        )
+
+        expect do
+          product.save_files!([{ external_id: SecureRandom.uuid, url: new_url, size: 123, display_name: "Guide" }], delete_missing: false)
+        end.to change { product.product_files.alive.count }.by(1)
+        expect(requested_keys.size).to eq(cap + 1)
+      end
+
       it "prefers a referenced duplicate file row before the oldest matching row" do
         product = create(:product)
         url = "#{S3_BASE_URL}attachments/referenced/original/guide.pdf"

--- a/spec/modules/with_product_files_spec.rb
+++ b/spec/modules/with_product_files_spec.rb
@@ -317,21 +317,6 @@ describe WithProductFiles do
     context "when called on a Link record" do
       let(:product) { create(:product_with_pdf_files_with_size) }
 
-      it "does not reuse a row another param in the same request addresses by external_id" do
-        product = create(:product)
-        url = "#{S3_BASE_URL}attachments/shared/original/guide.pdf"
-        existing = product.product_files.create!(url:, size: 123)
-        fresh_id = SecureRandom.uuid
-
-        product.save_files!(
-          [{ external_id: existing.external_id, url:, size: 123 }, { external_id: fresh_id, url:, size: 123 }],
-          [],
-          delete_missing: false
-        )
-
-        expect(product.product_files.alive.count).to eq(2)
-      end
-
       it "reuses the same row across repeated identical editor retry requests" do
         product = create(:product)
         url = "#{S3_BASE_URL}attachments/retry/original/guide.pdf"

--- a/spec/modules/with_product_files_spec.rb
+++ b/spec/modules/with_product_files_spec.rb
@@ -297,8 +297,117 @@ describe WithProductFiles do
   end
 
   describe "#save_files!" do
+    def stub_s3_etags(etags_by_key)
+      requested_keys = []
+      resource = double("s3 resource")
+      bucket = double("s3 bucket")
+      allow(Aws::S3::Resource).to receive(:new).and_return(resource)
+      allow(resource).to receive(:bucket).with(S3_BUCKET).and_return(bucket)
+      allow(bucket).to receive(:object) do |key|
+        requested_keys << key
+        double("s3 object", etag: etags_by_key.fetch(key))
+      end
+      requested_keys
+    end
+
+    def s3_key_for(url)
+      ProductFile.new(url:).s3_key
+    end
+
     context "when called on a Link record" do
       let(:product) { create(:product_with_pdf_files_with_size) }
+
+      it "reuses the same row across repeated identical editor retry requests" do
+        product = create(:product)
+        url = "#{S3_BASE_URL}attachments/retry/original/guide.pdf"
+
+        5.times do
+          temporary_id = SecureRandom.uuid
+          rich_content_params = [{ "type" => "fileEmbed", "attrs" => { "id" => temporary_id, "uid" => SecureRandom.uuid } }]
+          file_id_mappings = product.save_files!([{ external_id: temporary_id, url:, size: 123 }], rich_content_params, delete_missing: false)
+          product_file = product.product_files.alive.sole
+
+          expect(file_id_mappings).to eq(temporary_id => product_file.external_id)
+          expect(rich_content_params.first.dig("attrs", "id")).to eq(product_file.external_id)
+        end
+
+        expect(product.product_files.alive.count).to eq(1)
+      end
+
+      it "returns file id mappings so consecutive saves reuse the canonical file id without a reload" do
+        product = create(:product)
+        url = "#{S3_BASE_URL}attachments/consecutive/original/guide.pdf"
+        temporary_id = SecureRandom.uuid
+        first_mapping = product.save_files!([{ external_id: temporary_id, url:, size: 123 }], [{ "type" => "fileEmbed", "attrs" => { "id" => temporary_id } }], delete_missing: false)
+        canonical_id = first_mapping.fetch(temporary_id)
+
+        expect do
+          product.save_files!([{ external_id: canonical_id, url:, size: 123 }], [{ "type" => "fileEmbed", "attrs" => { "id" => canonical_id } }], delete_missing: false)
+        end.not_to change { product.product_files.alive.count }
+      end
+
+      it "dedupes files with different urls when their S3 ETag and size match" do
+        product = create(:product)
+        original_url = "#{S3_BASE_URL}attachments/fingerprint/original/guide.pdf"
+        retried_url = "#{S3_BASE_URL}attachments/fingerprint-retry/original/guide.pdf"
+        original_file = create(:product_file, link: product, url: original_url, size: 123)
+        temporary_id = SecureRandom.uuid
+        requested_keys = stub_s3_etags(
+          s3_key_for(original_url) => "\"same-etag\"",
+          s3_key_for(retried_url) => "\"same-etag\"",
+        )
+
+        expect do
+          file_id_mappings = product.save_files!([{ external_id: temporary_id, url: retried_url, size: 123, display_name: "Guide" }], delete_missing: false)
+          expect(file_id_mappings).to eq(temporary_id => original_file.external_id)
+        end.not_to change { product.product_files.alive.count }
+        expect(requested_keys).to include(s3_key_for(original_url), s3_key_for(retried_url))
+      end
+
+      it "keeps same-name same-size files with different S3 fingerprints separate" do
+        product = create(:product)
+        original_url = "#{S3_BASE_URL}attachments/fingerprint-a/original/guide.pdf"
+        new_url = "#{S3_BASE_URL}attachments/fingerprint-b/original/guide.pdf"
+        create(:product_file, link: product, url: original_url, size: 123, display_name: "Guide")
+        requested_keys = stub_s3_etags(
+          s3_key_for(original_url) => "\"first-etag\"",
+          s3_key_for(new_url) => "\"second-etag\"",
+        )
+
+        expect do
+          product.save_files!([{ external_id: SecureRandom.uuid, url: new_url, size: 123, display_name: "Guide" }], delete_missing: false)
+        end.to change { product.product_files.alive.count }.by(1)
+        expect(requested_keys).to include(s3_key_for(original_url), s3_key_for(new_url))
+      end
+
+      it "prefers a referenced duplicate file row before the oldest matching row" do
+        product = create(:product)
+        url = "#{S3_BASE_URL}attachments/referenced/original/guide.pdf"
+        create(:product_file, link: product, url:, size: 123, created_at: 2.days.ago)
+        referenced_file = create(:product_file, link: product, url:, size: 123, created_at: 1.day.ago)
+        create(:rich_content, entity: product, description: [
+                 { "type" => "fileEmbed", "attrs" => { "id" => referenced_file.external_id, "uid" => SecureRandom.uuid } },
+               ])
+        temporary_id = SecureRandom.uuid
+
+        expect do
+          file_id_mappings = product.save_files!([{ external_id: temporary_id, url:, size: 123 }], delete_missing: false)
+          expect(file_id_mappings).to eq(temporary_id => referenced_file.external_id)
+        end.not_to change { product.product_files.alive.count }
+      end
+
+      it "prefers the oldest duplicate file row when none are referenced" do
+        product = create(:product)
+        url = "#{S3_BASE_URL}attachments/oldest/original/guide.pdf"
+        oldest_file = create(:product_file, link: product, url:, size: 123, created_at: 2.days.ago)
+        create(:product_file, link: product, url:, size: 123, created_at: 1.day.ago)
+        temporary_id = SecureRandom.uuid
+
+        expect do
+          file_id_mappings = product.save_files!([{ external_id: temporary_id, url:, size: 123 }], delete_missing: false)
+          expect(file_id_mappings).to eq(temporary_id => oldest_file.external_id)
+        end.not_to change { product.product_files.alive.count }
+      end
 
       it "enqueues a `PdfUnstampableNotifierJob` job when new stampable files are added" do
         product_files_params = product.product_files.each_with_object([]) { |file, params| params << { external_id: file.external_id, url: file.url } }

--- a/spec/modules/with_product_files_spec.rb
+++ b/spec/modules/with_product_files_spec.rb
@@ -317,6 +317,21 @@ describe WithProductFiles do
     context "when called on a Link record" do
       let(:product) { create(:product_with_pdf_files_with_size) }
 
+      it "does not reuse a row another param in the same request addresses by external_id" do
+        product = create(:product)
+        url = "#{S3_BASE_URL}attachments/shared/original/guide.pdf"
+        existing = product.product_files.create!(url:, size: 123)
+        fresh_id = SecureRandom.uuid
+
+        product.save_files!(
+          [{ external_id: existing.external_id, url:, size: 123 }, { external_id: fresh_id, url:, size: 123 }],
+          [],
+          delete_missing: false
+        )
+
+        expect(product.product_files.alive.count).to eq(2)
+      end
+
       it "reuses the same row across repeated identical editor retry requests" do
         product = create(:product)
         url = "#{S3_BASE_URL}attachments/retry/original/guide.pdf"

--- a/test/controllers/links_controller_test.rb
+++ b/test/controllers/links_controller_test.rb
@@ -3294,6 +3294,136 @@ class LinksControllerUpdateTest < ActionController::TestCase
     urls.map { { id: SecureRandom.uuid, url: _1 } }
   end
 
+  def stub_s3_etags(etags_by_key)
+    requested_keys = []
+    s3_object = Struct.new(:etag)
+    bucket = Object.new
+    bucket.define_singleton_method(:object) do |key|
+      requested_keys << key
+      s3_object.new(etags_by_key.fetch(key))
+    end
+    resource = Object.new
+    resource.define_singleton_method(:bucket) do |bucket_name|
+      raise "Unexpected bucket #{bucket_name}" unless bucket_name == S3_BUCKET
+
+      bucket
+    end
+    Aws::S3::Resource.stubs(:new).returns(resource)
+    requested_keys
+  end
+
+  def s3_key_for(url)
+    ProductFile.new(url:).s3_key
+  end
+
+  def clear_setup_files
+    @product.product_files.alive.each(&:mark_deleted!)
+    @product.cached_alive_product_files = nil
+  end
+
+  test "PUT update reuses the same file row across repeated identical editor retry requests" do
+    Feature.activate_user(Product::SaveContract::FEATURE_NAME, @seller)
+    clear_setup_files
+    rich_content = create_product_rich_content(entity: @product, description: [{ "type" => "paragraph" }])
+    url = "#{S3_BASE_URL}attachments/retry/original/guide.pdf"
+
+    5.times do
+      temporary_id = SecureRandom.uuid
+      post :update, params: @params.merge(
+        files: [{ id: temporary_id, url:, size: 123 }],
+        rich_content: [{ id: rich_content.external_id, title: "Files", description: { type: "doc", content: [{ type: "fileEmbed", attrs: { id: temporary_id, uid: SecureRandom.uuid } }] } }]
+      ), format: :json
+
+      assert_response :success
+      product_file = @product.product_files.alive.sole
+      assert_equal product_file.external_id, response.parsed_body.dig("file_id_mappings", temporary_id)
+      assert_equal [product_file.id], rich_content.reload.embedded_product_file_ids_in_order
+    end
+
+    assert_equal 1, @product.product_files.alive.count
+  end
+
+  test "PUT update returns file id mappings and a consecutive save without reload reuses the file row" do
+    Feature.activate_user(Product::SaveContract::FEATURE_NAME, @seller)
+    clear_setup_files
+    rich_content = create_product_rich_content(entity: @product, description: [{ "type" => "paragraph" }])
+    url = "#{S3_BASE_URL}attachments/consecutive/original/guide.pdf"
+    temporary_id = SecureRandom.uuid
+
+    post :update, params: @params.merge(
+      files: [{ id: temporary_id, url:, size: 123 }],
+      rich_content: [{ id: rich_content.external_id, title: "Files", description: { type: "doc", content: [{ type: "fileEmbed", attrs: { id: temporary_id, uid: "file-uid" } }] } }]
+    ), format: :json
+
+    assert_response :success
+    product_file = @product.product_files.alive.sole
+    canonical_id = response.parsed_body.dig("file_id_mappings", temporary_id)
+    assert_equal product_file.external_id, canonical_id
+
+    post :update, params: @params.merge(
+      files: [{ id: canonical_id, url:, size: 123 }],
+      rich_content: [{ id: rich_content.external_id, title: "Files", description: { type: "doc", content: [{ type: "fileEmbed", attrs: { id: canonical_id, uid: "file-uid" } }] } }]
+    ), format: :json
+
+    assert_response :success
+    assert_equal [product_file.id], @product.reload.product_files.alive.ids
+    assert_equal [product_file.id], rich_content.reload.embedded_product_file_ids_in_order
+  end
+
+  test "PUT update dedupes different urls when S3 ETag and size match" do
+    clear_setup_files
+    original_url = "#{S3_BASE_URL}attachments/fingerprint/original/guide.pdf"
+    retried_url = "#{S3_BASE_URL}attachments/fingerprint-retry/original/guide.pdf"
+    product_file = create_product_file(link: @product, url: original_url, size: 123, display_name: "Guide")
+    temporary_id = SecureRandom.uuid
+    requested_keys = stub_s3_etags(
+      s3_key_for(original_url) => "\"same-etag\"",
+      s3_key_for(retried_url) => "\"same-etag\"",
+    )
+
+    assert_no_difference -> { @product.product_files.alive.count } do
+      post :update, params: @params.merge(
+        files: [
+          { id: product_file.external_id, url: original_url, size: 123, display_name: "Guide" },
+          { id: temporary_id, url: retried_url, size: 123, display_name: "Guide" },
+        ]
+      ), format: :json
+    end
+
+    assert_response :success
+    assert_equal product_file.external_id, response.parsed_body.dig("file_id_mappings", temporary_id)
+    assert_includes requested_keys, s3_key_for(original_url)
+    assert_includes requested_keys, s3_key_for(retried_url)
+  end
+
+  test "PUT update keeps same-name same-size files with different S3 fingerprints separate" do
+    clear_setup_files
+    original_url = "#{S3_BASE_URL}attachments/fingerprint-a/original/guide.pdf"
+    new_url = "#{S3_BASE_URL}attachments/fingerprint-b/original/guide.pdf"
+    product_file = create_product_file(link: @product, url: original_url, size: 123, display_name: "Guide")
+    temporary_id = SecureRandom.uuid
+    requested_keys = stub_s3_etags(
+      s3_key_for(original_url) => "\"first-etag\"",
+      s3_key_for(new_url) => "\"second-etag\"",
+    )
+
+    assert_difference -> { @product.product_files.alive.count }, 1 do
+      post :update, params: @params.merge(
+        files: [
+          { id: product_file.external_id, url: original_url, size: 123, display_name: "Guide" },
+          { id: temporary_id, url: new_url, size: 123, display_name: "Guide" },
+        ]
+      ), format: :json
+    end
+
+    assert_response :success
+    new_file = @product.product_files.alive.find_by!(url: new_url)
+    assert_equal new_file.external_id, response.parsed_body.dig("file_id_mappings", temporary_id)
+    assert_not_equal product_file.external_id, response.parsed_body.dig("file_id_mappings", temporary_id)
+    assert_includes requested_keys, s3_key_for(original_url)
+    assert_includes requested_keys, s3_key_for(new_url)
+  end
+
   test "PUT update preserves correct s3 key for s3 files containing percent and ampersand" do
     urls = ["#{AWS_S3_ENDPOINT}/#{S3_BUCKET}/specs/test file %26 & ) %29.txt"]
     post :update, params: @params.merge!(files: files_data_from_urls(urls)), format: :json

--- a/test/controllers/links_controller_test.rb
+++ b/test/controllers/links_controller_test.rb
@@ -3384,7 +3384,6 @@ class LinksControllerUpdateTest < ActionController::TestCase
     assert_no_difference -> { @product.product_files.alive.count } do
       post :update, params: @params.merge(
         files: [
-          { id: product_file.external_id, url: original_url, size: 123, display_name: "Guide" },
           { id: temporary_id, url: retried_url, size: 123, display_name: "Guide" },
         ]
       ), format: :json
@@ -3420,8 +3419,31 @@ class LinksControllerUpdateTest < ActionController::TestCase
     new_file = @product.product_files.alive.find_by!(url: new_url)
     assert_equal new_file.external_id, response.parsed_body.dig("file_id_mappings", temporary_id)
     assert_not_equal product_file.external_id, response.parsed_body.dig("file_id_mappings", temporary_id)
-    assert_includes requested_keys, s3_key_for(original_url)
-    assert_includes requested_keys, s3_key_for(new_url)
+    # The payload names the original by its canonical id, so it is excluded
+    # from the candidate pool and never fingerprinted.
+    assert_not_includes requested_keys, s3_key_for(original_url)
+  end
+
+  test "PUT update keeps a deliberate second embed of an already-attached url" do
+    clear_setup_files
+    url = "#{S3_BASE_URL}attachments/deliberate/original/guide.pdf"
+    product_file = create_product_file(link: @product, url:, size: 123, display_name: "Guide")
+    temporary_id = SecureRandom.uuid
+
+    # The "Existing product files" picker names the canonical row AND adds a
+    # second entry for the same url. A retry can never name an id the client
+    # never received, so naming it means the seller wants both rows.
+    assert_difference -> { @product.product_files.alive.count }, 1 do
+      post :update, params: @params.merge(
+        files: [
+          { id: product_file.external_id, url:, size: 123, display_name: "Guide" },
+          { id: temporary_id, url:, size: 123, display_name: "Guide" },
+        ]
+      ), format: :json
+    end
+
+    assert_response :success
+    assert_not_equal product_file.external_id, response.parsed_body.dig("file_id_mappings", temporary_id)
   end
 
   test "PUT update preserves correct s3 key for s3 files containing percent and ampersand" do


### PR DESCRIPTION
## What

Makes product-editor file attachment saves **idempotent**. A retried or duplicated save no longer creates a second `ProductFile` row for a file that is already attached, while a *deliberate* re-attach of the same file (for example to a second version) still gets its own distinct row.

## Why

Sellers were accumulating duplicate rows — one report had **10 identical `ProductFile` rows** for a single file. Every retried save re-attached the same file, because a payload entry was only matched to an existing row by `external_id`; a save that arrived without one (a retry, a client that never received the response) always built a new row.

The server now also reuses an existing row when the URL matches, or when the S3 size + ETag fingerprint matches. Rows the payload names by canonical id are excluded as dedupe targets: a client can only name an id it was given, so a named row means the client wants *both*.

The save response now returns `file_id_mappings` (client id → canonical server id) alongside the existing variant and page mappings, so the editor's next save addresses the created rows instead of re-creating them.

## The boundary this PR is really about

Idempotency and deliberate re-attach pull in opposite directions, and getting that line right is the whole task:

- **Retried save** → must reuse the row (the bug).
- **Deliberate re-attach** (seller picks the same file from "Existing product files" for a second version) → must create a distinct row, because each version needs its own.

The second case is what the adversarial review caught, below.

## Test Results

- `spec/requests/products/edit/file_embeds_spec.rb:579` — **1 example, 0 failures** (this was the failing case; see below).
- `spec/modules/with_product_files_spec.rb` — **52 examples, 0 failures**.
- `test/controllers/links_controller_test.rb` — **488 runs, 1841 assertions, 0 failures, 0 errors, 0 skips**.
- `app/javascript/data/product_edit.test.ts` (vitest) — **20 passed**.
- CI at `1d82a163b`: **77 of 78 green, 0 pending**.

### The one red check is pre-existing on main

`Test Minitest 1` fails on `PurchaseTest#test_#json_data_for_mobile_uses_the_cached_resolved_discount_amount_for_offer_code_display`. The **identical** test fails on `main` (run `30722785030`, commit `609fefe6f`) — it is unrelated to this branch and not introduced here. The shard this branch actually broke, `Test Slow 9`, is now **green**.

## Regression found and fixed during review

Before this PR was opened, CI was red on `Test Slow 9` at `spec/requests/products/edit/file_embeds_spec.rb:579` — "allows embedding the same existing files that were uploaded and saved to another version", `expected: 2, got: 1`. That spec file is **not touched by this branch**, which made it the branch's own regression rather than flake.

Root cause was settled with temporary probe logging inside `save_files!` during a real run, not by reasoning:

- Save 1 (upload): entry carried a client GUID → new row → server mapped it to canonical id `X`.
- Save 2 (picker re-attach): the payload carried **two entries, both with id `X`**.

So the dedupe's `directly_addressed_files` exclusion never even fired — both entries resolved directly by `external_id` to the same row, collapsing two legitimately distinct rows into one. The server cannot resolve `[{id: X}, {id: X}]`; it has no way to know which version should get which row.

The cause was this branch's own **frontend** change: `applyCanonicalIds` rewrites the uploaded entry's client GUID to the canonical id after save 1, and the picker's entry (from `ProductPresenter#existing_files`) carries that same canonical id.

**Fix** (`1d82a163b`, `ContentTab/index.tsx`, +11/−2): when a picked file's id is already present in `product.files`, submit it under a fresh client GUID. The server's directly-addressed exclusion then creates a distinct row, and a *retry* of that same save still dedupes via the URL match — the fresh GUID never resolves by id, the original row stays directly addressed and excluded, and the newly created duplicate is the only URL candidate. The presenter's group-by-url guarantees the picker lists the product's own row whenever a URL match exists, so this covers the path completely.

Worth noting: the branch's own minitest for "keeps a deliberate second embed" sent the second entry under a fresh uuid — which is not what the real frontend sent. That is why the unit tests were green while the browser spec was red.

## QA steps

1. Open the product editor, upload a file, save. Save **again without reloading** — there must still be exactly one `ProductFile` row (this is the bug: previously each save added another).
2. Repeat several times to confirm no accumulation.
3. On a product with **versions**: upload a file to version 1 and save. Switch to version 2, use "Upload files" → "Existing product files", pick the same file, save. Both versions must show the file, and the product must end with **two** rows — one per version.
4. Then save again without reloading — still two rows, not four.
5. Confirm each version's content references its own row.

## Review request

Assigned to @gianfrancopiana (owner of gumroad-private#1642) alongside @nyomanjyotisa. The risk here is the idempotency-vs-deliberate-reattach boundary described above, and it is a data-shape change to how files are matched — please QA the versioned-product path in step 3 specifically, since that is where the regression appeared and it is not covered by unit tests in a realistic payload shape.

Not self-merging: this changes how existing seller file rows are matched and reused.

## AI disclosure

Written by Gumroad's AI agent (claude-opus-5). The CI regression above was diagnosed and fixed with empirical probe logging before this PR was opened.
