### PR TITLE
Do not report a clean unblock when the Stripe refusal scan was truncated

### DIFF
--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -331,6 +331,9 @@ module Purchase::Blockable
     # Reads left unmade mean an older refusal in the window may still stand. The two exits get
     # different copy because the agent's next move differs: a capped scan has attempts we never
     # looked at, a timed-out one may have nothing left to look at and just needs re-running.
+    #
+    # The cap wins when a slow scan hits both, and that ordering is the point: re-running a capped
+    # scan reads the same four attempts again, so only "go look in Stripe" is advice that can help.
     return { incomplete: true, truncated_by: :read_cap } if capped
     return { incomplete: true, truncated_by: :time_budget } if ran_out_of_time
 

--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -248,6 +248,10 @@ module Purchase::Blockable
   PROCESSOR_REFUSAL_MAX_READS = 4
   PROCESSOR_REFUSAL_TIME_BUDGET = 8.seconds
 
+  # Both timeout phases spend the same budget, so a read needs a second for each of them to be worth
+  # starting; with less left than this the attempt is counted unread instead.
+  PROCESSOR_REFUSAL_MIN_READ_SECONDS = 2
+
   # Whether the PROCESSOR is still refusing this buyer on one of our own risk rules, read from the
   # processor rather than inferred from our rows.
   #
@@ -280,20 +284,25 @@ module Purchase::Blockable
     candidates = eligible.first(PROCESSOR_REFUSAL_MAX_READS)
     return if candidates.empty?
 
-    unread = eligible.size > candidates.size
+    capped = eligible.size > candidates.size
+    ran_out_of_time = false
     deadline = Time.current + PROCESSOR_REFUSAL_TIME_BUDGET
 
     candidates.each do |candidate|
       # Checked BEFORE the call, not after: each read carries its own timeout, so a post-call check
       # lets the budget overrun by a whole read on a request whose unblock has already committed.
-      remaining = deadline - Time.current
-      if remaining <= 0
-        unread = true
+      remaining = (deadline - Time.current).floor
+      if remaining < PROCESSOR_REFUSAL_MIN_READ_SECONDS
+        ran_out_of_time = true
         break
       end
 
+      # Clamped together, because a connect and a read both spend this budget: leaving open_timeout
+      # at its default lets a late read outlive the deadline by the whole connect phase.
+      open_timeout = [PROCESSOR_REFUSAL_READ_OPTS[:open_timeout], remaining - 1].min
       read_opts = PROCESSOR_REFUSAL_READ_OPTS.merge(
-        read_timeout: [PROCESSOR_REFUSAL_READ_OPTS[:read_timeout], [remaining.floor, 1].max].min
+        open_timeout:,
+        read_timeout: [PROCESSOR_REFUSAL_READ_OPTS[:read_timeout], remaining - open_timeout].min
       )
       charge = Stripe::Charge.retrieve({ id: candidate.stripe_transaction_id, expand: %w[outcome.rule] },
                                        read_opts)
@@ -319,8 +328,11 @@ module Purchase::Blockable
       end
     end
 
-    # Reads left unmade mean an older refusal in the window may still stand.
-    return { incomplete: true } if unread
+    # Reads left unmade mean an older refusal in the window may still stand. The two exits get
+    # different copy because the agent's next move differs: a capped scan has attempts we never
+    # looked at, a timed-out one may have nothing left to look at and just needs re-running.
+    return { incomplete: true, truncated_by: :read_cap } if capped
+    return { incomplete: true, truncated_by: :time_budget } if ran_out_of_time
 
     nil
   rescue StandardError => e
@@ -335,6 +347,12 @@ module Purchase::Blockable
     return if refusal.blank?
     return "Could not check whether Stripe is still refusing this buyer — retry the check before promising anything." if refusal[:error].present?
     if refusal[:incomplete].present?
+      if refusal[:truncated_by] == :time_budget
+        return "Checked the buyer's most recent Stripe attempts and none of them was refused by our " \
+               "rules, but the check ran out of time before reading them all — re-run it, and if the " \
+               "buyer still fails, inspect their recent charges in Stripe before promising anything."
+      end
+
       return "Checked the buyer's most recent Stripe attempts and none of them was refused by our " \
              "rules, but there were more attempts in the last day than this check reads — if the " \
              "buyer still fails, inspect their recent charges in Stripe before promising anything."

--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -267,22 +267,36 @@ module Purchase::Blockable
   # Only platform-account charges are considered: a refusal on a creator's own Connect account came
   # from THEIR Radar rules, which we neither set nor can lift.
   #
-  # Returns nil when nothing on the processor side is holding them.
+  # Returns nil only when the whole window was read and nothing is holding them; a scan that ran out
+  # of reads or budget returns `incomplete` instead, because a nil there is indistinguishable from
+  # "clean" to the callers and that silence is the bug this method exists to end.
   def processor_rule_refusal
-    candidates = Purchase.where(email:)
-                         .where(created_at: PROCESSOR_REFUSAL_WINDOW.ago..)
-                         .where(charge_processor_id: StripeChargeProcessor.charge_processor_id)
-                         .where.not(stripe_transaction_id: nil)
-                         .order(created_at: :desc)
-                         .reject { |purchase| purchase.merchant_account&.is_a_stripe_connect_account? }
-                         .first(PROCESSOR_REFUSAL_MAX_READS)
+    eligible = Purchase.where(email:)
+                       .where(created_at: PROCESSOR_REFUSAL_WINDOW.ago..)
+                       .where(charge_processor_id: StripeChargeProcessor.charge_processor_id)
+                       .where.not(stripe_transaction_id: nil)
+                       .order(created_at: :desc)
+                       .reject { |purchase| purchase.merchant_account&.is_a_stripe_connect_account? }
+    candidates = eligible.first(PROCESSOR_REFUSAL_MAX_READS)
     return if candidates.empty?
 
+    unread = eligible.size > candidates.size
     deadline = Time.current + PROCESSOR_REFUSAL_TIME_BUDGET
 
     candidates.each do |candidate|
+      # Checked BEFORE the call, not after: each read carries its own timeout, so a post-call check
+      # lets the budget overrun by a whole read on a request whose unblock has already committed.
+      remaining = deadline - Time.current
+      if remaining <= 0
+        unread = true
+        break
+      end
+
+      read_opts = PROCESSOR_REFUSAL_READ_OPTS.merge(
+        read_timeout: [PROCESSOR_REFUSAL_READ_OPTS[:read_timeout], [remaining.ceil, 1].max].min
+      )
       charge = Stripe::Charge.retrieve({ id: candidate.stripe_transaction_id, expand: %w[outcome.rule] },
-                                       PROCESSOR_REFUSAL_READ_OPTS)
+                                       read_opts)
       outcome = charge["outcome"] || {}
 
       # A later authorised attempt means the buyer already got through, so an earlier refusal in the
@@ -303,9 +317,10 @@ module Purchase::Blockable
           attempted_at: candidate.created_at,
         }
       end
-
-      break if Time.current >= deadline
     end
+
+    # Reads left unmade mean an older refusal in the window may still stand.
+    return { incomplete: true } if unread
 
     nil
   rescue StandardError => e
@@ -319,6 +334,11 @@ module Purchase::Blockable
   def processor_rule_refusal_note(refusal)
     return if refusal.blank?
     return "Could not check whether Stripe is still refusing this buyer — retry the check before promising anything." if refusal[:error].present?
+    if refusal[:incomplete].present?
+      return "Checked the buyer's most recent Stripe attempts and none of them was refused by our " \
+             "rules, but there were more attempts in the last day than this check reads — if the " \
+             "buyer still fails, inspect their recent charges in Stripe before promising anything."
+    end
 
     case refusal[:kind]
     when :platform_block

--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -293,7 +293,7 @@ module Purchase::Blockable
       end
 
       read_opts = PROCESSOR_REFUSAL_READ_OPTS.merge(
-        read_timeout: [PROCESSOR_REFUSAL_READ_OPTS[:read_timeout], [remaining.ceil, 1].max].min
+        read_timeout: [PROCESSOR_REFUSAL_READ_OPTS[:read_timeout], [remaining.floor, 1].max].min
       )
       charge = Stripe::Charge.retrieve({ id: candidate.stripe_transaction_id, expand: %w[outcome.rule] },
                                        read_opts)

--- a/spec/models/concerns/purchase/blockable_spec.rb
+++ b/spec/models/concerns/purchase/blockable_spec.rb
@@ -671,6 +671,43 @@ describe Purchase::Blockable do
 
         expect(Stripe::Charge).to have_received(:retrieve).exactly(Purchase::Blockable::PROCESSOR_REFUSAL_MAX_READS).times
       end
+
+      # Cheap silence is the whole bug: an unread older attempt looks identical to "nothing is
+      # holding them" at the callers, which is how #1739's buyer got told to retry.
+      it "reports an incomplete scan rather than nil when the read cap leaves attempts unread" do
+        create_list(:purchase, 5, link: product, email: buyer_email, purchaser: buyer, created_at: 2.hours.ago)
+          .each { |record| record.update_column(:stripe_transaction_id, "ch_extra") }
+        allow(Stripe::Charge).to receive(:retrieve).and_return(outcome_for(type: "issuer_declined", reason: "generic_decline"))
+
+        refusal = refused_purchase.processor_rule_refusal
+
+        expect(refusal).to eq({ incomplete: true })
+        expect(refused_purchase.processor_rule_refusal_note(refusal)).to include("more attempts in the last day")
+      end
+
+      it "reports an incomplete scan when the time budget runs out before every attempt is read" do
+        allow(Stripe::Charge).to receive(:retrieve) do
+          travel Purchase::Blockable::PROCESSOR_REFUSAL_TIME_BUDGET + 1.second
+          outcome_for(type: "issuer_declined", reason: "generic_decline")
+        end
+
+        expect(refused_purchase.processor_rule_refusal).to eq({ incomplete: true })
+        expect(Stripe::Charge).to have_received(:retrieve).once
+      end
+
+      # A read may not outlive the budget it is spending: the unblock is already committed and the
+      # admin request is still open.
+      it "shortens the per-read timeout to what is left of the budget" do
+        allow(Stripe::Charge).to receive(:retrieve) do |_params, opts|
+          travel Purchase::Blockable::PROCESSOR_REFUSAL_TIME_BUDGET - 2.seconds
+          @observed_timeouts = (@observed_timeouts || []) << opts[:read_timeout]
+          outcome_for(type: "issuer_declined", reason: "generic_decline")
+        end
+
+        refused_purchase.processor_rule_refusal
+
+        expect(@observed_timeouts).to eq([Purchase::Blockable::PROCESSOR_REFUSAL_READ_OPTS[:read_timeout], 2])
+      end
     end
 
     it "names the charge in both notes so the agent can inspect it" do

--- a/spec/models/concerns/purchase/blockable_spec.rb
+++ b/spec/models/concerns/purchase/blockable_spec.rb
@@ -681,32 +681,53 @@ describe Purchase::Blockable do
 
         refusal = refused_purchase.processor_rule_refusal
 
-        expect(refusal).to eq({ incomplete: true })
+        expect(refusal).to eq({ incomplete: true, truncated_by: :read_cap })
         expect(refused_purchase.processor_rule_refusal_note(refusal)).to include("more attempts in the last day")
       end
 
+      # The two truncation exits are not interchangeable: telling the agent there were more attempts
+      # than we read, when the scan actually timed out, is a reason they cannot act on.
       it "reports an incomplete scan when the time budget runs out before every attempt is read" do
         allow(Stripe::Charge).to receive(:retrieve) do
           travel Purchase::Blockable::PROCESSOR_REFUSAL_TIME_BUDGET + 1.second
           outcome_for(type: "issuer_declined", reason: "generic_decline")
         end
 
-        expect(refused_purchase.processor_rule_refusal).to eq({ incomplete: true })
+        refusal = refused_purchase.processor_rule_refusal
+
+        expect(refusal).to eq({ incomplete: true, truncated_by: :time_budget })
         expect(Stripe::Charge).to have_received(:retrieve).once
+        expect(refused_purchase.processor_rule_refusal_note(refusal)).to include("ran out of time")
+        expect(refused_purchase.processor_rule_refusal_note(refusal)).not_to include("more attempts in the last day")
       end
 
       # A read may not outlive the budget it is spending: the unblock is already committed and the
-      # admin request is still open.
-      it "shortens the per-read timeout to what is left of the budget" do
+      # admin request is still open. Both phases are clamped, because a connect that starts inside
+      # the budget can still finish outside it.
+      it "shortens both per-read timeouts to what is left of the budget" do
         allow(Stripe::Charge).to receive(:retrieve) do |_params, opts|
           travel Purchase::Blockable::PROCESSOR_REFUSAL_TIME_BUDGET - 2.seconds
-          @observed_timeouts = (@observed_timeouts || []) << opts[:read_timeout]
+          @observed = (@observed || []) << [opts[:open_timeout], opts[:read_timeout]]
           outcome_for(type: "issuer_declined", reason: "generic_decline")
         end
 
         refused_purchase.processor_rule_refusal
 
-        expect(@observed_timeouts).to eq([Purchase::Blockable::PROCESSOR_REFUSAL_READ_OPTS[:read_timeout], 2])
+        defaults = Purchase::Blockable::PROCESSOR_REFUSAL_READ_OPTS
+        expect(@observed).to eq([[defaults[:open_timeout], defaults[:read_timeout]], [1, 1]])
+        expect(@observed.last.sum).to be <= 2
+      end
+
+      # With less than a connect-plus-read left there is no timeout pair that fits, so the read is
+      # not worth starting at all.
+      it "does not start a read it cannot finish inside the budget" do
+        allow(Stripe::Charge).to receive(:retrieve) do
+          travel Purchase::Blockable::PROCESSOR_REFUSAL_TIME_BUDGET - 1.second
+          outcome_for(type: "issuer_declined", reason: "generic_decline")
+        end
+
+        expect(refused_purchase.processor_rule_refusal).to eq({ incomplete: true, truncated_by: :time_budget })
+        expect(Stripe::Charge).to have_received(:retrieve).once
       end
     end
 

--- a/spec/models/concerns/purchase/blockable_spec.rb
+++ b/spec/models/concerns/purchase/blockable_spec.rb
@@ -729,6 +729,23 @@ describe Purchase::Blockable do
         expect(refused_purchase.processor_rule_refusal).to eq({ incomplete: true, truncated_by: :time_budget })
         expect(Stripe::Charge).to have_received(:retrieve).once
       end
+
+      # A slow scan over more attempts than the cap trips both limits. The cap has to win: a re-run
+      # reads the same four attempts, so the timeout's "run it again" is the one useless answer here.
+      it "prefers the read cap over the time budget when a slow scan trips both" do
+        create_list(:purchase, 5, link: product, email: buyer_email, purchaser: buyer, created_at: 2.hours.ago)
+          .each { |record| record.update_column(:stripe_transaction_id, "ch_extra") }
+        allow(Stripe::Charge).to receive(:retrieve) do
+          travel Purchase::Blockable::PROCESSOR_REFUSAL_TIME_BUDGET - 1.second
+          outcome_for(type: "issuer_declined", reason: "generic_decline")
+        end
+
+        refusal = refused_purchase.processor_rule_refusal
+
+        expect(Stripe::Charge).to have_received(:retrieve).once
+        expect(refusal).to eq({ incomplete: true, truncated_by: :read_cap })
+        expect(refused_purchase.processor_rule_refusal_note(refusal)).to include("more attempts in the last day")
+      end
     end
 
     it "names the charge in both notes so the agent can inspect it" do


### PR DESCRIPTION
## Status

- [x] Scope — three unaddressed Greptile P1s on #6874, which merged before they were answered, plus three follow-up Greptile P1s on this PR (all real; fixed in `0668d5e` and `a49d886`).
- [x] Design — the two truncation exits must not be indistinguishable from "clean" *or from each other*; neither timeout phase may outlive the budget it spends.
- [x] Build — `processor_rule_refusal` returns `{ incomplete: true, truncated_by: … }`, and both `open_timeout` and `read_timeout` are clamped to the remaining budget.
- [x] QA — executed, below.
- [ ] Ship — not merged yet; @nyomanjyotisa reviews.
- [x] Market — n/a, internal admin response copy.
- [x] Sell — n/a, no seller-facing surface.

## What

Follow-up to #6874. Six things in `Purchase::Blockable#processor_rule_refusal` — three from #6874's unanswered review, three raised by Greptile on this PR:

1. **Read cap silently swallowed refusals.** `.first(PROCESSOR_REFUSAL_MAX_READS)` (4) was applied before any outcome was examined, so four newer non-rule attempts (issuer declines, mistyped cards) hid a fifth blocked/rule attempt still inside the 24h window. The method returned `nil`.
2. **Budget exhaustion did the same.** `break if Time.current >= deadline` fell through to `nil`.
3. **The budget could overrun by a whole read.** `PROCESSOR_REFUSAL_TIME_BUDGET` is 8s but the deadline was only checked *after* a synchronous `Stripe::Charge.retrieve` returned, each carrying its own 5s `read_timeout` — so two reads could take 10s on an admin request whose unblock had already committed.
4. **Only one of the two timeout phases was clamped.** With the read timeout narrowed to the remaining budget but `open_timeout` left at 2s, a read starting with 1s left could still spend 2s establishing the connection and overrun the deadline. Both phases now share the remaining seconds, and a read with less than `PROCESSOR_REFUSAL_MIN_READ_SECONDS` (2) left is not started at all — there is no timeout pair that fits inside it.
5. **Both truncation exits shared the read-cap wording.** A scan that stopped because its 8s budget elapsed told the agent "there were more attempts in the last day than this check reads", which is the wrong reason and not something they can act on — with four or fewer eligible attempts it is also simply false. The result now carries `truncated_by: :read_cap | :time_budget` and the note branches: the cap says inspect Stripe, the timeout says re-run the check.
6. **A slow scan can trip both limits, so the precedence needed pinning.** Greptile's follow-up on `0668d5e` is right that more than four eligible attempts sets `capped` before any read, and a slow first read can then set `ran_out_of_time` too. I kept the cap winning rather than reversing to timeout-first as suggested: a re-run of a capped scan reads the same four newest attempts again, so "run it again" is the one instruction that cannot help, while "go look at their recent charges in Stripe" is correct in both cases. That ordering is now a spec and a comment instead of an accident of line order.

## Why

`nil` means "nothing on the processor side is holding this buyer" to both callers (`Admin::PurchasesController#unblock_buyer` and the internal admin endpoint), and both then render the clean-success response. A truncated scan returning `nil` therefore produces exactly the false reassurance gp#1739 was filed about: support clears a mistaken block, tells the buyer to retry, Stripe refuses him anyway, and the admin response says nothing. The #1739 buyer made **16 attempts in the window** with a cap of 4 — this is the common case for the population the check exists for, not an edge.

The wording split matters for the same reason the state exists at all: an agent reading "more attempts than this check reads" goes and looks at Stripe, which is right for a capped scan and a dead end for a timed-out one where the fix is to re-run. Both callers pass the refusal hash through whole, so `truncated_by` reaches the internal endpoint's JSON as well as the note.

## Before / After

| Situation | Before (`origin/main`) | After |
| --- | --- | --- |
| 4 newer non-rule attempts + older blocked/rule in window | `nil` → "Buyer unblocked!" | `{ incomplete: true, truncated_by: :read_cap }` → note tells the agent to inspect recent charges |
| 8s budget spent before all attempts read | `nil` → "Buyer unblocked!" | `{ incomplete: true, truncated_by: :time_budget }` → note tells the agent to re-run the check |
| Budget-truncated scan with ≤ 4 eligible attempts | — | no longer claims there were more attempts than the check reads |
| First read consumes 5s, second read starts | second read allowed another 5s + 2s connect (10–12s total) | second read gets `open_timeout: 1, read_timeout: 1` |
| 7s of the 8s budget spent, one attempt left | read started with a 2s connect allowance it could not honour | read not started; `truncated_by: :time_budget` |
| Slow scan over 5+ attempts trips cap *and* budget | — | `truncated_by: :read_cap` — the re-run advice would be useless here |
| A rule refusal is found | unchanged | unchanged |
| Nothing eligible / issuer decline only, whole window read | `nil` | `nil` (unchanged — no false alarm) |

Note copy, shared by both admin surfaces:

> **Read cap:** Checked the buyer's most recent Stripe attempts and none of them was refused by our rules, but there were more attempts in the last day than this check reads — if the buyer still fails, inspect their recent charges in Stripe before promising anything.

> **Time budget:** Checked the buyer's most recent Stripe attempts and none of them was refused by our rules, but the check ran out of time before reading them all — re-run it, and if the buyer still fails, inspect their recent charges in Stripe before promising anything.

## Test Results

Checks run at `a49d886`:

- `bundle exec rspec spec/models/concerns/purchase/blockable_spec.rb -e "#processor_rule_refusal"` — 16 examples, 0 failures
- `bundle exec rspec spec/controllers/admin/purchases_controller_spec.rb -e "POST unblock_buyer"` — 4 examples, 0 failures (the existing `nil`-stub examples still pass; the clean path is unchanged)
- `bundle exec rubocop app/models/concerns/purchase/blockable.rb spec/models/concerns/purchase/blockable_spec.rb` — 2 files inspected, no offenses
- `ruby -c` on both changed files — Syntax OK
- Mutation check on the round-two behaviours, run and restored: dropping `open_timeout:` from the merged read opts → **1 failure**; collapsing `truncated_by: :time_budget` onto `:read_cap` → **2 failures**; reverting the minimum-read guard to `remaining <= 0` → **1 failure**. All three new behaviours are load-bearing.
- Mutation check on the precedence (round three): reversing the two returns to timeout-first, exactly as the review suggested → **1 failure** (`blockable_spec.rb:735`). The ordering is pinned, not incidental.
- Round-one mutation check (kept from `62fdae4`): replacing the `incomplete` return with `return nil` → 2 failures; dropping the per-read timeout clamp → 1 failure.

The first run of the timeout spec was RED against my own implementation — `remaining.ceil` rounded the clamp *up* to 3s with 2s of budget left, i.e. the fix still overran the budget it was added to enforce. Fixed to `floor` in `62fdae4`.

Five specs cover the truncation states: read-cap truncation, budget truncation (asserting the copy branch and that it does *not* carry the cap wording), the two-phase timeout clamp asserting the observed `[open, read]` pairs are `[[2, 5], [1, 1]]` with the late pair summing to ≤ 2, the not-worth-starting read at 1s remaining, and the cap-beats-budget precedence when a slow scan trips both.

## QA steps

Executed. This is a return value read by two JSON endpoints, so the QA is the specs plus the mutation harness, all run locally at `a49d886`:

1. Built a buyer with 6 platform-account Stripe attempts inside the 24h window, all `issuer_declined` (spec `blockable_spec.rb:677`). `processor_rule_refusal` returned `{ incomplete: true, truncated_by: :read_cap }` where main returns `nil`, and the note rendered the "more attempts in the last day" copy instead of silence.
2. Stubbed `Stripe::Charge.retrieve` to `travel` past the 8s budget on its first call (`:690`). One read made, `truncated_by: :time_budget` returned, note says "ran out of time" and asserts the cap wording is absent.
3. Recorded the timeout pair each read was given (`:707`) after burning 6s of the budget: `[[2, 5], [1, 1]]` — the second read cannot outlive the budget in either phase.
4. Burned 7s of the budget on the first read (`:723`): the second read is not attempted at all, and the scan reports `:time_budget`.
5. Same 7s burn but with 6 eligible attempts (`:735`): both flags true, result is `:read_cap`. Reversing the two returns turns this spec red, which is the check that the precedence is deliberate.
6. Re-ran the four pre-existing `POST unblock_buyer` controller examples: the clean-success and surviving-block paths are byte-identical in behaviour. Neither controller spec asserts the refusal hash's shape, so the added key is additive.
7. Re-ran the untouched `:velocity_rule` / `:platform_block` branch examples — unchanged.

---

AI disclosure: authored by Hermes Agent (claude-opus-5) on Sahil's instruction to clear the outstanding review findings on #6874. Human review requested before merge.
