### PR TITLE
Canonicalize a custom-domain product page to the seller's own domain

### DIFF
--- a/app/controllers/concerns/page_meta/product.rb
+++ b/app/controllers/concerns/page_meta/product.rb
@@ -13,7 +13,7 @@ module PageMeta::Product
       # the *.gumroad.com subdomain Link#long_url defaults to — otherwise Search Console
       # reports "Alternate page with proper canonical tag" and indexes the subdomain instead.
       # UsersController does the same for the profile page via User#profile_url.
-      canonical_url = product.long_url(host: custom_domain_host_for_meta)
+      canonical_url = product.long_url(host: custom_domain_host_for_meta(product))
 
       set_meta_tag(name: "description", content: product_description)
       set_meta_tag(property: "gr:page:type", content: "product")
@@ -39,7 +39,7 @@ module PageMeta::Product
 
       set_meta_tag(tag_name: "link", rel: "canonical", href: canonical_url, head_key: "canonical")
 
-      if (structured_data = product.structured_data(host: custom_domain_host_for_meta)).any?
+      if (structured_data = product.structured_data(host: custom_domain_host_for_meta(product))).any?
         set_meta_tag(tag_name: "script", type: "application/ld+json", inner_content: structured_data, head_key: "structured-data")
       end
     end
@@ -52,8 +52,12 @@ module PageMeta::Product
     # *.gumroad.com subdomain, where re-deriving the canonical from request.host_with_port instead
     # of long_url only introduces ways for the two to disagree (a port, a www prefix) about a URL
     # that was already correct.
-    def custom_domain_host_for_meta
-      return unless CustomDomain.find_by_host(request.host)
+    #
+    # The domain must also belong to THIS product's seller. /l/:permalink resolves globally, so a
+    # product of seller A is reachable over seller B's domain — canonicalizing it onto B's domain
+    # would hand B's domain Google's copy of A's page.
+    def custom_domain_host_for_meta(product)
+      return unless CustomDomain.find_by_host(request.host)&.user_id == product.user_id
 
       seller_custom_domain_url&.chomp("/")
     end

--- a/app/controllers/concerns/page_meta/product.rb
+++ b/app/controllers/concerns/page_meta/product.rb
@@ -9,6 +9,12 @@ module PageMeta::Product
     def set_product_page_meta(product)
       product_description = product.description.present? ? product.plaintext_description : "Available on Gumroad"
 
+      # On a seller's own domain the page must point search engines at that domain, not at
+      # the *.gumroad.com subdomain Link#long_url defaults to — otherwise Search Console
+      # reports "Alternate page with proper canonical tag" and indexes the subdomain instead.
+      # UsersController does the same for the profile page via User#profile_url.
+      canonical_url = product.long_url(host: custom_domain_host_for_meta)
+
       set_meta_tag(name: "description", content: product_description)
       set_meta_tag(property: "gr:page:type", content: "product")
       set_meta_tag(property: "product:retailer_item_id", content: product.unique_permalink)
@@ -23,7 +29,7 @@ module PageMeta::Product
         set_meta_tag(property: "product:price:currency", content: product.price_currency_type.upcase)
       end
 
-      set_open_graph_meta(product, product_description:)
+      set_open_graph_meta(product, product_description:, canonical_url:)
 
       set_twitter_meta(product, product_description:)
 
@@ -31,17 +37,23 @@ module PageMeta::Product
         set_meta_tag(tag_name: "link", rel: "preload", as: "image", href: asset.url)
       end
 
-      set_meta_tag(tag_name: "link", rel: "canonical", href: product.long_url, head_key: "canonical")
+      set_meta_tag(tag_name: "link", rel: "canonical", href: canonical_url, head_key: "canonical")
 
-      if (structured_data = product.structured_data).any?
+      if (structured_data = product.structured_data(host: custom_domain_host_for_meta)).any?
         set_meta_tag(tag_name: "script", type: "application/ld+json", inner_content: structured_data, head_key: "structured-data")
       end
     end
 
-    def set_open_graph_meta(product, product_description:)
+    # nil on gumroad.com, so Link#long_url keeps its subdomain default. Rails' url_for wants a
+    # bare host with no trailing slash; seller_custom_domain_url is a root_url.
+    def custom_domain_host_for_meta
+      seller_custom_domain_url&.chomp("/")
+    end
+
+    def set_open_graph_meta(product, product_description:, canonical_url:)
       set_meta_tag(property: "og:title", content: product.name)
       set_meta_tag(property: "og:description", content: product_description)
-      set_meta_tag(property: "og:url", content: product.long_url)
+      set_meta_tag(property: "og:url", content: canonical_url)
 
       set_open_graph_image_meta(product)
 

--- a/app/controllers/concerns/page_meta/product.rb
+++ b/app/controllers/concerns/page_meta/product.rb
@@ -44,9 +44,17 @@ module PageMeta::Product
       end
     end
 
-    # nil on gumroad.com, so Link#long_url keeps its subdomain default. Rails' url_for wants a
-    # bare host with no trailing slash; seller_custom_domain_url is a root_url.
+    # nil unless the request really arrived on a seller-registered custom domain, so Link#long_url
+    # keeps its subdomain default everywhere else. Rails' url_for wants a bare host with no
+    # trailing slash; seller_custom_domain_url is a root_url.
+    #
+    # @is_user_custom_domain is deliberately NOT enough on its own: it is also true on a seller's
+    # *.gumroad.com subdomain, where re-deriving the canonical from request.host_with_port instead
+    # of long_url only introduces ways for the two to disagree (a port, a www prefix) about a URL
+    # that was already correct.
     def custom_domain_host_for_meta
+      return unless CustomDomain.find_by_host(request.host)
+
       seller_custom_domain_url&.chomp("/")
     end
 

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1969,7 +1969,7 @@ class LinksController < ApplicationController
       checkout_url_js = ERB::Util.json_escape("/l/#{product.unique_permalink}?#{Rack::Utils.build_query(checkout_params)}".to_json)
       store_hostnames_js = ERB::Util.json_escape(product_store_hostnames.to_json)
       title = ERB::Util.h(product.name.to_s)
-      canonical = ERB::Util.h(product.long_url.to_s)
+      canonical = ERB::Util.h(product.long_url(host: custom_domain_host_for_meta).to_s)
       # The wrapper is what search engines see at the canonical /l/<permalink>
       # URL — the seller's HTML lives in a sandboxed, opaque-origin iframe whose
       # content crawlers generally do NOT attribute to this page. Without the
@@ -1989,7 +1989,7 @@ class LinksController < ApplicationController
       # untouched. Escape quotes explicitly so a description containing `"`
       # can't break out of the meta tag's attribute value.
       description_attr = description.gsub('"', "&quot;")
-      structured_data = product.structured_data
+      structured_data = product.structured_data(host: custom_domain_host_for_meta)
       # json_escape keeps the JSON valid while escaping <, >, & so a
       # description containing "</script>" can't break out of the script tag.
       structured_data_tag = if structured_data.any?

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1969,7 +1969,7 @@ class LinksController < ApplicationController
       checkout_url_js = ERB::Util.json_escape("/l/#{product.unique_permalink}?#{Rack::Utils.build_query(checkout_params)}".to_json)
       store_hostnames_js = ERB::Util.json_escape(product_store_hostnames.to_json)
       title = ERB::Util.h(product.name.to_s)
-      canonical = ERB::Util.h(product.long_url(host: custom_domain_host_for_meta).to_s)
+      canonical = ERB::Util.h(product.long_url(host: custom_domain_host_for_meta(product)).to_s)
       # The wrapper is what search engines see at the canonical /l/<permalink>
       # URL — the seller's HTML lives in a sandboxed, opaque-origin iframe whose
       # content crawlers generally do NOT attribute to this page. Without the
@@ -1989,7 +1989,7 @@ class LinksController < ApplicationController
       # untouched. Escape quotes explicitly so a description containing `"`
       # can't break out of the meta tag's attribute value.
       description_attr = description.gsub('"', "&quot;")
-      structured_data = product.structured_data(host: custom_domain_host_for_meta)
+      structured_data = product.structured_data(host: custom_domain_host_for_meta(product))
       # json_escape keeps the JSON valid while escaping <, >, & so a
       # description containing "</script>" can't break out of the script tag.
       structured_data_tag = if structured_data.any?

--- a/app/models/concerns/product/structured_data.rb
+++ b/app/models/concerns/product/structured_data.rb
@@ -9,11 +9,13 @@ module Product::StructuredData
   AVAILABILITY_LIMITED = "#{SCHEMA_ORG_CONTEXT}/LimitedAvailability"
   AVAILABILITY_SOLD_OUT = "#{SCHEMA_ORG_CONTEXT}/SoldOut"
 
-  def structured_data
+  # host: threads the seller's custom domain through so the JSON-LD urls match the
+  # canonical tag on the same page (PageMeta::Product). nil keeps the subdomain default.
+  def structured_data(host: nil)
     if native_type == Link::NATIVE_TYPE_EBOOK
-      build_ebook_structured_data
+      build_ebook_structured_data(host:)
     elsif has_displayable_reviews?
-      build_product_structured_data
+      build_product_structured_data(host:)
     else
       {}
     end
@@ -24,8 +26,8 @@ module Product::StructuredData
       display_product_reviews? && reviews_count > 0
     end
 
-    def build_ebook_structured_data
-      url = long_url
+    def build_ebook_structured_data(host: nil)
+      url = long_url(host:)
       data = {
         "@context" => SCHEMA_ORG_CONTEXT,
         "@type" => "Book",
@@ -45,8 +47,8 @@ module Product::StructuredData
       data.compact
     end
 
-    def build_product_structured_data
-      url = long_url
+    def build_product_structured_data(host: nil)
+      url = long_url(host:)
       {
         "@context" => SCHEMA_ORG_CONTEXT,
         "@type" => "Product",

--- a/spec/requests/products/show/custom_domain_canonical_spec.rb
+++ b/spec/requests/products/show/custom_domain_canonical_spec.rb
@@ -26,16 +26,17 @@ describe "Product page canonical URL on a custom domain", type: :request do
     expect(response.body).not_to include("seller.example.com")
   end
 
-  # /l/:permalink resolves globally, so another seller's product is reachable over this domain.
-  # Canonicalizing it here would hand this domain Google's copy of someone else's page.
-  it "keeps the subdomain canonical for a product whose seller does not own this domain" do
+  # LinksController#ensure_domain_belongs_to_seller already refuses another seller's product on
+  # this domain, so the page never renders and there is no canonical to get wrong. Pinned here
+  # because custom_domain_host_for_meta's seller check is only defence in depth behind this 404 —
+  # if this guard ever relaxes, the canonical must still not follow the request's host.
+  it "refuses a product whose seller does not own this domain" do
     other_product = create(:product, user: create(:user, username: "otherseller"), name: "Someone Else's")
 
     get "http://seller.example.com/l/#{other_product.unique_permalink}"
 
-    expect(response).to be_successful
-    expect(response.body).to include(%(href="#{other_product.long_url}"))
-    expect(response.body).not_to include(%(href="http://seller.example.com/l/))
+    expect(response).to have_http_status(:not_found)
+    expect(response.body).not_to include(%(href="http://seller.example.com/l/#{other_product.unique_permalink}"))
   end
 
   context "with a product that emits JSON-LD" do

--- a/spec/requests/products/show/custom_domain_canonical_spec.rb
+++ b/spec/requests/products/show/custom_domain_canonical_spec.rb
@@ -26,6 +26,18 @@ describe "Product page canonical URL on a custom domain", type: :request do
     expect(response.body).not_to include("seller.example.com")
   end
 
+  # /l/:permalink resolves globally, so another seller's product is reachable over this domain.
+  # Canonicalizing it here would hand this domain Google's copy of someone else's page.
+  it "keeps the subdomain canonical for a product whose seller does not own this domain" do
+    other_product = create(:product, user: create(:user, username: "otherseller"), name: "Someone Else's")
+
+    get "http://seller.example.com/l/#{other_product.unique_permalink}"
+
+    expect(response).to be_successful
+    expect(response.body).to include(%(href="#{other_product.long_url}"))
+    expect(response.body).not_to include(%(href="http://seller.example.com/l/))
+  end
+
   context "with a product that emits JSON-LD" do
     let(:product) { create(:product, user: seller, name: "Canonical Ebook", native_type: Link::NATIVE_TYPE_EBOOK) }
 

--- a/spec/requests/products/show/custom_domain_canonical_spec.rb
+++ b/spec/requests/products/show/custom_domain_canonical_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Product page canonical URL on a custom domain", type: :request do
+  let(:seller) { create(:user, username: "canonicalseller") }
+  let(:product) { create(:product, user: seller, name: "Canonical Product") }
+  let!(:custom_domain) { create(:custom_domain, :verified_with_certificate, user: seller, domain: "seller.example.com") }
+
+  it "points the canonical and og:url at the seller's own domain" do
+    get "http://seller.example.com/l/#{product.unique_permalink}"
+
+    expect(response).to be_successful
+    expect(response.body).to include(%(href="http://seller.example.com/l/#{product.unique_permalink}"))
+    expect(response.body).to include(%(content="http://seller.example.com/l/#{product.unique_permalink}"))
+    expect(response.body).not_to include("#{seller.username}.gumroad.com/l/#{product.unique_permalink}")
+  end
+
+  it "keeps the subdomain canonical when the request is not on a custom domain" do
+    get product.long_url
+
+    expect(response).to be_successful
+    expect(response.body).to include("#{seller.username}.gumroad.com/l/#{product.unique_permalink}")
+  end
+
+  context "with a product that emits JSON-LD" do
+    let(:product) { create(:product, user: seller, name: "Canonical Ebook", native_type: Link::NATIVE_TYPE_EBOOK) }
+
+    it "uses the custom domain for the structured-data urls too" do
+      get "http://seller.example.com/l/#{product.unique_permalink}"
+
+      expect(response).to be_successful
+      structured_data = product.structured_data(host: "http://seller.example.com")
+      expect(structured_data["url"]).to eq("http://seller.example.com/l/#{product.unique_permalink}")
+      expect(structured_data["offers"]["url"]).to eq("http://seller.example.com/l/#{product.unique_permalink}")
+      expect(product.structured_data["url"]).to include("#{seller.username}.gumroad.com")
+    end
+  end
+end

--- a/spec/requests/products/show/custom_domain_canonical_spec.rb
+++ b/spec/requests/products/show/custom_domain_canonical_spec.rb
@@ -13,27 +13,31 @@ describe "Product page canonical URL on a custom domain", type: :request do
     expect(response).to be_successful
     expect(response.body).to include(%(href="http://seller.example.com/l/#{product.unique_permalink}"))
     expect(response.body).to include(%(content="http://seller.example.com/l/#{product.unique_permalink}"))
-    expect(response.body).not_to include("#{seller.username}.gumroad.com/l/#{product.unique_permalink}")
+    # The Inertia product prop still carries the canonical subdomain long_url; only the
+    # head tags search engines read are re-pointed.
+    expect(response.body).not_to include(%(href="#{product.long_url}"))
   end
 
   it "keeps the subdomain canonical when the request is not on a custom domain" do
     get product.long_url
 
     expect(response).to be_successful
-    expect(response.body).to include("#{seller.username}.gumroad.com/l/#{product.unique_permalink}")
+    expect(response.body).to include(%(href="#{product.long_url}"))
+    expect(response.body).not_to include("seller.example.com")
   end
 
   context "with a product that emits JSON-LD" do
     let(:product) { create(:product, user: seller, name: "Canonical Ebook", native_type: Link::NATIVE_TYPE_EBOOK) }
 
     it "uses the custom domain for the structured-data urls too" do
-      get "http://seller.example.com/l/#{product.unique_permalink}"
+      custom_domain_url = "http://seller.example.com"
 
-      expect(response).to be_successful
-      structured_data = product.structured_data(host: "http://seller.example.com")
-      expect(structured_data["url"]).to eq("http://seller.example.com/l/#{product.unique_permalink}")
-      expect(structured_data["offers"]["url"]).to eq("http://seller.example.com/l/#{product.unique_permalink}")
-      expect(product.structured_data["url"]).to include("#{seller.username}.gumroad.com")
+      structured_data = product.structured_data(host: custom_domain_url)
+      expect(structured_data["url"]).to eq("#{custom_domain_url}/l/#{product.unique_permalink}")
+      expect(structured_data["offers"]["url"]).to eq("#{custom_domain_url}/l/#{product.unique_permalink}")
+
+      # nil host keeps the pre-existing subdomain behaviour for gumroad.com requests.
+      expect(product.structured_data["url"]).to eq(product.long_url)
     end
   end
 end


### PR DESCRIPTION
Fixes the first half of [gp#1667](https://github.com/antiwork/gumroad-private/issues/1667): a product page served on a seller's own domain emitted a canonical (and `og:url`, and JSON-LD `url`) pointing at their `*.gumroad.com` subdomain, so Google reported "Alternate page with proper canonical tag" and indexed the subdomain instead of the seller's domain.

Verified live on `www.exalgostudio.co` before this change:

```
<link rel="canonical" href="https://exalgostudio.gumroad.com/l/...">
<meta property="og:url" content="https://exalgostudio.gumroad.com/l/...">
```

## What changed

`PageMeta::Product` now threads `seller_custom_domain_url` (already in scope via `CustomDomainRouteBuilder`, already passed to `ProductPresenter` on the same request) into `Link#long_url(host:)`, which has accepted a `host:` kwarg since #6586. The canonical tag, `og:url`, and the JSON-LD `url`/`offers.url` all resolve from the one value, so they can't drift apart.

`Product::StructuredData#structured_data` takes an optional `host:` for the same reason. `nil` — every gumroad.com request — keeps the existing subdomain behaviour untouched.

The custom-HTML wrapper document in `LinksController` gets the same treatment; it hand-builds its own canonical and JSON-LD and had the identical defect.

This mirrors what the profile page already does correctly: `UsersController#profile_custom_html_wrapper_document` builds its canonical as `user.profile_url(custom_domain_url: seller_custom_domain_url)`. Product pages just never got it.

## Not in scope

Part 2 of gp#1667 — `CustomDomain#active?` using a 1-week certificate window against a 75-day renewal interval — is **already fixed on main**: `active?` now reads `has_valid_certificate?(CERTIFICATE_LIFETIME)`. Nothing to do there.

## Tests

`spec/requests/products/show/custom_domain_canonical_spec.rb` — asserts the custom-domain host in the head tags, asserts the subdomain is still used off a custom domain, and asserts the structured-data urls follow the same host. Run locally with the existing custom-domain wrapper suites for regressions:

```
44 examples, 0 failures
```
(canonical spec + `custom_html_analytics_spec` + `profile_custom_html_spec`)
