### PR TITLE
Merge json_data writes onto the current row instead of overwriting it

### DIFF
--- a/app/models/concerns/json_data.rb
+++ b/app/models/concerns/json_data.rb
@@ -11,6 +11,8 @@ module JsonData
 
   included do
     serialize :json_data, coder: JSON
+
+    before_save :merge_json_data_with_current_row, if: -> { persisted? && json_data_changed? }
   end
 
   class_methods do
@@ -74,4 +76,31 @@ module JsonData
 
     default
   end
+
+  private
+    # `json_data` is one text column holding many independent attributes, so a save writes the
+    # whole blob from whatever this instance loaded. An instance that has been in memory across
+    # another request's write therefore reverts that write — silently, since nothing about the
+    # column is stale from ActiveRecord's point of view.
+    #
+    # Rebase our own delta (loaded value vs in-memory value) onto the row as it stands now, so a
+    # save only moves the keys this instance actually touched. The FOR UPDATE read holds the row
+    # until the enclosing save commits; without it the merge is just a narrower version of the
+    # same race.
+    def merge_json_data_with_current_row
+      base = (json_data_was || {}).deep_stringify_keys
+      mine = json_data
+
+      current = self.class.unscoped.lock.where(id:).pick(:json_data)
+      return if current.nil?
+
+      merged = current.deep_stringify_keys
+      (base.keys | mine.keys).each do |key|
+        next if base.key?(key) == mine.key?(key) && base[key] == mine[key]
+
+        mine.key?(key) ? merged[key] = mine[key] : merged.delete(key)
+      end
+
+      self[:json_data] = merged
+    end
 end

--- a/spec/models/concerns/json_data_spec.rb
+++ b/spec/models/concerns/json_data_spec.rb
@@ -78,4 +78,56 @@ describe JsonData do
       expect(model.json_data["attribute"]).to eq("hi")
     end
   end
+
+  describe "concurrent writers" do
+    let!(:user) { create(:user) }
+
+    it "keeps an attribute another writer set after this instance loaded json_data" do
+      stale = User.find(user.id)
+      stale.payout_threshold_cents
+
+      fresh = User.find(user.id)
+      fresh.au_backtax_sales_cents = 4321
+      fresh.save!
+
+      stale.payout_threshold_cents = 9999
+      stale.save!
+
+      expect(user.reload.au_backtax_sales_cents).to eq(4321)
+      expect(user.payout_threshold_cents).to eq(9999)
+    end
+
+    it "still deletes a key this instance removed" do
+      user.update!(gumroad_day_timezone: "UTC")
+
+      stale = User.find(user.id)
+      stale.json_data
+
+      User.find(user.id).update!(au_backtax_sales_cents: 4321)
+
+      stale.json_data.delete("gumroad_day_timezone")
+      stale.save!
+
+      expect(user.reload.json_data).not_to have_key("gumroad_day_timezone")
+      expect(user.au_backtax_sales_cents).to eq(4321)
+    end
+
+    it "lets this instance overwrite a key the other writer also set" do
+      stale = User.find(user.id)
+      stale.json_data
+
+      User.find(user.id).update!(au_backtax_sales_cents: 4321)
+
+      stale.au_backtax_sales_cents = 1111
+      stale.save!
+
+      expect(user.reload.au_backtax_sales_cents).to eq(1111)
+    end
+
+    it "does not read the row back when json_data is untouched" do
+      expect(User).not_to receive(:unscoped)
+
+      user.update!(name: "Fresh name")
+    end
+  end
 end


### PR DESCRIPTION
## Review status

Out of draft, CI green at head (81 passing / 10 skipped / 0 failing), mergeable, awaiting a human review from @gianfrancopiana.

Two things a reviewer should weigh rather than take on trust:

- Greptile's focused `JsonData` validation never started in its own lane (missing `spring` gem), so the four merge-behaviour examples — preserving independent changes, honouring key deletion, an intentional same-key overwrite, and skipping the extra row read when `json_data` is untouched — are covered by the CI suite but not by that separate pass.
- The added `SELECT … FOR UPDATE` is held until the enclosing save commits. `Purchase` is the highest-volume `JsonData` consumer, so its save latency is the post-deploy watch point.

## What

A stale in-memory record that saves any `json_data` attribute no longer overwrites the whole column from its own snapshot. `JsonData` now rebases the instance's own delta onto a locked read of the row as it stands at save time, so a save moves only the keys that instance actually touched.

## Why

`json_data` is one text column holding many independent attributes. `set_json_data_for_attr` mutates the deserialized hash and `save` writes the entire column, so the last writer wins on the whole blob rather than on the attribute it set. Two requests touching different settings on the same seller in the same window silently revert one of them — no error, nothing in Sentry, nothing stale from ActiveRecord's point of view.

`User` alone carries 13 `attr_json_data_accessor` attributes, several financial: `payout_threshold_cents`, `payout_frequency`, `au_backtax_sales_cents`, `au_backtax_owed_cents`, `payout_date_of_last_payment_failure_email`. The concern is also mixed into `Purchase`, `Refund`, `MerchantAccount`, `UserComplianceInfo`, `Integration` and others, so the class is not User-specific.

The one existing defence is in the dashboard nav code, which re-reads under `with_lock` and merges before writing. That protocol is correct and now lives in the concern, so every consumer gets it instead of one.

Reported in gumroad-private#1657 (@slavingia: "Fix").

### Design

- `before_save`, gated on `persisted? && json_data_changed?` — an unsaved record has no row to merge against, and an untouched column costs no extra query.
- The delta is computed against `json_data_was` (the value this instance loaded), not against the current row, so a key this instance *deleted* is deleted and a key it never touched is left exactly as the other writer left it.
- The read is `SELECT … FOR UPDATE`, which holds the row until the enclosing save commits. Without the lock the merge is just a narrower version of the same race.
- Rejected: optimistic locking on the column (turns a silent revert into a `StaleObjectError` in a dozen callers that have no retry path) and a database-side JSON merge (MySQL `JSON_MERGE_PATCH` cannot express key deletion, and the column is `text`, not `json`).

## Before / After

Same instance, same operation order, same row — `stale` loads `json_data`, another writer sets `au_backtax_sales_cents = 4321`, then `stale` writes `payout_threshold_cents = 9999`:

| attribute | Before (main) | After (this branch) |
|---|---|---|
| `au_backtax_sales_cents` (other writer) | `0` — **lost** | `4321` — kept |
| `payout_threshold_cents` (this writer) | `9999` | `9999` |

Produced by a `rails runner` probe that toggles only the new callback between the two runs, so the column is the sole variable. This is the issue's own reproduction, unchanged.

## Test Results

`spec/models/concerns/json_data_spec.rb` — 4 new examples under `concurrent writers`, all green:

- keeps an attribute another writer set after this instance loaded `json_data`
- still deletes a key this instance removed
- lets this instance overwrite a key the other writer also set
- does not read the row back when `json_data` is untouched

**Mutation proof.** With the `before_save` line deleted and nothing else changed, the two examples that assert the merge go red (`4 examples, 2 failures` — lines 85 and 100); the delete-still-works and no-extra-query examples stay green, which is correct since they do not depend on the merge. The specs are not vacuous.

The other 11 examples in this file fail identically **on unmodified `origin/main` in this lane** — `create(:purchase)` → `Validation failed: We couldn't charge your card`, the known local MerchantAccount env preamble. Verified by running the same file at `origin/main` in the same lane: same 11 failures, same lines. Not attributable to this diff; CI runs them with a working merchant fixture.

## QA steps

Backend-only, no rendered surface. To exercise it:

```ruby
stale = User.find(id); stale.payout_threshold_cents
User.find(id).update!(au_backtax_sales_cents: 4321)
stale.payout_threshold_cents = 9999; stale.save!
User.find(id).au_backtax_sales_cents   # => 4321 (was 0 before this change)
```

Post-deploy watch point: one extra `SELECT … FOR UPDATE` per save that touches `json_data`, inside the save's existing transaction. Worth a look at `Purchase` save latency, which is the highest-volume `JsonData` consumer.

---

🤖 Written by [Hermes Agent](https://github.com/NousResearch/hermes-agent) running `claude-opus-5`.
Instructions given: fix gumroad-private#1657 — a stale `User` instance silently wipes other `json_data` attributes, including payout settings.

