### PR TITLE
Require shipped_at before the structured shipping slots claim a delivery

### DIFF
--- a/app/services/dispute_evidence/create_from_dispute_service.rb
+++ b/app/services/dispute_evidence/create_from_dispute_service.rb
@@ -85,10 +85,9 @@ class DisputeEvidence::CreateFromDisputeService
     # single submission. Checked as at checkout, not live: a seller disabling shipping later
     # must not erase delivery proof for an order that genuinely shipped.
     #
-    # `shipped_at` is required for the same reason. A row the seller created but never marked
-    # shipped carries no delivery date and, in production, no carrier or tracking either, so the
-    # structured slots would assert delivery to the network with nothing substantiating it. The
-    # free-text summary already holds this line.
+    # `shipped_at` is required because a row created and never marked shipped carries no date, and
+    # in production no carrier or tracking either, so the slots would assert a delivery with nothing
+    # behind it. GenerateUncategorizedTextService's tracking-URL row is deliberately ungated.
     def shipment_for(purchase)
       shipment = purchase.shipment
       return if shipment.blank?

--- a/app/services/dispute_evidence/create_from_dispute_service.rb
+++ b/app/services/dispute_evidence/create_from_dispute_service.rb
@@ -84,9 +84,15 @@ class DisputeEvidence::CreateFromDisputeService
     # into a digital-product dispute — an assertion the buyer can trivially disprove, on our
     # single submission. Checked as at checkout, not live: a seller disabling shipping later
     # must not erase delivery proof for an order that genuinely shipped.
+    #
+    # `shipped_at` is required for the same reason. A row the seller created but never marked
+    # shipped carries no delivery date and, in production, no carrier or tracking either, so the
+    # structured slots would assert delivery to the network with nothing substantiating it. The
+    # free-text summary already holds this line.
     def shipment_for(purchase)
       shipment = purchase.shipment
       return if shipment.blank?
+      return if shipment.shipped_at.blank?
       return unless purchase.required_delivery_at_checkout?
 
       shipment

--- a/app/services/dispute_evidence/generate_uncategorized_text_service.rb
+++ b/app/services/dispute_evidence/generate_uncategorized_text_service.rb
@@ -54,8 +54,9 @@ class DisputeEvidence::GenerateUncategorizedTextService
     # newline would put seller-written lines into evidence Stripe reads as Gumroad's own. Dropping
     # an unusable row costs less than vouching for its text.
     def submission_safe_tracking_url
-      # Same gate as CreateFromDisputeService#shipment_for: a shipment row predating Shipment's
-      # create-time validation can hang off a digital purchase, and its URL is shipping evidence too.
+      # Same checkout-time gate as CreateFromDisputeService#shipment_for, which additionally
+      # requires shipped_at — this row deliberately does not, because a seller-supplied URL is
+      # labelled as theirs and a buyer can follow it whether or not the state was ever flipped.
       return unless purchase.required_delivery_at_checkout?
 
       # `scrub` before `strip`: on an invalid byte sequence `strip` raises

--- a/spec/services/dispute_evidence/create_from_dispute_service_spec.rb
+++ b/spec/services/dispute_evidence/create_from_dispute_service_spec.rb
@@ -660,5 +660,92 @@ describe DisputeEvidence::CreateFromDisputeService, :vcr, :versioning do
         expect(dispute_evidence.shipping_tracking_number).to be_nil
       end
     end
+
+    # 110 of the 122 disputed charges holding a shipment select a row the seller created and never
+    # marked shipped, which in production carries no carrier and no tracking either. Filling the
+    # address slot off it asserts delivery to the network with nothing behind it.
+    context "when the only shipment is still pending" do
+      let!(:sibling_shipment) do
+        create(
+          :shipment,
+          carrier: nil,
+          tracking_number: nil,
+          purchase: shipped_sibling,
+          ship_state: "not_shipped",
+          shipped_at: nil
+        )
+      end
+
+      it "leaves every slot empty rather than claiming an unsubstantiated delivery" do
+        dispute_evidence = DisputeEvidence.create_from_dispute!(dispute)
+
+        expect(dispute_evidence.shipping_address).to be_nil
+        expect(dispute_evidence.shipped_at).to be_nil
+        expect(dispute_evidence.shipping_carrier).to be_nil
+        expect(dispute_evidence.shipping_tracking_number).to be_nil
+      end
+    end
+
+    context "when a pending sibling is ordered before one that shipped" do
+      # The outer sibling_shipment is a let!, so shipped_sibling always exists before anything
+      # defined here. Both sibling purchases are therefore built in one hook, in the order the case
+      # needs: the pending row has to sort first for presence-only selection to have preferred it.
+      let(:pending_sibling) { siblings.first }
+      let(:shipped_sibling) { siblings.last }
+
+      let(:siblings) do
+        pending = create(
+          :purchase,
+          total_transaction_cents: 5_00,
+          link: create(:physical_product, name: "Pending sibling"),
+          email: "customer@example.com",
+          full_name: "John Example",
+          street_address: "1 Pending Pl",
+          city: "Fresno",
+          state: "CA",
+          zip_code: "93701",
+          country: "United States"
+        )
+        shipped = create(
+          :purchase,
+          total_transaction_cents: 10_00,
+          link: physical_product,
+          email: "customer@example.com",
+          full_name: "John Example",
+          street_address: "500 Sibling Way",
+          city: "Oakland",
+          state: "CA",
+          zip_code: "94607",
+          country: "United States"
+        )
+        [pending, shipped]
+      end
+
+      let!(:pending_shipment) do
+        create(:shipment, carrier: "USPS", tracking_number: "9400100000000000000000",
+                          purchase: pending_sibling, ship_state: "not_shipped", shipped_at: nil)
+      end
+
+      let(:charge) do
+        charge = create(:charge)
+        charge.purchases << pending_sibling
+        charge.purchases << shipped_sibling
+        charge.purchases << representative
+        charge
+      end
+
+      it "skips the pending row and submits the sibling that actually shipped" do
+        # Without this the case is vacuous: the pending row has to sort first for the old
+        # presence-only selection to have preferred it.
+        expect(pending_sibling.id).to be < shipped_sibling.id
+
+        dispute_evidence = DisputeEvidence.create_from_dispute!(dispute)
+
+        expect(dispute_evidence.shipped_at).to eq(sibling_shipment.shipped_at)
+        expect(dispute_evidence.shipping_carrier).to eq("UPS")
+        expect(dispute_evidence.shipping_tracking_number).to eq("1Z999AA10123456784")
+        expect(dispute_evidence.shipping_address).to eq("500 Sibling Way, Oakland, CA, 94607, United States")
+      end
+    end
   end
 end

--- a/spec/support/fixtures/vcr_cassettes/DisputeEvidence_CreateFromDisputeService/structured_shipping_slots_on_a_combined_charge/when_a_pending_sibling_is_ordered_before_one_that_shipped/skips_the_pending_row_and_submits_the_sibling_that_actually_shipped.yml
+++ b/spec/support/fixtures/vcr_cassettes/DisputeEvidence_CreateFromDisputeService/structured_shipping_slots_on_a_combined_charge/when_a_pending_sibling_is_ordered_before_one_that_shipped/skips_the_pending_row_and_submits_the_sibling_that_actually_shipped.yml
@@ -1,0 +1,145 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_createDispute
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_a5qI59GQPHJZ5M","request_duration_ms":321}}'
+      Idempotency-Key:
+      - ae16500a-46fc-40e3-8a67-a08ee8fe2831
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 03 Aug 2026 00:36:02 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=ejkuHxUKS_IfZtRSw9g_74tbK0ORIbAqaRBFW5iws_76qm2uIPkMmq9CIPNrrRsoyghnsVbyw2TLxR0O;
+        report-to csp
+      Idempotency-Key:
+      - ae16500a-46fc-40e3-8a67-a08ee8fe2831
+      Original-Request:
+      - req_jhOQPPr0pMtapx
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=ejkuHxUKS_IfZtRSw9g_74tbK0ORIbAqaRBFW5iws_76qm2uIPkMmq9CIPNrrRsoyghnsVbyw2TLxR0O&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=ejkuHxUKS_IfZtRSw9g_74tbK0ORIbAqaRBFW5iws_76qm2uIPkMmq9CIPNrrRsoyghnsVbyw2TLxR0O&t=1"
+      Request-Id:
+      - req_jhOQPPr0pMtapx
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1U09rKIBOqvOFDrfghFPbTqp",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "xhj6XkBnqmm1SCzj",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "0259",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1785717362,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Mon, 03 Aug 2026 00:36:02 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/DisputeEvidence_CreateFromDisputeService/structured_shipping_slots_on_a_combined_charge/when_the_only_shipment_is_still_pending/leaves_every_slot_empty_rather_than_claiming_an_unsubstantiated_delivery.yml
+++ b/spec/support/fixtures/vcr_cassettes/DisputeEvidence_CreateFromDisputeService/structured_shipping_slots_on_a_combined_charge/when_the_only_shipment_is_still_pending/leaves_every_slot_empty_rather_than_claiming_an_unsubstantiated_delivery.yml
@@ -1,0 +1,145 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_createDispute
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_fhpW5m7vJTvgLa","request_duration_ms":2}}'
+      Idempotency-Key:
+      - 4f9fc309-3596-4c51-a316-ecc814e2b9eb
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 03 Aug 2026 00:36:00 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=ejkuHxUKS_IfZtRSw9g_74tbK0ORIbAqaRBFW5iws_76qm2uIPkMmq9CIPNrrRsoyghnsVbyw2TLxR0O;
+        report-to csp
+      Idempotency-Key:
+      - 4f9fc309-3596-4c51-a316-ecc814e2b9eb
+      Original-Request:
+      - req_a5qI59GQPHJZ5M
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=ejkuHxUKS_IfZtRSw9g_74tbK0ORIbAqaRBFW5iws_76qm2uIPkMmq9CIPNrrRsoyghnsVbyw2TLxR0O&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=ejkuHxUKS_IfZtRSw9g_74tbK0ORIbAqaRBFW5iws_76qm2uIPkMmq9CIPNrrRsoyghnsVbyw2TLxR0O&t=1"
+      Request-Id:
+      - req_a5qI59GQPHJZ5M
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1U09rIIBOqvOFDrfsm7oPtGi",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "xhj6XkBnqmm1SCzj",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "0259",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1785717360,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Mon, 03 Aug 2026 00:36:00 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
Follow-up to #6880, which closed gp#1694's objective half. Greptile left an unresolved P1 on that PR and it was correct; measuring it in production turned up a second, much larger shape of the same missing guard.

## The defect

`shipment_for` accepted any shipment row that existed, so `evidence_shipment_and_purchase` selected on presence alone. A row the seller created but never marked shipped has no `shipped_at`, and in production carries no carrier and no tracking either — so `shipping_address` went out asserting a delivery to the card network with nothing substantiating it, and `shipped_at`, `shipping_carrier` and `shipping_tracking_number` went out empty beside it. We submit once.

The free-text summary already required `shipped_at` before writing a shipping line (`other_disputed_items_rows`). The structured slots, which are the fields Stripe's automated review actually reads, did not. That inconsistency is the bug.

## Size, measured in production

Across the 4,000 most recent disputes carrying a charge:

| selection outcome | disputed charges |
|---|---|
| a **pending** shipment selected | **110** |
| a genuinely shipped row selected | 12 |
| no shipment at all | 3,878 |

So 110 of the 122 charges that had any shipment to reason about picked the unsubstantiated row. Every sampled one had `carrier=nil`, `tracking_number` absent and no tracking URL — the slots carried an address and nothing else.

**101 of those 110 have evidence built but not yet submitted**, so this is not purely retrospective; those rows still go out on the current code.

## Greptile's P1

The reported shape — a pending sibling sorted ahead of one that genuinely shipped, whose blank tracking replaces real delivery proof — is fixed by the same guard and has its own spec. I looked for it in production and found **0 occurrences across 436 disputed combined charges**, so it is a latent ordering hazard rather than an active loss. Recording that rather than implying I fixed 110 instances of the reported bug; the 110 are the adjacent single-shipment shape.

## What this does not claim

The pending cohort loses 81.6% of decided disputes (80 lost / 18 won) against a 72.2% baseline across all disputed charges. That is **not** evidence the bad claim causes losses — the cohort that selected a genuinely shipped row lost 100% of 12. Physical-goods disputes lose more regardless of what we submit. The argument for this fix is that we should not assert a delivery we cannot substantiate, not a measured win-rate gain.

## Does the guard ever discard real delivery evidence?

No — this is the one question that could have made the change harmful, so I checked it across every shipment in production rather than reasoning about it:

| check | rows |
|---|---|
| shipments total | 2,052,455 |
| `shipped_at` nil | 1,742,536 |
| `shipped_at` nil **and** carrier present | **0** |
| `shipped_at` nil **and** tracking_number present | **0** |
| `shipped_at` nil **and** tracking_url present | **0** |

The state invariant is exact: `ship_state = "not_shipped"` ⟺ `shipped_at IS NULL` (1,742,536 rows both ways), and `ship_state = "shipped"` has zero nil dates. So a row without `shipped_at` never carries carrier, tracking number, or tracking URL — there is no "seller shipped but forgot to flip the state" population whose evidence this drops. The only thing the guard removes from the payload is a bare `shipping_address` on an order with no delivery proof of any kind.

## Change

One guard in `shipment_for`, so both the structured slots and the free-text summary answer to the same rule:

```ruby
return if shipment.shipped_at.blank?
```

`GenerateUncategorizedTextService#submission_safe_tracking_url` is deliberately **not** given the same guard: a seller-supplied tracking URL is independent evidence a buyer can follow, and requiring `shipped_at` there would discard real proof on rows where the seller never flipped the state.

## Test results

Run locally at head, not predicted:

- `spec/services/dispute_evidence/create_from_dispute_service_spec.rb` — **27 examples, 0 failures**
- `generate_uncategorized_text_service_spec.rb` + `generate_access_activity_logs_service_spec.rb` — **37 examples, 0 failures** (they share the gate)

**Mutation check** — the guard reverted in place, the two new examples re-run, then restored:

| mutant | result |
|---|---|
| `return if shipment.shipped_at.blank?` removed | **2 failures** |
| restored | 27 examples, 0 failures |

Both new specs were caught being vacuous first: an earlier revision asserted `pending_sibling.id < shipped_sibling.id` while the outer `let!(:sibling_shipment)` forced the shipped purchase to exist first, so the pending row always took the higher id and the ordering under test never arose. Both siblings are now built in one hook in the required order, and the id assertion is kept so the case cannot silently go vacuous again.

## QA steps

The behaviour is a payload we hand a card network, so the boundary is the evidence row itself:

1. Combined charge, only shipment pending → all four structured slots nil (previously: address filled, rest blank).
2. Combined charge, pending sibling sorted before a shipped sibling → slots filled from the shipped one, `expect(pending_sibling.id).to be < shipped_sibling.id` proving the pending row was reached first.
3. Representative genuinely shipped → unchanged, its own shipment kept.
4. Nothing shipped → unchanged, all slots nil.
5. Pre-existing single-purchase and Connect cases re-run unchanged to confirm the guard only removes the unsubstantiated case.


---

AI disclosure: authored by Hermes Agent (claude-opus-5) as the follow-up to the unresolved Greptile P1 left on #6880. Production figures above were read from the replica, not estimated. Human review requested before merge.
