### PR TITLE
Duplicate profile sections, label them by type, and stop seeding subscribe copy

### DIFF
--- a/app/javascript/components/Profile/EditPage.tsx
+++ b/app/javascript/components/Profile/EditPage.tsx
@@ -122,7 +122,9 @@ export const EditProfile = ({ controls = true, selectedTabIndex, onChange, ...pr
     setSections((currentSections) => (isEqual(currentSections, props.sections) ? currentSections : props.sections));
   }, [props.sections]);
 
-  React.useEffect(() => onChange?.({ sections, tabs: tabsWithoutIds(tabs) }), [onChange, sections, tabs]);
+  React.useEffect(() => {
+    onChange?.({ sections, tabs: tabsWithoutIds(tabs) });
+  }, [onChange, sections, tabs]);
 
   const addTab = () => {
     const tab = { id: GuidGenerator.generate(), name: "New page", sections: [] };

--- a/app/javascript/components/Profile/EditSections.tsx
+++ b/app/javascript/components/Profile/EditSections.tsx
@@ -685,7 +685,6 @@ export const AddSectionButton = ({ side, index }: { index: number; side?: "top" 
               return {
                 ...commonProps,
                 type,
-                header: `Subscribe to receive email updates from ${state.creator_profile.name}.`,
                 button_label: "Subscribe",
               };
             case "SellerProfileFeaturedProductSection":

--- a/app/javascript/components/Profile/SectionsForm.test.tsx
+++ b/app/javascript/components/Profile/SectionsForm.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment happy-dom
+//
+// Covers the three profile-section-editor gaps a seller reported after building a four-tab profile
+// (gumroad-private#1714): a section could only be rebuilt by hand, a named section's row showed its
+// heading with nothing tying it to the kind of block it labels, and a new subscribe section arrived
+// with pre-filled copy that reads as intentional while every other section type starts blank.
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { assertDefined } from "$app/utils/assert";
+
+import { ProfileSectionsForm, type ProfileSectionsFormProps } from "$app/components/Profile/SectionsForm";
+
+type FormState = Parameters<NonNullable<ProfileSectionsFormProps["onChange"]>>[0];
+
+vi.stubGlobal("Routes", { root_url: () => "https://creator.gumroad.com/" });
+
+const props = (): ProfileSectionsFormProps => ({
+  bio: null,
+  currency_code: "usd",
+  creator_profile: {
+    external_id: "seller-1",
+    avatar_url: "",
+    name: "Creator",
+    twitter_handle: null,
+    subdomain: "creator.gumroad.com",
+    is_verified: false,
+    can_edit: true,
+  },
+  tabs: [{ name: "Home", sections: ["section-1"] }],
+  sections: [
+    {
+      id: "section-1",
+      type: "SellerProfilePostsSection",
+      header: "About me",
+      hide_header: false,
+      shown_posts: [],
+    },
+  ],
+  products: [],
+  posts: [],
+  wishlist_options: [],
+});
+
+const sectionRows = () => within(screen.getByRole("list", { name: "Sections" })).getAllByRole("listitem");
+
+const firstRow = () => assertDefined(sectionRows()[0]);
+
+const trackState = () => {
+  const states: FormState[] = [];
+  return {
+    onChange: (state: FormState) => void states.push(state),
+    latest: () => assertDefined(states.at(-1)),
+  };
+};
+
+afterEach(cleanup);
+
+describe("ProfileSectionsForm", () => {
+  it("duplicates a section directly below the original without touching the original", () => {
+    const tracked = trackState();
+    render(<ProfileSectionsForm {...props()} onChange={tracked.onChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Duplicate section" }));
+
+    const rows = sectionRows();
+    expect(rows).toHaveLength(2);
+    for (const row of rows) expect(within(row).getByRole("heading", { level: 3 }).textContent).toBe("About me");
+
+    const state = tracked.latest();
+    const [originalId, copyId] = assertDefined(state.tabs[0]).sections;
+    expect(originalId).toBe("section-1");
+    expect(copyId).not.toBe("section-1");
+    // The copy carries the original's content; only its identity differs, so saving it creates a
+    // second section rather than overwriting the one it was copied from.
+    expect(state.sections.find(({ id }) => id === copyId)).toMatchObject({
+      type: "SellerProfilePostsSection",
+      header: "About me",
+    });
+  });
+
+  it("inserts the copy after the section it came from, not at the end of the page", () => {
+    const withThree = props();
+    withThree.tabs = [{ name: "Home", sections: ["section-1", "section-2"] }];
+    withThree.sections = [
+      ...withThree.sections,
+      { id: "section-2", type: "SellerProfilePostsSection", header: "Contact", hide_header: false, shown_posts: [] },
+    ];
+    const tracked = trackState();
+    render(<ProfileSectionsForm {...withThree} onChange={tracked.onChange} />);
+
+    fireEvent.click(assertDefined(screen.getAllByRole("button", { name: "Duplicate section" })[0]));
+
+    const ids = assertDefined(tracked.latest().tabs[0]).sections;
+    expect(ids[0]).toBe("section-1");
+    expect(ids[2]).toBe("section-2");
+  });
+
+  it("names the section type alongside a custom heading so the row says what it labels", () => {
+    render(<ProfileSectionsForm {...props()} />);
+
+    const row = firstRow();
+    expect(within(row).getByRole("heading", { level: 3 }).textContent).toBe("About me");
+    expect(row.querySelector("h3 + small")?.textContent).toBe("Posts");
+  });
+
+  it("does not repeat the type when the heading is already the type name", () => {
+    const unnamed = props();
+    unnamed.sections = [{ ...assertDefined(unnamed.sections[0]), header: "" }];
+    render(<ProfileSectionsForm {...unnamed} />);
+
+    expect(within(firstRow()).getByRole("heading", { level: 3 }).textContent).toBe("Posts");
+    expect(firstRow().querySelector("h3 + small")).toBeNull();
+  });
+
+  it("creates a subscribe section with an empty heading like every other section type", () => {
+    const empty = props();
+    empty.tabs = [{ name: "Home", sections: [] }];
+    empty.sections = [];
+    const tracked = trackState();
+    render(<ProfileSectionsForm {...empty} onChange={tracked.onChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add section" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Subscribe" }));
+
+    expect(tracked.latest().sections[0]).toMatchObject({
+      type: "SellerProfileSubscribeSection",
+      header: "",
+      button_label: "Subscribe",
+    });
+  });
+});

--- a/app/javascript/components/Profile/SectionsForm.test.tsx
+++ b/app/javascript/components/Profile/SectionsForm.test.tsx
@@ -15,7 +15,16 @@ import { ProfileSectionsForm, type ProfileSectionsFormProps } from "$app/compone
 
 type FormState = Parameters<NonNullable<ProfileSectionsFormProps["onChange"]>>[0];
 
-vi.stubGlobal("Routes", { root_url: () => "https://creator.gumroad.com/" });
+// A rich text section mounts UpsellSelectModal, which fetches its product list on mount. Both the
+// route helper and the fetch have to exist or vitest reports the rejection as an unhandled error
+// and fails the whole run, even though every assertion passed.
+vi.stubGlobal("Routes", {
+  root_url: () => "https://creator.gumroad.com/",
+  checkout_upsells_products_path: () => "/checkout/upsells/products",
+});
+vi.stubGlobal("fetch", () =>
+  Promise.resolve(new Response("[]", { status: 200, headers: { "Content-Type": "application/json" } })),
+);
 // `SSR` is a vite `define`, so it does not exist under vitest; RichTextEditor reads it at render.
 vi.stubGlobal("SSR", false);
 

--- a/app/javascript/components/Profile/SectionsForm.test.tsx
+++ b/app/javascript/components/Profile/SectionsForm.test.tsx
@@ -10,11 +10,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { assertDefined } from "$app/utils/assert";
 
+import { type Section } from "$app/components/Profile/EditSections";
 import { ProfileSectionsForm, type ProfileSectionsFormProps } from "$app/components/Profile/SectionsForm";
 
 type FormState = Parameters<NonNullable<ProfileSectionsFormProps["onChange"]>>[0];
 
 vi.stubGlobal("Routes", { root_url: () => "https://creator.gumroad.com/" });
+// `SSR` is a vite `define`, so it does not exist under vitest; RichTextEditor reads it at render.
+vi.stubGlobal("SSR", false);
 
 const props = (): ProfileSectionsFormProps => ({
   bio: null,
@@ -112,6 +115,46 @@ describe("ProfileSectionsForm", () => {
 
     expect(within(firstRow()).getByRole("heading", { level: 3 }).textContent).toBe("Posts");
     expect(firstRow().querySelector("h3 + small")).toBeNull();
+  });
+
+  it("gives a duplicated rich text section its own upsell cards", () => {
+    const withUpsell = props();
+    withUpsell.sections = [
+      {
+        id: "section-1",
+        type: "SellerProfileRichTextSection",
+        header: "Pitch",
+        hide_header: false,
+        text: {
+          content: [
+            { type: "upsellCard", attrs: { id: "upsell-1", productId: "prod-1" } },
+            { type: "paragraph", attrs: { id: "keep-me" } },
+          ],
+        },
+      },
+    ];
+    const tracked = trackState();
+    render(<ProfileSectionsForm {...withUpsell} onChange={tracked.onChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Duplicate section" }));
+
+    const nodes = (section: Section): unknown[] => {
+      if (section.type !== "SellerProfileRichTextSection") throw new Error("expected a rich text section");
+      const content: unknown = section.text.content;
+      if (!Array.isArray(content)) throw new Error("expected rich text content");
+      return content;
+    };
+
+    const state = tracked.latest();
+    // The card keeps everything the server needs to mint a replacement upsell; only the id of the
+    // original's Upsell row is dropped, and only on the copy.
+    const copied = nodes(assertDefined(state.sections.find(({ id }) => id !== "section-1")));
+    expect(copied[0]).toEqual({ type: "upsellCard", attrs: { productId: "prod-1" } });
+    expect(copied[1]).toEqual({ type: "paragraph", attrs: { id: "keep-me" } });
+    expect(nodes(assertDefined(state.sections.find(({ id }) => id === "section-1")))[0]).toEqual({
+      type: "upsellCard",
+      attrs: { id: "upsell-1", productId: "prod-1" },
+    });
   });
 
   it("creates a subscribe section with an empty heading like every other section type", () => {

--- a/app/javascript/components/Profile/SectionsForm.tsx
+++ b/app/javascript/components/Profile/SectionsForm.tsx
@@ -633,10 +633,11 @@ export const ProfileSectionsForm = ({ onChange, disabled = false, ...props }: Pr
     ? deletionModalSection.header || SECTION_TYPE_LABELS[deletionModalSection.type]
     : "";
 
-  React.useEffect(
-    () => onChange?.({ sections, tabs: tabsWithoutIds(tabs), selectedTabIndex }),
-    [onChange, sections, selectedTabIndex, tabs],
-  );
+  React.useEffect(() => {
+    // Braces, not a concise body: React reads a returned value as a cleanup function, and `onChange`
+    // is typed `=> void`, which does not stop a caller returning something.
+    onChange?.({ sections, tabs: tabsWithoutIds(tabs), selectedTabIndex });
+  }, [onChange, sections, selectedTabIndex, tabs]);
 
   const updateSection = (updated: Section) => {
     if (disabled) return;

--- a/app/javascript/components/Profile/SectionsForm.tsx
+++ b/app/javascript/components/Profile/SectionsForm.tsx
@@ -1,4 +1,16 @@
-import { Bell, Box, ChevronDown, ChevronUp, Copy, Envelope, FileDetail, Grid, Plus, Trash } from "@boxicons/react";
+import {
+  Bell,
+  Box,
+  ChevronDown,
+  ChevronUp,
+  Copy,
+  CopyPlus,
+  Envelope,
+  FileDetail,
+  Grid,
+  Plus,
+  Trash,
+} from "@boxicons/react";
 import { EditorContent } from "@tiptap/react";
 import { isEqual, sortBy } from "lodash-es";
 import * as React from "react";
@@ -200,6 +212,7 @@ const SectionRow = ({
   disabled,
   shouldFocusHeader,
   updateSection,
+  onDuplicate,
   onDelete,
 }: {
   section: Section;
@@ -207,6 +220,7 @@ const SectionRow = ({
   disabled: boolean;
   shouldFocusHeader: boolean;
   updateSection: (section: Section) => void;
+  onDuplicate: () => void;
   onDelete: () => void;
 }) => {
   const uid = React.useId();
@@ -239,11 +253,19 @@ const SectionRow = ({
         <ReorderingHandle disabled={disabled} />
         {SECTION_TYPE_ICONS[section.type]}
         <h3>{sectionTitle}</h3>
+        {/* A named section otherwise shows only its own heading, so several sections on one page
+            read as a list of unrelated titles with no clue which block each one labels. */}
+        {section.header ? <small>{SECTION_TYPE_LABELS[section.type]}</small> : null}
       </RowContent>
       <RowActions>
         <WithTooltip tip="Copy link">
           <Button size="icon" onClick={copyLink} aria-label="Copy link">
             <Copy className="size-5" />
+          </Button>
+        </WithTooltip>
+        <WithTooltip tip="Duplicate">
+          <Button size="icon" onClick={onDuplicate} disabled={disabled} aria-label="Duplicate section">
+            <CopyPlus className="size-5" />
           </Button>
         </WithTooltip>
         <DrawerToggle
@@ -692,7 +714,6 @@ export const ProfileSectionsForm = ({ onChange, disabled = false, ...props }: Pr
         return {
           ...commonProps,
           type,
-          header: `Subscribe to receive email updates from ${props.creator_profile.name}.`,
           button_label: "Subscribe",
         };
       case "SellerProfileFeaturedProductSection":
@@ -719,6 +740,27 @@ export const ProfileSectionsForm = ({ onChange, disabled = false, ...props }: Pr
     );
     setLastAddedSectionId(section.id);
     setSections((currentSections) => [...currentSections, section]);
+    setSelectedTab(nextTabs.find((tab) => tab.id === selectedTab.id) ?? selectedTab);
+    setTabs(nextTabs);
+  };
+
+  const duplicateSection = (sectionId: string) => {
+    if (disabled || !selectedTab) return;
+
+    const original = sections.find((section) => section.id === sectionId);
+    if (!original) return;
+
+    const copy = { ...original, id: GuidGenerator.generate() };
+    const nextTabs = tabs.map((tab) => {
+      if (tab.id !== selectedTab.id) return tab;
+      const index = tab.sections.indexOf(sectionId);
+      if (index < 0) return tab;
+      const nextSections = [...tab.sections];
+      nextSections.splice(index + 1, 0, copy.id);
+      return { ...tab, sections: nextSections };
+    });
+    setLastAddedSectionId(copy.id);
+    setSections((currentSections) => [...currentSections, copy]);
     setSelectedTab(nextTabs.find((tab) => tab.id === selectedTab.id) ?? selectedTab);
     setTabs(nextTabs);
   };
@@ -786,6 +828,7 @@ export const ProfileSectionsForm = ({ onChange, disabled = false, ...props }: Pr
               disabled={disabled}
               shouldFocusHeader={section.id === lastAddedSectionId}
               updateSection={updateSection}
+              onDuplicate={() => duplicateSection(section.id)}
               onDelete={() => setDeletionModalSectionId(section.id)}
             />
           ))}

--- a/app/javascript/components/Profile/SectionsForm.tsx
+++ b/app/javascript/components/Profile/SectionsForm.tsx
@@ -206,6 +206,36 @@ const OptionRow = ({
   </Row>
 );
 
+const withFreshUpsellCards = (section: Section): Section => {
+  if (section.type !== "SellerProfileRichTextSection") return section;
+  // An upsellCard's `attrs.id` is a persisted Upsell row. SaveContentUpsellsService only mints a
+  // new one for a card that arrives without an id, so a copy keeping the original's id makes both
+  // sections share one Upsell — and removing the card from either then soft-deletes it (and its
+  // offer code) out from under the other.
+  const content = section.text.content;
+  if (!Array.isArray(content)) return section;
+  return {
+    ...section,
+    text: {
+      ...section.text,
+      content: content.map((node: unknown) => {
+        if (!isUpsellCard(node)) return node;
+        const { id: _id, ...attrs } = node.attrs;
+        return { ...node, attrs };
+      }),
+    },
+  };
+};
+
+const isUpsellCard = (node: unknown): node is { type: string; attrs: Record<string, unknown> } =>
+  typeof node === "object" &&
+  node !== null &&
+  "type" in node &&
+  node.type === "upsellCard" &&
+  "attrs" in node &&
+  typeof node.attrs === "object" &&
+  node.attrs !== null;
+
 const SectionRow = ({
   section,
   state,
@@ -751,7 +781,7 @@ export const ProfileSectionsForm = ({ onChange, disabled = false, ...props }: Pr
     const original = sections.find((section) => section.id === sectionId);
     if (!original) return;
 
-    const copy = { ...original, id: GuidGenerator.generate() };
+    const copy = withFreshUpsellCards({ ...original, id: GuidGenerator.generate() });
     const nextTabs = tabs.map((tab) => {
       if (tab.id !== selectedTab.id) return tab;
       const index = tab.sections.indexOf(sectionId);

--- a/spec/requests/user/profile_spec.rb
+++ b/spec/requests/user/profile_spec.rb
@@ -689,16 +689,17 @@ describe "User profile page", type: :system, js: true do
 
         add_section "Subscribe"
 
+        # A new subscribe section starts unnamed, like every other section type: no heading in the
+        # preview, and an empty Section name to fill in. The header follow form also renders an
+        # email field, so assert on the section's own name field rather than the preview's inputs.
         within_profile_editor_preview do
-          within_section "Subscribe to receive email updates from Gumbot.", section_element: :section do
-            expect(page).to have_field("Your email address")
-            expect(page).to have_button("Subscribe")
-          end
+          expect(page).to_not have_text("Subscribe to receive email updates from Gumbot.")
         end
 
         expect(seller.seller_profile_sections.count).to eq 0
 
-        within_section_form "Subscribe to receive email updates from Gumbot." do
+        within_section_form "Subscribe" do
+          expect(page).to have_field("Section name", with: "")
           fill_in "Section name", with: "Subscribe now or else"
           fill_in "Button label", with: "Follow"
         end


### PR DESCRIPTION
## Status

- [x] Scope — gp#1714 items 2, 3 and 4, per @slavingia: *"Fix 2, 3, and 4 in a PR"*. Item 1 (live preview) is out of scope.
- [x] Design — all three land in the sections editor (`SectionsForm.tsx`), the surface the seller was actually using.
- [x] Build — branch `gp1714-profile-section-editor`.
- [ ] Ship — **merged, not deployed.** @slavingia merged `bc8cf17` at 2026-08-03 00:27:34Z. No release tag contains it: the newest release is `v2026.08.02.29` (published 2026-08-02 23:22:07Z, 5 min before the merge) and 19 commits sit stranded on `main`, because production deploys are blocked by antiwork/gumroad-private#1699 (Nomad scheduler evaluating 1 node per eval, @ershad). Nothing here reaches sellers until that ships.
- [ ] QA captures — still owed, and no longer takeable from a preview app: the branch is merged and the preview tier was serving no certificate for any SNI through the whole merge window (same root cause, gumroad-private#1699). They come from production once a release carrying `bc8cf17` goes out; the QA steps below are what to walk.
- [x] Market — n/a, editor UX fix.
- [x] Sell — n/a.

## What

Three of the four friction points a seller reported after building a four-tab profile:

1. **Duplicate a section.** Each section row gets a "Duplicate section" action that inserts a copy of the section — content and all — directly below the original, with a fresh id, and focuses its name field. Previously the only way to repeat a layout across pages was to rebuild it by hand.
2. **Tie a heading to what it labels.** A section row whose heading is a custom string now also shows its section type beneath the heading (`About me` / *Posts*). When the seller has not named the section the row already shows the type as its heading, so nothing is repeated.
3. **Stop seeding subscribe copy.** A new Subscribe section now starts with an empty header like every other section type. It previously arrived pre-filled with `Subscribe to receive email updates from <name>.`, which reads as intentional copy rather than a placeholder — the seller nearly shipped it duplicated on two tabs. Removed in both editors (`SectionsForm.tsx` and the legacy `EditSections.tsx`).

A fable-5 adversarial review found a P1 that a naive duplicate would have shipped, now fixed in-branch: a rich-text section's `upsellCard` nodes carry `attrs.id`, a persisted `Upsell` row. `SaveContentUpsellsService#from_rich_content` only mints a new upsell for a card that arrives **without** an id, so a verbatim copy would leave two sections pointing at one `Upsell` — and removing the card from either then soft-deletes it and its offer code out from under the other. `withFreshUpsellCards` strips only `attrs.id` from the copy's upsell cards; `productId` / `variantId` / `discount` survive, so the server mints a replacement.

One further fix found while writing the tests: `ProfileSectionsForm`'s `onChange` effect used a concise arrow body, so React treated `onChange`'s return value as a cleanup function and threw `TypeError: destroy is not a function` on the next render whenever a caller's handler returned anything. The same shape was in `EditPage.tsx`; both now use a statement body.

## Why

Unsolicited, specific feedback from a creator (`smallbizaiau.gumroad.com`) with a four-tab profile. Each complaint was verified against the components on `main` before building: no `duplicate` in `EditSections.tsx`, the subscribe seed at `SectionsForm.tsx:668`, and the header input rendered with no type context.

Refs antiwork/gumroad-private#1714.

## Before/After

| | Before | After |
|---|---|---|
| Repeating a section | Rebuild by hand on every page | "Duplicate section" inserts a copy below the original |
| A named section's row | Only the seller's heading; nothing says what kind of block it is | Heading, with the section type named under it |
| New Subscribe section | Pre-filled `Subscribe to receive email updates from <name>.` | Empty header, like every other section type |

Captures owed — see the QA box above; the preview tier was down for the whole life of this branch (gumroad-private#1699), so there was never a hosted surface to capture.

## Test Results

- `npx vitest run app/javascript/components/Profile/SectionsForm.test.tsx` — 6 passed (new file).
- `spec/requests/user/profile_spec.rb:687` ("allows creating subscribe sections") pinned the old seeded copy and went red in CI; updated to assert the new empty header instead.
- Mutation-checked every new behavior. Reverting `splice(index + 1, …)` to `push`, deleting the type `<small>`, and restoring the subscribe seed each redden their own example; dropping `withFreshUpsellCards` reddens the upsell example alone.
- `npx eslint` and `npx prettier --check` on all four touched files — clean.
- `npx tsc --noEmit` — no diagnostics in `app/javascript/components/Profile/`.

## QA steps

1. Settings → Profile → Pages tab (the sections editor).
2. Add a Subscribe section — its **Section name** field is empty, not pre-filled.
3. Give a section a name; its row shows the name with the section type underneath.
4. Click the duplicate icon on that row — an identical section appears directly beneath it, and **Update profile** saves both.
5. For the P1: duplicate a Rich text section containing an upsell card, save, then delete the card from one copy and save again. The other copy's card still resolves.

---

🤖 AI disclosure: written by Gumclaw (Hermes Agent, `claude-opus-5`) from antiwork/gumroad-private#1714 and @slavingia's instruction to fix items 2, 3 and 4.