### PR TITLE
Keep the cybersecurity category when a rollback keeps one of its children

### DIFF
--- a/db/migrate/20261206000026_add_cybersecurity_taxonomy.rb
+++ b/db/migrate/20261206000026_add_cybersecurity_taxonomy.rb
@@ -40,25 +40,30 @@ class AddCybersecurityTaxonomy < ActiveRecord::Migration[7.1]
     bust_taxonomy_cache
   end
 
-  # Only removes a subcategory that is empty. A seller who categorised a product here between
-  # deploy and rollback would otherwise have it silently repointed by the foreign key, and losing
-  # a seller's categorisation is worse than leaving a row behind.
+  # Only removes rows no product points at. A seller who categorised a product here between deploy
+  # and rollback would otherwise lose that categorisation, which is worse than leaving a row behind.
   def down
     category = Taxonomy.find_by_path([PARENT_SLUG, CATEGORY_SLUG])
     return if category.nil?
 
-    rows = Taxonomy.where(parent: category).to_a << category
-    in_use = Link.where(taxonomy_id: rows.map(&:id)).distinct.pluck(:taxonomy_id)
+    children = Taxonomy.where(parent: category).to_a
+    in_use = Link.where(taxonomy_id: children.map(&:id) << category.id).distinct.pluck(:taxonomy_id)
 
-    if in_use.any?
-      say "Keeping #{in_use.size} cybersecurity taxonomy row(s) still referenced by products"
-      rows.reject! { |row| in_use.include?(row.id) }
+    removable = children.reject { |child| in_use.include?(child.id) }
+    # The parent goes only once nothing is left under it. Dropping it while a kept child still
+    # hangs off it would orphan that child, putting the seller's product on a taxonomy path that
+    # no longer resolves to a root — worse than the rollback simply leaving the subtree in place.
+    keep_category = in_use.include?(category.id) || removable.size < children.size
+
+    if keep_category
+      say "Keeping the cybersecurity category and #{children.size - removable.size} subcategory(ies) still referenced by products"
     end
 
     # destroy, not delete_all: closure_tree maintains taxonomy_hierarchies through callbacks, and
     # a bare delete would strand those rows, leaving self_and_ancestors wrong for the subtree.
     # Children first, so the parent is childless by the time it goes.
-    rows.sort_by { |row| row.slug == CATEGORY_SLUG ? 1 : 0 }.each(&:destroy!)
+    removable.each(&:destroy!)
+    category.destroy! unless keep_category
     bust_taxonomy_cache
   end
 

--- a/spec/migrations/add_cybersecurity_taxonomy_spec.rb
+++ b/spec/migrations/add_cybersecurity_taxonomy_spec.rb
@@ -98,6 +98,34 @@ describe AddCybersecurityTaxonomy do
       expect(Taxonomy.find_by_path(%w[software-development cybersecurity penetration-testing])).to be_nil
     end
 
+    it "keeps the parent category when a child is kept, so the child is never orphaned" do
+      migration.up
+      in_use = Taxonomy.find_by_path(%w[software-development cybersecurity network-security])
+      create(:product, taxonomy: in_use)
+
+      migration.down
+
+      # Removing the parent while keeping the child would leave the seller's product on a path
+      # that no longer resolves up to a root.
+      category = Taxonomy.find_by_path([described_class::PARENT_SLUG, described_class::CATEGORY_SLUG])
+      expect(category).to be_present
+      expect(in_use.reload.parent).to eq(category)
+      expect(in_use.self_and_ancestors.pluck(:slug)).to eq(
+        %w[network-security cybersecurity software-development]
+      )
+    end
+
+    it "keeps the category when a product points at the category itself" do
+      migration.up
+      category = Taxonomy.find_by_path([described_class::PARENT_SLUG, described_class::CATEGORY_SLUG])
+      create(:product, taxonomy: category)
+
+      migration.down
+
+      expect(category.reload).to be_present
+      expect(Taxonomy.where(parent: category)).to be_empty
+    end
+
     it "does nothing when the category is already absent" do
       expect { migration.down }.not_to raise_error
     end


### PR DESCRIPTION
## What

Fixes the rollback path of the cybersecurity taxonomy migration, which merged in #6870 before this
finding was addressed.

`down` removed the parent category unconditionally while sparing any child a product pointed at:

```ruby
rows = Taxonomy.where(parent: category).to_a << category
in_use = Link.where(taxonomy_id: rows.map(&:id)).distinct.pluck(:taxonomy_id)
rows.reject! { |row| in_use.include?(row.id) }   # spares the child...
rows.sort_by { ... }.each(&:destroy!)            # ...but the parent was never in in_use
```

So a rollback after a seller had categorised a product under, say, Network Security kept that
subcategory and destroyed Cybersecurity above it. The child is left with a `parent_id` pointing at
a deleted row, and the seller's product sits on a taxonomy path that no longer resolves up to a
root. That is a worse outcome than the rollback simply leaving the subtree in place, which is what
the guard was there to achieve in the first place.

The parent now goes only when every child went with it.

## Why it matters despite being a `down`

The whole point of the original guard was that losing a seller's categorisation is worse than
leaving a row behind. Orphaning the row loses it just the same, only less visibly — nothing raises,
and the breakage shows up later as a category that renders without a root in the nav.

## Credit

Greptile flagged this on #6870. Its T-Rex validation could not execute the check (no `rspec` in the
bundle, no MySQL on the runner), so the behaviour was unverified there — it is verified here.

## Tests

20 examples, 0 failures (`spec/migrations/add_cybersecurity_taxonomy_spec.rb` +
`spec/presenters/discover/taxonomy_presenter_spec.rb`), run against an isolated database
(`gumroad_test_cyber6870`), since sibling sessions were using the shared `gumroad_test`.

Two new examples:

- the parent survives when a child is kept, asserted via
  `self_and_ancestors == %w[network-security cybersecurity software-development]` rather than a
  presence check, so it pins the ancestry rather than just the row existing;
- the category survives when a product points at the category itself.

Mutation-checked rather than assumed — restoring the exact merged behaviour
(`keep_category = in_use.include?(category.id)`, dropping the kept-children clause) turns the
orphan example RED on `expect(category).to be_present`. Restored, back to 20 green.

RuboCop clean on both files.

## QA steps

1. Run the migration, categorise a product under Cybersecurity > Network Security, then roll back.
2. Confirm Cybersecurity and Network Security both survive, the other three subcategories are gone,
   and the product's category still resolves to Software Development at the root.
3. Roll back with no products categorised and confirm the whole subtree is removed as before.
