### PR TITLE
Add reply path to Stripe payout pause emails

### DIFF
--- a/app/mailers/merchant_registration_mailer.rb
+++ b/app/mailers/merchant_registration_mailer.rb
@@ -41,12 +41,12 @@ class MerchantRegistrationMailer < ApplicationMailer
 
   def stripe_payouts_disabled(user_id)
     user = User.find(user_id)
-    mail(subject: "Action required: Your payouts are paused", from: NOREPLY_EMAIL_WITH_NAME, to: user.email)
+    mail(subject: "Action required: Your payouts are paused", from: NOREPLY_EMAIL_WITH_NAME, reply_to: SUPPORT_EMAIL, to: user.email)
   end
 
   def stripe_payouts_under_review(user_id)
     user = User.find(user_id)
-    mail(subject: "Your payouts are temporarily paused", from: NOREPLY_EMAIL_WITH_NAME, to: user.email)
+    mail(subject: "Your payouts are temporarily paused", from: NOREPLY_EMAIL_WITH_NAME, reply_to: SUPPORT_EMAIL, to: user.email)
   end
 
   def stripe_account_rejected(user_id)

--- a/app/views/merchant_registration_mailer/stripe_payouts_disabled.html.erb
+++ b/app/views/merchant_registration_mailer/stripe_payouts_disabled.html.erb
@@ -7,5 +7,6 @@
     <li>We'll review your information</li>
   </ol>
   <p>Once the verification is successful, we'll immediately start processing your payouts again.</p>
+  <p>If you have questions, reply to this email or contact <%= mail_to ApplicationMailer::SUPPORT_EMAIL %>.</p>
   <p>Thank you for your patience and understanding.</p>
 </div>

--- a/app/views/merchant_registration_mailer/stripe_payouts_under_review.html.erb
+++ b/app/views/merchant_registration_mailer/stripe_payouts_under_review.html.erb
@@ -3,5 +3,6 @@
   <p>Our payments processor has temporarily paused payouts on your account while it completes a review. There's nothing you need to do right now.</p>
   <p>We'll let you know as soon as the review is complete and your payouts resume. If we need anything from you, we'll reach out.</p>
   <p>You can check your current status anytime on your <%= link_to "payments settings page", settings_payments_url %>.</p>
+  <p>If you have questions, reply to this email or contact <%= mail_to ApplicationMailer::SUPPORT_EMAIL %>.</p>
   <p>Thank you for your patience and understanding.</p>
 </div>

--- a/spec/mailers/merchant_registration_mailer_spec.rb
+++ b/spec/mailers/merchant_registration_mailer_spec.rb
@@ -89,11 +89,14 @@ describe MerchantRegistrationMailer do
       expect(mail.subject).to eq("Action required: Your payouts are paused")
       expect(mail.to).to include(user.email)
       expect(mail.from).to eq([ApplicationMailer::NOREPLY_EMAIL])
+      expect(mail.reply_to).to eq([ApplicationMailer::SUPPORT_EMAIL])
       expect(mail.body.encoded).to include("We have temporarily paused payouts on your account because our payments processor requires more information about you.")
       expect(mail.body.encoded).to include("To resume payouts:")
       expect(mail.body.encoded).to include("Submit the required documentation")
       expect(mail.body.encoded).to include("We'll review your information")
       expect(mail.body.encoded).to include("Once the verification is successful, we'll immediately start processing your payouts again.")
+      expect(mail.body.encoded).to include("reply to this email")
+      expect(mail.body.encoded).to include(ApplicationMailer::SUPPORT_EMAIL)
       expect(mail.body.encoded).to include("Thank you for your patience and understanding.")
     end
   end
@@ -106,8 +109,11 @@ describe MerchantRegistrationMailer do
       expect(mail.subject).to eq("Your payouts are temporarily paused")
       expect(mail.to).to include(user.email)
       expect(mail.from).to eq([ApplicationMailer::NOREPLY_EMAIL])
+      expect(mail.reply_to).to eq([ApplicationMailer::SUPPORT_EMAIL])
       expect(mail.body.encoded).to include("temporarily paused payouts on your account while it completes a review")
       expect(mail.body.encoded).to include("There's nothing you need to do right now.")
+      expect(mail.body.encoded).to include("reply to this email")
+      expect(mail.body.encoded).to include(ApplicationMailer::SUPPORT_EMAIL)
       expect(mail.body.encoded).to include("Thank you for your patience and understanding.")
     end
   end


### PR DESCRIPTION
## What

- Adds `Reply-To: support@gumroad.com` to both Stripe payout-pause seller emails:
  - `stripe_payouts_disabled`
  - `stripe_payouts_under_review`
- Adds explicit "reply to this email or contact support@gumroad.com" copy to both email templates.
- Covers both mailers in `MerchantRegistrationMailer` specs.

## Why

Refs antiwork/gumroad-private#1721. PR #6849 already shipped the high-volume suppression for zero-stakes `under_review` pauses. This finishes the remaining dead-end sender path so a seller who receives either payout-pause email has an obvious support route.

## Before / After

- Before: payout-pause emails came from noreply and did not tell sellers where to ask questions.
- After: both payout-pause emails still send from noreply but set `Reply-To: support@gumroad.com` and state the support route in the body.

## Test Results

- `bundle exec rspec spec/mailers/merchant_registration_mailer_spec.rb:85 spec/mailers/merchant_registration_mailer_spec.rb:105` — 2 examples, 0 failures.
- Mutation proof: reverse-applying only the mailer/template hunks while leaving the new specs in place gives 2 examples, 2 failures; restoring the hunks gives 2 examples, 0 failures.
- First run of the full mailer spec failed before assertions because this fresh worktree had no `node_modules`, so Vite could not resolve `entrypoints/email.ts`. I linked the existing main-clone `node_modules` into the worktree and reran the two touched examples successfully.

## QA steps

- Rendered both touched mailers through their existing specs and verified:
  - `mail.reply_to == [ApplicationMailer::SUPPORT_EMAIL]`
  - body includes "reply to this email"
  - body includes `support@gumroad.com`

## Fable-5 adversarial review

Verdict: READY-TO-MERGE on commit `9bc668c9d`.

- Confirmed scope is exactly four expected files; no DOB-drift, #6849 residue, node_modules symlink, or QA artifacts.
- Confirmed both payout-pause mailers have the support reply route, and unrelated sales/charge-disabled mailers are untouched.
- Confirmed `SUPPORT_EMAIL` resolves from `ApplicationMailer`, `reply_to:` is a standard `mail()` header option, and `mail_to ApplicationMailer::SUPPORT_EMAIL` matches existing template precedent.
- Confirmed specs pin both header and body route for both touched mailers.
- Only finding was P3: optionally use `SUPPORT_EMAIL_WITH_NAME`; accepted as not required because the repo mixes bare and named reply-to styles and the bare address is the intended routing guarantee.

---

AI disclosure: Implemented by Hermes Agent using `claude-opus-5`. Prompt: finish antiwork/gumroad-private#1721 in one PR and close it out ASAP.