### PR TITLE
Correct the commission deposit hold claim in the Help Center

### DIFF
--- a/app/views/help_center/articles/contents/_70-can-i-sell-services.html.erb
+++ b/app/views/help_center/articles/contents/_70-can-i-sell-services.html.erb
@@ -12,7 +12,7 @@
   <p>We also recommend reading <a href="149-adding-a-product" target="_self">this article</a> as creating a service-type product is similar to creating a digital product.</p>
   <h3 id="commission">Commission</h3>
   <p>Commissions allow you to sell unique tailored work or services to your customers. We collect 50% of the total amount from the customer as the up-front deposit, and the remaining half after the project’s completion.</p>
-  <p><strong>Note: </strong>The 50% deposit will not be added to your balance or paid out until the commission is completed.</p>
+  <p><strong>Note: </strong>The 50% deposit is added to your balance when the customer pays it, and is paid out on your normal payout schedule like any other sale. It is not held until the commission is completed.</p>
   <p>You can ask the customer to upload any instructions or files required for your project by using input fields in the Content tab.</p>
   <figure><%= image_tag "help_center/commission-content.png" %></figure>
   <p>The customers' inputs will be available in the Order information section of their drawer in the <a href="https://gumroad.com/customers/" target="_self">Sales dashboard</a>. You can also refund the customer’s deposit if you wish to reject their commission.</p>


### PR DESCRIPTION
## What

Corrects the Help Center's claim that a commission's 50% deposit is held from the seller's balance until the commission completes. It is not held; it is credited immediately like any other sale.

## Why

gumroad-private#1666 (defect 4), reported by an external security researcher and verified against `main` and production.

`app/views/help_center/articles/contents/_70-can-i-sell-services.html.erb` said:

> The 50% deposit will not be added to your balance or paid out until the commission is completed.

No such hold exists in the code. The deposit is an ordinary successful purchase — `Purchase#update_balance_and_mark_successful!` calls `increment_sellers_balance!` unconditionally, and no payout path filters on commission status. Grepping `app/` and `lib/` for a commission-linked payout hold returns only affiliate-commission references, which are unrelated.

Production confirms the money has already moved. Across `in_progress` commissions:

| Deposit balance state | Count | Amount |
|---|---|---|
| **paid (already paid out)** | **1,163** | **$44,778.50** |
| unpaid | 383 | $10,074.99 |
| processing | 2 | $40.21 |
| forfeited | 3 | $13.00 |

~75% of open-commission deposits have already reached the seller, so the article was describing a buyer protection that does not exist.

@slavingia ruled on the issue: *"I think the hold is too complex to fix so just update copy."* This is that copy change. Building the actual hold is explicitly not in scope.

## Before / after

| | Text |
|---|---|
| Before | The 50% deposit **will not be added to your balance or paid out until the commission is completed.** |
| After | The 50% deposit **is added to your balance when the customer pays it, and is paid out on your normal payout schedule like any other sale. It is not held until the commission is completed.** |

The correction states the behaviour positively first, then explicitly negates the old claim — sellers who read the previous wording and planned around it need to see that the hold is gone, not just a new sentence that omits it.

## Test results

Content-only change to one help-center article. No code path, no spec touched.

ERB parse check on the edited template:

```
$ ruby -e 'require "erb"; ERB.new(File.read("app/views/help_center/articles/contents/_70-can-i-sell-services.html.erb"), trim_mode: "-").src; puts "ERB OK"'
ERB OK
```

Swept for the claim on any other surface (`app/`, `config/`, across `.erb`/`.rb`/`.tsx`/`.ts`/`.yml`) — this article was the only place it appeared.

## Not in this PR

- The deposit hold itself. Ruled too complex; the copy is the agreed fix.
- gumroad-private#1666's other defects: the refunded-deposit charge gate shipped as #6819, and the deliverable gate (require ≥1 file to complete, reject mutations once completed) is a separate change.

Ref antiwork/gumroad-private#1666

---

Written by Claude Opus 4.6 (`anthropic/claude-opus-4-6`) running as the Hermes autonomous dev dispatcher, acting on @slavingia's instruction on gumroad-private#1666: *"Update help center. I think the hold is too complex to fix so just update copy"*. The agent verified the absence of the hold in code, cross-checked the production balance states, and swept for other surfaces carrying the same claim before editing.
