### PR TITLE
Fix the objective dispute-evidence defects: shipping slots, access log, source selection, idempotency

### DIFF
--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -794,34 +794,41 @@ class StripeChargeProcessor
     with_stripe_error_handler do
       charge = Stripe::Charge.retrieve(stripe_charge_id)
 
-      Stripe::Dispute.update(
-        charge.dispute,
-        evidence: {
-          billing_address: dispute_evidence.billing_address,
-          customer_email_address: dispute_evidence.customer_email,
-          customer_name: dispute_evidence.customer_name,
-          customer_purchase_ip: dispute_evidence.customer_purchase_ip,
-          product_description: dispute_evidence.product_description,
-          receipt: create_dispute_evidence_stripe_file(dispute_evidence.receipt_image),
-          service_date: dispute_evidence.purchased_at.to_fs(:formatted_date_full_month),
-          shipping_address: dispute_evidence.shipping_address,
-          shipping_carrier: dispute_evidence.shipping_carrier,
-          shipping_date: dispute_evidence.shipped_at&.to_fs(:formatted_date_full_month),
-          shipping_tracking_number: dispute_evidence.shipping_tracking_number,
-          uncategorized_text: [
-            "The merchant should win the dispute because:\n#{dispute_evidence.reason_for_winning}",
-            dispute_evidence.uncategorized_text
-          ].compact.join("\n\n"),
-          access_activity_log: dispute_evidence.access_activity_log,
-          cancellation_policy: create_dispute_evidence_stripe_file(dispute_evidence.cancellation_policy_image),
-          cancellation_policy_disclosure: dispute_evidence.cancellation_policy_disclosure,
-          refund_policy: create_dispute_evidence_stripe_file(dispute_evidence.refund_policy_image),
-          refund_policy_disclosure: dispute_evidence.refund_policy_disclosure,
-          cancellation_rebuttal: dispute_evidence.cancellation_rebuttal,
-          refund_refusal_explanation: dispute_evidence.refund_refusal_explanation,
-          customer_communication: create_dispute_evidence_stripe_file(dispute_evidence.customer_communication_file),
-        }
-      )
+      evidence = {
+        billing_address: dispute_evidence.billing_address,
+        customer_email_address: dispute_evidence.customer_email,
+        customer_name: dispute_evidence.customer_name,
+        customer_purchase_ip: dispute_evidence.customer_purchase_ip,
+        product_description: dispute_evidence.product_description,
+        receipt: create_dispute_evidence_stripe_file(dispute_evidence.receipt_image),
+        service_date: dispute_evidence.purchased_at.to_fs(:formatted_date_full_month),
+        shipping_address: dispute_evidence.shipping_address,
+        shipping_carrier: dispute_evidence.shipping_carrier,
+        shipping_date: dispute_evidence.shipped_at&.to_fs(:formatted_date_full_month),
+        shipping_tracking_number: dispute_evidence.shipping_tracking_number,
+        uncategorized_text: [
+          "The merchant should win the dispute because:\n#{dispute_evidence.reason_for_winning}",
+          dispute_evidence.uncategorized_text
+        ].compact.join("\n\n"),
+        access_activity_log: dispute_evidence.access_activity_log,
+        cancellation_policy: create_dispute_evidence_stripe_file(dispute_evidence.cancellation_policy_image),
+        cancellation_policy_disclosure: dispute_evidence.cancellation_policy_disclosure,
+        refund_policy: create_dispute_evidence_stripe_file(dispute_evidence.refund_policy_image),
+        refund_policy_disclosure: dispute_evidence.refund_policy_disclosure,
+        cancellation_rebuttal: dispute_evidence.cancellation_rebuttal,
+        refund_refusal_explanation: dispute_evidence.refund_refusal_explanation,
+        customer_communication: create_dispute_evidence_stripe_file(dispute_evidence.customer_communication_file),
+      }
+
+      # A dispute accepts evidence once, and FightDisputeJob has five Sidekiq retries: a network
+      # failure on a call that actually landed would otherwise spend the submission a second time.
+      # Keyed on the payload as well as the row so a retry carrying different evidence (the seller
+      # writing a statement between attempts) gets its own key instead of Stripe rejecting the
+      # parameter mismatch.
+      idempotency_key = "dispute_evidence_#{dispute_evidence.external_id}_" \
+                        "#{Digest::SHA256.hexdigest(evidence.sort.to_s)[0, 16]}"
+
+      Stripe::Dispute.update(charge.dispute, { evidence: }, { idempotency_key: })
     end
   end
 

--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -820,14 +820,15 @@ class StripeChargeProcessor
         customer_communication: create_dispute_evidence_stripe_file(dispute_evidence.customer_communication_file),
       }
 
-      # A dispute accepts evidence once, and FightDisputeJob has five Sidekiq retries: a network
-      # failure on a call that actually landed would otherwise spend the submission a second time.
-      # Keyed on the row's `updated_at` rather than the payload, because the payload is not stable
-      # across attempts — `create_dispute_evidence_stripe_file` re-uploads and returns a fresh
-      # Stripe file id every call, so a payload digest would change on every retry and defeat the
-      # guard. `updated_at` moves exactly when the seller writes into the row, which is the one
-      # case a retry legitimately carries different evidence and needs its own key.
-      idempotency_key = "dispute_evidence_#{dispute_evidence.external_id}_#{dispute_evidence.updated_at.to_i}"
+      # A dispute accepts evidence once (gumroad-private#1612) and FightDisputeJob has five Sidekiq
+      # retries, so a network failure on a call that actually landed would otherwise spend the
+      # submission a second time. The key must be IMMUTABLE for that to work: anything derived from
+      # the payload or from `updated_at` changes between attempts — the payload because
+      # create_dispute_evidence_stripe_file re-uploads and returns a fresh Stripe file id on every
+      # call, `updated_at` because the seller writes their statement into the same row. One evidence
+      # row is one permitted submission (the job returns early once the row is resolved), so the
+      # row's own identity is the whole key.
+      idempotency_key = "dispute_evidence_#{dispute_evidence.external_id}"
 
       Stripe::Dispute.update(charge.dispute, { evidence: }, { idempotency_key: })
     end

--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -822,11 +822,12 @@ class StripeChargeProcessor
 
       # A dispute accepts evidence once, and FightDisputeJob has five Sidekiq retries: a network
       # failure on a call that actually landed would otherwise spend the submission a second time.
-      # Keyed on the payload as well as the row so a retry carrying different evidence (the seller
-      # writing a statement between attempts) gets its own key instead of Stripe rejecting the
-      # parameter mismatch.
-      idempotency_key = "dispute_evidence_#{dispute_evidence.external_id}_" \
-                        "#{Digest::SHA256.hexdigest(evidence.sort.to_s)[0, 16]}"
+      # Keyed on the row's `updated_at` rather than the payload, because the payload is not stable
+      # across attempts — `create_dispute_evidence_stripe_file` re-uploads and returns a fresh
+      # Stripe file id every call, so a payload digest would change on every retry and defeat the
+      # guard. `updated_at` moves exactly when the seller writes into the row, which is the one
+      # case a retry legitimately carries different evidence and needs its own key.
+      idempotency_key = "dispute_evidence_#{dispute_evidence.external_id}_#{dispute_evidence.updated_at.to_i}"
 
       Stripe::Dispute.update(charge.dispute, { evidence: }, { idempotency_key: })
     end

--- a/app/models/concerns/charge/disputable.rb
+++ b/app/models/concerns/charge/disputable.rb
@@ -37,7 +37,7 @@ module Charge::Disputable
         # and sort_by is not stable, so a tie at the maximum picked an arbitrary row between runs —
         # and this choice decides which purchase's facts go to the card network on a submission we
         # only get to make once.
-        selected_purchases.max_by { [_1.total_transaction_cents, _1.id] }
+        selected_purchases.min_by { [-_1.total_transaction_cents, _1.id] }
       else
         disputed_purchases.first
       end

--- a/app/models/concerns/charge/disputable.rb
+++ b/app/models/concerns/charge/disputable.rb
@@ -33,7 +33,11 @@ module Charge::Disputable
 
         selected_purchases ||= disputed_purchases
 
-        selected_purchases.sort_by(&:total_transaction_cents).last
+        # Break the amount tie on id: `disputed_purchases` comes off an unordered `purchases.to_a`
+        # and sort_by is not stable, so a tie at the maximum picked an arbitrary row between runs —
+        # and this choice decides which purchase's facts go to the card network on a submission we
+        # only get to make once.
+        selected_purchases.max_by { [_1.total_transaction_cents, _1.id] }
       else
         disputed_purchases.first
       end

--- a/app/models/concerns/charge/disputable.rb
+++ b/app/models/concerns/charge/disputable.rb
@@ -36,8 +36,9 @@ module Charge::Disputable
         # Break the amount tie on id: `disputed_purchases` comes off an unordered `purchases.to_a`
         # and sort_by is not stable, so a tie at the maximum picked an arbitrary row between runs —
         # and this choice decides which purchase's facts go to the card network on a submission we
-        # only get to make once.
-        selected_purchases.min_by { [-_1.total_transaction_cents, _1.id] }
+        # only get to make once. `to_i` because the column is nullable and a nil in the old sort
+        # raised rather than ranking.
+        selected_purchases.min_by { [-_1.total_transaction_cents.to_i, _1.id] }
       else
         disputed_purchases.first
       end

--- a/app/services/dispute_evidence/create_from_dispute_service.rb
+++ b/app/services/dispute_evidence/create_from_dispute_service.rb
@@ -29,14 +29,14 @@ class DisputeEvidence::CreateFromDisputeService
     # that we hold billing details we do not.
     dispute_evidence.billing_address = nil
     if shipment.present?
-      dispute_evidence.shipping_address = build_shipping_address(purchase_at_checkout)
+      dispute_evidence.shipping_address = build_shipping_address(as_at_checkout(shipment.purchase))
       dispute_evidence.shipped_at = shipment.shipped_at
       dispute_evidence.shipping_carrier, dispute_evidence.shipping_tracking_number =
         carrier_and_tracking_number(shipment)
     end
     dispute_evidence.product_description = generate_product_description(product:, purchase:)
     dispute_evidence.uncategorized_text = DisputeEvidence::GenerateUncategorizedTextService.perform(purchase)
-    dispute_evidence.access_activity_log = DisputeEvidence::GenerateAccessActivityLogsService.perform(purchase)
+    dispute_evidence.access_activity_log = DisputeEvidence::GenerateAccessActivityLogsService.perform(purchase, other_purchases: other_disputed_purchases)
     attach_receipt_image(dispute_evidence, purchase)
 
     dispute_evidence.policy_disclosure = generate_refund_policy_disclosure(purchase, refund_policy_fine_print_view_events)
@@ -61,8 +61,17 @@ class DisputeEvidence::CreateFromDisputeService
     # seller-facing writers mutate these columns afterwards, so a live read presents mutable
     # operational data to a card network as platform-generated evidence. Falls back to the live
     # record when no version covers the purchase, which is today's behaviour.
+    def as_at_checkout(source)
+      @_as_at_checkout ||= {}
+      @_as_at_checkout[source.id] ||= source.paper_trail.version_at(source.created_at) || source
+    end
+
     def purchase_as_at_checkout
-      @_purchase_as_at_checkout ||= purchase.paper_trail.version_at(purchase.created_at) || purchase
+      as_at_checkout(purchase)
+    end
+
+    def other_disputed_purchases
+      @_other_disputed_purchases ||= dispute.disputable.disputed_purchases.reject { _1.id == purchase.id }
     end
 
     def build_shipping_address(source)
@@ -83,8 +92,17 @@ class DisputeEvidence::CreateFromDisputeService
       shipment
     end
 
+    # Fill the shipping slots from whichever constituent purchase actually shipped, independently of
+    # which one `purchase_for_dispute_evidence` picked for identity and refund policy — that ranking
+    # never looks at shipments, so on a combined charge where the representative ships nothing and a
+    # sibling does, all four structured slots went out empty while the sibling's tracking sat in free
+    # text. Stripe reads the structured fields, and we submit once. Representative first so the
+    # single-purchase and already-correct cases are unchanged; ties among siblings break on id.
     def evidence_shipment
-      @_evidence_shipment ||= shipment_for(purchase)
+      return @_evidence_shipment if defined?(@_evidence_shipment)
+
+      @_evidence_shipment = shipment_for(purchase) ||
+        other_disputed_purchases.sort_by(&:id).lazy.filter_map { shipment_for(_1) }.first
     end
 
     # Sellers only ever supply a tracking URL, so derive from it when the columns are blank —
@@ -120,7 +138,7 @@ class DisputeEvidence::CreateFromDisputeService
     # Their own shipping details cannot go in the structured slots: Stripe holds one carrier,
     # one tracking number and one shipping date per dispute, and we submit once.
     def other_disputed_items_rows
-      other_purchases = dispute.disputable.disputed_purchases.reject { _1.id == purchase.id }
+      other_purchases = other_disputed_purchases
       return [] if other_purchases.empty?
 
       rows = ["", "This charge also covers #{other_purchases.size} other #{"item".pluralize(other_purchases.size)}:"]

--- a/app/services/dispute_evidence/create_from_dispute_service.rb
+++ b/app/services/dispute_evidence/create_from_dispute_service.rb
@@ -14,7 +14,7 @@ class DisputeEvidence::CreateFromDisputeService
 
   def perform!
     product = purchase.link.paper_trail.version_at(purchase.created_at) || purchase.link
-    shipment = evidence_shipment
+    shipment, shipped_purchase = evidence_shipment_and_purchase
     refund_policy_fine_print_view_events = find_refund_policy_fine_print_view_events(purchase)
     purchase_at_checkout = purchase_as_at_checkout
 
@@ -29,7 +29,7 @@ class DisputeEvidence::CreateFromDisputeService
     # that we hold billing details we do not.
     dispute_evidence.billing_address = nil
     if shipment.present?
-      dispute_evidence.shipping_address = build_shipping_address(as_at_checkout(shipment.purchase))
+      dispute_evidence.shipping_address = build_shipping_address(as_at_checkout(shipped_purchase))
       dispute_evidence.shipped_at = shipment.shipped_at
       dispute_evidence.shipping_carrier, dispute_evidence.shipping_tracking_number =
         carrier_and_tracking_number(shipment)
@@ -98,11 +98,19 @@ class DisputeEvidence::CreateFromDisputeService
     # sibling does, all four structured slots went out empty while the sibling's tracking sat in free
     # text. Stripe reads the structured fields, and we submit once. Representative first so the
     # single-purchase and already-correct cases are unchanged; ties among siblings break on id.
-    def evidence_shipment
-      return @_evidence_shipment if defined?(@_evidence_shipment)
+    #
+    # Returns the pair, because the address slot must come from the purchase that shipped and
+    # re-deriving it from `shipment.purchase` would ask the database for a row we already hold.
+    def evidence_shipment_and_purchase
+      return @_evidence_shipment_and_purchase if defined?(@_evidence_shipment_and_purchase)
 
-      @_evidence_shipment = shipment_for(purchase) ||
-        other_disputed_purchases.sort_by(&:id).lazy.filter_map { shipment_for(_1) }.first
+      candidates = [purchase, *other_disputed_purchases.sort_by(&:id)]
+      @_evidence_shipment_and_purchase =
+        candidates.lazy.map { [shipment_for(_1), _1] }.find { _1.first.present? } || [nil, nil]
+    end
+
+    def evidence_shipment
+      evidence_shipment_and_purchase.first
     end
 
     # Sellers only ever supply a tracking URL, so derive from it when the columns are blank —

--- a/app/services/dispute_evidence/generate_access_activity_logs_service.rb
+++ b/app/services/dispute_evidence/generate_access_activity_logs_service.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
 class DisputeEvidence::GenerateAccessActivityLogsService
-  def self.perform(purchase)
-    new(purchase).perform
+  def self.perform(purchase, other_purchases: [])
+    new(purchase, other_purchases:).perform
   end
 
   include ActionView::Helpers::NumberHelper
 
-  def initialize(purchase)
+  def initialize(purchase, other_purchases: [])
     @purchase = purchase
+    @other_purchases = other_purchases
     @url_redirect = purchase.url_redirect
   end
 
@@ -21,7 +22,7 @@ class DisputeEvidence::GenerateAccessActivityLogsService
   end
 
   private
-    attr_reader :purchase, :url_redirect
+    attr_reader :purchase, :other_purchases, :url_redirect
 
     def rental_activity
       return unless url_redirect.present? && url_redirect.rental_first_viewed_at.present?
@@ -39,16 +40,24 @@ class DisputeEvidence::GenerateAccessActivityLogsService
     # The disputed row on a bundle sale is the wrapper, but access rows are written against the
     # member purchases the buyer actually downloads. Both are counted: the wrapper's own download
     # page still increments when no member is library-visible.
+    #
+    # A combined charge is disputed as one amount, so the siblings count too: the representative is
+    # chosen on refund policy and amount, never on access, and reporting only its activity told
+    # Stripe "no access recorded" for orders the buyer demonstrably consumed elsewhere in the charge.
     def access_purchases
-      @_access_purchases ||= if bundle?
-        [purchase, *purchase.product_purchases.includes(:link, :url_redirect)]
-      else
-        [purchase]
-      end
+      @_access_purchases ||= [purchase, *other_purchases].flat_map { with_bundle_members(_1) }
     end
 
-    def bundle?
-      purchase.is_bundle_purchase?
+    def with_bundle_members(candidate)
+      return [candidate] unless candidate.is_bundle_purchase?
+
+      [candidate, *candidate.product_purchases.includes(:link, :url_redirect)]
+    end
+
+    # Name the product on each row once the log can span more than one of them, so an entry is
+    # attributable to the purchase it came from rather than reading as the representative's.
+    def attribute_products?
+      access_purchases.size > 1
     end
 
     def consumption_events
@@ -88,13 +97,13 @@ class DisputeEvidence::GenerateAccessActivityLogsService
     BASE_ROW_ATTRIBUTES = %w(consumed_at event_type platform ip_address).freeze
 
     def consumption_event_row_attributes
-      BASE_ROW_ATTRIBUTES + (bundle? ? ["product"] : [])
+      BASE_ROW_ATTRIBUTES + (attribute_products? ? ["product"] : [])
     end
 
     def consumption_event_rows
       consumption_events.last(LOG_RECORDS_LIMIT).map do |event|
         row = event.slice(*BASE_ROW_ATTRIBUTES).values
-        row += [product_name_for(event)] if bundle?
+        row += [product_name_for(event)] if attribute_products?
         row.join(",")
       end
     end

--- a/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
@@ -4391,6 +4391,7 @@ describe StripeChargeProcessor, "#fight_chargeback shipment evidence" do
   describe "idempotency key" do
     # A dispute accepts evidence once (gumroad-private#1612) and FightDisputeJob retries five
     # times, so the key is what stops a retry after a landed call spending the submission again.
+    # It only works if it is IMMUTABLE across attempts, which is what these pin.
     def capture_options(evidence_row = nil)
       captured = nil
       allow(Stripe::Dispute).to receive(:update) { |_id, _params, opts| captured = opts }
@@ -4401,10 +4402,10 @@ describe StripeChargeProcessor, "#fight_chargeback shipment evidence" do
     before { DisputeEvidence.create_from_dispute!(disputed_purchase.dispute.reload) }
 
     it "sends one derived from the evidence row" do
-      expect(capture_options[:idempotency_key]).to include(disputed_purchase.dispute.reload.dispute_evidence.external_id)
+      expect(capture_options[:idempotency_key]).to eq("dispute_evidence_#{disputed_purchase.dispute.reload.dispute_evidence.external_id}")
     end
 
-    it "is stable across a retry that re-reads the same unchanged row" do
+    it "is stable across a retry that re-reads the same row" do
       # The payload is NOT stable across attempts — create_dispute_evidence_stripe_file uploads a
       # fresh Stripe file each call — so anything digesting it would change here and let the retry
       # spend the one-shot submission.
@@ -4413,7 +4414,9 @@ describe StripeChargeProcessor, "#fight_chargeback shipment evidence" do
       expect(capture_options[:idempotency_key]).to eq(first[:idempotency_key])
     end
 
-    it "changes when the seller writes a statement between attempts" do
+    it "is stable after the seller writes a statement into the same row" do
+      # `updated_at` is not usable either: the seller legitimately writes into this row during the
+      # 2.19-day assembly-to-submission gap, and a retry after a landed call must still replay.
       first = capture_options
 
       evidence_row = disputed_purchase.dispute.reload.dispute_evidence
@@ -4421,7 +4424,18 @@ describe StripeChargeProcessor, "#fight_chargeback shipment evidence" do
         evidence_row.update!(reason_for_winning: "The buyer signed for the parcel.")
       end
 
-      expect(capture_options(evidence_row.reload)[:idempotency_key]).to_not eq(first[:idempotency_key])
+      expect(capture_options(evidence_row.reload)[:idempotency_key]).to eq(first[:idempotency_key])
+    end
+
+    it "differs between two evidence rows" do
+      other_purchase = create(:free_purchase, link: create(:physical_product))
+      create(:dispute_formalized, purchase: other_purchase)
+      DisputeEvidence.create_from_dispute!(other_purchase.dispute.reload)
+
+      mine = capture_options
+      theirs = capture_options(other_purchase.dispute.reload.dispute_evidence)
+
+      expect(theirs[:idempotency_key]).to_not eq(mine[:idempotency_key])
     end
   end
 end

--- a/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
@@ -545,22 +545,22 @@ describe StripeChargeProcessor, :vcr do
       expect(Stripe::Dispute).to receive(:update).with(
         stripe_charge.dispute,
         hash_including(evidence: hash_including({
-                                   billing_address: dispute_evidence.billing_address,
-                                   customer_email_address: dispute_evidence.customer_email,
-                                   customer_name: dispute_evidence.customer_name,
-                                   customer_purchase_ip: dispute_evidence.customer_purchase_ip,
-                                   product_description: dispute_evidence.product_description,
-                                   service_date: dispute_evidence.purchased_at.to_fs(:formatted_date_full_month),
-                                   shipping_address: dispute_evidence.shipping_address,
-                                   shipping_carrier: dispute_evidence.shipping_carrier,
-                                   shipping_date: dispute_evidence.shipped_at&.to_fs(:formatted_date_full_month),
-                                   shipping_tracking_number: dispute_evidence.shipping_tracking_number,
-                                   uncategorized_text: expected_uncategorized_text,
-                                   access_activity_log: dispute_evidence.access_activity_log,
-                                   refund_policy_disclosure: dispute_evidence.refund_policy_disclosure,
-                                   cancellation_rebuttal: dispute_evidence.cancellation_rebuttal,
-                                   refund_refusal_explanation: dispute_evidence.refund_refusal_explanation
-                                 })),
+                                                  billing_address: dispute_evidence.billing_address,
+                                                  customer_email_address: dispute_evidence.customer_email,
+                                                  customer_name: dispute_evidence.customer_name,
+                                                  customer_purchase_ip: dispute_evidence.customer_purchase_ip,
+                                                  product_description: dispute_evidence.product_description,
+                                                  service_date: dispute_evidence.purchased_at.to_fs(:formatted_date_full_month),
+                                                  shipping_address: dispute_evidence.shipping_address,
+                                                  shipping_carrier: dispute_evidence.shipping_carrier,
+                                                  shipping_date: dispute_evidence.shipped_at&.to_fs(:formatted_date_full_month),
+                                                  shipping_tracking_number: dispute_evidence.shipping_tracking_number,
+                                                  uncategorized_text: expected_uncategorized_text,
+                                                  access_activity_log: dispute_evidence.access_activity_log,
+                                                  refund_policy_disclosure: dispute_evidence.refund_policy_disclosure,
+                                                  cancellation_rebuttal: dispute_evidence.cancellation_rebuttal,
+                                                  refund_refusal_explanation: dispute_evidence.refund_refusal_explanation
+                                                })),
         hash_including(:idempotency_key)
       ).and_call_original
       subject.fight_chargeback(charge_id, disputed_purchase.dispute.dispute_evidence)

--- a/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
@@ -4428,7 +4428,7 @@ describe StripeChargeProcessor, "#fight_chargeback shipment evidence" do
     end
 
     it "differs between two evidence rows" do
-      other_purchase = create(:free_purchase, link: create(:physical_product))
+      other_purchase = create(:free_purchase)
       create(:dispute_formalized, purchase: other_purchase)
       DisputeEvidence.create_from_dispute!(other_purchase.dispute.reload)
 

--- a/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
@@ -4391,39 +4391,37 @@ describe StripeChargeProcessor, "#fight_chargeback shipment evidence" do
   describe "idempotency key" do
     # A dispute accepts evidence once (gumroad-private#1612) and FightDisputeJob retries five
     # times, so the key is what stops a retry after a landed call spending the submission again.
-    def submit_and_capture_options
-      DisputeEvidence.create_from_dispute!(disputed_purchase.dispute.reload)
+    def capture_options(evidence_row = nil)
       captured = nil
       allow(Stripe::Dispute).to receive(:update) { |_id, _params, opts| captured = opts }
-      described_class.new.fight_chargeback("ch_test", disputed_purchase.dispute.reload.dispute_evidence)
+      described_class.new.fight_chargeback("ch_test", evidence_row || disputed_purchase.dispute.reload.dispute_evidence)
       captured
     end
 
+    before { DisputeEvidence.create_from_dispute!(disputed_purchase.dispute.reload) }
+
     it "sends one derived from the evidence row" do
-      options = submit_and_capture_options
-
-      expect(options[:idempotency_key]).to include(disputed_purchase.dispute.reload.dispute_evidence.external_id)
+      expect(capture_options[:idempotency_key]).to include(disputed_purchase.dispute.reload.dispute_evidence.external_id)
     end
 
-    it "is stable across two submissions of the same payload" do
-      first = submit_and_capture_options
-      second = nil
-      allow(Stripe::Dispute).to receive(:update) { |_id, _params, opts| second = opts }
-      described_class.new.fight_chargeback("ch_test", disputed_purchase.dispute.reload.dispute_evidence)
+    it "is stable across a retry that re-reads the same unchanged row" do
+      # The payload is NOT stable across attempts — create_dispute_evidence_stripe_file uploads a
+      # fresh Stripe file each call — so anything digesting it would change here and let the retry
+      # spend the one-shot submission.
+      first = capture_options
 
-      expect(second[:idempotency_key]).to eq(first[:idempotency_key])
+      expect(capture_options[:idempotency_key]).to eq(first[:idempotency_key])
     end
 
-    it "changes when the seller's statement changes between attempts" do
-      first = submit_and_capture_options
+    it "changes when the seller writes a statement between attempts" do
+      first = capture_options
 
       evidence_row = disputed_purchase.dispute.reload.dispute_evidence
-      evidence_row.update!(reason_for_winning: "The buyer signed for the parcel.")
-      second = nil
-      allow(Stripe::Dispute).to receive(:update) { |_id, _params, opts| second = opts }
-      described_class.new.fight_chargeback("ch_test", evidence_row)
+      travel_to 1.hour.from_now do
+        evidence_row.update!(reason_for_winning: "The buyer signed for the parcel.")
+      end
 
-      expect(second[:idempotency_key]).to_not eq(first[:idempotency_key])
+      expect(capture_options(evidence_row.reload)[:idempotency_key]).to_not eq(first[:idempotency_key])
     end
   end
 end

--- a/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
@@ -544,7 +544,7 @@ describe StripeChargeProcessor, :vcr do
       ].join("\n\n")
       expect(Stripe::Dispute).to receive(:update).with(
         stripe_charge.dispute,
-        evidence: hash_including({
+        hash_including(evidence: hash_including({
                                    billing_address: dispute_evidence.billing_address,
                                    customer_email_address: dispute_evidence.customer_email,
                                    customer_name: dispute_evidence.customer_name,
@@ -560,7 +560,8 @@ describe StripeChargeProcessor, :vcr do
                                    refund_policy_disclosure: dispute_evidence.refund_policy_disclosure,
                                    cancellation_rebuttal: dispute_evidence.cancellation_rebuttal,
                                    refund_refusal_explanation: dispute_evidence.refund_refusal_explanation
-                                 })
+                                 })),
+        hash_including(:idempotency_key)
       ).and_call_original
       subject.fight_chargeback(charge_id, disputed_purchase.dispute.dispute_evidence)
     end
@@ -570,7 +571,8 @@ describe StripeChargeProcessor, :vcr do
       stripe_charge.refresh
       expect(Stripe::Dispute).to receive(:update).with(
         stripe_charge.dispute,
-        evidence: hash_including({ receipt: "receipt_file" })
+        hash_including(evidence: hash_including({ receipt: "receipt_file" })),
+        hash_including(:idempotency_key)
       )
 
       subject.fight_chargeback(charge_id, disputed_purchase.dispute.dispute_evidence)
@@ -584,7 +586,8 @@ describe StripeChargeProcessor, :vcr do
       stripe_charge.refresh
       expect(Stripe::Dispute).to receive(:update).with(
         stripe_charge.dispute,
-        evidence: hash_including({ customer_communication: "customer_communication_file" })
+        hash_including(evidence: hash_including({ customer_communication: "customer_communication_file" })),
+        hash_including(:idempotency_key)
       )
 
       subject.fight_chargeback(charge_id, disputed_purchase.dispute.dispute_evidence)
@@ -596,7 +599,8 @@ describe StripeChargeProcessor, :vcr do
         stripe_charge.refresh
         expect(Stripe::Dispute).to receive(:update).with(
           stripe_charge.dispute,
-          evidence: hash_including({ refund_policy: "refund_policy_file" })
+          hash_including(evidence: hash_including({ refund_policy: "refund_policy_file" })),
+          hash_including(:idempotency_key)
         )
 
         subject.fight_chargeback(charge_id, disputed_purchase.dispute.dispute_evidence)
@@ -621,7 +625,8 @@ describe StripeChargeProcessor, :vcr do
         stripe_charge.refresh
         expect(Stripe::Dispute).to receive(:update).with(
           stripe_charge.dispute,
-          evidence: hash_including({ cancellation_policy: "cancellation_policy_file" })
+          hash_including(evidence: hash_including({ cancellation_policy: "cancellation_policy_file" })),
+          hash_including(:idempotency_key)
         )
 
         subject.fight_chargeback(charge_id, disputed_purchase.dispute.dispute_evidence)
@@ -4358,7 +4363,7 @@ describe StripeChargeProcessor, "#fight_chargeback shipment evidence" do
   def evidence_sent_to_stripe
     DisputeEvidence.create_from_dispute!(disputed_purchase.dispute.reload)
     sent = nil
-    allow(Stripe::Dispute).to receive(:update) { |_id, evidence:| sent = evidence }
+    allow(Stripe::Dispute).to receive(:update) { |_id, params, _opts| sent = params[:evidence] }
     described_class.new.fight_chargeback("ch_test", disputed_purchase.dispute.reload.dispute_evidence)
     sent
   end
@@ -4381,5 +4386,44 @@ describe StripeChargeProcessor, "#fight_chargeback shipment evidence" do
 
     expect(evidence[:uncategorized_text]).to_not include("shipment tracking URL")
     expect(evidence[:uncategorized_text]).to_not include("confirmed delivery by phone")
+  end
+
+  describe "idempotency key" do
+    # A dispute accepts evidence once (gumroad-private#1612) and FightDisputeJob retries five
+    # times, so the key is what stops a retry after a landed call spending the submission again.
+    def submit_and_capture_options
+      DisputeEvidence.create_from_dispute!(disputed_purchase.dispute.reload)
+      captured = nil
+      allow(Stripe::Dispute).to receive(:update) { |_id, _params, opts| captured = opts }
+      described_class.new.fight_chargeback("ch_test", disputed_purchase.dispute.reload.dispute_evidence)
+      captured
+    end
+
+    it "sends one derived from the evidence row" do
+      options = submit_and_capture_options
+
+      expect(options[:idempotency_key]).to include(disputed_purchase.dispute.reload.dispute_evidence.external_id)
+    end
+
+    it "is stable across two submissions of the same payload" do
+      first = submit_and_capture_options
+      second = nil
+      allow(Stripe::Dispute).to receive(:update) { |_id, _params, opts| second = opts }
+      described_class.new.fight_chargeback("ch_test", disputed_purchase.dispute.reload.dispute_evidence)
+
+      expect(second[:idempotency_key]).to eq(first[:idempotency_key])
+    end
+
+    it "changes when the seller's statement changes between attempts" do
+      first = submit_and_capture_options
+
+      evidence_row = disputed_purchase.dispute.reload.dispute_evidence
+      evidence_row.update!(reason_for_winning: "The buyer signed for the parcel.")
+      second = nil
+      allow(Stripe::Dispute).to receive(:update) { |_id, _params, opts| second = opts }
+      described_class.new.fight_chargeback("ch_test", evidence_row)
+
+      expect(second[:idempotency_key]).to_not eq(first[:idempotency_key])
+    end
   end
 end

--- a/spec/models/concerns/charge/disputable_spec.rb
+++ b/spec/models/concerns/charge/disputable_spec.rb
@@ -199,15 +199,18 @@ describe Charge::Disputable, :vcr do
           charge.purchases << @first
         end
 
-        it "resolves deterministically to the lowest id rather than whichever row came back first" do
-          expect(charge.purchase_for_dispute_evidence).to eq [@first, @second].min_by(&:id)
-        end
+        # Both orders are asserted against the SAME expected row, because that is the property:
+        # `disputed_purchases` comes off an unordered `purchases.to_a`, so whichever order MySQL
+        # happens to return must not change which purchase's facts go to the card network.
+        [:as_inserted, :reversed].each do |ordering|
+          it "resolves to the lowest id at the maximum (#{ordering})" do
+            constituents = [@second, @first]
+            constituents = constituents.reverse if ordering == :reversed
+            subject_charge = Charge.find(charge.id)
+            allow(subject_charge).to receive(:disputed_purchases).and_return(constituents)
 
-        it "returns the same purchase however the constituents are ordered" do
-          reversed = Charge.find(charge.id)
-          allow(reversed).to receive(:disputed_purchases).and_return([@second, @first])
-
-          expect(reversed.purchase_for_dispute_evidence).to eq charge.purchase_for_dispute_evidence
+            expect(subject_charge.purchase_for_dispute_evidence).to eq [@first, @second].min_by(&:id)
+          end
         end
       end
     end

--- a/spec/models/concerns/charge/disputable_spec.rb
+++ b/spec/models/concerns/charge/disputable_spec.rb
@@ -190,6 +190,26 @@ describe Charge::Disputable, :vcr do
           expect(charge.purchase_for_dispute_evidence).to eq @regular_purchase
         end
       end
+
+      context "when two purchases tie at the highest amount" do
+        before do
+          @first = create(:purchase, total_transaction_cents: 15_00)
+          @second = create(:purchase, total_transaction_cents: 15_00)
+          charge.purchases << @second
+          charge.purchases << @first
+        end
+
+        it "resolves deterministically to the lowest id rather than whichever row came back first" do
+          expect(charge.purchase_for_dispute_evidence).to eq [@first, @second].min_by(&:id)
+        end
+
+        it "returns the same purchase however the constituents are ordered" do
+          reversed = Charge.find(charge.id)
+          allow(reversed).to receive(:disputed_purchases).and_return([@second, @first])
+
+          expect(reversed.purchase_for_dispute_evidence).to eq charge.purchase_for_dispute_evidence
+        end
+      end
     end
   end
 

--- a/spec/models/purchase/purchase_refunds_spec.rb
+++ b/spec/models/purchase/purchase_refunds_spec.rb
@@ -1209,7 +1209,7 @@ describe "PurchaseRefunds", :vcr do
           sample_image = File.read(Rails.root.join("spec", "support", "fixtures", "test-small.jpg"))
           allow(DisputeEvidence::GenerateReceiptImageService).to receive(:perform).with(purchase).and_return(sample_image)
           allow(DisputeEvidence::GenerateUncategorizedTextService).to receive(:perform).with(purchase).and_return("Sample uncategorized text")
-          allow(DisputeEvidence::GenerateAccessActivityLogsService).to receive(:perform).with(purchase).and_return("Sample activity logs")
+          allow(DisputeEvidence::GenerateAccessActivityLogsService).to receive(:perform).with(purchase, other_purchases: []).and_return("Sample activity logs")
           Purchase.handle_charge_event(charge_event_dispute)
           expect(FightDisputeJob).to have_enqueued_sidekiq_job(purchase.dispute.id)
           purchase.reload

--- a/spec/services/dispute_evidence/create_from_dispute_service_spec.rb
+++ b/spec/services/dispute_evidence/create_from_dispute_service_spec.rb
@@ -198,7 +198,7 @@ describe DisputeEvidence::CreateFromDisputeService, :vcr, :versioning do
         receive(:perform).with(purchase).and_return("Sample uncategorized text")
       )
       allow(DisputeEvidence::GenerateAccessActivityLogsService).to(
-        receive(:perform).with(purchase).and_return("Sample activity logs")
+        receive(:perform).with(purchase, other_purchases: anything).and_return("Sample activity logs")
       )
       allow(DisputeEvidence::GenerateReceiptImageService).to receive(:perform).with(purchase).and_return(sample_image)
     end

--- a/spec/services/dispute_evidence/create_from_dispute_service_spec.rb
+++ b/spec/services/dispute_evidence/create_from_dispute_service_spec.rb
@@ -548,4 +548,116 @@ describe DisputeEvidence::CreateFromDisputeService, :vcr, :versioning do
       end
     end
   end
+
+  describe "structured shipping slots on a combined charge" do
+    let(:digital_product) { create(:product, name: "Digital headliner") }
+    let(:physical_product) { create(:physical_product, name: "Shipped sibling") }
+
+    # The representative: highest amount, so purchase_for_dispute_evidence picks it, and digital,
+    # so it has no shipment at all.
+    let(:representative) do
+      create(:purchase, total_transaction_cents: 100_00, link: digital_product, email: "customer@example.com")
+    end
+
+    let(:shipped_sibling) do
+      create(
+        :purchase,
+        total_transaction_cents: 10_00,
+        link: physical_product,
+        email: "customer@example.com",
+        full_name: "John Example",
+        street_address: "500 Sibling Way",
+        city: "Oakland",
+        state: "CA",
+        zip_code: "94607",
+        country: "United States"
+      )
+    end
+
+    let!(:sibling_shipment) do
+      create(
+        :shipment,
+        carrier: "UPS",
+        tracking_number: "1Z999AA10123456784",
+        purchase: shipped_sibling,
+        ship_state: "shipped",
+        shipped_at: DateTime.parse("2023-02-10 14:55:32")
+      )
+    end
+
+    let(:charge) do
+      charge = create(:charge)
+      charge.purchases << shipped_sibling
+      charge.purchases << representative
+      charge
+    end
+
+    let(:dispute) { create(:dispute_on_charge, charge:) }
+
+    before do
+      expect(charge.purchase_for_dispute_evidence).to eq representative
+      allow(DisputeEvidence::GenerateReceiptImageService).to receive(:perform).and_return(sample_image)
+      allow(DisputeEvidence::GenerateUncategorizedTextService).to receive(:perform).and_return("text")
+      allow(DisputeEvidence::GenerateAccessActivityLogsService).to receive(:perform).and_return("logs")
+    end
+
+    it "fills all four slots from the sibling that shipped, not the unshipped representative" do
+      dispute_evidence = DisputeEvidence.create_from_dispute!(dispute)
+
+      expect(dispute_evidence.shipped_at).to eq(sibling_shipment.shipped_at)
+      expect(dispute_evidence.shipping_carrier).to eq("UPS")
+      expect(dispute_evidence.shipping_tracking_number).to eq("1Z999AA10123456784")
+      expect(dispute_evidence.shipping_address).to eq("500 Sibling Way, Oakland, CA, 94607, United States")
+    end
+
+    context "when the representative itself shipped" do
+      let(:representative) do
+        create(
+          :purchase,
+          total_transaction_cents: 100_00,
+          link: create(:physical_product, name: "Shipped headliner"),
+          email: "customer@example.com",
+          street_address: "1 Representative Rd",
+          city: "Berkeley",
+          state: "CA",
+          zip_code: "94702",
+          country: "United States"
+        )
+      end
+
+      let!(:representative_shipment) do
+        create(
+          :shipment,
+          carrier: "FedEx",
+          tracking_number: "123456789012",
+          purchase: representative,
+          ship_state: "shipped",
+          shipped_at: DateTime.parse("2023-03-01 09:00:00")
+        )
+      end
+
+      it "keeps the representative's shipment rather than preferring a sibling" do
+        dispute_evidence = DisputeEvidence.create_from_dispute!(dispute)
+
+        expect(dispute_evidence.shipping_carrier).to eq("FedEx")
+        expect(dispute_evidence.shipping_tracking_number).to eq("123456789012")
+        expect(dispute_evidence.shipped_at).to eq(representative_shipment.shipped_at)
+        expect(dispute_evidence.shipping_address).to eq("1 Representative Rd, Berkeley, CA, 94702, United States")
+      end
+    end
+
+    context "when no constituent shipped" do
+      let!(:sibling_shipment) { nil }
+      let(:shipped_sibling) { create(:purchase, total_transaction_cents: 10_00, link: digital_product, email: "customer@example.com") }
+
+      it "leaves every slot empty" do
+        dispute_evidence = DisputeEvidence.create_from_dispute!(dispute)
+
+        expect(dispute_evidence.shipping_address).to be_nil
+        expect(dispute_evidence.shipped_at).to be_nil
+        expect(dispute_evidence.shipping_carrier).to be_nil
+        expect(dispute_evidence.shipping_tracking_number).to be_nil
+      end
+    end
+  end
 end

--- a/spec/services/dispute_evidence/create_from_dispute_service_spec.rb
+++ b/spec/services/dispute_evidence/create_from_dispute_service_spec.rb
@@ -64,7 +64,7 @@ describe DisputeEvidence::CreateFromDisputeService, :vcr, :versioning do
       receive(:perform).with(disputed_purchase).and_return("Sample uncategorized text")
     )
     allow(DisputeEvidence::GenerateAccessActivityLogsService).to(
-      receive(:perform).with(disputed_purchase).and_return("Sample activity logs")
+      receive(:perform).with(disputed_purchase, other_purchases: []).and_return("Sample activity logs")
     )
     dispute_evidence = DisputeEvidence.create_from_dispute!(disputed_purchase.dispute)
 
@@ -617,6 +617,7 @@ describe DisputeEvidence::CreateFromDisputeService, :vcr, :versioning do
           total_transaction_cents: 100_00,
           link: create(:physical_product, name: "Shipped headliner"),
           email: "customer@example.com",
+          full_name: "John Example",
           street_address: "1 Representative Rd",
           city: "Berkeley",
           state: "CA",

--- a/spec/services/dispute_evidence/generate_access_activity_logs_service_spec.rb
+++ b/spec/services/dispute_evidence/generate_access_activity_logs_service_spec.rb
@@ -404,4 +404,47 @@ describe DisputeEvidence::GenerateAccessActivityLogsService do
       )
     end
   end
+
+  describe "combined charge siblings" do
+    let(:sibling_product) { create(:product, user: seller, name: "Sibling Product") }
+    let(:sibling) { create(:purchase, link: sibling_product, seller:, email: purchase.email) }
+
+    it "reports a sibling's consumption events when the selected purchase has none" do
+      create(:consumption_event, purchase_id: sibling.id, consumed_at: DateTime.parse("2024-05-08"), ip_address: "1.2.3.4")
+
+      expect(described_class.perform(purchase, other_purchases: [sibling])).to eq(
+        <<~TEXT.strip_heredoc.rstrip
+        The customer accessed the product 1 time.
+
+        consumed_at,event_type,platform,ip_address,product
+        2024-05-08 00:00:00 UTC,watch,web,1.2.3.4,"Sibling Product"
+        TEXT
+      )
+    end
+
+    it "counts a sibling's redirect uses when nothing has consumption events" do
+      purchase.create_url_redirect!
+      purchase.url_redirect.update!(uses: 2)
+      sibling.create_url_redirect!
+      sibling.url_redirect.update!(uses: 3)
+
+      expect(described_class.perform(purchase, other_purchases: [sibling])).to eq("The customer accessed the product 5 times.")
+    end
+
+    it "attributes each row to its own purchase's product" do
+      create(:consumption_event, purchase_id: purchase.id, consumed_at: DateTime.parse("2024-05-08 00:01"), ip_address: "0.0.0.0")
+      create(:consumption_event, purchase_id: sibling.id, consumed_at: DateTime.parse("2024-05-08 00:02"), ip_address: "1.2.3.4")
+
+      content = described_class.perform(purchase, other_purchases: [sibling])
+
+      expect(content).to include("2024-05-08 00:01:00 UTC,watch,web,0.0.0.0,\"#{product.name}\"")
+      expect(content).to include("2024-05-08 00:02:00 UTC,watch,web,1.2.3.4,\"Sibling Product\"")
+    end
+
+    it "leaves output byte-identical when no siblings are passed" do
+      create(:consumption_event, purchase_id: purchase.id, consumed_at: DateTime.parse("2024-05-08"), ip_address: "0.0.0.0")
+
+      expect(described_class.perform(purchase, other_purchases: [])).to eq(described_class.perform(purchase))
+    end
+  end
 end

--- a/spec/support/fixtures/vcr_cassettes/DisputeEvidence_CreateFromDisputeService/structured_shipping_slots_on_a_combined_charge/fills_all_four_slots_from_the_sibling_that_shipped_not_the_unshipped_representative.yml
+++ b/spec/support/fixtures/vcr_cassettes/DisputeEvidence_CreateFromDisputeService/structured_shipping_slots_on_a_combined_charge/fills_all_four_slots_from_the_sibling_that_shipped_not_the_unshipped_representative.yml
@@ -1,0 +1,145 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_createDispute
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_k2dj6IgdcgpQ53","request_duration_ms":6}}'
+      Idempotency-Key:
+      - 9a4de2a4-80bc-4dda-bfa8-9ce83a2bf24c
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 02 Aug 2026 22:02:42 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=dJ0zaX2NrucYH0bk75WrBq91X0YHhlMRAOfM5RvnpP4jZf00g0Lu-sOFIJGjawYnj8XoMptLU_1CG033;
+        report-to csp
+      Idempotency-Key:
+      - 9a4de2a4-80bc-4dda-bfa8-9ce83a2bf24c
+      Original-Request:
+      - req_DuGoLMiC46VFU1
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=dJ0zaX2NrucYH0bk75WrBq91X0YHhlMRAOfM5RvnpP4jZf00g0Lu-sOFIJGjawYnj8XoMptLU_1CG033&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=dJ0zaX2NrucYH0bk75WrBq91X0YHhlMRAOfM5RvnpP4jZf00g0Lu-sOFIJGjawYnj8XoMptLU_1CG033&t=1"
+      Request-Id:
+      - req_DuGoLMiC46VFU1
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1U07SwIBOqvOFDrfJzdDjgc0",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "xhj6XkBnqmm1SCzj",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "0259",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1785708162,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sun, 02 Aug 2026 22:02:42 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/DisputeEvidence_CreateFromDisputeService/structured_shipping_slots_on_a_combined_charge/when_no_constituent_shipped/leaves_every_slot_empty.yml
+++ b/spec/support/fixtures/vcr_cassettes/DisputeEvidence_CreateFromDisputeService/structured_shipping_slots_on_a_combined_charge/when_no_constituent_shipped/leaves_every_slot_empty.yml
@@ -1,0 +1,145 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_createDispute
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_qhMNgyfLBQs2KB","request_duration_ms":175}}'
+      Idempotency-Key:
+      - 0f22f8a7-f7de-420e-b37d-fa4d0c641ce9
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 02 Aug 2026 22:02:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=dJ0zaX2NrucYH0bk75WrBq91X0YHhlMRAOfM5RvnpP4jZf00g0Lu-sOFIJGjawYnj8XoMptLU_1CG033;
+        report-to csp
+      Idempotency-Key:
+      - 0f22f8a7-f7de-420e-b37d-fa4d0c641ce9
+      Original-Request:
+      - req_fhpW5m7vJTvgLa
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=dJ0zaX2NrucYH0bk75WrBq91X0YHhlMRAOfM5RvnpP4jZf00g0Lu-sOFIJGjawYnj8XoMptLU_1CG033&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=dJ0zaX2NrucYH0bk75WrBq91X0YHhlMRAOfM5RvnpP4jZf00g0Lu-sOFIJGjawYnj8XoMptLU_1CG033&t=1"
+      Request-Id:
+      - req_fhpW5m7vJTvgLa
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1U07T0IBOqvOFDrfgIiIIIix",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "xhj6XkBnqmm1SCzj",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "0259",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1785708166,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sun, 02 Aug 2026 22:02:46 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/DisputeEvidence_CreateFromDisputeService/structured_shipping_slots_on_a_combined_charge/when_the_representative_itself_shipped/keeps_the_representative_s_shipment_rather_than_preferring_a_sibling.yml
+++ b/spec/support/fixtures/vcr_cassettes/DisputeEvidence_CreateFromDisputeService/structured_shipping_slots_on_a_combined_charge/when_the_representative_itself_shipped/keeps_the_representative_s_shipment_rather_than_preferring_a_sibling.yml
@@ -1,0 +1,145 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_createDispute
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_DuGoLMiC46VFU1","request_duration_ms":274}}'
+      Idempotency-Key:
+      - e11592d7-7aa4-4568-be3e-e9809fb70ca5
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 02 Aug 2026 22:02:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=dJ0zaX2NrucYH0bk75WrBq91X0YHhlMRAOfM5RvnpP4jZf00g0Lu-sOFIJGjawYnj8XoMptLU_1CG033;
+        report-to csp
+      Idempotency-Key:
+      - e11592d7-7aa4-4568-be3e-e9809fb70ca5
+      Original-Request:
+      - req_qhMNgyfLBQs2KB
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=dJ0zaX2NrucYH0bk75WrBq91X0YHhlMRAOfM5RvnpP4jZf00g0Lu-sOFIJGjawYnj8XoMptLU_1CG033&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=dJ0zaX2NrucYH0bk75WrBq91X0YHhlMRAOfM5RvnpP4jZf00g0Lu-sOFIJGjawYnj8XoMptLU_1CG033&t=1"
+      Request-Id:
+      - req_qhMNgyfLBQs2KB
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1U07SyIBOqvOFDrfRCetgJTW",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "xhj6XkBnqmm1SCzj",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "0259",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1785708164,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sun, 02 Aug 2026 22:02:45 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## What

Four objective defects on the Stripe dispute-evidence submission path, from gumroad-private#1694 where @slavingia said *"Fix what's easy and objective, leave the rest."* No schema change, no new persisted structure, no provenance-classification contract — those are the design-decision half of that issue and are deliberately left (listed at the bottom).

**1. The structured shipping slots follow the purchase that shipped, not the representative one.**
`Charge::Disputable#purchase_for_dispute_evidence` ranks candidates by refund policy, then subscription, then highest `total_transaction_cents` — it never asks whether a purchase has a shipment. `evidence_shipment` then read the shipment of *that* purchase only, so on a combined charge where the representative ships nothing and a sibling does, all four structured slots (`shipping_address`, `shipped_at`, `shipping_carrier`, `shipping_tracking_number`) went out empty while the sibling's tracking sat in free text. Stripe's automated review reads the structured fields, and we submit once. The representative is still tried first, so every single-purchase and already-correct case is unchanged; only the previously-empty case moves. `shipping_address` now comes from the purchase that shipped, as at *its* checkout.

**2. `access_activity_log` is assembled from every constituent purchase of the charge.**
`GenerateAccessActivityLogsService` was handed the representative alone, so a sibling's download record was dropped whenever the selected purchase had none. #1694 measured that on **10 of 78** combined charges we submitted "no access recorded" to Stripe for an order the buyer demonstrably consumed, with **157** download uses sitting on purchases we never mentioned. That is the strongest evidence class in a digital-goods dispute. Rows now carry the product name whenever the log can span more than one purchase, so an entry is attributable rather than reading as the representative's. Bundle handling is unchanged and now applies per constituent.

**3. The combined-charge source selection is deterministic.**
`selected_purchases.sort_by(&:total_transaction_cents).last` over an unordered `purchases.to_a` — `sort_by` is not stable, so a tie at the maximum picked an arbitrary row between runs. #1694 measured a tie at the maximum on **12 of 78** combined rows. Now `min_by { [-total_transaction_cents.to_i, id] }`; `to_i` because the column is nullable and a nil raised in the old sort rather than ranking.

**4. `Stripe::Dispute.update` carries an idempotency key.**
`FightDisputeJob` runs `retry: 5` and a dispute accepts evidence exactly once (gumroad-private#1612), so a network failure on a call that actually landed could spend the one permitted submission a second time. The key is `dispute_evidence_<external_id>` and is deliberately **immutable**: anything derived from the payload would change on every attempt, because `create_dispute_evidence_stripe_file` re-uploads and returns a fresh Stripe file id per call, and anything derived from `updated_at` would change because the seller legitimately writes `reason_for_winning` into the same row during the 2.19-day assembly-to-submission gap #1694 measured. One evidence row is one permitted submission — the job returns early once the row is resolved — so the row's identity is the whole key. Two earlier iterations of this (payload digest, then `updated_at`) were both caught in review and are recorded here because the mutation table below pins against them.

## Why

Each of the four is a defect the code proves on its own — no design decision, no new contract, no schema. Deliberately **not** built, per "leave the rest": the durable checkout snapshot, the per-field provenance vocabulary (`exact` / `positive_witness` / `proxy` / `unknown`), `sealed_at` at processor submission, the deadline contract, per-field `source_purchase_id`, scheduled processor-state reconciliation, and the access-evidence wording change. Those need a persisted structure and an owner's call.

## Before / After

| scenario | before | after |
|---|---|---|
| combined charge, representative unshipped, sibling shipped | 4 structured shipping slots empty | filled from the shipped sibling, address as at its checkout |
| combined charge, representative has no access rows, sibling does | log reports no access | union of all constituents, rows attributed by product |
| combined charge with a tie at the maximum amount | arbitrary purchase between runs | lowest id at the maximum, stable in both orders |
| `FightDisputeJob` retry after a landed call | second submission consumes the one-shot | same key, Stripe replays the first result |

## Test Results

Run locally at head in a fresh worktree off `origin/main`:

- `spec/models/concerns/charge/disputable_spec.rb -e purchase_for_dispute_evidence` — 10 examples, 0 failures
- `spec/services/dispute_evidence/create_from_dispute_service_spec.rb` — 25 examples, 0 failures
- `spec/services/dispute_evidence/generate_access_activity_logs_service_spec.rb` — 28 examples, 0 failures
- `spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb -e fight_chargeback` — 12 examples, 0 failures (these `and_call_original` against real Stripe, which is what confirms the 3-arg `Stripe::Dispute.update(id, params, opts)` form on stripe-ruby 12.5.0)
- `spec/sidekiq/fight_dispute_job_spec.rb`, `spec/services/dispute_evidence/generate_uncategorized_text_service_spec.rb`, `spec/models/dispute_evidence_spec.rb` — 61 examples, 0 failures

**Mutation checks** — each fix reverted in place, its spec re-run, then restored (tree verified clean and at the reviewed head afterwards):

| mutant | result |
|---|---|
| tie-break back to unstable `sort_by(&:total_transaction_cents).last` | 1 failure |
| shipment candidates reduced to the representative only | 1 failure |
| access log drops the sibling purchases | 3 failures |
| idempotency key removed entirely | 2 failures |
| key digests the mutable payload | 2 failures |
| key derived from the mutable `updated_at` | 2 failures |
| key made constant across all rows | 2 failures |
| baseline and restored, all four spec files | 0 failures |

The tie-break spec was vacuous on its first round (mutant survived with 0 failures) and was rewritten to assert both constituent orders against a single expected row; the table above is the re-run.

## QA steps

Executed, not predicted — the behaviour is invisible in the UI (it is a payload we hand a card network), so the QA is the payload boundary itself:

1. `spec/business/.../stripe_charge_processor_spec.rb -e fight_chargeback` builds a real `DisputeEvidence` from a formalized dispute and asserts on the hash actually passed to `Stripe::Dispute.update`, including the third options argument. Green, 12 examples — this is the only surface where the four fixes become an outbound submission.
2. Combined-charge shipping selection exercised end to end through `DisputeEvidence.create_from_dispute!` in three shapes: representative unshipped with a shipped sibling (slots filled from the sibling), representative shipped (its own shipment kept, sibling not preferred), nothing shipped (all four slots nil).
3. Idempotency key re-derived across a plain retry and across a seller writing `reason_for_winning` into the row between attempts — identical both times; distinct between two different evidence rows.
4. Pre-existing dispute-evidence suites re-run unchanged to confirm the new `other_purchases:` keyword did not silently change single-purchase output; one example asserts byte-identical output when no siblings are passed.

## Status

- [x] **Scope** — four objective fixes; design-decision items named and excluded (below).
- [x] **Design** — no new persisted structure by construction; that is the excluded half.
- [x] **Build** — pushed.
- [x] **QA** — done, steps above, executed not predicted.
- [ ] **Ship** — not merged. Human merge call wanted (dispute money path, one-shot submission).
- [ ] **Market** — n/a, internal correctness fix with no user-visible surface.
- [ ] **Sell** — n/a.

Review: adversarial pre-merge review run on the pushed branch; its P1 (payload-derived idempotency key) and Greptile's P1 (`updated_at`-derived key) were the same defect class and are both fixed, with mutation checks pinning against each. Auto-merge deliberately **not** armed: this is the chargeback/dispute money path with an irreversible one-shot submission to a card network, so it wants a human's eyes. @nyomanjyotisa — the judgement call worth your attention is fix 1: on a combined charge we now assert a shipping address belonging to a *different* constituent purchase than the identity fields, which is strictly better than four empty slots but is still one purchase's delivery standing in for the order.

---

AI disclosure: written by Hermes Agent (claude-opus-5) acting for @gumclaw, on @slavingia's direction in gumroad-private#1694.
