### PR TITLE
Pin the bundle dispute access log byte-exactly

### DIFF
--- a/spec/services/dispute_evidence/generate_access_activity_logs_service_spec.rb
+++ b/spec/services/dispute_evidence/generate_access_activity_logs_service_spec.rb
@@ -257,7 +257,7 @@ describe DisputeEvidence::GenerateAccessActivityLogsService do
       end
 
       context "when the email info is associated with a charge" do
-        let(:charge) { create(:charge, purchases: [purchase], seller:) }
+        let(:charge) { create(:charge, purchases: [purchase], seller:, merchant_account: nil) }
         let(:order) { charge.order }
 
         before do
@@ -299,18 +299,27 @@ describe DisputeEvidence::GenerateAccessActivityLogsService do
     it "reports consumption events recorded against the member purchases" do
       create(:consumption_event, purchase_id: member_purchase.id, consumed_at: DateTime.parse("2024-05-08"), ip_address: "1.2.3.4")
 
-      content = described_class.perform(bundle_purchase)
+      expect(described_class.perform(bundle_purchase)).to eq(
+        <<~TEXT.strip_heredoc.rstrip
+        The customer accessed the product 1 time.
 
-      expect(content).to include("The customer accessed the product 1 time.")
-      expect(content).to include("consumed_at,event_type,platform,ip_address,product\n")
-      expect(content).to end_with("web,1.2.3.4,\"Member One\"")
+        consumed_at,event_type,platform,ip_address,product
+        2024-05-08 00:00:00 UTC,watch,web,1.2.3.4,"Member One"
+        TEXT
+      )
     end
 
-    it "counts url_redirect uses on the members when there are no consumption events" do
+    it "returns nil when neither the wrapper nor members have access" do
+      expect(described_class.perform(bundle_purchase)).to be_nil
+    end
+
+    it "counts url_redirect uses on the wrapper and members when there are no consumption events" do
+      bundle_purchase.create_url_redirect!
+      bundle_purchase.url_redirect.update!(uses: 2)
       member_purchase.create_url_redirect!
       member_purchase.url_redirect.update!(uses: 7)
 
-      expect(described_class.perform(bundle_purchase)).to include("The customer accessed the product 7 times.")
+      expect(described_class.perform(bundle_purchase)).to eq("The customer accessed the product 9 times.")
     end
 
     it "reports a redirect-only member's uses alongside another member's consumption events" do
@@ -348,14 +357,42 @@ describe DisputeEvidence::GenerateAccessActivityLogsService do
       expect(described_class.perform(bundle_purchase)).to include("The customer accessed the product 2 times.")
     end
 
-    it "leaves the CSV shape unchanged for a non-bundle purchase" do
+    it "limits bundle consumption rows after merging member events by time" do
+      second_member = create(:purchase, link: create(:product, user: seller, name: "Member Two"), seller:, email: bundle_purchase.email, is_bundle_product_purchase: true)
+      create(:bundle_product_purchase, bundle_purchase:, product_purchase: second_member)
+      consumed_at = DateTime.parse("2024-05-08")
+
+      12.times do |i|
+        create(
+          :consumption_event,
+          purchase_id: i.even? ? member_purchase.id : second_member.id,
+          consumed_at: consumed_at + i.minutes,
+          ip_address: "10.0.0.#{i}"
+        )
+      end
+
+      content = described_class.perform(bundle_purchase)
+      rows = content.lines.grep(/10\.0\.0\./).map(&:strip)
+      expected_rows = described_class::LOG_RECORDS_LIMIT.times.map do |i|
+        product_name = i.even? ? "Member One" : "Member Two"
+        "2024-05-08 00:0#{i}:00 UTC,watch,web,10.0.0.#{i},\"#{product_name}\""
+      end
+
+      expect(content).to include("The customer accessed the product 12 times. Most recent 10 log records:")
+      expect(rows).to eq(expected_rows)
+    end
+
+    it "leaves non-bundle output byte-identical" do
       create(:consumption_event, purchase_id: purchase.id, consumed_at: DateTime.parse("2024-05-08"), ip_address: "0.0.0.0")
 
-      content = described_class.perform(purchase)
+      expect(described_class.perform(purchase)).to eq(
+        <<~TEXT.strip_heredoc.rstrip
+        The customer accessed the product 1 time.
 
-      expect(content).to include("consumed_at,event_type,platform,ip_address\n")
-      expect(content).to end_with("web,0.0.0.0")
-      expect(content).to_not include(purchase.link.name)
+        consumed_at,event_type,platform,ip_address
+        2024-05-08 00:00:00 UTC,watch,web,0.0.0.0
+        TEXT
+      )
     end
   end
 end


### PR DESCRIPTION
## What

Tightens the specs for `DisputeEvidence::GenerateAccessActivityLogsService` so the bundle access
log — a chargeback evidence artifact — is pinned byte-exactly rather than by fragment.

- Converts `include(...)` / `end_with(...)` assertions to total `eq(...)` on the full generated
  output.
- Adds three cases the merged suite has no equivalent for: the nil contract when neither the
  wrapper nor its members have any access, wrapper + member `url_redirect` use summation, and
  `LOG_RECORDS_LIMIT` applied *after* member events are merged by time.

Spec-only. No production code changes.

## Why

#6806 fixed the real bug: bundle dispute evidence read access activity off the wrapper purchase,
which never records any, so 30 of 44 bundle dispute packets in 90 days shipped with an empty
download log. The specs that shipped with it asserted fragments (`include("...1 time.")`,
`end_with("web,1.2.3.4,\"Member One\"")`). For a document we submit to a bank, "contains this
substring" is the wrong strength — the whole artifact is the contract.

These commits were pushed to the original branch after #6806 merged and were never reviewed, so
they are cherry-picked onto current `main` here rather than opened from a branch that forked before
main's dispute refactors.

## Test results

`spec/services/dispute_evidence/generate_access_activity_logs_service_spec.rb`, on a worktree at
current `origin/main` with these specs applied:

```
23 examples, 0 failures
```

## Fable-5 adversarial review

Verdict **READY-TO-MERGE** at the reviewed head. No P1s. The review's core deliverable was a
per-example revert analysis — a spec-only commit that does not bite is worthless:

| Example | Fails if #6806 is reverted? | Why |
|---|---|---|
| reports consumption events recorded against the member purchases | **yes** | event lives on the member only; wrapper-only service returns nil |
| counts url_redirect uses on the wrapper and members | **yes** | revert counts only the wrapper's 2 → "2 times" ≠ "9 times"; also discriminates a member-only implementation (7 ≠ 9) |
| limits bundle consumption rows after merging member events by time | **yes** | all 12 events live on members; wrapper-only returns nil |
| returns nil when neither wrapper nor members have access | no | deliberate contract pin — bundle nil case has no prior coverage |
| leaves non-bundle output byte-identical | no | deliberate no-regression pin |

| ID | Sev | Finding | Disposition |
|----|-----|---------|-------------|
| 1 | P2 | The limit example eq-pins a factual mislabel in bank evidence: the service `order(:consumed_at, :id)` then `.first(10)` — the **oldest** ten — under a header reading "Most recent 10 log records:". | **Out of scope, filed as antiwork/gumroad-private#1723.** Pre-existing since the service's initial commit and preserved by #6806; this branch is spec-only, and fixing it is a production change to an evidence path that wants its own review. The specs pin HEAD faithfully. |
| 2 | P3 | `merchant_account: nil` on one `let(:charge)` is unexplained and unrelated to bundles. | Accepted. Verified behavior-neutral: the tested path (`receipt_email_info` → `uses_charge_receipt?` → `Charge#receipt_email_info`) never reads `merchant_account`, and `Charge` has no callbacks or validations touching it. It spares an unrelated `user` + `merchant_account` row. |
| 3 | P3 | "leaves non-bundle output byte-identical" duplicates the top-level `.perform` example. | Accepted, kept deliberately as a co-located contrast pin next to the bundle examples. |

**Confirmed safe by the review:** every `eq` heredoc literal was walked against the service line by
line (blank-line placement, `,product` header, quoting of product names, no trailing newline hidden
by `.rstrip`); **no matcher got looser** — each deleted assertion is subsumed by a total `eq`,
including the `to_not include(purchase.link.name)` leak check; and the **9-count is not
double-counting** — a bundle wrapper's `download_page` is redirected to the library by a
`before_action` whenever any member is library-visible, and a halted before_action skips
after_actions, so that click increments nothing on the wrapper. Wrapper uses accrue only when the
wrapper page actually renders. Summing counts disjoint page renders.

## QA steps

@nyomanjyotisa — spec-only, so the risk is confined to CI. Worth a glance at the finding-1
disposition: I filed the mislabel as gumroad-private#1723 rather than folding it in here, since
changing what we submit as evidence should not ride along in a spec commit. Say the word if you
would rather see them together.

## AI disclosure

Written by Claude Opus 4.5 (`claude-opus-5`) running as Gumclaw, reviewed adversarially by fable-5.

Refs antiwork/gumroad-private#1690, antiwork/gumroad-private#1723
