### PR TITLE
Restrict profile section search to visitor-settable filters

### DIFF
--- a/app/controllers/concerns/search_products.rb
+++ b/app/controllers/concerns/search_products.rb
@@ -38,28 +38,34 @@ module SearchProducts
         search_params[:ids] = search_params[:ids].split(",").map(&:strip)
       end
 
-      search_params[:from] = Array.wrap(search_params[:from]).first.to_i if search_params[:from].present?
+      # These reach ES as `terms` clauses, which reject a nested structure with a 400.
+      %i[tags filetypes ids].each do |key|
+        next unless search_params[key].is_a?(Array)
 
-      if search_params[:size].is_a?(String)
-        search_params[:size] = search_params[:size].to_i
-      elsif search_params[:size].is_a?(Array)
-        search_params[:size] = search_params[:size].first.to_i
+        search_params[key] = search_params[key].filter_map { |element| scalar_search_value(element)&.to_s }
       end
 
-      # search_options builds `simple_query_string` and numeric clauses from these; none accepts
-      # a nested structure, and it coerces unconditionally (`.to_i`, `.to_f`). Take the first
-      # element of an array (matching how :from and :size already collapse) and drop a hash,
-      # whose values have no scalar reading.
-      %i[query rating min_price max_price sort recommended_by].each do |key|
-        value = search_params[key]
-        next unless value.is_a?(Array) || value.is_a?(Hash) || value.is_a?(ActionController::Parameters)
-
-        search_params[key] = value.is_a?(Array) ? value.first : nil
+      # search_options coerces each of these unconditionally (`.to_i`, `.to_f`) or hands it to ES
+      # as a scalar; a crafted `?query[][]=x` would otherwise 500 a public profile URL.
+      %i[query rating min_price max_price sort recommended_by from size].each do |key|
+        search_params[key] = scalar_search_value(search_params[key]) if search_params.key?(key)
       end
+
+      search_params[:from] = search_params[:from].to_i if search_params[:from].present?
+      # search_options computes MAX_RESULT_WINDOW - size and clamps against it, so an oversized
+      # or negative size raises on the range rather than returning nothing.
+      search_params[:size] = search_params[:size].to_i.clamp(0, Link::MAX_RESULT_WINDOW) if search_params[:size].present?
 
       search_params.delete(:search) unless search_params[:search].is_a?(Hash)
 
       search_params
+    end
+
+    # Collapses a crafted nested param to the scalar the search layer expects, or nil when it has
+    # no scalar reading. A deeper nesting collapses to nil rather than being unwrapped further.
+    def scalar_search_value(value)
+      value = value.first if value.is_a?(Array)
+      value.is_a?(String) || value.is_a?(Numeric) ? value : nil
     end
 
     def format_search_params!

--- a/app/controllers/concerns/search_products.rb
+++ b/app/controllers/concerns/search_products.rb
@@ -19,32 +19,53 @@ module SearchProducts
       }
     end
 
+    # Value-shape coercions only. Split out from format_search_params! so callers that build
+    # their own params hash (ProfileSectionsPresenter reads the raw query string) get the same
+    # normalization — search_options coerces these unconditionally (`.to_i`, `.to_f`,
+    # `each_with_index`), so an unexpected shape 400s Elasticsearch or raises.
+    def normalize_search_param_values!(search_params)
+      if search_params[:tags].is_a?(String)
+        search_params[:tags] = search_params[:tags].split(",").map { |t| t.tr("-", " ").squish.downcase }
+      elsif search_params[:tags].is_a?(ActionController::Parameters) || search_params[:tags].is_a?(Hash)
+        search_params[:tags] = search_params[:tags].values.map { |t| t.to_s.tr("-", " ").squish.downcase }
+      end
+
+      if search_params[:filetypes].is_a?(String)
+        search_params[:filetypes] = search_params[:filetypes].split(",").map { |f| f.squish.downcase }
+      end
+
+      if search_params[:ids].is_a?(String)
+        search_params[:ids] = search_params[:ids].split(",").map(&:strip)
+      end
+
+      search_params[:from] = Array.wrap(search_params[:from]).first.to_i if search_params[:from].present?
+
+      if search_params[:size].is_a?(String)
+        search_params[:size] = search_params[:size].to_i
+      elsif search_params[:size].is_a?(Array)
+        search_params[:size] = search_params[:size].first.to_i
+      end
+
+      # search_options builds `simple_query_string` and numeric clauses from these; none accepts
+      # a nested structure, and it coerces unconditionally (`.to_i`, `.to_f`). Take the first
+      # element of an array (matching how :from and :size already collapse) and drop a hash,
+      # whose values have no scalar reading.
+      %i[query rating min_price max_price sort recommended_by].each do |key|
+        value = search_params[key]
+        next unless value.is_a?(Array) || value.is_a?(Hash) || value.is_a?(ActionController::Parameters)
+
+        search_params[key] = value.is_a?(Array) ? value.first : nil
+      end
+
+      search_params.delete(:search) unless search_params[:search].is_a?(Hash)
+
+      search_params
+    end
+
     def format_search_params!
-      if params[:tags].is_a?(String)
-        params[:tags] = params[:tags].split(",").map { |t| t.tr("-", " ").squish.downcase }
-      elsif params[:tags].is_a?(ActionController::Parameters) || params[:tags].is_a?(Hash)
-        params[:tags] = params[:tags].values.map { |t| t.to_s.tr("-", " ").squish.downcase }
-      end
-
-      if params[:filetypes].is_a?(String)
-        params[:filetypes] = params[:filetypes].split(",").map { |f| f.squish.downcase }
-      end
-
-      if params[:ids].is_a?(String)
-        params[:ids] = params[:ids].split(",").map(&:strip)
-      end
+      normalize_search_param_values!(params)
 
       params[:offer_code] = "__no_match__" if params[:offer_code].present? && !offer_codes_search_feature_active?(params)
-
-      params[:from] = Array.wrap(params[:from]).first.to_i if params[:from].present?
-
-      if params[:size].is_a?(String)
-        params[:size] = params[:size].to_i
-      elsif params[:size].is_a?(Array)
-        params[:size] = params[:size].first.to_i
-      end
-
-      params.delete(:search) unless params[:search].is_a?(Hash)
     end
 
     def offer_codes_search_feature_active?(params)

--- a/app/modules/product/searchable.rb
+++ b/app/modules/product/searchable.rb
@@ -386,7 +386,10 @@ module Product::Searchable
       end
 
       search_options = search_options.to_hash
-      search_options[:query][:bool][:must] << params[:search] if params[:search]
+      # Only a Hash is a well-formed ES clause. Callers that read raw query parameters (the
+      # profile presenter uses request.query_parameters, bypassing format_search_params!) can
+      # pass a bare `?search=foo` string, which ES rejects with a 400 and 500s the page.
+      search_options[:query][:bool][:must] << params[:search] if params[:search].is_a?(Hash)
 
       if (params[:ids].present? || params[:section].is_a?(SellerProfileSection)) && params[:sort] == ProductSortKey::PAGE_LAYOUT
         product_ids = Array(params[:ids] || params[:section].shown_products)

--- a/app/modules/product/searchable.rb
+++ b/app/modules/product/searchable.rb
@@ -386,9 +386,8 @@ module Product::Searchable
       end
 
       search_options = search_options.to_hash
-      # Only a Hash is a well-formed ES clause. Callers that read raw query parameters (the
-      # profile presenter uses request.query_parameters, bypassing format_search_params!) can
-      # pass a bare `?search=foo` string, which ES rejects with a 400 and 500s the page.
+      # Only a Hash is a well-formed ES clause; a bare `?search=foo` from a caller that reads raw
+      # query parameters would 400 the whole query. Matches format_search_params!'s own predicate.
       search_options[:query][:bool][:must] << params[:search] if params[:search].is_a?(Hash)
 
       if (params[:ids].present? || params[:section].is_a?(SellerProfileSection)) && params[:sort] == ProductSortKey::PAGE_LAYOUT

--- a/app/presenters/profile_sections_presenter.rb
+++ b/app/presenters/profile_sections_presenter.rb
@@ -123,8 +123,14 @@ class ProfileSectionsPresenter
       end
     end
 
+    # Visitor-settable search filters. This reads the RAW query string, which never went through
+    # format_search_params!, so anything not listed here reaches Link.search_options unsanitised —
+    # including internal-only keys (`section`, `curated_product_ids`) and `search`, whose nested
+    # form is an arbitrary ES clause that can range-probe indexed revenue fields.
+    VISITOR_SEARCH_PARAMS = %i[query tags filetypes min_price max_price rating sort from size recommended_by].freeze
+
     def section_props(section, cached_props:, request:, pundit_user:, seller_custom_domain_url:, editing:)
-      params = request.query_parameters
+      params = request.query_parameters.slice(*VISITOR_SEARCH_PARAMS)
       # `editing` selects the owner/editing payload shape. Product visibility (hiding sold-out
       # products) instead follows the real viewer, so the seller still sees every product on their
       # own public profile even though it renders the visitor shape.

--- a/app/presenters/profile_sections_presenter.rb
+++ b/app/presenters/profile_sections_presenter.rb
@@ -125,12 +125,12 @@ class ProfileSectionsPresenter
 
     # Visitor-settable search filters. This reads the RAW query string, which never went through
     # format_search_params!, so anything not listed here reaches Link.search_options unsanitised —
-    # including internal-only keys (`section`, `curated_product_ids`) and `search`, whose nested
-    # form is an arbitrary ES clause that can range-probe indexed revenue fields.
+    # including `search`, whose nested form is an arbitrary ES clause that can range-probe indexed
+    # revenue fields, and `curated_product_ids`, which the controller decrypts before use.
     VISITOR_SEARCH_PARAMS = %i[query tags filetypes min_price max_price rating sort from size recommended_by].freeze
 
     def section_props(section, cached_props:, request:, pundit_user:, seller_custom_domain_url:, editing:)
-      params = request.query_parameters.slice(*VISITOR_SEARCH_PARAMS)
+      params = normalize_search_param_values!(request.query_parameters.slice(*VISITOR_SEARCH_PARAMS))
       # `editing` selects the owner/editing payload shape. Product visibility (hiding sold-out
       # products) instead follows the real viewer, so the seller still sees every product on their
       # own public profile even though it renders the visitor shape.

--- a/spec/modules/product/searchable/search_spec.rb
+++ b/spec/modules/product/searchable/search_spec.rb
@@ -132,6 +132,22 @@ describe "Product::Searchable - Search scenarios" do
         expect(records).to be_an(Elasticsearch::Model::Response::Records)
       end
 
+      it "ignores a non-Hash :search param instead of injecting it into the bool query" do
+        params = { search: "gnomes png file" }
+        search_options = Link.search_options(params)
+
+        expect(search_options[:query][:bool][:must]).to all(be_a(Hash))
+        records = Link.search(search_options).records
+        expect(records).to be_an(Elasticsearch::Model::Response::Records)
+      end
+
+      it "still appends a Hash :search param as a query clause" do
+        params = { search: { term: { is_recommendable: true } } }
+        search_options = Link.search_options(params)
+
+        expect(search_options[:query][:bool][:must]).to include({ term: { is_recommendable: true } })
+      end
+
       describe "is_alive_on_profile" do
         let(:seller) { create(:user) }
         let!(:product) { create(:product, user: seller) }

--- a/spec/requests/user/profile_search_params_spec.rb
+++ b/spec/requests/user/profile_search_params_spec.rb
@@ -4,8 +4,8 @@ require "spec_helper"
 
 # The profile page renders its product sections through ProfileSectionsPresenter, which reads
 # `request.query_parameters` directly rather than the controller's params. That copy never went
-# through `format_search_params!`, so every one of these query strings reaches
-# Link.search_options unsanitised and used to build a malformed Elasticsearch query.
+# through `format_search_params!`, so these query strings reach Link.search_options unsanitised
+# unless the presenter slices and normalizes them itself.
 describe "Profile page search params", :elasticsearch_wait_for_refresh, type: :request do
   let(:seller) { create(:user, username: "searchparamseller") }
   let!(:product) { create(:product, user: seller, name: "Georgia state outline") }
@@ -23,14 +23,17 @@ describe "Profile page search params", :elasticsearch_wait_for_refresh, type: :r
     get_profile("?search=georgia")
 
     expect(response).to be_successful
+    expect(response.body).to include(product.name)
   end
 
-  it "renders when a crafted nested ?search[] clause is supplied" do
-    # A Hash passes the well-formed-clause guard but is still an arbitrary ES clause; slicing it
-    # out at the presenter is what keeps it from reaching the query at all.
+  it "ignores a crafted nested ?search[] range clause instead of applying it" do
+    # The revenue oracle: unsliced, this range clause reaches Elasticsearch and filters the
+    # product out, so whether the section renders answers "does this seller earn >= X?".
+    # The product's total_fee_cents is 0, so a `gte: 1` clause would exclude it.
     get_profile("?search[range][total_fee_cents][gte]=1")
 
     expect(response).to be_successful
+    expect(response.body).to include(product.name)
   end
 
   it "renders when ?search has no value at all" do
@@ -38,11 +41,10 @@ describe "Profile page search params", :elasticsearch_wait_for_refresh, type: :r
     get_profile("?search")
 
     expect(response).to be_successful
+    expect(response.body).to include(product.name)
   end
 
   it "renders when a visitor supplies a comma-joined ?ids= list" do
-    # format_search_params! splits this into an array; unsanitised it reaches ES as a bare
-    # String where a `terms` clause requires an array.
     get_profile("?ids=1,2")
 
     expect(response).to be_successful
@@ -54,9 +56,20 @@ describe "Profile page search params", :elasticsearch_wait_for_refresh, type: :r
     expect(response).to be_successful
   end
 
-  it "still applies a legitimate visitor filter" do
-    get_profile("?query=georgia")
+  it "renders when scalar filters arrive as arrays" do
+    # search_options coerces these unconditionally (`.to_i`/`.to_f`), so an array shape raises
+    # NoMethodError or 400s Elasticsearch unless normalized first.
+    get_profile("?from[]=2&rating[]=4&query[]=a&min_price[]=1&size[]=3")
 
     expect(response).to be_successful
+  end
+
+  it "still applies a legitimate visitor filter" do
+    get_profile("?query=zzzznomatch")
+
+    expect(response).to be_successful
+    # Asserting absence is what catches a filter key wrongly dropped from the allowlist: if
+    # :query stopped reaching Elasticsearch, the unfiltered product would render.
+    expect(response.body).to_not include(product.name)
   end
 end

--- a/spec/requests/user/profile_search_params_spec.rb
+++ b/spec/requests/user/profile_search_params_spec.rb
@@ -45,9 +45,15 @@ describe "Profile page search params", :elasticsearch_wait_for_refresh, type: :r
   end
 
   it "renders when a visitor supplies a comma-joined ?ids= list" do
-    get_profile("?ids=1,2")
+    other_seller_product = create(:product, user: create(:user), name: "Someone else's product")
+
+    get_profile("?ids=#{other_seller_product.id}")
 
     expect(response).to be_successful
+    # :ids replaces the section's curated product list outright, so it staying out of the
+    # allowlist is what keeps a visitor from renaming the section's contents.
+    expect(response.body).to_not include(other_seller_product.name)
+    expect(response.body).to include(product.name)
   end
 
   it "renders when a visitor supplies internal-only curated sort params" do
@@ -60,6 +66,35 @@ describe "Profile page search params", :elasticsearch_wait_for_refresh, type: :r
     # search_options coerces these unconditionally (`.to_i`/`.to_f`), so an array shape raises
     # NoMethodError or 400s Elasticsearch unless normalized first.
     get_profile("?from[]=2&rating[]=4&query[]=a&min_price[]=1&size[]=3")
+
+    expect(response).to be_successful
+  end
+
+  it "renders when scalar filters arrive nested more than one level deep" do
+    # The nested scalars collapse to their innermost value, so `query` really filters here;
+    # the point of the example is that the crafted shape renders instead of raising.
+    get_profile("?query[][]=a&rating[][]=4&from[][]=2&size[][]=3&min_price[x]=1&sort[x]=y")
+
+    expect(response).to be_successful
+  end
+
+  it "renders when list filters arrive nested" do
+    get_profile("?tags[][]=a&filetypes[][]=pdf&ids[][]=1")
+
+    expect(response).to be_successful
+  end
+
+  it "renders when a visitor asks for more results than the result window allows" do
+    # search_options clamps `from` into 0..(MAX_RESULT_WINDOW - size), which raises on an
+    # inverted range unless size is bounded first.
+    get_profile("?size=20000")
+
+    expect(response).to be_successful
+    expect(response.body).to include(product.name)
+  end
+
+  it "renders when a visitor asks for a negative page size" do
+    get_profile("?size=-1")
 
     expect(response).to be_successful
   end

--- a/spec/requests/user/profile_search_params_spec.rb
+++ b/spec/requests/user/profile_search_params_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# The profile page renders its product sections through ProfileSectionsPresenter, which reads
+# `request.query_parameters` directly rather than the controller's params. That copy never went
+# through `format_search_params!`, so every one of these query strings reaches
+# Link.search_options unsanitised and used to build a malformed Elasticsearch query.
+describe "Profile page search params", :elasticsearch_wait_for_refresh, type: :request do
+  let(:seller) { create(:user, username: "searchparamseller") }
+  let!(:product) { create(:product, user: seller, name: "Georgia state outline") }
+
+  before do
+    create(:seller_profile_products_section, seller:, shown_products: [product.id])
+    Link.import(refresh: true, force: true)
+  end
+
+  def get_profile(query = nil)
+    get "#{seller.subdomain_with_protocol}/#{query}", headers: { "X-Inertia" => "true" }
+  end
+
+  it "renders when a visitor supplies a plain ?search= string" do
+    get_profile("?search=georgia")
+
+    expect(response).to be_successful
+  end
+
+  it "renders when a crafted nested ?search[] clause is supplied" do
+    # A Hash passes the well-formed-clause guard but is still an arbitrary ES clause; slicing it
+    # out at the presenter is what keeps it from reaching the query at all.
+    get_profile("?search[range][total_fee_cents][gte]=1")
+
+    expect(response).to be_successful
+  end
+
+  it "renders when ?search has no value at all" do
+    # Parses to { "search" => nil }, which Rails' deep-munge does not compact out of a hash.
+    get_profile("?search")
+
+    expect(response).to be_successful
+  end
+
+  it "renders when a visitor supplies a comma-joined ?ids= list" do
+    # format_search_params! splits this into an array; unsanitised it reaches ES as a bare
+    # String where a `terms` clause requires an array.
+    get_profile("?ids=1,2")
+
+    expect(response).to be_successful
+  end
+
+  it "renders when a visitor supplies internal-only curated sort params" do
+    get_profile("?sort=curated&curated_product_ids=abc")
+
+    expect(response).to be_successful
+  end
+
+  it "still applies a legitimate visitor filter" do
+    get_profile("?query=georgia")
+
+    expect(response).to be_successful
+  end
+end


### PR DESCRIPTION
## What

`ProfileSectionsPresenter` builds its search params from `request.query_parameters` — the raw query string, which never passes through `format_search_params!`. Every key a visitor put in the URL reached `Link.search_options` untouched.

This narrows the presenter to an explicit allowlist of visitor-settable filters, and extracts the value-shape coercions so both callers share them.

## Why

Three consequences on any public profile URL, no login required:

- `?search[range][total_fee_cents][gte]=N` is a well-formed Hash, so it passed the clause guard and was appended straight into the ES `bool` query. Whether the section renders a product is then a boolean oracle on **indexed revenue fields** — a stranger can binary-search a seller's lifetime fee revenue off their public page.
- `?ids=1,2` reached a `terms` clause as a String and `?search` with no value parsed to a nil-valued Hash; both 400 in Elasticsearch and 500 the page.
- `?sort=curated&curated_product_ids=abc` called `each_with_index` on a String.

`ids` is the sharper one of the middle group: it replaces the section's curated product list outright, so it is a section-curation bypass as well as a 500.

## Why an allowlist rather than patching each key

`search_options` consumes 28 keys. Some are set by the server *after* the visitor params merge (`user_id`, `section`, `is_alive_on_profile`, `track_total_hits`), so merge order already protected those — but `search`, `ids`, `exclude_ids`, `curated_product_ids`, `taxonomy_id` and `offer_code` had no protection at all. Enumerating what a visitor **may** send is the only form that stays correct as `search_options` grows.

The allowlist was checked against what the profile UI really sends: `Profile/index.tsx` writes only `section` to the URL, and filter changes go by AJAX to `LinksController#search` using the `SearchRequest` type. Every profile-meaningful key in that type is allowlisted, so nothing user-facing narrows.

## Test results

`spec/requests/user/profile_search_params_spec.rb` — **11 examples, 0 failures**
`spec/modules/product/searchable/search_spec.rb` — **47 examples**, green (one pre-existing order-dependent flake at `:567`, passes in isolation on repeat runs and is untouched by this diff)

CI on branch head `0d7980e35`: **77 checks, 0 failures, 0 cancelled.**

Mutation checks proving the new normalization is load-bearing:

| Mutation | Result |
|---|---|
| Drop the scalar type check in `scalar_search_value` | 1 failure |
| Drop the `size` clamp | 2 failures |
| Drop the list (`tags`/`filetypes`/`ids`) scalarization | 1 failure |
| Revert the presenter's allowlist slice | reddens (earlier round) |
| Drop `:query` from the allowlist | reddens (earlier round) |

## QA steps

On a seller profile with at least one product, all of these must render 200 rather than 500, and the range probe must not filter:

1. `?search[range][total_fee_cents][gte]=1` — product still renders (the clause is dropped, not honoured).
2. `?ids=<another seller's product id>` — that product must **not** appear; the section's own product must.
3. `?sort=curated&curated_product_ids=abc`
4. `?from[]=2&rating[]=4&query[]=a&min_price[]=1&size[]=3`
5. `?query[][]=a&rating[][]=4&from[][]=2&size[][]=3&min_price[x]=1&sort[x]=y`
6. `?tags[][]=a&filetypes[][]=pdf&ids[][]=1`
7. `?size=20000` and `?size=-1`
8. `?query=<a real word from a product title>` — filtering still works; `?query=zzzznomatch` excludes it.

## Fable-5 adversarial review

Ran on the branch before this PR was opened. Verdict: **READY-TO-MERGE, no P1** — the security narrowing is correct, complete for its stated goal, and non-vacuously tested. The findings below were fixed in `0d7980e35`.

| Sev | Finding | Disposition |
|---|---|---|
| P2 | Shape coercion was one pass and skipped keys: `?query[][]=a` left an Array (ES 400), `?from[x]=1` raised `NoMethodError`, `?size[x]=1` raised in `search_options`, `?tags[][]=a` produced a nested `terms` clause. All still 500'd a public URL | Fixed in `0d7980e35` — one `scalar_search_value` helper covering every allowlisted scalar key including `from`/`size`, plus element-wise scalarization of the list keys |
| P3 | `?size=20000` still 500'd: `MAX_RESULT_WINDOW - size` went negative and `clamp` raised on an inverted range | Fixed in `0d7980e35` — size bounded to the result window |
| P3 | The `?ids=1,2` example asserted only a 200, so re-adding `ids` to the allowlist (restoring the curation bypass) would pass silently | Fixed in `0d7980e35` — now builds another seller's product and asserts it stays absent |
| P3 | "renders when `?search` has no value" passes on `main` unmodified — it pins no line of this diff | Kept deliberately: it documents Rails' deep-munge behaviour for the nil-valued case. Noted as not load-bearing |
| P3 | Comment slop in the extracted method | Fixed in `0d7980e35` |

**Confirmed safe by the review, with evidence:**

- **Allowlist completeness.** All 28 keys `search_options` consumes were enumerated and classified; every privileged key is absent from `VISITOR_SEARCH_PARAMS`, and the four server-set ones are additionally protected by merge order.
- **Nothing legitimate was dropped.** The profile frontend never writes filter params to the URL; `min_reviews_count` has no producer outside specs.
- **`is_a?(Hash)` vs `ActionController::Parameters`** — on controller paths a nested `?search[...]` is `Parameters`, not `Hash`, so it is deleted. Grep of `app/` and `lib/` found **zero** internal callers that set `:search`, so only attacker-supplied values are affected.
- **`Hash → nil` is safe for every key in the coercion table** — each consumer was read individually (`query`/`min_price`/`max_price` use `present?`, `rating` uses a truthy check, `sort` has an explicit `nil` branch, `recommended_by` defaults downstream).
- **The `offer_code` feature gate** is vacuously satisfied on the presenter path because `offer_code` is sliced out entirely — which also closes a pre-existing hole where `?offer_code=X` on a profile URL bypassed the feature check.

**Only verifiable live:** that no seller has an integration relying on a filter param in a profile URL. Nothing in the codebase or frontend produces one, but a URL someone pasted into a newsletter would be invisible here.

## AI disclosure

Written by gumclaw (Claude Opus 4.5 via Hermes Agent). Reviewed adversarially by a separate headless model instance before this PR was opened; every fix was verified by running the suite and by mutating the guard to confirm the spec reddens.
