### PR TITLE
Resolve a dispute by the processor's case identity, not the disputable's has_one

### DIFF
--- a/app/models/concerns/charge/disputable.rb
+++ b/app/models/concerns/charge/disputable.rb
@@ -256,13 +256,56 @@ module Charge::Disputable
     ContactingCreatorMailer.chargeback_lost_no_refund_policy(dispute.id).deliver_later
   end
 
+  # Resolve the dispute for this event by the PROCESSOR's case identity first, falling back to
+  # this disputable's has_one only when no such row exists.
+  #
+  # The has_one alone is not a stable identity. Charge::Chargeable.find_by_stripe_event resolves
+  # a combined charge's processor transaction id to the Charge before the Purchase, so a case
+  # formalized when the resolver returned the Purchase and closed after it returned the Charge
+  # would find a nil has_one on the Charge and build a SECOND row for one processor case — the
+  # original staying `formalized` forever while its twin went terminal. Anything keyed on the
+  # local row (the formalized side-effect marker, the mailers, the evidence uniqueness index)
+  # is bypassed the same way. Keying on the case makes the record an event updates independent
+  # of which object the resolver happened to return.
+  #
+  # The found row is attached to the in-memory association only; its purchase_id / charge_id are
+  # left alone, so this never reparents a historical dispute — it only makes `dispute` in this
+  # request point at the row the event is actually about.
   def find_or_build_dispute(event)
-    self.dispute ||= build_dispute(
+    return dispute if dispute.present?
+
+    existing = find_dispute_by_processor_case(event)
+    if existing.present?
+      association(:dispute).target = existing
+      return existing
+    end
+
+    self.dispute = build_dispute(
       charge_processor_id: charge_processor,
       charge_processor_dispute_id: event.extras.try(:[], :charge_processor_dispute_id),
       reason: event.extras.try(:[], :reason),
       event_created_at: event.created_at,
     )
+  end
+
+  # Blank processor dispute ids cannot form a case key — every Braintree row and a block of
+  # legacy PayPal rows have none — so they always fall through to the has_one.
+  def find_dispute_by_processor_case(event)
+    processor_dispute_id = event.extras.try(:[], :charge_processor_dispute_id)
+    return if processor_dispute_id.blank?
+
+    Dispute.where(charge_processor_id: charge_processor, charge_processor_dispute_id: processor_dispute_id)
+           .where(purchase_id: disputed_purchase_ids)
+           .order(:id)
+           .first
+  end
+
+  # The purchases this disputable covers, plus — when it is a Charge — nothing else: a case's
+  # older twin is always purchase-grain, hanging off one of the charge's own purchases. Scoping
+  # to them keeps the lookup from matching an unrelated seller's row should a processor ever
+  # reuse a dispute id.
+  def disputed_purchase_ids
+    disputed_purchases.map(&:id)
   end
 
   def create_dispute_evidence_if_needed!

--- a/spec/models/concerns/charge/disputable_spec.rb
+++ b/spec/models/concerns/charge/disputable_spec.rb
@@ -1546,6 +1546,86 @@ describe Charge::Disputable, :vcr do
         end
       end
 
+      # gumroad-private#1705: the chargeable resolver returns the Charge before the Purchase for a
+      # shared processor transaction id, so a case formalized at purchase grain and closed at
+      # charge grain used to build a SECOND dispute row and leave the original `formalized`
+      # forever. The close must land on the row the case already owns.
+      context "when a close event resolves to the charge but the case is already recorded on a purchase" do
+        let(:seller) { create(:user) }
+        let(:product) { create(:product, user: seller) }
+        let(:transaction_id) { "ch_mixed_grain_1705" }
+        let(:processor_dispute_id) { "PP-D-1705" }
+        let!(:purchase) do
+          create(:purchase, link: product, seller:, stripe_transaction_id: transaction_id,
+                            price_cents: 100, total_transaction_cents: 100, fee_cents: 30,
+                            chargeback_date: 10.days.ago)
+        end
+        let!(:charge) do
+          create(:charge, processor_transaction_id: transaction_id, amount_cents: 100,
+                          disputed_at: 10.days.ago, purchases: [purchase],
+                          merchant_account: create(:merchant_account, user: create(:user), charge_processor_merchant_id: "acct_1705_#{SecureRandom.hex(6)}"))
+        end
+        let!(:existing_dispute) do
+          create(:dispute_formalized, purchase:, charge_processor_id: StripeChargeProcessor.charge_processor_id,
+                                      charge_processor_dispute_id: processor_dispute_id)
+        end
+        let(:event) do
+          build(:charge_event_dispute_lost, charge_id: transaction_id,
+                                            extras: { charge_processor_dispute_id: processor_dispute_id })
+        end
+
+        it "closes the existing purchase-grain dispute instead of building a second row" do
+          expect { charge.handle_event(event) }.not_to change { Dispute.count }
+
+          expect(existing_dispute.reload.state).to eq("lost")
+          expect(Dispute.where(charge_processor_dispute_id: processor_dispute_id).count).to eq(1)
+        end
+
+        it "does not reparent the dispute onto the charge" do
+          charge.handle_event(event)
+          expect(existing_dispute.reload.purchase_id).to eq(purchase.id)
+          expect(existing_dispute.charge_id).to be_nil
+        end
+
+        context "when the close is a win" do
+          let(:event) do
+            build(:charge_event_dispute_won, charge_id: transaction_id,
+                                             extras: { charge_processor_dispute_id: processor_dispute_id })
+          end
+
+          it "closes the existing row and reverses the chargeback on the purchase" do
+            expect { charge.handle_event(event) }.not_to change { Dispute.count }
+            expect(existing_dispute.reload.state).to eq("won")
+            expect(purchase.reload.chargeback_reversed).to be(true)
+          end
+        end
+
+        context "when a formalization replays at the other grain" do
+          let(:event) do
+            build(:charge_event_dispute_formalized, charge_id: transaction_id,
+                                                    extras: { reason: "fraud", charge_processor_dispute_id: processor_dispute_id })
+          end
+
+          it "is a no-op rather than a second formalization with its own side-effect marker" do
+            expect { charge.handle_event(event) }.not_to change { Dispute.count }
+            expect(existing_dispute.reload.state).to eq("formalized")
+          end
+        end
+
+        context "when the processor dispute id is blank" do
+          let!(:existing_dispute) do
+            create(:dispute_formalized, purchase:, charge_processor_id: StripeChargeProcessor.charge_processor_id,
+                                        charge_processor_dispute_id: nil)
+          end
+          let(:event) { build(:charge_event_dispute_lost, charge_id: transaction_id) }
+
+          it "cannot form a case key and falls back to the has_one, as before" do
+            charge.handle_event(event)
+            expect(charge.reload.dispute).to be_present
+          end
+        end
+      end
+
       describe "dispute lost" do
         let(:initial_balance) { 200 }
         let(:seller) { create(:user, unpaid_balance_cents: initial_balance) }


### PR DESCRIPTION
Closes part of antiwork/gumroad-private#1705 (Approach steps 1, 3, 7).

### The defect

`Charge::Chargeable.find_by_stripe_event` checks `Charge.where(processor_transaction_id:)` **before** `Purchase.where(stripe_transaction_id:)` (changed in #5779, merged 2026-07-15). The comment above those lines explains the precedence is deliberate — for refund events, a purchase lookup would match one arbitrary constituent and miss the canonical Charge.

Nothing scoped that away from **dispute** events, and `Dispute` hangs off the disputable via `has_one`. So a resolution-order change was silently also a **dispute identity** change.

A case formalized when the resolver returned the `Purchase`, then closed after it returned the `Charge`, hits `find_or_build_dispute`'s `self.dispute ||= build_dispute(...)` with `self` now the Charge and its `dispute` nil — and builds a **second** row carrying the same `charge_processor_dispute_id`. The original stays `formalized` forever.

Production, audited console 2026-08-02:

| | before 2026-07-15 | on/after |
|---|---|---|
| purchase-grain member created | **19** | 1 |
| charge-grain member created | **0** | **20** |

All 20 groups straddle the deploy date in one direction. Newest charge-grain member 2026-07-29. The grain flipped wholesale for PayPal at that deploy (339 purchase-grain / 0 charge-grain in the 3 months before; 19 / 66 since), which is why Stripe-shaped monitoring never saw it.

Every group is a genuine duplicate: 20 of 20, the charge named by the second row *contains* the purchase named by the first, same `seller_id`, one `event_created_at` per group.

**Forward exposure: 1,222 open purchase-grain PayPal dispute rows predate the change.** Of 37 sampled, 35 resolve to an existing `Charge` today — their close events will orphan them the same way.

### Why this is worse than a duplicate row

Every guard in this area is keyed on the *local row*, so a second row bypasses all of them:

- **The formalized side-effect marker.** `formalized_side_effects_finished_at` is checked on the row `find_or_build_dispute` returned. A second row has its own NULL marker, so the entire fanout re-runs — balance decrement, subscription cancellation, chargeback flags, payout pause, buyer block, all three mailers, ping endpoints, `FightDisputeJob`. **5 PayPal cases ran it twice; one ran it three times** (`PP-R-WVL-516586609`, dispute ids 100334/100335/100336).
- **Analytics.** Those 5 purchases carry 11 `chargeback` events where 5 are correct.
- **Mailers.** `chargeback_notice`, `chargeback_notify` and `chargeback_notice_to_customer` are addressed by `dispute.id`, so `SentEmailInfo` uniqueness cannot dedupe across two ids — seller, admin and buyer each got a second full notice set.
- **Money, in one case.** `PP-R-EVD-501085025` (dispute ids 95502 + 95503, purchase 196907214) has two `balance_transactions` of −30 cents from distinct dispute rows against the same balance, which absorbed both. Three years old and trivially small, but it disproves "the local-grain replay guard stops money movement".
- **`index_dispute_evidences_on_dispute_id` is UNIQUE on `dispute_id`** — local grain — so two rows for one case could each submit evidence. Unprotected rather than proven safe; it has not happened only because `eligible_for_dispute_evidence?` excludes PayPal.

### What this changes

`find_or_build_dispute` resolves by `(charge_processor_id, charge_processor_dispute_id)` first, scoped to this disputable's own purchases, and falls back to the `has_one` only when no such row exists. The record an event updates no longer depends on which object the resolver happened to return.

Two deliberate properties:

- **Blank processor dispute ids keep the old behaviour.** All 27,986 Braintree rows and 2,560 legacy PayPal rows have none, so no case key can be formed for them at all. They fall through to the `has_one` exactly as before.
- **Nothing is reparented.** The found row is attached to the in-memory association only; `purchase_id` / `charge_id` are untouched. This makes `dispute` point at the right row *for this request*, it does not migrate history.

This also gets Approach step 7 largely for free: once the resolver finds the existing row, no second row exists and the existing side-effect marker governs.

### Not in this PR

- **Backfill of the 20 orphaned purchase-grain rows** to the terminal state their twin already carries. All 20 have empty `balance_transactions` on both members today, but that must be re-verified per row at write time, and a row whose twin moved money should halt rather than be written.
- **The uniqueness constraint on `(charge_processor_id, charge_processor_dispute_id)`** — it needs the backfill first, and must exclude blank keys.
- Re-keying the three mailers off `dispute.id`, the evidence index at processor-case grain, and the correction for the 30-cent double debit. All tracked on gumroad-private#1705.

### Tests

`spec/models/concerns/charge/disputable_spec.rb`, new context "when a close event resolves to the charge but the case is already recorded on a purchase": a lost close lands on the existing row and creates no second row; a won close does the same and reverses the chargeback on the purchase; a formalization replaying at the other grain is a no-op rather than a second formalization with its own marker; the dispute is not reparented onto the charge; a blank processor dispute id still falls back to the `has_one`.

Full file: **145 examples, 25 failures on this branch vs 140 examples, 25 failures on `origin/main`** — the 5 new examples all pass and the failing set is identical by name. Those 25 are environmental in this sandbox (Stripe fixtures and a vite build).
