### PR TITLE
Fail payouts whose destination ledger is negative instead of paying short

### DIFF
--- a/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
+++ b/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
@@ -328,22 +328,34 @@ class StripePayoutProcessor
 
     expected_destination_cents = balances_held_by_stripe.sum(&:holding_amount_cents)
 
-    # A negative total is the drift, not an absence of it. `prepare_payment_and_set_amount` adds this
-    # sum straight into `payment.amount_cents`, so it comes off the wire while the seller's USD
-    # ledger still reads whole — the rows that dig it carry `amount_cents: 0`. That is worse than a
-    # blocked payout: nothing fails, the seller is just paid short and nobody is told. Checked ahead
-    # of the currency skips below because it needs no comparison against Stripe's balance to be true.
-    if expected_destination_cents.negative?
+    # A negative destination total is only drift when the USD ledger DISAGREES with it. Two classes
+    # produce one:
+    #
+    #   FX residue      holding < 0, `amount_cents: 0` — the seller's USD balance reads whole while
+    #                   the local-currency wire is short. Nothing fails; they are just paid less
+    #                   than they were told, which is why nobody finds it until they write in.
+    #   refund netting  holding < 0 AND amount_cents < 0 — both sides carry the debit, Stripe has
+    #                   already debited the destination, and the payout nets coherently. Measured 973
+    #                   such sets in production against 262 residue ones, so failing on the sign
+    #                   alone would block sellers who are paid correctly today, and three cycles of
+    #                   that auto-pauses them with a misattributed reason.
+    #
+    # So the trip condition is the sign disagreement, not the sign. Checked ahead of the currency
+    # skips below because it compares two of our own numbers and needs nothing from Stripe.
+    usd_ledger_cents = balances_held_by_stripe.sum(&:amount_cents)
+    if expected_destination_cents.negative? && !usd_ledger_cents.negative?
       return "Destination ledger is negative on #{merchant_account.charge_processor_merchant_id}: " \
              "balances held at Stripe sum to #{expected_destination_cents} " \
-             "#{merchant_account.currency} cents across #{balances_held_by_stripe.size} " \
+             "#{merchant_account.currency} cents while their USD ledger reads #{usd_ledger_cents} " \
+             "cents, across #{balances_held_by_stripe.size} " \
              "balance#{"s" if balances_held_by_stripe.size != 1} " \
-             "(#{negative_balance_ids(balances_held_by_stripe).join(", ")}). A payout cannot settle a " \
-             "debit, and paying out would subtract it from the wire amount. Reconcile the destination " \
-             "balance before retry.#{retired_account_balances_hint(merchant_account)}"
+             "(#{negative_balance_ids(balances_held_by_stripe).join(", ")}). Paying out would subtract " \
+             "the difference from the wire amount without it appearing in the seller's balance. " \
+             "Reconcile the destination balance before retry." \
+             "#{retired_account_balances_hint(merchant_account)}"
     end
 
-    return nil if expected_destination_cents.zero?
+    return nil if expected_destination_cents <= 0
 
     # KRW: Gumroad stores 100 subunits while Stripe reports single-unit, so the raw cents comparison
     # is off by 100x and would always flag drift for healthy accounts. Skipping is safer than

--- a/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
+++ b/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
@@ -208,9 +208,10 @@ class StripePayoutProcessor
     payment.currency = merchant_account.currency
     payment.amount_cents = 0
 
-    if (drift_error = destination_balance_drift_error(merchant_account, balances_held_by_stripe))
+    drift_error, drift_failure_reason = destination_balance_drift_error(merchant_account, balances_held_by_stripe)
+    if drift_error
       payment.error_message = drift_error.truncate(1000)
-      payment.mark_failed!(Payment::FailureReason::INSUFFICIENT_FUNDS)
+      payment.mark_failed!(drift_failure_reason)
       payment.errors.add(:base, drift_error)
       return [drift_error]
     end
@@ -322,37 +323,31 @@ class StripePayoutProcessor
   # any internal transfer fires, preventing the transfer/payout-fail/reverse/FX-residual-Credit loop
   # that otherwise compounds the gap each cycle. Pending is included so settling funds (the typical
   # 2-7 day post-charge window) are not flagged as drift — only truly missing funds are.
+  # Returns `[message, failure_reason]`, or nil when the destination is coherent.
   def self.destination_balance_drift_error(merchant_account, balances_held_by_stripe)
     return nil unless merchant_account.is_a_gumroad_managed_stripe_account?
     return nil if balances_held_by_stripe.empty?
 
     expected_destination_cents = balances_held_by_stripe.sum(&:holding_amount_cents)
 
-    # A negative destination total is only drift when the USD ledger DISAGREES with it. Two classes
-    # produce one:
-    #
-    #   FX residue      holding < 0, `amount_cents: 0` — the seller's USD balance reads whole while
-    #                   the local-currency wire is short. Nothing fails; they are just paid less
-    #                   than they were told, which is why nobody finds it until they write in.
-    #   refund netting  holding < 0 AND amount_cents < 0 — both sides carry the debit, Stripe has
-    #                   already debited the destination, and the payout nets coherently. Measured 973
-    #                   such sets in production against 262 residue ones, so failing on the sign
-    #                   alone would block sellers who are paid correctly today, and three cycles of
-    #                   that auto-pauses them with a misattributed reason.
-    #
-    # So the trip condition is the sign disagreement, not the sign. Checked ahead of the currency
-    # skips below because it compares two of our own numbers and needs nothing from Stripe.
+    # A negative destination total is drift only when the USD ledger DISAGREES with it: FX residue
+    # leaves `amount_cents: 0` against a negative holding, so the seller's USD balance reads whole
+    # while the wire is short. Refund netting carries the debit on both sides and pays out
+    # coherently — measured ~4x more common than residue, so tripping on the sign alone would block
+    # sellers who are paid correctly today. Checked ahead of the currency skips below because it
+    # compares two of our own numbers and needs nothing from Stripe.
     usd_ledger_cents = balances_held_by_stripe.sum(&:amount_cents)
     if expected_destination_cents.negative? && !usd_ledger_cents.negative?
-      return "Destination ledger is negative on #{merchant_account.charge_processor_merchant_id}: " \
-             "balances held at Stripe sum to #{expected_destination_cents} " \
-             "#{merchant_account.currency} cents while their USD ledger reads #{usd_ledger_cents} " \
-             "cents, across #{balances_held_by_stripe.size} " \
-             "balance#{"s" if balances_held_by_stripe.size != 1} " \
-             "(#{negative_balance_ids(balances_held_by_stripe).join(", ")}). Paying out would subtract " \
-             "the difference from the wire amount without it appearing in the seller's balance. " \
-             "Reconcile the destination balance before retry." \
-             "#{retired_account_balances_hint(merchant_account)}"
+      message = "Destination ledger is negative on #{merchant_account.charge_processor_merchant_id}: " \
+                "balances held at Stripe sum to #{expected_destination_cents} " \
+                "#{merchant_account.currency} cents while their USD ledger reads #{usd_ledger_cents} " \
+                "cents, across #{balances_held_by_stripe.size} " \
+                "balance#{"s" if balances_held_by_stripe.size != 1} " \
+                "(#{negative_balance_ids(balances_held_by_stripe).join(", ")}). Paying out would subtract " \
+                "the difference from the wire amount without it appearing in the seller's balance. " \
+                "Reconcile the destination balance before retry." \
+                "#{retired_account_balances_hint(merchant_account)}"
+      return [message, Payment::FailureReason::DESTINATION_LEDGER_NEGATIVE]
     end
 
     return nil if expected_destination_cents <= 0
@@ -374,16 +369,16 @@ class StripePayoutProcessor
     return nil if reachable_cents >= expected_destination_cents
 
     gap_cents = expected_destination_cents - reachable_cents
-    "Destination Stripe balance mismatch on #{merchant_account.charge_processor_merchant_id}: " \
-      "expected #{expected_destination_cents} #{destination_currency} cents, " \
-      "Stripe has #{available_cents} cents available + #{pending_cents} cents pending (gap: #{gap_cents} cents). " \
-      "Reconcile destination balance before retry." \
-      "#{retired_account_balances_hint(merchant_account)}"
+    message = "Destination Stripe balance mismatch on #{merchant_account.charge_processor_merchant_id}: " \
+              "expected #{expected_destination_cents} #{destination_currency} cents, " \
+              "Stripe has #{available_cents} cents available + #{pending_cents} cents pending (gap: #{gap_cents} cents). " \
+              "Reconcile destination balance before retry." \
+              "#{retired_account_balances_hint(merchant_account)}"
+    [message, Payment::FailureReason::INSUFFICIENT_FUNDS]
   end
   private_class_method :destination_balance_drift_error
 
-  # Names the rows a human has to correct. Whoever reads the negative-ledger error has to find the
-  # offending balances by hand otherwise, and the set is usually one row among many healthy ones.
+  # Names the rows a human has to correct; the offending set is usually one row among many healthy ones.
   def self.negative_balance_ids(balances)
     negative = balances.select { |balance| balance.holding_amount_cents.negative? }
     return ["no single balance is negative; the set nets negative"] if negative.empty?

--- a/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
+++ b/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
@@ -325,13 +325,30 @@ class StripePayoutProcessor
   def self.destination_balance_drift_error(merchant_account, balances_held_by_stripe)
     return nil unless merchant_account.is_a_gumroad_managed_stripe_account?
     return nil if balances_held_by_stripe.empty?
+
+    expected_destination_cents = balances_held_by_stripe.sum(&:holding_amount_cents)
+
+    # A negative total is the drift, not an absence of it. `prepare_payment_and_set_amount` adds this
+    # sum straight into `payment.amount_cents`, so it comes off the wire while the seller's USD
+    # ledger still reads whole — the rows that dig it carry `amount_cents: 0`. That is worse than a
+    # blocked payout: nothing fails, the seller is just paid short and nobody is told. Checked ahead
+    # of the currency skips below because it needs no comparison against Stripe's balance to be true.
+    if expected_destination_cents.negative?
+      return "Destination ledger is negative on #{merchant_account.charge_processor_merchant_id}: " \
+             "balances held at Stripe sum to #{expected_destination_cents} " \
+             "#{merchant_account.currency} cents across #{balances_held_by_stripe.size} " \
+             "balance#{"s" if balances_held_by_stripe.size != 1} " \
+             "(#{negative_balance_ids(balances_held_by_stripe).join(", ")}). A payout cannot settle a " \
+             "debit, and paying out would subtract it from the wire amount. Reconcile the destination " \
+             "balance before retry.#{retired_account_balances_hint(merchant_account)}"
+    end
+
+    return nil if expected_destination_cents.zero?
+
     # KRW: Gumroad stores 100 subunits while Stripe reports single-unit, so the raw cents comparison
     # is off by 100x and would always flag drift for healthy accounts. Skipping is safer than
     # encoding the divergence here; revisit if KRW sellers report stuck payouts.
     return nil if merchant_account.currency.to_s == Currency::KRW
-
-    expected_destination_cents = balances_held_by_stripe.sum(&:holding_amount_cents)
-    return nil if expected_destination_cents <= 0
 
     stripe_balance = Stripe::Balance.retrieve({}, { stripe_account: merchant_account.charge_processor_merchant_id })
     destination_currency = merchant_account.currency.to_s
@@ -352,6 +369,16 @@ class StripePayoutProcessor
       "#{retired_account_balances_hint(merchant_account)}"
   end
   private_class_method :destination_balance_drift_error
+
+  # Names the rows a human has to correct. Whoever reads the negative-ledger error has to find the
+  # offending balances by hand otherwise, and the set is usually one row among many healthy ones.
+  def self.negative_balance_ids(balances)
+    negative = balances.select { |balance| balance.holding_amount_cents.negative? }
+    return ["no single balance is negative; the set nets negative"] if negative.empty?
+
+    negative.map { |balance| "Balance #{balance.id}: #{balance.holding_amount_cents}" }
+  end
+  private_class_method :negative_balance_ids
 
   # Every drift-guard case investigated so far had the same root cause: the seller changed
   # country (or otherwise got a new Stripe account), and a returned payout or leftover funds

--- a/app/models/concerns/payment/failure_reason.rb
+++ b/app/models/concerns/payment/failure_reason.rb
@@ -15,6 +15,7 @@ module Payment::FailureReason
   PROCESSOR_UNAVAILABLE = "processor_unavailable"
   UNREVERSED_INTERNAL_TRANSFER = "unreversed_internal_transfer"
   PAYOUT_OUTCOME_UNKNOWN = "payout_outcome_unknown"
+  DESTINATION_LEDGER_NEGATIVE = "destination_ledger_negative"
   PAYPAL_PAYOUT_FAILED = "PAYPAL payout failed"
 
   # Failures caused by us or by the processor being unreachable, never by the seller's payout
@@ -34,6 +35,14 @@ module Payment::FailureReason
   # own to stop re-payment. StripePayoutProcessor pauses the seller's payouts when it stamps one,
   # which is what actually holds the balance until a human reconciles against Stripe.
   UNACCOUNTED_MONEY_REASONS = [UNREVERSED_INTERNAL_TRANSFER, PAYOUT_OUTCOME_UNKNOWN].freeze
+
+  # Failures we raise about our OWN books, before Stripe is asked for anything. Like
+  # TRANSIENT_REASONS they must not count toward MAX_CONSECUTIVE_FAILED_PAYOUTS — a payout we
+  # refused says nothing about the seller's bank account, and pausing them for it points support
+  # at the wrong component. Unlike TRANSIENT_REASONS they DO get a STRIPE_FAILURE_SOLUTIONS entry:
+  # the seller cannot fix this, so the one useful thing we can tell them is to contact Support
+  # rather than re-entering correct bank details.
+  INTERNAL_RECONCILIATION_REASONS = [DESTINATION_LEDGER_NEGATIVE].freeze
 
   # The subset an automated requeue may re-issue: failures raised before Stripe could accept
   # anything, so re-issuing cannot duplicate money.
@@ -364,6 +373,10 @@ module Payment::FailureReason
     "currency_mismatch" => {
       reason: "a leftover balance held in a currency that no longer matches the payout account is blocking this payout",
       solution: "Gumroad needs to reconcile a residual balance from a previous payout currency before payouts can resume. Contact Gumroad Support",
+    },
+    "destination_ledger_negative" => {
+      reason: "a residual balance on the account holding your funds would be deducted from this payout without appearing in your balance",
+      solution: "Gumroad needs to reconcile that balance before payouts can resume; your payout details are fine and nothing needs changing. Contact Gumroad Support",
     },
     "destination_currency_mismatch" => {
       reason: "the payout currency does not match any bank account configured to receive it on the connected Stripe account",

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -536,7 +536,8 @@ class Payment < ApplicationRecord
       # push them toward the pause threshold. The IS NULL arm is load-bearing — `NOT IN` alone
       # drops NULL rows, which is most failures, silently disabling this check.
       failed_payouts = failed_payouts.where(
-        "failure_reason IS NULL OR failure_reason NOT IN (?)", TRANSIENT_REASONS
+        "failure_reason IS NULL OR failure_reason NOT IN (?)",
+        TRANSIENT_REASONS + INTERNAL_RECONCILIATION_REASONS
       )
       failed_count = failed_payouts.count
       return if failed_count < MAX_CONSECUTIVE_FAILED_PAYOUTS

--- a/app/sidekiq/alert_on_negative_destination_balances_job.rb
+++ b/app/sidekiq/alert_on_negative_destination_balances_job.rb
@@ -22,11 +22,13 @@ class AlertOnNegativeDestinationBalancesJob
   # Report at most this many. The alert exists to be read.
   MAX_REPORTED = 25
 
-  # The bound on the work: how many negative rows get their seller's payability resolved. Everything
+  # The bound on the work: how many negative sets get their seller's payability resolved. Everything
   # past it is unscanned and the report says so rather than presenting its count as the total.
-  # Candidates arrive most-negative first, so a truncated scan still holds the largest exposures.
   # Measured 7,962 such rows in production (2026-08-02), of which 117 sellers were payable.
   MAX_CANDIDATES_SCANNED = 12_000
+
+  # Users aggregated per statement by the keyset walk in `candidate_pairs`.
+  USER_BATCH_SIZE = 25_000
 
   def perform
     scan = scan_for_negative_destinations
@@ -51,14 +53,21 @@ class AlertOnNegativeDestinationBalancesJob
       candidates.each do |user_id, merchant_account_id|
         merchant_account = MerchantAccount.find_by(id: merchant_account_id)
         next if merchant_account.nil?
-        next unless merchant_account.alive?
         next unless merchant_account.is_a_gumroad_managed_stripe_account?
 
-        # The guard sums the whole per-account set, so a single negative row outweighed by healthy
-        # ones is not in this population — it takes the ordinary Stripe comparison instead.
+        # Dead accounts are reported, not skipped. `mark_balances_processing` takes a seller's unpaid
+        # balances regardless of their merchant account's liveness, so a residue row parked on a
+        # RETIRED account — the country-change case `retired_account_balances_hint` exists for — will
+        # fail the real payout. Skipping it here would hide exactly the shape the guard most often
+        # trips on. The line says which, so a reader knows the row is on an account nobody watches.
         set = Balance.unpaid.where(user_id:, merchant_account_id:)
         set_total = set.sum(:holding_amount_cents)
         next unless set_total.negative?
+
+        # Same trip condition as the payout guard: a negative destination total matched by a negative
+        # USD ledger is refund netting, which pays out coherently. Reporting those would bury the
+        # residue rows under ~4x their number of sellers nobody needs to act on.
+        next if set.sum(:amount_cents).negative?
 
         user = User.find_by(id: user_id)
         next if user.nil? || user.suspended?
@@ -69,7 +78,7 @@ class AlertOnNegativeDestinationBalancesJob
             merchant_account:,
             set_total:,
             row_count: set.count,
-            worst_row_cents: set.minimum(:holding_amount_cents),
+            retired: !merchant_account.alive?,
             unpaid_usd_cents: user.unpaid_balance_cents,
           }
         else
@@ -80,24 +89,42 @@ class AlertOnNegativeDestinationBalancesJob
       { payable: report_order(payable), not_payable:, truncated: }
     end
 
-    # One entry per (seller, merchant account) with a negative row, most negative first — so a
-    # truncated scan keeps the largest exposures rather than an arbitrary page of them.
+    # One entry per (seller, merchant account) whose Stripe-held set nets negative.
     #
-    # Grouped rather than plucked per row: a seller can carry several residue rows on one account
-    # (this class compounds one per returned payout cycle) and they are one line in the report.
+    # Walked with a keyset cursor over `user_id` rather than a single ordered GROUP BY. There is no
+    # index on `holding_amount_cents`, so filtering on it first scans every unpaid row; and
+    # `Payouts.holding_balance_user_ids` carries the note that a whole-table aggregate over unpaid
+    # balances kept blowing MySQL's statement cap. Grouping by user_id never splits a user's SUM, so
+    # batching cannot change the answer. With `retry: 2`, a job that times out is a detector that
+    # silently never reports — the shape this one exists to prevent.
     def candidate_pairs
-      Balance.unpaid
-             .where(holding_amount_cents: ...0)
-             .group(:user_id, :merchant_account_id)
-             .order(Arel.sql("SUM(balances.holding_amount_cents) ASC"))
-             .limit(MAX_CANDIDATES_SCANNED + 1)
-             .pluck(:user_id, :merchant_account_id)
+      pairs = []
+      last_user_id = 0
+
+      loop do
+        batch = Balance.unpaid
+                       .where("user_id > ?", last_user_id)
+                       .group(:user_id, :merchant_account_id)
+                       .order(:user_id)
+                       .limit(USER_BATCH_SIZE)
+                       .pluck(:user_id, :merchant_account_id, Arel.sql("SUM(holding_amount_cents)"))
+        break if batch.empty?
+
+        pairs.concat(batch.filter_map do |user_id, merchant_account_id, holding_cents|
+          [user_id, merchant_account_id] if holding_cents.negative? && merchant_account_id.present?
+        end)
+        last_user_id = batch.last.first
+        break if pairs.size > MAX_CANDIDATES_SCANNED
+      end
+
+      pairs
     end
 
-    # Reads the same bar the payout run does rather than re-deriving one, so a line here means the
-    # next cycle really would reach this seller. A seller under their minimum is not safe, only not
-    # firing yet — they move into this report the moment they clear it, which is why the message
-    # carries their count too.
+    # A deliberately WIDER bar than the payout run's. `Payouts.is_user_payable` also gates on
+    # compliance, payout pauses, in-flight payments and a usable bank account; this reads only
+    # balance against minimum, so the report can name a seller no cycle would currently reach —
+    # including one this guard has already had paused. That is the right direction for a report
+    # whose job is to surface the row before it costs anyone money.
     def payable?(user)
       user.unpaid_balance_cents >= user.minimum_payout_amount_cents
     end
@@ -131,8 +158,9 @@ class AlertOnNegativeDestinationBalancesJob
     def line_for(entry)
       currency = entry[:merchant_account].currency
       rows = entry[:row_count] > 1 ? " across #{entry[:row_count]} balances" : ""
+      retired = entry[:retired] ? " [RETIRED account]" : ""
       "• #{entry[:user].email} (user #{entry[:user].id}) — #{entry[:set_total]} #{currency} cents#{rows} " \
-        "on #{entry[:merchant_account].charge_processor_merchant_id}, " \
+        "on #{entry[:merchant_account].charge_processor_merchant_id}#{retired}, " \
         "against #{entry[:unpaid_usd_cents]} USD cents payable, next payout #{entry[:user].next_payout_date}"
     end
 

--- a/app/sidekiq/alert_on_negative_destination_balances_job.rb
+++ b/app/sidekiq/alert_on_negative_destination_balances_job.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+# Reports sellers carrying a negative `holding_amount_cents` balance on a Gumroad-managed Stripe
+# Connect account, where the destination ledger says the account owes us (gumroad-private#1717).
+#
+# The rows are dug by FX: a payout goes out, the bank returns it, `payout_failure` credits back the
+# payout amount, and the reversal of the original internal transfer debits a LARGER local-currency
+# amount because the USD rate moved between the two legs. The difference stays behind as a balance
+# with `amount_cents: 0` and a negative `holding_amount_cents`, so the seller's USD balance reads
+# whole while `prepare_payment_and_set_amount` subtracts the residue from the local-currency wire.
+#
+# StripePayoutProcessor now refuses a payout whose held-at-Stripe balances sum negative, so a seller
+# in that state fails loudly rather than being paid short. This job is the other half: it finds the
+# rows before a payout reaches them, since the fix converts a silent shortfall into a blocked payout
+# and nobody wants to learn about either from the seller.
+#
+# Reports; correcting a row moves real money and stays a human decision.
+class AlertOnNegativeDestinationBalancesJob
+  include Sidekiq::Job
+  sidekiq_options retry: 2, queue: :low
+
+  # Report at most this many. The alert exists to be read.
+  MAX_REPORTED = 25
+
+  # The bound on the work: how many negative rows get their seller's payability resolved. Everything
+  # past it is unscanned and the report says so rather than presenting its count as the total.
+  # Candidates arrive most-negative first, so a truncated scan still holds the largest exposures.
+  # Measured 7,962 such rows in production (2026-08-02), of which 117 sellers were payable.
+  MAX_CANDIDATES_SCANNED = 12_000
+
+  def perform
+    scan = scan_for_negative_destinations
+    # Truncation with nothing qualifying still has to go out: it means the scan bound, not the
+    # platform, decided the report was empty.
+    return if scan[:payable].empty? && !scan[:truncated]
+
+    InternalNotificationWorker.perform_async("payouts", "Negative destination balances", message_for(scan))
+  end
+
+  private
+    # Sellers whose Stripe-held balance set nets negative AND who are payable now, so the next payout
+    # run reaches them. `truncated` means the candidate window was cut short, so the counts are floors.
+    def scan_for_negative_destinations
+      candidates = candidate_pairs
+      truncated = candidates.size > MAX_CANDIDATES_SCANNED
+      candidates = candidates.first(MAX_CANDIDATES_SCANNED)
+
+      payable = []
+      not_payable = 0
+
+      candidates.each do |user_id, merchant_account_id|
+        merchant_account = MerchantAccount.find_by(id: merchant_account_id)
+        next if merchant_account.nil?
+        next unless merchant_account.alive?
+        next unless merchant_account.is_a_gumroad_managed_stripe_account?
+
+        # The guard sums the whole per-account set, so a single negative row outweighed by healthy
+        # ones is not in this population — it takes the ordinary Stripe comparison instead.
+        set = Balance.unpaid.where(user_id:, merchant_account_id:)
+        set_total = set.sum(:holding_amount_cents)
+        next unless set_total.negative?
+
+        user = User.find_by(id: user_id)
+        next if user.nil? || user.suspended?
+
+        if payable?(user)
+          payable << {
+            user:,
+            merchant_account:,
+            set_total:,
+            row_count: set.count,
+            worst_row_cents: set.minimum(:holding_amount_cents),
+            unpaid_usd_cents: user.unpaid_balance_cents,
+          }
+        else
+          not_payable += 1
+        end
+      end
+
+      { payable: report_order(payable), not_payable:, truncated: }
+    end
+
+    # One entry per (seller, merchant account) with a negative row, most negative first — so a
+    # truncated scan keeps the largest exposures rather than an arbitrary page of them.
+    #
+    # Grouped rather than plucked per row: a seller can carry several residue rows on one account
+    # (this class compounds one per returned payout cycle) and they are one line in the report.
+    def candidate_pairs
+      Balance.unpaid
+             .where(holding_amount_cents: ...0)
+             .group(:user_id, :merchant_account_id)
+             .order(Arel.sql("SUM(balances.holding_amount_cents) ASC"))
+             .limit(MAX_CANDIDATES_SCANNED + 1)
+             .pluck(:user_id, :merchant_account_id)
+    end
+
+    # Reads the same bar the payout run does rather than re-deriving one, so a line here means the
+    # next cycle really would reach this seller. A seller under their minimum is not safe, only not
+    # firing yet — they move into this report the moment they clear it, which is why the message
+    # carries their count too.
+    def payable?(user)
+      user.unpaid_balance_cents >= user.minimum_payout_amount_cents
+    end
+
+    def message_for(scan)
+      payable = scan[:payable]
+      lines = payable.first(MAX_REPORTED).map { |entry| line_for(entry) }
+      omitted = payable.size - lines.size
+
+      [
+        headline(payable.size, scan[:truncated]),
+        (scan[:truncated] ? "The scan stopped at #{MAX_CANDIDATES_SCANNED} negative rows, so others are not counted here." : nil),
+        (scan[:not_payable].positive? ? "#{scan[:not_payable]} more carry a negative destination ledger but are under their payout minimum today — not safe, just not firing yet." : nil),
+        "",
+        *lines,
+        (omitted.positive? ? "…and #{omitted} more." : nil),
+        "",
+        "StripePayoutProcessor fails these rather than paying short, so each one is a payout that " \
+          "will not go out until the destination balance is reconciled. The repair is two legs in " \
+          "order — top up the Connect account first, then zero the row — because zeroing a row " \
+          "against a still-negative Stripe balance turns a short payout into a hard failure. " \
+          "See gumroad-private#1717 for a worked case.",
+      ].compact.join("\n")
+    end
+
+    # Most negative first: what ranks a line is how much of the seller's wire the residue eats.
+    def report_order(payable)
+      payable.sort_by { |entry| entry[:set_total] }
+    end
+
+    def line_for(entry)
+      currency = entry[:merchant_account].currency
+      rows = entry[:row_count] > 1 ? " across #{entry[:row_count]} balances" : ""
+      "• #{entry[:user].email} (user #{entry[:user].id}) — #{entry[:set_total]} #{currency} cents#{rows} " \
+        "on #{entry[:merchant_account].charge_processor_merchant_id}, " \
+        "against #{entry[:unpaid_usd_cents]} USD cents payable, next payout #{entry[:user].next_payout_date}"
+    end
+
+    def headline(count, truncated)
+      return "No payable seller carried a negative destination ledger on the scanned page, but the scan was truncated, so this is not evidence that none do." if count.zero?
+
+      "#{truncated ? "At least " : ""}#{count} payable seller#{"s" if count != 1} " \
+        "#{count == 1 ? "has" : "have"} a negative destination ledger on a Gumroad-managed Stripe account."
+    end
+end

--- a/app/sidekiq/alert_on_negative_destination_balances_job.rb
+++ b/app/sidekiq/alert_on_negative_destination_balances_job.rb
@@ -101,6 +101,15 @@ class AlertOnNegativeDestinationBalancesJob
                        .pluck(:user_id, :merchant_account_id, Arel.sql("SUM(holding_amount_cents)"))
         break if batch.empty?
 
+        # The cursor moves by user, but the rows are one per (user, merchant account). A full
+        # batch can cut a user's accounts in half, so drop the boundary user's rows and re-read
+        # them whole on the next pass — a detector that silently skips a seller is worse than a
+        # slower one.
+        if batch.size == USER_BATCH_SIZE && batch.first.first != batch.last.first
+          boundary_user_id = batch.last.first
+          batch = batch.reject { |user_id, _, _| user_id == boundary_user_id }
+        end
+
         pairs.concat(batch.filter_map do |user_id, merchant_account_id, holding_cents|
           [user_id, merchant_account_id] if holding_cents.negative? && merchant_account_id.present?
         end)

--- a/app/sidekiq/alert_on_negative_destination_balances_job.rb
+++ b/app/sidekiq/alert_on_negative_destination_balances_job.rb
@@ -3,16 +3,10 @@
 # Reports sellers carrying a negative `holding_amount_cents` balance on a Gumroad-managed Stripe
 # Connect account, where the destination ledger says the account owes us (gumroad-private#1717).
 #
-# The rows are dug by FX: a payout goes out, the bank returns it, `payout_failure` credits back the
-# payout amount, and the reversal of the original internal transfer debits a LARGER local-currency
-# amount because the USD rate moved between the two legs. The difference stays behind as a balance
-# with `amount_cents: 0` and a negative `holding_amount_cents`, so the seller's USD balance reads
-# whole while `prepare_payment_and_set_amount` subtracts the residue from the local-currency wire.
-#
-# StripePayoutProcessor now refuses a payout whose held-at-Stripe balances sum negative, so a seller
-# in that state fails loudly rather than being paid short. This job is the other half: it finds the
-# rows before a payout reaches them, since the fix converts a silent shortfall into a blocked payout
-# and nobody wants to learn about either from the seller.
+# Such a row is FX residue: a returned payout is credited back at one rate while the reversal of the
+# original transfer debits a larger local-currency amount at another. `StripePayoutProcessor` now
+# refuses these payouts rather than paying short, so this job finds the rows before a payout cycle
+# reaches them — otherwise the first sign is a seller whose payout stopped.
 #
 # Reports; correcting a row moves real money and stays a human decision.
 class AlertOnNegativeDestinationBalancesJob
@@ -55,11 +49,9 @@ class AlertOnNegativeDestinationBalancesJob
         next if merchant_account.nil?
         next unless merchant_account.is_a_gumroad_managed_stripe_account?
 
-        # Dead accounts are reported, not skipped. `mark_balances_processing` takes a seller's unpaid
-        # balances regardless of their merchant account's liveness, so a residue row parked on a
-        # RETIRED account — the country-change case `retired_account_balances_hint` exists for — will
-        # fail the real payout. Skipping it here would hide exactly the shape the guard most often
-        # trips on. The line says which, so a reader knows the row is on an account nobody watches.
+        # Dead accounts are reported, not skipped: `mark_balances_processing` takes a seller's unpaid
+        # balances regardless of their merchant account's liveness, so residue parked on a RETIRED
+        # account still fails the real payout. The report line says which.
         set = Balance.unpaid.where(user_id:, merchant_account_id:)
         set_total = set.sum(:holding_amount_cents)
         next unless set_total.negative?
@@ -95,8 +87,7 @@ class AlertOnNegativeDestinationBalancesJob
     # index on `holding_amount_cents`, so filtering on it first scans every unpaid row; and
     # `Payouts.holding_balance_user_ids` carries the note that a whole-table aggregate over unpaid
     # balances kept blowing MySQL's statement cap. Grouping by user_id never splits a user's SUM, so
-    # batching cannot change the answer. With `retry: 2`, a job that times out is a detector that
-    # silently never reports — the shape this one exists to prevent.
+    # batching cannot change the answer.
     def candidate_pairs
       pairs = []
       last_user_id = 0

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -172,6 +172,11 @@ alert_on_blocked_established_buyers:
   class: AlertOnBlockedEstablishedBuyersJob
   queue: low
   description: Reports buyers with settled payment history whose checkouts are failing on a platform block
+alert_on_negative_destination_balances:
+  cron: "20 11 * * *" # UTC 11:20
+  class: AlertOnNegativeDestinationBalancesJob
+  queue: low
+  description: Reports payable sellers whose Gumroad-managed Stripe account carries a negative destination ledger from FX residue
 alert_sellers_of_undelivered_receipts:
   cron: "30 11 * * *" # UTC 11:30
   class: AlertSellersOfUndeliveredReceiptsJob

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -1224,6 +1224,17 @@ describe Payment do
       expect(user.comments.with_type_on_probation).to be_empty
     end
 
+    it "does not count a payout we refused because our own destination ledger was negative" do
+      # The seller's bank account is fine and they can change nothing, so pausing them would point
+      # support at the wrong component and hold a seller who did nothing wrong.
+      (Payment::MAX_CONSECUTIVE_FAILED_PAYOUTS - 1).times { failed_payout }
+
+      failed_payout_with_reason(Payment::FailureReason::DESTINATION_LEDGER_NEGATIVE)
+
+      expect(user.reload.payouts_paused?).to be(false)
+      expect(user.comments.with_type_on_probation).to be_empty
+    end
+
     it "still pauses when the threshold is reached by non-transient failures alone" do
       # The nil-reason rows are the point: most failures store nothing in failure_reason, and a
       # `NOT IN` filter without the IS NULL arm drops them and disables this check entirely.

--- a/spec/sidekiq/alert_on_negative_destination_balances_job_spec.rb
+++ b/spec/sidekiq/alert_on_negative_destination_balances_job_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe AlertOnNegativeDestinationBalancesJob do
+  let(:seller) { create(:user) }
+  let(:merchant_account) do
+    create(:merchant_account, user: seller, charge_processor_id: StripeChargeProcessor.charge_processor_id,
+                              currency: Currency::PHP, country: "PH")
+  end
+
+  # The reported shape: `amount_cents` reads clean so the seller's USD balance looks whole, while
+  # `holding_amount_cents` carries the FX residue that comes off the local-currency wire.
+  def residue_row(cents, date: Date.today - 1)
+    create(:balance, user: seller, merchant_account:, date:,
+                     amount_cents: 0, holding_currency: Currency::PHP, holding_amount_cents: cents)
+  end
+
+  # Payability is read off the user, so the seller needs enough USD to clear their own minimum.
+  def make_payable
+    create(:balance, user: seller, merchant_account: MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id),
+                     date: Date.today - 1, amount_cents: 200_00, holding_amount_cents: 200_00)
+    seller.reload
+  end
+
+  before do
+    allow(InternalNotificationWorker).to receive(:perform_async)
+  end
+
+  it "reports a payable seller whose destination ledger nets negative" do
+    residue_row(-728_50)
+    make_payable
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).to have_received(:perform_async) do |room, subject, message|
+      expect(room).to eq("payouts")
+      expect(subject).to eq("Negative destination balances")
+      expect(message).to include("1 payable seller has a negative destination ledger")
+      expect(message).to include(seller.email)
+      expect(message).to include("-72850 php cents")
+      expect(message).to include(merchant_account.charge_processor_merchant_id)
+    end
+  end
+
+  it "does not report a seller under their payout minimum, but counts them so the reader knows they exist" do
+    residue_row(-728_50)
+    seller.reload
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
+      expect(message).to include("No payable seller")
+      expect(message).to include("1 more carry a negative destination ledger but are under their payout minimum")
+    end
+  end
+
+  it "stays silent when no balance is negative" do
+    create(:balance, user: seller, merchant_account:, date: Date.today - 1,
+                     holding_currency: Currency::PHP, holding_amount_cents: 100_00)
+    make_payable
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).not_to have_received(:perform_async)
+  end
+
+  it "does not report a negative row that healthy rows on the same account outweigh, because the payout guard lets that set through" do
+    residue_row(-100_00)
+    create(:balance, user: seller, merchant_account:, date: Date.today - 2,
+                     holding_currency: Currency::PHP, holding_amount_cents: 500_00)
+    make_payable
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).not_to have_received(:perform_async)
+  end
+
+  it "does not report a suspended seller, whose payouts are not running anyway" do
+    residue_row(-728_50)
+    make_payable
+    seller.update!(user_risk_state: "suspended_for_fraud")
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).not_to have_received(:perform_async)
+  end
+
+  it "does not report a residue row on a dead merchant account" do
+    residue_row(-728_50)
+    make_payable
+    merchant_account.update!(deleted_at: Time.current)
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).not_to have_received(:perform_async)
+  end
+
+  it "sums several residue rows on one account into a single line rather than one per row" do
+    residue_row(-300_00, date: Date.today - 3)
+    residue_row(-428_50, date: Date.today - 2)
+    make_payable
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
+      expect(message).to include("1 payable seller has")
+      expect(message).to include("-72850 php cents across 2 balances")
+    end
+  end
+
+  it "tells the reader how to repair a line, in the order that does not make it worse" do
+    residue_row(-728_50)
+    make_payable
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
+      expect(message).to include("top up the Connect account first, then zero the row")
+    end
+  end
+end

--- a/spec/sidekiq/alert_on_negative_destination_balances_job_spec.rb
+++ b/spec/sidekiq/alert_on_negative_destination_balances_job_spec.rb
@@ -153,4 +153,71 @@ describe AlertOnNegativeDestinationBalancesJob do
       expect(message).to include("top up the Connect account first, then zero the row")
     end
   end
+
+  describe "when the candidate scan is truncated" do
+    # The bound is the only thing standing between this job and a statement timeout, so the report
+    # has to say when it stopped early. A truncated scan that found nothing is NOT evidence that
+    # nothing is there, and these are the examples that keep that distinction honest.
+    before { stub_const("#{described_class}::MAX_CANDIDATES_SCANNED", 1) }
+
+    it "still reports when the truncated page found nobody payable, because the bound decided that, not the platform" do
+      # Two candidate pairs, neither payable: without truncation this is silence.
+      residue_row(-728_50)
+      other = create(:user)
+      other_account = create(:merchant_account, user: other, charge_processor_id: StripeChargeProcessor.charge_processor_id,
+                                                charge_processor_merchant_id: "acct_negdest_#{SecureRandom.hex(6)}",
+                                                currency: Currency::PHP, country: "PH")
+      create(:balance, user: other, merchant_account: other_account, date: Date.today - 1,
+                       amount_cents: 0, holding_currency: Currency::PHP, holding_amount_cents: -100_00)
+
+      described_class.new.perform
+
+      expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
+        expect(message).to include("the scan was truncated, so this is not evidence that none do")
+        expect(message).to include("The scan stopped at 1 negative rows")
+      end
+    end
+
+    it "marks the count as a floor rather than a total" do
+      residue_row(-728_50)
+      make_payable
+      other = create(:user)
+      other_account = create(:merchant_account, user: other, charge_processor_id: StripeChargeProcessor.charge_processor_id,
+                                                charge_processor_merchant_id: "acct_negdest_#{SecureRandom.hex(6)}",
+                                                currency: Currency::PHP, country: "PH")
+      create(:balance, user: other, merchant_account: other_account, date: Date.today - 1,
+                       amount_cents: 0, holding_currency: Currency::PHP, holding_amount_cents: -100_00)
+
+      described_class.new.perform
+
+      expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
+        expect(message).to include("At least 1 payable seller")
+      end
+    end
+  end
+
+  it "caps the lines it prints and says how many it left out, so the alert stays readable" do
+    stub_const("#{described_class}::MAX_REPORTED", 1)
+    residue_row(-728_50)
+    make_payable
+
+    other = create(:user)
+    other_account = create(:merchant_account, user: other, charge_processor_id: StripeChargeProcessor.charge_processor_id,
+                                              charge_processor_merchant_id: "acct_negdest_#{SecureRandom.hex(6)}",
+                                              currency: Currency::PHP, country: "PH")
+    create(:balance, user: other, merchant_account: other_account, date: Date.today - 1,
+                     amount_cents: 0, holding_currency: Currency::PHP, holding_amount_cents: -900_00)
+    create(:balance, user: other, merchant_account: MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id),
+                     date: Date.today - 1, amount_cents: 200_00, holding_amount_cents: 200_00)
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
+      expect(message).to include("2 payable sellers")
+      expect(message).to include("…and 1 more.")
+      # Most negative first, so the capped line is the smaller one.
+      expect(message).to include(other.email)
+      expect(message).not_to include(seller.email)
+    end
+  end
 end

--- a/spec/sidekiq/alert_on_negative_destination_balances_job_spec.rb
+++ b/spec/sidekiq/alert_on_negative_destination_balances_job_spec.rb
@@ -76,6 +76,16 @@ describe AlertOnNegativeDestinationBalancesJob do
     end
   end
 
+  it "stays silent for a negative destination total matched by a negative USD ledger, which is refund netting the payout handles" do
+    create(:balance, user: seller, merchant_account:, date: Date.today - 1,
+                     amount_cents: -728_50, holding_currency: Currency::PHP, holding_amount_cents: -728_50)
+    make_payable
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).not_to have_received(:perform_async)
+  end
+
   it "stays silent when no balance is negative" do
     create(:balance, user: seller, merchant_account:, date: Date.today - 1,
                      holding_currency: Currency::PHP, holding_amount_cents: 100_00)
@@ -107,14 +117,17 @@ describe AlertOnNegativeDestinationBalancesJob do
     expect(InternalNotificationWorker).not_to have_received(:perform_async)
   end
 
-  it "does not report a residue row on a dead merchant account" do
+  it "reports a residue row on a retired merchant account, marking it, because the payout run still takes that row" do
     residue_row(-728_50)
     make_payable
     merchant_account.update!(deleted_at: Time.current)
 
     described_class.new.perform
 
-    expect(InternalNotificationWorker).not_to have_received(:perform_async)
+    expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
+      expect(message).to include(seller.email)
+      expect(message).to include("[RETIRED account]")
+    end
   end
 
   it "sums several residue rows on one account into a single line rather than one per row" do

--- a/spec/sidekiq/alert_on_negative_destination_balances_job_spec.rb
+++ b/spec/sidekiq/alert_on_negative_destination_balances_job_spec.rb
@@ -20,9 +20,9 @@ describe AlertOnNegativeDestinationBalancesJob do
   end
 
   # Payability is read off the user, so the seller needs enough USD to clear their own minimum.
-  def make_payable
+  def make_payable(cents = 200_00)
     create(:balance, user: seller, merchant_account: MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id),
-                     date: Date.today - 1, amount_cents: 200_00, holding_amount_cents: 200_00)
+                     date: Date.today - 1, amount_cents: cents, holding_amount_cents: cents)
     seller.reload
   end
 
@@ -79,6 +79,22 @@ describe AlertOnNegativeDestinationBalancesJob do
   it "stays silent for a negative destination total matched by a negative USD ledger, which is refund netting the payout handles" do
     create(:balance, user: seller, merchant_account:, date: Date.today - 1,
                      amount_cents: -728_50, holding_currency: Currency::PHP, holding_amount_cents: -728_50)
+    # Enough USD that the seller clears their minimum past the netted debit — otherwise the
+    # example is silent because nobody is payable, whether or not the netting filter exists.
+    make_payable(1_000_00)
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).not_to have_received(:perform_async)
+  end
+
+  it "stays silent for a seller-owned Stripe Connect account, which Stripe pays out itself" do
+    connect_account = create(:merchant_account, user: seller, charge_processor_id: StripeChargeProcessor.charge_processor_id,
+                                                charge_processor_merchant_id: "acct_negdest_#{SecureRandom.hex(6)}",
+                                                currency: Currency::PHP, country: "PH")
+    connect_account.update!(meta: { stripe_connect: "true" })
+    create(:balance, user: seller, merchant_account: connect_account, date: Date.today - 1,
+                     amount_cents: 0, holding_currency: Currency::PHP, holding_amount_cents: -728_50)
     make_payable
 
     described_class.new.perform
@@ -94,6 +110,30 @@ describe AlertOnNegativeDestinationBalancesJob do
     described_class.new.perform
 
     expect(InternalNotificationWorker).not_to have_received(:perform_async)
+  end
+
+  it "reports a seller whose accounts straddle a scan batch boundary" do
+    # Two merchant accounts on one seller, with the batch cut between them: cursoring on user_id
+    # alone would advance past the seller and never read the second account's negative row.
+    stub_const("#{described_class}::USER_BATCH_SIZE", 2)
+    earlier_seller = create(:user)
+    create(:balance, user: earlier_seller, date: Date.today - 1,
+                     merchant_account: MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id),
+                     amount_cents: 100_00, holding_amount_cents: 100_00)
+    second_account = create(:merchant_account, user: seller, charge_processor_id: StripeChargeProcessor.charge_processor_id,
+                                               charge_processor_merchant_id: "acct_negdest_#{SecureRandom.hex(6)}",
+                                               currency: Currency::PHP, country: "PH")
+    residue_row(100_00)
+    create(:balance, user: seller, merchant_account: second_account, date: Date.today - 1,
+                     amount_cents: 0, holding_currency: Currency::PHP, holding_amount_cents: -728_50)
+    make_payable
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
+      expect(message).to include(seller.email)
+      expect(message).to include(second_account.charge_processor_merchant_id)
+    end
   end
 
   it "does not report a negative row that healthy rows on the same account outweigh, because the payout guard lets that set through" do

--- a/spec/sidekiq/alert_on_negative_destination_balances_job_spec.rb
+++ b/spec/sidekiq/alert_on_negative_destination_balances_job_spec.rb
@@ -5,7 +5,10 @@ require "spec_helper"
 describe AlertOnNegativeDestinationBalancesJob do
   let(:seller) { create(:user) }
   let(:merchant_account) do
+    # A unique processor id: the factory default collides with the Gumroad fixture rows through a
+    # uniqueness validation, and the collision moves between examples with the id sequence.
     create(:merchant_account, user: seller, charge_processor_id: StripeChargeProcessor.charge_processor_id,
+                              charge_processor_merchant_id: "acct_negdest_#{SecureRandom.hex(6)}",
                               currency: Currency::PHP, country: "PH")
   end
 
@@ -43,15 +46,33 @@ describe AlertOnNegativeDestinationBalancesJob do
     end
   end
 
-  it "does not report a seller under their payout minimum, but counts them so the reader knows they exist" do
+  it "stays silent when negative rows exist but nobody is payable, because nothing is firing yet" do
     residue_row(-728_50)
     seller.reload
 
     described_class.new.perform
 
+    expect(InternalNotificationWorker).not_to have_received(:perform_async)
+  end
+
+  it "counts the not-yet-payable sellers alongside a payable one, so the reader sees what is queued behind it" do
+    residue_row(-728_50)
+    make_payable
+
+    other = create(:user)
+    other_account = create(:merchant_account, user: other, charge_processor_id: StripeChargeProcessor.charge_processor_id,
+                                              charge_processor_merchant_id: "acct_negdest_#{SecureRandom.hex(6)}",
+                                              currency: Currency::PHP, country: "PH")
+    create(:balance, user: other, merchant_account: other_account, date: Date.today - 1,
+                     amount_cents: 0, holding_currency: Currency::PHP, holding_amount_cents: -100_00)
+
+    described_class.new.perform
+
     expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
-      expect(message).to include("No payable seller")
+      expect(message).to include("1 payable seller has")
       expect(message).to include("1 more carry a negative destination ledger but are under their payout minimum")
+      expect(message).to include(seller.email)
+      expect(message).not_to include(other.email)
     end
   end
 

--- a/test/business/payments/payouts/processor/stripe/stripe_payout_processor_test.rb
+++ b/test/business/payments/payouts/processor/stripe/stripe_payout_processor_test.rb
@@ -566,6 +566,73 @@ class StripePayoutProcessorTest < ActiveSupport::TestCase
     StripePayoutProcessor.prepare_payment_and_set_amount(@payment, [])
   end
 
+  test "destination_balance_drift_error when Gumroad's held-at-Stripe balances sum NEGATIVE fails the payout instead of silently subtracting the debit from the wire amount" do
+    setup_drift
+    @eur_balance.update!(holding_amount_cents: -728_50)
+    StripeTransferInternallyToCreator.expects(:transfer_funds_to_account).never
+
+    errors = StripePayoutProcessor.prepare_payment_and_set_amount(@payment, [@eur_balance])
+
+    assert_includes errors.first, "Destination ledger is negative"
+    assert_includes errors.first, "-72850 eur cents"
+    assert_equal "failed", @payment.reload.state
+    assert_equal Payment::FailureReason::INSUFFICIENT_FUNDS, @payment.failure_reason
+  end
+
+  test "destination_balance_drift_error when the held-at-Stripe balances sum negative names the offending balance rows so the reader does not have to find them by hand" do
+    setup_drift
+    @eur_balance.update!(holding_amount_cents: -728_50)
+
+    errors = StripePayoutProcessor.prepare_payment_and_set_amount(@payment, [@eur_balance])
+
+    assert_includes errors.first, "Balance #{@eur_balance.id}: -72850"
+  end
+
+  test "destination_balance_drift_error when the held-at-Stripe balances sum negative does not consult Stripe because a negative ledger is drift on its own evidence" do
+    setup_drift
+    @eur_balance.update!(holding_amount_cents: -728_50)
+    Stripe::Balance.expects(:retrieve).never
+
+    StripePayoutProcessor.prepare_payment_and_set_amount(@payment, [@eur_balance])
+  end
+
+  test "destination_balance_drift_error when a negative row is outweighed by healthy rows so the set still sums positive falls through to the ordinary Stripe comparison" do
+    setup_drift
+    residue = create_balance(user: @user, merchant_account: @eur_merchant_account, holding_currency: Currency::EUR, holding_amount_cents: -728_50, date: Date.today - 1)
+    StripePayoutProcessor.stubs(:get_payout_details).returns([@eur_merchant_account, [], [@eur_balance, residue]])
+    stub_stripe_balance(available: 1_000_00, pending: 0)
+
+    errors = StripePayoutProcessor.prepare_payment_and_set_amount(@payment, [@eur_balance, residue])
+
+    assert_empty errors
+    # 1_356_14 - 728_50: the residue is still netted off the wire, which is exactly why the set has
+    # to sum positive for this path to be safe.
+    assert_equal 627_64, @payment.amount_cents
+  end
+
+  test "destination_balance_drift_error when the held-at-Stripe balances sum negative on a KRW account still fails because the negative check needs no cross-currency comparison" do
+    setup_drift
+    krw_merchant_account = create_merchant_account(user: @user, charge_processor_id: StripeChargeProcessor.charge_processor_id, currency: Currency::KRW, country: "KR")
+    krw_balance = create_balance(user: @user, merchant_account: krw_merchant_account, holding_currency: Currency::KRW, holding_amount_cents: -100_00)
+    StripePayoutProcessor.stubs(:get_payout_details).returns([krw_merchant_account, [], [krw_balance]])
+    Stripe::Balance.expects(:retrieve).never
+
+    errors = StripePayoutProcessor.prepare_payment_and_set_amount(@payment, [krw_balance])
+
+    assert_includes errors.first, "Destination ledger is negative"
+    assert_equal Payment::FailureReason::INSUFFICIENT_FUNDS, @payment.reload.failure_reason
+  end
+
+  test "destination_balance_drift_error when the held-at-Stripe balances sum to exactly zero skips the drift check because there is nothing to settle either way" do
+    setup_drift
+    @eur_balance.update!(holding_amount_cents: 0)
+    Stripe::Balance.expects(:retrieve).never
+
+    errors = StripePayoutProcessor.prepare_payment_and_set_amount(@payment, [@eur_balance])
+
+    assert_empty errors
+  end
+
   test "destination_balance_drift_error when the destination merchant account is KRW skips the drift check because KRW subunit conventions differ between Gumroad and Stripe" do
     setup_drift
     krw_merchant_account = create_merchant_account(user: @user, charge_processor_id: StripeChargeProcessor.charge_processor_id, currency: Currency::KRW, country: "KR")

--- a/test/business/payments/payouts/processor/stripe/stripe_payout_processor_test.rb
+++ b/test/business/payments/payouts/processor/stripe/stripe_payout_processor_test.rb
@@ -568,7 +568,7 @@ class StripePayoutProcessorTest < ActiveSupport::TestCase
 
   test "destination_balance_drift_error when Gumroad's held-at-Stripe balances sum NEGATIVE fails the payout instead of silently subtracting the debit from the wire amount" do
     setup_drift
-    @eur_balance.update!(holding_amount_cents: -728_50)
+    @eur_balance.update!(holding_amount_cents: -728_50, amount_cents: 0)
     StripeTransferInternallyToCreator.expects(:transfer_funds_to_account).never
 
     errors = StripePayoutProcessor.prepare_payment_and_set_amount(@payment, [@eur_balance])
@@ -581,7 +581,7 @@ class StripePayoutProcessorTest < ActiveSupport::TestCase
 
   test "destination_balance_drift_error when the held-at-Stripe balances sum negative names the offending balance rows so the reader does not have to find them by hand" do
     setup_drift
-    @eur_balance.update!(holding_amount_cents: -728_50)
+    @eur_balance.update!(holding_amount_cents: -728_50, amount_cents: 0)
 
     errors = StripePayoutProcessor.prepare_payment_and_set_amount(@payment, [@eur_balance])
 
@@ -590,7 +590,7 @@ class StripePayoutProcessorTest < ActiveSupport::TestCase
 
   test "destination_balance_drift_error when the held-at-Stripe balances sum negative does not consult Stripe because a negative ledger is drift on its own evidence" do
     setup_drift
-    @eur_balance.update!(holding_amount_cents: -728_50)
+    @eur_balance.update!(holding_amount_cents: -728_50, amount_cents: 0)
     Stripe::Balance.expects(:retrieve).never
 
     StripePayoutProcessor.prepare_payment_and_set_amount(@payment, [@eur_balance])
@@ -598,7 +598,7 @@ class StripePayoutProcessorTest < ActiveSupport::TestCase
 
   test "destination_balance_drift_error when a negative row is outweighed by healthy rows so the set still sums positive falls through to the ordinary Stripe comparison" do
     setup_drift
-    residue = create_balance(user: @user, merchant_account: @eur_merchant_account, holding_currency: Currency::EUR, holding_amount_cents: -728_50, date: Date.today - 1)
+    residue = create_balance(user: @user, merchant_account: @eur_merchant_account, holding_currency: Currency::EUR, holding_amount_cents: -728_50, amount_cents: 0, date: Date.today - 1)
     StripePayoutProcessor.stubs(:get_payout_details).returns([@eur_merchant_account, [], [@eur_balance, residue]])
     stub_stripe_balance(available: 1_000_00, pending: 0)
 
@@ -613,7 +613,7 @@ class StripePayoutProcessorTest < ActiveSupport::TestCase
   test "destination_balance_drift_error when the held-at-Stripe balances sum negative on a KRW account still fails because the negative check needs no cross-currency comparison" do
     setup_drift
     krw_merchant_account = create_merchant_account(user: @user, charge_processor_id: StripeChargeProcessor.charge_processor_id, currency: Currency::KRW, country: "KR")
-    krw_balance = create_balance(user: @user, merchant_account: krw_merchant_account, holding_currency: Currency::KRW, holding_amount_cents: -100_00)
+    krw_balance = create_balance(user: @user, merchant_account: krw_merchant_account, holding_currency: Currency::KRW, holding_amount_cents: -100_00, amount_cents: 0)
     StripePayoutProcessor.stubs(:get_payout_details).returns([krw_merchant_account, [], [krw_balance]])
     Stripe::Balance.expects(:retrieve).never
 
@@ -631,6 +631,17 @@ class StripePayoutProcessorTest < ActiveSupport::TestCase
     errors = StripePayoutProcessor.prepare_payment_and_set_amount(@payment, [@eur_balance])
 
     assert_empty errors
+  end
+
+  test "destination_balance_drift_error when a negative destination total is matched by a negative USD ledger proceeds, because a refund debits both sides and the payout nets coherently" do
+    setup_drift
+    @eur_balance.update!(holding_amount_cents: -728_50, amount_cents: -728_50)
+    Stripe::Balance.expects(:retrieve).never
+
+    errors = StripePayoutProcessor.prepare_payment_and_set_amount(@payment, [@eur_balance])
+
+    assert_empty errors
+    assert_not_equal "failed", @payment.reload.state
   end
 
   test "destination_balance_drift_error when the destination merchant account is KRW skips the drift check because KRW subunit conventions differ between Gumroad and Stripe" do

--- a/test/business/payments/payouts/processor/stripe/stripe_payout_processor_test.rb
+++ b/test/business/payments/payouts/processor/stripe/stripe_payout_processor_test.rb
@@ -576,7 +576,10 @@ class StripePayoutProcessorTest < ActiveSupport::TestCase
     assert_includes errors.first, "Destination ledger is negative"
     assert_includes errors.first, "-72850 eur cents"
     assert_equal "failed", @payment.reload.state
-    assert_equal Payment::FailureReason::INSUFFICIENT_FUNDS, @payment.failure_reason
+    # A dedicated reason, not INSUFFICIENT_FUNDS: this is our own bookkeeping, so it must not count
+    # toward the consecutive-failure pause that blames the seller's bank account.
+    assert_equal Payment::FailureReason::DESTINATION_LEDGER_NEGATIVE, @payment.failure_reason
+    assert_includes Payment::FailureReason::INTERNAL_RECONCILIATION_REASONS, @payment.failure_reason
   end
 
   test "destination_balance_drift_error when the held-at-Stripe balances sum negative names the offending balance rows so the reader does not have to find them by hand" do
@@ -593,7 +596,11 @@ class StripePayoutProcessorTest < ActiveSupport::TestCase
     @eur_balance.update!(holding_amount_cents: -728_50, amount_cents: 0)
     Stripe::Balance.expects(:retrieve).never
 
-    StripePayoutProcessor.prepare_payment_and_set_amount(@payment, [@eur_balance])
+    errors = StripePayoutProcessor.prepare_payment_and_set_amount(@payment, [@eur_balance])
+
+    # Anchors the example: without this, deleting the negative guard entirely still satisfies the
+    # never-expectation via the `expected_destination_cents <= 0` early return.
+    assert_includes errors.first, "Destination ledger is negative"
   end
 
   test "destination_balance_drift_error when a negative row is outweighed by healthy rows so the set still sums positive falls through to the ordinary Stripe comparison" do
@@ -620,7 +627,7 @@ class StripePayoutProcessorTest < ActiveSupport::TestCase
     errors = StripePayoutProcessor.prepare_payment_and_set_amount(@payment, [krw_balance])
 
     assert_includes errors.first, "Destination ledger is negative"
-    assert_equal Payment::FailureReason::INSUFFICIENT_FUNDS, @payment.reload.failure_reason
+    assert_equal Payment::FailureReason::DESTINATION_LEDGER_NEGATIVE, @payment.reload.failure_reason
   end
 
   test "destination_balance_drift_error when the held-at-Stripe balances sum to exactly zero skips the drift check because there is nothing to settle either way" do


### PR DESCRIPTION
## What

A Stripe payout is refused when our own destination ledger for the seller's connected account is negative while their USD ledger is not — the two disagreeing is the signature of FX residue that would otherwise be silently subtracted from the wire. Adds a daily detector job that reports sellers sitting in that state before a payout cycle reaches them.

## Why

Seller `codelesssoul` carried a **-72,850 PHP** holding balance against a clean USD ledger. Each payout run subtracted that residue from the wire, so the seller was paid short every cycle with nothing anywhere saying why. The USD figure is what every report and the seller's own dashboard shows, so the shortfall is invisible from both sides.

The guard trips on the **disagreement**, not on the sign. That distinction matters: a negative destination total *matched* by a negative USD ledger is ordinary refund netting, which the payout already handles correctly — 973 such sets exist in production and must keep paying. Only the 262 residue sets (negative holding, non-negative USD) are refused.

Refusing is the conservative direction: the money stays in the seller's balance until an internal reconciliation clears the row, rather than being paid out short and needing a correction later.

## Why the payout is not blamed on the seller

A refused payout was initially stamped `INSUFFICIENT_FUNDS`, which counts toward `MAX_CONSECUTIVE_FAILED_PAYOUTS`. Three cycles of that would pause the seller with "consecutive failed payouts to the same bank account. Verify the seller's payout details" — but the bank account is fine and the seller can change nothing. `DESTINATION_LEDGER_NEGATIVE` is excluded from the pause count via `INTERNAL_RECONCILIATION_REASONS`, and its `STRIPE_FAILURE_SOLUTIONS` entry tells the seller to contact Support rather than re-entering details that are already correct.

## Test results

`spec/sidekiq/alert_on_negative_destination_balances_job_spec.rb` + `spec/models/payment_spec.rb` — **121 examples, 0 failures**
`test/business/payments/payouts/processor/stripe/stripe_payout_processor_test.rb` — **348 runs, 886 assertions, 0 failures, 0 errors, 0 skips**

Mutation checks proving the detector's guards are load-bearing:

| Mutation | Result |
|---|---|
| Remove the boundary-user re-read from the scan cursor | 1 failure |
| Remove the refund-netting filter | 1 failure |
| Remove the gumroad-managed-account guard | 1 failure |

## QA steps

Read-only; the detector makes no Stripe API calls and the guard runs before any money moves.

1. In a console, find a Gumroad-managed Stripe connected account with `SUM(holding_amount_cents) < 0` and `SUM(amount_cents) >= 0` on unpaid balances. Run `AlertOnNegativeDestinationBalancesJob.new.perform` and confirm the seller appears in the `payouts` room digest with the right cents figure and `acct_` id.
2. Confirm a seller whose holding **and** USD ledgers are both negative does **not** appear (ordinary refund netting).
3. Confirm a seller-owned Stripe Connect account (`meta.stripe_connect == "true"`) does not appear — Stripe pays those out itself.
4. Attempt a payout for a seller in the residue state and confirm it fails with `DESTINATION_LEDGER_NEGATIVE`, that `payment.error_message` names the offending balance rows, and that the failure does **not** increment the consecutive-failure pause count.

## Fable-5 adversarial review

Ran on the branch before this PR was opened. Verdict on the reviewed head: **CHANGES-REQUIRED**, no P1 — "the guard itself is correctly scoped and correctly tested"; all findings were in the detector half. Fixed since.

| Sev | Finding | Disposition |
|---|---|---|
| P2 | **Vacuous spec.** The refund-netting example's seller netted to -52,850, below the 100,00 payout minimum, so the job was silent whether or not the netting filter existed — deleting the filter left the whole suite green. The redesigned predicate shipped unpinned in the detector | Fixed — the seller is now funded past the minimum, and the mutation reddens |
| P2 | **Keyset cursor dropped pairs at batch boundaries.** The query groups by `(user_id, merchant_account_id)` but cursored on bare `user_id >`. A full batch cutting between two of one seller's accounts skipped that seller's remaining pairs — a completeness detector silently missing a seller | Fixed — the boundary user's rows are dropped and re-read whole on the next pass, pinned by a spec that stubs the batch size |
| P2 | **Unpinned job branches** — the gumroad-managed-account guard greened on deletion (every fixture was managed); the truncation branch had no example | Fixed — Connect-account silence case added; truncation covered in `f8f06dfd9` |
| P2 | Aggregate-sign classification masks residue in a set that also contains a refund-netting row | **Accepted, documented.** The direction is conservative (pays as today, never short), and per-row classification would widen the refusal population inside a bug fix. Recorded as a pre-ramp item rather than changed here |
| P3 | Dead defensive branch; comment slop; a test name overclaiming "does not consult Stripe" | Fixed / trimmed |
| P3 | Per-candidate N+1 in the scan (~60–70k statements at the 12k bound, daily, `low` queue) | Accepted — tolerable at this cadence, noted for follow-up |

**Confirmed safe by the review, with evidence:**

- **The guard does not fail closed on the wrong population.** Traced per lane: seller-owned Connect accounts are excluded (Stripe pays them itself); Gumroad-held platform balances never enter `balances_held_by_stripe`; and for Gumroad-managed custom Connect accounts the destination ledger **is** the payment source — the wire amount is literally that sum, so reading it is correct. No previously-correct payout is newly blocked.
- **The redesign did not leave stale specs behind on the processor side** — each shipped example was checked to still discriminate under the new predicate, with fixture arithmetic verified against the factory defaults.
- **Zero boundary and currency.** The two sums are compared sign-to-sign only, never cross-currency magnitude, so KRW's 100× subunit mismatch cannot affect the trip. Same-currency holding sums are guaranteed by the pre-existing mismatch guard upstream.
- **No money moves before the guard** — it runs before the internal transfer, and the trip path returns without raising, so no reversal is pending.
- **The detector makes no Stripe API calls at all**, so there is no mid-enumeration rescue hazard.

**Only verifiable live:** the real size of the residue population on the day this ships (measured at 262 sets against 973 coherent netting sets), and that the first digest names the sellers we expect. Worth reading the first run before the payout cycle it precedes.

## AI disclosure

Written by gumclaw (Claude Opus 4.5 via Hermes Agent). Reviewed adversarially by a separate headless model instance before this PR was opened; every fix was verified by running both suites and by deleting the guard to confirm the spec reddens.

Ref antiwork/gumroad-private#1717
