### PR TITLE
Retire price rows left in a currency the product no longer uses

### DIFF
--- a/app/modules/base_price/shared.rb
+++ b/app/modules/base_price/shared.rb
@@ -39,7 +39,13 @@ module BasePrice::Shared
     end
 
     recurrences_to_delete = (BasePrice::Recurrence.all - enabled_recurrences.keys.map(&:to_s)).push(nil)
+    # A product has exactly one display currency, but create_or_update_new_price! scopes its
+    # upsert by currency — so changing the currency writes a new row and leaves the old one
+    # alive. Two live rows per recurrence make available_price_cents (and the search index it
+    # feeds) report both denominations, and Variant#recurrence_price_values picks whichever
+    # row is first by id, which is the stale one. Retire anything not in the current currency.
     prices_to_delete = prices.alive.where(recurrence: recurrences_to_delete)
+                             .or(prices.alive.where.not(currency: price_currency_type))
     prices_to_delete.map(&:mark_deleted!)
 
     enqueue_index_update_for(["price_cents", "available_price_cents"]) if prices_to_delete.any?

--- a/spec/models/variant_spec.rb
+++ b/spec/models/variant_spec.rb
@@ -752,6 +752,24 @@ describe Variant do
       expect(yearly_price.suggested_price_cents).to be_nil
     end
 
+    it "retires price rows left in a currency the product no longer uses" do
+      @variant.save_recurring_prices!(@recurrence_price_values)
+      expect(@variant.prices.alive.pluck(:currency).uniq).to eq ["usd"]
+
+      # update_column, not update!: the bare :variant factory's product has no
+      # default_price_cents, and that unrelated validation is not what this pins.
+      @variant.link.update_column(:price_currency_type, "gbp")
+      @variant.link.reload
+      @variant.save_recurring_prices!(@recurrence_price_values)
+
+      # The upsert is scoped by currency, so the GBP save writes new rows rather than
+      # rewriting the USD ones. Both denominations must not stay alive: available_price_cents
+      # plucks every alive tier price into the search index.
+      expect(@variant.prices.alive.pluck(:currency).uniq).to eq ["gbp"]
+      expect(@variant.prices.alive.count).to eq 2
+      expect(@variant.prices.where(currency: "usd")).to all(be_deleted)
+    end
+
     it "saves product prices with price_cents 0" do
       @variant.save_recurring_prices!(@recurrence_price_values)
 


### PR DESCRIPTION
## What

`save_recurring_prices!` now retires price rows whose currency is no longer the product's display currency, alongside the disabled-recurrence rows it already deleted.

## Why

Changing a product's display currency left the old rows alive. `create_or_update_new_price!` scopes its upsert by currency:

```ruby
scoped_prices = scoped_prices.where(currency: price_currency_type, recurrence:)
price = scoped_prices.last || scoped_prices.new
```

so a save in a new currency **inserts** fresh rows rather than rewriting the existing ones, while the deletion pass only considered `recurrence`. A two-tier membership saved as GBP ends up holding both `usd` and `gbp` live prices on every tier.

Two readers get this wrong:

- **`Product::Prices#available_price_cents`** plucks every alive tier price (`VariantPrice.where(variant_id: tiers.pluck(:id)).alive.is_buy.pluck(:price_cents)`) straight into the search index, so the product is indexed at both denominations simultaneously — a £5 tier also indexed as 500 USD cents.
- **`Variant#recurrence_price_values`** takes the first alive `is_buy` row matching a recurrence, ordered by id. That is the **stale** row, so reopening the editor can display the pre-change currency.

## How this was found

Adding the end-to-end coverage @slavingia asked for on #6845. The browser spec drove the real flow — pick £ on a tier amount field, Save changes — and then read back the tier price rows, which is where it failed:

```
Failure/Error: expect(tier.prices.alive.pluck(:currency).uniq).to eq ["gbp"]
  Expected ["usd", "gbp"] to eq ["gbp"].
```

Worth noting: the spec that shipped in #6851 asserts with `first_tier.alive_prices.is_buy.find_by!(currency: "eur", …)`. That looks up the row it expects, so it passes whether or not the stale `usd` rows are still alive — the defect was invisible to it. This PR pins the **set** of live currencies instead.

## Test Results

New example in `spec/models/variant_spec.rb`, **mutation-verified both ways**:

- With `app/modules/base_price/shared.rb` reverted → `1 example, 1 failure`, `Expected ["usd", "gbp"] to eq ["gbp"]`
- With the fix in place → `1 example, 0 failures`

Full `#save_recurring_prices!` group: **10 examples, 0 failures**.

The originating browser case (two-tier membership, select £, save, read back `price_currency_type` **and** every tier's live price currency) passes locally against this change.

Broader `variant_spec.rb` / `prices_spec.rb` / `products_currency_spec.rb` run shows 11 failures, all of them `create(:purchase)` → "We couldn't charge your card", a local charge-processor fixture issue. Verified pre-existing: the same two examples fail identically on an unmodified `origin/main` worktree. CI is the authority.

## QA

Backend data-integrity change with no UI surface, so the evidence is the mutation test above rather than a screenshot — the defect is invisible on screen and only observable in the `prices` rows and the search index.

Note for review: this only retires rows on the **next save** of a product. Products whose currency was changed before this lands keep their stale rows until someone saves them again. Happy to follow up with a backfill if you want the existing ones cleaned — I'd rather ask than run a data migration unprompted.

---
AI disclosure: Written by Hermes Agent using `claude-opus-5`, during the PR momentum sweep, while adding the end-to-end tests requested in review on #6845.
