### PR TITLE
Let a transferred membership's owner open its earlier renewals

### DIFF
--- a/app/controllers/url_redirects_controller.rb
+++ b/app/controllers/url_redirects_controller.rb
@@ -471,7 +471,12 @@ class UrlRedirectsController < ApplicationController
         return withdrawn_content_response
       end
 
-      return redirect_to url_redirect_check_purchaser_path(@url_redirect.token, next: request.path) if purchase && user_signed_in? && purchase.purchaser.present? && logged_in_user != purchase.purchaser && !logged_in_user.is_team_member?
+      subscription_owner = purchase&.subscription&.user
+      # The subscription owner can read any purchase in it; transferred memberships can leave
+      # individual renewals attributed to the previous purchaser.
+      viewer_owns_subscription = subscription_owner.present? && logged_in_user == subscription_owner
+
+      return redirect_to url_redirect_check_purchaser_path(@url_redirect.token, next: request.path) if purchase && user_signed_in? && purchase.purchaser.present? && logged_in_user != purchase.purchaser && !viewer_owns_subscription && !logged_in_user.is_team_member?
 
       return redirect_to url_redirect_rental_expired_page_path(@url_redirect.token) if @url_redirect.rental_expired?
 

--- a/app/controllers/url_redirects_controller.rb
+++ b/app/controllers/url_redirects_controller.rb
@@ -297,11 +297,12 @@ class UrlRedirectsController < ApplicationController
     end
     return e404_json if @url_redirect.rental_expired?
     return e404_json if purchase&.subscription && !purchase.subscription.grant_access_to_product?
-    if purchase && user_signed_in? && purchase.purchaser.present? && logged_in_user != purchase.purchaser && !logged_in_user.is_team_member?
+    if purchase && user_signed_in? && purchase.purchaser.present? && logged_in_user != purchase.purchaser && !viewer_owns_subscription?(purchase) && !logged_in_user.is_team_member?
       return e404_json
     end
     if purchase.present? && @url_redirect.has_been_seen && @url_redirect.imported_customer.blank?
       identity_verified = cookies.encrypted[:confirmed_redirect] == @url_redirect.token ||
+                          viewer_owns_subscription?(purchase) ||
                           (purchase.purchaser.present? && purchase.purchaser == logged_in_user) ||
                           purchase.ip_address == request.remote_ip
       return e404_json if !identity_verified
@@ -458,6 +459,17 @@ class UrlRedirectsController < ApplicationController
       withdrawn_content_response if !has_files && !can_view_product_download_page_without_files
     end
 
+    # The subscription owner can read any purchase in it; transferred memberships can leave
+    # individual renewals attributed to the previous purchaser. The gift receiver leg is excluded:
+    # Gift::ConvertToNonGiftService re-points subscription.user at the payer to move BILLING
+    # ownership and says explicitly that the giftee keeps the seat.
+    def viewer_owns_subscription?(purchase)
+      return false if purchase.nil? || purchase.is_gift_receiver_purchase
+
+      owner = purchase.subscription&.user
+      user_signed_in? && owner.present? && logged_in_user == owner
+    end
+
     def check_permissions
       fetch_url_redirect
 
@@ -471,12 +483,7 @@ class UrlRedirectsController < ApplicationController
         return withdrawn_content_response
       end
 
-      subscription_owner = purchase && !purchase.is_gift_receiver_purchase ? purchase.subscription&.user : nil
-      # The subscription owner can read any purchase in it; transferred memberships can leave
-      # individual renewals attributed to the previous purchaser. The gift receiver leg is excluded:
-      # Gift::ConvertToNonGiftService re-points subscription.user at the payer to move BILLING
-      # ownership and says explicitly that the giftee keeps the seat.
-      viewer_owns_subscription = user_signed_in? && subscription_owner.present? && logged_in_user == subscription_owner
+      viewer_owns_subscription = viewer_owns_subscription?(purchase)
 
       return redirect_to url_redirect_check_purchaser_path(@url_redirect.token, next: request.path) if purchase && user_signed_in? && purchase.purchaser.present? && logged_in_user != purchase.purchaser && !viewer_owns_subscription && !logged_in_user.is_team_member?
 

--- a/app/controllers/url_redirects_controller.rb
+++ b/app/controllers/url_redirects_controller.rb
@@ -460,14 +460,18 @@ class UrlRedirectsController < ApplicationController
     end
 
     # The subscription owner can read any purchase in it; transferred memberships can leave
-    # individual renewals attributed to the previous purchaser. The gift receiver leg is excluded:
-    # Gift::ConvertToNonGiftService re-points subscription.user at the payer to move BILLING
-    # ownership and says explicitly that the giftee keeps the seat.
+    # individual renewals attributed to the previous purchaser. Gift-origin subscriptions get no
+    # bypass at all: Gift::ConvertToNonGiftService re-points subscription.user at the payer to
+    # move BILLING ownership while the giftee keeps the seat, and a renewal charged before the
+    # conversion carries the giftee as purchaser with no gift flag — only the surviving Gift row
+    # on the true original purchase marks it. The gift lookup runs last so its extra queries
+    # only fire for a viewer who actually owns the subscription.
     def viewer_owns_subscription?(purchase)
       return false if purchase.nil? || purchase.is_gift_receiver_purchase
 
-      owner = purchase.subscription&.user
-      user_signed_in? && owner.present? && logged_in_user == owner
+      subscription = purchase.subscription
+      user_signed_in? && subscription&.user.present? && logged_in_user == subscription.user &&
+        subscription.true_original_purchase&.gift_given.nil?
     end
 
     def check_permissions

--- a/app/controllers/url_redirects_controller.rb
+++ b/app/controllers/url_redirects_controller.rb
@@ -471,10 +471,12 @@ class UrlRedirectsController < ApplicationController
         return withdrawn_content_response
       end
 
-      subscription_owner = purchase&.subscription&.user
+      subscription_owner = purchase && !purchase.is_gift_receiver_purchase ? purchase.subscription&.user : nil
       # The subscription owner can read any purchase in it; transferred memberships can leave
-      # individual renewals attributed to the previous purchaser.
-      viewer_owns_subscription = subscription_owner.present? && logged_in_user == subscription_owner
+      # individual renewals attributed to the previous purchaser. The gift receiver leg is excluded:
+      # Gift::ConvertToNonGiftService re-points subscription.user at the payer to move BILLING
+      # ownership and says explicitly that the giftee keeps the seat.
+      viewer_owns_subscription = user_signed_in? && subscription_owner.present? && logged_in_user == subscription_owner
 
       return redirect_to url_redirect_check_purchaser_path(@url_redirect.token, next: request.path) if purchase && user_signed_in? && purchase.purchaser.present? && logged_in_user != purchase.purchaser && !viewer_owns_subscription && !logged_in_user.is_team_member?
 
@@ -494,7 +496,10 @@ class UrlRedirectsController < ApplicationController
         end
       end
 
-      if cookies.encrypted[:confirmed_redirect] == @url_redirect.token ||
+      # Confirmation asks for the purchase's own email, which a transferred membership's new owner
+      # does not have — so clearing the gate above without clearing this one would only move them
+      # from one dead end to another on any renewal the previous owner had already opened.
+      if cookies.encrypted[:confirmed_redirect] == @url_redirect.token || viewer_owns_subscription ||
          (purchase && ((purchase.purchaser && purchase.purchaser == logged_in_user) || purchase.ip_address == request.remote_ip))
         return
       end

--- a/spec/controllers/url_redirects_controller_spec.rb
+++ b/spec/controllers/url_redirects_controller_spec.rb
@@ -824,10 +824,55 @@ describe UrlRedirectsController, inertia: true do
     end
 
     describe "memberships" do
+      it "allows the subscription owner to view a renewal purchase from another purchaser" do
+        product = create(:membership_product, price_cents: 100)
+        create(:readable_document, link: product)
+        subscription_owner = create(:user)
+        previous_owner = create(:user)
+        subscription = create(:subscription, link: product, user: subscription_owner)
+        # A transferred membership: the signup moved to the new owner, the renewal kept the old one.
+        create(:purchase, price_cents: 100, purchaser: subscription_owner, link: product, subscription:, is_original_subscription_purchase: true)
+        renewal = create(:purchase, price_cents: 100, purchaser: previous_owner, link: product, subscription:)
+        url_redirect = create(:url_redirect, link: product, purchase: renewal)
+
+        sign_in subscription_owner
+        get :download_page, params: { id: url_redirect.token }
+
+        expect(response).to have_http_status(:ok)
+        expect(response).to_not be_redirect
+      end
+
+      it "redirects signed-in users who are neither the purchaser nor subscription owner to check purchaser" do
+        product = create(:membership_product, price_cents: 100)
+        subscription = create(:subscription, link: product, user: create(:user))
+        create(:purchase, price_cents: 100, purchaser: subscription.user, link: product, subscription:, is_original_subscription_purchase: true)
+        renewal = create(:purchase, price_cents: 100, purchaser: create(:user), link: product, subscription:)
+        url_redirect = create(:url_redirect, link: product, purchase: renewal)
+
+        sign_in create(:user)
+        get :download_page, params: { id: url_redirect.token }
+
+        expect(response).to redirect_to "#{url_redirect_check_purchaser_path(url_redirect.token)}?next=#{CGI.escape request.path}"
+      end
+
       it "redirects to the expiration page if the membership inactive" do
         product = create(:membership_product, price_cents: 100)
         subscription = create(:subscription, link: product, user: create(:user), failed_at: Time.current)
         purchase = create(:purchase, price_cents: 100, purchaser: subscription.user, link: product, subscription:, is_original_subscription_purchase: true)
+        product.update_attribute(:block_access_after_membership_cancellation, true)
+        url_redirect = create(:url_redirect, link: product, purchase:)
+
+        sign_in subscription.user
+        get :download_page, params: { id: url_redirect.token }
+        expect(response).to redirect_to(url_redirect_membership_inactive_page_path(id: url_redirect.token))
+      end
+
+      # Pins the ordering: authorizing the subscription owner must not let them past the
+      # membership-inactive branch on a renewal another purchaser paid for.
+      it "redirects the subscription owner to the expiration page when the membership is inactive and the purchase is another purchaser's" do
+        product = create(:membership_product, price_cents: 100)
+        subscription = create(:subscription, link: product, user: create(:user), failed_at: Time.current)
+        purchase = create(:purchase, price_cents: 100, purchaser: create(:user), link: product, subscription:, is_original_subscription_purchase: true)
         product.update_attribute(:block_access_after_membership_cancellation, true)
         url_redirect = create(:url_redirect, link: product, purchase:)
 

--- a/spec/controllers/url_redirects_controller_spec.rb
+++ b/spec/controllers/url_redirects_controller_spec.rb
@@ -909,6 +909,28 @@ describe UrlRedirectsController, inertia: true do
         expect(response.parsed_body["error"]).to_not eq("Not found")
       end
 
+      # A renewal charged while the membership was still gifted keeps the giftee as purchaser but
+      # carries no gift flag; the conversion clears the sender flag and leaves only the Gift row
+      # on the original purchase to mark the subscription's gift origin.
+      it "does not let a converted gift's payer open a renewal charged while the giftee held the membership" do
+        product = create(:membership_product, price_cents: 100)
+        create(:readable_document, link: product)
+        giftee = create(:user)
+        payer = create(:user)
+        subscription = create(:subscription, link: product, user: payer)
+        original_purchase = create(:purchase, price_cents: 100, purchaser: payer, link: product, subscription:, is_original_subscription_purchase: true)
+        receiver_purchase = create(:purchase, price_cents: 0, purchaser: giftee, link: product, subscription:,
+                                              is_gift_receiver_purchase: true)
+        create(:gift, link: product, gifter_purchase: original_purchase, giftee_purchase: receiver_purchase)
+        renewal = create(:purchase, price_cents: 100, purchaser: giftee, link: product, subscription:)
+        url_redirect = create(:url_redirect, link: product, purchase: renewal, has_been_seen: true)
+
+        sign_in payer
+        get :download_page, params: { id: url_redirect.token }
+
+        expect(response).to redirect_to "#{url_redirect_check_purchaser_path(url_redirect.token)}?next=#{CGI.escape request.path}"
+      end
+
       it "redirects to the expiration page if the membership inactive" do
         product = create(:membership_product, price_cents: 100)
         subscription = create(:subscription, link: product, user: create(:user), failed_at: Time.current)

--- a/spec/controllers/url_redirects_controller_spec.rb
+++ b/spec/controllers/url_redirects_controller_spec.rb
@@ -891,6 +891,24 @@ describe UrlRedirectsController, inertia: true do
         expect(response).to redirect_to "#{url_redirect_check_purchaser_path(url_redirect.token)}?next=#{CGI.escape request.path}"
       end
 
+      # send_to_kindle does not run check_permissions — it carries its own copy of the purchaser
+      # gate, so the owner cleared above would still be refused here. The file itself does not
+      # resolve for this fixture; what is pinned is that the request gets past that gate.
+      it "lets the subscription owner past the purchaser gate on a renewal's Send to Kindle" do
+        product = create(:membership_product, price_cents: 100)
+        create(:readable_document, link: product)
+        subscription_owner = create(:user)
+        subscription = create(:subscription, link: product, user: subscription_owner)
+        create(:purchase, price_cents: 100, purchaser: subscription_owner, link: product, subscription:, is_original_subscription_purchase: true)
+        renewal = create(:purchase, price_cents: 100, purchaser: create(:user), link: product, subscription:)
+        url_redirect = create(:url_redirect, link: product, purchase: renewal, has_been_seen: true)
+
+        sign_in subscription_owner
+        post :send_to_kindle, params: { id: url_redirect.token, email: "reader@kindle.com", file_external_id: product.product_files.first.external_id }
+
+        expect(response.parsed_body["error"]).to_not eq("Not found")
+      end
+
       it "redirects to the expiration page if the membership inactive" do
         product = create(:membership_product, price_cents: 100)
         subscription = create(:subscription, link: product, user: create(:user), failed_at: Time.current)

--- a/spec/controllers/url_redirects_controller_spec.rb
+++ b/spec/controllers/url_redirects_controller_spec.rb
@@ -855,6 +855,42 @@ describe UrlRedirectsController, inertia: true do
         expect(response).to redirect_to "#{url_redirect_check_purchaser_path(url_redirect.token)}?next=#{CGI.escape request.path}"
       end
 
+      # The email-confirmation gate lower down only accepts the purchase's own email, so a renewal
+      # the previous owner had already opened has to clear both gates or the fix changes nothing.
+      it "allows the subscription owner to view a renewal that has already been seen" do
+        product = create(:membership_product, price_cents: 100)
+        create(:readable_document, link: product)
+        subscription_owner = create(:user)
+        subscription = create(:subscription, link: product, user: subscription_owner)
+        create(:purchase, price_cents: 100, purchaser: subscription_owner, link: product, subscription:, is_original_subscription_purchase: true)
+        renewal = create(:purchase, price_cents: 100, purchaser: create(:user), link: product, subscription:)
+        url_redirect = create(:url_redirect, link: product, purchase: renewal, has_been_seen: true)
+
+        sign_in subscription_owner
+        get :download_page, params: { id: url_redirect.token }
+
+        expect(response).to have_http_status(:ok)
+        expect(response).to_not be_redirect
+      end
+
+      # Gift::ConvertToNonGiftService re-points subscription.user at the payer to move billing
+      # ownership; its scope note is explicit that the giftee keeps the seat.
+      it "does not let a gifted membership's payer open the giftee's purchase after conversion" do
+        product = create(:membership_product, price_cents: 100)
+        create(:readable_document, link: product)
+        giftee = create(:user)
+        payer = create(:user)
+        subscription = create(:subscription, link: product, user: payer)
+        receiver_purchase = create(:purchase, price_cents: 0, purchaser: giftee, link: product, subscription:,
+                                              is_gift_receiver_purchase: true)
+        url_redirect = create(:url_redirect, link: product, purchase: receiver_purchase)
+
+        sign_in payer
+        get :download_page, params: { id: url_redirect.token }
+
+        expect(response).to redirect_to "#{url_redirect_check_purchaser_path(url_redirect.token)}?next=#{CGI.escape request.path}"
+      end
+
       it "redirects to the expiration page if the membership inactive" do
         product = create(:membership_product, price_cents: 100)
         subscription = create(:subscription, link: product, user: create(:user), failed_at: Time.current)


### PR DESCRIPTION
- [x] Scope — antiwork/gumroad-private#1646
- [x] Design — n/a: backend authorization change, no user-facing surface
- [x] Build — `4b61c2517` + `4496007d3` + `4ba6eb814`, specs green locally
- [ ] Ship — merges via review, closes with the release pipeline
- [ ] Market — n/a: bug fix for a broken content link, nothing to announce
- [ ] Sell — n/a

Fixes antiwork/gumroad-private#1646.

## What

`UrlRedirectsController` now authorizes the owner of a subscription for any purchase inside it, instead of only the rendered purchase's own `purchaser` — on the `check_permissions` gate and on `send_to_kindle`'s own copy of the same gate.

## Why

Transferring a membership moves the signup purchase to the new owner, but earlier renewals keep the previous owner as their `purchaser`. The gate only ever compared the viewer against that field:

```ruby
... if purchase && user_signed_in? && purchase.purchaser.present? && logged_in_user != purchase.purchaser && !logged_in_user.is_team_member?
```

So the new owner — whose subscription it now is, and which is active — hit purchaser verification on any renewal redirect, and that check can only be cleared with the **previous owner's** email. Nothing below the gate helped: `grant_access_to_product?` is the only subscription-aware logic and it asks whether the membership is alive, never who owns it.

The sharpest version: a transferred membership whose signup was refunded and whose only paid renewal sits on the previous owner has **no working library link at all**. #6737 fixed refunded membership cards by pointing them at a paid renewal but deliberately restricted candidates to renewals *the viewer purchased*, precisely because of this gate — a previous owner's renewal would produce a link that cannot resolve. That constraint is recorded in a comment in `LibraryPresenter#replacement_redirects_for`; this PR removes the reason for it.

## How

```ruby
def viewer_owns_subscription?(purchase)
  return false if purchase.nil? || purchase.is_gift_receiver_purchase

  subscription = purchase.subscription
  user_signed_in? && subscription&.user.present? && logged_in_user == subscription.user &&
    subscription.true_original_purchase&.gift_given.nil?
end
```

`viewer_owns_subscription?` clears **two** gates in `check_permissions`: the check-purchaser redirect, and the email-confirmation gate further down. That second one matters — it compares the typed email against `@url_redirect.purchase.email` (the previous owner's) and is reached for any redirect that has been opened even once (`has_been_seen`), which is exactly the renewal a transferred member is trying to read. Clearing only the first gate moves them from one dead end to another. `send_to_kindle` does not run `check_permissions` and carries its own copy of both checks, so the same helper clears those too — otherwise the owner could read a renewal in the browser but not send it to their device.

Why `subscription.user` is a safe relationship rather than a new one:

- **It already authorizes a strictly stronger right.** `SubscriptionsController#check_can_manage` returns early on `logged_in_user == @subscription.user` — that grants *managing* the membership (change card, cancel). Read access to the content is weaker.
- **It adds no new trust class.** In the unauthenticated-checkout case `set_purchaser_for` resolves an account from a typed email and `create_subscription` copies that same value into `subscription.user`, so the unproven identity lands on *both* sides of the comparison, not just one.

**One deliberate exclusion: subscriptions that originated as a gift.** `Gift::ConvertToNonGiftService` re-points `subscription.user` at the payer to move *billing* ownership, and its scope note is explicit that the giftee keeps the seat the seller provisioned. Excluding only the flagged `is_gift_receiver_purchase` leg is not enough — Greptile's P1 on the first push was right that a renewal charged **before** the conversion carries the giftee as `purchaser` with no gift flag at all (`Subscription#build_purchase` copies the then-current `subscription.user` into `purchaser`), so subscription ownership would have handed the payer that renewal's download page and (because consumption events and `latest_media_locations` key on the redirect's purchase) let the payer overwrite the giftee's playback position. The conversion clears the sender flag but keeps the `Gift` row for audit, so the row on `true_original_purchase` is the durable marker: any subscription that has one gets no owner bypass on purchases attributed to someone else. This is where the parallel with `check_can_manage` stops holding: that method answers a subscription-scoped question, this one is purchase-scoped, and gift conversion is a case the codebase deliberately answers differently.

Nothing else in the gate moves: the refund/chargeback response above, rental expiry, `is_access_revoked`, and the membership-inactive branch are untouched — an inactive membership is still stopped by `grant_access_to_product?`, pinned by a spec for the owner-viewing-another-purchaser case.

## Scope

Production replica, trailing 365 days (from the issue): 3,351 refunded membership signups, 711 with a renewal, of which **2** are ownership-split and get no link today. Small by count, and pre-existing rather than a regression — but it is a broken content-delivery path for an entitled buyer, and it is the blocker keeping #6737's lookup artificially narrow.

## Tests

`spec/controllers/url_redirects_controller_spec.rb` — 6 new examples:

- the subscription owner can open a renewal purchased by the previous owner;
- the same, on a redirect that has **already been seen** (proves the confirmation gate is cleared too, not just the first one);
- the owner gets past `send_to_kindle`'s copy of the purchaser gate on such a renewal;
- a converted gift's payer is **still** refused the giftee's flagged gift purchase;
- a converted gift's payer is refused a renewal charged while the giftee held the membership (Greptile's P1 scenario — the renewal has no gift flag, only the surviving `Gift` row marks it);
- an inactive membership still routes the owner to the membership-inactive page when the purchase is another purchaser's;
- plus the pre-existing stranger-rejection guard, unchanged, proving the gate did not open to everyone.

**Run locally at `4ba6eb814`:**

```
$ bundle exec rspec spec/controllers/url_redirects_controller_spec.rb -e "memberships" -e "check purchaser" -e "gift" -e "Kindle"
14 examples, 0 failures
```

The full `url_redirects_controller_spec.rb` file also runs green locally apart from one pre-existing failure (`reading Product ... gets current product file if replaced`) that fails identically without this change — a local MinIO fixture issue, not a gate regression.

**Mutation-checked — each mutation kills exactly its intended example:**

| mutation | fails |
|---|---|
| drop the gift-receiver exclusion | the converted-gift example |
| drop the gift-origin (`gift_given`) exclusion | the pre-conversion renewal example |
| drop `viewer_owns_subscription` from the confirmation gate | the already-seen example |
| drop ` && !viewer_owns_subscription` (pre-fix gate) | both owner examples + the ordering pin |

Adversarial pre-merge review returned **DO NOT SHIP** on the first commit with 2 P2s — the half-fixed journey and the gift boundary — and both are fixed in the second commit; Greptile's P1 on the remaining pre-conversion-renewal hole is fixed in `4ba6eb814`. Its P3 about `send_to_kindle` carrying the same gate is addressed in `4496007d3`; the subscription/gift lookups cost extra queries on the download path, ordered last so they only run for a viewer who actually owns the subscription.
