### PR TITLE
Record why a purchase became uncontactable

### DIFF
--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -125,6 +125,7 @@ class PurchasesController < ApplicationController
     # One rebuild per buyer at the end of the loop rather than one per purchase row.
     Purchase.deferring_audience_member_rebuilds do
       Purchase.where(email: @purchase.email, seller_id: @purchase.seller_id, can_contact: false).find_each do |purchase|
+        purchase.can_contact_reason = nil
         purchase.update!(can_contact: true)
       rescue ActiveRecord::RecordInvalid
         # Mirrors `Purchase#unsubscribe_buyer`. Some old purchase rows no longer pass today's
@@ -134,6 +135,7 @@ class PurchasesController < ApplicationController
         Rails.logger.info "Could not update purchase (#{purchase.id}) with validations turned on. Re-subscribing the buyer without running validations."
 
         purchase.can_contact = true
+        purchase.can_contact_reason = nil
         purchase.save(validate: false)
       end
     end

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -103,8 +103,8 @@ class Purchase < ApplicationRecord
   # first-party consent signals and must never be reversed by an automated restore.
   CAN_CONTACT_REASON_BUYER_UNSUBSCRIBE = "buyer_unsubscribe"
   CAN_CONTACT_REASON_SPAM_REPORT = "spam_report"
-  # Nobody acted on THIS row: it was born uncontactable because a sibling row for the same
-  # (email, seller) already was. Reversing it is safe iff the row it inherited from is reversed.
+  # Nobody acted on THIS row: it was born uncontactable because a sibling already was.
+  # Reversing it is safe iff the row it inherited from is reversed.
   CAN_CONTACT_REASON_INHERITED = "inherited"
 
   alias_attribute :total_transaction_cents_usd, :total_transaction_cents
@@ -3197,6 +3197,8 @@ class Purchase < ApplicationRecord
       purchase.save(validate: false)
     end
 
+    upgrade_reversible_reasons_in_cohort(reason)
+
     Follower.unsubscribe(seller_id, email)
   end
 
@@ -5451,6 +5453,21 @@ class Purchase < ApplicationRecord
         payment_option.installment_plan_snapshot.calculate_installment_payment_price_cents
       else
         fetch_installment_plan.calculate_installment_payment_price_cents(total_price_cents)
+      end
+    end
+
+    # First-party consent outranks an inherited or unrecorded suppression. Those rows are
+    # already `can_contact: false` so the loop above skips them, which would leave a
+    # reversible reason standing after the buyer themselves acted -- exactly the misreading
+    # this attribute exists to prevent.
+    def upgrade_reversible_reasons_in_cohort(reason)
+      return if reason == CAN_CONTACT_REASON_INHERITED
+
+      Purchase.where(email:, seller_id:, can_contact: false).find_each do |purchase|
+        next if purchase.can_contact_reason.in?([CAN_CONTACT_REASON_BUYER_UNSUBSCRIBE, CAN_CONTACT_REASON_SPAM_REPORT])
+
+        purchase.can_contact_reason = reason
+        purchase.save(validate: false)
       end
     end
 

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -93,6 +93,19 @@ class Purchase < ApplicationRecord
   # debit actually booked. Snapshotted at debit time so the dispute-won re-credit books
   # exactly the same amount, even when refunds land between the debit and the win.
   attr_json_data_accessor :presentment_dispute_debited_gross_cents
+  # Why `can_contact` is false. Until now the only way to tell a buyer's own unsubscribe from a
+  # machine-written suppression was `versions.request_path` being non-NULL, which is an audit
+  # side effect with a retention window — see antiwork/gumroad-private#1745, where a restore had
+  # to be reconstructed forensically and anything past retention was unrecoverable.
+  attr_json_data_accessor :can_contact_reason
+
+  # Buyer acted: clicked the receipt-footer unsubscribe, or reported the email as spam. Both are
+  # first-party consent signals and must never be reversed by an automated restore.
+  CAN_CONTACT_REASON_BUYER_UNSUBSCRIBE = "buyer_unsubscribe"
+  CAN_CONTACT_REASON_SPAM_REPORT = "spam_report"
+  # Nobody acted on THIS row: it was born uncontactable because a sibling row for the same
+  # (email, seller) already was. Reversing it is safe iff the row it inherited from is reversed.
+  CAN_CONTACT_REASON_INHERITED = "inherited"
 
   alias_attribute :total_transaction_cents_usd, :total_transaction_cents
 
@@ -3172,13 +3185,15 @@ class Purchase < ApplicationRecord
   end
 
   # Unsubscribe the buyer of this purchase from all of the seller's emails
-  def unsubscribe_buyer
+  def unsubscribe_buyer(reason: CAN_CONTACT_REASON_BUYER_UNSUBSCRIBE)
     Purchase.where(email:, seller_id:, can_contact: true).find_each do |purchase|
+      purchase.can_contact_reason = reason
       purchase.update!(can_contact: false)
     rescue ActiveRecord::RecordInvalid
       Rails.logger.info "Could not update purchase (#{purchase.id}) with validations turned on. Unsubscribing the buyer without running validations."
 
       purchase.can_contact = false
+      purchase.can_contact_reason = reason
       purchase.save(validate: false)
     end
 
@@ -5452,5 +5467,6 @@ class Purchase < ApplicationRecord
       return if subscription&.original_purchase&.can_contact?
 
       self.can_contact = false
+      self.can_contact_reason = CAN_CONTACT_REASON_INHERITED
     end
 end

--- a/app/services/handle_email_event_info/for_installment_email.rb
+++ b/app/services/handle_email_event_info/for_installment_email.rb
@@ -138,7 +138,7 @@ class HandleEmailEventInfo::ForInstallmentEmail
       purchase = Purchase.find_by(id: email_event_info.purchase_id)
 
       if purchase.present?
-        purchase.unsubscribe_buyer
+        purchase.unsubscribe_buyer(reason: Purchase::CAN_CONTACT_REASON_SPAM_REPORT)
       else
         # Unsubscribe the follower
         seller_id = Installment.find(email_event_info.installment_id).seller_id

--- a/app/services/handle_email_event_info/for_receipt_email.rb
+++ b/app/services/handle_email_event_info/for_receipt_email.rb
@@ -23,7 +23,8 @@ class HandleEmailEventInfo::ForReceiptEmail
       email_info.mark_opened!(email_event_info.created_at)
     when EmailEventInfo::EVENT_COMPLAINED
       unless email_event_info.email_provider == MailerInfo::EMAIL_PROVIDER_RESEND
-        Purchase.find_by(id: email_event_info.purchase_id)&.unsubscribe_buyer
+        Purchase.find_by(id: email_event_info.purchase_id)
+                &.unsubscribe_buyer(reason: Purchase::CAN_CONTACT_REASON_SPAM_REPORT)
       end
     end
   end

--- a/spec/controllers/purchases_controller_spec.rb
+++ b/spec/controllers/purchases_controller_spec.rb
@@ -1460,6 +1460,18 @@ describe PurchasesController, :vcr do
         expect(member.details["purchases"].map { _1["id"] }).to eq([purchase.id])
       end
 
+      it "clears can_contact_reason so a later restore cannot read a stale buyer unsubscribe" do
+        purchase = create(:purchase, can_contact: true)
+        purchase.unsubscribe_buyer
+        expect(purchase.reload.can_contact_reason).to eq(Purchase::CAN_CONTACT_REASON_BUYER_UNSUBSCRIBE)
+
+        post :subscribe, params: { id: purchase.external_id }
+
+        expect(response).to be_successful
+        expect(purchase.reload.can_contact).to eq true
+        expect(purchase.can_contact_reason).to be_nil
+      end
+
       it "keeps re-subscribing the remaining purchases when one fails validation" do
         purchase = create(:purchase, can_contact: false)
         invalid = create(:purchase, seller_id: purchase.seller.id, link: create(:product, user: purchase.seller), email: purchase.email, can_contact: false)

--- a/spec/models/purchase/can_contact_reason_spec.rb
+++ b/spec/models/purchase/can_contact_reason_spec.rb
@@ -43,6 +43,36 @@ describe "Purchase can_contact_reason" do
       expect(purchase.reload.locale).to eq("fr")
       expect(purchase.can_contact_reason).to eq(Purchase::CAN_CONTACT_REASON_BUYER_UNSUBSCRIBE)
     end
+
+    # The suppression loop only touches `can_contact: true` rows, so a cohort already
+    # suppressed by inheritance would keep a reversible reason after the buyer themselves
+    # acted -- an automated restore would then undo real consent.
+    it "upgrades an inherited sibling to the buyer's own reason" do
+      purchase.unsubscribe_buyer
+      inherited = create(:purchase, link: product, seller:, email: purchase.email)
+      expect(inherited.can_contact_reason).to eq(Purchase::CAN_CONTACT_REASON_INHERITED)
+
+      inherited.unsubscribe_buyer(reason: Purchase::CAN_CONTACT_REASON_SPAM_REPORT)
+
+      expect(inherited.reload.can_contact_reason).to eq(Purchase::CAN_CONTACT_REASON_SPAM_REPORT)
+    end
+
+    it "stamps a reason on a row suppressed before this attribute existed" do
+      purchase.update_columns(can_contact: false)
+      expect(purchase.reload.can_contact_reason).to be_nil
+
+      purchase.unsubscribe_buyer
+
+      expect(purchase.reload.can_contact_reason).to eq(Purchase::CAN_CONTACT_REASON_BUYER_UNSUBSCRIBE)
+    end
+
+    it "never downgrades one first-party consent signal to another" do
+      purchase.unsubscribe_buyer(reason: Purchase::CAN_CONTACT_REASON_SPAM_REPORT)
+
+      purchase.unsubscribe_buyer(reason: Purchase::CAN_CONTACT_REASON_BUYER_UNSUBSCRIBE)
+
+      expect(purchase.reload.can_contact_reason).to eq(Purchase::CAN_CONTACT_REASON_SPAM_REPORT)
+    end
   end
 
   describe "a new row born uncontactable" do

--- a/spec/models/purchase/can_contact_reason_spec.rb
+++ b/spec/models/purchase/can_contact_reason_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Purchase can_contact_reason" do
+  let(:seller) { create(:user) }
+  let(:product) { create(:product, user: seller) }
+  let!(:purchase) { create(:purchase, link: product, seller:, email: "buyer@example.com") }
+
+  describe "#unsubscribe_buyer" do
+    it "records a buyer unsubscribe by default" do
+      purchase.unsubscribe_buyer
+
+      purchase.reload
+      expect(purchase.can_contact).to be(false)
+      expect(purchase.can_contact_reason).to eq(Purchase::CAN_CONTACT_REASON_BUYER_UNSUBSCRIBE)
+    end
+
+    it "records the caller's reason on every row it suppresses" do
+      sibling = create(:purchase, link: product, seller:, email: purchase.email)
+
+      purchase.unsubscribe_buyer(reason: Purchase::CAN_CONTACT_REASON_SPAM_REPORT)
+
+      [purchase, sibling].each do |row|
+        expect(row.reload.can_contact_reason).to eq(Purchase::CAN_CONTACT_REASON_SPAM_REPORT)
+      end
+    end
+
+    it "records the reason even when the row fails today's validations" do
+      purchase.update_columns(street_address: nil, country: nil, zip_code: nil)
+      allow_any_instance_of(Purchase).to receive(:valid?).and_return(false)
+
+      purchase.unsubscribe_buyer
+
+      expect(purchase.reload.can_contact_reason).to eq(Purchase::CAN_CONTACT_REASON_BUYER_UNSUBSCRIBE)
+    end
+
+    it "leaves json_data's other attributes intact" do
+      purchase.update!(locale: "fr")
+
+      purchase.unsubscribe_buyer
+
+      expect(purchase.reload.locale).to eq("fr")
+      expect(purchase.can_contact_reason).to eq(Purchase::CAN_CONTACT_REASON_BUYER_UNSUBSCRIBE)
+    end
+  end
+
+  describe "a new row born uncontactable" do
+    it "is marked inherited, not as a buyer action" do
+      purchase.unsubscribe_buyer
+
+      later = create(:purchase, link: product, seller:, email: purchase.email)
+
+      expect(later.can_contact).to be(false)
+      expect(later.can_contact_reason).to eq(Purchase::CAN_CONTACT_REASON_INHERITED)
+    end
+
+    it "leaves the reason unset when the buyer never unsubscribed" do
+      fresh = create(:purchase, link: product, seller:, email: "someone-else@example.com")
+
+      expect(fresh.can_contact).to be(true)
+      expect(fresh.can_contact_reason).to be_nil
+    end
+  end
+
+  describe "spam reports" do
+    it "records a spam report from a receipt complaint" do
+      email_event_info = double(
+        type: EmailEventInfo::EVENT_COMPLAINED,
+        email_provider: MailerInfo::EMAIL_PROVIDER_SENDGRID,
+        purchase_id: purchase.id,
+        charge_id: nil,
+        mailer_method: "receipt",
+      )
+
+      HandleEmailEventInfo::ForReceiptEmail.perform(email_event_info)
+
+      expect(purchase.reload.can_contact_reason).to eq(Purchase::CAN_CONTACT_REASON_SPAM_REPORT)
+    end
+  end
+end


### PR DESCRIPTION
## What

Stamps a **reason** on `Purchase#can_contact` whenever it is set to `false`, and clears it when a buyer re-subscribes. Three values, on `json_data` (no migration):

| constant | written by | safe for an automated restore to reverse? |
|---|---|---|
| `CAN_CONTACT_REASON_BUYER_UNSUBSCRIBE` | receipt-footer unsubscribe (`Purchase#unsubscribe_buyer` default) | **never** — first-party consent |
| `CAN_CONTACT_REASON_SPAM_REPORT` | `HandleEmailEventInfo::ForReceiptEmail` complaint + `ForInstallmentEmail#handle_spamreport_event!` | **never** — first-party consent |
| `CAN_CONTACT_REASON_INHERITED` | `toggle_off_can_contact_if_buyer_has_unsubscribed` on a newly created row | yes, iff the row it inherited from is reversed |

## Why

antiwork/gumroad-private#1745, point 2. `can_contact` is a bare boolean, so the only discriminator between "the buyer clicked unsubscribe" and "our own bounce handler wrote this" was `versions.request_path` being non-NULL — an *audit* side effect, retained from 2026-05-20 only.

That cost real work and real coverage:

- gp#1745's restore of ~1,060 bounce-suppressed rows across 313 sellers had to be reconstructed forensically from PaperTrail.
- Anything older than PaperTrail retention is **unrecoverable by that method**. There is no second source.
- `request_path` is a proxy that happens to work, not a designed signal. A future unsubscribe path that runs outside a controller would be indistinguishable from a bug.

With a reason column recorded at write time, the next restore is a `WHERE` clause instead of a version-history scan, and the exclusion rule that gp#1736 and gp#1745 both had to derive by hand ("never touch a web-driven flip") becomes readable straight off the row.

## Before-After

Backend-only; no rendered surface changes. The before/after is the stored value, at the four write sites:

| write site | before | after |
|---|---|---|
| receipt-footer unsubscribe (`GET /purchases/:id/unsubscribe`) | `can_contact: false`, reason unknowable except via `versions.request_path` | `can_contact: false`, `can_contact_reason: "buyer_unsubscribe"` |
| spam report on a receipt (`EVENT_COMPLAINED`) | `can_contact: false`, indistinguishable from a bounce | `can_contact: false`, `can_contact_reason: "spam_report"` |
| spam report on an installment | same | same |
| new purchase row inheriting a sibling's suppression | `can_contact: false`, reads as a fresh unsubscribe | `can_contact: false`, `can_contact_reason: "inherited"` |
| re-subscribe (`POST /purchases/:id/subscribe`) | `can_contact: true`, stale suppression context left behind | `can_contact: true`, `can_contact_reason: nil` |

The `inherited` row is the one that matters most for a future restore: today those rows are the largest source of false "the buyer unsubscribed" readings, because nobody unsubscribed them — they were born suppressed by a sibling.

`json_data` writes go through `merge_json_data_with_current_row`, so setting the reason rebases onto the current row rather than clobbering `locale`, `card_country_source`, and the rest of the blob. There is a spec for that specifically.

**Not in this PR:** the actual restore of gp#1745's 1,060 rows (a bulk production data operation, still parked on a human), and the `Follower` question (`mark_deleted!` nulls `confirmed_at`, so restoring would assert a confirmation we no longer have evidence for — a product decision, per the issue).

## Test Results

Checks run:

- `spec/models/purchase/can_contact_reason_spec.rb` — new file, **7 examples, 0 failures** locally covering: the default buyer-unsubscribe reason; the caller's reason propagating to *every* row for the (email, seller) pair; the reason surviving the `save(validate: false)` fallback path for rows that no longer pass today's validations; `json_data`'s other attributes surviving the write; `inherited` on a row born uncontactable; and `nil` on a normal contactable row.
- `spec/controllers/purchases_controller_spec.rb` — one added example asserting `POST /subscribe` clears the reason, driven through the real controller rather than the model.
- `ruby -c` on all five changed files.
- Full `Tests` workflow on this branch (link in the checks below).

**Mutation proof** (fix committed first, restored via an `EXIT` trap pinned to HEAD, tree verified clean after):

| mutation | result |
|---|---|
| drop `self.can_contact_reason = CAN_CONTACT_REASON_INHERITED` from `toggle_off_can_contact_if_buyer_has_unsubscribed` | RED — `Failure/Error: expect(later.can_contact_reason).to eq(Purchase::CAN_CONTACT_REASON_INHERITED)` (1 of 7) |
| revert the receipt-complaint call site to a bare `unsubscribe_buyer` | RED — `Failure/Error: expect(purchase.reload.can_contact_reason).to eq(Purchase::CAN_CONTACT_REASON_SPAM_REPORT)` (1 of 7) |

Each mutation reddened exactly one example, on the assertion that names the mutated symbol — so neither new spec is vacuous.

Locally, `spec/controllers/purchases_controller_spec.rb` fails **environmentally** in a fresh worktree: 9 of 21 examples, including untouched pre-existing ones (`sets can_contact to true for all purchases`, `handles correct confirmation_text`), all die on the same `ViteRuby.instance.manifest.resolve_entries` line — a missing vite manifest, not this diff. CI runs that file against a built manifest.

No spec-run screenshots — per the current convention, backend test evidence is the list of checks, not a PNG of them.

## QA steps

No preview surface: this changes a stored attribute, not markup. To exercise it on a preview app or console:

```ruby
p = Purchase.last
p.unsubscribe_buyer
p.reload.can_contact_reason            # => "buyer_unsubscribe"

later = create(:purchase, link: p.link, seller: p.seller, email: p.email)
later.can_contact                      # => false
later.can_contact_reason               # => "inherited"   <- the row nobody unsubscribed
```

Then `POST /purchases/#{p.external_id}/subscribe` and re-read: `can_contact` is `true` and `can_contact_reason` is `nil`.

---

🤖 Written by Gumclaw (Hermes Agent, claude-opus-5) on antiwork/gumroad-private#1745. Instruction: drain the qualifying-issue backlog; gp#1745 point 2 asked for a durable consent reason so a future restore is a query rather than a forensic reconstruction. Points 1 and 3 of that issue are deliberately out of scope — one is a bulk production data operation and the other needs a product decision.
