### PR TITLE
Say "too large" in the unreviewable-image copy, not "re-encode"

### DIFF
--- a/app/services/content_moderation/moderate_record_service.rb
+++ b/app/services/content_moderation/moderate_record_service.rb
@@ -108,8 +108,14 @@ class ContentModeration::ModerateRecordService
       # Unlike the transient branch above, retrying can never fix this: the
       # image itself is something our review can’t read, so the seller has to
       # change it and the copy has to say so.
-      "This #{noun} includes an image in a format we can’t review (such as an SVG data URL or a very large inline image), " \
-      "so we can’t publish it as is. Re-encode that image as a regular PNG, JPEG, GIF, or WebP file and try again."
+      #
+      # Format and size are both named, and no byte figure is quoted: the two
+      # ceilings differ (MAX_DATA_IMAGE_BYTES for an inline payload, OpenAI's
+      # own limit for a URL it downloads), so one number here would be wrong for
+      # whichever case the seller is actually in. "Smaller" is what they can act
+      # on either way.
+      "This #{noun} includes an image we can’t review, because the format is unsupported (such as an SVG data URL) " \
+      "or the file is too large. Replace it with a smaller PNG, JPEG, GIF, or WebP and try again."
     elsif rs.any? { |r| r.to_s.start_with?(TOO_MANY_IMAGES_REASON_PREFIX) }
       "This #{noun} has more images than we can review, so we can’t publish it as is. " \
       "Reduce it to at most #{ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS} images " \

--- a/app/services/content_moderation/strategies/classifier_strategy.rb
+++ b/app/services/content_moderation/strategies/classifier_strategy.rb
@@ -40,7 +40,9 @@ class ContentModeration::Strategies::ClassifierStrategy
   UNSUPPORTED = :unsupported
   PERMANENT_REJECTION_CODES = %w[invalid_data_url invalid_image_format file_too_large].freeze
   UNAVAILABLE_REASON = "We cannot moderate the content at this time, please try again later or update the content."
-  UNSUPPORTED_IMAGE_REASON = "The content contains an inline image the moderation endpoint cannot review (unsupported format or too large)."
+  # Not "inline": `file_too_large` reaches here for a remote URL OpenAI
+  # downloaded and refused, not only for a `data:` payload we refused locally.
+  UNSUPPORTED_IMAGE_REASON = "The content contains an image the moderation endpoint cannot review (unsupported format or too large)."
 
   DEFAULT_THRESHOLDS = {
     "harassment" => 0.8,

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -109,6 +109,25 @@ describe Page do
       described_class.new(pageable: user, slug: "about", title: "About", custom_html: "<p>Visible copy</p><marquee>hiddenFromSanitizer</marquee>").valid?
     end
 
+    it "sends a video's poster to the classifier and never the video file itself" do
+      # gumroad-private#1728: the video src rode along with the poster, and a
+      # file over OpenAI's limit then blocked the publish for good. Asserted at
+      # the save rather than on the extractor alone, because the poster has to
+      # survive the sanitizer and reach the strategy for the page to publish.
+      expect(ContentModeration::Strategies::ClassifierStrategy).to receive(:new) do |text:, image_urls:, max_images:|
+        expect(image_urls).to eq(["https://cdn.example.com/frame.jpg"])
+        instance_double(ContentModeration::Strategies::ClassifierStrategy,
+                        perform: strategy_result.new(status: "compliant", reasoning: []))
+      end
+
+      page = described_class.new(
+        pageable: user, slug: "about", title: "About",
+        custom_html: %(<video src="https://public-files.gumroad.com/clip.mov" poster="https://cdn.example.com/frame.jpg"></video>)
+      )
+
+      expect(page).to be_valid
+    end
+
     it "lets a seller unpublish a page without waiting on the moderation service" do
       page = described_class.create!(pageable: user, custom_html: "<p>Hand-lettered posters</p>")
       stub_strategies(blocklist: "flagged", reasons: ["Matched blocked word: forbidden"])

--- a/spec/services/content_moderation/moderate_record_service_spec.rb
+++ b/spec/services/content_moderation/moderate_record_service_spec.rb
@@ -987,10 +987,24 @@ RSpec.describe ContentModeration::ModerateRecordService, :vcr do
       )
 
       expect(message).to eq(
-        "This page includes an image in a format we can’t review (such as an SVG data URL or a very large inline image), " \
-        "so we can’t publish it as is. Re-encode that image as a regular PNG, JPEG, GIF, or WebP file and try again."
+        "This page includes an image we can’t review, because the format is unsupported (such as an SVG data URL) " \
+        "or the file is too large. Replace it with a smaller PNG, JPEG, GIF, or WebP and try again."
       )
       expect(message).not_to include("temporary issue")
+    end
+
+    it "does not tell a seller whose asset is only oversized to re-encode a format they are already using" do
+      # `file_too_large` reaches this branch for a plain PNG on the seller's own
+      # CDN (gumroad-private#1728), so copy naming only the format sent them at
+      # a property of the file that was never the problem.
+      message = described_class.seller_message(
+        [ContentModeration::Strategies::ClassifierStrategy::UNSUPPORTED_IMAGE_REASON],
+        "page"
+      )
+
+      expect(message).to include("too large")
+      expect(message).not_to include("inline")
+      expect(message).not_to include("Re-encode")
     end
 
     it "explains what is missing for an off-platform fulfillment flag" do

--- a/spec/services/content_moderation/strategies/classifier_strategy_spec.rb
+++ b/spec/services/content_moderation/strategies/classifier_strategy_spec.rb
@@ -161,13 +161,23 @@ RSpec.describe ContentModeration::Strategies::ClassifierStrategy, :vcr do
   end
 
   it "tells the seller an oversized remote asset cannot be reviewed rather than to retry" do
-    image_urls = ["https://public-files.gumroad.com/tce9t60y8ecmiqx1b81v1gnzj28r"]
+    # The gumroad-private#1728 shape: one oversized asset among many, so the
+    # whole batch 400s and every image is re-asked individually. The reason has
+    # to survive that fallback — the good images come back moderated, and the
+    # only unreviewed one is a rejection no retry can change.
+    oversized = "https://public-files.gumroad.com/tce9t60y8ecmiqx1b81v1gnzj28r"
+    image_urls = ["https://cdn.example.com/ok.png", oversized]
     bad_response = instance_double(Faraday::Response, status: 400, body: "", headers: {})
     bad_error = Faraday::BadRequestError.new(
       { status: 400, body: { "error" => { "code" => "file_too_large", "message" => "File size exceeds the limit." } } },
       bad_response
     )
-    allow(client).to receive(:moderations).and_raise(bad_error)
+    allow(client).to receive(:moderations) do |parameters:|
+      urls = parameters[:input].map { |part| part.dig(:image_url, :url) }
+      raise bad_error if urls.include?(oversized)
+
+      { "results" => [{ "category_scores" => {} }] }
+    end
 
     result = described_class.new(text: "", image_urls:, max_images: :all).perform
 


### PR DESCRIPTION
## What

Follow-up to #6850. That PR added `file_too_large` to `PERMANENT_REJECTION_CODES` so an oversized asset stops telling sellers to wait for a condition that will never change. The sentence sellers actually read still described a different problem, so this fixes the copy and fills two gaps in the coverage.

- The unreviewable-image message names format and size, and asks for a smaller file.
- `UNSUPPORTED_IMAGE_REASON` drops the word "inline", since `file_too_large` arrives for a remote URL OpenAI downloaded and refused.
- The classifier spec sends the oversized asset alongside a good one, so it takes the same path the reported incident took.
- A `Page` spec covers sanitizer through validation: the poster reaches the classifier and the video `src` never does.

## Why

#6850 said the copy it selects "already reads unsupported format **or too large**". That is `UNSUPPORTED_IMAGE_REASON`, an internal string. What the seller reads is `ModerateRecordService.seller_message`, and it called the asset an inline image in an unsupported format and asked them to re-encode it as a PNG. `file_too_large` reaches that branch for a plain PNG on a seller's own CDN (gumroad-private#1728), so the seller moved from "try again in a few minutes", which could never come true, to advice about a property of the file that was never the problem.

The new copy quotes no byte figure. The two ceilings differ by two orders of magnitude — `MAX_DATA_IMAGE_BYTES` (200 KB) for a payload we refuse locally, OpenAI's own limit (20 MB) for a URL it downloads — so one number would be wrong for whichever case the seller is in. "Smaller" holds either way.

On coverage: #6850's classifier spec passed a single URL, and `moderate_images` short-circuits one URL straight to the per-image path. The reported incident carried 13 images, so the batch failed as a whole and every image was re-asked individually. The spec now rides the oversized asset alongside a good one and takes that route. Separately, every test sat at unit level, and the bug lived in the span from sanitizer to extractor to validation, so a `Page` spec now covers it end to end.

## Before / after

The seller-facing message when a page carries an image moderation cannot review:

**Before**

> This page includes an image in a format we can't review (such as an SVG data URL or a very large inline image), so we can't publish it as is. Re-encode that image as a regular PNG, JPEG, GIF, or WebP file and try again.

**After**

> This page includes an image we can't review, because the format is unsupported (such as an SVG data URL) or the file is too large. Replace it with a smaller PNG, JPEG, GIF, or WebP and try again.

No video on this one, and here is the reason rather than a claim that it is too small to matter. The only user-visible surface is this validation message. Reaching it needs a 400 from OpenAI, and the classifier returns compliant without an access token, so a local or preview environment cannot produce the state at all. The message is asserted verbatim in `moderate_record_service_spec.rb`, which is the closest thing to a screenshot this branch can offer.

## Test Results

```
bundle exec rspec spec/services/content_moderation spec/models/page_spec.rb spec/controllers/api/v2/users_controller_custom_html_spec.rb
290 examples, 0 failures

bundle exec rubocop app/services/content_moderation spec/services/content_moderation spec/models/page_spec.rb
13 files inspected, no offenses detected
```

Both new specs were confirmed to fail when the change they cover is reverted:

- restoring the pre-#6850 `page_image_urls` fails the new `Page` spec
- restoring the old sentence fails the new `seller_message` spec

---

AI disclosure: written with Claude Opus 5.
