### PR TITLE
Seller-level reputation summary behind seller_reputation_summary flag

### DIFF
--- a/app/javascript/components/Product/index.tsx
+++ b/app/javascript/components/Product/index.tsx
@@ -8,7 +8,6 @@ import { trackUserProductAction } from "$app/data/user_action_event";
 import { incrementProductViews } from "$app/data/view_event";
 import { Wishlist } from "$app/data/wishlists";
 import { Discount } from "$app/parsers/checkout";
-import { SellerReputation } from "$app/parsers/profile";
 import {
   AnalyticsData,
   AssetPreview,
@@ -20,6 +19,7 @@ import {
   Ratings,
   RatingsWithPercentages,
 } from "$app/parsers/product";
+import { SellerReputation } from "$app/parsers/profile";
 import { classNames } from "$app/utils/classNames";
 import {
   BuyerLocalCurrencyContext,

--- a/app/javascript/components/Product/index.tsx
+++ b/app/javascript/components/Product/index.tsx
@@ -8,6 +8,7 @@ import { trackUserProductAction } from "$app/data/user_action_event";
 import { incrementProductViews } from "$app/data/view_event";
 import { Wishlist } from "$app/data/wishlists";
 import { Discount } from "$app/parsers/checkout";
+import { SellerReputation } from "$app/parsers/profile";
 import {
   AnalyticsData,
   AssetPreview,
@@ -126,6 +127,9 @@ export type Product = {
   pwyw: { suggested_price_cents: number | null } | null;
   installment_plan: InstallmentPlan | null;
   ratings: RatingsWithPercentages | null;
+  // Present only while seller_reputation_summary is on for the seller. Always
+  // excludes this product's own reviews (hence "other products" in the copy).
+  seller_reputation?: SellerReputation | null;
   is_legacy_subscription: boolean;
   is_tiered_membership: boolean;
   is_recurring_billing: boolean;
@@ -727,6 +731,13 @@ export const Product = ({
           ) : null}
         </section>
         {product.ratings ? <Reviews ratings={product.ratings} productId={product.id} seller={product.seller} /> : null}
+        {product.seller_reputation ? (
+          <SellerReputationSection
+            reputation={product.seller_reputation}
+            hasOwnReviews={product.ratings != null && product.ratings.count > 0}
+            seller={product.seller}
+          />
+        ) : null}
       </section>
       {purchase && (purchase.membership || purchase.subscription_has_lapsed) && product.is_recurring_billing ? (
         <SubscriptionChoiceModal
@@ -992,6 +1003,37 @@ const Review = ({
     <ReviewComponent review={review} seller={seller} canRespond={canRespond} />
     {isLast ? null : <hr />}
   </>
+);
+
+// Labelled creator context, never the product's own rating: the two copy
+// states keep an unreviewed product visibly unreviewed, and the count links
+// through to the seller's profile so the aggregate's composition is inspectable.
+const SellerReputationSection = ({
+  reputation,
+  hasOwnReviews,
+  seller,
+}: {
+  reputation: SellerReputation;
+  hasOwnReviews: boolean;
+  seller: Seller | null;
+}) => (
+  <section className="grid gap-2 p-6 not-first:border-t" aria-label="Creator rating">
+    {!hasOwnReviews ? <div>This product has no reviews yet.</div> : null}
+    <div className="flex flex-wrap items-center gap-1">
+      <Star pack="filled" className="size-5" />
+      <span>
+        Creator rating: {reputation.average} from{" "}
+        {seller ? (
+          <a href={seller.profile_url}>
+            {reputation.count} verified {reputation.count === 1 ? "review" : "reviews"}
+          </a>
+        ) : (
+          `${reputation.count} verified ${reputation.count === 1 ? "review" : "reviews"}`
+        )}{" "}
+        across {reputation.products_count} other products.
+      </span>
+    </div>
+  </section>
 );
 
 export const RatingsSummary = ({ ratings, className }: { ratings: Ratings; className?: string }) => (

--- a/app/javascript/components/Profile/Layout.tsx
+++ b/app/javascript/components/Profile/Layout.tsx
@@ -1,4 +1,4 @@
-import { Pencil, TwitterX } from "@boxicons/react";
+import { Pencil, Star, TwitterX } from "@boxicons/react";
 import * as React from "react";
 
 import { CreatorProfile } from "$app/parsers/profile";
@@ -72,6 +72,12 @@ export const Layout = ({ creatorProfile, hideFollowForm, children }: LayoutProps
                 </WithTooltip>
               ) : null}
             </a>
+            {creatorProfile.reputation ? (
+              <div className="flex items-center gap-1 text-sm text-muted" aria-label="Creator rating">
+                <Star pack="filled" className="size-4" />
+                {`${creatorProfile.reputation.average} from ${creatorProfile.reputation.count} verified ${creatorProfile.reputation.count === 1 ? "review" : "reviews"} across ${creatorProfile.reputation.products_count} products`}
+              </div>
+            ) : null}
             {!isDesktop ? headerButtons : null}
           </div>
           {!hideFollowForm ? (

--- a/app/javascript/parsers/profile.ts
+++ b/app/javascript/parsers/profile.ts
@@ -11,7 +11,12 @@ export type CreatorProfile = {
   // several previews build a CreatorProfile client-side without one; a missing
   // key and a null key both mean "no challenge".
   follow_recaptcha_site_key?: string | null;
+  // Present only while seller_reputation_summary is enabled for the seller;
+  // null when they miss the display thresholds (10+ reviews across 2+ products).
+  reputation?: SellerReputation | null;
 };
+
+export type SellerReputation = { average: number; count: number; products_count: number };
 
 export type Tab = { name: string; sections: string[] };
 export type ProfileSettings = {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,7 @@ class User < ApplicationRecord
           DirectAffiliates, AsJson, Tier, Recommendations, Team, AustralianBacktaxes, WithCdnUrl,
           TwoFactorAuthentication, Versionable, Comments, VipCreator, SignedUrlHelper, Purchases, SecureExternalId,
           AttributeBlockable, PayoutInfo, EmailNormalization, SingleUseResetPasswordToken,
-          DashboardNavItems
+          DashboardNavItems, ReputationSummary
 
   has_many :user_external_authentications, dependent: :destroy
 

--- a/app/modules/user/reputation_summary.rb
+++ b/app/modules/user/reputation_summary.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Seller-level rating rollup over per-product review stats, computed on read
+# (same maths as Link#bundle_rating_stats: sum the per-star counters, weight by
+# review count). Everything here is gated on the :seller_reputation_summary
+# Flipper flag via reputation_summary_enabled?.
+module User::ReputationSummary
+  # Below these the rollup reads as noise, not signal (gumroad-private#1669).
+  # Product-owned numbers: change them in one line, not by redesign.
+  MIN_REVIEWS = 10
+  MIN_PRODUCTS = 2
+
+  def reputation_summary_enabled?
+    Feature.active?(:seller_reputation_summary, self)
+  end
+
+  # Returns { average:, count:, products_count: } or nil when the seller does
+  # not meet the display gate. exclude_product keeps a product page's rollup
+  # from silently counting that product's own reviews.
+  def seller_reputation_summary(exclude_product: nil)
+    return nil unless reputation_summary_enabled?
+
+    counts = Hash.new(0)
+    products_count = 0
+    # display_product_reviews is a Link flag bit, not a column, so opted-out
+    # products are rejected in Ruby rather than in SQL.
+    stats = ProductReviewStat.joins(:link)
+      .merge(Link.alive)
+      .where(links: { user_id: id })
+      .where.not(reviews_count: 0)
+      .preload(:link)
+    stats.each do |stat|
+      next if exclude_product && stat.link_id == exclude_product.id
+      next unless stat.link.display_product_reviews?
+
+      products_count += 1
+      stat.rating_counts.each { |rating, count| counts[rating] += count.to_i }
+    end
+
+    total = counts.values.sum
+    return nil if total < MIN_REVIEWS || products_count < MIN_PRODUCTS
+
+    {
+      average: (counts.sum { |rating, count| rating * count }.to_f / total).round(1),
+      count: total,
+      products_count:,
+    }
+  end
+end

--- a/app/presenters/product_presenter/product_props.rb
+++ b/app/presenters/product_presenter/product_props.rb
@@ -34,6 +34,9 @@ class ProductPresenter::ProductProps
         long_url: product.long_url,
         is_sales_limited: product.max_purchase_count?,
         ratings: product.display_product_reviews? ? product.bundle_rating_stats : nil,
+        # Excludes this product so its own reviews never inflate the seller
+        # rollup shown on its page (gumroad-private#1669).
+        **(seller.reputation_summary_enabled? ? { seller_reputation: seller.seller_reputation_summary(exclude_product: product) } : {}),
         custom_button_text_option: product.custom_button_text_option,
         is_compliance_blocked: product.compliance_blocked(request.remote_ip),
         is_published: !product.draft && product.alive?,

--- a/app/presenters/profile_presenter.rb
+++ b/app/presenters/profile_presenter.rb
@@ -24,6 +24,9 @@ class ProfilePresenter
       # key and FollowersController verifies the resulting token against the
       # same one, since Google ties a token to the key that produced it.
       follow_recaptcha_site_key: FollowRecaptcha.required?(seller) ? FollowRecaptcha.site_key : nil,
+      # Key present only while the flag is on, so flipping it off removes the
+      # surface entirely instead of shipping a null the frontend must know about.
+      **(seller.reputation_summary_enabled? ? { reputation: seller.seller_reputation_summary } : {}),
     }
   end
 

--- a/app/services/pages/profile_data.rb
+++ b/app/services/pages/profile_data.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class Pages::ProfileData
-  # Bumped when the shape of the cached payload changes (v5 added the *_total counts and
-  # moved product/post URLs onto the seller's live custom domain), so already-cached entries
-  # built by the previous shape are not served to pages that now expect the new keys.
-  CACHE_VERSION = "v5"
+  # Bumped when the shape of the cached payload changes (v6 added seller_rating), so
+  # already-cached entries built by the previous shape are not served to pages that
+  # now expect the new keys.
+  CACHE_VERSION = "v6"
   MAX_ITEMS = 100
   DESCRIPTION_LIMIT = 200
 
@@ -25,6 +25,9 @@ class Pages::ProfileData
         # advertising an incomplete catalogue (gumroad-private#1522).
         products_total: products_total(seller),
         posts_total: posts_total(seller),
+        # nil both when gated off and when the seller misses the display
+        # thresholds; a page treats the two identically (show nothing).
+        seller_rating: seller.seller_reputation_summary,
       }
     end
   end
@@ -40,6 +43,11 @@ class Pages::ProfileData
       seller.products.cache_key_with_version,
       seller.installments.visible_on_profile.cache_key_with_version,
       seller_profile&.cache_key_with_version,
+      # Review writes touch product_review_stats, not links, so the products key
+      # above never moves when a rating lands; the flag state and stat high-water
+      # mark keep the cached seller_rating honest.
+      seller.reputation_summary_enabled?,
+      seller.reputation_summary_enabled? ? ProductReviewStat.joins(:link).where(links: { user_id: seller.id }).maximum(:updated_at) : nil,
     ].join("/")
   end
 

--- a/app/services/pages/profile_data.rb
+++ b/app/services/pages/profile_data.rb
@@ -25,9 +25,11 @@ class Pages::ProfileData
         # advertising an incomplete catalogue (gumroad-private#1522).
         products_total: products_total(seller),
         posts_total: posts_total(seller),
-        # nil both when gated off and when the seller misses the display
-        # thresholds; a page treats the two identically (show nothing).
-        seller_rating: seller.seller_reputation_summary,
+        # Omitted rather than nil when gated off, matching ProfilePresenter and
+        # ProductProps, so a seller without the flag gets a byte-identical payload.
+        # Present-but-nil still happens when the flag is on and the seller misses
+        # the display thresholds; a page treats absent and nil identically.
+        **(seller.reputation_summary_enabled? ? { seller_rating: seller.seller_reputation_summary } : {}),
       }
     end
   end

--- a/spec/modules/user/reputation_summary_spec.rb
+++ b/spec/modules/user/reputation_summary_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe User::ReputationSummary do
+  let(:seller) { create(:user) }
+  let(:product_one) { create(:product, user: seller) }
+  let(:product_two) { create(:product, user: seller) }
+
+  def create_stat(product, five: 0, four: 0, one: 0)
+    total = five + four + one
+    ProductReviewStat.create!(
+      link: product,
+      reviews_count: total,
+      average_rating: total.zero? ? 0 : ((five * 5 + four * 4 + one).to_f / total).round(1),
+      ratings_of_five_count: five,
+      ratings_of_four_count: four,
+      ratings_of_one_count: one,
+    )
+  end
+
+  describe "#seller_reputation_summary" do
+    context "when the flag is off" do
+      it "returns nil even when thresholds are met" do
+        create_stat(product_one, five: 8)
+        create_stat(product_two, four: 4)
+
+        expect(seller.seller_reputation_summary).to be_nil
+      end
+    end
+
+    context "when the flag is on" do
+      before { Feature.activate_user(:seller_reputation_summary, seller) }
+
+      it "sums per-star counts across products and weights the average by review count" do
+        create_stat(product_one, five: 8)
+        create_stat(product_two, four: 3, one: 1)
+
+        expect(seller.seller_reputation_summary).to eq(
+          average: ((8 * 5 + 3 * 4 + 1).to_f / 12).round(1),
+          count: 12,
+          products_count: 2,
+        )
+      end
+
+      it "returns nil below #{User::ReputationSummary::MIN_REVIEWS} reviews" do
+        create_stat(product_one, five: 5)
+        create_stat(product_two, four: 4)
+
+        expect(seller.seller_reputation_summary).to be_nil
+      end
+
+      it "returns nil when reviews span fewer than #{User::ReputationSummary::MIN_PRODUCTS} products" do
+        create_stat(product_one, five: 15)
+
+        expect(seller.seller_reputation_summary).to be_nil
+      end
+
+      it "skips products that opted out of displaying reviews" do
+        create_stat(product_one, five: 8)
+        create_stat(product_two, four: 4)
+        opted_out = create(:product, user: seller, display_product_reviews: false)
+        create_stat(opted_out, one: 50)
+
+        expect(seller.seller_reputation_summary).to eq(average: 4.7, count: 12, products_count: 2)
+      end
+
+      it "skips deleted products" do
+        create_stat(product_one, five: 8)
+        create_stat(product_two, four: 4)
+        deleted = create(:product, user: seller, deleted_at: Time.current)
+        create_stat(deleted, one: 50)
+
+        expect(seller.seller_reputation_summary).to eq(average: 4.7, count: 12, products_count: 2)
+      end
+
+      it "does not count another seller's products" do
+        create_stat(product_one, five: 8)
+        create_stat(product_two, four: 4)
+        create_stat(create(:product), one: 50)
+
+        expect(seller.seller_reputation_summary).to eq(average: 4.7, count: 12, products_count: 2)
+      end
+
+      it "excludes the given product and its reviews" do
+        create_stat(product_one, five: 8)
+        create_stat(product_two, four: 4)
+        third = create(:product, user: seller)
+        create_stat(third, five: 4)
+
+        expect(seller.seller_reputation_summary(exclude_product: third)).to eq(average: 4.7, count: 12, products_count: 2)
+      end
+
+      it "returns nil when the exclusion drops the seller below the thresholds" do
+        create_stat(product_one, five: 8)
+        create_stat(product_two, four: 4)
+
+        expect(seller.seller_reputation_summary(exclude_product: product_one)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/presenters/product_presenter/product_props_spec.rb
+++ b/spec/presenters/product_presenter/product_props_spec.rb
@@ -482,6 +482,22 @@ describe ProductPresenter::ProductProps do
       end
     end
 
+    context "seller reputation" do
+      let(:product) { create(:product, user: seller) }
+
+      it "omits the key when the seller_reputation_summary flag is off" do
+        expect(described_class.new(product:).props(seller_custom_domain_url: nil, request:, pundit_user: nil)[:product]).not_to have_key(:seller_reputation)
+      end
+
+      it "includes the summary excluding the viewed product when the flag is on" do
+        Feature.activate_user(:seller_reputation_summary, seller)
+        summary = { average: 4.8, count: 12, products_count: 2 }
+        expect_any_instance_of(User).to receive(:seller_reputation_summary).with(exclude_product: product).and_return(summary)
+
+        expect(described_class.new(product:).props(seller_custom_domain_url: nil, request:, pundit_user: nil)[:product][:seller_reputation]).to eq(summary)
+      end
+    end
+
     context "bundle product" do
       let(:bundle) { create(:product, user: seller, is_bundle: true) }
 

--- a/spec/presenters/profile_presenter_spec.rb
+++ b/spec/presenters/profile_presenter_spec.rb
@@ -68,6 +68,26 @@ describe ProfilePresenter do
       expect(described_class.new(pundit_user:, seller:).creator_profile[:can_edit]).to eq(false)
     end
 
+    describe "reputation" do
+      it "omits the key when the seller_reputation_summary flag is off" do
+        expect(presenter.creator_profile).not_to have_key(:reputation)
+      end
+
+      it "includes the summary when the flag is on" do
+        Feature.activate_user(:seller_reputation_summary, seller)
+        summary = { average: 4.8, count: 12, products_count: 2 }
+        allow(seller).to receive(:seller_reputation_summary).and_return(summary)
+
+        expect(presenter.creator_profile[:reputation]).to eq(summary)
+      end
+
+      it "includes a nil summary when the flag is on but thresholds are unmet" do
+        Feature.activate_user(:seller_reputation_summary, seller)
+
+        expect(presenter.creator_profile[:reputation]).to be_nil
+      end
+    end
+
     it "sets can_edit to false for profile view-only team members" do
       support_user = create(:user)
       create(:team_membership, user: support_user, seller:, role: TeamMembership::ROLE_SUPPORT)

--- a/spec/requests/profile_custom_html_spec.rb
+++ b/spec/requests/profile_custom_html_spec.rb
@@ -312,6 +312,16 @@ describe "Profile custom HTML rendering", type: :request do
       expect(data["products"].first.keys).to match_array(%w[name url price native_type thumbnail_url cover_url description])
     end
 
+    it "adds seller_rating to the payload only once the seller_reputation_summary flag is on" do
+      create(:product, user: seller, name: "Cool thing")
+      Feature.activate_user(:seller_reputation_summary, seller)
+
+      get "http://seller.example.com/landing/embed"
+
+      json = response.body[%r{<script id="gumroad-data"[^>]*>(.*?)</script>}m, 1]
+      expect(JSON.parse(json).keys).to match_array(%w[products posts pages products_total posts_total seller_rating])
+    end
+
     it "embeds a per-request price blob keyed by permalink alongside the cached catalog" do
       product = create(:product, user: seller, name: "Cool thing", price_cents: 1400)
       seller.update!(custom_html: %(<main><script>document.getElementById("gumroad-prices")</script></main>))

--- a/spec/services/pages/profile_data_spec.rb
+++ b/spec/services/pages/profile_data_spec.rb
@@ -36,8 +36,8 @@ describe Pages::ProfileData do
     end
 
     describe "seller_rating" do
-      it "is nil when the seller_reputation_summary flag is off" do
-        expect(Pages::ProfileData.build(seller)[:seller_rating]).to be_nil
+      it "is absent when the seller_reputation_summary flag is off" do
+        expect(Pages::ProfileData.build(seller)).not_to have_key(:seller_rating)
       end
 
       it "carries the summary when the flag is on and thresholds are met" do

--- a/spec/services/pages/profile_data_spec.rb
+++ b/spec/services/pages/profile_data_spec.rb
@@ -35,6 +35,31 @@ describe Pages::ProfileData do
       end
     end
 
+    describe "seller_rating" do
+      it "is nil when the seller_reputation_summary flag is off" do
+        expect(Pages::ProfileData.build(seller)[:seller_rating]).to be_nil
+      end
+
+      it "carries the summary when the flag is on and thresholds are met" do
+        Feature.activate_user(:seller_reputation_summary, seller)
+        summary = { average: 4.8, count: 12, products_count: 2 }
+        allow_any_instance_of(User).to receive(:seller_reputation_summary).and_return(summary)
+
+        expect(Pages::ProfileData.build(seller)[:seller_rating]).to eq(summary)
+      end
+
+      it "changes the cache key when a qualifying review stat moves" do
+        Feature.activate_user(:seller_reputation_summary, seller)
+        product = create(:product, user: seller)
+        seller_profile = SellerProfile.find_by(seller_id: seller.id)
+        key_before = Pages::ProfileData.cache_key(seller.reload, seller_profile)
+
+        create(:product_review, purchase: create(:purchase, link: product), rating: 5)
+
+        expect(Pages::ProfileData.cache_key(seller.reload, seller_profile)).not_to eq(key_before)
+      end
+    end
+
     it "does not expose draft products in the public profile data payload" do
       published_product = create(:product, user: seller, name: "Published product", draft: false)
       draft_product = create(:product, user: seller, name: "Draft product", draft: true)

--- a/spec/services/pages/profile_data_spec.rb
+++ b/spec/services/pages/profile_data_spec.rb
@@ -54,7 +54,7 @@ describe Pages::ProfileData do
         seller_profile = SellerProfile.find_by(seller_id: seller.id)
         key_before = Pages::ProfileData.cache_key(seller.reload, seller_profile)
 
-        create(:product_review, purchase: create(:purchase, link: product), rating: 5)
+        ProductReviewStat.create!(link: product, reviews_count: 1, average_rating: 5, ratings_of_five_count: 1)
 
         expect(Pages::ProfileData.cache_key(seller.reload, seller_profile)).not_to eq(key_before)
       end
@@ -391,12 +391,12 @@ describe Pages::ProfileData do
     it "does not serve a v4 payload without the totals" do
       seller_profile = SellerProfile.find_by(seller_id: seller.id)
       current_key = Pages::ProfileData.cache_key(seller, seller_profile)
-      v4_key = current_key.sub("profile_data/v5/", "profile_data/v4/")
+      v4_key = current_key.sub("profile_data/v6/", "profile_data/v4/")
       Rails.cache.write(v4_key, { products: [], posts: [], pages: [] })
 
       data = Pages::ProfileData.build(seller)
 
-      expect(current_key).to start_with("profile_data/v5/")
+      expect(current_key).to start_with("profile_data/v6/")
       expect(data).to include(products_total: 0, posts_total: 0)
     end
 


### PR DESCRIPTION
Builds the seller-level reputation summary approved in gumroad-private#1669 ("I agree with your recommendation. Build!"): A1 compute-on-read + B3 both surfaces + the custom-page payload key, all behind the `seller_reputation_summary` Flipper flag.

## What this does

- **`User::ReputationSummary`** — one grouped read over `ProductReviewStat.joins(:link)` for the seller, summing the five per-star counters (the `bundle_rating_stats` maths, review-count weighted). Returns `{ average:, count:, products_count: }` or `nil`. Display gate: **10+ reviews across 2+ products** (`MIN_REVIEWS` / `MIN_PRODUCTS` constants, changeable in one line). Skips deleted products and products with `display_product_reviews` off (a `Link` flag bit, so filtered in Ruby, not SQL).
- **Profile header** (`ProfilePresenter#creator_profile` → `Profile/Layout.tsx`) — `4.8 from 312 verified reviews across 8 products` next to the creator name. Key emitted only while the flag is on.
- **Product page** (`ProductPresenter::ProductProps` → `Product/index.tsx`) — labelled creator-context section below the reviews block. **Always excludes the viewed product** (`exclude_product:`), so a product's own reviews never inflate the rollup on its own page; copy says "other products" and an unreviewed product first shows "This product has no reviews yet." The count links through to the seller's profile so the aggregate's composition is inspectable.
- **Custom-page payload** (`Pages::ProfileData`) — new `seller_rating` key, `CACHE_VERSION` v5→v6, and the cache key now includes the flag state plus the seller's review-stat high-water mark (review writes don't touch `links`, so the products key alone would serve a stale rating).

Not in v1, per the issue spec: no new table/migration, no Discover ranking input, no "trusted seller" badge, no sales-range/tenure/verification bundling.

## Checklist
- [x] Scope — approved shape from gumroad-private#1669 (A1 + B3 + payload key)
- [x] Design — spec'd in the issue thread; design options approved by @slavingia
- [x] Build — compute-on-read module, 3 surfaces, Flipper-gated
- [ ] QA — enable `seller_reputation_summary` for a seller with reviews on 2+ products; check profile header, an unreviewed product's page, and the custom-page payload
- [ ] Shipped
- [ ] Market
- [ ] Sell

## Tests

New/updated specs:
- `spec/modules/user/reputation_summary_spec.rb` — thresholds, weighting, opt-out/deleted/foreign-product exclusion, `exclude_product`, flag off
- `spec/presenters/profile_presenter_spec.rb` — key omitted when flag off; summary/nil when on
- `spec/presenters/product_presenter/product_props_spec.rb` — key omitted when flag off; `exclude_product:` passed when on
- `spec/services/pages/profile_data_spec.rb` — `seller_rating` nil/populated; cache key moves when a review lands

Local runs (isolated test DB `gumroad_test_1669`, private Redis db 13):

```
bundle exec rspec spec/modules/user/reputation_summary_spec.rb        # 9 examples, 0 failures
bundle exec rspec spec/services/pages/profile_data_spec.rb            # 36 examples, 0 failures
bundle exec rspec spec/presenters/profile_presenter_spec.rb           # 29 examples, 0 failures
bundle exec rspec spec/presenters/product_presenter/product_props_spec.rb -e "seller reputation"  # 2 examples, 0 failures
```

`rubocop --format github` clean on all touched Ruby files; `npx tsc --noEmit` reports no errors in the touched frontend files.

Closes gumroad-private#1669 scope for v1.


## QA media — blocked on the preview tier, not omitted

This PR renders a real UI surface (`Profile/Layout.tsx`, `Product/index.tsx`), so it owes before/after
screenshots from the hosted preview. It cannot have them right now: the whole preview tier serves no TLS
certificate for any SNI, so `gp1669-seller-reputation-summary.apps.staging.gumroad.org` completes no
handshake. Measured 22:5xZ — 40 of 47 preview hosts dead the same way, every surviving certificate
issued before 13:16:04Z, production 200 from the same machine. Tracked and reopened as
gumroad-private#1699 (assigned @ershad).

Staying draft until the preview serves this branch's head and the media is captured. Local renders are
not evidence for this and I am not substituting them.
