### PR TITLE
Reach the seller through the charge on a charge-keyed receipt

### DIFF
--- a/app/sidekiq/alert_sellers_of_undelivered_receipts_job.rb
+++ b/app/sidekiq/alert_sellers_of_undelivered_receipts_job.rb
@@ -134,13 +134,16 @@ class AlertSellersOfUndeliveredReceiptsJob
       :collected
     end
 
+    # A charge receipt covers the whole order, so any of its purchases identifies the seller and
+    # carries the buyer's email. `Charge#purchase_as_orderable` does not exist — that method is
+    # private on `Order` — so read the charge's own successful purchases.
     def purchase_for(row)
       return Purchase.find_by(id: row.purchase_id) if row.purchase_id.present?
 
       charge_id = EmailInfoCharge.where(email_info_id: row.id).pick(:charge_id)
       return nil if charge_id.nil?
 
-      Charge.find_by(id: charge_id)&.purchase_as_orderable
+      Charge.find_by(id: charge_id)&.purchases&.all_success_states_including_test&.first
     end
 
     # Enqueues one digest per seller. Answers whether every buyer in this run is accounted for —

--- a/app/sidekiq/alert_sellers_of_undelivered_receipts_job.rb
+++ b/app/sidekiq/alert_sellers_of_undelivered_receipts_job.rb
@@ -134,16 +134,16 @@ class AlertSellersOfUndeliveredReceiptsJob
       :collected
     end
 
-    # A charge receipt covers the whole order, so any of its purchases identifies the seller and
-    # carries the buyer's email. `Charge#purchase_as_orderable` does not exist — that method is
-    # private on `Order` — so read the charge's own successful purchases.
+    # A charge receipt covers the whole order, so any of the charge's successful purchases carries
+    # the seller and the buyer's email. Scoped to the charge rather than the order: an order can
+    # hold charges for several sellers, and the receipt row belongs to one of them.
     def purchase_for(row)
       return Purchase.find_by(id: row.purchase_id) if row.purchase_id.present?
 
       charge_id = EmailInfoCharge.where(email_info_id: row.id).pick(:charge_id)
       return nil if charge_id.nil?
 
-      Charge.find_by(id: charge_id)&.purchases&.all_success_states_including_test&.first
+      Charge.find_by(id: charge_id)&.successful_purchases&.first
     end
 
     # Enqueues one digest per seller. Answers whether every buyer in this run is accounted for —

--- a/spec/sidekiq/alert_sellers_of_undelivered_receipts_job_spec.rb
+++ b/spec/sidekiq/alert_sellers_of_undelivered_receipts_job_spec.rb
@@ -25,6 +25,22 @@ describe AlertSellersOfUndeliveredReceiptsJob do
       .with(seller.id, [purchase.id])
   end
 
+  # Charge-keyed rows carry no purchase_id, and combined-cart orders make them a large share of real
+  # receipts. `Charge#purchase_as_orderable` does not exist (it is private on `Order`), so reaching
+  # the seller this way raised NoMethodError and the sweep died on the very cohort it exists to find.
+  it "emails the seller about a charge-keyed receipt that carries no purchase_id" do
+    charge = create(:charge, seller:)
+    purchase = create(:purchase, seller:, link: product)
+    charge.purchases << purchase
+    charge.update!(order: create(:order))
+    create(:customer_email_info, purchase: nil, state: "sent", sent_at: 3.days.ago,
+                                 email_info_charge_attributes: { charge_id: charge.id })
+
+    expect { described_class.new.perform }
+      .to have_enqueued_mail(ContactingCreatorMailer, :undelivered_receipts)
+      .with(seller.id, [purchase.id])
+  end
+
   it "emails nobody when every receipt was delivered" do
     purchase = create(:purchase, seller:, link: product)
     create(:customer_email_info, purchase:, state: "delivered", sent_at: 3.days.ago, delivered_at: 3.days.ago)


### PR DESCRIPTION
## What

`AlertSellersOfUndeliveredReceiptsJob#purchase_for` resolved a charge-keyed receipt row through `Charge#purchase_as_orderable`. That method does not exist on `Charge` — it is `private` on `Order` — so every charge-keyed row raised `NoMethodError`. It now reads `Charge#successful_purchases`.

## Why

Charge-keyed rows are the ones with no `purchase_id`, which is how a receipt covering a combined-cart order is stored. They are a large share of real receipts, so the nightly sweep from #6749 raised on the cohort it exists to find, and no spec covered the path.

Measured on the audited production replica for one settled day (2026-07-26), excluding one suspended-for-TOS account that alone produced 143,746 of that day's 145,547 receipt bounces: 231 purchases across 103 sellers had a bounced receipt whose buyer also never opened their content, plus 112 across 54 sellers stuck at `sent`. The charge-keyed share of that cohort is exactly what this raised on.

Scoping to the charge rather than the order is also more correct than the original intent: an order can hold charges for several sellers, and the receipt row belongs to one of them.

Refs gumroad-private#1635. Follow-up to #6749.

## Before / after

Before — on a receipt row with `purchase_id` nil and an `email_info_charges` join:

```
NoMethodError: undefined method 'purchase_as_orderable' for an instance of Charge
  app/sidekiq/alert_sellers_of_undelivered_receipts_job.rb:146
```

After — the seller is emailed about that buyer. The new example asserts the mail is enqueued for the right seller with the right purchase id, not merely that nothing raised.

## Test Results

`bundle exec rspec spec/sidekiq/alert_sellers_of_undelivered_receipts_job_spec.rb` — **27 examples, 0 failures**.

The regression example is load-bearing: reverting the one-line fix reddens **that example only** (26 others stay green), with the original `NoMethodError`. The spec builds a genuinely charge-keyed row — `purchase: nil` overrides the factory default and `email_info_charge_attributes:` creates the join — and the `charge.update!(order:)` line is required, since without an order `uses_charge_receipt?` is false and the re-judgment could not resolve the row.

CI green at `610e473c`: **78 jobs, 0 failed, 0 pending.**

Rubocop clean on both changed files.

## QA steps

No user-facing surface changes; this is a Sidekiq job whose only output is an existing seller email. There is nothing to click through, so the spec run is the artifact.

To exercise it against a charge-keyed row in a console:

1. Pick a `Charge` with an `email_info_charges` row whose `EmailInfo` is `state: "sent"`, `sent_at` more than 2 days ago, and whose buyer has no `url_redirect.uses`.
2. `$redis.set(RedisKey.undelivered_receipt_sweep_cursor, <id below that row>)`
3. `AlertSellersOfUndeliveredReceiptsJob.new.perform`
4. Before this change: `NoMethodError`. After: one `ContactingCreatorMailer#undelivered_receipts` enqueued for that charge's seller.

## Adversarial review

Local fable-5 review at `e160cc2e`: **SHIP**, no P1/P2. Two P3s, both taken in `610e473c`:

- the replacement restated the body of the existing `Charge#successful_purchases` — now calls that method instead;
- the code comment narrated the dead bug, against this repo's comment guidance — that history lives in the commit message.

The reviewer independently confirmed determinism (`.first` on an unordered relation gets `ORDER BY purchases.id ASC`), that picking any purchase from one charge yields the same seller and buyer email, that the nil-purchase path matches how the purchase-keyed branch handles a deleted purchase, and that including test purchases is parity with every other receipt-side resolver.

Left open by the reviewer as data questions rather than code defects: whether charge-keyed rows with zero success-state purchases exist in production, and the real volume of test purchases reaching this path.

---

## AI disclosure

Written by **claude-opus-5** (`model.default` in the agent config) running as the Gumclaw agent.

Instructions given: continue work on gumroad-private#1635 ("keep going"). The agent sized the platform-wide non-delivery rate on the audited read-only production replica, found that a sibling session had already shipped the seller-notification sweep in #6749, ran a local adversarial review against that merged code, found this crash on the charge-keyed path, and opened this fix. No production writes were made; every production read went through the audited console.
