### PR TITLE
Let sellers change a membership's display currency from tier pricing

### DIFF
--- a/app/javascript/components/ProductEdit/ProductTab/TiersEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/TiersEditor.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 
 import { sendSamplePriceChangeEmail } from "$app/data/membership_tiers";
 import { confirmRichContentMoveSourceDeletions } from "$app/data/product_save_contract";
-import { getIsSingleUnitCurrency } from "$app/utils/currency";
+import { CurrencyCode, currencyCodeList, getIsSingleUnitCurrency } from "$app/utils/currency";
 import { priceCentsToUnit } from "$app/utils/price";
 import {
   numberOfMonthsInRecurrence,
@@ -160,7 +160,7 @@ const TierEditor = ({
   onDelete: () => void;
 }) => {
   const uid = React.useId();
-  const { product, currencyType } = useProductEditContext();
+  const { product, currencyType, setCurrencyType } = useProductEditContext();
 
   const [isOpen, setIsOpen] = React.useState(true);
 
@@ -301,6 +301,10 @@ const TierEditor = ({
                     suffix={perRecurrenceLabels[recurrence]}
                     disabled={!value.enabled}
                     ariaLabel={`Amount ${perRecurrenceLabels[recurrence]}`}
+                    currencyCodeSelector={{
+                      options: currencyCodeList,
+                      onChange: (currencyCode: CurrencyCode) => setCurrencyType(currencyCode),
+                    }}
                   />
                 </div>
               ))}

--- a/test/controllers/links_controller_test.rb
+++ b/test/controllers/links_controller_test.rb
@@ -2029,6 +2029,31 @@ class LinksControllerUpdateTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "PUT update re-denominates membership tier prices when the editor changes display currency" do
+    product = create_membership_product_with_preset_tiered_pricing(user: @seller, price_currency_type: "usd")
+    first_tier = product.tiers.find_by!(name: "First Tier")
+    second_tier = product.tiers.find_by!(name: "Second Tier")
+
+    post :update, params: {
+      id: product.unique_permalink,
+      name: product.name,
+      price_currency_type: "eur",
+      variants: [
+        { id: first_tier.external_id, name: first_tier.name,
+          updated_at: Product::StaleContentWriteGuard.snapshot_at(first_tier).as_json,
+          recurrence_price_values: { monthly: { enabled: true, price_cents: 300 } } },
+        { id: second_tier.external_id, name: second_tier.name,
+          updated_at: Product::StaleContentWriteGuard.snapshot_at(second_tier).as_json,
+          recurrence_price_values: { monthly: { enabled: true, price_cents: 500 } } },
+      ]
+    }, format: :json
+
+    assert_response :success
+    assert_equal "eur", product.reload.price_currency_type
+    assert_equal 300, first_tier.reload.alive_prices.is_buy.find_by!(currency: "eur", recurrence: BasePrice::Recurrence::MONTHLY).price_cents
+    assert_equal 500, second_tier.reload.alive_prices.is_buy.find_by!(currency: "eur", recurrence: BasePrice::Recurrence::MONTHLY).price_cents
+  end
+
   test "PUT update rejects a stale tier save that would re-enable a recurrence another session turned off" do
     enforce_stale_content_block!
     # Both tiers carry the same set of recurrences — the editor enforces that,


### PR DESCRIPTION
## What

Adds the display-currency selector to membership tier amount fields.

The product editor already stores a single `currencyType` in context and saves it as `price_currency_type`; membership tier prices already render with that currency. This PR wires the same selector regular products use into each tier amount input, so changing the selector updates the membership display currency before save.

## Why

Bundles now have the selector. Memberships were the remaining editor surface where the price inputs displayed the current currency but gave sellers no self-serve way to change it.

## Before / After

Before:
- Membership tier amount inputs displayed the product currency.
- No currency dropdown was rendered on those amount fields.

After, intended:
- Tier amount inputs render the currency dropdown.
- Selecting a currency updates the product editor currency state.
- Saving with `price_currency_type` writes tier price rows in the selected currency.

## Progress

- [x] Scope — membership tier editor only; bundles already shipped separately.
- [x] Design — use the existing global product-editor `currencyType` / `setCurrencyType` state; do not add per-tier currencies.
- [x] Build — first UI selector + controller regression test committed at `e4669ad45`.
- [x] QA — focused controller test, ESLint, TypeScript check, and branch CI are green.
- [ ] Fable fixes — adversarial review found blocking backend/display hazards; draft stays draft.
- [ ] Ship — not ready.

## Fable findings to fix before ready

- P1: switching currency creates target-currency tier price rows but leaves old-currency rows alive; tier read paths do not consistently filter by product `price_currency_type`, so stale rows can win display/editor reads.
- P1: existing subscriber renewal denomination needs a policy/guard; exposing this selector could silently move active subscribers from `$10` to `€10` without price-change notification.
- P2: selector is duplicated per tier recurrence for one global value; likely wants one global selector location.

## Tests

- `bin/rails test test/controllers/links_controller_test.rb -n /re-denominates\ membership\ tier\ prices/` → 1 run, 4 assertions, 0 failures, 0 errors.
- `npm run lint-fast -- app/javascript/components/ProductEdit/ProductTab/TiersEditor.tsx` → passed.
- `npm run typecheck` → passed.
- Branch CI at `e4669ad45` → 79 success, 10 skipped, 0 failures.

## QA

- [x] Backend: focused controller test proves an editor save with `price_currency_type=eur` writes EUR price rows for both submitted membership tiers with the same cents.
- [ ] Backend fix still needed: old-currency rows/read path and active subscriber renewal behavior.
- [ ] Preview/UI after fix.

---
AI disclosure: Written by Hermes Agent using `claude-opus-5`; instructed to finish the membership/remaining half after the bundle display-currency selector shipped.