### PR TITLE
Exempt a whole account from content moderation, not one product at a time

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -224,6 +224,28 @@ class Admin::UsersController < Admin::BaseController
     render json: { success: false, message: e.message }
   end
 
+  # Granting the exemption also marks the account adult: the sellers this is for work in a
+  # category we allow but rate adult, and leaving that half-done puts their listings in
+  # Discover unrated. Revoking it does not unmark them -- that is a separate call.
+  def toggle_content_moderation_disabled
+    enabling = !@user.content_moderation_disabled?
+
+    @user.content_moderation_disabled = enabling
+    @user.all_adult_products = true if enabling
+    @user.save!
+
+    @user.comments.create!(
+      author_id: current_user.id,
+      author_name: current_user.name,
+      comment_type: Comment::COMMENT_TYPE_NOTE,
+      content: enabling ? "Disabled content moderation for this account (all products, including future ones) and marked it adult" : "Re-enabled content moderation for this account"
+    )
+
+    render json: { success: true }
+  rescue => e
+    render json: { success: false, message: e.message }
+  end
+
   private
     def create_scheduled_payout_if_requested
       sp_params = params.dig(:scheduled_payout)

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -230,16 +230,20 @@ class Admin::UsersController < Admin::BaseController
   def toggle_content_moderation_disabled
     enabling = !@user.content_moderation_disabled?
 
-    @user.content_moderation_disabled = enabling
-    @user.all_adult_products = true if enabling
-    @user.save!
+    # One transaction: a committed toggle with no audit comment would report failure to the
+    # admin, who then retries and flips the persisted state back.
+    ActiveRecord::Base.transaction do
+      @user.content_moderation_disabled = enabling
+      @user.all_adult_products = true if enabling
+      @user.save!
 
-    @user.comments.create!(
-      author_id: current_user.id,
-      author_name: current_user.name,
-      comment_type: Comment::COMMENT_TYPE_NOTE,
-      content: enabling ? "Disabled content moderation for this account (all products, including future ones) and marked it adult" : "Re-enabled content moderation for this account"
-    )
+      @user.comments.create!(
+        author_id: current_user.id,
+        author_name: current_user.name,
+        comment_type: Comment::COMMENT_TYPE_NOTE,
+        content: enabling ? "Disabled content moderation for this account (all products, including future ones) and marked it adult" : "Re-enabled content moderation for this account"
+      )
+    end
 
     render json: { success: true }
   rescue => e

--- a/app/javascript/components/Admin/Users/Actions/DisableContentModerationAction.tsx
+++ b/app/javascript/components/Admin/Users/Actions/DisableContentModerationAction.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+import AdminAction from "$app/components/Admin/ActionButton";
+import { type User } from "$app/components/Admin/Users/User";
+
+type DisableContentModerationActionProps = {
+  user: User;
+};
+
+const DisableContentModerationAction = ({
+  user: { external_id, content_moderation_disabled },
+}: DisableContentModerationActionProps) =>
+  content_moderation_disabled ? (
+    <AdminAction
+      label="Enable content moderation"
+      url={Routes.toggle_content_moderation_disabled_admin_user_path(external_id)}
+      confirm_message={`Are you sure you want to re-enable content moderation for user ${external_id}?`}
+      done="Disable content moderation"
+      success_message="Content moderation enabled."
+    />
+  ) : (
+    <AdminAction
+      label="Disable content moderation"
+      url={Routes.toggle_content_moderation_disabled_admin_user_path(external_id)}
+      confirm_message={`Are you sure you want to disable content moderation for user ${external_id}? Every product they create from now on skips moderation, and the account is marked adult.`}
+      done="Enable content moderation"
+      success_message="Content moderation disabled and account marked as adult."
+    />
+  );
+
+export default DisableContentModerationAction;

--- a/app/javascript/components/Admin/Users/Actions/index.tsx
+++ b/app/javascript/components/Admin/Users/Actions/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import ConfirmEmailAction from "$app/components/Admin/Users/Actions/ConfirmEmailAction";
+import DisableContentModerationAction from "$app/components/Admin/Users/Actions/DisableContentModerationAction";
 import GdprEraseAction from "$app/components/Admin/Users/Actions/GdprEraseAction";
 import ImpersonateAction from "$app/components/Admin/Users/Actions/ImpersonateAction";
 import InvalidateActiveSessionsAction from "$app/components/Admin/Users/Actions/InvalidateActiveSessionsAction";
@@ -23,6 +24,7 @@ const AdminUserActions = ({ user }: AdminUserActionsProps) => (
     <ConfirmEmailAction user={user} />
     <InvalidateActiveSessionsAction user={user} />
     <MarkAsAdultAction user={user} />
+    <DisableContentModerationAction user={user} />
     <GdprEraseAction user={user} />
   </div>
 );

--- a/app/javascript/components/Admin/Users/User.tsx
+++ b/app/javascript/components/Admin/Users/User.tsx
@@ -80,6 +80,7 @@ export type User = {
   impersonatable: boolean;
   verified: boolean | null;
   all_adult_products: boolean;
+  content_moderation_disabled: boolean;
   admin_manageable_user_memberships: UserMembership[];
   alive_user_compliance_info?: ComplianceInfoProps | null;
   compliant?: boolean | null;

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -364,6 +364,7 @@ class User < ApplicationRecord
             54 => :disable_review_reminders, # Seller setting: when enabled, buyers of this seller's products don't receive review reminder emails.
             55 => :ach_payments_enabled, # Seller opt-in (checkout settings page): offers ACH Direct Debit (us_bank_account) at checkout. Off by default — ACH settles in ~4 business days and content only delivers on settlement, which surprises buyers of time-sensitive digital products (gumroad-private#1143).
             56 => :gifting_disabled, # Seller opt-out (checkout settings page): removes the "Give as a gift" option at checkout for all of this seller's products (gumroad-private#1191).
+            57 => :content_moderation_disabled, # Admin-only: exempts every product this seller creates from automated content moderation, including ones that don't exist yet. Link#content_moderation_disabled only covers products that already exist when support grants it (gumroad-private#1742).
             :column => "flags",
             :flag_query_mode => :bit_operator,
             check_for_column: false

--- a/app/presenters/admin/user_presenter/card.rb
+++ b/app/presenters/admin/user_presenter/card.rb
@@ -48,6 +48,7 @@ class Admin::UserPresenter::Card
       flagged_for_tos_violation: user.flagged_for_tos_violation?,
       on_probation: user.on_probation?,
       all_adult_products: user.all_adult_products?,
+      content_moderation_disabled: user.content_moderation_disabled?,
 
       # Risk & moderation
       user_risk_state: user.user_risk_state.humanize,

--- a/app/services/content_moderation/moderate_record_service.rb
+++ b/app/services/content_moderation/moderate_record_service.rb
@@ -220,13 +220,13 @@ class ContentModeration::ModerateRecordService
     end
 
     def record_moderation_disabled?
-      # An account-level exemption is a decision about the seller and their genre, so it
-      # has to cover products that don't exist yet -- the per-record flag below only ever
-      # covers the catalogue as it stood when support granted it.
-      return true if user&.content_moderation_disabled?
-
       case entity_type
-      when :product then record.content_moderation_disabled?
+      # An account-level exemption is a decision about the seller and their genre, so it
+      # has to cover products that don't exist yet -- the per-record flag only ever covers
+      # the catalogue as it stood when support granted it. It is scoped to products
+      # deliberately: posts are not part of the catalogue an exemption is granted over, so
+      # an exempt seller's posts still go through moderation.
+      when :product then user&.content_moderation_disabled? || record.content_moderation_disabled?
       # A page inherits the escape hatch from the product it takes over, so
       # turning moderation off for a product covers its landing page too --
       # otherwise the exemption would hold for the product and then block the

--- a/app/services/content_moderation/moderate_record_service.rb
+++ b/app/services/content_moderation/moderate_record_service.rb
@@ -220,6 +220,11 @@ class ContentModeration::ModerateRecordService
     end
 
     def record_moderation_disabled?
+      # An account-level exemption is a decision about the seller and their genre, so it
+      # has to cover products that don't exist yet -- the per-record flag below only ever
+      # covers the catalogue as it stood when support granted it.
+      return true if user&.content_moderation_disabled?
+
       case entity_type
       when :product then record.content_moderation_disabled?
       # A page inherits the escape hatch from the product it takes over, so

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -64,6 +64,7 @@ namespace :admin do
       post :flag_for_fraud
       post :set_custom_fee
       post :toggle_adult_products
+      post :toggle_content_moderation_disabled
       post :gdpr_erase
     end
   end

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -324,6 +324,18 @@ describe Admin::UsersController, type: :controller, inertia: true do
       expect(user.all_adult_products?).to be(true)
       expect(user.comments.last.content).to include("Re-enabled content moderation")
     end
+
+    # A committed toggle with a failed audit write reports failure to the admin, who then
+    # retries and flips the persisted state a second time.
+    it "leaves the flag untouched when the audit comment cannot be written" do
+      allow_any_instance_of(Comment).to receive(:save!).and_raise(ActiveRecord::RecordInvalid)
+
+      post :toggle_content_moderation_disabled, params: { external_id: user.external_id }
+
+      expect(response.parsed_body["success"]).to be(false)
+      expect(user.reload.content_moderation_disabled?).to be(false)
+      expect(user.all_adult_products?).to be(false)
+    end
   end
 
   describe "POST #toggle_adult_products" do

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -301,6 +301,31 @@ describe Admin::UsersController, type: :controller, inertia: true do
     end
   end
 
+  describe "POST #toggle_content_moderation_disabled" do
+    let(:user) { create(:user, all_adult_products: false) }
+
+    it "disables moderation for the account and marks it adult" do
+      post :toggle_content_moderation_disabled, params: { external_id: user.external_id }
+
+      expect(response).to be_successful
+      expect(response.parsed_body["success"]).to be(true)
+      expect(user.reload.content_moderation_disabled?).to be(true)
+      expect(user.all_adult_products?).to be(true)
+      expect(user.comments.last.content).to include("Disabled content moderation")
+    end
+
+    it "re-enables moderation without unmarking the account as adult" do
+      user.update!(content_moderation_disabled: true, all_adult_products: true)
+
+      post :toggle_content_moderation_disabled, params: { external_id: user.external_id }
+
+      expect(response).to be_successful
+      expect(user.reload.content_moderation_disabled?).to be(false)
+      expect(user.all_adult_products?).to be(true)
+      expect(user.comments.last.content).to include("Re-enabled content moderation")
+    end
+  end
+
   describe "POST #toggle_adult_products" do
     let(:user) { create(:user) }
 

--- a/spec/services/content_moderation/moderate_record_service_spec.rb
+++ b/spec/services/content_moderation/moderate_record_service_spec.rb
@@ -60,6 +60,16 @@ RSpec.describe ContentModeration::ModerateRecordService, :vcr do
       expect(result.reasons).to eq([])
     end
 
+    it "skips moderation for every product of a seller with account-level content_moderation_disabled" do
+      product.user.update!(content_moderation_disabled: true)
+      expect(ContentModeration::ContentExtractor).not_to receive(:new)
+
+      result = described_class.check(create(:product, user: product.user), :product)
+
+      expect(result.passed).to eq(true)
+      expect(result.reasons).to eq([])
+    end
+
     it "returns passed when content is empty" do
       allow_any_instance_of(ContentModeration::ContentExtractor).to receive(:extract_from_product)
         .and_return(ContentModeration::ContentExtractor::Result.new(text: "", image_urls: []))

--- a/spec/services/content_moderation/moderate_record_service_spec.rb
+++ b/spec/services/content_moderation/moderate_record_service_spec.rb
@@ -70,6 +70,19 @@ RSpec.describe ContentModeration::ModerateRecordService, :vcr do
       expect(result.reasons).to eq([])
     end
 
+    # The exemption is granted over a seller's catalogue, so it must not silently also
+    # exempt their posts. A skip would return passed, so a block proves moderation ran.
+    it "still moderates a post by a seller with account-level content_moderation_disabled" do
+      seller.update!(content_moderation_disabled: true)
+      post = create(:installment, seller: seller, name: "Post", message: "<p>Body</p>")
+      allow(ContentModeration::Strategies::ClassifierStrategy).to receive(:new).and_return(
+        instance_double(ContentModeration::Strategies::ClassifierStrategy,
+                        perform: strategy_result.new(status: "flagged", reasoning: ["OpenAI moderation flagged: sexual"]))
+      )
+
+      expect(described_class.check(post, :post).passed).to eq(false)
+    end
+
     it "returns passed when content is empty" do
       allow_any_instance_of(ContentModeration::ContentExtractor).to receive(:extract_from_product)
         .and_return(ContentModeration::ContentExtractor::Result.new(text: "", image_urls: []))


### PR DESCRIPTION
## What

Adds an **account-level** content moderation exemption on `User` (flag bit 57, `content_moderation_disabled`), checked in `ContentModeration::ModerateRecordService#record_moderation_disabled?` alongside the existing per-product flag. Grantable from the admin user page as "Disable content moderation", which also marks the account adult.

Closes antiwork/gumroad-private#1742.

## Why

`content_moderation_disabled` is a per-**product** `json_data` flag (`Link#content_moderation_disabled`). When support human-reviews a catalogue and rules it compliant, the exemption only covers the products that exist at that moment. Every product created afterwards is moderated from scratch and re-blocked.

Live case in the issue: seller 28426469 was blocked 12 times across 7 products over three days by the OpenAI `sexual` preset at 0.836–0.928 against a 0.8 threshold. At 21:34Z support reviewed the catalogue, ruled it compliant, and set the flag on all 17 live products. **Six minutes later the seller created product 13698431 and was blocked again** — the new record came into existence with `content_moderation_disabled = false`, outside the exemption that had just been granted.

The only account-wide escape hatch today is `User#vip_creator?`, a pure revenue threshold (>$5,000 gross paid payouts). This seller has $1.86 lifetime, so no amount of human clearing reaches them.

@slavingia on the issue: *"Account level NSFW exemption etc is good to have I agree, which would also auto set nsfw on all their products"* — so granting the exemption sets `all_adult_products` too. Revoking does not unset it; unmarking adult is a separate, existing action, and silently un-rating a catalogue on revoke would be worse than leaving it rated.

## Before-After

| | Before | After |
|---|---|---|
| Support clears a catalogue | sets `content_moderation_disabled` on each existing product | one account-level toggle |
| Seller uploads a new product | moderated from scratch, blocked again, new support ticket | `record_moderation_disabled?` returns true, publish goes through |
| Adult rating on that new product | unrated unless support also marks the account | `all_adult_products` set when the exemption is granted, so `Link#rated_as_adult?` is true via `user.all_adult_products?` |
| Audit trail | none for the exemption itself | a `Comment` on the account naming who granted or revoked it |

The seller-facing surface has **no visual delta** — the change is the absence of a block. The admin surface gains one button in the existing user Actions row, next to "Mark as adult", following `MarkAsAdultAction` exactly.

## Test Results

Checks run locally in the lane worktree:

- `ruby -c` on all five changed Ruby files and both spec files — clean.
- `npx prettier --write` on the three TSX files — `DisableContentModerationAction.tsx` reformatted, other two already clean.

New examples (running in CI on this head):

- `spec/services/content_moderation/moderate_record_service_spec.rb` — "skips moderation for every product of a seller with account-level content_moderation_disabled". Constructed so it cannot pass by accident: the exempted product is created **after** the flag is set, which is exactly the case the per-product flag misses, and it asserts `ContentModeration::ContentExtractor` is never instantiated.
- `spec/controllers/admin/users_controller_spec.rb` — "disables moderation for the account and marks it adult" and "re-enables moderation without unmarking the account as adult" (pins the asymmetry described above).

## QA steps

**Preview app is unavailable: the staging cluster is down as of this writing.** `staging.gumroad.com` returns **503**, and every `*.apps.staging.gumroad.org` preview host fails the TLS handshake with `tlsv1 alert internal error`, while `gumroad.com` returns 200 from the same machine. I will attach admin-page captures once it answers rather than substituting a local render.

Reviewer path, on a preview once one is reachable:

1. Admin → user page for any seller. The Actions row now shows **Disable content moderation** after "Mark as adult".
2. Click it, confirm. The button flips to "Enable content moderation"; the account's comments gain a note naming you as the author.
3. As that seller, create a product with content the `sexual` or `adult_content` preset would normally block. It publishes.
4. Check the product's `rated_as_adult?` — true, inherited from `all_adult_products`.
5. Click **Enable content moderation**. The next publish is moderated normally, and the account stays marked adult.

Console equivalent for step 3 without a preview:

```ruby
u = User.find(<id>); u.update!(content_moderation_disabled: true)
ContentModeration::ModerateRecordService.check(u.links.create!(name: "test"), :product).passed  # => true
```

## Not in this PR

- **No expiry or re-review.** The issue asks whether the exemption should expire. It does not here — the toggle is symmetric and revocable, and an expiry policy is a decision about how long a human review stays valid, which is Trust & Safety's call rather than mine.
- **No page-level exemption.** Pages already inherit from the product they take over; gumroad-private#1684 covers the gap where they do not.
- **No bulk backfill.** Sellers who already have per-product exemptions keep them; the two checks are independent.

---

🤖 Generated with [Hermes Agent](https://github.com/NousResearch/hermes-agent) using claude-opus-5

Instructions given: the standing autonomous-dispatcher order to drain qualifying gumroad-private issues into PRs, applied to #1742, plus @slavingia's comment on that issue that an account-level exemption should also set NSFW on all their products.
