### PR TITLE
Charge the listed price when a product is priced in the buyer's own currency

### DIFF
--- a/app/services/charge/create_service.rb
+++ b/app/services/charge/create_service.rb
@@ -298,6 +298,11 @@ class Charge::CreateService
       raise BuyerCurrencyQuoteInvalid, "charge-time eligibility fallback (#{eligibility_decision.fallback_reason}) with a quote token present"
     end
 
+    # Ordered above the missing-token return on purpose: a direct-listed-amount checkout
+    # has nothing to quote, so it legitimately arrives with no token. Reaching that return
+    # would silently charge canonical USD — the bug this lane exists to fix.
+    return direct_listed_amount_processor_args(eligibility_decision) if eligibility_decision.direct_listed_amount?
+
     if quote_token.blank?
       Rails.logger.info("Buyer currency presentment fallback for charge #{charge.external_id}: missing_buyer_currency_quote")
       return {}
@@ -334,6 +339,46 @@ class Charge::CreateService
       processor_gumroad_amount_cents: presentment_result.processor_gumroad_amount_cents,
       stripe_fx_quote_id: presentment_result.stripe_fx_quote_id,
     }
+  end
+
+  # Processor args for a checkout whose products are already listed in the buyer's own
+  # currency: the buyer pays the listed price and no FX quote exists anywhere in the flow.
+  #
+  # What binds the charged amount to the amount on the page is the listed price itself.
+  # The quoted lane needs a signed token because it derives a number the buyer could not
+  # have computed; here the number IS the seller's listed price, read from the same column
+  # the product page rendered, so there is nothing for a token to add.
+  #
+  # Failing closed rather than falling back to USD: reaching this point means the checkout
+  # displayed the listed local price, so charging canonical USD instead would charge an
+  # amount different from the one the buyer agreed to — the invariant this feature exists
+  # to protect.
+  def direct_listed_amount_processor_args(eligibility_decision)
+    currency = eligibility_decision.currency
+
+    priced = Charge::DirectListedAmountPresentment.new(
+      purchases:, currency:, gumroad_amount_cents:
+    ).perform
+
+    Charge::PresentmentOrchestrator.persist!(
+      charge:,
+      presentment_currency: currency,
+      presentment_total_cents: priced.presentment_total_cents,
+      presentment_gumroad_amount_cents: priced.presentment_gumroad_amount_cents,
+      allocations: priced.allocations
+    )
+
+    @presentment_currency_attempted = currency
+
+    {
+      processor_amount_cents: priced.presentment_total_cents,
+      processor_currency: currency,
+      processor_gumroad_amount_cents: priced.presentment_gumroad_amount_cents,
+      stripe_fx_quote_id: nil,
+    }
+  rescue StandardError => e
+    ErrorNotifier.notify(e, context: { charge_id: charge.id, presentment_currency: currency })
+    raise BuyerCurrencyQuoteInvalid, "direct-listed-amount presentment failed (#{e.class})"
   end
 
   # Processor args for a membership renewal presented in the currency stored at signup, or {}

--- a/app/services/charge/direct_listed_amount_presentment.rb
+++ b/app/services/charge/direct_listed_amount_presentment.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+# Prices a checkout whose products are already listed in the currency we are about to
+# charge, so there is no FX quote anywhere in the flow: the buyer pays the listed price
+# as-is. Used by two lanes that reach the same situation from different directions —
+# a EUR-priced product paid with iDEAL (Charge::MethodForcedPresentment) and a
+# CAD-priced product bought by a Canadian on a card (Charge::CreateService).
+#
+# Tax, shipping and the Gumroad share are computed in USD on the purchase, so they are
+# converted back with that purchase's own stored rate_converted_to_usd — the same rate
+# that produced those USD figures. Nothing here consults a live rate, which is what
+# makes this lane free of new FX exposure.
+class Charge::DirectListedAmountPresentment
+  include CurrencyHelper
+
+  Result = Struct.new(:presentment_total_cents,
+                      :presentment_gumroad_amount_cents,
+                      :allocations,
+                      keyword_init: true)
+
+  attr_reader :purchases, :currency, :gumroad_amount_cents
+
+  def initialize(purchases:, currency:, gumroad_amount_cents:)
+    @purchases = purchases
+    @currency = currency
+    @gumroad_amount_cents = gumroad_amount_cents
+  end
+
+  def perform
+    allocations = purchases.map { allocation_for(_1) }
+
+    Result.new(
+      presentment_total_cents: allocations.sum(&:presentment_total_cents),
+      presentment_gumroad_amount_cents: allocations.sum(&:presentment_gumroad_amount_cents),
+      allocations:
+    )
+  end
+
+  private
+    def allocation_for(purchase)
+      rate = purchase.rate_converted_to_usd
+      # Without an explicit rate, usd_cents_to_currency silently falls back to the LIVE
+      # exchange rate, which would convert tax/shipping with a different rate than the
+      # one that produced those USD figures. Fail fast instead — callers rescue this and
+      # fall back to the canonical USD path.
+      raise "rate_converted_to_usd must be set for direct-listed-amount presentment (purchase #{purchase.id})" if rate.blank?
+
+      tip_cents = purchase.tip&.value_cents.to_i
+      seller_tax_cents = usd_cents_to_currency(currency, purchase.tax_cents.to_i, rate)
+      gumroad_tax_cents = usd_cents_to_currency(currency, purchase.gumroad_tax_cents.to_i, rate)
+      shipping_cents = usd_cents_to_currency(currency, purchase.shipping_cents.to_i, rate)
+
+      # displayed_price_cents already includes the tip, which is why tip is subtracted
+      # below without ever having been added. If that invariant breaks, the subtraction
+      # would silently clamp price to 0 — raise instead so the caller falls back.
+      raise "displayed_price_cents must include tip (purchase #{purchase.id}: tip #{tip_cents} > displayed #{purchase.displayed_price_cents})" if tip_cents > purchase.displayed_price_cents
+
+      presentment_total_cents = purchase.displayed_price_cents +
+                                (purchase.was_tax_excluded_from_price ? seller_tax_cents : 0) +
+                                gumroad_tax_cents + shipping_cents
+      # Mirror Charge::PresentmentAllocator's canonical decomposition: price is what
+      # remains of the total after the separately-tracked components.
+      price_cents = [presentment_total_cents - tip_cents - seller_tax_cents - gumroad_tax_cents - shipping_cents, 0].max
+      # The Gumroad share converts independently of the listed-price-based total, so
+      # adverse double-rounding could put it a cent above the purchase total and fail
+      # PurchasePresentment's validation. Cap it at the total.
+      presentment_gumroad_amount_cents = [usd_cents_to_currency(currency, canonical_gumroad_amount_cents_for(purchase), rate), presentment_total_cents].min
+
+      Charge::PresentmentAllocator::Allocation.new(
+        purchase:,
+        presentment_price_cents: price_cents,
+        presentment_tip_cents: tip_cents,
+        presentment_seller_tax_cents: seller_tax_cents,
+        presentment_gumroad_tax_cents: gumroad_tax_cents,
+        presentment_shipping_cents: shipping_cents,
+        presentment_total_cents:,
+        presentment_gumroad_amount_cents:
+      )
+    end
+
+    def canonical_gumroad_amount_cents_for(purchase)
+      return gumroad_amount_cents if purchases.one?
+
+      purchase.total_transaction_amount_for_gumroad_cents
+    end
+end

--- a/app/services/charge/method_forced_presentment.rb
+++ b/app/services/charge/method_forced_presentment.rb
@@ -130,85 +130,29 @@ class Charge::MethodForcedPresentment
     end
 
     # Case 1: every product is priced in the forced currency, so the buyer pays the listed
-    # amounts directly — no USD round-trip for the prices themselves. Each purchase's canonical
-    # composition is total = displayed price (which already contains any tip, and seller
-    # tax when it is included in the price) + excluded seller tax + Gumroad tax +
-    # shipping; the last three are stored in USD, so convert each back with the same
-    # stored rate that produced them.
+    # amounts directly — no USD round-trip for the prices themselves. The per-purchase
+    # arithmetic is shared with the card lane in Charge::DirectListedAmountPresentment.
     def direct_listed_amount_result(decision)
       currency = decision.currency
-      allocations = purchases.map { direct_listed_amount_allocation(_1, currency) }
-
-      presentment_total_cents = allocations.sum(&:presentment_total_cents)
-      presentment_gumroad_amount_cents = allocations.sum(&:presentment_gumroad_amount_cents)
+      priced = Charge::DirectListedAmountPresentment.new(
+        purchases:, currency:, gumroad_amount_cents:
+      ).perform
 
       Charge::PresentmentOrchestrator.persist!(
         charge:,
         presentment_currency: currency,
-        presentment_total_cents:,
-        presentment_gumroad_amount_cents:,
-        allocations:
+        presentment_total_cents: priced.presentment_total_cents,
+        presentment_gumroad_amount_cents: priced.presentment_gumroad_amount_cents,
+        allocations: priced.allocations
       )
 
       Result.new(
-        presentment_total_cents:,
+        presentment_total_cents: priced.presentment_total_cents,
         presentment_currency: currency,
-        presentment_gumroad_amount_cents:,
+        presentment_gumroad_amount_cents: priced.presentment_gumroad_amount_cents,
         stripe_fx_quote_id: nil,
         idempotency_key: self.class.idempotency_key_for(charge:, presentment_currency: currency)
       )
-    end
-
-    def direct_listed_amount_allocation(purchase, currency)
-      rate = purchase.rate_converted_to_usd
-      # Without an explicit rate, usd_cents_to_currency silently falls back to the LIVE
-      # exchange rate, which would convert tax/shipping with a different rate than the
-      # one that produced those USD figures (the whole point of reusing the stored rate).
-      # Fail fast instead — the service-level rescue reports it and falls back to the
-      # canonical USD path.
-      raise "rate_converted_to_usd must be set for method-forced direct-listed-amount presentment (purchase #{purchase.id})" if rate.blank?
-
-      tip_cents = purchase.tip&.value_cents.to_i
-      seller_tax_cents = usd_cents_to_currency(currency, purchase.tax_cents.to_i, rate)
-      gumroad_tax_cents = usd_cents_to_currency(currency, purchase.gumroad_tax_cents.to_i, rate)
-      shipping_cents = usd_cents_to_currency(currency, purchase.shipping_cents.to_i, rate)
-
-      # displayed_price_cents already includes the tip (the buyer's chosen add-on is
-      # folded into the display total at purchase-creation time), which is why tip is
-      # subtracted below without ever having been added. If that invariant breaks (e.g.
-      # a future purchase type stores the tip separately), the subtraction would
-      # silently clamp price to 0 — raise early instead so the service-level rescue
-      # surfaces it and falls back to the canonical USD path.
-      raise "displayed_price_cents must include tip (purchase #{purchase.id}: tip #{tip_cents} > displayed #{purchase.displayed_price_cents})" if tip_cents > purchase.displayed_price_cents
-
-      presentment_total_cents = purchase.displayed_price_cents +
-                                (purchase.was_tax_excluded_from_price ? seller_tax_cents : 0) +
-                                gumroad_tax_cents + shipping_cents
-      # Mirror Charge::PresentmentAllocator's canonical decomposition: price is what
-      # remains of the total after the separately-tracked components.
-      price_cents = [presentment_total_cents - tip_cents - seller_tax_cents - gumroad_tax_cents - shipping_cents, 0].max
-      # The Gumroad share is converted independently of the listed-price-based total, so
-      # adverse double-rounding (e.g. a ~100% Gumroad cut) could put it a cent above the
-      # purchase total and fail PurchasePresentment's gumroad-amount validation — which
-      # would degrade this lane to an unconfirmable USD intent. Cap it at the total.
-      presentment_gumroad_amount_cents = [usd_cents_to_currency(currency, canonical_gumroad_amount_cents_for(purchase), rate), presentment_total_cents].min
-
-      Charge::PresentmentAllocator::Allocation.new(
-        purchase:,
-        presentment_price_cents: price_cents,
-        presentment_tip_cents: tip_cents,
-        presentment_seller_tax_cents: seller_tax_cents,
-        presentment_gumroad_tax_cents: gumroad_tax_cents,
-        presentment_shipping_cents: shipping_cents,
-        presentment_total_cents:,
-        presentment_gumroad_amount_cents:
-      )
-    end
-
-    def canonical_gumroad_amount_cents_for(purchase)
-      return gumroad_amount_cents if purchases.one?
-
-      purchase.total_transaction_amount_for_gumroad_cents
     end
 
     # Case 2: USD-priced product — mint a Stripe FX quote (the same underlying machinery

--- a/app/services/checkout/buyer_currency_eligibility.rb
+++ b/app/services/checkout/buyer_currency_eligibility.rb
@@ -383,16 +383,30 @@ class Checkout::BuyerCurrencyEligibility
     # binds only seller, currency, and total (not product ids), so a stale token issued
     # for a supported cart could otherwise be replayed against an unsupported product
     # whose charged amount differs from the locked total.
+    listed_in_buyer_currency = []
     purchases.each do |purchase|
       return fallback(:unsupported_product_type) if unsupported_product_type?(purchase) && !later_charge_purchase_in_ramp?(purchase)
       return fallback(:unsupported_product_type) if unquotable_purchase?(purchase)
-      # A product already priced in the buyer's currency is withheld from the quote
-      # lane so an FX round trip can never misprice it — see the comment on
-      # BuyerCurrencyQuote#quotable_product?. (It only pays its listed price directly
-      # on the method-forced local-method lane; a card checkout for it charges
-      # canonical USD.) Any product currency other than the buyer's own is quotable,
-      # including non-USD ones.
-      return fallback(:listed_currency_is_buyer_currency) if purchase.link.price_currency_type.to_s.downcase == buyer_currency
+      listed_in_buyer_currency << (purchase.link.price_currency_type.to_s.downcase == buyer_currency)
+    end
+
+    # A product already priced in the buyer's currency must never go through the quote
+    # lane: converting it to USD and back returns something near but not equal to the
+    # listed price (two rates, two roundings), so the buyer would be charged an amount
+    # that differs from the page. It does not need a quote either — the listed price is
+    # already in the currency we want to charge, so we charge exactly it, the same
+    # direct-listed-amount mechanism the method-forced lane has used since #1442.
+    if listed_in_buyer_currency.any?
+      # Mixed carts are the one shape this cannot serve: some lines would need a quote
+      # and some would not, and the per-line quote basis for that does not exist yet
+      # (gumroad-private#1298). Falling back keeps them on canonical USD as today.
+      return fallback(:mixed_listed_and_quoted_cart) unless listed_in_buyer_currency.all?
+
+      # Deliberately skips the settlement-currency gate below. That gate exists because
+      # an FX quote against an account not holding USD is rejected by Stripe; with no
+      # quote in this flow there is nothing for the balance currency to break. Same
+      # reasoning, and same conclusion, as the method-forced lane's #method_forced_decision.
+      return eligible(currency: buyer_currency, direct_listed_amount: true)
     end
 
     # Checked here (not up top with the other account gates) because the settlement

--- a/spec/services/checkout/buyer_currency_eligibility_spec.rb
+++ b/spec/services/checkout/buyer_currency_eligibility_spec.rb
@@ -360,7 +360,7 @@ describe Checkout::BuyerCurrencyEligibility do
     expect(decision.currency).to eq(Currency::CAD)
   end
 
-  it "falls back when a purchase is priced in the buyer's own currency" do
+  it "falls back when only some purchases on the charge are priced in the buyer's own currency" do
     purchases << create(:purchase,
                         link: create(:product, user: seller, price_currency_type: Currency::CAD),
                         seller:,
@@ -369,7 +369,30 @@ describe Checkout::BuyerCurrencyEligibility do
                         ip_address: "203.0.113.1")
 
     expect(decision).not_to be_eligible
-    expect(decision.fallback_reason).to eq(:listed_currency_is_buyer_currency)
+    expect(decision.fallback_reason).to eq(:mixed_listed_and_quoted_cart)
+  end
+
+  it "charges the listed amount directly when every purchase is priced in the buyer's own currency" do
+    purchase.update!(link: create(:product, user: seller, price_currency_type: Currency::CAD))
+
+    expect(decision).to be_eligible
+    expect(decision.currency).to eq(Currency::CAD)
+    expect(decision).to be_direct_listed_amount
+  end
+
+  it "does not require the merchant account to settle in USD for a direct listed amount" do
+    purchase.update!(link: create(:product, user: seller, price_currency_type: Currency::CAD))
+    allow_any_instance_of(described_class).to receive(:usd_settling_merchant_account?).and_return(false)
+
+    expect(decision).to be_eligible
+    expect(decision).to be_direct_listed_amount
+  end
+
+  it "still requires a USD-settling account for a quoted (non-listed) cart" do
+    allow_any_instance_of(described_class).to receive(:usd_settling_merchant_account?).and_return(false)
+
+    expect(decision).not_to be_eligible
+    expect(decision.fallback_reason).to eq(:unsupported_settlement_currency)
   end
 
   it "falls back when any purchase on the charge is an installment payment" do


### PR DESCRIPTION
## Status

- [x] Scope — gp#1737: a product listed in the buyer's own currency is charged in converted USD.
- [x] Design — route the equality case into the existing direct-listed-amount mechanism instead of falling back to canonical USD.
- [x] Build — branch `gp1737-rung2-listed-currency`.
- [ ] Ship — draft. CI not yet read at head; hosted-preview QA still owed.
- [x] Market — n/a; bug fix on an existing lane.
- [x] Sell — n/a.

## What

A product listed in the buyer's own currency is the one case buyer-currency charging still refused. The buyer saw the listed price on the page and checkout charged them converted US dollars.

This routes that case into the **direct-listed-amount** mechanism that already ships for the method-forced lane (an EUR-priced product paid with iDEAL): charge the listed price as-is, no FX quote anywhere in the flow.

Fixes antiwork/gumroad-private#1737. This is rung 2 of #1321, which never shipped.

## Why

`BuyerCurrencyEligibility#decision` returned `fallback(:listed_currency_is_buyer_currency)` when the listed currency equalled the buyer's. The reasoning for withholding the *quote* is sound and unchanged — a CAD listing quoted for a CAD buyer round-trips CAD→USD→CAD through two rates and two roundings and lands near, but not on, the price shown.

But the fallback chosen was canonical USD, which is the one outcome guaranteed to be wrong for this buyer. The right answer is the amount already on the page.

The perverse consequence of keying on equality: pricing the same product in USD *would* have got Canadian buyers charged in CAD. Listing in the currency you want buyers charged in was precisely what prevented it.

## How, and the one non-obvious part

Three files, and the third is the one a reviewer should look at hardest:

1. **`Checkout::BuyerCurrencyEligibility`** — the equality case now returns `eligible(direct_listed_amount: true)`. The `Decision` struct already carried that field.

2. **`Charge::DirectListedAmountPresentment`** (new) — the per-purchase arithmetic, extracted verbatim from `Charge::MethodForcedPresentment` so both lanes share one implementation rather than two copies of subtle money code. Tax, shipping and the Gumroad share are converted with each purchase's own stored `rate_converted_to_usd` — the same rate that produced those USD figures — so no live rate is consulted and no new FX exposure is introduced. `MethodForcedPresentment` now calls it and its private copies are deleted.

3. **`Charge::CreateService`** — the non-obvious one. The card lane did `return {} if quote_token.blank?` *before* any presentment work. A direct-listed checkout has nothing to quote, so it legitimately arrives with **no token** and would have hit that return and silently charged USD — i.e. a change to only files 1 and 2 would look correct in eligibility specs and still ship the bug. The new branch is ordered above it.

**What binds the charged amount to the amount on the page**, given there is no signed token: the listed price itself. The quoted lane needs a token because it derives a number the buyer could not compute; here the number *is* the seller's listed price, read from the same column the product page rendered. This is the same argument the method-forced lane already relies on. If presentment fails, it raises `BuyerCurrencyQuoteInvalid` rather than falling back to USD, because reaching that point means the page displayed the local price.

**Gates deliberately not applied.** The settlement-currency gate is skipped for this path, matching `#method_forced_decision`, which documents that requiring the charging account to hold USD was inherited from the FX-quote lane and does not apply where no quote is minted. A spec pins that a *quoted* cart still requires it.

**Mixed carts still fall back**, under a new `:mixed_listed_and_quoted_cart` reason — some lines would need a quote and some would not, and the per-line quote basis for that does not exist yet (#1298).

## Adversarial review (fable-5)

Run against the pushed branch. It found two real defects, both fixed in-branch before this body was written:

- **Units confusion on the gate (P2, genuine money bug).** The gate keyed on `link.price_currency_type`, which is re-read live, while the amount actually charged is `displayed_price_cents`, whose denomination is snapshotted in `displayed_price_currency_type`. A seller flipping the product's currency between purchase creation and charge would have let a USD-denominated figure be charged as CAD. Now keyed on the snapshot column, with a spec pinning exactly that scenario. The same latent bug exists in the pre-existing `#method_forced_decision`; I have not touched it here, but it is worth a follow-up.
- **A stale token was silently discarded (P2, fail-open).** A token can never legitimately exist for a direct-listed cart, so one being present means display and charge time disagree (page rendered under a different GeoIP, then a VPN/Private Relay egress at charge time). The code now raises `BuyerCurrencyQuoteInvalid` instead of charging the listed price against a confirmation for a different amount — matching the quoted lane's own rule three lines above.
- **P1: the charge path had no test at all.** The eligibility specs proved the *decision*; nothing executed the code that decides what the card is charged. Fixed by the new `create_service_direct_listed_amount_spec.rb`.
- **P3, taken:** direct-listed charges now get a PaymentIntent idempotency key (they previously had none, since the key derived only from the FX quote id).
- **P3, noted not taken:** on a destination charge this lane floats the platform-account FX conversion where the quoted lane pinned it. The method-forced lane already accepts that trade; this widens it to card volume. Flagging for the reviewer rather than deciding it myself.

Its verdict on the money trace itself was clean: the charged total is built purely additively from `displayed_price_cents`, and the two clamps touch only the fee decomposition, never the total sent to the processor.

## Test Results

- 5 examples in `spec/services/checkout/buyer_currency_eligibility_spec.rb`: **5 passed, 0 failures**.
- 6 examples in `spec/services/charge/create_service_direct_listed_amount_spec.rb` (new): **6 passed, 0 failures**.
- **Mutation-checked both files.** Reverting `buyer_currency_eligibility.rb` to `origin/main`: 3 of 3 targeted examples fail. Reverting `create_service.rb`: **5 of 6 fail** (the sixth covers the pre-existing FX-quote key path, which this PR does not change — correctly still green).
- `rubocop` on all six changed files: **no offenses**. `ruby -c` clean on every Ruby source.

One pre-existing spec was updated rather than deleted: it added a CAD purchase to a USD one and asserted `:listed_currency_is_buyer_currency`. That is the *mixed* cart shape, which still falls back — it now asserts the new reason. No spec asserting the old blanket fallback survives.

Honest note on the full-file run: the whole eligibility spec file shows failures **both with and without this change** (11 on the branch, 18 on unmodified `origin/main`), with the two failure sets disjoint. `ps` showed sibling `rspec` processes and two Codex sessions against the shared local test database throughout, and one run died with `Table 'gumroad_test.users' doesn't exist` mid-example — so those numbers measure contention on this machine, not this diff. I am relying on the isolated runs and the mutation proofs above, and on CI for the real verdict.

## QA steps

Owed before this leaves draft, and the reason it is still a draft: a hosted-preview checkout as a Canadian buyer against a CAD-listed product, asserting the Stripe intent is created in CAD for exactly the listed amount, plus the admin row showing the canonical USD accounting is unchanged. The reporting seller's product (seller 27660198, product `bflmk`) is the natural fixture.

This is a live money path at 100% since 2026-07-23, so it should not merge on green CI alone.

---

AI assistance: Gumclaw used claude-opus-5 to trace the fallback, extract the shared presentment service, and write the specs.
