### PR TITLE
Send a video's poster to image moderation, not the video

### DIFF
--- a/app/services/content_moderation/content_extractor.rb
+++ b/app/services/content_moderation/content_extractor.rb
@@ -168,9 +168,12 @@ class ContentModeration::ContentExtractor
     # refuses them and counts them unmoderated, which blocks the page, where
     # dropping them here would publish it.
     def page_image_urls(document)
-      sources = document.css("img[src], video[poster]").flat_map do |node|
-        [node["src"], node["poster"]]
-      end
+      # Each attribute is read only off the element it belongs to: a <video src poster> matched
+      # by the old combined selector also yielded its src, sending the video file to the image
+      # classifier. Anything over 20 MB is rejected, and a rejection counts against full
+      # coverage, so an oversized video blocked the page behind "try again in a few minutes".
+      sources = document.css("img[src]").map { |node| node["src"] }
+      sources += document.css("video[poster]").map { |node| node["poster"] }
       sources += document.css("img[srcset], source[srcset]").flat_map do |node|
         srcset_urls(node["srcset"])
       end

--- a/app/services/content_moderation/strategies/classifier_strategy.rb
+++ b/app/services/content_moderation/strategies/classifier_strategy.rb
@@ -38,7 +38,7 @@ class ContentModeration::Strategies::ClassifierStrategy
   # caller like nil/UNREACHED, but must not read as transient: the input is
   # static, so "try again later" can never come true.
   UNSUPPORTED = :unsupported
-  PERMANENT_REJECTION_CODES = %w[invalid_data_url invalid_image_format].freeze
+  PERMANENT_REJECTION_CODES = %w[invalid_data_url invalid_image_format file_too_large].freeze
   UNAVAILABLE_REASON = "We cannot moderate the content at this time, please try again later or update the content."
   UNSUPPORTED_IMAGE_REASON = "The content contains an inline image the moderation endpoint cannot review (unsupported format or too large)."
 

--- a/spec/services/content_moderation/content_extractor_spec.rb
+++ b/spec/services/content_moderation/content_extractor_spec.rb
@@ -149,6 +149,48 @@ RSpec.describe ContentModeration::ContentExtractor do
       Page.new(pageable:, slug: "about", title:, custom_html:, content:)
     end
 
+    it "moderates a video's poster image without sending the video file to the image endpoint" do
+      page = page_for(custom_html: <<~HTML)
+        <p>Watch the process</p>
+        <video src="https://public-files.gumroad.com/tce9t60y8ecmiqx1b81v1gnzj28r"
+               poster="https://cdn.example.com/frame.jpg"></video>
+      HTML
+
+      result = extractor.extract_from_page(page)
+
+      expect(result.image_urls).to eq(["https://cdn.example.com/frame.jpg"])
+    end
+
+    it "collects a video's poster whether or not the element carries a src" do
+      page = page_for(custom_html: <<~HTML)
+        <video poster="https://cdn.example.com/no-src.jpg"></video>
+        <video src="https://public-files.gumroad.com/withsrc.mov"
+               poster="https://cdn.example.com/with-src.jpg"></video>
+      HTML
+
+      result = extractor.extract_from_page(page)
+
+      expect(result.image_urls).to contain_exactly(
+        "https://cdn.example.com/no-src.jpg",
+        "https://cdn.example.com/with-src.jpg"
+      )
+    end
+
+    it "keeps an img src and a sibling video's poster, and takes neither element's other attribute" do
+      page = page_for(custom_html: <<~HTML)
+        <img src="https://cdn.example.com/photo.png" poster="https://cdn.example.com/ignored.jpg">
+        <video src="https://public-files.gumroad.com/clip.mov"
+               poster="https://cdn.example.com/frame.jpg"></video>
+      HTML
+
+      result = extractor.extract_from_page(page)
+
+      expect(result.image_urls).to contain_exactly(
+        "https://cdn.example.com/photo.png",
+        "https://cdn.example.com/frame.jpg"
+      )
+    end
+
     it "extracts the title, visible text, link targets, and remote image URLs" do
       page = page_for(custom_html: <<~HTML)
         <html><head><style>.a { color: red }</style></head>

--- a/spec/services/content_moderation/strategies/classifier_strategy_spec.rb
+++ b/spec/services/content_moderation/strategies/classifier_strategy_spec.rb
@@ -160,6 +160,21 @@ RSpec.describe ContentModeration::Strategies::ClassifierStrategy, :vcr do
     expect(result.reasoning).to eq([described_class::UNSUPPORTED_IMAGE_REASON])
   end
 
+  it "tells the seller an oversized remote asset cannot be reviewed rather than to retry" do
+    image_urls = ["https://public-files.gumroad.com/tce9t60y8ecmiqx1b81v1gnzj28r"]
+    bad_response = instance_double(Faraday::Response, status: 400, body: "", headers: {})
+    bad_error = Faraday::BadRequestError.new(
+      { status: 400, body: { "error" => { "code" => "file_too_large", "message" => "File size exceeds the limit." } } },
+      bad_response
+    )
+    allow(client).to receive(:moderations).and_raise(bad_error)
+
+    result = described_class.new(text: "", image_urls:, max_images: :all).perform
+
+    expect(result.status).to eq("flagged")
+    expect(result.reasoning).to eq([described_class::UNSUPPORTED_IMAGE_REASON])
+  end
+
   it "keeps the retry reason when a transient failure sits alongside an unsupported payload" do
     # Retrying can still resolve the fetch failure, and once it does, the next
     # save reports the unsupported image on its own.


### PR DESCRIPTION
## What

A `<video>` with a `poster` sent the **video file** to the image-moderation endpoint. OpenAI refuses anything over 20 MB, and page moderation runs at full coverage, so a single refusal blocked the page — behind a message saying the problem was temporary.

Nothing was temporary. The input is static, so every retry failed identically. Reported on Helper ticket `2593a8e5b36933534d467bf15e0ea89c` (seller KROMATIK.TOOLS, product `osgnkq`): 4 blocked publish attempts in 25 minutes, each identical.

## Why

`page_image_urls` matched `img[src], video[poster]`, then read **both** attributes off every match:

```ruby
sources = document.css("img[src], video[poster]").flat_map do |node|
  [node["src"], node["poster"]]
end
```

For `<video src="…" poster="…">`, `node["src"]` is the video. `remote_url?` only tests the scheme, so a 24.8 MB QuickTime file passed as an image URL and OpenAI returned `file_too_large`. That counts as `skipped`, and the full-coverage branch blocks:

```
1 image(s) rejected by OpenAI, 0 with an unreviewable payload, 0 not reached within 60s, of 13
```

The refusal bought no safety either way — `PromptStrategy filtered out all 13 image URLs (unsupported formats)`, so the video was never reviewed as a video. It only blocked the page.

## Fix

Each attribute is read only off the element that carries it, so a poster is moderated and a video file is never sent as an image.

`file_too_large` also joins `PERMANENT_REJECTION_CODES`. The copy that code selects already reads "unsupported format **or too large**", so this routes an oversized asset to the message written for it rather than telling the seller to wait for a condition that will never change.

## Before / after

Same page, `<video src poster>` where the video is 24.8 MB:

| | Before | After |
|---|---|---|
| Sent to image endpoint | video file (24.8 MB) | poster image |
| OpenAI response | `file_too_large` | reviewed normally |
| Publish | blocked, permanently | succeeds |
| Copy when an asset *is* oversized | "temporary issue… try again in a few minutes" | names the asset as unreviewable |

## Scope

Fixes the poster bug and the misleading copy. **Not** addressed: a `<video>` with no `poster` is still never inspected, so a page's moderation outcome partly depends on whether the seller set one. That's video moderation as a capability — a design question, and deliberately out of scope here. Noted in gumroad-private#1728.

## Tests

- poster is collected, video `src` is not, when both are present
- poster collected whether or not the element carries a `src`
- an `img`'s `src` and a sibling `video`'s `poster` both collected; neither element's other attribute is
- `file_too_large` yields the unreviewable-asset copy, not the retry copy

## QA

- [ ] Custom page with `<video poster="…">` where the video exceeds 20 MB → publishes
- [ ] The poster image itself is still moderated (swap in a violating poster → blocked)
- [ ] Page with an oversized `<img>` → error names the asset, does not promise a retry

Fixes antiwork/gumroad-private#1728
