### PR TITLE
Tell a seller with a locked PayPal account what actually happened

### DIFF
--- a/app/mailers/contacting_creator_mailer.rb
+++ b/app/mailers/contacting_creator_mailer.rb
@@ -252,6 +252,9 @@ class ContactingCreatorMailer < ApplicationMailer
     @retries_paused_by_pause = !@retries_stopped && @seller.payouts_paused?
     # And when they can clear it on the account they already have, lead with that fix.
     @can_receive_us_dollars_on_same_account = @payment.repairable_in_place_paypal_failure?
+    # A locked or inactive receiving account needs its own fix copy: only PayPal can lift it, and
+    # the country-based alternatives below are the wrong diagnosis for it (gumroad-private#1661).
+    @locked_paypal_account = @payment.locked_account_paypal_failure?
     # Ask the seller to reply rather than promising the next payout date, because an admin or
     # system hold outlives the payout-method fix this email prescribes and only support can lift
     # it. A hold Stripe placed is lifted automatically when the seller changes their payout details

--- a/app/models/concerns/payment/failure_reason.rb
+++ b/app/models/concerns/payment/failure_reason.rb
@@ -45,8 +45,11 @@ module Payment::FailureReason
   # receive US dollars, and Gumroad always pays PayPal out in USD.
   #
   # Everything else in PAYPAL_MASS_PAY stays a support-only note. In particular a locked or inactive
-  # receiving account (3015) and a declined transaction (9302) are deliberately NOT here: those are
-  # about one attempt, not about what the seller holds.
+  # receiving account (3015) is here as of gumroad-private#1661: it looked like a one-attempt
+  # failure, but for the 2,152 Russia-KYC sellers holding $173K it is the permanent state of the
+  # account, and the repeated-failure pause (Payment#pause_payouts_after_repeated_failures) stops
+  # their payouts after three tries WITHOUT telling them anything at all. A declined transaction
+  # (9302) is still deliberately absent: that one really is about a single attempt.
   #
   # The keys are the rejections; the values are what the seller is told about each. Written in the
   # second person because, unlike every other PayPal failure note, these are shown to the seller:
@@ -54,6 +57,7 @@ module Payment::FailureReason
   EXPLAINED_PAYPAL_FAILURE_SELLER_REASONS = {
     "PAYPAL 3148" => "PayPal will not send payouts to your PayPal account, because payments cannot be received in the country on that account's address",
     "PAYPAL 14159" => "PayPal will not send your payout, because your PayPal account cannot receive US dollars",
+    "PAYPAL 3015" => "PayPal will not send your payout, because your PayPal account is locked or inactive",
   }.freeze
 
   # Which of those rejections additionally STOP the weekly retry.
@@ -98,6 +102,25 @@ module Payment::FailureReason
   # retried, and the seller-facing copy has to offer the in-place fix rather than only telling them
   # to find another account.
   REPAIRABLE_IN_PLACE_PAYPAL_FAILURE_REASONS = ["PAYPAL 14159"].freeze
+
+  # Rejections that are a property of the RECEIVING ACCOUNT'S STATE rather than of its country or
+  # its currencies. PayPal has locked or deactivated the account; only PayPal can unlock it, and
+  # nothing in the seller's Gumroad payout settings changes the outcome.
+  #
+  # Kept out of RETRY_BLOCKING deliberately. An unlocked account starts receiving again, and an
+  # address-keyed block would never notice — the same argument that keeps 14159 retried. What
+  # actually stops the retries here is the generic repeated-failure pause, at three consecutive
+  # failures to the same address.
+  #
+  # It also gets its own fix copy, because the generic PayPal-only wording tells the seller to go
+  # find a PayPal account in a country that can receive payments — advice that is both wrong (the
+  # country is not the problem) and, for the Russia cohort in gumroad-private#1661, unfollowable.
+  LOCKED_ACCOUNT_PAYPAL_FAILURE_REASONS = ["PAYPAL 3015"].freeze
+
+  # A locked account is by definition repairable — by PayPal — so blocking retries on it would
+  # freeze a seller out the moment PayPal restores them.
+  raise "a locked-account rejection must stay retryable" unless
+    (LOCKED_ACCOUNT_PAYPAL_FAILURE_REASONS & RETRY_BLOCKING_PAYPAL_FAILURE_REASONS).empty?
 
   # Every code that stops the retries must also have seller-facing wording, because the payout walk
   # looks that wording up by code (Payment#terminal_paypal_failure_seller_note) while deciding
@@ -144,6 +167,9 @@ module Payment::FailureReason
     ].freeze,
     "PAYPAL 14159" => [
       "PayPal will not send your payout, because your PayPal account cannot receive US dollars",
+    ].freeze,
+    "PAYPAL 3015" => [
+      "PayPal will not send your payout, because your PayPal account is locked or inactive",
     ].freeze,
   }.freeze
 
@@ -236,6 +262,23 @@ module Payment::FailureReason
     "method we can offer in your country, so the alternative is to use a different PayPal account that can " \
     "receive US dollars, which you can change in your payout settings."
 
+  # For a locked or inactive receiving account. Only PayPal can lift that, so the first step is
+  # always PayPal rather than anything in our settings.
+  TERMINAL_PAYPAL_FAILURE_SELLER_FIX_LOCKED_ACCOUNT_WITH_BANK =
+    "Sign in to PayPal to see whether there are restrictions on your account, or contact PayPal to have them " \
+    "lifted. You can also add a bank account in your payout settings, or use a different PayPal account."
+  # Said where PayPal is the only rail Gumroad offers in the seller's country AND that PayPal
+  # account is locked. This is the dead end in gumroad-private#1661: telling this seller to "use a
+  # PayPal account registered in a country that can receive payments" is an instruction with no
+  # action behind it, because the country was never the problem and, for much of this cohort,
+  # there is no second PayPal account to go get. So we say plainly that we may have no way to pay
+  # them, and that we hope to have one — rather than sending them after a fix that does not exist.
+  TERMINAL_PAYPAL_FAILURE_SELLER_FIX_LOCKED_ACCOUNT_PAYPAL_ONLY =
+    "Sign in to PayPal to see whether there are restrictions on your account, or contact PayPal to have them " \
+    "lifted. PayPal is the only payout method we can offer in your country, so if PayPal cannot restore your " \
+    "account and you do not have another one, we have no way to pay you right now. We hope to have a way to pay " \
+    "out your balance in the future."
+
   # What happens after they fix it. Three consecutive failed payouts to the same destination trip
   # an automatic hold on the whole account (Payment#pause_payouts_after_repeated_failures), and
   # sellers here have failed dozens of times, so many are already holding one. That hold is checked
@@ -316,10 +359,6 @@ module Payment::FailureReason
     "PAYPAL 11711" => {
       reason: "per-transaction sending limit exceeded",
       solution: "Contact PayPal to get receiving limit on the account increased. If that's not possible, Gumroad can split their payout, please contact Gumroad Support"
-    },
-    "PAYPAL 3015" => {
-      reason: "receiver's account is locked or inactive",
-      solution: "Log in to your PayPal account and ensure there are no restrictions on it, or contact PayPal Support for more information"
     },
     "PAYPAL 8330" => {
       reason: "receiving limit exceeded",

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -315,6 +315,15 @@ class Payment < ApplicationRecord
       FailureReason::REPAIRABLE_IN_PLACE_PAYPAL_FAILURE_REASONS.include?(failure_reason)
   end
 
+  # True when PayPal has locked or deactivated the receiving account. Only PayPal can lift that, so
+  # the fix copy has to start there rather than in our payout settings — and must not blame the
+  # account's country, which is not what failed.
+  # See Payment::FailureReason::LOCKED_ACCOUNT_PAYPAL_FAILURE_REASONS.
+  def locked_account_paypal_failure?
+    processor == PayoutProcessorType::PAYPAL &&
+      FailureReason::LOCKED_ACCOUNT_PAYPAL_FAILURE_REASONS.include?(failure_reason)
+  end
+
   # True when there is no payout method left to point the seller at: PayPal refuses the country on
   # the account's address, and bank transfer is not offered in the seller's. Read off the terminal
   # list rather than naming 3148, but the copy it selects only holds while that list stays
@@ -348,6 +357,14 @@ class Payment < ApplicationRecord
   def terminal_paypal_failure_seller_solution
     fix = if paypal_failure_without_available_payout_rail?
       FailureReason::TERMINAL_PAYPAL_FAILURE_SELLER_SOLUTION_NO_PAYOUT_RAIL
+    elsif locked_account_paypal_failure?
+      # Only PayPal can unlock the account, so neither branch sends the seller after a
+      # differently-registered PayPal account — the country was never the problem.
+      if user.can_setup_bank_payouts?
+        FailureReason::TERMINAL_PAYPAL_FAILURE_SELLER_FIX_LOCKED_ACCOUNT_WITH_BANK
+      else
+        FailureReason::TERMINAL_PAYPAL_FAILURE_SELLER_FIX_LOCKED_ACCOUNT_PAYPAL_ONLY
+      end
     elsif repairable_in_place_paypal_failure?
       # The seller can clear this on the account they already use, so lead with that — see
       # Payment::FailureReason::REPAIRABLE_IN_PLACE_PAYPAL_FAILURE_REASONS.

--- a/app/services/onetime/resolve_terminal_paypal_payout_failures.rb
+++ b/app/services/onetime/resolve_terminal_paypal_payout_failures.rb
@@ -2,7 +2,7 @@
 
 # Explain the stopped payouts to the sellers who were already stuck when we shipped the fix.
 #
-# PayPal rejections 3148 and 14159 describe the receiving PayPal account, so re-sending the same
+# PayPal rejections 3148, 14159 and 3015 describe the receiving PayPal account, so re-sending the same
 # payout can never succeed until the seller changes something. The payout pipeline retried them
 # every week anyway — sellers here have a median of 22 identical failures each, worst case 37 — and
 # told the seller nothing beyond a generic "payouts were paused by the system" note

--- a/app/views/contacting_creator_mailer/paypal_payout_permanently_failed.html.erb
+++ b/app/views/contacting_creator_mailer/paypal_payout_permanently_failed.html.erb
@@ -37,6 +37,20 @@
         Or <a href='<%= settings_payments_url %>'>use a different PayPal account</a> that can receive US dollars.
       <% end %>
     </p>
+  <% elsif @locked_paypal_account %>
+    <p>
+      <%# Only PayPal can unlock the account, so the first step is always PayPal — never our
+          settings, and never a differently-registered account, since the country did not fail. %>
+      Sign in to PayPal to see whether there are restrictions on your account, or contact PayPal to have them lifted.
+      <% if @can_use_bank_account %>
+        You can also <a href='<%= settings_payments_url %>'>add a bank account in your payout settings</a>, or use a different PayPal account.
+      <% else %>
+        <%# The gumroad-private#1661 dead end: no bank rail, and telling them to find another PayPal
+            account is an instruction much of this cohort has no way to follow. Say so plainly. %>
+        PayPal is the only payout method we can offer in your country, so if PayPal cannot restore your account and you do not have
+        <a href='<%= settings_payments_url %>'>another one to use</a>, we have no way to pay you right now. We hope to have a way to pay out your balance in the future.
+      <% end %>
+    </p>
   <% elsif @can_use_bank_account %>
     <p>
       <%# Reached only for the rejection that also takes the address off the account, so the copy

--- a/spec/mailers/contacting_creator_mailer_spec.rb
+++ b/spec/mailers/contacting_creator_mailer_spec.rb
@@ -103,6 +103,42 @@ describe ContactingCreatorMailer do
       expect(mail.body.encoded).to_not include("keep trying on your usual payout schedule")
     end
 
+    # gumroad-private#1661. A locked receiving account is not a country problem, so the old copy
+    # sent this seller after a PayPal account "registered in a country that can receive PayPal
+    # payments" — the wrong diagnosis, and for the 2,152 Russia-KYC sellers in that issue an
+    # instruction with no action behind it.
+    context "when PayPal has locked the receiving account" do
+      before { payment.update!(failure_reason: "PAYPAL 3015") }
+
+      it "names the lock and points the seller at PayPal, not at their country" do
+        mail = ContactingCreatorMailer.paypal_payout_permanently_failed(payment.id)
+
+        expect(mail.body.encoded).to include("your PayPal account is locked or inactive")
+        expect(mail.body.encoded).to include("contact PayPal to have them lifted")
+        expect(mail.body.encoded).to_not include("registered in a country that can receive PayPal payments")
+      end
+
+      it "tells a seller with no bank rail plainly that we may have no way to pay them" do
+        payment.user.alive_user_compliance_info.mark_deleted!
+        create(:user_compliance_info, user: payment.user, country: "Ukraine")
+        expect(payment.user.reload.can_setup_bank_payouts?).to be(false)
+
+        mail = ContactingCreatorMailer.paypal_payout_permanently_failed(payment.id)
+
+        expect(mail.body.encoded).to include("we have no way to pay you right now")
+        expect(mail.body.encoded).to include("We hope to have a way to pay out your balance in the future")
+      end
+
+      # Only PayPal can unlock it, so an address-keyed block would freeze out a seller the moment
+      # PayPal restores them. The retries continue and the copy must not claim otherwise.
+      it "does not claim the retries stopped" do
+        mail = ContactingCreatorMailer.paypal_payout_permanently_failed(payment.id)
+
+        expect(mail.body.encoded).to_not include("stopped retrying")
+        expect(mail.body.encoded).to include("keep trying on your usual payout schedule")
+      end
+    end
+
     # The payout gate exits on payouts_paused? before any processor runs, so a paused seller is not
     # being retried on schedule whatever the rejection code says. Promising it contradicts the pause
     # this same email describes further down. Reviewer finding on #6526.

--- a/spec/models/concerns/payment/failure_reason_spec.rb
+++ b/spec/models/concerns/payment/failure_reason_spec.rb
@@ -11,7 +11,7 @@ describe Payment::FailureReason do
   # retry is a strictly stronger claim than explaining, so it must apply to strictly fewer codes.
   describe "TERMINAL_PAYPAL_FAILURE_REASONS" do
     it "explains both account-level rejections but only blocks retries on the unrepairable one" do
-      expect(described_class::EXPLAINED_PAYPAL_FAILURE_REASONS).to match_array(["PAYPAL 3148", "PAYPAL 14159"])
+      expect(described_class::EXPLAINED_PAYPAL_FAILURE_REASONS).to match_array(["PAYPAL 3148", "PAYPAL 14159", "PAYPAL 3015"])
 
       # 14159 — "your PayPal account cannot receive US dollars" — is explained but still retried,
       # because PayPal lets a recipient add receive currencies on the same account. The block is
@@ -203,6 +203,55 @@ describe Payment::FailureReason do
                 "receive US dollars, which you can change in your payout settings. " \
                 "Your balance is safe in the meantime and will be paid out on the next payout date after a working payout method is on file."
               )
+            end
+
+            # gumroad-private#1661: the Russia cohort. The old copy sent them after a PayPal
+            # account registered in a receivable country, which is both the wrong diagnosis and,
+            # for much of that cohort, unfollowable.
+            it "tells a locked-account seller with no bank rail that we may have no way to pay them" do
+              switch_to_paypal_only_country
+
+              payment.mark_failed!("PAYPAL 3015")
+
+              solution = payment.reload.terminal_paypal_failure_seller_solution
+              expect(solution).to eq(
+                "Sign in to PayPal to see whether there are restrictions on your account, or contact PayPal to have them " \
+                "lifted. PayPal is the only payout method we can offer in your country, so if PayPal cannot restore your " \
+                "account and you do not have another one, we have no way to pay you right now. We hope to have a way to pay " \
+                "out your balance in the future. " \
+                "Your balance is safe in the meantime and will be paid out on the next payout date after a working payout method is on file."
+              )
+              expect(solution).to_not include("registered in a country that can receive PayPal payments")
+            end
+
+            it "offers the bank rail to a locked-account seller who has one" do
+              expect(payment.user.can_setup_bank_payouts?).to be(true)
+
+              payment.mark_failed!("PAYPAL 3015")
+
+              expect(payment.reload.terminal_paypal_failure_seller_solution).to eq(
+                "Sign in to PayPal to see whether there are restrictions on your account, or contact PayPal to have them " \
+                "lifted. You can also add a bank account in your payout settings, or use a different PayPal account. " \
+                "Your balance is safe in the meantime and will be paid out on the next payout date after a working payout method is on file."
+              )
+            end
+
+            it "writes the locked-account explanation as a seller-visible note instead of a support-only one" do
+              expect do
+                payment.mark_failed!("PAYPAL 3015")
+              end.to change { payment.user.comments.count }.by(1)
+
+              note = payment.user.comments.last
+              expect(note.content).to include("your PayPal account is locked or inactive")
+              expect(note.content).to_not include("Solution: Log in to your PayPal account")
+            end
+
+            it "does not stop retrying a locked account, since only PayPal can unlock it" do
+              payment.mark_failed!("PAYPAL 3015")
+
+              expect(payment.reload.terminal_paypal_failure?).to be(false)
+              expect(payment.locked_account_paypal_failure?).to be(true)
+              expect(payment.explained_paypal_failure?).to be(true)
             end
 
             # The no-rail wording replaces the fix, not the pause disclosure: a hold is a separate

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -201,10 +201,21 @@ describe Payment do
       expect(compliant_creator.reload.payouts_paused?).to eq(false)
     end
 
-    it "does not email for a retryable PayPal rejection" do
+    # 3015 stays retryable, but it is explained as of gumroad-private#1661, so the seller now
+    # hears about it. 9302 is the remaining support-only shape this case was written to cover.
+    it "does not email for a rejection the seller is not told about" do
+      expect do
+        payment.mark_failed!("PAYPAL 9302")
+      end.to_not have_enqueued_mail(ContactingCreatorMailer, :paypal_payout_permanently_failed)
+    end
+
+    it "emails for a locked account even though its payouts keep retrying" do
       expect do
         payment.mark_failed!("PAYPAL 3015")
-      end.to_not have_enqueued_mail(ContactingCreatorMailer, :paypal_payout_permanently_failed)
+      end.to have_enqueued_mail(ContactingCreatorMailer, :paypal_payout_permanently_failed).with(payment.id)
+
+      expect(payment.reload.locked_account_paypal_failure?).to eq(true)
+      expect(Payment::FailureReason::RETRY_BLOCKING_PAYPAL_FAILURE_REASONS).not_to include("PAYPAL 3015")
     end
 
     describe "invalidating the payout address" do

--- a/spec/services/onetime/resolve_terminal_paypal_payout_failures_spec.rb
+++ b/spec/services/onetime/resolve_terminal_paypal_payout_failures_spec.rb
@@ -317,6 +317,20 @@ describe Onetime::ResolveTerminalPaypalPayoutFailures do
       expect(content).to_not include("registered in a country")
     end
 
+    # The half of the cohort gp#1661 is actually about: locked account AND no bank rail. This is
+    # where the old copy dead-ended, so the backfill has to reach it with the honest answer.
+    it "gives a locked-account seller with no bank rail the plain no-rail answer" do
+      create(:user_compliance_info, user: seller, country: "Ukraine")
+      terminal_failure_for(seller, reason: "PAYPAL 3015")
+
+      described_class.process(dry_run: false)
+
+      content = latest_seller_visible_note(seller).content
+      expect(content).to include("we have no way to pay you right now")
+      expect(content).to include("We hope to have a way to pay out your balance in the future")
+      expect(content).to_not include("add a bank account")
+    end
+
     # A currency rejection is explained but still retried, so nothing this task writes may claim
     # the payouts have stopped. Reviewer finding on #6526: the eligibility check deliberately uses
     # the wider EXPLAINED set rather than the retry-blocking one, and that is only defensible while

--- a/spec/services/onetime/resolve_terminal_paypal_payout_failures_spec.rb
+++ b/spec/services/onetime/resolve_terminal_paypal_payout_failures_spec.rb
@@ -288,12 +288,33 @@ describe Onetime::ResolveTerminalPaypalPayoutFailures do
       end.to_not change { seller_visible_note_count(seller) }
     end
 
-    it "ignores retryable rejections" do
-      terminal_failure_for(seller, reason: "PAYPAL 3015")
+    # A code with no seller-facing wording is still support-only, so this task must stay silent on
+    # it — a note it cannot explain would be worse than no note.
+    it "ignores rejections that have no seller-facing explanation" do
+      terminal_failure_for(seller, reason: "PAYPAL 9302")
 
       expect do
         described_class.process(dry_run: false)
       end.to_not change { seller_visible_note_count(seller) }
+    end
+
+    # 3015 became seller-visible in gumroad-private#1661 and is the dominant code in the Russia-KYC
+    # cohort, so this task is the path that finally explains it to sellers who were already stuck.
+    # It stays retryable, so the copy must name the account state without claiming a stop.
+    it "explains a locked-account rejection without claiming the retries stopped" do
+      allow_bank_payouts_for(seller)
+      terminal_failure_for(seller, reason: "PAYPAL 3015")
+
+      expect do
+        described_class.process(dry_run: false)
+      end.to change { seller_visible_note_count(seller) }.from(0).to(1)
+
+      content = latest_seller_visible_note(seller).content
+      expect(content).to include("your PayPal account is locked or inactive")
+      expect(content).to_not include("stopped retrying")
+      expect(content).to_not include("we have stopped")
+      # Only PayPal can lift the lock, so the country-based wording would be the wrong diagnosis.
+      expect(content).to_not include("registered in a country")
     end
 
     # A currency rejection is explained but still retried, so nothing this task writes may claim


### PR DESCRIPTION
Fixes the copy half of [gp#1661](https://github.com/antiwork/gumroad-private/issues/1661), on @slavingia's direction: *"Just say that and say we hope there's a way to pay out their balance in the future."*

## The problem

`PAYPAL 3015` — receiver's account locked or inactive — dominates the Russia-KYC failure mix (5,272 rows, 185 sellers). It was a support-only note, so the seller was told **nothing at all**: their payouts stop after three consecutive failures via `Payment#pause_payouts_after_repeated_failures`, silently. That is what produced *"PayPal is not available for russian users, so i guess i can not take my money."*

Worse, on the paths where a seller does see copy, `TERMINAL_PAYPAL_FAILURE_SELLER_FIX_PAYPAL_ONLY` tells them to go get "a PayPal account registered in a country that can receive PayPal payments". For 3015 that is the **wrong diagnosis** — the country was never the problem, the account state was — and for the 2,152 Russia-KYC sellers holding $173,238 with no bank rail, it is an instruction with no available action behind it.

## What changed

- **3015 becomes a seller-visible explanation.** Added to `EXPLAINED_PAYPAL_FAILURE_SELLER_REASONS` (and `HISTORICAL_SELLER_REASONS`, per the reword contract in that file): *"PayPal will not send your payout, because your PayPal account is locked or inactive."* Its old `PAYPAL_FAILURE_SOLUTIONS` support-only entry is removed, since it now gets the seller-facing path instead.
- **New `LOCKED_ACCOUNT_PAYPAL_FAILURE_REASONS` cohort** with its own fix copy, so it never inherits the country-based wording. Two variants — one that offers the bank rail, one for PayPal-only countries that says plainly *"if PayPal cannot restore your account and you do not have another one, we have no way to pay you right now. We hope to have a way to pay out your balance in the future."*
- **Still retried.** 3015 stays out of `RETRY_BLOCKING_PAYPAL_FAILURE_REASONS`, guarded by a new constant-level `raise`. An unlocked account starts receiving again and an address-keyed block would never notice — the same argument that keeps 14159 retried. What stops the retries remains the generic repeated-failure pause at three failures, and the email correctly says *"we'll keep trying on your usual payout schedule"* rather than claiming a stop that did not happen.
- Both the payout note (`Payment#terminal_paypal_failure_seller_solution`) and the email (`paypal_payout_permanently_failed`) select the new copy off `Payment#locked_account_paypal_failure?`.

## Not in scope

Two policy calls stay with @nyomanjyotisa and are deliberately untouched here: whether 3015 should become formally terminal for PayPal-only countries (that reopens the gp#1478 design), and what ultimately happens to the $173K, which has no dormancy or escheatment path today. Balances are unaffected — verified against `ForfeitBalanceService`, only the account-closure branch would take them and nothing is closing these accounts.

## Tests

```
spec/models/concerns/payment/failure_reason_spec.rb   33 examples, 0 failures
spec/mailers/contacting_creator_mailer_spec.rb
  -e "paypal payout permanently failed"               22 examples, 0 failures
```

New coverage: locked-account copy with and without a bank rail, the seller-visible note replacing the support-only one, that we never emit the country wording for 3015, and that we never claim the retries stopped.
