### PR TITLE
Submit the most recent access records in chargeback evidence, not the oldest

### DIFF
--- a/app/services/dispute_evidence/generate_access_activity_logs_service.rb
+++ b/app/services/dispute_evidence/generate_access_activity_logs_service.rb
@@ -92,7 +92,7 @@ class DisputeEvidence::GenerateAccessActivityLogsService
     end
 
     def consumption_event_rows
-      consumption_events.first(LOG_RECORDS_LIMIT).map do |event|
+      consumption_events.last(LOG_RECORDS_LIMIT).map do |event|
         row = event.slice(*BASE_ROW_ATTRIBUTES).values
         row += [product_name_for(event)] if bundle?
         row.join(",")

--- a/spec/services/dispute_evidence/generate_access_activity_logs_service_spec.rb
+++ b/spec/services/dispute_evidence/generate_access_activity_logs_service_spec.rb
@@ -381,9 +381,10 @@ describe DisputeEvidence::GenerateAccessActivityLogsService do
 
       content = described_class.perform(bundle_purchase)
       rows = content.lines.grep(/10\.0\.0\./).map(&:strip)
-      expected_rows = described_class::LOG_RECORDS_LIMIT.times.map do |i|
+      # Events 0 and 1 are the oldest of the twelve, so the most-recent window is 2..11.
+      expected_rows = (2..11).map do |i|
         product_name = i.even? ? "Member One" : "Member Two"
-        "2024-05-08 00:0#{i}:00 UTC,watch,web,10.0.0.#{i},\"#{product_name}\""
+        "2024-05-08 00:#{format('%02d', i)}:00 UTC,watch,web,10.0.0.#{i},\"#{product_name}\""
       end
 
       expect(content).to include("The customer accessed the product 12 times. Most recent 10 log records:")

--- a/spec/services/dispute_evidence/generate_access_activity_logs_service_spec.rb
+++ b/spec/services/dispute_evidence/generate_access_activity_logs_service_spec.rb
@@ -164,14 +164,12 @@ describe DisputeEvidence::GenerateAccessActivityLogsService do
             end
           end
 
-          it "limits content to the last 10 events" do
+          it "includes the most recent 10 events, still in chronological order" do
             expect(usage_activity).to eq(
               <<~TEXT.strip_heredoc.rstrip
               The customer accessed the product 12 times. Most recent 10 log records:
 
               consumed_at,event_type,platform,ip_address
-              2024-05-06 09:00:00 UTC,download,web,0.0.0.0
-              2024-05-06 15:00:00 UTC,watch,iphone,0.0.0.0
               2024-05-06 16:00:00 UTC,watch,iphone,0.0.0.0
               2024-05-06 17:00:00 UTC,watch,iphone,0.0.0.0
               2024-05-06 18:00:00 UTC,watch,iphone,0.0.0.0
@@ -180,8 +178,18 @@ describe DisputeEvidence::GenerateAccessActivityLogsService do
               2024-05-06 21:00:00 UTC,watch,iphone,0.0.0.0
               2024-05-06 22:00:00 UTC,watch,iphone,0.0.0.0
               2024-05-06 23:00:00 UTC,watch,iphone,0.0.0.0
+              2024-05-07 00:00:00 UTC,watch,web,0.0.0.0
+              2024-05-07 00:00:00 UTC,watch,iphone,0.0.0.0
               TEXT
             )
+          end
+
+          # The header's claim is the whole point of the fix: the two oldest accesses must be the
+          # ones dropped, never the most recent, which are what rebut a "never used it" dispute.
+          it "drops the oldest events rather than the newest" do
+            expect(usage_activity).to include("2024-05-07 00:00:00 UTC,watch,iphone")
+            expect(usage_activity).not_to include("2024-05-06 09:00:00 UTC,download,web")
+            expect(usage_activity).not_to include("2024-05-06 15:00:00 UTC,watch,iphone")
           end
         end
       end


### PR DESCRIPTION
## What

The access-activity log in our chargeback evidence announced "Most recent 10 log records:" and then
listed the ten **oldest** accesses.

`consumption_events` is ordered `(:consumed_at, :id)` ascending, so `.first(LOG_RECORDS_LIMIT)` took
the earliest events. Changed to `.last(LOG_RECORDS_LIMIT)`.

## Why

This is a factual misstatement in a document submitted to a bank, and it drops exactly the rows that
rebut the dispute. Recent accesses are what disprove "never received / never used it" — a buyer who
downloaded once at purchase and a dozen more times last week appeared in our own evidence to have
only accessed the product around purchase time.

Affects any disputed purchase with more than 10 consumption events. Not a regression: present since
the service's initial commit.

## Before / after

Twelve accesses, most recent ten requested. **Before** — the header claims "most recent" while the
two newest accesses (`00:00` on 05-07) are the ones missing:

```
The customer accessed the product 12 times. Most recent 10 log records:

consumed_at,event_type,platform,ip_address
2024-05-06 09:00:00 UTC,download,web,0.0.0.0   <- oldest, included
2024-05-06 15:00:00 UTC,watch,iphone,0.0.0.0
...
2024-05-06 23:00:00 UTC,watch,iphone,0.0.0.0
                                               <- the two most recent accesses: dropped
```

**After** — the two oldest drop out, the newest are present, order still chronological:

```
The customer accessed the product 12 times. Most recent 10 log records:

consumed_at,event_type,platform,ip_address
2024-05-06 16:00:00 UTC,watch,iphone,0.0.0.0
...
2024-05-07 00:00:00 UTC,watch,web,0.0.0.0      <- most recent, now included
2024-05-07 00:00:00 UTC,watch,iphone,0.0.0.0
```

`.last(n)` on the unloaded ascending relation issues `ORDER BY consumed_at DESC, id DESC LIMIT 10`
and reverses the result, so the packet still reads oldest-to-newest — only the window moves. Query
count is unchanged.

## Tests

`bundle exec rspec spec/services/dispute_evidence/generate_access_activity_logs_service_spec.rb`
→ **24 examples, 0 failures**, run at `3196f8055`.

Two existing examples asserted the buggy window and were corrected:

- `"limits content to the last 10 events"` was named for the intended behavior but eq-pinned output
  omitting the two newest rows. Renamed and re-pinned.
- `"limits bundle consumption rows after merging member events by time"` landed on main after this
  branch was cut and built its expectation from `LOG_RECORDS_LIMIT.times` (events 0..9, the oldest
  ten). Now events 2..11.

Added `"drops the oldest events rather than the newest"`, which pins the *direction* of the drop so a
future revert to `.first` cannot pass silently. A revert now fails three independent assertions.

Fixes antiwork/gumroad-private#1723

## QA steps

No UI surface — this changes the text of an evidence packet submitted to the processor. Verify in
the Rails console on the preview app:

1. Find a purchase with more than 10 consumption events:
   `p = ConsumptionEvent.group(:purchase_id).having("count(*) > 10").count.first&.first&.then { Purchase.find(_1) }`
2. `puts DisputeEvidence::GenerateAccessActivityLogsService.perform(p)`
3. Confirm the ten `consumed_at` values under "Most recent 10 log records:" are the ten **newest**
   for that purchase (compare against
   `ConsumptionEvent.where(purchase_id: p.id).order(consumed_at: :desc).limit(10).pluck(:consumed_at)`),
   and that the rows still read oldest-to-newest.

---

AI disclosure: written by claude-opus-5 (Hermes Agent), from the instruction "go through gumroad
private, pick the simplest issue that doesn't have a PR open for it, and build it" — which selected
antiwork/gumroad-private#1723 — plus that issue's own description of the bug and its suggested fix.
The adversarial pre-merge review was run locally by a separate claude-opus-5 instance; it returned
SHIP with one pre-existing P3 outside this diff (noted on the issue, not fixed here).
