### PR TITLE
Key method-forced direct-listed charging on the purchase's currency snapshot

### DIFF
--- a/app/services/checkout/buyer_currency_eligibility.rb
+++ b/app/services/checkout/buyer_currency_eligibility.rb
@@ -480,7 +480,14 @@ class Checkout::BuyerCurrencyEligibility
       end
     end
 
-    priced_in_forced_currency = product_currencies.all? { _1 == forced_currency }
+    # The direct lane charges `displayed_price_cents`, denominated in the currency snapshotted
+    # on the purchase at creation (Purchase#assign_price_currency), not the product's current
+    # one. A seller who repriced between the row being built and the charge would otherwise
+    # get the old currency's cents sent as the new one. Requiring both to agree degrades a
+    # repriced-mid-flight checkout to the quoted lane, which converts canonical USD and is
+    # unaffected by the snapshot.
+    priced_in_forced_currency = product_currencies.all? { _1 == forced_currency } &&
+                                purchases.all? { _1.displayed_price_currency_type.to_s.downcase == forced_currency }
 
     # The USD-priced case converts through a Stripe FX quote (forced currency -> USD),
     # which is exactly the call a fresh mismatch marker predicts Stripe will reject —

--- a/spec/services/checkout/buyer_currency_eligibility_spec.rb
+++ b/spec/services/checkout/buyer_currency_eligibility_spec.rb
@@ -556,7 +556,7 @@ describe Checkout::BuyerCurrencyEligibility do
     # reaches this state: the row is never rewritten, so its whole snapshot stays USD-consistent.
     it "withholds the direct listed-amount path when the purchase's snapshotted currency disagrees with the repriced product" do
       purchase
-      product.update!(price_currency_type: Currency::EUR)
+      product.update!(price_currency_type: Currency::EUR, price_cents: 20_00)
 
       expect(forced_decision).to be_eligible
       expect(forced_decision.currency).to eq(Currency::EUR)
@@ -571,7 +571,7 @@ describe Checkout::BuyerCurrencyEligibility do
                           seller:,
                           merchant_account:,
                           purchase_state: "in_progress")
-      repriced_product.update!(price_currency_type: Currency::INR)
+      repriced_product.update!(price_currency_type: Currency::INR, price_cents: 7300)
 
       upi_decision = described_class.new(order:,
                                          seller:,

--- a/spec/services/checkout/buyer_currency_eligibility_spec.rb
+++ b/spec/services/checkout/buyer_currency_eligibility_spec.rb
@@ -22,12 +22,16 @@ describe Checkout::BuyerCurrencyEligibility do
   let(:setup_future_charges) { false }
   let(:off_session) { false }
 
-  # Re-point a purchase at a differently-priced product the way a real checkout would build
-  # it: the currency snapshot on the row is taken from the product at creation
-  # (Purchase#prepare_for_charge), so a spec that swaps only `link` leaves a stale snapshot
-  # behind and no longer models the case it is named for.
+  # Re-point a purchase at a differently-priced product the way a real checkout builds the row.
+  # The whole monetary snapshot — amount, currency, USD conversion rate, canonical price, total —
+  # is written together by Purchase#set_price_and_rate, so a spec that swaps only `link` (or only
+  # `link` and the currency label) leaves the previous product's figures behind and models a row
+  # production never creates.
   def relist_purchase(purchase, product, **attrs)
-    purchase.update!(link: product, displayed_price_currency_type: product.price_currency_type, **attrs)
+    purchase.assign_attributes(link: product, **attrs)
+    purchase.set_price_and_rate
+    purchase.save!
+    purchase
   end
 
   subject(:decision) do
@@ -548,10 +552,11 @@ describe Checkout::BuyerCurrencyEligibility do
 
     # gumroad-private#1743. displayed_price_cents is denominated in the currency snapshotted
     # on the purchase, so a product repriced after the row was built would otherwise have its
-    # old-currency cents charged as the new currency.
+    # old-currency cents charged as the new currency. Repricing the product is how production
+    # reaches this state: the row is never rewritten, so its whole snapshot stays USD-consistent.
     it "withholds the direct listed-amount path when the purchase's snapshotted currency disagrees with the repriced product" do
-      purchase.update!(link: create(:product, user: seller, price_currency_type: Currency::EUR),
-                       displayed_price_currency_type: Currency::USD)
+      purchase
+      product.update!(price_currency_type: Currency::EUR)
 
       expect(forced_decision).to be_eligible
       expect(forced_decision.currency).to eq(Currency::EUR)
@@ -559,14 +564,14 @@ describe Checkout::BuyerCurrencyEligibility do
     end
 
     it "withholds the direct listed-amount path when one line of a multi-item cart carries a stale snapshot" do
-      purchase.update!(link: create(:product, user: seller, price_currency_type: Currency::INR, price_cents: 7300),
-                       displayed_price_currency_type: Currency::INR)
+      relist_purchase(purchase, create(:product, user: seller, price_currency_type: Currency::INR, price_cents: 7300))
+      repriced_product = create(:product, user: seller, price_currency_type: Currency::USD, price_cents: 7300)
       purchases << create(:purchase,
-                          link: create(:product, user: seller, price_currency_type: Currency::INR, price_cents: 7300),
+                          link: repriced_product,
                           seller:,
                           merchant_account:,
-                          displayed_price_currency_type: Currency::USD,
                           purchase_state: "in_progress")
+      repriced_product.update!(price_currency_type: Currency::INR)
 
       upi_decision = described_class.new(order:,
                                          seller:,
@@ -920,12 +925,13 @@ describe Checkout::BuyerCurrencyEligibility do
 
     it "allows the direct listed-amount path for multi-item carts uniformly priced in the forced currency" do
       relist_purchase(purchase, create(:product, user: seller, price_currency_type: Currency::INR, price_cents: 7300))
-      purchases << create(:purchase,
-                          link: create(:product, user: seller, price_currency_type: Currency::INR, price_cents: 7300),
-                          displayed_price_currency_type: Currency::INR,
-                          seller:,
-                          merchant_account:,
-                          purchase_state: "in_progress")
+      second_product = create(:product, user: seller, price_currency_type: Currency::INR, price_cents: 7300)
+      purchases << relist_purchase(create(:purchase,
+                                          link: second_product,
+                                          seller:,
+                                          merchant_account:,
+                                          purchase_state: "in_progress"),
+                                   second_product)
 
       upi_decision = described_class.new(order:,
                                          seller:,

--- a/spec/services/checkout/buyer_currency_eligibility_spec.rb
+++ b/spec/services/checkout/buyer_currency_eligibility_spec.rb
@@ -539,7 +539,7 @@ describe Checkout::BuyerCurrencyEligibility do
     end
 
     it "allows iDEAL in EUR for an EUR-priced product and flags the direct listed-amount case" do
-      purchase.update!(link: create(:product, user: seller, price_currency_type: Currency::EUR))
+      relist_purchase(purchase, create(:product, user: seller, price_currency_type: Currency::EUR))
 
       expect(forced_decision).to be_eligible
       expect(forced_decision.currency).to eq(Currency::EUR)

--- a/spec/services/checkout/buyer_currency_eligibility_spec.rb
+++ b/spec/services/checkout/buyer_currency_eligibility_spec.rb
@@ -22,6 +22,14 @@ describe Checkout::BuyerCurrencyEligibility do
   let(:setup_future_charges) { false }
   let(:off_session) { false }
 
+  # Re-point a purchase at a differently-priced product the way a real checkout would build
+  # it: the currency snapshot on the row is taken from the product at creation
+  # (Purchase#prepare_for_charge), so a spec that swaps only `link` leaves a stale snapshot
+  # behind and no longer models the case it is named for.
+  def relist_purchase(purchase, product, **attrs)
+    purchase.update!(link: product, displayed_price_currency_type: product.price_currency_type, **attrs)
+  end
+
   subject(:decision) do
     described_class.new(order:,
                         seller:,
@@ -538,6 +546,40 @@ describe Checkout::BuyerCurrencyEligibility do
       expect(forced_decision.direct_listed_amount?).to eq(true)
     end
 
+    # gumroad-private#1743. displayed_price_cents is denominated in the currency snapshotted
+    # on the purchase, so a product repriced after the row was built would otherwise have its
+    # old-currency cents charged as the new currency.
+    it "withholds the direct listed-amount path when the purchase's snapshotted currency disagrees with the repriced product" do
+      purchase.update!(link: create(:product, user: seller, price_currency_type: Currency::EUR),
+                       displayed_price_currency_type: Currency::USD)
+
+      expect(forced_decision).to be_eligible
+      expect(forced_decision.currency).to eq(Currency::EUR)
+      expect(forced_decision.direct_listed_amount?).to eq(false)
+    end
+
+    it "withholds the direct listed-amount path when one line of a multi-item cart carries a stale snapshot" do
+      purchase.update!(link: create(:product, user: seller, price_currency_type: Currency::INR, price_cents: 7300),
+                       displayed_price_currency_type: Currency::INR)
+      purchases << create(:purchase,
+                          link: create(:product, user: seller, price_currency_type: Currency::INR, price_cents: 7300),
+                          seller:,
+                          merchant_account:,
+                          displayed_price_currency_type: Currency::USD,
+                          purchase_state: "in_progress")
+
+      upi_decision = described_class.new(order:,
+                                         seller:,
+                                         merchant_account:,
+                                         chargeable:,
+                                         purchases:,
+                                         params:,
+                                         setup_future_charges:,
+                                         off_session:).method_forced_decision(payment_method: "upi")
+
+      expect(upi_decision.direct_listed_amount?).to eq(false)
+    end
+
     it "allows Bancontact in EUR" do
       bancontact_decision = described_class.new(order:,
                                                 seller:,
@@ -591,7 +633,7 @@ describe Checkout::BuyerCurrencyEligibility do
     # Payment Element can only confirm an EUR intent, so the prepare service passes the
     # element's mount currency explicitly for methods with no registry entry of their own.
     it "allows card with an explicit forced currency (EUR-mounted element) and flags the direct listed-amount case" do
-      purchase.update!(link: create(:product, user: seller, price_currency_type: Currency::EUR))
+      relist_purchase(purchase, create(:product, user: seller, price_currency_type: Currency::EUR))
 
       card_decision = described_class.new(order:,
                                           seller:,
@@ -673,7 +715,7 @@ describe Checkout::BuyerCurrencyEligibility do
     it "allows a card token from a forced-currency element in live mode when a method forcing that currency is launched" do
       allow(Stripe).to receive(:api_key).and_return("sk_live_currency")
       Feature.activate_user(:checkout_local_method_ideal, seller)
-      purchase.update!(link: create(:product, user: seller, price_currency_type: Currency::EUR))
+      relist_purchase(purchase, create(:product, user: seller, price_currency_type: Currency::EUR))
 
       card_decision = described_class.new(order:,
                                           seller:,
@@ -690,7 +732,7 @@ describe Checkout::BuyerCurrencyEligibility do
 
     it "withholds a card token from a forced-currency element in live mode when no method forcing that currency is launched" do
       allow(Stripe).to receive(:api_key).and_return("sk_live_currency")
-      purchase.update!(link: create(:product, user: seller, price_currency_type: Currency::EUR))
+      relist_purchase(purchase, create(:product, user: seller, price_currency_type: Currency::EUR))
 
       card_decision = described_class.new(order:,
                                           seller:,
@@ -739,7 +781,7 @@ describe Checkout::BuyerCurrencyEligibility do
     it "allows the method for a seller-managed destination-charge model" do
       platform_merchant_account
       merchant_account.update!(json_data: {}, currency: Currency::USD)
-      purchase.update!(link: create(:product, user: seller, price_currency_type: Currency::EUR))
+      relist_purchase(purchase, create(:product, user: seller, price_currency_type: Currency::EUR))
 
       expect(forced_decision).to be_eligible
       expect(forced_decision.currency).to eq(Currency::EUR)
@@ -751,7 +793,7 @@ describe Checkout::BuyerCurrencyEligibility do
     # EUR-settling Belgian account is the most natural shape there is. Requiring US
     # dollars here withheld iDEAL and Bancontact from most eurozone sellers.
     it "allows the method for merchant accounts that settle in a non-USD currency when the product is priced in the forced currency" do
-      purchase.update!(link: create(:product, user: seller, price_currency_type: Currency::EUR))
+      relist_purchase(purchase, create(:product, user: seller, price_currency_type: Currency::EUR))
       merchant_account.update!(currency: Currency::EUR)
 
       expect(forced_decision).to be_eligible
@@ -760,7 +802,7 @@ describe Checkout::BuyerCurrencyEligibility do
     end
 
     it "allows the method for a merchant account settling in a third currency, unrelated to the forced one" do
-      purchase.update!(link: create(:product, user: seller, price_currency_type: Currency::EUR))
+      relist_purchase(purchase, create(:product, user: seller, price_currency_type: Currency::EUR))
       merchant_account.update!(currency: Currency::CAD)
 
       expect(forced_decision).to be_eligible
@@ -774,7 +816,7 @@ describe Checkout::BuyerCurrencyEligibility do
     it "keeps the method available for a destination-charge seller whose own account settles in a non-USD currency" do
       platform_merchant_account.update!(currency: Currency::USD)
       destination_merchant_account = create(:merchant_account, user: seller, charge_processor_id: StripeChargeProcessor.charge_processor_id, currency: Currency::GBP, country: "GB")
-      purchase.update!(link: create(:product, user: seller, price_currency_type: Currency::INR, price_cents: 81_800_00), merchant_account: destination_merchant_account)
+      relist_purchase(purchase, create(:product, user: seller, price_currency_type: Currency::INR, price_cents: 81_800_00), merchant_account: destination_merchant_account)
 
       upi_decision = described_class.new(order:,
                                          seller:,
@@ -793,7 +835,7 @@ describe Checkout::BuyerCurrencyEligibility do
     it "keeps the method available when the Gumroad platform account the destination charge is created on holds a non-USD balance" do
       platform_merchant_account.update!(currency: Currency::CAD)
       destination_merchant_account = create(:merchant_account, user: seller, charge_processor_id: StripeChargeProcessor.charge_processor_id, currency: Currency::USD)
-      purchase.update!(link: create(:product, user: seller, price_currency_type: Currency::EUR), merchant_account: destination_merchant_account)
+      relist_purchase(purchase, create(:product, user: seller, price_currency_type: Currency::EUR), merchant_account: destination_merchant_account)
 
       destination_decision = described_class.new(order:,
                                                  seller:,
@@ -814,7 +856,7 @@ describe Checkout::BuyerCurrencyEligibility do
     # take iDEAL. The direct-listed-amount lane charges the listed EUR price without an
     # FX quote, so the marker must not withhold the method there.
     it "keeps the method available for a product priced in the forced currency when the mismatch marker is set for that currency" do
-      purchase.update!(link: create(:product, user: seller, price_currency_type: Currency::EUR))
+      relist_purchase(purchase, create(:product, user: seller, price_currency_type: Currency::EUR))
       merchant_account.record_settlement_currency_mismatch!(Currency::EUR)
 
       expect(forced_decision).to be_eligible
@@ -877,9 +919,10 @@ describe Checkout::BuyerCurrencyEligibility do
     end
 
     it "allows the direct listed-amount path for multi-item carts uniformly priced in the forced currency" do
-      purchase.update!(link: create(:product, user: seller, price_currency_type: Currency::INR, price_cents: 7300))
+      relist_purchase(purchase, create(:product, user: seller, price_currency_type: Currency::INR, price_cents: 7300))
       purchases << create(:purchase,
                           link: create(:product, user: seller, price_currency_type: Currency::INR, price_cents: 7300),
+                          displayed_price_currency_type: Currency::INR,
                           seller:,
                           merchant_account:,
                           purchase_state: "in_progress")


### PR DESCRIPTION
> **Open question for review:** is degrading a stale-snapshot checkout to the quoted lane the right
> behaviour on the local-method rails (iDEAL/Bancontact/UPI)? The alternative — recomputing the snapshot
> at intent time — rewrites a money row mid-checkout, which I rejected as the worse trade for a narrow window.

## What

`Checkout::BuyerCurrencyEligibility#method_forced_decision` now requires the purchase's **snapshotted** currency (`displayed_price_currency_type`) to agree with the forced currency before it flags the direct-listed-amount lane, not just the product's *current* `price_currency_type`.

## Why

The direct-listed lane charges `purchase.displayed_price_cents`. That figure is denominated in `purchase.displayed_price_currency_type`, snapshotted at purchase creation (`Purchase#prepare_for_charge!`, `app/models/purchase.rb:2388`), and never re-read from the product afterwards.

Eligibility, however, read only the product's live currency:

```ruby
product_currency = purchase.link.price_currency_type.to_s.downcase
# ...
priced_in_forced_currency = product_currencies.all? { _1 == forced_currency }
```

A seller who repriced a product between the purchase row being built and the intent being created therefore had the **old currency's cents sent to Stripe as the new currency**. A product repriced USD 20.00 → EUR after the row was built sends `2000` as EUR 20.00 — the buyer is overcharged by the FX difference, with no error raised anywhere.

The card lane grew the same code path in #6875 and adversarial review caught it there before it shipped; that PR added `purchases.all? { _1.displayed_price_currency_type.to_s.downcase == buyer_currency }` and deliberately left `#method_forced_decision` alone to keep a live money-path PR scoped. This is that follow-up (gumroad-private#1743).

**Blast radius:** method-forced volume only — iDEAL, Bancontact, UPI, Pix. Card volume is unaffected. A stale-snapshot checkout is not withheld; it degrades to the quoted (canonical-USD → forced currency via Stripe FX) lane, which converts from USD and is unaffected by the snapshot. No buyer loses a payment method.

**Measured (2026-08-03):** occurrences to date **zero**. Audited prod reads (`20260803T005649Z-0779e770`, `20260803T010427Z-b89aac7d`, `20260803T010710Z-a976acb8`, `20260803T011019Z-96c3162d`) over all 497 forced-currency charges (2026-07-23 → 2026-08-02, 493 successful, 365 products): every row's snapshot currency agrees with its method's forced currency, and no `price_currency_type` change has ever landed inside a purchase's `created_at → succeeded_at` window.

The window is a 31-second median (min 11s, p90 65s, one 3,948s outlier) at ~47 charges/day — roughly 64 seconds of exposure per product across the lane's whole 10.5-day life.

It is reachable rather than theoretical, but less common than a first read suggests: of 154 PaperTrail versions touching `price_currency_type` on these products, **122 are product-CREATE rows** (`[null, "eur"]`), which cannot collide with a checkout on their own product. Genuine currency changes are **32 across 19 products** — and real churn exists inside that set (product `13607295` flipped `usd↔inr` four times in 2.5 hours). The nearest miss is **73 seconds**, on the safe side: product `11813835` was repriced 14:54:35 UTC on 2026-07-27 and UPI purchase `348241788` was built 14:55:48, so the snapshot picked up the new currency correctly. A reprice landing 73 seconds *later* instead would have been a silent overcharge, which is why this ships as a code fix rather than a comment.

Expected rate from `reprices × exposure_fraction` is ~0.001 charges over the observed period. Two caveats, both pointing up: it assumes repricing is independent of checkout timing (a seller correcting a currency mistake plausibly does it while traffic arrives), and it scales linearly with a lane that is still ramping. Full sizing on gumroad-private#1743.

## Before / After

| | product `price_currency_type` | purchase `displayed_price_currency_type` | `direct_listed_amount?` | amount sent to Stripe |
|---|---|---|---|---|
| **Before** | EUR | USD (stale) | `true` | `displayed_price_cents` (USD cents) charged **as EUR** — overcharge |
| **After** | EUR | USD (stale) | `false` | quoted lane: canonical USD converted through a Stripe FX quote |
| Unchanged | EUR | EUR | `true` | listed EUR price, as today |
| Unchanged | USD | USD | `false` | quoted lane, as today |

No rendered surface changes — this decides which charging lane a method-forced intent takes, both of which already exist and already render identically at checkout. The evidence is the value table above plus the spec pins below; there is no preview surface for a currency-snapshot disagreement.

### Stale-snapshot fidelity in the existing specs

Eleven existing examples in `buyer_currency_eligibility_spec.rb` re-pointed a purchase with `purchase.update!(link: create(:product, price_currency_type: EUR))`, which swaps the product but leaves the row's snapshot at the factory default USD — i.e. they were *accidentally* modelling the repriced-mid-flight case while claiming to test the ordinary EUR-priced one. Under the new clause they would have gone red for the right reason but the wrong scenario. They now go through a `relist_purchase` helper.

That helper calls `Purchase#set_price_and_rate`, the same method the checkout path and the factories use, so it rebuilds the **whole** monetary snapshot together — `displayed_price_cents`, `displayed_price_currency_type`, `rate_converted_to_usd`, `price_cents`, `total_transaction_cents`. An earlier revision updated only `link` and the currency label, which left the previous product's amount, rate, and totals in place; Greptile reproduced that as a P1 (a row production never builds, which could let a later amount assertion pass against an internally inconsistent fixture). A throwaway probe now confirms a relisted purchase matches a freshly built one on all five fields:

```
RELISTED: {displayed_price_cents: 1000, displayed_price_currency_type: :eur, rate_converted_to_usd: "0.81127", price_cents: 1233, total_transaction_cents: 1233}
FRESH:    {displayed_price_cents: 1000, displayed_price_currency_type: :eur, rate_converted_to_usd: "0.81127", price_cents: 1233, total_transaction_cents: 1233}
```

The two new examples no longer hand-write a mismatched snapshot at all. They reach the stale state the way production does — build the purchase against a USD product, then reprice that product to EUR/INR — so the row stays internally USD-consistent and only the *product* has moved on. That is exactly the window the fix closes.

## Test Results

Checks run locally on `cc5f133edb`:

- `bundle exec rspec spec/services/checkout/buyer_currency_eligibility_spec.rb` — full file, including the two new examples
- `bundle exec rubocop` on both changed files — no offenses detected
- A throwaway snapshot-coherence probe comparing a relisted purchase against a freshly built one (output above); deleted, not committed
- `ruby -c` on both changed files
- CI `Tests` workflow at head

Result: **84 examples, 0 failures.**

**CI at head `cc5f133edb` (the sha cited above is the current head — nothing has landed since):** 79 success, 0 failed, 0 pending, of which **70 of 70 `Test*` shards green**. The 10 skipped checks are internal-PR noop jobs, not absent coverage.

I tried to re-run the spec file independently in a fresh worktree to confirm the 84 above rather than carry it forward. That run died after one example: this machine's Redis has 16 databases and a sibling test run held the free blocks (`[test-redis-isolation] no free Redis database block ... 0 concurrent runs`), so it fell back to shared databases and was killed. That is local contention, not a signal about this branch, and I would rather report it than quote a number I did not watch finish. CI's 70 green shards is the authoritative check here.

### Composes with #6875

#6875 adds the same snapshot clause to `#decision` (the card lane); this adds it to `#method_forced_decision` (the local-method lane). Verified they do not collide rather than assuming it:

- Both are `mergeable: MERGEABLE` / `mergeStateStatus: CLEAN` against `main`.
- Neither contains the other (`git merge-base --is-ancestor` false both ways) — they are independent, not stacked, so either can merge first.
- The two clauses sit in different methods of `buyer_currency_eligibility.rb`, so a three-way merge of the pair produces no conflict markers in that file.

Merge order does not matter, and neither PR needs the other to be correct.

New examples:
- `withholds the direct listed-amount path when the purchase's snapshotted currency disagrees with the repriced product`
- `withholds the direct listed-amount path when one line of a multi-item cart carries a stale snapshot`

### Mutation proof

Deleted the added clause in place, re-ran only the two new examples, restored:

```
=== MUTATION: delete the snapshot clause ===
grep -c displayed_price_currency_type  ->  0
Failure/Error: expect(forced_decision.direct_listed_amount?).to eq(false)
Failure/Error: expect(upi_decision.direct_listed_amount?).to eq(false)
2 examples, 2 failures
=== RESTORE ===
guard grep (want 1): 1
```

Both redden on the assertion the fix exists to satisfy, not on an incidental nil — so neither is vacuous.

## QA steps

No clickable preview surface: this is a charge-lane selection with identical checkout rendering on both sides. Reviewer path:

1. Read `app/services/checkout/buyer_currency_eligibility.rb` around `priced_in_forced_currency` and compare with the equivalent clause #6875 added to `#decision`.
2. Confirm `Purchase#prepare_for_charge!` (`app/models/purchase.rb:2388`) is the only writer of `displayed_price_currency_type`, so the snapshot really can diverge from the product.
3. Run the spec file above; the two new examples red against `origin/main` (they assert `direct_listed_amount? == false` where main returns `true`).
4. Optionally in console: build an in-progress purchase on an EUR product, `update_columns(displayed_price_currency_type: "usd")`, and check `method_forced_decision(payment_method: "ideal").direct_listed_amount?` is now `false`.

## Status

- [x] Scope — `#method_forced_decision` only; the card lane's equivalent clause shipped in #6875. No schema, no rollout, no rendered surface.
- [x] Design — require the purchase's snapshotted currency to agree with the forced currency, degrading a repriced-mid-flight checkout to the quoted lane. Rejected: recomputing the snapshot at intent time (rewrites a money row mid-checkout for a narrow window).
- [x] Build — `cc5f133edb` on `gp1743-method-forced-snapshot-currency`; one service clause plus spec-fidelity work.
- [x] QA — full spec file green at head (84 examples, 0 failures), plus the mutation proof and snapshot-coherence probe in the Test Results section. No preview surface: both charging lanes already render identically at checkout.
- [ ] Shipped — needs a human merge; live money path, not auto-merging.
- [ ] Market — n/a, internal charge-lane correctness with no user-visible change.
- [ ] Sell — n/a, no revenue or customer-facing follow-up.

---

AI disclosure: written by Hermes Agent (`claude-opus-5`) running autonomously as gumclaw. Instructions: build the fix for gumroad-private#1743, which was filed from adversarial review of #6875, then address review findings on this PR.


