### PR TITLE
Resample an adult-content flag when the model only saw text

### DIFF
--- a/app/services/content_moderation/moderate_record_service.rb
+++ b/app/services/content_moderation/moderate_record_service.rb
@@ -182,10 +182,11 @@ class ContentModeration::ModerateRecordService
     ai_results = run_ai_strategies(content)
     flagged = ai_results.select { |r| r.status == "flagged" }
 
-    # Judgment-preset flags (spam, off-platform fulfillment) that didn't
-    # reproduce when PromptStrategy resampled them. They don't block the
-    # publish, but we still leave a note so the flag rate and false-positive
-    # rate can be measured against blocked publishes.
+    # Judgment-preset flags (spam, off-platform fulfillment, and adult content the
+    # model judged on text alone) that didn't reproduce when PromptStrategy
+    # resampled them. They don't block the publish, but we still leave a note so
+    # the flag rate and false-positive rate can be measured against blocked
+    # publishes.
     audit_reasons = ai_results.flat_map { |r| r.respond_to?(:audit_reasoning) ? Array(r.audit_reasoning) : [] }
 
     reasons = flagged.flat_map(&:reasoning)
@@ -515,10 +516,10 @@ class ContentModeration::ModerateRecordService
           # images come from our own uploads and their galleries are unbounded.
           max_images: entity_type == :page ? :all : ContentModeration::Strategies::ClassifierStrategy::MAX_IMAGES_TO_MODERATE,
         ),
-        # `corroborate_judgment_flags` makes a spam or off-platform-fulfillment
-        # flag block only when it reproduces on resampling; a lone flag is
-        # returned as audit_reasoning and recorded as a non-blocking note
-        # instead (see `check` above).
+        # `corroborate_judgment_flags` makes a spam, off-platform-fulfillment, or
+        # text-only adult-content flag block only when it reproduces on resampling;
+        # a lone flag is returned as audit_reasoning and recorded as a non-blocking
+        # note instead (see `check` above).
         ContentModeration::Strategies::PromptStrategy.new(
           text: content.text,
           image_urls: content.image_urls,

--- a/app/services/content_moderation/strategies/prompt_strategy.rb
+++ b/app/services/content_moderation/strategies/prompt_strategy.rb
@@ -26,10 +26,15 @@ class ContentModeration::Strategies::PromptStrategy
   CORROBORATION_RESAMPLES = 2
 
   # Which presets are judgment calls that need corroboration before they may
-  # block a publish. Adult-content flags are NOT resampled: they key off
-  # concrete depicted content rather than an inference about the seller's
-  # intent, so a single sample is reliable enough to act on.
+  # block a publish. Adult-content flags are corroborated only when the sample
+  # carried no images (see #corroborated_preset?): with a picture in front of it
+  # the model is reading concrete depicted content, but on text alone the flag is
+  # the same kind of intent inference as spam, and one noisy sample should not
+  # block a publish.
   CORROBORATED_PRESETS = %w[spam off_platform_fulfillment].freeze
+
+  # Presets that graduate into CORROBORATED_PRESETS when no image reached the model.
+  TEXT_ONLY_CORROBORATED_PRESETS = %w[adult_content].freeze
 
   ADULT_CONTENT_RULES = <<~RULES
     You are a content moderator. Evaluate the following content for adult/sexual content policy violations.
@@ -234,7 +239,7 @@ class ContentModeration::Strategies::PromptStrategy
       next if result[:status] == "compliant"
       next unless passes_uncertainty_check?(result[:reasoning])
 
-      if CORROBORATED_PRESETS.include?(preset[:name]) && @corroborate_judgment_flags
+      if corroborated_preset?(preset) && @corroborate_judgment_flags
         flagged_resamples, resamples_run = run_resamples(preset)
         corroborated = flagged_resamples == CORROBORATION_RESAMPLES
         Rails.logger.info(
@@ -279,6 +284,20 @@ class ContentModeration::Strategies::PromptStrategy
         list << { name: "off_platform_fulfillment", rules: OFF_PLATFORM_FULFILLMENT_RULES, skip_images: true }
       end
       list
+    end
+
+    # An adult-content flag on a record that sent no image is an inference about
+    # words, not a reading of a picture, so it earns the same resampling as spam.
+    # `skip_images` covers presets that never send images; `sampled_image_urls`
+    # being empty covers a record that simply has none to send (a profile page's
+    # prose, a text-only listing) — and, because it is memoized per instance, a
+    # preset that fell back to text-only after OpenAI could not fetch an image
+    # still counts as having had images available.
+    def corroborated_preset?(preset)
+      return true if CORROBORATED_PRESETS.include?(preset[:name])
+      return false unless TEXT_ONLY_CORROBORATED_PRESETS.include?(preset[:name])
+
+      preset[:skip_images] || sampled_image_urls.empty?
     end
 
     # Re-runs a preset to see whether the initial flag reproduces, and

--- a/app/services/content_moderation/strategies/prompt_strategy.rb
+++ b/app/services/content_moderation/strategies/prompt_strategy.rb
@@ -239,7 +239,7 @@ class ContentModeration::Strategies::PromptStrategy
       next if result[:status] == "compliant"
       next unless passes_uncertainty_check?(result[:reasoning])
 
-      if corroborated_preset?(preset) && @corroborate_judgment_flags
+      if @corroborate_judgment_flags && corroborated_preset?(preset, images_sent: result[:images_sent])
         flagged_resamples, resamples_run = run_resamples(preset)
         corroborated = flagged_resamples == CORROBORATION_RESAMPLES
         Rails.logger.info(
@@ -286,18 +286,22 @@ class ContentModeration::Strategies::PromptStrategy
       list
     end
 
-    # An adult-content flag on a record that sent no image is an inference about
-    # words, not a reading of a picture, so it earns the same resampling as spam.
-    # `skip_images` covers presets that never send images; `sampled_image_urls`
-    # being empty covers a record that simply has none to send (a profile page's
-    # prose, a text-only listing) — and, because it is memoized per instance, a
-    # preset that fell back to text-only after OpenAI could not fetch an image
-    # still counts as having had images available.
-    def corroborated_preset?(preset)
+    # An adult-content flag the model reached without seeing a picture is an
+    # inference about words, not a reading of an image, so it earns the same
+    # resampling as spam. Keyed on what the flagging sample actually sent rather
+    # than on what the record holds: a preset that fell back to text-only because
+    # OpenAI could not fetch the image (see #evaluate_preset) also reasoned about
+    # prose alone, and blocking it on one sample is the bug this addresses.
+    def corroborated_preset?(preset, images_sent:)
       return true if CORROBORATED_PRESETS.include?(preset[:name])
       return false unless TEXT_ONLY_CORROBORATED_PRESETS.include?(preset[:name])
 
-      preset[:skip_images] || sampled_image_urls.empty?
+      !images_sent
+    end
+
+    # Whether a chat call built with this `skip_images` actually carried images.
+    def images_sent?(skip_images:)
+      !skip_images && sampled_image_urls.any?
     end
 
     # Re-runs a preset to see whether the initial flag reproduces, and
@@ -339,6 +343,7 @@ class ContentModeration::Strategies::PromptStrategy
       {
         status: parsed["flagged"] ? "flagged" : "compliant",
         reasoning: parsed["reasoning"].to_s,
+        images_sent: images_sent?(skip_images:),
       }
     rescue Faraday::BadRequestError => e
       # OpenAI regularly fails to download some of our image URLs (signed

--- a/app/services/content_moderation/strategies/prompt_strategy.rb
+++ b/app/services/content_moderation/strategies/prompt_strategy.rb
@@ -240,7 +240,7 @@ class ContentModeration::Strategies::PromptStrategy
       next unless passes_uncertainty_check?(result[:reasoning])
 
       if @corroborate_judgment_flags && corroborated_preset?(preset, images_sent: result[:images_sent])
-        flagged_resamples, resamples_run = run_resamples(preset)
+        flagged_resamples, resamples_run = run_resamples(preset, skip_images: !result[:images_sent])
         corroborated = flagged_resamples == CORROBORATION_RESAMPLES
         Rails.logger.info(
           "ContentModeration::PromptStrategy #{preset[:name]} corroboration: #{flagged_resamples}/#{resamples_run} resamples flagged; " \
@@ -314,12 +314,18 @@ class ContentModeration::Strategies::PromptStrategy
     # not flagging (evaluate_preset already maps those to compliant), so
     # transient API trouble fails open — toward publishing — like the rest of
     # this class.
-    def run_resamples(preset)
+    #
+    # `skip_images` is the flagging sample's effective payload, not the
+    # preset's default: a flag that came from the text-only retry (OpenAI
+    # rejected the image URL) must be corroborated text-only, or each resample
+    # re-sends the URL that just failed — and, if the fetch transiently
+    # succeeds, corroborates a text verdict with image-bearing samples.
+    def run_resamples(preset, skip_images:)
       flagged = 0
       run = 0
       CORROBORATION_RESAMPLES.times do
         run += 1
-        break unless evaluate_preset(preset)[:status] == "flagged"
+        break unless evaluate_preset(preset, skip_images:)[:status] == "flagged"
         flagged += 1
       end
       [flagged, run]

--- a/spec/services/content_moderation/strategies/prompt_strategy_spec.rb
+++ b/spec/services/content_moderation/strategies/prompt_strategy_spec.rb
@@ -74,11 +74,11 @@ RSpec.describe ContentModeration::Strategies::PromptStrategy, :vcr do
 
     it "blocks a text-only adult_content flag when every resample reproduces it" do
       allow(client).to receive(:chat).and_return(
-        json_chat_response(flagged: true, reasoning: "adult prose"),
-        json_chat_response(uncertain: false),
-        json_chat_response(flagged: true, reasoning: "adult prose"),
-        json_chat_response(flagged: true, reasoning: "adult prose"),
-        json_chat_response(flagged: false, reasoning: "")
+        json_chat_response(flagged: true, reasoning: "adult prose"),  # adult_content preset
+        json_chat_response(uncertain: false),                         # uncertainty check
+        json_chat_response(flagged: true, reasoning: "adult prose"),  # resample 1
+        json_chat_response(flagged: true, reasoning: "adult prose"),  # resample 2 agrees
+        json_chat_response(flagged: false, reasoning: "")             # spam preset
       )
 
       result = described_class.new(text: "profile copy", corroborate_judgment_flags: true).perform
@@ -92,10 +92,10 @@ RSpec.describe ContentModeration::Strategies::PromptStrategy, :vcr do
     # even though the caller passed a URL.
     it "corroborates when the only image URL is an unsupported format" do
       allow(client).to receive(:chat).and_return(
-        json_chat_response(flagged: true, reasoning: "adult prose"),
-        json_chat_response(uncertain: false),
-        json_chat_response(flagged: false, reasoning: ""),
-        json_chat_response(flagged: false, reasoning: "")
+        json_chat_response(flagged: true, reasoning: "adult prose"),  # adult_content preset
+        json_chat_response(uncertain: false),                         # uncertainty check
+        json_chat_response(flagged: false, reasoning: ""),            # resample 1 decides
+        json_chat_response(flagged: false, reasoning: "")             # spam preset
       )
 
       result = described_class.new(

--- a/spec/services/content_moderation/strategies/prompt_strategy_spec.rb
+++ b/spec/services/content_moderation/strategies/prompt_strategy_spec.rb
@@ -112,6 +112,9 @@ RSpec.describe ContentModeration::Strategies::PromptStrategy, :vcr do
     # text-only. That retry's verdict rests on prose, so it is resampled like any
     # other text-only flag — keying on the record's images instead would leave this
     # path hard-blocking on one sample, which is the same bug in a second place.
+    # The resamples must also be text-only: they corroborate the prose verdict,
+    # and re-sending the URL OpenAI just rejected would either fail again or
+    # answer a different question.
     it "corroborates a flag from the text-only retry after OpenAI could not fetch the image" do
       bad_request = Faraday::BadRequestError.new(
         { status: 400, body: { "error" => { "code" => "invalid_image_url", "message" => "could not fetch" } } }
@@ -123,8 +126,11 @@ RSpec.describe ContentModeration::Strategies::PromptStrategy, :vcr do
         json_chat_response(flagged: false, reasoning: "")             # spam preset
       ]
       call = 0
-      allow(client).to receive(:chat) do
+      image_counts_per_call = []
+      allow(client).to receive(:chat) do |parameters:|
         call += 1
+        content = parameters[:messages].last[:content]
+        image_counts_per_call << (content.is_a?(Array) ? content.count { |part| part[:type] == "image_url" } : 0)
         raise bad_request if call == 1
 
         responses[call - 2]
@@ -138,6 +144,8 @@ RSpec.describe ContentModeration::Strategies::PromptStrategy, :vcr do
 
       expect(result.status).to eq("compliant")
       expect(result.audit_reasoning).to eq(["adult_content (uncorroborated, 1/2 samples flagged): adult prose"])
+      # rejected image attempt, text-only retry, uncertainty check, resample, spam
+      expect(image_counts_per_call).to eq([1, 0, 0, 0, 0])
     end
 
     it "leaves a text-only adult_content flag blocking when corroboration is not requested" do

--- a/spec/services/content_moderation/strategies/prompt_strategy_spec.rb
+++ b/spec/services/content_moderation/strategies/prompt_strategy_spec.rb
@@ -51,6 +51,99 @@ RSpec.describe ContentModeration::Strategies::PromptStrategy, :vcr do
     expect(result.reasoning).to eq(["spam: clear spam"])
   end
 
+  # An adult-content flag reads a picture when there is one, but on text alone it
+  # is the same intent inference as spam — so it earns the same resampling. This
+  # is what let a compliant NSFW seller's profile-page prose be hard-blocked on a
+  # single nondeterministic sample (gumroad-private#1684).
+  describe "adult_content corroboration when no image was sent" do
+    it "downgrades a text-only adult_content flag to audit-only when a resample disagrees" do
+      allow(client).to receive(:chat).and_return(
+        json_chat_response(flagged: true, reasoning: "adult prose"),  # adult_content preset
+        json_chat_response(uncertain: false),                         # uncertainty check
+        json_chat_response(flagged: true, reasoning: "adult prose"),  # resample 1
+        json_chat_response(flagged: false, reasoning: ""),            # resample 2 disagrees
+        json_chat_response(flagged: false, reasoning: "")             # spam preset
+      )
+
+      result = described_class.new(text: "profile copy", corroborate_judgment_flags: true).perform
+
+      expect(result.status).to eq("compliant")
+      expect(result.reasoning).to eq([])
+      expect(result.audit_reasoning).to eq(["adult_content (uncorroborated, 2/3 samples flagged): adult prose"])
+    end
+
+    it "blocks a text-only adult_content flag when every resample reproduces it" do
+      allow(client).to receive(:chat).and_return(
+        json_chat_response(flagged: true, reasoning: "adult prose"),
+        json_chat_response(uncertain: false),
+        json_chat_response(flagged: true, reasoning: "adult prose"),
+        json_chat_response(flagged: true, reasoning: "adult prose"),
+        json_chat_response(flagged: false, reasoning: "")
+      )
+
+      result = described_class.new(text: "profile copy", corroborate_judgment_flags: true).perform
+
+      expect(result.status).to eq("flagged")
+      expect(result.reasoning).to eq(["adult_content: adult prose"])
+      expect(result.audit_reasoning).to eq([])
+    end
+
+    # The original single-sample rule still governs a flag that actually looked at
+    # an image: no resample, and it blocks immediately.
+    it "does not resample an adult_content flag when an image was sent" do
+      allow(client).to receive(:chat).and_return(
+        json_chat_response(flagged: true, reasoning: "explicit image"),
+        json_chat_response(uncertain: false),
+        json_chat_response(flagged: false, reasoning: "")
+      )
+
+      result = described_class.new(
+        text: "listing copy",
+        image_urls: ["https://example.com/cover.jpg"],
+        corroborate_judgment_flags: true
+      ).perform
+
+      expect(result.status).to eq("flagged")
+      expect(result.reasoning).to eq(["adult_content: explicit image"])
+      expect(result.audit_reasoning).to eq([])
+      expect(client).to have_received(:chat).exactly(3).times
+    end
+
+    # An unsupported extension never reaches the model, so the flag was text-only
+    # even though the caller passed a URL.
+    it "corroborates when the only image URL is an unsupported format" do
+      allow(client).to receive(:chat).and_return(
+        json_chat_response(flagged: true, reasoning: "adult prose"),
+        json_chat_response(uncertain: false),
+        json_chat_response(flagged: false, reasoning: ""),
+        json_chat_response(flagged: false, reasoning: "")
+      )
+
+      result = described_class.new(
+        text: "profile copy",
+        image_urls: ["https://example.com/design.svg"],
+        corroborate_judgment_flags: true
+      ).perform
+
+      expect(result.status).to eq("compliant")
+      expect(result.audit_reasoning).to eq(["adult_content (uncorroborated, 1/2 samples flagged): adult prose"])
+    end
+
+    it "leaves a text-only adult_content flag blocking when corroboration is not requested" do
+      allow(client).to receive(:chat).and_return(
+        json_chat_response(flagged: true, reasoning: "adult prose"),
+        json_chat_response(uncertain: false),
+        json_chat_response(flagged: false, reasoning: "")
+      )
+
+      result = described_class.new(text: "profile copy").perform
+
+      expect(result.status).to eq("flagged")
+      expect(result.reasoning).to eq(["adult_content: adult prose"])
+      expect(client).to have_received(:chat).exactly(3).times
+    end
+  end
+
   # A single language-model sample is nondeterministic, so a lone spam flag
   # must not block a publish. These specs pin the corroboration gate: the flag
   # only blocks when every resample reproduces it.

--- a/spec/services/content_moderation/strategies/prompt_strategy_spec.rb
+++ b/spec/services/content_moderation/strategies/prompt_strategy_spec.rb
@@ -108,6 +108,38 @@ RSpec.describe ContentModeration::Strategies::PromptStrategy, :vcr do
       expect(result.audit_reasoning).to eq(["adult_content (uncorroborated, 1/2 samples flagged): adult prose"])
     end
 
+    # OpenAI regularly cannot fetch our signed image URLs and the preset retries
+    # text-only. That retry's verdict rests on prose, so it is resampled like any
+    # other text-only flag — keying on the record's images instead would leave this
+    # path hard-blocking on one sample, which is the same bug in a second place.
+    it "corroborates a flag from the text-only retry after OpenAI could not fetch the image" do
+      bad_request = Faraday::BadRequestError.new(
+        { status: 400, body: { "error" => { "code" => "invalid_image_url", "message" => "could not fetch" } } }
+      )
+      responses = [
+        json_chat_response(flagged: true, reasoning: "adult prose"),  # text-only retry flags
+        json_chat_response(uncertain: false),                         # uncertainty check
+        json_chat_response(flagged: false, reasoning: ""),            # resample 1 decides
+        json_chat_response(flagged: false, reasoning: "")             # spam preset
+      ]
+      call = 0
+      allow(client).to receive(:chat) do
+        call += 1
+        raise bad_request if call == 1
+
+        responses[call - 2]
+      end
+
+      result = described_class.new(
+        text: "profile copy",
+        image_urls: ["https://files.gumroad.com/signed/cover.png"],
+        corroborate_judgment_flags: true
+      ).perform
+
+      expect(result.status).to eq("compliant")
+      expect(result.audit_reasoning).to eq(["adult_content (uncorroborated, 1/2 samples flagged): adult prose"])
+    end
+
     it "leaves a text-only adult_content flag blocking when corroboration is not requested" do
       allow(client).to receive(:chat).and_return(
         json_chat_response(flagged: true, reasoning: "adult prose"),

--- a/spec/services/content_moderation/strategies/prompt_strategy_spec.rb
+++ b/spec/services/content_moderation/strategies/prompt_strategy_spec.rb
@@ -88,27 +88,6 @@ RSpec.describe ContentModeration::Strategies::PromptStrategy, :vcr do
       expect(result.audit_reasoning).to eq([])
     end
 
-    # The original single-sample rule still governs a flag that actually looked at
-    # an image: no resample, and it blocks immediately.
-    it "does not resample an adult_content flag when an image was sent" do
-      allow(client).to receive(:chat).and_return(
-        json_chat_response(flagged: true, reasoning: "explicit image"),
-        json_chat_response(uncertain: false),
-        json_chat_response(flagged: false, reasoning: "")
-      )
-
-      result = described_class.new(
-        text: "listing copy",
-        image_urls: ["https://example.com/cover.jpg"],
-        corroborate_judgment_flags: true
-      ).perform
-
-      expect(result.status).to eq("flagged")
-      expect(result.reasoning).to eq(["adult_content: explicit image"])
-      expect(result.audit_reasoning).to eq([])
-      expect(client).to have_received(:chat).exactly(3).times
-    end
-
     # An unsupported extension never reaches the model, so the flag was text-only
     # even though the caller passed a URL.
     it "corroborates when the only image URL is an unsupported format" do
@@ -214,14 +193,22 @@ RSpec.describe ContentModeration::Strategies::PromptStrategy, :vcr do
       expect(result.audit_reasoning).to eq(["spam (uncorroborated, 1/2 samples flagged): clear spam"])
     end
 
-    it "does not resample adult content flags" do
+    # Superseded by the "adult_content corroboration when no image was sent" group
+    # above: a flag the model reached on text alone IS now resampled. This example
+    # keeps the original no-resample rule pinned for the case it was written for —
+    # a flag that actually saw an image.
+    it "does not resample adult content flags that saw an image" do
       allow(client).to receive(:chat).and_return(
         json_chat_response(flagged: true, reasoning: "clear adult content"),  # adult_content preset
         json_chat_response(uncertain: false),                                 # uncertainty check
         json_chat_response(flagged: false, reasoning: "")                     # spam preset
       )
 
-      result = described_class.new(text: "moderate me", corroborate_judgment_flags: true).perform
+      result = described_class.new(
+        text: "moderate me",
+        image_urls: ["https://example.com/cover.jpg"],
+        corroborate_judgment_flags: true
+      ).perform
 
       expect(result.status).to eq("flagged")
       expect(result.reasoning).to eq(["adult_content: clear adult content"])


### PR DESCRIPTION
Fixes half of antiwork/gumroad-private#1684.

## What

`ContentModeration::Strategies::PromptStrategy` now resamples an `adult_content` flag when the model reached it **without seeing an image**, instead of hard-blocking on a single sample.

Corroboration (`CORROBORATION_RESAMPLES = 2`, added in #1148) re-asks the model and only blocks when every resample reproduces the flag; otherwise the flag becomes a non-blocking audit note. #1148 deliberately excluded `adult_content` on the grounds that those flags "key off concrete depicted content rather than an inference about the seller's intent."

That holds for a flag that looked at a picture. It does not hold when no image reached the model — then the verdict rests on prose, which is the same nondeterministic judgment call as spam.

## Why

A policy-compliant NSFW seller could not save **any** edit to their custom profile page, including CSS-only edits that change no text and no imagery, because `adult_content` blocked the save on the page's existing prose. There is no page-level adult flag and no exemption path, so a single `gpt-4o-mini` sample was enough to lock them out of their own storefront.

## Before / after

| | before | after |
|---|---|---|
| adult flag, model saw an image | blocks on 1 sample | unchanged — blocks on 1 sample |
| adult flag, no image sent | **blocks on 1 sample** | blocks only if 3/3 samples flag; else audit note |
| adult flag, image fetch failed → text-only retry | **blocks on 1 sample** | blocks only if 3/3 samples flag |
| spam / off-platform fulfillment | corroborated | unchanged |
| callers not opting in (e.g. `CreatePublicMediaService`) | 1 sample | unchanged |

The predicate keys on what the *flagging sample* actually sent, not on what the record holds. That distinction matters on a live path: OpenAI regularly cannot fetch our signed `files.gumroad.com` URLs, and the preset retries text-only. The record has images, but the sample that flagged did not — and the first version of this branch still hard-blocked it. `evaluate_preset` now reports whether it sent images and the decision reads that.

## Scope limits — read before approving

- **This is a mitigation, not the actual fix.** Problem 1 of the issue (the product-level NSFW toggle does not propagate to the profile page; there is no page-level adult flag) is untouched — `grep is_adult app/services/content_moderation/moderate_record_service.rb` returns nothing. That needs a product decision about a page-level exemption and is not in this PR.
- **It only reaches records with zero model-visible images.** A profile page carrying even one supported banner image still takes the single-sample path. I could not read the reported seller's page to confirm its image count, so I cannot promise this unblocks that specific seller.
- **The resamples are correlated.** `temperature: 0.1`, same model, same prompt. A profile whose copy genuinely reads as pornographic will draw 3/3 and stay blocked. This rescues flags that were already marginal — which bounds both the benefit and the risk.
- **It is grindable, and that trade is deliberate.** Each save attempt is a fresh 3-draw trial, so a seller can retry. #1148 accepted this for `spam`; this extends it to a stricter category. Mitigating factors: every downgrade leaves an admin note (`ModerateRecordService` records `audit_reasoning` preset-agnostically, so grinding is visible), and image moderation is completely untouched — `ClassifierStrategy` has no extension allowlist and is unaffected by any of this.
- **Latency:** worst case on the synchronous save path rises by 2 model calls per corroborating preset. `run_resamples` breaks on the first clean sample, so the realistic add is 1-2 calls, and only on a flag.

## Tests

`spec/services/content_moderation/strategies/prompt_strategy_spec.rb` — 37 examples, 0 failures. Five new examples: text-only downgrade, text-only block when all resamples agree, unsupported-extension URL (never reaches the model, so it counts as text-only), the `invalid_image_url` text-only retry, and no-corroboration-requested. One pre-existing example was scoped to the image case it now describes — it passed a text-only record and asserted no resampling, which is exactly the behaviour this changes; it was green in a full-file run only because the shared stub happened to return a clean third response, and failed as soon as it ran alone.

Mutation-tested — each mutation and the examples that kill it:

| mutation | killed by |
|---|---|
| `!images_sent` → `true` | image-case example |
| `!images_sent` → `false` | all 4 text-only examples |
| `images_sent?` uses `.empty?` instead of `.any?` | 4 examples |
| drop the `skip_images` term (breaks the retry path) | the `invalid_image_url` retry example |
| `TEXT_ONLY_CORROBORATED_PRESETS = %w[]` | all 4 text-only examples |

One known survivor: deleting the `TEXT_ONLY_CORROBORATED_PRESETS` guard line changes nothing today, because `adult_content` is the only preset that can reach it. It is a forward-looking allowlist that keeps a future fourth preset from silently graduating into corroboration.

CI: 76/76 green on 821a330a1 (run 30746143143). Adversarially reviewed locally; the `invalid_image_url` gap above was found in that review and fixed in this branch, not deferred.
