### PR TITLE
Stop the API host from redirecting an invalidated session to /login

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -277,6 +277,14 @@ class ApplicationController < ActionController::Base
       return if last_sign_in_at && last_sign_in_at.to_i >= logged_in_user.last_active_sessions_invalidated_at.to_i
 
       sign_out
+
+      # Cookies are set for `.gumroad.com`, so a browser session cookie also travels to the API
+      # host — and on Android the app's WebView cookie jar is shared with `fetch`. `/login` does
+      # not exist on the API host, so redirecting there answers an OAuth-token API call with a
+      # 404 for a page it never asked for. Token auth runs after this, and is unaffected by the
+      # cookie session being signed out, so let the request continue instead.
+      return if VALID_API_REQUEST_HOSTS.include?(request.host)
+
       flash[:warning] = "We're sorry; you have been logged out. Please login again."
       redirect_to login_path
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -278,12 +278,11 @@ class ApplicationController < ActionController::Base
 
       sign_out
 
-      # Cookies are set for `.gumroad.com`, so a browser session cookie also travels to the API
-      # host — and on Android the app's WebView cookie jar is shared with `fetch`. `/login` does
-      # not exist on the API host, so redirecting there answers an OAuth-token API call with a
-      # 404 for a page it never asked for. Token auth runs after this, and is unaffected by the
-      # cookie session being signed out, so let the request continue instead.
-      return if VALID_API_REQUEST_HOSTS.include?(request.host)
+      # The session cookie is scoped to `.gumroad.com`, so it also travels to the API host, where
+      # `login_path` is not routed at all — redirecting there answers a token-authenticated API
+      # call with a 404 for a page it never asked for. Doorkeeper runs after this and ignores the
+      # cookie session, so continue instead and let token auth answer.
+      return unless GumroadDomainConstraint.matches?(request)
 
       flash[:warning] = "We're sorry; you have been logged out. Please login again."
       redirect_to login_path

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -42,6 +42,15 @@ describe ApplicationController do
       index
       expect(response).to redirect_to(login_path)
     end
+
+    it "signs the user out without redirecting on the API host, where /login does not exist" do
+      sign_in user
+      user.update!(last_active_sessions_invalidated_at: 1.day.from_now)
+      @request.host = VALID_API_REQUEST_HOSTS.first
+      index
+      expect(response).to be_successful
+      expect(controller.send(:current_user)).to be_nil
+    end
   end
 
   describe "includes CustomDomainRouteBuilder" do

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -43,10 +43,10 @@ describe ApplicationController do
       expect(response).to redirect_to(login_path)
     end
 
-    it "signs the user out without redirecting on the API host, where /login does not exist" do
+    it "signs the user out without redirecting where login is not routed, e.g. the API host" do
       sign_in user
       user.update!(last_active_sessions_invalidated_at: 1.day.from_now)
-      @request.host = VALID_API_REQUEST_HOSTS.first
+      @request.host = API_DOMAIN.split(":").first
       index
       expect(response).to be_successful
       expect(controller.send(:current_user)).to be_nil


### PR DESCRIPTION
## What

Stop redirecting a session-invalidated request to `/login` on hosts where `login` is not routed — in practice the API host, `api.gumroad.com`. The sign-out side effect is unchanged; only the redirect is dropped.

Fixes the Android half of antiwork/gumroad-private#1616 — `RequestError: Request failed: 404 Not found` in the mobile app, 548 events / 458 users over 14 days (Sentry GUMROAD-MOBILE-Z5), every current-build event on Android.

## Why

`ApplicationController#invalidate_session_if_necessary` is a global `before_action`. When a user's `last_active_sessions_invalidated_at` is newer than their cookie session's `last_sign_in_at`, it signs the cookie session out and redirects to `login_path`. On a token-authenticated API request that redirect is both useless and harmful:

1. **The cookie reaches the API host.** `config/initializers/session_store.rb` sets `domain: :all` with `tld_length` 2, so `_gumroad_app_session` is scoped to `.gumroad.com` and is sent to `api.gumroad.com` too.
2. **Android shares the cookie jar with `fetch`.** React Native's `ForwardingCookieHandler` is backed by the WebView `CookieManager`, so cookies the in-app WebView stored are attached to plain `fetch` calls. The app runs a WebView on the Gumroad origin (`lib/use-webview-session.ts`), so a stale invalidated session cookie rides along on API reads. iOS does not share the jar the same way, which matches every current-build event being Android.
3. **`login` is not routed on the API host.** It is declared inside `constraints GumroadDomainConstraint` (`config/routes.rb:468`, `540`), which matches `VALID_REQUEST_HOSTS` only; the API host is a separate `ApiDomainConstraint` block. So the 302 lands on a 404 HTML page.

The client follows that redirect transparently and **downgrades the method to GET**, which is why Sentry breadcrumbs show `method: GET` with `status_code: 404` on calls the app makes as `POST`. `auth_path=refresh_failed` on 898 of 1631 events confirms the failure surfaces on the refresh path.

Continuing the request is safe: everything routed on the API host authenticates with an OAuth token through Doorkeeper (`doorkeeper_authorize!`) or a bearer/HMAC token, never the cookie session. `current_seller` is gated on `user_signed_in?` and `impersonated_user` keys off `current_api_user || current_user`, so both correctly go nil after `sign_out`. A stale token now gets the clean 401 the client already knows how to refresh from — and `User#invalidate_active_sessions!` revokes the mobile OAuth tokens too, so that 401 is the correct answer.

No client-side fix could work: on Android `NetworkingModule` reports the *originally requested* URL as the XHR `responseURL`, so the redirect is invisible to JS. It has to be fixed here.

The guard is keyed on `GumroadDomainConstraint.matches?(request)` — the same constraint that decides whether `login` is routed at all — rather than on a host list, so the predicate cannot drift from the route it is protecting.

## Before / After

Live probe against production, showing the responder the mobile events see:

| Request | Status | Size |
|---|---|---|
| `GET https://api.gumroad.com/login` (browser-shaped `Accept`) | 404 | 1253 B |
| `GET https://api.gumroad.com/oauth/token` (browser-shaped `Accept`) | 404 | 1253 B |
| `GET https://api.gumroad.com/login` (`Accept: */*`) | 404 | 900 B |
| `GET https://api.gumroad.com/mobile/purchases/index` (no token) | 401 | 45 B |

1253 bytes is the exact `response_body_size` on the Sentry events — the API-host 404 page with Cloudflare's RUM beacon injected (Cloudflare adds it only to HTML responses for a browser-shaped `Accept`). That pins the events to the API host's 404 rather than the web `/login` page.

| Host | Before | After |
|---|---|---|
| `gumroad.com` / `app.gumroad.com` | signed out, 302 → `/login` | unchanged |
| `api.gumroad.com` | signed out, 302 → `/login` → **404** | signed out, request continues; token auth answers (401 for a revoked token) |

## Test Results

- `spec/controllers/application_controller_spec.rb -e "invalidate_session_if_necessary"` — 4 examples, 0 failures (3 pre-existing, 1 new).
- Mutation checks on the new example, both proving it bites: deleting the guard line makes it fail on `expect(response).to be_successful`; replacing the guard with an unconditional `return` makes the pre-existing web-host example fail on the redirect. Neither direction is vacuous.
- `ruby -c` on both changed files.
- Adversarial pre-merge review: no P1/P2. It found and I confirmed one wrong claim in an earlier draft of this description (see below), plus P3 notes now folded in or recorded as follow-ups.
- Wider local run of `spec/controllers/api/mobile/` was environmentally red in this worktree (`ActiveRecord::RecordInvalid: We couldn't charge your card` from the `:purchase` factory) — identically red on `origin/main`, 8/8 the same examples, so it is not this diff. CI is the signal there and was fully green on the first commit.

**Correction to an earlier draft of this description:** it said the redirect hit the `/oauth/token` endpoint itself. It does not. `Oauth::TokensController` inherits `Doorkeeper::TokensController` → `ApplicationMetalController` → `ActionController::API` (only `base_controller` is overridden in `config/initializers/doorkeeper.rb:19`, not `base_metal_controller`), so this `before_action` never ran there. What breaks is token-*authenticated* resource calls on the API host, which is what the events are.

## Known gaps (not fixed here)

- `api_routes` is drawn a second time under the web domain as `/api/v2/...`, where `login` *does* exist, so a token-authenticated call to `gumroad.com/api/v2/...` carrying a stale browser cookie still gets an HTML login page instead of a 401. Same bug class, different host; the mobile app does not use that alias. Happy to follow up if you want it covered.
- On branch/preview deployments `config/domain.rb:96` pushes the bare web preview domain into `VALID_API_REQUEST_HOSTS` for CORS. Keying on `GumroadDomainConstraint` instead of that list means preview apps are unaffected by this change — this is why the constraint is the better predicate.

## QA steps

Executed against production to establish the mechanism, results in the Before/After table: probed `api.gumroad.com/login` and `api.gumroad.com/oauth/token` with and without a browser-shaped `Accept` header, and matched the resulting 1253-byte body to the `response_body_size` recorded on the Sentry events.

Server-side behaviour is verified by the controller specs and mutation checks above rather than a device build: the change is a redirect suppression with no UI surface, and reproducing it on a device requires an invalidated session cookie inside a store build.

## Status

- [x] **Scope** — hosts where `login` is not routed. The redirect on the web hosts is untouched and pinned by a spec.
- [x] **Design** — suppress the redirect, keyed on the constraint that routes `login`. Rejected: changing `login`'s routing, changing the session cookie domain, and an `authenticate_user!`-style `request.format` carve-out (the failing requests send a browser-shaped `Accept`, so a json/js check would never fire for them, and it would change behaviour for web XHRs that today correctly redirect).
- [x] **Build** — one guard clause, one mutation-verified spec.
- [x] **Ship** — CI green at `eff7d5d5` (81 checks passed, 0 failed). Auto-merge deliberately **not** armed: this touches an auth path that runs on every request, so it wants one human read before merge. @nyomanjyotisa
- [x] **Market** — not applicable; the user-visible effect is an error that stops happening.
- [x] **Sell** — not applicable.

Merging must **not** close GUMROAD-MOBILE-Z5: confirm the event rate drops after the production deploy first.

---

AI disclosure: written by Gumclaw (claude-opus-5).

