### PR TITLE
Stop counting signal-free failures toward the card-testing velocity rules

### DIFF
--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -81,11 +81,6 @@ module Purchase::Blockable
 
   MAX_BUYER_CHARGEBACKS_BEFORE_BLOCK = 5
 
-  # How many recent failures the velocity counter inspects. Generous next to the threshold of 4,
-  # bounded so an old browser_guid cannot make the counter scan its whole history mid-checkout.
-  CARD_TESTING_COUNT_SCAN_LIMIT = 200
-  private_constant :CARD_TESTING_COUNT_SCAN_LIMIT
-
   class_methods do
     # Shared with Onetime::ClearMistakenBuyerBlocks, which must reproduce these rules exactly: if
     # it counts differently it clears a block a live rule still wants, switching enforcement off
@@ -106,21 +101,24 @@ module Purchase::Blockable
     #
     # Keyed on card_visual, which holds the payer email PayPal attested for the order, NOT
     # purchases.email: the buyer types that one, so keying on it would let an attacker cycle any
-    # number of stolen wallets under a single checkout email and count as one forever.
+    # number of stolen wallets under a single checkout email and count as one forever. A wallet
+    # with no attested payer is not provably the same wallet as any other, so it counts on its
+    # own token rather than merging into one free unit.
+    #
+    # Returns at most MAX_NUMBER_OF_FAILED_FINGERPRINTS — every caller only compares against
+    # that threshold. Deduplicating in SQL and stopping at the threshold is what bounds the scan
+    # (the guid rule has no time window, and this runs inside the purchase state-machine
+    # transition): a newest-N row cap before the dedup made the count depend on retry order, so
+    # a tester could flush an older card out of the window by retrying fewer cards more often.
     def distinct_card_count(relation)
-      # Capped: the guid rule has no time window, so a long-lived guid can match a lot of rows and
-      # this runs inside the purchase state-machine transition. Any window wide enough to hold the
-      # threshold answers the question — we only ever compare against a count of 4.
-      rows = relation.order(created_at: :desc)
-                     .limit(CARD_TESTING_COUNT_SCAN_LIMIT)
-                     .pluck(:charge_processor_id, :stripe_fingerprint, :card_visual)
-      paypal_id = PaypalChargeProcessor.charge_processor_id
-      stripe_cards, paypal_rows = rows.partition { |processor, _, _| processor != paypal_id }
-
-      # A wallet with no attested payer is not provably the same wallet as any other, so count
-      # each such row on its own token rather than merging them into one free unit.
-      wallets = paypal_rows.map { |_, fingerprint, payer| payer.presence || "token:#{fingerprint}" }
-      stripe_cards.map { |_, fingerprint, _| fingerprint }.uniq.size + wallets.uniq.size
+      paypal_id = ActiveRecord::Base.connection.quote(PaypalChargeProcessor.charge_processor_id)
+      identity = <<~SQL.squish
+        CASE WHEN charge_processor_id = #{paypal_id}
+             THEN CONCAT('wallet:', COALESCE(NULLIF(card_visual, ''), CONCAT('token:', stripe_fingerprint)))
+             ELSE CONCAT('card:', stripe_fingerprint)
+        END
+      SQL
+      relation.distinct.limit(MAX_NUMBER_OF_FAILED_FINGERPRINTS).pluck(Arel.sql(identity)).size
     end
   end
 

--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -47,24 +47,31 @@ module Purchase::Blockable
 
   # Failures the buyer had no part in, so they cannot be evidence of card testing.
   #
-  # The temporary-network codes mean our call to the processor never completed — the card was
-  # never contacted, so the attempt says nothing about it. Counting them lets a processor
-  # incident manufacture its own fraud evidence against everyone who retried during it.
+  # Split by the column each lands in: our own outage codes are written to `error_code`, while a
+  # card decline is written to `stripe_error_code` (and leaves `error_code` NULL — see
+  # #failure_code, which reads `stripe_error_code || error_code`).
   #
-  # The issuer declines below are the ordinary ones. A card tester's declines look like
-  # `card_declined_fraudulent` / `card_declined_do_not_honor`; "no money on this card" is what a
-  # real wallet looks like when somebody hunts for one with room on it. Composed the way
-  # StripeErrorHandler builds them: "card_declined" + "_" + Stripe's decline_code.
+  # The outage codes mean our call to the processor never completed, so the card was never
+  # contacted and the attempt says nothing about it. Counting them lets a processor incident
+  # manufacture its own fraud evidence against everyone who retried during it.
   CARD_TESTING_UNCOUNTED_ERROR_CODES = [
     PurchaseErrorCode::STRIPE_UNAVAILABLE,
     PurchaseErrorCode::PAYPAL_UNAVAILABLE,
     PurchaseErrorCode::PROCESSING_ERROR,
     PurchaseErrorCode::PROCESSOR_INVALID_REQUEST,
-    PurchaseErrorCode::STRIPE_INSUFFICIENT_FUNDS,
-    "card_declined_transaction_not_allowed",
-    "card_declined_generic_decline",
   ].freeze
   private_constant :CARD_TESTING_UNCOUNTED_ERROR_CODES
+
+  # Issuer declines that describe the buyer's balance rather than the card's standing. "No money
+  # on this card" is what a real wallet looks like when somebody hunts for one with room on it.
+  # Deliberately narrow: generic_decline is the issuer's catch-all and is common in genuine
+  # card-testing traffic, so excluding it would blunt the rule against the people it exists for.
+  # Spelled the way StripeErrorHandler composes them: "card_declined" + "_" + decline_code.
+  CARD_TESTING_UNCOUNTED_DECLINE_CODES = [
+    PurchaseErrorCode::STRIPE_INSUFFICIENT_FUNDS,
+    "card_declined_transaction_not_allowed",
+  ].freeze
+  private_constant :CARD_TESTING_UNCOUNTED_DECLINE_CODES
 
   MAX_BUYER_CHARGEBACKS_BEFORE_BLOCK = 5
 
@@ -439,10 +446,8 @@ module Purchase::Blockable
     def ban_fraudulent_buyer_browser_guid!
       return unless stripe_fingerprint
 
-      unique_failed_fingerprints = countable_card_testing_failures
-                                     .select("distinct stripe_fingerprint")
-                                     .where(browser_guid:)
-      return if unique_failed_fingerprints.count < MAX_NUMBER_OF_FAILED_FINGERPRINTS
+      recent_failures = countable_card_testing_failures.where(browser_guid:)
+      return if distinct_card_count(recent_failures) < MAX_NUMBER_OF_FAILED_FINGERPRINTS
       return if buyer_has_clean_checkout_history?
 
       PlatformBlock.add!(object_type: PlatformBlock::TYPES[:browser_guid], object_value: browser_guid)
@@ -578,29 +583,46 @@ module Purchase::Blockable
     end
 
     def block_buyer_based_on_recent_failures!
-      unique_failed_fingerprints = countable_card_testing_failures
-                                           .select("distinct stripe_fingerprint")
-                                           .where("email = ? or browser_guid = ?", email, browser_guid)
-                                           .where(created_at: CARD_TESTING_WATCH_PERIOD.ago..)
+      recent_failures = countable_card_testing_failures
+                          .where("email = ? or browser_guid = ?", email, browser_guid)
+                          .where(created_at: CARD_TESTING_WATCH_PERIOD.ago..)
 
-      return if unique_failed_fingerprints.count < MAX_NUMBER_OF_FAILED_FINGERPRINTS
+      return if distinct_card_count(recent_failures) < MAX_NUMBER_OF_FAILED_FINGERPRINTS
       return if buyer_has_clean_checkout_history?
 
       block_buyer!
     end
 
     # The velocity rules count DISTINCT fingerprints as a proxy for "how many different cards has
-    # this person tried". Two things break that proxy, and both strand real buyers:
+    # this person tried". Signal-free failures break that proxy: see CARD_TESTING_UNCOUNTED_*.
     #
-    # PayPal writes a per-transaction billing-agreement token into stripe_fingerprint, so one
-    # wallet mints a fresh "card" on every attempt — four retries on a single funding source trip
-    # a four-card rule. Scoping to Stripe rows keeps the proxy honest; PayPal abuse is caught by
-    # the per-product and IP limits, which do not depend on the fingerprint being a card.
+    # The two lists are matched against different columns — a card decline writes
+    # stripe_error_code and leaves error_code NULL, while our own outage codes write error_code
+    # (see #failure_code, which reads `stripe_error_code || error_code`). Both comparisons must
+    # survive NULL: `col NOT IN (...)` evaluates to NULL, not TRUE, when col is NULL, which would
+    # silently drop every real decline from the count.
     #
-    # Signal-free failures are excluded outright: see CARD_TESTING_UNCOUNTED_ERROR_CODES.
+    # Deliberately NOT scoped to Stripe: PayPal rows still count toward the buyer and IP rules,
+    # which are the only thing standing between us and somebody cycling stolen PayPal accounts.
+    # Their per-transaction token problem is fixed by counting them per wallet, not by hiding them.
     def countable_card_testing_failures
-      Purchase.failed.stripe.with_stripe_fingerprint
-              .where.not(error_code: CARD_TESTING_UNCOUNTED_ERROR_CODES)
+      Purchase.failed.with_stripe_fingerprint
+              .where("(stripe_error_code NOT IN (?) OR stripe_error_code IS NULL)", CARD_TESTING_UNCOUNTED_DECLINE_CODES)
+              .where("(error_code NOT IN (?) OR error_code IS NULL)", CARD_TESTING_UNCOUNTED_ERROR_CODES)
+    end
+
+    # PayPal writes a per-transaction billing-agreement token into stripe_fingerprint, so one
+    # wallet mints a fresh "card" on every attempt and four retries on a single funding source
+    # trip a four-card rule. Collapse each PayPal payer to one unit of evidence — a buyer cycling
+    # several stolen PayPal accounts still accumulates one per account — while every Stripe
+    # fingerprint stays its own card.
+    def distinct_card_count(relation)
+      rows = relation.pluck(:charge_processor_id, :stripe_fingerprint, :email)
+      stripe_cards = rows.reject { |processor, _, _| processor == PaypalChargeProcessor.charge_processor_id }
+                         .map { |_, fingerprint, _| fingerprint }
+      paypal_payers = rows.select { |processor, _, _| processor == PaypalChargeProcessor.charge_processor_id }
+                          .map { |_, _, payer| payer }
+      stripe_cards.uniq.size + paypal_payers.uniq.size
     end
 
     # The velocity rules' version of #buyer_has_clean_payment_history?, which cannot be reused here:
@@ -680,12 +702,11 @@ module Purchase::Blockable
     def block_ip_address_based_on_recent_failures!
       return if PlatformBlock.ip_address.active.find_by(object_value: ip_address).present?
 
-      unique_failed_fingerprints = countable_card_testing_failures
-                                           .select("distinct stripe_fingerprint")
-                                           .where("ip_address = ?", ip_address)
-                                           .where(created_at: CARD_TESTING_IP_ADDRESS_WATCH_PERIOD.ago..)
+      recent_failures = countable_card_testing_failures
+                          .where("ip_address = ?", ip_address)
+                          .where(created_at: CARD_TESTING_IP_ADDRESS_WATCH_PERIOD.ago..)
 
-      return if unique_failed_fingerprints.count < MAX_NUMBER_OF_FAILED_FINGERPRINTS
+      return if distinct_card_count(recent_failures) < MAX_NUMBER_OF_FAILED_FINGERPRINTS
 
       PlatformBlock.add!(
         object_type: PlatformBlock::TYPES[:ip_address],

--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -75,6 +75,12 @@ module Purchase::Blockable
 
   MAX_BUYER_CHARGEBACKS_BEFORE_BLOCK = 5
 
+  # How many recent failures the velocity counter inspects. Generous next to the threshold of 4,
+  # bounded so an old browser_guid cannot make the counter scan its whole history mid-checkout.
+  CARD_TESTING_COUNT_SCAN_LIMIT = 200
+  private_constant :CARD_TESTING_COUNT_SCAN_LIMIT
+
+
 
   # How many of the buyer's other purchases #unblock_buyer! collects identifiers from. An admin
   # click has to stay bounded, and past a few hundred rows a buyer stops contributing new browser
@@ -605,24 +611,41 @@ module Purchase::Blockable
     # Deliberately NOT scoped to Stripe: PayPal rows still count toward the buyer and IP rules,
     # which are the only thing standing between us and somebody cycling stolen PayPal accounts.
     # Their per-transaction token problem is fixed by counting them per wallet, not by hiding them.
+    #
+    # Restricted to the two processors that write a fingerprint we understand. A row with no
+    # charge_processor_id is not evidence about any card, and counting it made ordinary test and
+    # legacy rows trip the rule.
     def countable_card_testing_failures
       Purchase.failed.with_stripe_fingerprint
+              .where(charge_processor_id: [StripeChargeProcessor.charge_processor_id,
+                                           PaypalChargeProcessor.charge_processor_id])
               .where("(stripe_error_code NOT IN (?) OR stripe_error_code IS NULL)", CARD_TESTING_UNCOUNTED_DECLINE_CODES)
               .where("(error_code NOT IN (?) OR error_code IS NULL)", CARD_TESTING_UNCOUNTED_ERROR_CODES)
     end
 
     # PayPal writes a per-transaction billing-agreement token into stripe_fingerprint, so one
     # wallet mints a fresh "card" on every attempt and four retries on a single funding source
-    # trip a four-card rule. Collapse each PayPal payer to one unit of evidence — a buyer cycling
-    # several stolen PayPal accounts still accumulates one per account — while every Stripe
+    # trip a four-card rule. Collapse each PayPal wallet to one unit of evidence — somebody
+    # cycling several stolen wallets still accumulates one per wallet — while every Stripe
     # fingerprint stays its own card.
+    #
+    # Keyed on card_visual, which holds the payer email PayPal attested for the order, NOT
+    # purchases.email: the buyer types that one, so keying on it would let an attacker cycle any
+    # number of stolen wallets under a single checkout email and count as one forever.
     def distinct_card_count(relation)
-      rows = relation.pluck(:charge_processor_id, :stripe_fingerprint, :email)
-      stripe_cards = rows.reject { |processor, _, _| processor == PaypalChargeProcessor.charge_processor_id }
-                         .map { |_, fingerprint, _| fingerprint }
-      paypal_payers = rows.select { |processor, _, _| processor == PaypalChargeProcessor.charge_processor_id }
-                          .map { |_, _, payer| payer }
-      stripe_cards.uniq.size + paypal_payers.uniq.size
+      # Capped: the guid rule has no time window, so a long-lived guid can match a lot of rows and
+      # this runs inside the purchase state-machine transition. Any window wide enough to hold the
+      # threshold answers the question — we only ever compare against a count of 4.
+      rows = relation.order(created_at: :desc)
+                     .limit(CARD_TESTING_COUNT_SCAN_LIMIT)
+                     .pluck(:charge_processor_id, :stripe_fingerprint, :card_visual)
+      paypal_id = PaypalChargeProcessor.charge_processor_id
+      stripe_cards, paypal_rows = rows.partition { |processor, _, _| processor != paypal_id }
+
+      # A wallet with no attested payer is not provably the same wallet as any other, so count
+      # each such row on its own token rather than merging them into one free unit.
+      wallets = paypal_rows.map { |_, fingerprint, payer| payer.presence || "token:#{fingerprint}" }
+      stripe_cards.map { |_, fingerprint, _| fingerprint }.uniq.size + wallets.uniq.size
     end
 
     # The velocity rules' version of #buyer_has_clean_payment_history?, which cannot be reused here:

--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -62,14 +62,20 @@ module Purchase::Blockable
   ].freeze
   private_constant :CARD_TESTING_UNCOUNTED_ERROR_CODES
 
-  # Issuer declines that describe the buyer's balance rather than the card's standing. "No money
-  # on this card" is what a real wallet looks like when somebody hunts for one with room on it.
-  # Deliberately narrow: generic_decline is the issuer's catch-all and is common in genuine
-  # card-testing traffic, so excluding it would blunt the rule against the people it exists for.
-  # Spelled the way StripeErrorHandler composes them: "card_declined" + "_" + decline_code.
+  # Card errors carrying no signal about the card, spelled the way StripeErrorHandler composes
+  # them ("card_declined" + "_" + decline_code) plus Braintree's own network code.
+  #
+  # Only failures the processor could not answer about belong here. A decline the ISSUER answered
+  # stays counted, insufficient_funds included: the issuer accepted the number, expiry and CVC and
+  # refused only on balance, which is the positive validity signal a tester is buying — and since
+  # the attacker picks the amount, they can push live stolen cards into it at will. Exempting it
+  # would turn the rule's blind spot into a card-validation oracle, while doing nothing for the
+  # stranded buyer this exists for: one person retrying one card is one fingerprint and can never
+  # reach a four-card threshold.
   CARD_TESTING_UNCOUNTED_DECLINE_CODES = [
-    PurchaseErrorCode::STRIPE_INSUFFICIENT_FUNDS,
-    "card_declined_transaction_not_allowed",
+    "card_declined_processing_error",
+    "processing_error",
+    "3000", # Braintree: Processor Network Unavailable - Try Again
   ].freeze
   private_constant :CARD_TESTING_UNCOUNTED_DECLINE_CODES
 
@@ -80,7 +86,43 @@ module Purchase::Blockable
   CARD_TESTING_COUNT_SCAN_LIMIT = 200
   private_constant :CARD_TESTING_COUNT_SCAN_LIMIT
 
+  class_methods do
+    # Shared with Onetime::ClearMistakenBuyerBlocks, which must reproduce these rules exactly: if
+    # it counts differently it clears a block a live rule still wants, switching enforcement off
+    # for that identifier.
+    def countable_card_testing_failures
+      Purchase.failed.with_stripe_fingerprint
+              .where(charge_processor_id: [StripeChargeProcessor.charge_processor_id,
+                                           PaypalChargeProcessor.charge_processor_id])
+              .where("(stripe_error_code NOT IN (?) OR stripe_error_code IS NULL)", CARD_TESTING_UNCOUNTED_DECLINE_CODES)
+              .where("(error_code NOT IN (?) OR error_code IS NULL)", CARD_TESTING_UNCOUNTED_ERROR_CODES)
+    end
 
+    # PayPal writes a per-transaction billing-agreement token into stripe_fingerprint, so one
+    # wallet mints a fresh "card" on every attempt and four retries on a single funding source
+    # trip a four-card rule. Collapse each PayPal wallet to one unit of evidence — somebody
+    # cycling several stolen wallets still accumulates one per wallet — while every Stripe
+    # fingerprint stays its own card.
+    #
+    # Keyed on card_visual, which holds the payer email PayPal attested for the order, NOT
+    # purchases.email: the buyer types that one, so keying on it would let an attacker cycle any
+    # number of stolen wallets under a single checkout email and count as one forever.
+    def distinct_card_count(relation)
+      # Capped: the guid rule has no time window, so a long-lived guid can match a lot of rows and
+      # this runs inside the purchase state-machine transition. Any window wide enough to hold the
+      # threshold answers the question — we only ever compare against a count of 4.
+      rows = relation.order(created_at: :desc)
+                     .limit(CARD_TESTING_COUNT_SCAN_LIMIT)
+                     .pluck(:charge_processor_id, :stripe_fingerprint, :card_visual)
+      paypal_id = PaypalChargeProcessor.charge_processor_id
+      stripe_cards, paypal_rows = rows.partition { |processor, _, _| processor != paypal_id }
+
+      # A wallet with no attested payer is not provably the same wallet as any other, so count
+      # each such row on its own token rather than merging them into one free unit.
+      wallets = paypal_rows.map { |_, fingerprint, payer| payer.presence || "token:#{fingerprint}" }
+      stripe_cards.map { |_, fingerprint, _| fingerprint }.uniq.size + wallets.uniq.size
+    end
+  end
 
   # How many of the buyer's other purchases #unblock_buyer! collects identifiers from. An admin
   # click has to stay bounded, and past a few hundred rows a buyer stops contributing new browser
@@ -616,36 +658,11 @@ module Purchase::Blockable
     # charge_processor_id is not evidence about any card, and counting it made ordinary test and
     # legacy rows trip the rule.
     def countable_card_testing_failures
-      Purchase.failed.with_stripe_fingerprint
-              .where(charge_processor_id: [StripeChargeProcessor.charge_processor_id,
-                                           PaypalChargeProcessor.charge_processor_id])
-              .where("(stripe_error_code NOT IN (?) OR stripe_error_code IS NULL)", CARD_TESTING_UNCOUNTED_DECLINE_CODES)
-              .where("(error_code NOT IN (?) OR error_code IS NULL)", CARD_TESTING_UNCOUNTED_ERROR_CODES)
+      Purchase.countable_card_testing_failures
     end
 
-    # PayPal writes a per-transaction billing-agreement token into stripe_fingerprint, so one
-    # wallet mints a fresh "card" on every attempt and four retries on a single funding source
-    # trip a four-card rule. Collapse each PayPal wallet to one unit of evidence — somebody
-    # cycling several stolen wallets still accumulates one per wallet — while every Stripe
-    # fingerprint stays its own card.
-    #
-    # Keyed on card_visual, which holds the payer email PayPal attested for the order, NOT
-    # purchases.email: the buyer types that one, so keying on it would let an attacker cycle any
-    # number of stolen wallets under a single checkout email and count as one forever.
     def distinct_card_count(relation)
-      # Capped: the guid rule has no time window, so a long-lived guid can match a lot of rows and
-      # this runs inside the purchase state-machine transition. Any window wide enough to hold the
-      # threshold answers the question — we only ever compare against a count of 4.
-      rows = relation.order(created_at: :desc)
-                     .limit(CARD_TESTING_COUNT_SCAN_LIMIT)
-                     .pluck(:charge_processor_id, :stripe_fingerprint, :card_visual)
-      paypal_id = PaypalChargeProcessor.charge_processor_id
-      stripe_cards, paypal_rows = rows.partition { |processor, _, _| processor != paypal_id }
-
-      # A wallet with no attested payer is not provably the same wallet as any other, so count
-      # each such row on its own token rather than merging them into one free unit.
-      wallets = paypal_rows.map { |_, fingerprint, payer| payer.presence || "token:#{fingerprint}" }
-      stripe_cards.map { |_, fingerprint, _| fingerprint }.uniq.size + wallets.uniq.size
+      Purchase.distinct_card_count(relation)
     end
 
     # The velocity rules' version of #buyer_has_clean_payment_history?, which cannot be reused here:

--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -45,7 +45,29 @@ module Purchase::Blockable
                          PurchaseErrorCode::EXCEEDING_OFFER_CODE_QUANTITY]
   private_constant :IGNORED_ERROR_CODES
 
+  # Failures the buyer had no part in, so they cannot be evidence of card testing.
+  #
+  # The temporary-network codes mean our call to the processor never completed — the card was
+  # never contacted, so the attempt says nothing about it. Counting them lets a processor
+  # incident manufacture its own fraud evidence against everyone who retried during it.
+  #
+  # The issuer declines below are the ordinary ones. A card tester's declines look like
+  # `card_declined_fraudulent` / `card_declined_do_not_honor`; "no money on this card" is what a
+  # real wallet looks like when somebody hunts for one with room on it. Composed the way
+  # StripeErrorHandler builds them: "card_declined" + "_" + Stripe's decline_code.
+  CARD_TESTING_UNCOUNTED_ERROR_CODES = [
+    PurchaseErrorCode::STRIPE_UNAVAILABLE,
+    PurchaseErrorCode::PAYPAL_UNAVAILABLE,
+    PurchaseErrorCode::PROCESSING_ERROR,
+    PurchaseErrorCode::PROCESSOR_INVALID_REQUEST,
+    PurchaseErrorCode::STRIPE_INSUFFICIENT_FUNDS,
+    "card_declined_transaction_not_allowed",
+    "card_declined_generic_decline",
+  ].freeze
+  private_constant :CARD_TESTING_UNCOUNTED_ERROR_CODES
+
   MAX_BUYER_CHARGEBACKS_BEFORE_BLOCK = 5
+
 
   # How many of the buyer's other purchases #unblock_buyer! collects identifiers from. An admin
   # click has to stay bounded, and past a few hundred rows a buyer stops contributing new browser
@@ -417,9 +439,9 @@ module Purchase::Blockable
     def ban_fraudulent_buyer_browser_guid!
       return unless stripe_fingerprint
 
-      unique_failed_fingerprints = Purchase.failed.select("distinct stripe_fingerprint").where(
-        "browser_guid = ? and stripe_fingerprint is not null", browser_guid
-      )
+      unique_failed_fingerprints = countable_card_testing_failures
+                                     .select("distinct stripe_fingerprint")
+                                     .where(browser_guid:)
       return if unique_failed_fingerprints.count < MAX_NUMBER_OF_FAILED_FINGERPRINTS
       return if buyer_has_clean_checkout_history?
 
@@ -556,7 +578,7 @@ module Purchase::Blockable
     end
 
     def block_buyer_based_on_recent_failures!
-      unique_failed_fingerprints = Purchase.failed.stripe.with_stripe_fingerprint
+      unique_failed_fingerprints = countable_card_testing_failures
                                            .select("distinct stripe_fingerprint")
                                            .where("email = ? or browser_guid = ?", email, browser_guid)
                                            .where(created_at: CARD_TESTING_WATCH_PERIOD.ago..)
@@ -565,6 +587,20 @@ module Purchase::Blockable
       return if buyer_has_clean_checkout_history?
 
       block_buyer!
+    end
+
+    # The velocity rules count DISTINCT fingerprints as a proxy for "how many different cards has
+    # this person tried". Two things break that proxy, and both strand real buyers:
+    #
+    # PayPal writes a per-transaction billing-agreement token into stripe_fingerprint, so one
+    # wallet mints a fresh "card" on every attempt — four retries on a single funding source trip
+    # a four-card rule. Scoping to Stripe rows keeps the proxy honest; PayPal abuse is caught by
+    # the per-product and IP limits, which do not depend on the fingerprint being a card.
+    #
+    # Signal-free failures are excluded outright: see CARD_TESTING_UNCOUNTED_ERROR_CODES.
+    def countable_card_testing_failures
+      Purchase.failed.stripe.with_stripe_fingerprint
+              .where.not(error_code: CARD_TESTING_UNCOUNTED_ERROR_CODES)
     end
 
     # The velocity rules' version of #buyer_has_clean_payment_history?, which cannot be reused here:
@@ -644,7 +680,7 @@ module Purchase::Blockable
     def block_ip_address_based_on_recent_failures!
       return if PlatformBlock.ip_address.active.find_by(object_value: ip_address).present?
 
-      unique_failed_fingerprints = Purchase.failed.stripe.with_stripe_fingerprint
+      unique_failed_fingerprints = countable_card_testing_failures
                                            .select("distinct stripe_fingerprint")
                                            .where("ip_address = ?", ip_address)
                                            .where(created_at: CARD_TESTING_IP_ADDRESS_WATCH_PERIOD.ago..)

--- a/app/services/onetime/clear_mistaken_buyer_blocks.rb
+++ b/app/services/onetime/clear_mistaken_buyer_blocks.rb
@@ -129,11 +129,11 @@ class Onetime::ClearMistakenBuyerBlocks
       return blocked_pairs_for(purchase) if velocity_threshold_met?(recent_email_or_browser_failures)
 
       # Purchase::Blockable#ban_fraudulent_buyer_browser_guid! blocks the browser only, and counts
-      # over all time rather than a window, and — unlike the two rules above — over every failed
-      # purchase carrying a card fingerprint, whatever charge processor it went through.
+      # over all time rather than a window. Same countable scope as the live rule: counting rows
+      # it ignores would retain exactly the outage-manufactured blocks this cleanup exists to
+      # clear.
       if purchase.browser_guid.present?
-        browser_failures = Purchase.failed.with_stripe_fingerprint
-                                   .select("distinct stripe_fingerprint")
+        browser_failures = Purchase.countable_card_testing_failures
                                    .where(created_at: ..window.end)
                                    .where(browser_guid: purchase.browser_guid)
         protected_pairs << [PlatformBlock::TYPES[:browser_guid], purchase.browser_guid] if velocity_threshold_met?(browser_failures)

--- a/app/services/onetime/clear_mistaken_buyer_blocks.rb
+++ b/app/services/onetime/clear_mistaken_buyer_blocks.rb
@@ -153,13 +153,12 @@ class Onetime::ClearMistakenBuyerBlocks
     # period runs back from the START of the window, not its end, so the range covers every period
     # the live rule could have used; from the end it would undercount and expose a wanted row.
     def distinct_failed_stripe_fingerprints(window, watch_period)
-      Purchase.failed.stripe.with_stripe_fingerprint
-              .select("distinct stripe_fingerprint")
+      Purchase.countable_card_testing_failures
               .where(created_at: (window.begin - watch_period)..window.end)
     end
 
     def velocity_threshold_met?(scope)
-      scope.count >= Purchase::Blockable::MAX_NUMBER_OF_FAILED_FINGERPRINTS
+      Purchase.distinct_card_count(scope) >= Purchase::Blockable::MAX_NUMBER_OF_FAILED_FINGERPRINTS
     end
 
     # When the failure could have happened: creation at the earliest, the SCA deadline at the

--- a/spec/models/concerns/purchase/blockable_velocity_noise_spec.rb
+++ b/spec/models/concerns/purchase/blockable_velocity_noise_spec.rb
@@ -101,25 +101,39 @@ RSpec.describe Purchase::Blockable do
     end
 
     context "with PayPal per-transaction tokens" do
+      # card_visual holds the payer email PayPal attested for the order; purchases.email is typed
+      # by the buyer at checkout. These specs vary them independently on purpose.
+      def paypal_attempt(token:, payer:, checkout_email: email)
+        create(:failed_purchase, email: checkout_email, browser_guid: guid, ip_address: ip,
+                                 charge_processor_id: "paypal",
+                                 stripe_fingerprint: token, card_visual: payer,
+                                 stripe_error_code: PurchaseErrorCode::CARD_DECLINED_FRAUDULENT)
+      end
+
       it "does not treat one wallet's retries as four cards" do
         %w[B-4RX09118X48790402 B-1E323802CG6792744 B-9KL22119Y11002931 B-7PQ55410Z22114882]
-          .each { |token| declined(PurchaseErrorCode::CARD_DECLINED_FRAUDULENT, fingerprint: token, processor: "paypal") }
+          .each { |token| paypal_attempt(token:, payer: "wallet@example.com") }
 
         live_attempt(processor: "paypal", fingerprint: "B-live").send(:ban_fraudulent_buyer_browser_guid!)
 
         expect(PlatformBlock.active.find_by(object_value: guid)).to be_nil
       end
 
-      it "still blocks somebody cycling four different PayPal accounts" do
+      it "blocks four different wallets even when they share one checkout email" do
         4.times do |i|
-          create(:failed_purchase, email: "payer#{i}-#{SecureRandom.hex(3)}@example.com",
-                                   browser_guid: guid, ip_address: ip,
-                                   charge_processor_id: "paypal",
-                                   stripe_fingerprint: "B-#{SecureRandom.hex(8)}",
-                                   stripe_error_code: PurchaseErrorCode::CARD_DECLINED_FRAUDULENT)
+          paypal_attempt(token: "B-#{SecureRandom.hex(8)}", payer: "stolen#{i}@example.com",
+                         checkout_email: email)
         end
 
         live_attempt(processor: "paypal", fingerprint: "B-live2").send(:ban_fraudulent_buyer_browser_guid!)
+
+        expect(PlatformBlock.active.find_by(object_value: guid)).to be_present
+      end
+
+      it "counts wallets with no attested payer on their own token" do
+        4.times { paypal_attempt(token: "B-#{SecureRandom.hex(8)}", payer: nil) }
+
+        live_attempt(processor: "paypal", fingerprint: "B-live3").send(:ban_fraudulent_buyer_browser_guid!)
 
         expect(PlatformBlock.active.find_by(object_value: guid)).to be_present
       end

--- a/spec/models/concerns/purchase/blockable_velocity_noise_spec.rb
+++ b/spec/models/concerns/purchase/blockable_velocity_noise_spec.rb
@@ -8,79 +8,120 @@ RSpec.describe Purchase::Blockable do
     let(:email) { "buyer-#{SecureRandom.hex(4)}@example.com" }
     let(:ip) { "203.0.113.44" }
 
-    def failed_attempt(error_code:, fingerprint:, processor: "stripe", guid_override: nil)
-      create(:failed_purchase,
-             email:,
-             browser_guid: guid_override || guid,
-             ip_address: ip,
-             charge_processor_id: processor,
-             stripe_fingerprint: fingerprint,
-             error_code:)
+    # Card declines land in stripe_error_code and leave error_code NULL, which is the row shape
+    # production actually writes (see Purchase#handle_charge_processor_card_error). Setting
+    # error_code instead would test a row that never exists and hide a wrong-column filter.
+    def declined(code, fingerprint:, processor: "stripe")
+      create(:failed_purchase, email:, browser_guid: guid, ip_address: ip,
+                               charge_processor_id: processor,
+                               stripe_fingerprint: fingerprint,
+                               stripe_error_code: code)
     end
 
-    # The trigger under test fires at MAX_NUMBER_OF_FAILED_FINGERPRINTS (4) distinct fingerprints.
-    def trip_with(error_code:, processor: "stripe")
-      4.times { |i| failed_attempt(error_code:, fingerprint: "fp#{i}#{SecureRandom.hex(3)}", processor:) }
-      purchase = build(:purchase, email:, browser_guid: guid, ip_address: ip,
-                                  stripe_fingerprint: "fp-live-#{SecureRandom.hex(3)}")
-      purchase.send(:block_buyer_based_on_recent_failures!)
-      purchase
+    def outage(code, fingerprint:, processor: "stripe")
+      create(:failed_purchase, email:, browser_guid: guid, ip_address: ip,
+                               charge_processor_id: processor,
+                               stripe_fingerprint: fingerprint,
+                               error_code: code)
     end
 
-    context "when the failures are ordinary issuer declines" do
+    def live_attempt(fingerprint: "fp-live-#{SecureRandom.hex(3)}", processor: "stripe")
+      create(:failed_purchase, email:, browser_guid: guid, ip_address: ip,
+                               charge_processor_id: processor, stripe_fingerprint: fingerprint)
+    end
+
+    context "when four distinct cards are declined for fraud" do
+      it "still blocks the buyer" do
+        4.times { |i| declined(PurchaseErrorCode::CARD_DECLINED_FRAUDULENT, fingerprint: "fraud#{i}") }
+
+        live_attempt.send(:block_buyer_based_on_recent_failures!)
+
+        expect(PlatformBlock.active.find_by(object_value: email)).to be_present
+      end
+
+      it "still blocks the browser guid" do
+        4.times { |i| declined(PurchaseErrorCode::CARD_DECLINED_FRAUDULENT, fingerprint: "guidfraud#{i}") }
+
+        live_attempt.send(:ban_fraudulent_buyer_browser_guid!)
+
+        expect(PlatformBlock.active.find_by(object_value: guid)).to be_present
+      end
+
+      it "still blocks the ip address" do
+        4.times { |i| declined(PurchaseErrorCode::CARD_DECLINED_FRAUDULENT, fingerprint: "ipfraud#{i}") }
+
+        live_attempt.send(:block_ip_address_based_on_recent_failures!)
+
+        expect(PlatformBlock.active.find_by(object_value: ip)).to be_present
+      end
+    end
+
+    context "when the declines describe the buyer's balance" do
       it "does not block on insufficient funds" do
-        trip_with(error_code: PurchaseErrorCode::STRIPE_INSUFFICIENT_FUNDS)
+        4.times { |i| declined(PurchaseErrorCode::STRIPE_INSUFFICIENT_FUNDS, fingerprint: "nsf#{i}") }
+
+        live_attempt.send(:block_buyer_based_on_recent_failures!)
 
         expect(PlatformBlock.active.find_by(object_value: email)).to be_nil
-        expect(PlatformBlock.active.find_by(object_value: guid)).to be_nil
       end
 
       it "does not block on transaction_not_allowed" do
-        trip_with(error_code: "card_declined_transaction_not_allowed")
+        4.times { |i| declined("card_declined_transaction_not_allowed", fingerprint: "tna#{i}") }
 
-        expect(PlatformBlock.active.find_by(object_value: email)).to be_nil
-      end
-    end
-
-    context "when the failures are our own outage codes" do
-      it "does not block on stripe_unavailable" do
-        trip_with(error_code: PurchaseErrorCode::STRIPE_UNAVAILABLE)
+        live_attempt.send(:block_buyer_based_on_recent_failures!)
 
         expect(PlatformBlock.active.find_by(object_value: email)).to be_nil
       end
 
-      it "does not write an IP block during a processor incident" do
-        4.times { |i| failed_attempt(error_code: PurchaseErrorCode::STRIPE_UNAVAILABLE, fingerprint: "ip-fp#{i}") }
-        purchase = build(:purchase, email:, browser_guid: guid, ip_address: ip,
-                                    stripe_fingerprint: "fp-live")
-        purchase.send(:block_ip_address_based_on_recent_failures!)
+      it "still blocks on the issuer's catch-all decline" do
+        4.times { |i| declined("card_declined_generic_decline", fingerprint: "gen#{i}") }
 
-        expect(PlatformBlock.active.find_by(object_value: ip)).to be_nil
-      end
-    end
-
-    context "when the failures are genuine fraud declines" do
-      it "still blocks the buyer" do
-        4.times { |i| failed_attempt(error_code: PurchaseErrorCode::CARD_DECLINED_FRAUDULENT, fingerprint: "fraud-fp#{i}") }
-        purchase = create(:failed_purchase, email:, browser_guid: guid, ip_address: ip,
-                                            stripe_fingerprint: "fp-live-fraud",
-                                            error_code: PurchaseErrorCode::CARD_DECLINED_FRAUDULENT)
-        purchase.send(:block_buyer_based_on_recent_failures!)
+        live_attempt.send(:block_buyer_based_on_recent_failures!)
 
         expect(PlatformBlock.active.find_by(object_value: email)).to be_present
       end
     end
 
-    context "when the distinct fingerprints are PayPal per-transaction tokens" do
-      it "does not treat one wallet as four cards" do
-        %w[B-4RX09118X48790402 B-1E323802CG6792744 B-9KL22119Y11002931 B-7PQ55410Z22114882]
-          .each { |token| failed_attempt(error_code: PurchaseErrorCode::PAYPAL_UNAVAILABLE, fingerprint: token, processor: "paypal") }
+    context "when the failures are our own outage codes" do
+      it "does not block the buyer" do
+        4.times { |i| outage(PurchaseErrorCode::STRIPE_UNAVAILABLE, fingerprint: "out#{i}") }
 
-        purchase = build(:purchase, email:, browser_guid: guid, ip_address: ip,
-                                    stripe_fingerprint: "B-live-token")
-        purchase.send(:ban_fraudulent_buyer_browser_guid!)
+        live_attempt.send(:block_buyer_based_on_recent_failures!)
+
+        expect(PlatformBlock.active.find_by(object_value: email)).to be_nil
+      end
+
+      it "does not write an IP block during a processor incident" do
+        4.times { |i| outage(PurchaseErrorCode::STRIPE_UNAVAILABLE, fingerprint: "outip#{i}") }
+
+        live_attempt.send(:block_ip_address_based_on_recent_failures!)
+
+        expect(PlatformBlock.active.find_by(object_value: ip)).to be_nil
+      end
+    end
+
+    context "with PayPal per-transaction tokens" do
+      it "does not treat one wallet's retries as four cards" do
+        %w[B-4RX09118X48790402 B-1E323802CG6792744 B-9KL22119Y11002931 B-7PQ55410Z22114882]
+          .each { |token| declined(PurchaseErrorCode::CARD_DECLINED_FRAUDULENT, fingerprint: token, processor: "paypal") }
+
+        live_attempt(processor: "paypal", fingerprint: "B-live").send(:ban_fraudulent_buyer_browser_guid!)
 
         expect(PlatformBlock.active.find_by(object_value: guid)).to be_nil
+      end
+
+      it "still blocks somebody cycling four different PayPal accounts" do
+        4.times do |i|
+          create(:failed_purchase, email: "payer#{i}-#{SecureRandom.hex(3)}@example.com",
+                                   browser_guid: guid, ip_address: ip,
+                                   charge_processor_id: "paypal",
+                                   stripe_fingerprint: "B-#{SecureRandom.hex(8)}",
+                                   stripe_error_code: PurchaseErrorCode::CARD_DECLINED_FRAUDULENT)
+        end
+
+        live_attempt(processor: "paypal", fingerprint: "B-live2").send(:ban_fraudulent_buyer_browser_guid!)
+
+        expect(PlatformBlock.active.find_by(object_value: guid)).to be_present
       end
     end
   end

--- a/spec/models/concerns/purchase/blockable_velocity_noise_spec.rb
+++ b/spec/models/concerns/purchase/blockable_velocity_noise_spec.rb
@@ -56,17 +56,27 @@ RSpec.describe Purchase::Blockable do
       end
     end
 
-    context "when the declines describe the buyer's balance" do
-      it "does not block on insufficient funds" do
+    context "when the issuer answered about the card" do
+      # The attacker picks the amount and the card, so exempting an issuer-answered decline hands
+      # them a velocity-free oracle for validating a stolen list.
+      it "still blocks on insufficient funds" do
         4.times { |i| declined(PurchaseErrorCode::STRIPE_INSUFFICIENT_FUNDS, fingerprint: "nsf#{i}") }
 
         live_attempt.send(:block_buyer_based_on_recent_failures!)
 
-        expect(PlatformBlock.active.find_by(object_value: email)).to be_nil
+        expect(PlatformBlock.active.find_by(object_value: email)).to be_present
       end
 
-      it "does not block on transaction_not_allowed" do
+      it "still blocks on transaction_not_allowed" do
         4.times { |i| declined("card_declined_transaction_not_allowed", fingerprint: "tna#{i}") }
+
+        live_attempt.send(:block_buyer_based_on_recent_failures!)
+
+        expect(PlatformBlock.active.find_by(object_value: email)).to be_present
+      end
+
+      it "does not block when our own call never reached the processor" do
+        4.times { |i| declined("card_declined_processing_error", fingerprint: "pe#{i}") }
 
         live_attempt.send(:block_buyer_based_on_recent_failures!)
 

--- a/spec/models/concerns/purchase/blockable_velocity_noise_spec.rb
+++ b/spec/models/concerns/purchase/blockable_velocity_noise_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Purchase::Blockable do
+  describe "card-testing velocity counting (gumroad-private#1701)" do
+    let(:guid) { SecureRandom.uuid }
+    let(:email) { "buyer-#{SecureRandom.hex(4)}@example.com" }
+    let(:ip) { "203.0.113.44" }
+
+    def failed_attempt(error_code:, fingerprint:, processor: "stripe", guid_override: nil)
+      create(:failed_purchase,
+             email:,
+             browser_guid: guid_override || guid,
+             ip_address: ip,
+             charge_processor_id: processor,
+             stripe_fingerprint: fingerprint,
+             error_code:)
+    end
+
+    # The trigger under test fires at MAX_NUMBER_OF_FAILED_FINGERPRINTS (4) distinct fingerprints.
+    def trip_with(error_code:, processor: "stripe")
+      4.times { |i| failed_attempt(error_code:, fingerprint: "fp#{i}#{SecureRandom.hex(3)}", processor:) }
+      purchase = build(:purchase, email:, browser_guid: guid, ip_address: ip,
+                                  stripe_fingerprint: "fp-live-#{SecureRandom.hex(3)}")
+      purchase.send(:block_buyer_based_on_recent_failures!)
+      purchase
+    end
+
+    context "when the failures are ordinary issuer declines" do
+      it "does not block on insufficient funds" do
+        trip_with(error_code: PurchaseErrorCode::STRIPE_INSUFFICIENT_FUNDS)
+
+        expect(PlatformBlock.active.find_by(object_value: email)).to be_nil
+        expect(PlatformBlock.active.find_by(object_value: guid)).to be_nil
+      end
+
+      it "does not block on transaction_not_allowed" do
+        trip_with(error_code: "card_declined_transaction_not_allowed")
+
+        expect(PlatformBlock.active.find_by(object_value: email)).to be_nil
+      end
+    end
+
+    context "when the failures are our own outage codes" do
+      it "does not block on stripe_unavailable" do
+        trip_with(error_code: PurchaseErrorCode::STRIPE_UNAVAILABLE)
+
+        expect(PlatformBlock.active.find_by(object_value: email)).to be_nil
+      end
+
+      it "does not write an IP block during a processor incident" do
+        4.times { |i| failed_attempt(error_code: PurchaseErrorCode::STRIPE_UNAVAILABLE, fingerprint: "ip-fp#{i}") }
+        purchase = build(:purchase, email:, browser_guid: guid, ip_address: ip,
+                                    stripe_fingerprint: "fp-live")
+        purchase.send(:block_ip_address_based_on_recent_failures!)
+
+        expect(PlatformBlock.active.find_by(object_value: ip)).to be_nil
+      end
+    end
+
+    context "when the failures are genuine fraud declines" do
+      it "still blocks the buyer" do
+        4.times { |i| failed_attempt(error_code: PurchaseErrorCode::CARD_DECLINED_FRAUDULENT, fingerprint: "fraud-fp#{i}") }
+        purchase = create(:failed_purchase, email:, browser_guid: guid, ip_address: ip,
+                                            stripe_fingerprint: "fp-live-fraud",
+                                            error_code: PurchaseErrorCode::CARD_DECLINED_FRAUDULENT)
+        purchase.send(:block_buyer_based_on_recent_failures!)
+
+        expect(PlatformBlock.active.find_by(object_value: email)).to be_present
+      end
+    end
+
+    context "when the distinct fingerprints are PayPal per-transaction tokens" do
+      it "does not treat one wallet as four cards" do
+        %w[B-4RX09118X48790402 B-1E323802CG6792744 B-9KL22119Y11002931 B-7PQ55410Z22114882]
+          .each { |token| failed_attempt(error_code: PurchaseErrorCode::PAYPAL_UNAVAILABLE, fingerprint: token, processor: "paypal") }
+
+        purchase = build(:purchase, email:, browser_guid: guid, ip_address: ip,
+                                    stripe_fingerprint: "B-live-token")
+        purchase.send(:ban_fraudulent_buyer_browser_guid!)
+
+        expect(PlatformBlock.active.find_by(object_value: guid)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/models/concerns/purchase/blockable_velocity_noise_spec.rb
+++ b/spec/models/concerns/purchase/blockable_velocity_noise_spec.rb
@@ -11,11 +11,12 @@ RSpec.describe Purchase::Blockable do
     # Card declines land in stripe_error_code and leave error_code NULL, which is the row shape
     # production actually writes (see Purchase#handle_charge_processor_card_error). Setting
     # error_code instead would test a row that never exists and hide a wrong-column filter.
-    def declined(code, fingerprint:, processor: "stripe")
+    def declined(code, fingerprint:, processor: "stripe", created_at: Time.current)
       create(:failed_purchase, email:, browser_guid: guid, ip_address: ip,
                                charge_processor_id: processor,
                                stripe_fingerprint: fingerprint,
-                               stripe_error_code: code)
+                               stripe_error_code: code,
+                               created_at:)
     end
 
     def outage(code, fingerprint:, processor: "stripe")
@@ -107,6 +108,33 @@ RSpec.describe Purchase::Blockable do
         live_attempt.send(:block_ip_address_based_on_recent_failures!)
 
         expect(PlatformBlock.active.find_by(object_value: ip)).to be_nil
+      end
+    end
+
+    context "when a flood of newer retries outnumbers any bounded scan" do
+      # Bulk-copies the row: hundreds of factory purchases would dominate the suite's runtime,
+      # and the flood only has to exist, not to be individually distinct.
+      def flood_with_copies_of(purchase, count:)
+        columns = (Purchase.column_names - ["id"]).map { |column| "`#{column}`" }.join(", ")
+        count.times do
+          ActiveRecord::Base.connection.execute(
+            "INSERT INTO purchases (#{columns}) SELECT #{columns} FROM purchases WHERE id = #{purchase.id}"
+          )
+        end
+      end
+
+      # A newest-N row cap taken before deduplication made the count depend on retry order: a
+      # tester could hold to three cards, retry them past the cap, and the fourth card fell out
+      # of the window before it was ever counted.
+      it "still counts a card that only appears past the flood" do
+        declined(PurchaseErrorCode::CARD_DECLINED_FRAUDULENT, fingerprint: "older-card", created_at: 2.hours.ago)
+        declined(PurchaseErrorCode::CARD_DECLINED_FRAUDULENT, fingerprint: "flood-a", created_at: 1.hour.ago)
+        flood_source = declined(PurchaseErrorCode::CARD_DECLINED_FRAUDULENT, fingerprint: "flood-b", created_at: 1.hour.ago)
+        flood_with_copies_of(flood_source, count: 201)
+
+        live_attempt.send(:ban_fraudulent_buyer_browser_guid!)
+
+        expect(PlatformBlock.active.find_by(object_value: guid)).to be_present
       end
     end
 

--- a/spec/services/onetime/clear_mistaken_buyer_blocks_spec.rb
+++ b/spec/services/onetime/clear_mistaken_buyer_blocks_spec.rb
@@ -241,6 +241,22 @@ describe Onetime::ClearMistakenBuyerBlocks do
 
       expect { described_class.new(dry_run: false).process }.to change { PlatformBlock.active.count }.from(3).to(0)
     end
+
+    # The browser reconstruction has to filter the same rows the live rule filters: counting
+    # failures the live rule ignores retains exactly the outage-manufactured blocks this cleanup
+    # exists to clear.
+    it "clears a browser block that only processor-outage failures supported" do
+      Purchase::Blockable::MAX_NUMBER_OF_FAILED_FINGERPRINTS.times do |index|
+        # update_column: creating against the already-blocked guid overwrites error_code with
+        # "blocked_browser_guid", which is not the row shape a processor outage writes.
+        create(:purchase, purchase_state: "failed",
+                          stripe_fingerprint: "outage-fingerprint-#{index}", created_at: 1.day.ago,
+                          browser_guid: failed_purchase.browser_guid)
+          .update_column(:error_code, PurchaseErrorCode::STRIPE_UNAVAILABLE)
+      end
+
+      expect { described_class.new(dry_run: false).process }.to change { PlatformBlock.active.count }.from(3).to(0)
+    end
   end
 
   # Most buyers here checked out as guests, so the purchase has no account attached and the


### PR DESCRIPTION
- [x] Scope — gumroad-private#1701 (buyers stranded by outage noise and PayPal per-attempt tokens)
- [x] Design — n/a — backend rule change with no UI surface; approach laid out under Why
- [x] Build — 7f15144aa (velocity fixes + revert-sensitive specs, review findings dispositioned below)
- [ ] Ship — merges and deploys via the release pipeline
- [x] Market — n/a — fraud-rule internals, nothing creator-facing to announce
- [x] Sell — n/a — no sellable surface

## What

Stops the card-testing velocity rules counting failures that carry no evidence about a card, and counts a PayPal wallet as one card instead of one per attempt.

## Why

The velocity rules count distinct `stripe_fingerprint` values on recent failed purchases as a proxy for "how many different cards has this person tried", then block the buyer, their browser guid, or their IP. Two things broke that proxy and stranded real buyers (gumroad-private#1701):

**Our own outage codes counted.** `stripe_unavailable` / `paypal_unavailable` mean the call never reached the processor, so the card was never contacted. A processor incident manufactured its own fraud evidence against everyone who retried during it.

**PayPal mints a fresh "card" per attempt.** PayPal writes a per-transaction billing-agreement token into `stripe_fingerprint`, so four retries on a single funding source trip a four-card rule.

#6817 gave these paths a clean-history exemption, which rescues established buyers. This fixes the trigger instead, so a first-time buyer on a new device is not blocked by a processor blip or by retrying PayPal.

Fraud declines still block: `card_declined_fraudulent` is untouched, and pinned on all three paths.

## Before / after

| Scenario | Before | After |
|---|---|---|
| 4 retries during a Stripe outage, new buyer | Buyer + IP blocked | Not counted, not blocked |
| 4 retries on one PayPal wallet | Counted as 4 cards → blocked | Counted as 1 wallet → not blocked |
| 4 stolen PayPal wallets, one checkout email | *(mid-branch regression)* counted as 1 | Counted as 4 → blocked |
| 4 cards declined `insufficient_funds` | *(mid-branch)* not counted | Counted → blocked |
| 4 cards declined `card_declined_fraudulent` | Blocked | Blocked (unchanged) |

## Fable-5 review

Full adversarial review run against the branch before opening. Findings and dispositions:

| Finding | Verdict | Disposition |
|---|---|---|
| **P1** PayPal collapse keyed on `purchases.email` — the checkout-form field the *buyer types*. An attacker holds it constant and cycles stolen wallets, collapsing any number to one unit of evidence. Weaker than `main`, which at least counted each token | Confirmed — `card_visual` holds the attested payer email and is what `attr_blockable :paypal_email` already blocks on | Fixed in e571e6469 — keyed on `card_visual`; rows with no attested payer fall back to their own token instead of merging |
| **P1** Excluding `insufficient_funds` gives testers a steerable card-validation oracle: the issuer accepted number/expiry/CVC and refused only on balance, and the attacker picks the amount. Meanwhile it does nothing for the stranded buyer — one person retrying one card is one fingerprint and can never reach a four-card threshold | Confirmed — the branch's own argument for keeping `generic_decline` applies with more force here | Fixed in 74e86e43e — dropped, with `transaction_not_allowed` on the same reasoning |
| **P2** `processing_error` and Braintree `3000` are the same signal-free class but land in `stripe_error_code`, so they were still counted | Confirmed | Fixed in 74e86e43e |
| **P2** `Onetime::ClearMistakenBuyerBlocks` must reproduce these rules exactly (blockable.rb's own comment says so) but still counted the old way — Stripe-only, no exclusions, no wallet collapse. Failed **open** (cleared a block a live rule still wanted when evidence was split across processors) and **closed** (protected the outage-noise blocks this branch calls mistaken) | Confirmed | Fixed in 74e86e43e — both callers share one implementation; 7f15144aa extends that to the browser-guid reconstruction, which was missed and still counted outage rows |
| **P2** `distinct_card_count` plucked unboundedly into Ruby; the guid rule has no time window at all | Confirmed | Fixed in e571e6469 as a newest-200 pre-dedup cap; Greptile then showed that cap made the count depend on retry order (a flood over three cards flushes the fourth out of the window before it is counted). Reworked in 7f15144aa: dedup happens in SQL and stops at the threshold, so the scan stays bounded without discarding evidence first |
| **P3** Column-pairing/NULL explanation written twice; stray blank lines | Confirmed | Trimmed |
| NULL / three-valued logic on both `NOT IN` clauses | **Confirmed safe** | Genuinely NULL-safe; column pairing correct — `ChargeProcessorCardError` → `stripe_error_code`, outage codes → `error_code` |
| Outage rows really do carry fingerprints | **Confirmed safe** | Copied from the chargeable at prepare time, before the failing call — the old code really was counting them |
| Caller parity across all three velocity rules | **Confirmed safe** | All three use the same counter; each keeps its own window and guards |
| Braintree PayPal left in the per-fingerprint bucket | **Confirmed safe** | It has a stable per-wallet fingerprint, unlike PayPal proper |
| Specs are revert-sensitive | **Confirmed safe** | Every "does not block" example fails on revert — 4 excluded rows + the live attempt = 5 distinct fingerprints under the old counting |
| `card_declined_fraudulent` still blocks | **Confirmed safe** | Pinned on buyer, guid and IP paths |

The review also flagged that the product-level and seller-level rules still count outage failures. That is a real gap but a **deliberate scope cut** — those rules block a *product* rather than a buyer and have their own thresholds and blast radius. Not silently dropped; worth its own issue.

## Test Results

`spec/models/concerns/purchase/blockable_velocity_noise_spec.rb` + `spec/services/onetime/clear_mistaken_buyer_blocks_spec.rb` — **34 examples, 0 failures**, run locally at head. Checks run:

- four distinct fraud declines still block the buyer, the browser guid, and the IP
- still blocks on `insufficient_funds` and on `transaction_not_allowed`
- still blocks on the issuer's catch-all `generic_decline`
- does not block when our own call never reached the processor (`processing_error`)
- does not block the buyer, and writes no IP block, during a processor incident
- one PayPal wallet's retries are not four cards
- **four PayPal wallets behind one checkout email still block** — the evasion the P1 was about
- **a card older than a 200-row flood of retries still counts** — Greptile's bypass; fails on revert to the pre-dedup cap
- **the cleanup clears a browser block that only outage noise supported** — fails on revert to the unfiltered reconstruction

Rows are built the way production writes them: declines set `stripe_error_code` with `error_code` NULL, outages the reverse. A fixture that set the wrong column would silently pass against a wrong-column filter, which is how the original bug in this branch survived its first round.

rubocop clean on all three changed files — this also clears the `Performance/SelectMap` offense that reddened Lint Ruby on the previous head.

## QA steps

1. On the preview app, fail a checkout four times with different test cards using `card_declined_fraudulent` → buyer/IP block still written. This is the guarantee that must not regress.
2. Retry a single PayPal wallet four times → no block.
3. Four distinct cards declining `insufficient_funds` → block written (this is the inverted case; before this PR's last commit it was exempt).
4. Simulate `stripe_unavailable` four times → no block, no IP block.

## AI disclosure

Written by Claude (Hermes agent) on Sahil's instruction. Reviewed adversarially by a separate fable-5 pass whose findings are dispositioned above. The wallet-key P1 was fixed in a parallel lane (e571e6469); rather than duplicating it I kept that fix, which is the better of the two, and applied the remaining findings on top.

