### PR TITLE
Keep the seller's IP carve-out to the seller's own IPs

### DIFF
--- a/app/modules/purchase/risk.rb
+++ b/app/modules/purchase/risk.rb
@@ -103,9 +103,12 @@ module Purchase::Risk
       return if Feature.inactive?(:purchase_check_for_fraudulent_ips)
 
       buyer_ip_addresses = User.where(email: blockable_emails_if_fraudulent_transaction).pluck(:current_sign_in_ip, :last_sign_in_ip, :account_created_ip).flatten.compact.uniq
-      ip_addresses_to_check = [seller.current_sign_in_ip, seller.last_sign_in_ip, seller.account_created_ip, ip_address].compact.concat(buyer_ip_addresses)
+      seller_ip_addresses = [seller.current_sign_in_ip, seller.last_sign_in_ip, seller.account_created_ip].compact
+      ip_addresses_to_check = (seller_ip_addresses + [ip_address].compact).concat(buyer_ip_addresses)
       return if PlatformBlock.active.where(object_value: ip_addresses_to_check).count == 0
-      return if PlatformBlock.active.where(object_value: ip_addresses_to_check[0..2]).present? && seller.compliant?
+      # Compacting before slicing let a nil seller slot pull the buyer's IP into the first three
+      # positions, so a blocked buyer satisfied the seller's own carve-out and checked out.
+      return if PlatformBlock.active.where(object_value: seller_ip_addresses).present? && seller.compliant?
 
       self.error_code = PurchaseErrorCode::BLOCKED_IP_ADDRESS
       errors.add :base, "Your card was not charged. Please try again on a different browser and/or internet connection."

--- a/spec/modules/purchase/risk_spec.rb
+++ b/spec/modules/purchase/risk_spec.rb
@@ -273,6 +273,26 @@ describe Purchase::Risk do
           .and change { purchase.errors.full_messages }.from([]).to(["Your card was not charged. Please try again on a different browser and/or internet connection."])
       end
 
+      it "returns error when a blocked buyer ip_address lands in the seller's slots because the seller has none" do
+        seller = create(:user, current_sign_in_ip: nil, last_sign_in_ip: nil, account_created_ip: nil)
+        purchase = build(:purchase, link: create(:product, user: seller), seller:, ip_address: blocked_ip_address)
+        allow(seller).to receive(:compliant?).and_return(true)
+
+        expect do
+          purchase.check_for_fraud
+        end.to change { purchase.error_code }
+          .from(nil).to(PurchaseErrorCode::BLOCKED_IP_ADDRESS)
+      end
+
+      it "still lets a compliant seller sell when it is the seller's own ip_address that is blocked" do
+        seller = create(:user, current_sign_in_ip: blocked_ip_address)
+        purchase = build(:purchase, link: create(:product, user: seller), seller:)
+        allow(seller).to receive(:compliant?).and_return(true)
+
+        purchase.check_for_fraud
+        expect(purchase.error_code).to be_nil
+      end
+
       describe "subscription purchase" do
         let(:subscription) { create(:subscription) }
 


### PR DESCRIPTION
## What

The compliant-seller carve-out in `check_for_past_fraudulent_ips` was meant to skip the IP block when the *seller's* own IP is blocked, so a legitimate seller isn't cut off by their own address. It sliced the first three entries to mean "the seller's three IP slots":

```ruby
ip_addresses_to_check = [seller.current_sign_in_ip, seller.last_sign_in_ip, seller.account_created_ip, ip_address].compact.concat(buyer_ip_addresses)
return if PlatformBlock.active.where(object_value: ip_addresses_to_check[0..2]).present? && seller.compliant?
```

`.compact` runs before the slice, so any nil seller slot pulls the **buyer's** `ip_address` into positions 0-2. For a compliant seller, a blocked buyer IP then satisfies the seller's carve-out and the purchase is allowed.

## Why it matters

I sampled production: **136 of 300 sellers have at least one nil IP slot.** For roughly half of sellers, an `ip_address` PlatformBlock silently stops enforcing — the block row exists, admin shows it active, and checkout lets the buyer through. The carve-out fails open, which is the worst direction for a fraud control.

Found while working [gumroad-private#1724](https://github.com/antiwork/gumroad-private/issues/1724), where a blocked ban-evasion buyer returned 70 minutes after being blocked and bought $366 more from the same seller.

## Before / after

Seller with no recorded IPs, buyer checking out from a blocked IP:

| | before | after |
|---|---|---|
| `ip_addresses_to_check[0..2]` | `["<buyer blocked ip>", ...]` | n/a — seller list built separately |
| carve-out fires for compliant seller | yes, wrongly | no |
| purchase | **allowed** | rejected with `BLOCKED_IP_ADDRESS` |

Seller whose own IP is blocked (the case the carve-out exists for) is unchanged: still allowed.

## Scope

This does **not** make IP blocks enforce on its own. `check_for_past_fraudulent_ips` is still gated by `Feature.inactive?(:purchase_check_for_fraudulent_ips)`, which is off in production; @slavingia confirmed on the issue that's accidental and wants it on. This fix is a prerequisite — enabling that flag without it would leave the block non-enforcing for the ~45% of sellers with a nil IP slot.

## Tests

Two new examples in `spec/modules/purchase/risk_spec.rb`:
- a blocked buyer IP is rejected when the seller has no recorded IPs (fails before this change, passes after)
- a compliant seller whose own IP is blocked can still sell (guards against over-correcting)

Ran `spec/modules/purchase/risk_spec.rb` on this branch and on unmodified `origin/main`: both show the same 18 pre-existing failures (all `create(:purchase)` raising "We couldn't charge your card" in the chargeback contexts, a local environment issue unrelated to this file's logic). My branch adds 2 examples, 40 → 42, with the failure count unchanged — both new examples pass. CI is the authoritative check here.

## QA steps

1. Block an IP with `PlatformBlock.add!(object_type: PlatformBlock::TYPES[:ip_address], object_value: "<ip>", expires_in: 1.hour)`.
2. Enable `purchase_check_for_fraudulent_ips` for the test seller.
3. As a compliant seller with at least one nil IP slot, attempt a purchase from the blocked IP — expect rejection with the "different browser and/or internet connection" message.
4. Block the seller's own IP instead and confirm their buyers can still check out.
