### PR TITLE
Enforce entitlement checks on the mobile download and stream API

### DIFF
--- a/app/controllers/api/mobile/url_redirects_controller.rb
+++ b/app/controllers/api/mobile/url_redirects_controller.rb
@@ -53,7 +53,7 @@ class Api::Mobile::UrlRedirectsController < Api::Mobile::BaseController
 
       # Stream-only files, external links and streamable rentals are viewable but never
       # fetchable as originals. The web path enforces this on its own download action.
-      e404 if action_name == "download" && !@url_redirect.is_file_downloadable?(@product_file)
+      fetch_error("Could not find url redirect") if action_name == "download" && !@url_redirect.is_file_downloadable?(@product_file)
     end
 
     def mark_rental_as_viewed

--- a/app/controllers/api/mobile/url_redirects_controller.rb
+++ b/app/controllers/api/mobile/url_redirects_controller.rb
@@ -5,7 +5,7 @@ class Api::Mobile::UrlRedirectsController < Api::Mobile::BaseController
   before_action :fetch_url_redirect_by_token, only: %i[stream hls_playlist download]
   before_action :check_permissions, only: %i[stream hls_playlist download]
   before_action :mark_rental_as_viewed, only: :hls_playlist
-  before_action :check_for_expired_rentals, only: %i[stream hls_playlist]
+  before_action :check_for_expired_rentals, only: %i[stream hls_playlist download]
   after_action :increment_product_uses_count, only: %i[stream download]
   after_action -> { create_consumption_event!(ConsumptionEvent::EVENT_TYPE_WATCH) }, only: [:stream, :hls_playlist]
   after_action -> { create_consumption_event!(ConsumptionEvent::EVENT_TYPE_DOWNLOAD) }, only: [:download]
@@ -50,6 +50,10 @@ class Api::Mobile::UrlRedirectsController < Api::Mobile::BaseController
         @url_redirect.product_file(permitted_params[:product_file_id])
       end
       e404 if @product_file.nil?
+
+      # Stream-only files, external links and streamable rentals are viewable but never
+      # fetchable as originals. The web path enforces this on its own download action.
+      e404 if action_name == "download" && !@url_redirect.is_file_downloadable?(@product_file)
     end
 
     def mark_rental_as_viewed

--- a/app/controllers/api/mobile/url_redirects_controller.rb
+++ b/app/controllers/api/mobile/url_redirects_controller.rb
@@ -3,6 +3,7 @@
 class Api::Mobile::UrlRedirectsController < Api::Mobile::BaseController
   before_action :fetch_url_redirect_by_external_id, only: :url_redirect_attributes
   before_action :fetch_url_redirect_by_token, only: %i[stream hls_playlist download]
+  before_action :check_permissions, only: %i[stream hls_playlist download]
   before_action :mark_rental_as_viewed, only: :hls_playlist
   before_action :check_for_expired_rentals, only: %i[stream hls_playlist]
   after_action :increment_product_uses_count, only: %i[stream download]
@@ -53,6 +54,19 @@ class Api::Mobile::UrlRedirectsController < Api::Mobile::BaseController
 
     def mark_rental_as_viewed
       @url_redirect.mark_rental_as_viewed!
+    end
+
+    def check_permissions
+      purchase = @url_redirect.purchase
+
+      return if purchase.nil?
+
+      if purchase.stripe_refunded ||
+         (purchase.chargeback_date.present? && !purchase.chargeback_reversed) ||
+         purchase.is_access_revoked ||
+         (purchase.subscription.present? && !purchase.subscription.grant_access_to_product?)
+        fetch_error("Could not find url redirect")
+      end
     end
 
     def check_for_expired_rentals

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -189,8 +189,10 @@ class Rack::Attack
   # Keyed per (token, file), not per token: one purchase legitimately fans out across every
   # file in a bundle or course, so a per-token counter would 429 a buyer part-way through a
   # large product. max_level: 1 keeps a stuck client from earning the multi-hour backoff tiers.
+  # The file capture stops at a dot so `.json`/`.xml` format variants share one bucket —
+  # route segments never contain dots, so anything after one is a format suffix.
   throttle_with_exponential_backoff(name: "mobile_url_redirect_download/token", requests: 60, period: 60.seconds, max_level: 1) do |req|
-    m = req.path.match(%r{\A/(?:api/)?mobile/url_redirects/download/(?<token>[^/]+)/(?<file>[^/]+)})
+    m = req.path.match(%r{\A/(?:api/)?mobile/url_redirects/download/(?<token>[^/]+)/(?<file>[^/.]+)})
     "#{m[:token]}/#{m[:file]}" if m
   end
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -186,8 +186,12 @@ class Rack::Attack
   throttle_by_ip path: "/purchases",                      requests: 40, period: 60.seconds # Initial: 40rpm,  Max: 200 requests/9 hours
   throttle_by_ip path: "/stripe/setup_intents",           requests: 40, period: 60.seconds # Initial: 40rpm,  Max: 200 requests/9 hours
   throttle_by_ip path: "/settings/credit_card",           requests: 3,  period: 20.seconds # Initial: 9rpm,   Max: 45  requests/9 hours
-  throttle_with_exponential_backoff(name: "mobile_url_redirect_download/token", requests: 30, period: 60.seconds) do |req|
-    req.path.match(%r{\A/(?:api/)?mobile/url_redirects/download/(?<token>[^/]+)/[^/]+})&.[](:token)
+  # Keyed per (token, file), not per token: one purchase legitimately fans out across every
+  # file in a bundle or course, so a per-token counter would 429 a buyer part-way through a
+  # large product. max_level: 1 keeps a stuck client from earning the multi-hour backoff tiers.
+  throttle_with_exponential_backoff(name: "mobile_url_redirect_download/token", requests: 60, period: 60.seconds, max_level: 1) do |req|
+    m = req.path.match(%r{\A/(?:api/)?mobile/url_redirects/download/(?<token>[^/]+)/(?<file>[^/]+)})
+    "#{m[:token]}/#{m[:file]}" if m
   end
 
   throttle_by_ip_for_period path: "/purchases", requests: 50, period: 1.hour

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -186,6 +186,9 @@ class Rack::Attack
   throttle_by_ip path: "/purchases",                      requests: 40, period: 60.seconds # Initial: 40rpm,  Max: 200 requests/9 hours
   throttle_by_ip path: "/stripe/setup_intents",           requests: 40, period: 60.seconds # Initial: 40rpm,  Max: 200 requests/9 hours
   throttle_by_ip path: "/settings/credit_card",           requests: 3,  period: 20.seconds # Initial: 9rpm,   Max: 45  requests/9 hours
+  throttle_with_exponential_backoff(name: "mobile_url_redirect_download/token", requests: 30, period: 60.seconds) do |req|
+    req.path.match(%r{\A/(?:api/)?mobile/url_redirects/download/(?<token>[^/]+)/[^/]+})&.[](:token)
+  end
 
   throttle_by_ip_for_period path: "/purchases", requests: 50, period: 1.hour
 

--- a/spec/controllers/api/mobile/url_redirects_controller_spec.rb
+++ b/spec/controllers/api/mobile/url_redirects_controller_spec.rb
@@ -160,6 +160,49 @@ describe Api::Mobile::UrlRedirectsController do
       expect(response.parsed_body).to eq({ success: false, message: "Your rental has expired." }.as_json)
     end
 
+    it "does not stream content for a terminated purchase" do
+      [
+        ->(purchase) { purchase.update!(stripe_refunded: true) },
+        ->(purchase) { purchase.update!(chargeback_date: Time.current) },
+        ->(purchase) { purchase.update!(is_access_revoked: true) },
+      ].each do |terminate_purchase|
+        purchase = create(:purchase, link: product)
+        blocked_url_redirect = create(:url_redirect, link: product, purchase:)
+        terminate_purchase.call(purchase)
+
+        expect do
+          get :stream, params: {
+            token: blocked_url_redirect.token,
+            product_file_id: file_1.external_id,
+            mobile_token: Api::Mobile::BaseController::MOBILE_TOKEN,
+            format: :json
+          }
+        end.to_not change(ConsumptionEvent, :count)
+
+        expect(response).to have_http_status(:not_found)
+        expect(response.parsed_body).to eq({ success: false, message: "Could not find url redirect" }.as_json)
+      end
+    end
+
+    it "does not stream content for an inactive membership" do
+      subscription = create(:subscription, link: product)
+      purchase = create(:purchase, link: product, subscription:)
+      blocked_url_redirect = create(:url_redirect, link: product, purchase:)
+      allow_any_instance_of(Subscription).to receive(:grant_access_to_product?).and_return(false)
+
+      expect do
+        get :stream, params: {
+          token: blocked_url_redirect.token,
+          product_file_id: file_1.external_id,
+          mobile_token: Api::Mobile::BaseController::MOBILE_TOKEN,
+          format: :json
+        }
+      end.to_not change(ConsumptionEvent, :count)
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to eq({ success: false, message: "Could not find url redirect" }.as_json)
+    end
+
     it "returns a progressive download url if a m3u8 location does not exist for the product file" do
       expect_any_instance_of(ProductFile).to receive(:hls_playlist).and_return(nil)
       allow_any_instance_of(Aws::S3::Object).to receive(:content_length).and_return(1_000_000)
@@ -333,6 +376,22 @@ describe Api::Mobile::UrlRedirectsController do
       expect(event.platform).to eq Platform::IPHONE
     end
 
+    it "does not return the playlist for a terminated purchase" do
+      purchase = create(:purchase, link: @url_redirect.link, is_access_revoked: true)
+      @url_redirect.update!(purchase:)
+
+      expect do
+        get :hls_playlist, params: {
+          token: @url_redirect.token,
+          product_file_id: @file_1.external_id,
+          mobile_token: Api::Mobile::BaseController::MOBILE_TOKEN
+        }
+      end.to_not change(ConsumptionEvent, :count)
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to eq({ success: false, message: "Could not find url redirect" }.as_json)
+    end
+
     it "never displays a confirmation page for mobile stream urls" do
       @url_redirect.mark_as_seen
       @url_redirect.increment!(:uses, 1)
@@ -369,6 +428,27 @@ describe Api::Mobile::UrlRedirectsController do
                                  product_file_id: @product.product_files.first.external_id,
                                  mobile_token: Api::Mobile::BaseController::MOBILE_TOKEN }
       end.to change { @url_redirect.reload.uses }.from(0).to(1)
+    end
+
+    it "does not download content for a terminated purchase" do
+      [
+        ->(purchase) { purchase.update!(stripe_refunded: true) },
+        ->(purchase) { purchase.update!(chargeback_date: Time.current) },
+        ->(purchase) { purchase.update!(is_access_revoked: true) },
+      ].each do |terminate_purchase|
+        purchase = create(:purchase, link: @product)
+        blocked_url_redirect = create(:url_redirect, link: @product, purchase:)
+        terminate_purchase.call(purchase)
+
+        expect do
+          get :download, params: { token: blocked_url_redirect.token,
+                                   product_file_id: @product.product_files.first.external_id,
+                                   mobile_token: Api::Mobile::BaseController::MOBILE_TOKEN }
+        end.to_not change(ConsumptionEvent, :count)
+
+        expect(response).to have_http_status(:not_found)
+        expect(response.parsed_body).to eq({ success: false, message: "Could not find url redirect" }.as_json)
+      end
     end
 
     it "never displays a confirmation page for download urls" do

--- a/spec/controllers/api/mobile/url_redirects_controller_spec.rb
+++ b/spec/controllers/api/mobile/url_redirects_controller_spec.rb
@@ -186,8 +186,8 @@ describe Api::Mobile::UrlRedirectsController do
 
     it "does not stream content for an inactive membership" do
       purchase = create(:membership_purchase)
+      purchase.subscription.update!(cancelled_at: 1.day.ago)
       blocked_url_redirect = create(:url_redirect, link: purchase.link, purchase:)
-      allow_any_instance_of(Subscription).to receive(:grant_access_to_product?).and_return(false)
 
       expect do
         get :stream, params: {
@@ -431,10 +431,10 @@ describe Api::Mobile::UrlRedirectsController do
 
     it "does not download content for a terminated purchase" do
       [
-        ->(purchase) { purchase.update!(stripe_refunded: true) },
-        ->(purchase) { purchase.update!(chargeback_date: Time.current) },
-        ->(purchase) { purchase.update!(is_access_revoked: true) },
-      ].each do |terminate_purchase|
+        [:refunded, ->(purchase) { purchase.update!(stripe_refunded: true) }],
+        [:charged_back, ->(purchase) { purchase.update!(chargeback_date: Time.current) }],
+        [:access_revoked, ->(purchase) { purchase.update!(is_access_revoked: true) }],
+      ].each do |label, terminate_purchase|
         purchase = create(:purchase, link: @product)
         blocked_url_redirect = create(:url_redirect, link: @product, purchase:)
         terminate_purchase.call(purchase)
@@ -443,11 +443,51 @@ describe Api::Mobile::UrlRedirectsController do
           get :download, params: { token: blocked_url_redirect.token,
                                    product_file_id: @product.product_files.first.external_id,
                                    mobile_token: Api::Mobile::BaseController::MOBILE_TOKEN }
-        end.to_not change(ConsumptionEvent, :count)
+        end.to_not change(ConsumptionEvent, :count), "#{label} was not blocked"
 
-        expect(response).to have_http_status(:not_found)
+        expect(response).to have_http_status(:not_found), "#{label} was not blocked"
         expect(response.parsed_body).to eq({ success: false, message: "Could not find url redirect" }.as_json)
       end
+    end
+
+    it "downloads content when a chargeback was reversed" do
+      purchase = create(:purchase, link: @product, chargeback_date: Time.current)
+      purchase.update!(chargeback_reversed: true)
+      allowed_url_redirect = create(:url_redirect, link: @product, purchase:)
+
+      get :download, params: { token: allowed_url_redirect.token,
+                               product_file_id: @product.product_files.first.external_id,
+                               mobile_token: Api::Mobile::BaseController::MOBILE_TOKEN }
+
+      expect(response).to have_http_status(:redirect)
+    end
+
+    it "does not download a stream-only file" do
+      @product.product_files.first.update!(stream_only: true)
+
+      expect do
+        get :download, params: { token: @url_redirect.token,
+                                 product_file_id: @product.product_files.first.external_id,
+                                 mobile_token: Api::Mobile::BaseController::MOBILE_TOKEN }
+      end.to_not change(ConsumptionEvent, :count)
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "does not download content for an expired rental" do
+      @url_redirect.purchase = create(:purchase, is_rental: true)
+      @url_redirect.purchase.save!
+      @url_redirect.update!(is_rental: true, rental_first_viewed_at: 10.days.ago)
+      ExpireRentalPurchasesWorker.new.perform
+
+      expect do
+        get :download, params: { token: @url_redirect.token,
+                                 product_file_id: @product.product_files.first.external_id,
+                                 mobile_token: Api::Mobile::BaseController::MOBILE_TOKEN }
+      end.to_not change(ConsumptionEvent, :count)
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.parsed_body).to eq({ success: false, message: "Your rental has expired." }.as_json)
     end
 
     it "never displays a confirmation page for download urls" do

--- a/spec/controllers/api/mobile/url_redirects_controller_spec.rb
+++ b/spec/controllers/api/mobile/url_redirects_controller_spec.rb
@@ -186,6 +186,7 @@ describe Api::Mobile::UrlRedirectsController do
 
     it "does not stream content for an inactive membership" do
       purchase = create(:membership_purchase)
+      purchase.link.update!(block_access_after_membership_cancellation: true)
       purchase.subscription.update!(cancelled_at: 1.day.ago)
       blocked_url_redirect = create(:url_redirect, link: purchase.link, purchase:)
 
@@ -451,6 +452,7 @@ describe Api::Mobile::UrlRedirectsController do
     end
 
     it "downloads content when a chargeback was reversed" do
+      allow_any_instance_of(Aws::S3::Object).to receive(:content_length).and_return(100)
       purchase = create(:purchase, link: @product, chargeback_date: Time.current)
       purchase.update!(chargeback_reversed: true)
       allowed_url_redirect = create(:url_redirect, link: @product, purchase:)

--- a/spec/controllers/api/mobile/url_redirects_controller_spec.rb
+++ b/spec/controllers/api/mobile/url_redirects_controller_spec.rb
@@ -185,9 +185,8 @@ describe Api::Mobile::UrlRedirectsController do
     end
 
     it "does not stream content for an inactive membership" do
-      subscription = create(:subscription, link: product)
-      purchase = create(:purchase, link: product, subscription:)
-      blocked_url_redirect = create(:url_redirect, link: product, purchase:)
+      purchase = create(:membership_purchase)
+      blocked_url_redirect = create(:url_redirect, link: purchase.link, purchase:)
       allow_any_instance_of(Subscription).to receive(:grant_access_to_product?).and_return(false)
 
       expect do

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -359,6 +359,46 @@ describe "Rack::Attack throttle", type: :request do
     end
   end
 
+  describe "GET /api/mobile/url_redirects/download throttle" do
+    before { reset_rack_attack! }
+    after { reset_rack_attack! }
+
+    it "shares one download throttle bucket across formatted route variants of the same file" do
+      request_for = lambda do |path|
+        Rack::Attack::Request.new(
+          Rack::MockRequest.env_for(path, method: "GET", input: "", "HTTP_CF_CONNECTING_IP" => "203.0.113.90")
+        )
+      end
+
+      travel_to(Time.current) do
+        60.times do |i|
+          request = request_for.call(i.even? ? "/api/mobile/url_redirects/download/token123/file456" : "/api/mobile/url_redirects/download/token123/file456.json")
+
+          expect(Rack::Attack.configuration.throttled?(request)).to be(false), "request #{i + 1} unexpectedly throttled"
+        end
+
+        expect(Rack::Attack.configuration.throttled?(request_for.call("/api/mobile/url_redirects/download/token123/file456.xml"))).to be(true)
+      end
+    end
+
+    it "counts different files under the same token separately" do
+      request_for = lambda do |path|
+        Rack::Attack::Request.new(
+          Rack::MockRequest.env_for(path, method: "GET", input: "", "HTTP_CF_CONNECTING_IP" => "203.0.113.91")
+        )
+      end
+
+      travel_to(Time.current) do
+        60.times do
+          expect(Rack::Attack.configuration.throttled?(request_for.call("/api/mobile/url_redirects/download/token123/file456"))).to be(false)
+        end
+
+        expect(Rack::Attack.configuration.throttled?(request_for.call("/api/mobile/url_redirects/download/token123/file456"))).to be(true)
+        expect(Rack::Attack.configuration.throttled?(request_for.call("/api/mobile/url_redirects/download/token123/file789"))).to be(false)
+      end
+    end
+  end
+
   describe "PUT /api/v2/products/:id per-token throttle" do
     before { reset_rack_attack! }
     after { reset_rack_attack! }


### PR DESCRIPTION
## What

The mobile download/stream API (`Api::Mobile::UrlRedirectsController`) never ran an entitlement check. A `url_redirect` token was the whole authorization: anyone holding one could keep downloading and streaming after a refund, a chargeback, an access revocation, or a membership lapse. The web path has enforced all of this for years — only the mobile route skipped it.

This adds `check_permissions` to `stream`, `hls_playlist` and `download`, extends the expired-rental check to `download`, applies the web path's `is_file_downloadable?` rule so stream-only files and external links are not fetchable as originals, and rate-limits the download route per (token, file).

## Why

`fetch_url_redirect_by_token` resolved the redirect and handed back a signed S3 URL with no reference to the purchase's state. A buyer who charged back a $995 basket kept full access to every file in it. The token does not expire, so the exposure is permanent and survives every remedy support has.

Refunded, charged-back (and not reversed), access-revoked, and lapsed-membership purchases now get the same 404 JSON body the mobile client already handles for a missing redirect.

## Test results

`spec/controllers/api/mobile/url_redirects_controller_spec.rb` — **33 examples, 0 failures** locally.
CI on the branch head `c68a2eeb8`: **78 checks, 0 failures, 0 cancelled, 0 pending.**

Mutation checks proving the new guards are load-bearing (each run against the restored 33-green branch):

| Mutation | Result |
|---|---|
| Delete the `is_file_downloadable?` gate | 1 failure |
| Delete the subscription limb of `check_permissions` | 1 failure |
| Revert `check_for_expired_rentals` to `stream`/`hls_playlist` only | 1 failure |

## QA steps

Run against a staging build of the mobile app, or curl the API directly with a valid `mobile_token`:

1. Buy a product, note the `url_redirect` token, confirm `GET /api/mobile/url_redirects/download/<token>/<file_id>` 302s to a signed URL.
2. Refund the purchase. Repeat the call — expect `404` with `{"success": false, "message": "Could not find url redirect"}`, and no new `ConsumptionEvent`.
3. Repeat for a charged-back purchase, then set `chargeback_reversed` — access must come **back**.
4. On a membership product with "block access after cancellation" enabled, cancel the subscription and confirm stream and download both 404.
5. Mark a file `stream_only` and confirm `download` 404s while `stream` still plays.
6. Rent a product, let the rental expire, confirm `download` 404s (previously it still handed out the original).

## Fable-5 adversarial review

A round ran on this branch before this PR was opened. Its findings were fixed in `e7ea364ad`, and reviewing that fix commit — which by construction was outside the round's own scope — turned up three red examples that had been sitting unnoticed on the branch. Those are fixed in `c68a2eeb8`.

| Finding | Disposition |
|---|---|
| `download` skipped `check_for_expired_rentals`, so an expired rental still yielded the original file | Fixed in `e7ea364ad` |
| `download` never applied `is_file_downloadable?`, so stream-only files were fetchable as originals | Fixed in `e7ea364ad` |
| Rack::Attack key was the purchase token, so a >30-file bundle 429'd a legitimate buyer mid-product | Fixed in `e7ea364ad` — keyed per (token, file), `max_level: 1` |
| Inactive-membership example stubbed `grant_access_to_product?`, so it would pass even if the predicate were wrong | Fixed in `e7ea364ad` — cancels a real subscription |
| The `is_file_downloadable?` refusal raised `e404` (a routing error) where every sibling refusal on these actions renders JSON | Fixed in `c68a2eeb8` |
| The inactive-membership fixture was unrealistic: `grant_access_to_product?` falls through to `!link.block_access_after_membership_cancellation`, so a cancelled subscription still grants access unless the seller opted in — the example asserted a refusal the predicate never makes | Fixed in `c68a2eeb8` (fixture, not the gate) |
| The reversed-chargeback example reached real S3 instead of stubbing `content_length` like its siblings | Fixed in `c68a2eeb8` |

**Confirmed safe by the review:** the four terminal-purchase conditions match the web path's own gate; `purchase.nil?` correctly returns early (installment and fileless redirects have no purchase); reversed chargebacks restore access rather than staying blocked; the after_action consumption events do not fire on a refused request.

**Only verifiable live:** that the mobile client renders the 404 JSON body as a friendly message rather than a crash — worth one pass on a real device.

## AI disclosure

Written by gumclaw (Claude Opus 4.5 via Hermes Agent). Reviewed adversarially by a separate headless model instance; every fix was verified by running the suite and by deleting the guard to confirm the spec reddens.

Ref antiwork/gumroad-private#1711
