### PR TITLE
Refuse to charge a commission completion with no deliverable attached

### DIFF
--- a/app/controllers/commissions_controller.rb
+++ b/app/controllers/commissions_controller.rb
@@ -37,7 +37,10 @@ class CommissionsController < ApplicationController
 
   private
     def ensure_files_can_be_changed!(commission)
-      return unless commission.is_completed?
+      # Also keyed on the completion charge, not the status alone: a completion still settling in
+      # the buyer's presentment currency leaves the commission in_progress with the buyer already
+      # charged, and a status-only gate would admit purging every file in that window.
+      return unless commission.is_completed? || commission.completion_purchase.present?
 
       commission.errors.add(:base, "This commission has already been completed, so its files can no longer be changed.")
       raise ActiveRecord::RecordInvalid, commission

--- a/app/controllers/commissions_controller.rb
+++ b/app/controllers/commissions_controller.rb
@@ -4,6 +4,7 @@ class CommissionsController < ApplicationController
   def update
     commission = Commission.find_by_external_id!(params[:id])
     authorize commission
+    ensure_files_can_be_changed!(commission)
 
     file_signed_ids = permitted_params[:file_signed_ids]
 
@@ -35,6 +36,13 @@ class CommissionsController < ApplicationController
   end
 
   private
+    def ensure_files_can_be_changed!(commission)
+      return unless commission.is_completed?
+
+      commission.errors.add(:base, "This commission has already been completed, so its files can no longer be changed.")
+      raise ActiveRecord::RecordInvalid, commission
+    end
+
     def permitted_params
       params.permit(file_signed_ids: [])
     end

--- a/app/javascript/components/Audience/CustomerDetailPage.tsx
+++ b/app/javascript/components/Audience/CustomerDetailPage.tsx
@@ -52,7 +52,7 @@ import FileUtils from "$app/utils/file";
 import { priceCentsToUnit } from "$app/utils/price";
 import { asyncVoid } from "$app/utils/promise";
 import { RecurrenceId, recurrenceLabels } from "$app/utils/recurringPricing";
-import { assertResponseError } from "$app/utils/request";
+import { assertResponseError, ResponseError } from "$app/utils/request";
 
 import { Button, NavigationButton, buttonVariants } from "$app/components/Button";
 import { CopyToClipboard } from "$app/components/CopyToClipboard";
@@ -2224,6 +2224,10 @@ const CommissionSection = ({
 }) => {
   const [isLoading, setIsLoading] = React.useState(false);
 
+  // The server refuses file changes once a completion purchase exists, so a commission that is
+  // completed (or whose completion is still settling) must not offer upload/delete affordances.
+  const filesAreEditable = commission.status === "in_progress";
+
   const handleFileChange = asyncVoid(async (event: React.ChangeEvent<HTMLInputElement>) => {
     if (!event.target.files?.length) return;
 
@@ -2264,8 +2268,11 @@ const CommissionSection = ({
       });
 
       showAlert("Uploaded successfully!", "success");
-    } catch {
-      showAlert("Error uploading files. Please try again.", "error");
+    } catch (e) {
+      // DirectUpload rejects with a plain Error, so this cannot use assertResponseError — that
+      // re-throws anything that is not a ResponseError and the seller would see no alert at all.
+      const message = e instanceof ResponseError && e.message ? e.message : "Error uploading files. Please try again.";
+      showAlert(message, "error");
     } finally {
       setIsLoading(false);
     }
@@ -2317,30 +2324,37 @@ const CommissionSection = ({
           <CardContent>
             <Rows role="list">
               {commission.files.map((file) => (
-                <FileRow key={file.id} file={file} onDelete={() => void handleDelete(file.id)} disabled={isLoading} />
+                <FileRow
+                  key={file.id}
+                  file={file}
+                  {...(filesAreEditable ? { onDelete: () => void handleDelete(file.id) } : {})}
+                  disabled={isLoading}
+                />
               ))}
             </Rows>
           </CardContent>
         ) : null}
-        <CardContent>
-          <div className="grid w-full gap-2">
-            <label className={buttonVariants({ className: "w-full" })}>
-              <input
-                type="file"
-                onChange={handleFileChange}
-                disabled={isLoading}
-                multiple
-                style={{ display: "none" }}
-              />
-              <Paperclip className="size-5" /> Upload files
-            </label>
-            {commission.status === "in_progress" ? (
-              <Button color="primary" disabled={isLoading} onClick={() => void handleCompletion()} className="w-full">
-                Submit and mark as complete
-              </Button>
-            ) : null}
-          </div>
-        </CardContent>
+        {filesAreEditable ? (
+          <CardContent>
+            <div className="grid w-full gap-2">
+              <label className={buttonVariants({ className: "w-full" })}>
+                <input
+                  type="file"
+                  onChange={handleFileChange}
+                  disabled={isLoading}
+                  multiple
+                  style={{ display: "none" }}
+                />
+                <Paperclip className="size-5" /> Upload files
+              </label>
+              {commission.status === "in_progress" ? (
+                <Button color="primary" disabled={isLoading} onClick={() => void handleCompletion()} className="w-full">
+                  Submit and mark as complete
+                </Button>
+              ) : null}
+            </div>
+          </CardContent>
+        ) : null}
       </section>
     </Card>
   );

--- a/app/javascript/data/customers.ts
+++ b/app/javascript/data/customers.ts
@@ -479,8 +479,10 @@ export const updateCommission = (commissionId: string, fileSignedIds: string[]) 
     accept: "json",
     url: Routes.commission_path(commissionId),
     data: { file_signed_ids: fileSignedIds },
-  }).then((response) => {
-    if (!response.ok) throw new ResponseError();
+  }).then(async (response) => {
+    if (!response.ok) {
+      throw new ResponseError(typia.assert<{ errors: string[] }>(await response.json()).errors[0]);
+    }
   });
 
 export const completeCommission = async (commissionId: string) => {

--- a/app/models/commission.rb
+++ b/app/models/commission.rb
@@ -32,6 +32,7 @@ class Commission < ApplicationRecord
   def create_completion_purchase!
     return if is_completed?
     ensure_deposit_is_chargeable!
+    ensure_deliverable_is_attached!
 
     completion_purchase_attributes = deposit_purchase.slice(
       :link, :purchaser, :credit_card_id, :email, :full_name, :street_address,
@@ -90,6 +91,13 @@ class Commission < ApplicationRecord
       return if deposit_is_chargeable?
 
       errors.add(:base, "This commission's deposit is no longer in a completable state, so it can no longer be completed.")
+      raise ActiveRecord::RecordInvalid, self
+    end
+
+    def ensure_deliverable_is_attached!
+      return if files.attached?
+
+      errors.add(:base, "Attach at least one file before completing this commission.")
       raise ActiveRecord::RecordInvalid, self
     end
 

--- a/spec/controllers/api/mobile/commissions_controller_spec.rb
+++ b/spec/controllers/api/mobile/commissions_controller_spec.rb
@@ -16,6 +16,7 @@ describe Api::Mobile::CommissionsController, :vcr do
   describe "POST complete" do
     it "creates a completion purchase" do
       expect_any_instance_of(Commission).to receive(:create_completion_purchase!).and_call_original
+      @commission.files.attach(file_fixture("test.pdf"))
 
       post :complete, params: @params.merge(id: @commission.external_id)
 

--- a/spec/controllers/commissions_controller_spec.rb
+++ b/spec/controllers/commissions_controller_spec.rb
@@ -48,6 +48,21 @@ describe CommissionsController, :vcr do
       expect(response.parsed_body).to eq({ "errors" => ["This commission has already been completed, so its files can no longer be changed."] })
     end
 
+    it "rejects purging files while the completion charge is still settling" do
+      commission.files.attach(file_fixture("test.png"))
+      commission.update!(
+        completion_purchase: create(:purchase, link: commission.deposit_purchase.link, seller: commission.deposit_purchase.seller, is_commission_completion_purchase: true)
+      )
+
+      expect do
+        put :update, params: { id: commission.external_id, file_signed_ids: [] }, as: :json
+      end.to not_change { commission.reload.files.count }
+
+      expect(commission.reload.status).to eq(Commission::STATUS_IN_PROGRESS)
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body).to eq({ "errors" => ["This commission has already been completed, so its files can no longer be changed."] })
+    end
+
     it "rejects purging files from completed commissions" do
       commission.files.attach(file_fixture("test.png"))
       commission.update!(status: Commission::STATUS_COMPLETED)

--- a/spec/controllers/commissions_controller_spec.rb
+++ b/spec/controllers/commissions_controller_spec.rb
@@ -18,7 +18,7 @@ describe CommissionsController, :vcr do
       let(:request_params) { { id: commission.external_id } }
     end
 
-    it "attaches new files and purges old files" do
+    it "allows in-progress commissions to attach new files and purge old files" do
       allow_any_instance_of(ActiveStorage::Blob).to receive(:purge).and_return(nil)
 
       commission.files.attach(file_fixture("test.png"))
@@ -33,6 +33,32 @@ describe CommissionsController, :vcr do
       expect(response).to be_successful
       expect(response).to have_http_status(:no_content)
       expect(commission.files.first.filename).to eq("test.pdf")
+    end
+
+    it "rejects attaching files to completed commissions" do
+      commission.update!(status: Commission::STATUS_COMPLETED)
+      file = fixture_file_upload("test.pdf")
+      blob = ActiveStorage::Blob.create_and_upload!(io: file, filename: "test.pdf")
+
+      expect do
+        put :update, params: { id: commission.external_id, file_signed_ids: [blob.signed_id] }, as: :json
+      end.to not_change { commission.reload.files.count }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body).to eq({ "errors" => ["This commission has already been completed, so its files can no longer be changed."] })
+    end
+
+    it "rejects purging files from completed commissions" do
+      commission.files.attach(file_fixture("test.png"))
+      commission.update!(status: Commission::STATUS_COMPLETED)
+
+      expect do
+        put :update, params: { id: commission.external_id, file_signed_ids: [] }, as: :json
+      end.to not_change { commission.reload.files.count }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body).to eq({ "errors" => ["This commission has already been completed, so its files can no longer be changed."] })
+      expect(commission.files.first.filename).to eq("test.png")
     end
 
     context "when commission is not found" do
@@ -53,6 +79,7 @@ describe CommissionsController, :vcr do
 
     it "creates a completion purchase" do
       expect_any_instance_of(Commission).to receive(:create_completion_purchase!).and_call_original
+      commission.files.attach(file_fixture("test.pdf"))
 
       post :complete, params: { id: commission.external_id }
 

--- a/spec/controllers/customers_controller_spec.rb
+++ b/spec/controllers/customers_controller_spec.rb
@@ -288,7 +288,10 @@ describe CustomersController, :vcr, type: :controller, inertia: true do
     context "when purchase is a commission deposit purchase", :vcr do
       let!(:commission) { create(:commission) }
 
-      before { commission.create_completion_purchase! }
+      before do
+        commission.files.attach(file_fixture("test.pdf"))
+        commission.create_completion_purchase!
+      end
 
       it "returns the deposit and completion purchases" do
         get :customer_charges, params: { purchase_id: commission.deposit_purchase.external_id, purchase_email: commission.deposit_purchase.email }

--- a/spec/mailers/customer_mailer_spec.rb
+++ b/spec/mailers/customer_mailer_spec.rb
@@ -779,6 +779,7 @@ describe CustomerMailer do
       let(:commission) { create(:commission) }
 
       before do
+        commission.files.attach(file_fixture("test.pdf"))
         commission.create_completion_purchase!
         commission.deposit_purchase.create_url_redirect!
       end

--- a/spec/models/commission_spec.rb
+++ b/spec/models/commission_spec.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 describe Commission, :vcr do
+  def attach_commission_file(commission)
+    commission.files.attach(file_fixture("test.pdf"))
+  end
+
   describe "validations" do
     it "validates inclusion of status in STATUSES" do
       commission = build(:commission, status: "invalid_status")
@@ -47,11 +51,27 @@ describe Commission, :vcr do
       end
     end
 
+    context "when no deliverable files are attached" do
+      let!(:commission) { create(:commission, status: Commission::STATUS_IN_PROGRESS) }
+
+      it "refuses to create a completion purchase" do
+        expect do
+          commission.create_completion_purchase!
+        end.to raise_error(ActiveRecord::RecordInvalid) { |error|
+          expect(error.record.errors.full_messages).to eq(["Attach at least one file before completing this commission."])
+        }.and not_change { Purchase.count }
+
+        expect(commission.reload.completion_purchase).to be_nil
+        expect(commission.status).to eq(Commission::STATUS_IN_PROGRESS)
+      end
+    end
+
     it "makes the commission's stored presentment available while processing the completion purchase" do
       product = create(:commission_product)
       merchant_account = create(:merchant_account, user: product.user, charge_processor_merchant_id: "commission-presentment-test")
       deposit_purchase = create(:purchase, link: product, merchant_account:, is_commission_deposit_purchase: true)
       commission = create(:commission, status: Commission::STATUS_IN_PROGRESS, deposit_purchase:)
+      attach_commission_file(commission)
       fixing = create(:later_charge_presentment, owner: commission, canonical_price_cents: deposit_purchase.price_cents)
       expect_any_instance_of(Purchase).to receive(:process!) do |completion_purchase|
         expect(completion_purchase.commission.current_later_charge_presentment).to eq(fixing)
@@ -107,6 +127,7 @@ describe Commission, :vcr do
       # dispute would strand the commission.
       it "still charges when a chargeback was reversed" do
         deposit_purchase.update!(chargeback_date: Date.today, chargeback_reversed: true)
+        attach_commission_file(commission)
 
         expect { commission.create_completion_purchase! }.to change { Purchase.count }.by(1)
         expect(commission.reload.status).to eq(Commission::STATUS_COMPLETED)
@@ -132,6 +153,7 @@ describe Commission, :vcr do
       # it charges nothing but is a supported flow, so the state gate must admit it.
       it "still charges when the deposit is a seller test purchase" do
         deposit_purchase.update_columns(purchase_state: "test_successful")
+        attach_commission_file(commission)
 
         expect { commission.create_completion_purchase! }.to change { Purchase.count }.by(1)
         expect(commission.reload.status).to eq(Commission::STATUS_COMPLETED)
@@ -144,6 +166,7 @@ describe Commission, :vcr do
       let(:product) { deposit_purchase.link }
 
       before do
+        attach_commission_file(commission)
         deposit_purchase.update!(zip_code: "10001")
         deposit_purchase.update!(displayed_price_cents: 100)
         deposit_purchase.create_tip!(value_cents: 20)
@@ -214,6 +237,8 @@ describe Commission, :vcr do
       let!(:deposit_purchase) { create(:commission_deposit_purchase, link: product) }
       let!(:commission) { create(:commission, status: Commission::STATUS_IN_PROGRESS, deposit_purchase: deposit_purchase) }
 
+      before { attach_commission_file(commission) }
+
       it "creates a completion purchase without any variant attributes" do
         expect(deposit_purchase.variant_attributes).to be_empty
         expect(deposit_purchase.price_cents).to eq(500)
@@ -233,6 +258,8 @@ describe Commission, :vcr do
 
       let!(:deposit_purchase) { create(:commission_deposit_purchase, link: product, variant_attributes: [variant]) }
       let!(:commission) { create(:commission, status: Commission::STATUS_IN_PROGRESS, deposit_purchase: deposit_purchase) }
+
+      before { attach_commission_file(commission) }
 
       context "variant price changed" do
         it "creates a completion purchase with the original price" do
@@ -282,6 +309,8 @@ describe Commission, :vcr do
 
       let!(:deposit_purchase) { create(:commission_deposit_purchase, link: product, offer_code:, discount_code: offer_code.code) }
       let!(:commission) { create(:commission, status: Commission::STATUS_IN_PROGRESS, deposit_purchase: deposit_purchase) }
+
+      before { attach_commission_file(commission) }
 
       it "creates a completion purchase with the original price" do
         expect(deposit_purchase.price_cents).to eq(500)
@@ -345,6 +374,8 @@ describe Commission, :vcr do
       end
 
       let!(:commission) { create(:commission, status: Commission::STATUS_IN_PROGRESS, deposit_purchase:) }
+
+      before { attach_commission_file(commission) }
 
       it "creates a completion purchase with PPP discount applied" do
         expect(deposit_purchase.is_purchasing_power_parity_discounted).to eq(true)

--- a/spec/requests/customers/customers_spec.rb
+++ b/spec/requests/customers/customers_spec.rb
@@ -1331,6 +1331,8 @@ describe "Sales page", type: :system, js: true do
       end
 
       it "allows completing a commission" do
+        commission.files.attach(file_fixture("test.pdf"))
+
         visit customer_sale_path(commission.deposit_purchase.external_id)
         expect(page).to have_text("In progress")
         click_on "Submit and mark as complete"
@@ -1352,6 +1354,7 @@ describe "Sales page", type: :system, js: true do
           deposit_purchase.update!(purchase_state: "in_progress", credit_card: create(:credit_card))
           deposit_purchase.process!
           deposit_purchase.mark_successful!
+          commission.files.attach(file_fixture("test.pdf"))
           commission.create_completion_purchase!
           allow_any_instance_of(User).to receive(:unpaid_balance_cents).and_return(10_00)
         end

--- a/spec/support/fixtures/vcr_cassettes/Commission/_create_completion_purchase_/when_no_deliverable_files_are_attached/refuses_to_create_a_completion_purchase.yml
+++ b/spec/support/fixtures/vcr_cassettes/Commission/_create_completion_purchase_/when_no_deliverable_files_are_attached/refuses_to_create_a_completion_purchase.yml
@@ -1,0 +1,398 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_7dMebJJ1k7l0Ma","request_duration_ms":0}}'
+      Idempotency-Key:
+      - cd07b479-18e7-4dcd-8755-9d5388c84e5c
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 02 Aug 2026 10:34:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=1Hx3mqPi__bGCti6TYA3UK79xJ10Fv5iDlWLzrKLsrfn8X6iIPp26tB25VzexEy_558bYHYJ9d_hj_NK;
+        report-to csp
+      Idempotency-Key:
+      - cd07b479-18e7-4dcd-8755-9d5388c84e5c
+      Original-Request:
+      - req_uz3Wzc4PQQ60Z9
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=1Hx3mqPi__bGCti6TYA3UK79xJ10Fv5iDlWLzrKLsrfn8X6iIPp26tB25VzexEy_558bYHYJ9d_hj_NK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=1Hx3mqPi__bGCti6TYA3UK79xJ10Fv5iDlWLzrKLsrfn8X6iIPp26tB25VzexEy_558bYHYJ9d_hj_NK&t=1"
+      Request-Id:
+      - req_uz3Wzc4PQQ60Z9
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TzwjDIBOqvOFDrfhoObGofL",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1785666888,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sun, 02 Aug 2026 10:34:48 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TzwjDIBOqvOFDrfhoObGofL
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_uz3Wzc4PQQ60Z9","request_duration_ms":235}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 02 Aug 2026 10:34:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=1Hx3mqPi__bGCti6TYA3UK79xJ10Fv5iDlWLzrKLsrfn8X6iIPp26tB25VzexEy_558bYHYJ9d_hj_NK;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=1Hx3mqPi__bGCti6TYA3UK79xJ10Fv5iDlWLzrKLsrfn8X6iIPp26tB25VzexEy_558bYHYJ9d_hj_NK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=1Hx3mqPi__bGCti6TYA3UK79xJ10Fv5iDlWLzrKLsrfn8X6iIPp26tB25VzexEy_558bYHYJ9d_hj_NK&t=1"
+      Request-Id:
+      - req_IOw5lm9S2e8cM9
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TzwjDIBOqvOFDrfhoObGofL",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1785666888,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sun, 02 Aug 2026 10:34:48 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: description=&payment_method=pm_1TzwjDIBOqvOFDrfhoObGofL
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_IOw5lm9S2e8cM9","request_duration_ms":146}}'
+      Idempotency-Key:
+      - 49686ea8-1271-48b7-9ed7-30cff406a7d1
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 02 Aug 2026 10:34:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '642'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=1Hx3mqPi__bGCti6TYA3UK79xJ10Fv5iDlWLzrKLsrfn8X6iIPp26tB25VzexEy_558bYHYJ9d_hj_NK;
+        report-to csp
+      Idempotency-Key:
+      - 49686ea8-1271-48b7-9ed7-30cff406a7d1
+      Original-Request:
+      - req_Mtd5y4FFt6uKR9
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=1Hx3mqPi__bGCti6TYA3UK79xJ10Fv5iDlWLzrKLsrfn8X6iIPp26tB25VzexEy_558bYHYJ9d_hj_NK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=1Hx3mqPi__bGCti6TYA3UK79xJ10Fv5iDlWLzrKLsrfn8X6iIPp26tB25VzexEy_558bYHYJ9d_hj_NK&t=1"
+      Request-Id:
+      - req_Mtd5y4FFt6uKR9
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "cus_UzwcjKtnPb9imN",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1785666888,
+          "currency": null,
+          "customer_account": null,
+          "default_source": null,
+          "delinquent": false,
+          "description": null,
+          "discount": null,
+          "email": null,
+          "invoice_prefix": "ZQ5S5BZP",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null,
+            "rendering_options": null
+          },
+          "livemode": false,
+          "metadata": {},
+          "name": null,
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [],
+          "shipping": null,
+          "tax_exempt": "none",
+          "test_clock": null
+        }
+  recorded_at: Sun, 02 Aug 2026 10:34:49 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/CommissionsController/PUT_update/allows_in-progress_commissions_to_attach_new_files_and_purge_old_files.yml
+++ b/spec/support/fixtures/vcr_cassettes/CommissionsController/PUT_update/allows_in-progress_commissions_to_attach_new_files_and_purge_old_files.yml
@@ -1,0 +1,398 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_MG8pqXLeEiuani","request_duration_ms":0}}'
+      Idempotency-Key:
+      - dbae2a2e-292b-4c13-b9e7-5e416d889b08
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 02 Aug 2026 10:34:54 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=MfQFUL1WwEUApJjo0yQEwN3J2OTnEkk5hpbzCTZEAUoCMXFgs4J3y1tviErAs9GluEymEPRzUZ0o8u2a;
+        report-to csp
+      Idempotency-Key:
+      - dbae2a2e-292b-4c13-b9e7-5e416d889b08
+      Original-Request:
+      - req_bE0OZU50sc81oV
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=MfQFUL1WwEUApJjo0yQEwN3J2OTnEkk5hpbzCTZEAUoCMXFgs4J3y1tviErAs9GluEymEPRzUZ0o8u2a&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=MfQFUL1WwEUApJjo0yQEwN3J2OTnEkk5hpbzCTZEAUoCMXFgs4J3y1tviErAs9GluEymEPRzUZ0o8u2a&t=1"
+      Request-Id:
+      - req_bE0OZU50sc81oV
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TzwjJIBOqvOFDrfnZO93Gtz",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1785666893,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sun, 02 Aug 2026 10:34:54 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TzwjJIBOqvOFDrfnZO93Gtz
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_bE0OZU50sc81oV","request_duration_ms":218}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 02 Aug 2026 10:34:54 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=MfQFUL1WwEUApJjo0yQEwN3J2OTnEkk5hpbzCTZEAUoCMXFgs4J3y1tviErAs9GluEymEPRzUZ0o8u2a;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=MfQFUL1WwEUApJjo0yQEwN3J2OTnEkk5hpbzCTZEAUoCMXFgs4J3y1tviErAs9GluEymEPRzUZ0o8u2a&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=MfQFUL1WwEUApJjo0yQEwN3J2OTnEkk5hpbzCTZEAUoCMXFgs4J3y1tviErAs9GluEymEPRzUZ0o8u2a&t=1"
+      Request-Id:
+      - req_oTQRN6PUgo4AbK
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TzwjJIBOqvOFDrfnZO93Gtz",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1785666893,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sun, 02 Aug 2026 10:34:54 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: description=&payment_method=pm_1TzwjJIBOqvOFDrfnZO93Gtz
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_oTQRN6PUgo4AbK","request_duration_ms":212}}'
+      Idempotency-Key:
+      - 0cddab62-df1d-4904-9198-6c999dbdb672
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 02 Aug 2026 10:34:54 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '642'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=MfQFUL1WwEUApJjo0yQEwN3J2OTnEkk5hpbzCTZEAUoCMXFgs4J3y1tviErAs9GluEymEPRzUZ0o8u2a;
+        report-to csp
+      Idempotency-Key:
+      - 0cddab62-df1d-4904-9198-6c999dbdb672
+      Original-Request:
+      - req_2q4GnYqsNT6Cp9
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=MfQFUL1WwEUApJjo0yQEwN3J2OTnEkk5hpbzCTZEAUoCMXFgs4J3y1tviErAs9GluEymEPRzUZ0o8u2a&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=MfQFUL1WwEUApJjo0yQEwN3J2OTnEkk5hpbzCTZEAUoCMXFgs4J3y1tviErAs9GluEymEPRzUZ0o8u2a&t=1"
+      Request-Id:
+      - req_2q4GnYqsNT6Cp9
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "cus_UzwcShoIE5nHwg",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1785666894,
+          "currency": null,
+          "customer_account": null,
+          "default_source": null,
+          "delinquent": false,
+          "description": null,
+          "discount": null,
+          "email": null,
+          "invoice_prefix": "CXBMXURR",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null,
+            "rendering_options": null
+          },
+          "livemode": false,
+          "metadata": {},
+          "name": null,
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [],
+          "shipping": null,
+          "tax_exempt": "none",
+          "test_clock": null
+        }
+  recorded_at: Sun, 02 Aug 2026 10:34:54 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/CommissionsController/PUT_update/rejects_attaching_files_to_completed_commissions.yml
+++ b/spec/support/fixtures/vcr_cassettes/CommissionsController/PUT_update/rejects_attaching_files_to_completed_commissions.yml
@@ -1,0 +1,398 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_2q4GnYqsNT6Cp9","request_duration_ms":737}}'
+      Idempotency-Key:
+      - 462c9808-3a52-42ff-9c99-c588cf21a545
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 02 Aug 2026 10:34:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=MfQFUL1WwEUApJjo0yQEwN3J2OTnEkk5hpbzCTZEAUoCMXFgs4J3y1tviErAs9GluEymEPRzUZ0o8u2a;
+        report-to csp
+      Idempotency-Key:
+      - 462c9808-3a52-42ff-9c99-c588cf21a545
+      Original-Request:
+      - req_Skkua1Vxjk8Mcr
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=MfQFUL1WwEUApJjo0yQEwN3J2OTnEkk5hpbzCTZEAUoCMXFgs4J3y1tviErAs9GluEymEPRzUZ0o8u2a&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=MfQFUL1WwEUApJjo0yQEwN3J2OTnEkk5hpbzCTZEAUoCMXFgs4J3y1tviErAs9GluEymEPRzUZ0o8u2a&t=1"
+      Request-Id:
+      - req_Skkua1Vxjk8Mcr
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TzwjLIBOqvOFDrfxPCMNgA6",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1785666895,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sun, 02 Aug 2026 10:34:55 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TzwjLIBOqvOFDrfxPCMNgA6
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_Skkua1Vxjk8Mcr","request_duration_ms":174}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 02 Aug 2026 10:34:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=MfQFUL1WwEUApJjo0yQEwN3J2OTnEkk5hpbzCTZEAUoCMXFgs4J3y1tviErAs9GluEymEPRzUZ0o8u2a;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=MfQFUL1WwEUApJjo0yQEwN3J2OTnEkk5hpbzCTZEAUoCMXFgs4J3y1tviErAs9GluEymEPRzUZ0o8u2a&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=MfQFUL1WwEUApJjo0yQEwN3J2OTnEkk5hpbzCTZEAUoCMXFgs4J3y1tviErAs9GluEymEPRzUZ0o8u2a&t=1"
+      Request-Id:
+      - req_V2jS7qyu1IvKsy
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TzwjLIBOqvOFDrfxPCMNgA6",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1785666895,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sun, 02 Aug 2026 10:34:55 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: description=&payment_method=pm_1TzwjLIBOqvOFDrfxPCMNgA6
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_V2jS7qyu1IvKsy","request_duration_ms":154}}'
+      Idempotency-Key:
+      - 3fc1a777-d3e9-449a-969c-48db8d68e0f8
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 02 Aug 2026 10:34:56 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '642'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=MfQFUL1WwEUApJjo0yQEwN3J2OTnEkk5hpbzCTZEAUoCMXFgs4J3y1tviErAs9GluEymEPRzUZ0o8u2a;
+        report-to csp
+      Idempotency-Key:
+      - 3fc1a777-d3e9-449a-969c-48db8d68e0f8
+      Original-Request:
+      - req_ezfNK9o9ROBcFe
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=MfQFUL1WwEUApJjo0yQEwN3J2OTnEkk5hpbzCTZEAUoCMXFgs4J3y1tviErAs9GluEymEPRzUZ0o8u2a&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=MfQFUL1WwEUApJjo0yQEwN3J2OTnEkk5hpbzCTZEAUoCMXFgs4J3y1tviErAs9GluEymEPRzUZ0o8u2a&t=1"
+      Request-Id:
+      - req_ezfNK9o9ROBcFe
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "cus_Uzwcuy0r9KrsgJ",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1785666895,
+          "currency": null,
+          "customer_account": null,
+          "default_source": null,
+          "delinquent": false,
+          "description": null,
+          "discount": null,
+          "email": null,
+          "invoice_prefix": "MIEXIDLD",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null,
+            "rendering_options": null
+          },
+          "livemode": false,
+          "metadata": {},
+          "name": null,
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [],
+          "shipping": null,
+          "tax_exempt": "none",
+          "test_clock": null
+        }
+  recorded_at: Sun, 02 Aug 2026 10:34:56 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/CommissionsController/PUT_update/rejects_purging_files_from_completed_commissions.yml
+++ b/spec/support/fixtures/vcr_cassettes/CommissionsController/PUT_update/rejects_purging_files_from_completed_commissions.yml
@@ -5,22 +5,22 @@ http_interactions:
     uri: https://api.stripe.com/v1/payment_methods
     body:
       encoding: UTF-8
-      string: type=card&card[number]=4242+4242+4242+4242&card[exp_month]=12&card[exp_year]=2024&card[cvc]=123
+      string: type=card&card[token]=tok_visa
     headers:
       User-Agent:
-      - Stripe/v1 RubyBindings/12.4.0
+      - Stripe/v1 RubyBindings/12.5.0
       Authorization:
       - Bearer <STRIPE_API_KEY>
       Content-Type:
       - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_ezfNK9o9ROBcFe","request_duration_ms":528}}'
       Idempotency-Key:
-      - 946fca0f-1f86-4414-a00c-aa6fe4c11052
+      - e625c4d4-9db4-4821-abc5-0d3348f5f79c
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
-      - '{"bindings_version":"12.4.0","lang":"ruby","lang_version":"3.3.4 p94 (2024-07-09)","platform":"arm64-darwin23","engine":"ruby","publisher":"stripe","uname":"Darwin
-        Connors-MBP 23.5.0 Darwin Kernel Version 23.5.0: Wed May  1 20:17:33 PDT 2024;
-        root:xnu-10063.121.3~5/RELEASE_ARM64_T6031 arm64","hostname":"Connors-MBP"}'
+      - "<STRIPE_CLIENT_USER_AGENT>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -33,17 +33,17 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 05 Aug 2024 21:24:46 GMT
+      - Sun, 02 Aug 2026 10:34:56 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '996'
+      - '1122'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
       - 'true'
       Access-Control-Allow-Methods:
-      - GET,HEAD,PUT,PATCH,POST,DELETE
+      - GET, HEAD, PUT, PATCH, POST, DELETE
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Expose-Headers:
@@ -54,40 +54,42 @@ http_interactions:
       Cache-Control:
       - no-cache, no-store
       Content-Security-Policy:
-      - report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_methods; block-all-mixed-content;
-        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
-        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
-      Cross-Origin-Opener-Policy-Report-Only:
-      - same-origin; report-to="coop"
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=MfQFUL1WwEUApJjo0yQEwN3J2OTnEkk5hpbzCTZEAUoCMXFgs4J3y1tviErAs9GluEymEPRzUZ0o8u2a;
+        report-to csp
       Idempotency-Key:
-      - 946fca0f-1f86-4414-a00c-aa6fe4c11052
+      - e625c4d4-9db4-4821-abc5-0d3348f5f79c
       Original-Request:
-      - req_JyxiQi40W6orvC
+      - req_dA8X0ru3VfPEub
       Report-To:
-      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=payins-bapi-srv"}],"include_subdomains":true}'
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=MfQFUL1WwEUApJjo0yQEwN3J2OTnEkk5hpbzCTZEAUoCMXFgs4J3y1tviErAs9GluEymEPRzUZ0o8u2a&t=1"}],"include_subdomains":true}'
       Reporting-Endpoints:
-      - coop="https://q.stripe.com/coop-report?s=payins-bapi-srv"
+      - csp="https://q.stripe.com/csp-report-v2?q=MfQFUL1WwEUApJjo0yQEwN3J2OTnEkk5hpbzCTZEAUoCMXFgs4J3y1tviErAs9GluEymEPRzUZ0o8u2a&t=1"
       Request-Id:
-      - req_JyxiQi40W6orvC
+      - req_dA8X0ru3VfPEub
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
       - '2023-10-16'
       Vary:
       - Origin
-      X-Content-Type-Options:
-      - nosniff
       X-Stripe-Priority-Routing-Enabled:
       - 'true'
       X-Stripe-Routing-Context-Priority-Tier:
       - api-testmode
+      X-Wc:
+      - 3c3
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
     body:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_0PkYOY9e1RjUNIyYwBc9UoSd",
+          "id": "pm_1TzwjMIBOqvOFDrfQRZT2Khs",
           "object": "payment_method",
           "allow_redisplay": "unspecified",
           "billing_details": {
@@ -101,7 +103,8 @@ http_interactions:
             },
             "email": null,
             "name": null,
-            "phone": null
+            "phone": null,
+            "tax_id": null
           },
           "card": {
             "brand": "visa",
@@ -112,9 +115,9 @@ http_interactions:
             },
             "country": "US",
             "display_brand": "visa",
-            "exp_month": 12,
-            "exp_year": 2024,
-            "fingerprint": "W691J2Ye3VDoq6Ij",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
             "funding": "credit",
             "generated_from": null,
             "last4": "4242",
@@ -124,39 +127,40 @@ http_interactions:
               ],
               "preferred": null
             },
+            "regulated_status": "unregulated",
             "three_d_secure_usage": {
               "supported": true
             },
             "wallet": null
           },
-          "created": 1722893086,
+          "created": 1785666896,
           "customer": null,
+          "customer_account": null,
           "livemode": false,
           "metadata": {},
+          "shared_payment_granted_token": null,
           "type": "card"
         }
-  recorded_at: Mon, 05 Aug 2024 21:24:46 GMT
+  recorded_at: Sun, 02 Aug 2026 10:34:56 GMT
 - request:
     method: get
-    uri: https://api.stripe.com/v1/payment_methods/pm_0PkYOY9e1RjUNIyYwBc9UoSd
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TzwjMIBOqvOFDrfQRZT2Khs
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Stripe/v1 RubyBindings/12.4.0
+      - Stripe/v1 RubyBindings/12.5.0
       Authorization:
       - Bearer <STRIPE_API_KEY>
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_JyxiQi40W6orvC","request_duration_ms":476}}'
+      - '{"last_request_metrics":{"request_id":"req_dA8X0ru3VfPEub","request_duration_ms":199}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
-      - '{"bindings_version":"12.4.0","lang":"ruby","lang_version":"3.3.4 p94 (2024-07-09)","platform":"arm64-darwin23","engine":"ruby","publisher":"stripe","uname":"Darwin
-        Connors-MBP 23.5.0 Darwin Kernel Version 23.5.0: Wed May  1 20:17:33 PDT 2024;
-        root:xnu-10063.121.3~5/RELEASE_ARM64_T6031 arm64","hostname":"Connors-MBP"}'
+      - "<STRIPE_CLIENT_USER_AGENT>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -169,17 +173,17 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 05 Aug 2024 21:24:46 GMT
+      - Sun, 02 Aug 2026 10:34:56 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '996'
+      - '1122'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
       - 'true'
       Access-Control-Allow-Methods:
-      - GET,HEAD,PUT,PATCH,POST,DELETE
+      - GET, HEAD, PUT, PATCH, POST, DELETE
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Expose-Headers:
@@ -190,35 +194,36 @@ http_interactions:
       Cache-Control:
       - no-cache, no-store
       Content-Security-Policy:
-      - report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_methods%2F%3Apayment_method;
-        block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action
-        'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
-        style-src 'self'
-      Cross-Origin-Opener-Policy-Report-Only:
-      - same-origin; report-to="coop"
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=MfQFUL1WwEUApJjo0yQEwN3J2OTnEkk5hpbzCTZEAUoCMXFgs4J3y1tviErAs9GluEymEPRzUZ0o8u2a;
+        report-to csp
       Report-To:
-      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=payins-bapi-srv"}],"include_subdomains":true}'
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=MfQFUL1WwEUApJjo0yQEwN3J2OTnEkk5hpbzCTZEAUoCMXFgs4J3y1tviErAs9GluEymEPRzUZ0o8u2a&t=1"}],"include_subdomains":true}'
       Reporting-Endpoints:
-      - coop="https://q.stripe.com/coop-report?s=payins-bapi-srv"
+      - csp="https://q.stripe.com/csp-report-v2?q=MfQFUL1WwEUApJjo0yQEwN3J2OTnEkk5hpbzCTZEAUoCMXFgs4J3y1tviErAs9GluEymEPRzUZ0o8u2a&t=1"
       Request-Id:
-      - req_wyvbmISokQIoMM
+      - req_tMM9nrLbyRf1WO
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
       Stripe-Version:
       - '2023-10-16'
       Vary:
       - Origin
-      X-Content-Type-Options:
-      - nosniff
       X-Stripe-Priority-Routing-Enabled:
       - 'true'
       X-Stripe-Routing-Context-Priority-Tier:
       - api-testmode
+      X-Wc:
+      - 3c3
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
     body:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_0PkYOY9e1RjUNIyYwBc9UoSd",
+          "id": "pm_1TzwjMIBOqvOFDrfQRZT2Khs",
           "object": "payment_method",
           "allow_redisplay": "unspecified",
           "billing_details": {
@@ -232,7 +237,8 @@ http_interactions:
             },
             "email": null,
             "name": null,
-            "phone": null
+            "phone": null,
+            "tax_id": null
           },
           "card": {
             "brand": "visa",
@@ -243,9 +249,9 @@ http_interactions:
             },
             "country": "US",
             "display_brand": "visa",
-            "exp_month": 12,
-            "exp_year": 2024,
-            "fingerprint": "W691J2Ye3VDoq6Ij",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
             "funding": "credit",
             "generated_from": null,
             "last4": "4242",
@@ -255,41 +261,42 @@ http_interactions:
               ],
               "preferred": null
             },
+            "regulated_status": "unregulated",
             "three_d_secure_usage": {
               "supported": true
             },
             "wallet": null
           },
-          "created": 1722893086,
+          "created": 1785666896,
           "customer": null,
+          "customer_account": null,
           "livemode": false,
           "metadata": {},
+          "shared_payment_granted_token": null,
           "type": "card"
         }
-  recorded_at: Mon, 05 Aug 2024 21:24:46 GMT
+  recorded_at: Sun, 02 Aug 2026 10:34:56 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/customers
     body:
       encoding: UTF-8
-      string: description=&payment_method=pm_0PkYOY9e1RjUNIyYwBc9UoSd
+      string: description=&payment_method=pm_1TzwjMIBOqvOFDrfQRZT2Khs
     headers:
       User-Agent:
-      - Stripe/v1 RubyBindings/12.4.0
+      - Stripe/v1 RubyBindings/12.5.0
       Authorization:
       - Bearer <STRIPE_API_KEY>
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_wyvbmISokQIoMM","request_duration_ms":241}}'
+      - '{"last_request_metrics":{"request_id":"req_tMM9nrLbyRf1WO","request_duration_ms":155}}'
       Idempotency-Key:
-      - 1292ae43-e6c2-4567-a9c6-6aeb1eab6be9
+      - 3011eaa1-9b36-4638-a82d-b53b51ae855d
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
-      - '{"bindings_version":"12.4.0","lang":"ruby","lang_version":"3.3.4 p94 (2024-07-09)","platform":"arm64-darwin23","engine":"ruby","publisher":"stripe","uname":"Darwin
-        Connors-MBP 23.5.0 Darwin Kernel Version 23.5.0: Wed May  1 20:17:33 PDT 2024;
-        root:xnu-10063.121.3~5/RELEASE_ARM64_T6031 arm64","hostname":"Connors-MBP"}'
+      - "<STRIPE_CLIENT_USER_AGENT>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -302,17 +309,17 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 05 Aug 2024 21:24:47 GMT
+      - Sun, 02 Aug 2026 10:34:57 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '614'
+      - '642'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
       - 'true'
       Access-Control-Allow-Methods:
-      - GET,HEAD,PUT,PATCH,POST,DELETE
+      - GET, HEAD, PUT, PATCH, POST, DELETE
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Expose-Headers:
@@ -323,51 +330,54 @@ http_interactions:
       Cache-Control:
       - no-cache, no-store
       Content-Security-Policy:
-      - report-uri https://q.stripe.com/csp-report?p=v1%2Fcustomers; block-all-mixed-content;
-        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
-        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
-      Cross-Origin-Opener-Policy-Report-Only:
-      - same-origin; report-to="coop"
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=MfQFUL1WwEUApJjo0yQEwN3J2OTnEkk5hpbzCTZEAUoCMXFgs4J3y1tviErAs9GluEymEPRzUZ0o8u2a;
+        report-to csp
       Idempotency-Key:
-      - 1292ae43-e6c2-4567-a9c6-6aeb1eab6be9
+      - 3011eaa1-9b36-4638-a82d-b53b51ae855d
       Original-Request:
-      - req_iVgfh4XFTxuvTT
+      - req_QLBTKgOGMukbjl
       Report-To:
-      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=mono-bapi-srv"}],"include_subdomains":true}'
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=MfQFUL1WwEUApJjo0yQEwN3J2OTnEkk5hpbzCTZEAUoCMXFgs4J3y1tviErAs9GluEymEPRzUZ0o8u2a&t=1"}],"include_subdomains":true}'
       Reporting-Endpoints:
-      - coop="https://q.stripe.com/coop-report?s=mono-bapi-srv"
+      - csp="https://q.stripe.com/csp-report-v2?q=MfQFUL1WwEUApJjo0yQEwN3J2OTnEkk5hpbzCTZEAUoCMXFgs4J3y1tviErAs9GluEymEPRzUZ0o8u2a&t=1"
       Request-Id:
-      - req_iVgfh4XFTxuvTT
+      - req_QLBTKgOGMukbjl
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
       - '2023-10-16'
       Vary:
       - Origin
-      X-Content-Type-Options:
-      - nosniff
       X-Stripe-Priority-Routing-Enabled:
       - 'true'
       X-Stripe-Routing-Context-Priority-Tier:
       - api-testmode
+      X-Wc:
+      - 3c3
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
     body:
       encoding: UTF-8
       string: |-
         {
-          "id": "cus_QblwSXHSbWwJHT",
+          "id": "cus_UzwcpVwwVpY23j",
           "object": "customer",
           "address": null,
           "balance": 0,
-          "created": 1722893086,
+          "created": 1785666896,
           "currency": null,
+          "customer_account": null,
           "default_source": null,
           "delinquent": false,
           "description": null,
           "discount": null,
           "email": null,
-          "invoice_prefix": "D5E08F87",
+          "invoice_prefix": "J9LWUZO8",
           "invoice_settings": {
             "custom_fields": null,
             "default_payment_method": null,
@@ -384,5 +394,5 @@ http_interactions:
           "tax_exempt": "none",
           "test_clock": null
         }
-  recorded_at: Mon, 05 Aug 2024 21:24:47 GMT
+  recorded_at: Sun, 02 Aug 2026 10:34:57 GMT
 recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/CommissionsController/PUT_update/rejects_purging_files_while_the_completion_charge_is_still_settling.yml
+++ b/spec/support/fixtures/vcr_cassettes/CommissionsController/PUT_update/rejects_purging_files_while_the_completion_charge_is_still_settling.yml
@@ -1,0 +1,398 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_ezfNK9o9ROBcFe","request_duration_ms":0}}'
+      Idempotency-Key:
+      - 033a4f27-afc7-4614-9284-e3ff8696b61e
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 02 Aug 2026 12:21:17 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=WNPu24nOsu8Z76OL6FjapK6fl3qSGsYGWuFT6kpflt50gbpFth1dagi_KXYkD-qj536LZymsA-KsgFfX;
+        report-to csp
+      Idempotency-Key:
+      - 033a4f27-afc7-4614-9284-e3ff8696b61e
+      Original-Request:
+      - req_DDjSC4QsVH88Rf
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=WNPu24nOsu8Z76OL6FjapK6fl3qSGsYGWuFT6kpflt50gbpFth1dagi_KXYkD-qj536LZymsA-KsgFfX&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=WNPu24nOsu8Z76OL6FjapK6fl3qSGsYGWuFT6kpflt50gbpFth1dagi_KXYkD-qj536LZymsA-KsgFfX&t=1"
+      Request-Id:
+      - req_DDjSC4QsVH88Rf
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TzyOHIBOqvOFDrf9WfaMywy",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1785673277,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sun, 02 Aug 2026 12:21:17 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TzyOHIBOqvOFDrf9WfaMywy
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_DDjSC4QsVH88Rf","request_duration_ms":341}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 02 Aug 2026 12:21:17 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=WNPu24nOsu8Z76OL6FjapK6fl3qSGsYGWuFT6kpflt50gbpFth1dagi_KXYkD-qj536LZymsA-KsgFfX;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=WNPu24nOsu8Z76OL6FjapK6fl3qSGsYGWuFT6kpflt50gbpFth1dagi_KXYkD-qj536LZymsA-KsgFfX&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=WNPu24nOsu8Z76OL6FjapK6fl3qSGsYGWuFT6kpflt50gbpFth1dagi_KXYkD-qj536LZymsA-KsgFfX&t=1"
+      Request-Id:
+      - req_lzvCOHE0u8eoOO
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TzyOHIBOqvOFDrf9WfaMywy",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1785673277,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sun, 02 Aug 2026 12:21:17 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: description=&payment_method=pm_1TzyOHIBOqvOFDrf9WfaMywy
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_lzvCOHE0u8eoOO","request_duration_ms":229}}'
+      Idempotency-Key:
+      - cd098f8d-f0d4-4886-a1c8-d57e00b53420
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 02 Aug 2026 12:21:18 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '642'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=WNPu24nOsu8Z76OL6FjapK6fl3qSGsYGWuFT6kpflt50gbpFth1dagi_KXYkD-qj536LZymsA-KsgFfX;
+        report-to csp
+      Idempotency-Key:
+      - cd098f8d-f0d4-4886-a1c8-d57e00b53420
+      Original-Request:
+      - req_rGG1mQhSMDzox4
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=WNPu24nOsu8Z76OL6FjapK6fl3qSGsYGWuFT6kpflt50gbpFth1dagi_KXYkD-qj536LZymsA-KsgFfX&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=WNPu24nOsu8Z76OL6FjapK6fl3qSGsYGWuFT6kpflt50gbpFth1dagi_KXYkD-qj536LZymsA-KsgFfX&t=1"
+      Request-Id:
+      - req_rGG1mQhSMDzox4
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "cus_UzyK3AIbtO8SHU",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1785673278,
+          "currency": null,
+          "customer_account": null,
+          "default_source": null,
+          "delinquent": false,
+          "description": null,
+          "discount": null,
+          "email": null,
+          "invoice_prefix": "DYFX7VUL",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null,
+            "rendering_options": null
+          },
+          "livemode": false,
+          "metadata": {},
+          "name": null,
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [],
+          "shipping": null,
+          "tax_exempt": "none",
+          "test_clock": null
+        }
+  recorded_at: Sun, 02 Aug 2026 12:21:18 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## What

Two gates on the commission workflow, so a buyer's completion payment cannot be charged for
nothing:

1. `Commission#ensure_deliverable_is_attached!` — `create_completion_purchase!` refuses to charge
   the completion payment unless the commission has at least one file attached.
2. `CommissionsController#ensure_files_can_be_changed!` — refuses file attach/purge once the
   completion charge exists, so the deliverable that justified the charge cannot be removed
   afterwards.

The frontend is gated to match: a commission that is no longer editable stops rendering the
Upload files control and the per-file Delete buttons, and `updateCommission` now surfaces the
server's actual message instead of a generic one.

## Why

gumroad-private#1666 found that **63% of commission completions have no deliverable at all** — the
buyer's second payment is taken and nothing is delivered. The sibling gate for the deposit side
(refusing to charge a completion when the deposit was refunded or disputed) shipped separately as
#6819; this is the deliverable half of the same issue.

The controller gate is keyed on `is_completed? || completion_purchase.present?`, not on status
alone. `create_completion_purchase!` leaves the commission `in_progress` when the completion charge
is still settling in the buyer's presentment currency, so a status-only gate left a window where
the buyer had already been charged and every file could still be purged.

## Test results

`spec/controllers/commissions_controller_spec.rb`, `spec/models/commission_spec.rb`,
`spec/controllers/api/mobile/commissions_controller_spec.rb`:

```
51 examples, 0 failures
```

`npx tsc --noEmit` exits 0.

**Mutation-verified.** Reverting the controller guard to `return unless commission.is_completed?`
fails the settlement-window spec at the assertion, not at a fixture:

```
Failure/Error:
  expected `commission.reload.files.count` not to have changed, but did change from 1 to 0
1 example, 1 failure
```

## Fable-5 adversarial review

Two rounds. Round 1 reviewed the deposit gate (shipped as #6819). Round 2 reviewed this branch's
deliverable gates at `d9982577f`; verdict **CHANGES-REQUIRED**, all merge-blocking findings fixed
in `3be09c663`.

| ID | Sev | Finding | Disposition |
|----|-----|---------|-------------|
| F1 | P1 | Frontend never gated: completed commissions still rendered Upload files + Delete, which could only 422. `updateCommission` threw a bare `ResponseError` without reading the body, so the server's message was unreachable and the seller saw "Error uploading files. Please try again." *after* the blobs were already direct-uploaded. | Fixed in `3be09c663` — controls gated on `in_progress`, message parsed from the 422 body. Uses an `instanceof` check rather than `assertResponseError`, which re-raises non-`ResponseError`s and would leave a DirectUpload failure with no alert at all. |
| F3 | P2 | Gate keyed on `is_completed?` only, so during buyer-presentment settlement the buyer is charged while files can still be purged. | Fixed in `3be09c663` + regression spec, mutation-verified above. |
| F2 | P2 | Blocking *attaching* files post-completion also removes the legitimate repair flow (replacing a corrupt deliverable); no admin surface exists as a fallback. | **Deliberate, flagged for QA.** Full immutability is the safer default for a charge-justifying artifact, but this is a product call — see QA note below. |
| F4 | P3 | Cancelled commissions still accept file writes. | Accepted. Harmless: buyers never see files unless completed, and `deposit_is_chargeable?` requires `in_progress`, so no charge can follow. |
| F5 | P3 | Guard mutates `errors` and raises for the same action's own rescue. | Accepted — keeps rendering uniform with the sibling deposit gate. |

**Confirmed safe by the review** (each with file:line evidence): every caller of
`create_completion_purchase!` handles `RecordInvalid` (both controllers rescue and render 422; no
job, service or callback calls it); existing zero-file `in_progress` commissions are not stranded —
the message is actionable and attaching is still permitted; the guard raises before anything is
purged; the deposit gate cannot satisfy the file gate's matcher (both messages are unique in the
codebase); all refusal cassettes contain only factory setup with **no `payment_intents` charge**, so
none was recorded against pre-fix code; and the new specs are non-vacuous under mutation.

## QA steps

@nyomanjyotisa — the merge is yours; this touches a charging path so I am not self-merging.

1. **The product call in F2.** A completed commission's files are now immutable, with no admin
   fallback. If a seller needs to fix a corrupt deliverable after completion, today's only route is
   a console operator. Confirm that is the behavior we want, or say the word and I will narrow the
   gate to "refuse purges, allow appends".
2. **Phantom blobs.** `files.attached?` proves an attachment row exists, not that a downloadable
   object does. The web UI only calls `updateCommission` after `DirectUpload` resolves, so this is
   an API-only edge — worth a look if you can post a signed_id for an empty blob.
3. **The settlement window** is the highest-value manual check: complete a commission in a
   presentment currency that settles asynchronously and confirm the file controls are gone while it
   is still `in_progress`.

## AI disclosure

Written by Claude Opus 4.5 (`claude-opus-5`) running as Gumclaw, reviewed adversarially by fable-5.

Closes antiwork/gumroad-private#1666
