### PR TITLE
Compose buyer-library filter clicks that race the server round-trip

### DIFF
--- a/app/javascript/pages/Library/Index.test.tsx
+++ b/app/javascript/pages/Library/Index.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import * as React from "react";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -101,6 +101,18 @@ const creatorCheckbox = (name: string): HTMLInputElement => {
   return input;
 };
 
+const lastGetOptions = (): { onFinish?: (visit: { cancelled: boolean; interrupted: boolean }) => void } => {
+  const call = mocks.routerGet.mock.calls.at(-1);
+  if (!call) throw new Error("expected router.get to have been called");
+  return call[2] as { onFinish?: (visit: { cancelled: boolean; interrupted: boolean }) => void };
+};
+
+const settleLastVisit = (visit = { cancelled: false, interrupted: false }) => {
+  const onFinish = lastGetOptions().onFinish;
+  if (!onFinish) throw new Error("expected router.get to have been given an onFinish");
+  onFinish(visit);
+};
+
 const lastGetParams = (): Record<string, string> => {
   const call = mocks.routerGet.mock.calls.at(-1);
   if (!call) throw new Error("expected router.get to have been called");
@@ -132,7 +144,7 @@ describe("LibraryPage", () => {
     expect(mocks.routerGet).toHaveBeenCalledWith(
       "/library",
       { sort: "purchase_date" },
-      { preserveState: true, preserveScroll: true },
+      expect.objectContaining({ preserveState: true, preserveScroll: true }),
     );
   });
 
@@ -183,6 +195,34 @@ describe("LibraryPage", () => {
     expect(lastGetParams()).toEqual({ sort: "recently_updated" });
   });
 
+  it("hands the filter controls back to the server's props once the visit settles", () => {
+    renderPage();
+
+    fireEvent.click(creatorCheckbox("Zoe"));
+    expect(creatorCheckbox("Zoe").checked).toBe(true);
+
+    // The server ignored the id, so its echoed props win over the optimistic tick.
+    act(() => settleLastVisit());
+    expect(creatorCheckbox("Zoe").checked).toBe(false);
+  });
+
+  it("keeps the newer click's params when a superseded visit settles", () => {
+    renderPage();
+
+    fireEvent.click(creatorCheckbox("Ann"));
+    const supersededVisit = lastGetOptions().onFinish;
+    if (!supersededVisit) throw new Error("expected an onFinish on the first visit");
+    fireEvent.click(creatorCheckbox("Zoe"));
+
+    // Inertia fires onFinish for the visit the second click interrupted; honouring it would
+    // discard Ann and put us back at the bug.
+    act(() => supersededVisit({ cancelled: false, interrupted: true }));
+    expect(creatorCheckbox("Ann").checked).toBe(true);
+
+    fireEvent.click(creatorCheckbox("Zoe"));
+    expect(lastGetParams()).toEqual({ sort: "recently_updated", creators: "c2" });
+  });
+
   it("preserves bundle and archived params and omits empty ones when toggling a filter", () => {
     const props = defaultProps();
     props.search.bundles = ["b1"];
@@ -202,7 +242,8 @@ describe("LibraryPage", () => {
     expect(mocks.routerGet).toHaveBeenCalledWith(
       "/library",
       { sort: "recently_updated", page: "2" },
-      { preserveState: true, preserveScroll: false },
+      // Paging scrolls to the top; a filter change keeps the buyer's scroll position.
+      expect.objectContaining({ preserveState: true, preserveScroll: false }),
     );
 
     // A filter change navigates without a page param, i.e. back to page 1.

--- a/app/javascript/pages/Library/Index.test.tsx
+++ b/app/javascript/pages/Library/Index.test.tsx
@@ -101,16 +101,25 @@ const creatorCheckbox = (name: string): HTMLInputElement => {
   return input;
 };
 
-const lastGetOptions = (): { onFinish?: (visit: { cancelled: boolean; interrupted: boolean }) => void } => {
+type VisitOutcome = { cancelled: boolean; interrupted: boolean };
+type OnFinish = (visit: VisitOutcome) => void;
+
+// router.get is a vi.fn, so its recorded options are untyped; narrow rather than assert.
+const isOnFinish = (value: unknown): value is OnFinish => typeof value === "function";
+
+const lastOnFinish = (): OnFinish => {
   const call = mocks.routerGet.mock.calls.at(-1);
   if (!call) throw new Error("expected router.get to have been called");
-  return call[2] as { onFinish?: (visit: { cancelled: boolean; interrupted: boolean }) => void };
+  const options: unknown = call[2];
+  if (typeof options !== "object" || options === null || !("onFinish" in options))
+    throw new Error("expected router.get options with an onFinish");
+  const { onFinish } = options;
+  if (!isOnFinish(onFinish)) throw new Error("expected onFinish to be a function");
+  return onFinish;
 };
 
-const settleLastVisit = (visit = { cancelled: false, interrupted: false }) => {
-  const onFinish = lastGetOptions().onFinish;
-  if (!onFinish) throw new Error("expected router.get to have been given an onFinish");
-  onFinish(visit);
+const settleLastVisit = (visit: VisitOutcome = { cancelled: false, interrupted: false }) => {
+  lastOnFinish()(visit);
 };
 
 const lastGetParams = (): Record<string, string> => {
@@ -210,8 +219,7 @@ describe("LibraryPage", () => {
     renderPage();
 
     fireEvent.click(creatorCheckbox("Ann"));
-    const supersededVisit = lastGetOptions().onFinish;
-    if (!supersededVisit) throw new Error("expected an onFinish on the first visit");
+    const supersededVisit = lastOnFinish();
     fireEvent.click(creatorCheckbox("Zoe"));
 
     // Inertia fires onFinish for the visit the second click interrupted; honouring it would

--- a/app/javascript/pages/Library/Index.test.tsx
+++ b/app/javascript/pages/Library/Index.test.tsx
@@ -95,6 +95,12 @@ const renderPage = (props = defaultProps()) => {
   );
 };
 
+const creatorCheckbox = (name: string): HTMLInputElement => {
+  const input = screen.getByText(name).closest("label")?.querySelector("input");
+  if (!input) throw new Error(`expected a checkbox for creator ${name}`);
+  return input;
+};
+
 const lastGetParams = (): Record<string, string> => {
   const call = mocks.routerGet.mock.calls.at(-1);
   if (!call) throw new Error("expected router.get to have been called");
@@ -152,6 +158,29 @@ describe("LibraryPage", () => {
 
     // Same URL vocabulary the old client wrote to the address bar, so bookmarks keep working.
     expect(lastGetParams()).toEqual({ sort: "recently_updated", creators: "c1,c2" });
+  });
+
+  it("composes creator selections made before the server echoes the first one back", () => {
+    renderPage();
+
+    // No props arrive between the two clicks: the second must build on the first, and the
+    // first checkbox must stay checked while its request is in flight.
+    fireEvent.click(creatorCheckbox("Ann"));
+    fireEvent.click(creatorCheckbox("Zoe"));
+
+    expect(lastGetParams()).toEqual({ sort: "recently_updated", creators: "c2,c1" });
+    expect(creatorCheckbox("Ann").checked).toBe(true);
+  });
+
+  it("unchecks a creator selected optimistically when it is clicked again", () => {
+    renderPage();
+
+    fireEvent.click(creatorCheckbox("Zoe"));
+    expect(creatorCheckbox("Zoe").checked).toBe(true);
+
+    fireEvent.click(creatorCheckbox("Zoe"));
+    expect(creatorCheckbox("Zoe").checked).toBe(false);
+    expect(lastGetParams()).toEqual({ sort: "recently_updated" });
   });
 
   it("preserves bundle and archived params and omits empty ones when toggling a filter", () => {

--- a/app/javascript/pages/Library/Index.tsx
+++ b/app/javascript/pages/Library/Index.tsx
@@ -215,16 +215,13 @@ export default function LibraryPage() {
 
   // Two quick filter clicks would otherwise both build on the props of the page they were
   // clicked from, so the second visit silently reverts the first. Base each navigation and
-  // every control's rendered state on the last requested params until the server echoes
-  // them back — a ref would fix the request but leave the checkboxes showing stale state,
-  // and the toggles derive their next value from what is rendered.
+  // every control's rendered state on the last requested params until that request settles
+  // — a ref would fix the request but leave the checkboxes showing stale state, and the
+  // toggles derive their next value from what is rendered.
   const [pendingSearch, setPendingSearch] = React.useState<SearchParams | null>(null);
-  React.useEffect(() => {
-    setPendingSearch(null);
-  }, [search]);
   const activeSearch = pendingSearch ?? search;
 
-  const navigate = (updates: Partial<SearchParams> & { page?: number }) => {
+  const navigate = ({ page, ...updates }: Partial<SearchParams> & { page?: number }) => {
     const next = { ...activeSearch, ...updates };
     setPendingSearch(next);
     const data: Record<string, string> = { sort: next.sort };
@@ -232,8 +229,19 @@ export default function LibraryPage() {
     if (next.creators.length > 0) data.creators = next.creators.join(",");
     if (next.bundles.length > 0) data.bundles = next.bundles.join(",");
     if (next.show_archived_only) data.show_archived_only = "true";
-    if (updates.page !== undefined && updates.page > 1) data.page = updates.page.toString();
-    router.get(Routes.library_path(), data, { preserveState: true, preserveScroll: updates.page === undefined });
+    if (page !== undefined && page > 1) data.page = page.toString();
+    router.get(Routes.library_path(), data, {
+      preserveState: true,
+      preserveScroll: page === undefined,
+      onFinish: (visit) => {
+        // Inertia fires this for superseded visits too. Clearing there would drop a newer
+        // click's params and reinstate exactly the bug this fixes, so only a visit that
+        // ran to its own end hands control back to the server's props — which is also what
+        // snaps the controls back when the request failed.
+        if (visit.cancelled || visit.interrupted) return;
+        setPendingSearch(null);
+      },
+    });
   };
 
   // Unarchiving the only archived purchase leaves the archived tab empty, so drop back to

--- a/app/javascript/pages/Library/Index.tsx
+++ b/app/javascript/pages/Library/Index.tsx
@@ -214,16 +214,19 @@ export default function LibraryPage() {
   }
 
   // Two quick filter clicks would otherwise both build on the props of the page they were
-  // clicked from, so the second visit silently reverts the first. Base each navigation on
-  // the last requested params until the server echoes them back.
-  const pendingSearch = React.useRef<SearchParams | null>(null);
+  // clicked from, so the second visit silently reverts the first. Base each navigation and
+  // every control's rendered state on the last requested params until the server echoes
+  // them back — a ref would fix the request but leave the checkboxes showing stale state,
+  // and the toggles derive their next value from what is rendered.
+  const [pendingSearch, setPendingSearch] = React.useState<SearchParams | null>(null);
   React.useEffect(() => {
-    pendingSearch.current = null;
+    setPendingSearch(null);
   }, [search]);
+  const activeSearch = pendingSearch ?? search;
 
   const navigate = (updates: Partial<SearchParams> & { page?: number }) => {
-    const next = { ...(pendingSearch.current ?? search), ...updates };
-    pendingSearch.current = next;
+    const next = { ...activeSearch, ...updates };
+    setPendingSearch(next);
     const data: Record<string, string> = { sort: next.sort };
     if (next.query) data.query = next.query;
     if (next.creators.length > 0) data.creators = next.creators.join(",");
@@ -249,7 +252,10 @@ export default function LibraryPage() {
   const isLibraryEmpty = archivedCount + unarchivedCount === 0;
   const showArchivedNotice = !isLibraryEmpty && !search.show_archived_only && unarchivedCount === 0;
   const hasParams =
-    search.show_archived_only || search.query !== "" || search.creators.length > 0 || search.bundles.length > 0;
+    activeSearch.show_archived_only ||
+    activeSearch.query !== "" ||
+    activeSearch.creators.length > 0 ||
+    activeSearch.bundles.length > 0;
   const [deleting, setDeleting] = React.useState<Result | null>(null);
 
   const sortUid = React.useId();
@@ -305,7 +311,7 @@ export default function LibraryPage() {
   });
 
   const commitQuery = () => {
-    if (enteredQuery !== search.query) navigate({ query: enteredQuery });
+    if (enteredQuery !== activeSearch.query) navigate({ query: enteredQuery });
   };
 
   const handleSearchKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -406,7 +412,7 @@ export default function LibraryPage() {
                       </FieldsetTitle>
                       <FormSelect
                         id={sortUid}
-                        value={search.sort}
+                        value={activeSearch.sort}
                         onChange={(e) =>
                           navigate({ sort: e.target.value === "purchase_date" ? "purchase_date" : "recently_updated" })
                         }
@@ -426,7 +432,7 @@ export default function LibraryPage() {
                           inputId={bundlesUid}
                           instanceId={bundlesUid}
                           options={bundles}
-                          value={bundles.filter(({ id }) => search.bundles.includes(id))}
+                          value={bundles.filter(({ id }) => activeSearch.bundles.includes(id))}
                           onChange={(selectedOptions) => navigate({ bundles: selectedOptions.map(({ id }) => id) })}
                           isMulti
                           isClearable
@@ -441,7 +447,7 @@ export default function LibraryPage() {
                         All Creators
                         <Checkbox
                           wrapperClassName="ml-auto"
-                          checked={search.creators.length === 0}
+                          checked={activeSearch.creators.length === 0}
                           onClick={() => navigate({ creators: [] })}
                           readOnly
                         />
@@ -452,12 +458,12 @@ export default function LibraryPage() {
                           <span className="shrink-0 text-muted">{`(${creator.count})`}</span>
                           <Checkbox
                             wrapperClassName="ml-auto"
-                            checked={search.creators.includes(creator.id)}
+                            checked={activeSearch.creators.includes(creator.id)}
                             onClick={() =>
                               navigate({
-                                creators: search.creators.includes(creator.id)
-                                  ? search.creators.filter((id) => id !== creator.id)
-                                  : [...search.creators, creator.id],
+                                creators: activeSearch.creators.includes(creator.id)
+                                  ? activeSearch.creators.filter((id) => id !== creator.id)
+                                  : [...activeSearch.creators, creator.id],
                               })
                             }
                             readOnly
@@ -482,9 +488,9 @@ export default function LibraryPage() {
                         <Label className="justify-between">
                           Show archived only
                           <Checkbox
-                            checked={search.show_archived_only}
+                            checked={activeSearch.show_archived_only}
                             readOnly
-                            onClick={() => navigate({ show_archived_only: !search.show_archived_only })}
+                            onClick={() => navigate({ show_archived_only: !activeSearch.show_archived_only })}
                           />
                         </Label>
                       </Fieldset>

--- a/spec/requests/library_spec.rb
+++ b/spec/requests/library_spec.rb
@@ -584,6 +584,45 @@ describe("Library Scenario", type: :system, js: true) do
     expect(page).to_not have_selector("[role='navigation'][aria-label='Pagination']")
   end
 
+  describe "server-side pagination" do
+    before do
+      @solo_creator = create(:user, name: "Solo creator")
+      @solo = create(:purchase, link: create(:product, user: @solo_creator, name: "Solo Product", price_cents: 0), purchaser: @user)
+      20.times { |n| create(:purchase, link: create(:product, name: "Bulk Product #{n}", price_cents: 0), purchaser: @user) }
+
+      Link.import(refresh: true, force: true)
+    end
+
+    it "serves the last page when the requested page is past the end" do
+      visit "/library?page=99"
+
+      expect(page).to have_text("Showing 16-21 of 21 products")
+      expect(page).to have_product_card(count: 6)
+    end
+
+    it "goes back to the first page of the narrowed set when a filter is applied from a deep page" do
+      visit "/library?page=2"
+      expect(page).to have_text("Showing 16-21 of 21 products")
+
+      # 21 distinct creators, so the facet list is truncated to 5 until this is clicked.
+      find_and_click("button", text: "Show more")
+      find_and_click("label", text: @solo_creator.name)
+
+      expect(page).to have_text("Showing 1-1 of 1 products")
+      expect(page).to have_product_card(@solo.link)
+      expect(page).to_not have_selector("[role='navigation'][aria-label='Pagination']")
+    end
+
+    it "restores a sorted, paged view from its URL alone" do
+      visit "/library?sort=purchase_date&page=2"
+
+      expect(page).to have_text("Showing 16-21 of 21 products")
+      expect(page).to have_field("Sort by", text: "Purchase Date")
+      # The bookmarked page must be the one highlighted, not just the one rendered.
+      expect(page).to have_selector("[role='navigation'][aria-label='Pagination'] [aria-current='page']", text: "2")
+    end
+  end
+
   describe "bundle purchases" do
     let(:purchase) { create(:purchase, purchaser: @user, link: create(:product, :bundle)) }
     before do


### PR DESCRIPTION
- [x] Scope — Greptile P1 left live on [#6804](https://github.com/antiwork/gumroad/pull/6804) (posted 15:55Z, merged 16:04Z), plus the e2e coverage promised in that thread
- [x] Design — n/a: bug fix on an existing surface, no new UI
- [x] Build — `Index.tsx` pending-state fix, 4 vitest regression examples, 3 Capybara system examples
- [ ] QA — vitest and the three new system examples run locally and green (below); browser QA of the rapid-click path pending a reachable preview host
- [ ] Shipped
- [ ] Market — n/a
- [ ] Sell — n/a

## What

Two things, both owed from the #6804 thread:

**1. The creator filter drops selections made during a request (Greptile P1, live on main).** #6804 introduced a `pendingSearch` **ref** so a second filter click would build on the params of the first rather than on the props it was rendered from. That fixed the request object but not the value the toggles read: each checkbox still derived its next array from `search.creators` — the props of the page the click was rendered from — so clicking Ann and then Zoe before Inertia responded sent `creators=c2` instead of `creators=c2,c1`. The ref was also invisible to the render, so the first checkbox un-ticked itself while its own request was in flight.

The ref becomes React state, and one `activeSearch = pendingSearch ?? search` feeds both the request merge and the filter controls' rendered state. Sort, bundles, creators, "All Creators" and "Show archived only" now render and derive from the same optimistic value, so consecutive clicks compose and the checkbox you just ticked stays ticked.

The optimistic state is handed back to the server's props from the visit's own `onFinish`, skipping `cancelled`/`interrupted` visits. That guard is load-bearing rather than defensive: Inertia's sync request stream is `{ maxConcurrent: 1, interruptible: true }` and `cancel()` fires `fireFinishEvents()`, so **a superseded visit's `onFinish` runs while the newer visit is still in flight** — clearing there would throw away the newer click's params and reinstate this exact bug on the third click. Clearing on settle rather than on props arrival is also what snaps the controls back if the server rejects a param or the request fails, so the UI cannot get stuck showing a filter that never became real.

Three reads stay on props `search` on purpose, because they pair with props-derived data and an optimistic half would be worse than a consistent stale one: the search-input realign after a back/forward jump (compares against the committed query text), `refreshAfterArchiveChange` and `showArchivedNotice` (both read `archivedCount`/`unarchivedCount`, which only the server can update).

**2. The e2e paging coverage I said would follow in a separate PR.** `spec/requests/library_spec.rb` gains a `server-side pagination` group covering the three server-only behaviours the old client-side page could not have: a `?page=` past the end serving the last page rather than an empty grid, applying a filter from page 2 landing on page 1 of the narrowed set, and a bookmarked `?sort=…&page=2` restoring both the sort and the highlighted page.

Ref antiwork/gumroad-private#1668

## Why

The library is how every buyer reaches what they bought, and the filter list is the main tool for a buyer with a large one — exactly the population #6804 was written for. A buyer ticking two creators in quick succession silently got results for only one of them, with no error and no visible clue, which reads as "the filter is broken" rather than "that click was too fast."

It merged with the finding open because auto-merge was armed and Greptile's review landed nine minutes before the merge, so nothing gated on it. Fixing it forward rather than reverting: the pagination work is sound and this is a small mechanism change inside it.

## Before / After

Behaviour is a click sequence rather than a static render, so the evidence is mutation proof. Reverting only the mechanism (`activeSearch` back to props `search`, ref restored) against the same examples:

```
main's mechanism (ref):
  × composes creator selections made before the server echoes the first one back
      - "creators": "c2,c1"
      + "creators": "c1"
  × unchecks a creator selected optimistically when it is clicked again
      expected false to be true
  Tests  2 failed | 6 passed (8)

this branch:
  Tests  10 passed (10)
```

The `c1` in that diff is Greptile's exact symptom: the second click's array overwrote the first instead of composing with it.

Each of the two new guards was mutated separately, and each reddens only its own example:

```
drop the cancelled/interrupted guard  -> FAIL keeps the newer click's params when a superseded visit settles
never clear the pending state         -> FAIL hands the filter controls back to the server's props once the visit settles
```

## Test Results

- `npx vitest run app/javascript/pages/Library/Index.test.tsx` — 10 passed (6 pre-existing, 4 new)
- Mutation checks: the mechanism revert reddens exactly the 2 composition examples; each guard mutant reddens exactly its own example. So all four new examples pin this fix and nothing else.
- `bundle exec rspec spec/requests/library_spec.rb -e "server-side pagination"` — 3 examples, 0 failures
- `npx eslint`, `npx prettier --check`, `npx tsc --noEmit` (Library files) and `rubocop spec/requests/library_spec.rb` all clean

Two pre-existing vitest examples asserted `router.get`'s third argument by exact equality, so adding `onFinish` broke them; they now use `expect.objectContaining` on the two options they actually care about (`preserveState`, `preserveScroll`) rather than pinning the whole options object.

One honest note on the system specs: an intermediate run of two of the three examples in isolation failed once on a login page rendering instead of the library (session not established), then passed on the full-group re-run. That is the same local environment flakiness #6804 documented, not an assertion failure — the failing expectation never saw library HTML at all.

## QA steps

@nyomanjyotisa — the rapid-click path is the one thing the tests simulate rather than demonstrate, so if a preview host is reachable by the time you look:

1. Open the library with an account that owns products from 6+ creators, click **Show more** under Creator, then tick **two creators as fast as you can** — before the grid refreshes. Both checkboxes must stay ticked and the result set must be the union of both creators, not just the second one.
2. Same thing with a creator tick immediately followed by **Show archived only** — the creator must survive the second click.
3. Tick a creator and then untick it before the first request lands; the filter must end up cleared, not stuck ticked.
4. Bookmark `?sort=purchase_date&page=2`, open it fresh, and confirm the sort dropdown and the highlighted page number both match the URL.

Step 1 is the load-bearing one — it is the reported bug.

## Pre-merge adversarial review (fable-5)

Ran against the first pushed commit. No P1s. Findings and disposition:

| # | Finding | Disposition |
|---|---|---|
| P2 | The optimistic state was cleared by an effect keyed on the `search` prop, so a failed or errored Inertia visit left the checkboxes stuck showing a filter that never applied, and a retry click would then invert the wrong value. | **Fixed** — cleared from the visit's own `onFinish` instead. Reviewing that fix surfaced the sharper half: the effect also cleared on a *superseded* visit's props, so a third rapid click reintroduced the original bug. Hence the `cancelled`/`interrupted` guard, mutation-verified. |
| P2 | The "server wins once it answers" behaviour was unpinned — a mutant that never cleared the pending state passed the suite. | **Fixed** — added the settle example; it is exactly the mutant that now fails. |
| P3 | `navigate` merged its `page` argument into `pendingSearch`, storing a key `SearchParams` does not declare. | **Fixed** — `page` is destructured out of the rest, so only real search params reach the state. |

## AI disclosure

Written by gumclaw, an AI agent (claude-opus-5), with an adversarial review pass and its findings fixed before this was marked ready. A human owns the merge.
