### PR TITLE
Find stale blocks by the blocks, not by who tried lately

### DIFF
--- a/app/sidekiq/alert_on_stale_blocks_holding_established_buyers_job.rb
+++ b/app/sidekiq/alert_on_stale_blocks_holding_established_buyers_job.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+# Reports buyers with settled payment history sitting behind an active platform block, keyed on the
+# BLOCKS rather than on recent failures (gumroad-private#1746).
+#
+# AlertOnBlockedEstablishedBuyersJob asks "who was refused lately, and is a block still holding
+# them?" — so it only ever sees someone who tried recently. A block is not retryable, so a buyer
+# refused once gives up and never generates another row; that job's own comment concedes they are
+# then "invisible to this report forever". Measured 2026-08-03: 5,001 emails had a block-declined
+# failure in a 30-day window while 39,701 active automated email blocks had none, the oldest written
+# 2021-04-29, and 18% of a sample of those cleared the clean-history gate.
+#
+# This job asks the inverted question — "which active blocks are standing in front of a settled
+# buyer?" — which reaches the ones who stopped trying. Overlap with the failure-keyed report is a
+# duplicate line in an internal alert, which is cheaper than a silent drop.
+#
+# Reports; clearing stays a human decision.
+class AlertOnStaleBlocksHoldingEstablishedBuyersJob
+  include Sidekiq::Job
+  sidekiq_options retry: 2, queue: :low
+
+  # Only `email` blocks. Their object_value IS the buyer's identity, so history joins to the block
+  # directly. The other types cannot be resolved from the block alone: a browser_guid or card
+  # fingerprint names a device rather than a person, and an email_domain covers everyone on that
+  # domain, so "the buyer behind this block" is not a question those rows can answer without a
+  # failure row to anchor on — which is exactly what the failure-keyed job already has.
+  BLOCK_TYPE = PlatformBlock::TYPES[:email]
+
+  # Report at most this many. The alert exists to be read.
+  MAX_REPORTED = 25
+
+  # The bound on the work: how many blocks get their buyer's history counted. Everything past it is
+  # unscanned, and the report says so rather than presenting its count as the total. Measured 40,000+
+  # candidate blocks, so a full pass is deliberately out of reach for one run — this job surfaces the
+  # worst of the backlog repeatedly rather than claiming to enumerate it.
+  MAX_CANDIDATES_SCANNED = 5_000
+
+  # Blocks are counted in batches to keep each grouped query's IN list bounded.
+  HISTORY_COUNT_BATCH = 500
+
+  def perform
+    scan = scan_for_stale_blocks
+    # Truncation with nothing qualifying still has to go out: it means the scan bound, not the
+    # platform, decided the report was empty.
+    return if scan[:stale].empty? && !scan[:truncated]
+
+    InternalNotificationWorker.perform_async("risk", "Stale blocks holding established buyers", message_for(scan))
+  end
+
+  private
+    # One entry per active block standing in front of a buyer with settled history, in the report's
+    # own ranking. `truncated` means the candidate window was cut short, so the counts are floors.
+    def scan_for_stale_blocks
+      candidates = candidate_blocks
+      truncated = candidates.size > MAX_CANDIDATES_SCANNED
+      candidates = candidates.first(MAX_CANDIDATES_SCANNED)
+
+      stale = []
+      candidates.each_slice(HISTORY_COUNT_BATCH) do |batch|
+        emails = batch.map { |block| block.object_value.downcase }
+
+        settled = settled_purchase_counts(emails)
+        next if settled.empty?
+
+        settled = reject_disputed(settled)
+        next if settled.empty?
+
+        batch.each do |block|
+          email = block.object_value.downcase
+          count = settled[email]
+          next if count.nil?
+
+          stale << {
+            email: block.object_value,
+            settled_purchases: count,
+            blocked_at: block.blocked_at,
+          }
+        end
+      end
+
+      { stale: report_order(stale), truncated: }
+    end
+
+    # Active email blocks nobody is named on, oldest first, one over the candidate budget so that
+    # exhausting it is distinguishable from a table holding exactly that many.
+    #
+    # Oldest first because age is the whole complaint: a block written years ago that still refuses a
+    # long-standing customer is the one a human should see, and a recent row is more likely to be a
+    # velocity rule firing for cause.
+    #
+    # `blocked_by: nil` keeps this to unattended rows. A named block is a decision about this buyer,
+    # not a rule that outlived itself. Not airtight — PlatformBlock.add! overwrites blocked_by on
+    # every re-block, so a human's row a rule later re-triggered arrives here as unattended, which is
+    # why the report tells its reader to re-check rather than presenting a line as proof.
+    def candidate_blocks
+      PlatformBlock.active
+                   .where(object_type: BLOCK_TYPE, blocked_by: nil)
+                   .where.not(object_value: nil)
+                   .order(blocked_at: :asc, id: :asc)
+                   .limit(MAX_CANDIDATES_SCANNED + 1)
+                   .to_a
+    end
+
+    # Downcased email => settled non-free purchase count, for buyers clearing the same bar
+    # Purchase::Blockable#buyer_has_clean_payment_history? sets: purchases old enough for a cardholder
+    # to have disputed them, none refunded, none charged back. Reading the same constants is what
+    # keeps a report of "this block should not be holding them" aligned with the rule that decides
+    # whether to write one.
+    #
+    # Keyed on the downcased address for the same reason DecliningPlatformBlocks does it: the column
+    # collates ci, so a mixed-case legacy row comes back under an arbitrary member's casing and would
+    # not join to a lowercase block value.
+    def settled_purchase_counts(emails)
+      Purchase.successful.non_free.not_fully_refunded.not_chargedback_or_chargedback_reversed
+              .where(created_at: ..Purchase::Blockable::MIN_PURCHASE_AGE_FOR_CLEAN_HISTORY.ago)
+              .where(email: emails)
+              .group(:email)
+              .count
+              .transform_keys(&:downcase)
+              .select { |_, count| count >= Purchase::Blockable::MIN_SUCCESSFUL_PURCHASES_FOR_CLEAN_HISTORY }
+    end
+
+    # Drops buyers carrying an unreversed chargeback on ANY purchase, which the counts above only
+    # excluded from the total: a buyer with three clean purchases and a fourth charged back would
+    # otherwise read as established, and a chargeback is exactly what a block is for.
+    def reject_disputed(settled)
+      # The exact complement of the not_chargedback_or_chargedback_reversed scope the counts above
+      # use, so the numerator and the veto cannot disagree about what a live dispute is.
+      disputed = Purchase.where(email: settled.keys)
+                         .where.not(chargeback_date: nil)
+                         .where("purchases.flags & :bit = 0", bit: Purchase.flag_mapping["flags"][:chargeback_reversed])
+                         .distinct
+                         .pluck(:email)
+                         .map(&:downcase)
+                         .to_set
+
+      settled.reject { |email, _| disputed.include?(email) }
+    end
+
+    def message_for(scan)
+      stale = scan[:stale]
+      lines = stale.first(MAX_REPORTED).map { |entry| line_for(entry) }
+      omitted = stale.size - lines.size
+
+      [
+        headline(stale.size, scan[:truncated]),
+        (scan[:truncated] ? "The scan stopped at #{MAX_CANDIDATES_SCANNED} active blocks, so this is a floor — the backlog is larger than the count above." : nil),
+        "",
+        *lines,
+        (omitted.positive? ? "…and #{omitted} more." : nil),
+        "",
+        "These buyers have NOT tried recently — that is why the failure-keyed report never named them. " \
+          "A line here is not proof the block is stale: a velocity rule writes `blocked_by` nil too, so " \
+          "check the rules before unblocking, and remember `unblock_buyer!` clears the buyer's whole " \
+          "identifier set rather than one row (see gumroad-private#1746).",
+      ].compact.join("\n")
+    end
+
+    # Oldest block first. Age is what makes a line worth reading here: unlike the failure-keyed
+    # report there is no recent attempt to rank by, and the buyer stuck since 2021 is the one whose
+    # block is least likely to still be justified.
+    def report_order(stale)
+      stale.sort_by { |entry| [entry[:blocked_at].to_i, -entry[:settled_purchases]] }
+    end
+
+    def line_for(entry)
+      "• #{entry[:email]} — #{entry[:settled_purchases]} settled purchases, " \
+        "blocked by email since #{entry[:blocked_at].to_date} (no recent attempt)"
+    end
+
+    def headline(count, truncated)
+      return "No active email block on the scanned page stands in front of an established buyer, but the scan was truncated, so this is not evidence that none do." if count.zero?
+
+      "#{truncated ? "At least " : ""}#{count} active email block#{"s" if count != 1} " \
+        "#{count == 1 ? "is" : "are"} holding a buyer with " \
+        "#{Purchase::Blockable::MIN_SUCCESSFUL_PURCHASES_FOR_CLEAN_HISTORY}+ settled purchases who has not tried to check out recently."
+    end
+end

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -177,6 +177,11 @@ alert_on_blocked_established_buyers:
   class: AlertOnBlockedEstablishedBuyersJob
   queue: low
   description: Reports buyers with settled payment history whose checkouts are failing on a platform block
+alert_on_stale_blocks_holding_established_buyers:
+  cron: "0 12 * * 1" # UTC 12:00 Monday
+  class: AlertOnStaleBlocksHoldingEstablishedBuyersJob
+  queue: low
+  description: Reports active platform blocks holding buyers with settled history who have stopped trying to check out
 alert_on_negative_destination_balances:
   cron: "20 11 * * *" # UTC 11:20
   class: AlertOnNegativeDestinationBalancesJob

--- a/spec/sidekiq/alert_on_stale_blocks_holding_established_buyers_job_spec.rb
+++ b/spec/sidekiq/alert_on_stale_blocks_holding_established_buyers_job_spec.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe AlertOnStaleBlocksHoldingEstablishedBuyersJob do
+  let(:email) { "established@example.com" }
+
+  # Settled history has to be old enough to count at all — MIN_PURCHASE_AGE_FOR_CLEAN_HISTORY is what
+  # makes a purchase evidence about the person rather than a fresh card that has not been disputed yet.
+  let(:history_starts_at) { 6.months.ago }
+
+  def settled_purchases(count, buyer_email: email, **attrs)
+    count.times.map do |index|
+      create(:purchase, email: buyer_email, purchase_state: "successful", price_cents: 500,
+                        created_at: history_starts_at + index.days, **attrs)
+    end
+  end
+
+  def block_email(value = email, blocked_at: 2.years.ago, **attrs)
+    travel_to(blocked_at) do
+      PlatformBlock.add!(object_type: PlatformBlock::TYPES[:email], object_value: value, **attrs)
+    end
+  end
+
+  def established_count
+    Purchase::Blockable::MIN_SUCCESSFUL_PURCHASES_FOR_CLEAN_HISTORY
+  end
+
+  def message
+    captured = nil
+    allow(InternalNotificationWorker).to receive(:perform_async) { |_, _, body| captured = body }
+    described_class.new.perform
+    captured
+  end
+
+  before do
+    allow(InternalNotificationWorker).to receive(:perform_async)
+  end
+
+  # The whole point of this job: no failure row anywhere, so the failure-keyed report cannot see this
+  # buyer at all.
+  it "reports a buyer who has never attempted a blocked checkout" do
+    settled_purchases(established_count)
+    block_email
+
+    expect(message).to include(email, "#{established_count} settled purchases", "no recent attempt")
+  end
+
+  it "names the date the block was written" do
+    settled_purchases(established_count)
+    block_email(blocked_at: Date.new(2021, 4, 29).to_time)
+
+    expect(message).to include("blocked by email since 2021-04-29")
+  end
+
+  it "ignores a buyer without enough settled purchases" do
+    settled_purchases(established_count - 1)
+    block_email
+
+    expect(InternalNotificationWorker).not_to receive(:perform_async)
+    described_class.new.perform
+  end
+
+  it "ignores purchases too recent to have been disputed" do
+    settled_purchases(established_count, created_at: 1.day.ago)
+    block_email
+
+    expect(InternalNotificationWorker).not_to receive(:perform_async)
+    described_class.new.perform
+  end
+
+  it "ignores free purchases, which cost a card tester nothing" do
+    settled_purchases(established_count, price_cents: 0)
+    block_email
+
+    expect(InternalNotificationWorker).not_to receive(:perform_async)
+    described_class.new.perform
+  end
+
+  it "ignores a buyer carrying a chargeback on another purchase" do
+    settled_purchases(established_count)
+    create(:purchase, email:, purchase_state: "successful", price_cents: 500,
+                      created_at: history_starts_at, chargeback_date: 1.month.ago)
+    block_email
+
+    expect(InternalNotificationWorker).not_to receive(:perform_async)
+    described_class.new.perform
+  end
+
+  it "still reports a buyer whose only chargeback was reversed" do
+    settled_purchases(established_count)
+    create(:purchase, email:, purchase_state: "successful", price_cents: 500,
+                      created_at: history_starts_at, chargeback_date: 1.month.ago,
+                      flags: Purchase.flag_mapping["flags"][:chargeback_reversed])
+    block_email
+
+    expect(message).to include(email)
+  end
+
+  # A named block is somebody's decision about this buyer, not a rule that outlived itself.
+  it "ignores a block a human wrote" do
+    settled_purchases(established_count)
+    block_email(by: create(:admin_user).id)
+
+    expect(InternalNotificationWorker).not_to receive(:perform_async)
+    described_class.new.perform
+  end
+
+  it "ignores a block that was already cleared" do
+    settled_purchases(established_count)
+    block_email.unblock!
+
+    expect(InternalNotificationWorker).not_to receive(:perform_async)
+    described_class.new.perform
+  end
+
+  it "ignores a block that has expired" do
+    settled_purchases(established_count)
+    block = block_email
+    block.update!(expires_at: 1.day.ago)
+
+    expect(InternalNotificationWorker).not_to receive(:perform_async)
+    described_class.new.perform
+  end
+
+  # Only email blocks name a person. A guid block names a device, so this job cannot say whose
+  # history to count and the failure-keyed report owns that case.
+  it "ignores a browser guid block" do
+    settled_purchases(established_count)
+    travel_to(2.years.ago) do
+      PlatformBlock.add!(object_type: PlatformBlock::TYPES[:browser_guid], object_value: "guid-abc")
+    end
+
+    expect(InternalNotificationWorker).not_to receive(:perform_async)
+    described_class.new.perform
+  end
+
+  it "ignores an email domain block, which holds more than one buyer" do
+    settled_purchases(established_count)
+    travel_to(2.years.ago) do
+      PlatformBlock.add!(object_type: PlatformBlock::TYPES[:email_domain], object_value: "example.com")
+    end
+
+    expect(InternalNotificationWorker).not_to receive(:perform_async)
+    described_class.new.perform
+  end
+
+  # The column collates ci, so a legacy mixed-case history row comes back under its own casing and
+  # would not join to a lowercase block value without normalising both sides.
+  it "matches legacy mixed-case history to the block value" do
+    settled_purchases(established_count, buyer_email: "Established@Example.com")
+    block_email
+
+    expect(message).to include("#{established_count} settled purchases")
+  end
+
+  it "reports the oldest block first" do
+    settled_purchases(established_count)
+    settled_purchases(established_count, buyer_email: "newer@example.com")
+    block_email("newer@example.com", blocked_at: 6.months.ago)
+    block_email(blocked_at: 3.years.ago)
+
+    lines = message.split("\n").select { |line| line.start_with?("•") }
+    expect(lines.first).to include(email)
+    expect(lines.second).to include("newer@example.com")
+  end
+
+  it "tells the reader these buyers have not tried recently" do
+    settled_purchases(established_count)
+    block_email
+
+    expect(message).to include("have NOT tried recently")
+  end
+
+  # A truncated scan that found nothing must still report: otherwise the bound, not the platform,
+  # decided the report was empty and nobody knows.
+  it "reports truncation even when nothing on the page qualified" do
+    stub_const("#{described_class}::MAX_CANDIDATES_SCANNED", 1)
+    block_email("nohistory1@example.com", blocked_at: 3.years.ago)
+    block_email("nohistory2@example.com", blocked_at: 2.years.ago)
+
+    expect(message).to include("not evidence that none do", "floor")
+  end
+
+  it "says the count is a floor when the scan was truncated" do
+    stub_const("#{described_class}::MAX_CANDIDATES_SCANNED", 1)
+    settled_purchases(established_count)
+    block_email(blocked_at: 3.years.ago)
+    block_email("other@example.com", blocked_at: 2.years.ago)
+
+    expect(message).to include("At least 1 active email block", "floor")
+  end
+
+  it "sends nothing when no block qualifies and the scan was not truncated" do
+    settled_purchases(established_count)
+
+    expect(InternalNotificationWorker).not_to receive(:perform_async)
+    described_class.new.perform
+  end
+end


### PR DESCRIPTION
## Status

- [x] Scope — gp#1746 point 3. Points 1-2 were already shipped in #6748; this is the remaining gap.
- [x] Design — invert the query: key on active blocks rather than on recent failures.
- [x] Build — branch `gp1746-block-keyed-sweep`.
- [x] QA — 18 specs green; production dry run confirms the population is real (below).
- [ ] Shipped
- [ ] Market — n/a, internal risk alert.
- [ ] Sell — n/a.

## What

Adds `AlertOnStaleBlocksHoldingEstablishedBuyersJob`, a weekly report of **active `email` platform blocks standing in front of buyers with settled payment history**, plus its schedule entry (UTC 12:00 Monday) and 18 specs.

Ref antiwork/gumroad-private#1746.

## Why

`AlertOnBlockedEstablishedBuyersJob` (#6748) asks *"who was refused lately, and is a block still holding them?"* — so it only ever sees someone who tried recently. A platform block is not a retryable error, so a buyer refused once gives up and never generates another row. That job's own comment concedes the consequence: such a buyer is *"invisible to this report forever."*

Measured on production 2026-08-03 (audited reads `20260803T012745Z-deeb127e`, `20260803T012921Z-7ff9656e`):

| measure | value |
|---|---|
| emails with a block-declined failure in a 30-day window (visible today) | 5,001 |
| active automated (`blocked_by: nil`) email blocks | 40,000+ (query cap — a floor) |
| **not covered by any recent failure row** | **39,701** |
| oldest such block | **2021-04-29** |
| of 1,200 sampled invisible blocks, clearing the clean-history gate | **220 (18%)** |

So the existing daily alert works the visible tip while roughly 7,000 established buyers sit behind blocks our own gates say should not hold them. This job asks the inverted question and reaches them.

## Design notes

**Scoped to `email` blocks only.** Their `object_value` *is* the buyer's identity, so history joins to the block directly. The other types cannot be resolved from a block alone — a `browser_guid` or card fingerprint names a device rather than a person, and an `email_domain` covers everyone on that domain. "Which buyer is behind this block?" is not a question those rows can answer without a failure row to anchor on, which is exactly what the failure-keyed job already has. Two specs pin those exclusions so the scope cannot quietly widen.

**Same gate as the writer.** Eligibility reads `Purchase::Blockable::MIN_SUCCESSFUL_PURCHASES_FOR_CLEAN_HISTORY` and `MIN_PURCHASE_AGE_FOR_CLEAN_HISTORY` — the same constants that decide whether to *write* a block — so a report claiming "this block should not be holding them" cannot drift from the rule that created it. Chargeback veto and the ci-collation downcasing follow #6748 for the same reason.

**Oldest block first.** There is no recent attempt to rank by here, and age is the complaint: a 2021 row still refusing a long-standing customer is the one worth a human's attention, while a recent row is more likely a velocity rule firing for cause.

**Reports; does not clear.** gp#1746 raised auto-clear as an open question and the answer is no, not yet — at ~7,000 buyers an automatic clear is a large unilateral action, and `blocked_by: nil` is not proof of staleness (velocity rules write it too). The message says so explicitly rather than implying every line is safe to clear.

**Truncation is loud.** `MAX_CANDIDATES_SCANNED = 5_000` against a 40,000+ population means a full pass is deliberately out of reach for one run; the job surfaces the worst of the backlog repeatedly instead of pretending to enumerate it. A truncated scan that finds nothing still sends, so the reader can tell "nobody is stranded" from "the bound decided the answer" — two specs cover that, including the empty-but-truncated case.

## Test Results

`spec/sidekiq/alert_on_stale_blocks_holding_established_buyers_job_spec.rb` — **18 examples, 0 failures** (`DISABLE_SPRING=1 bundle exec rspec`). `rubocop` clean on both files. `config/sidekiq_schedule.yml` parses and resolves to `0 12 * * 1 / AlertOnStaleBlocksHoldingEstablishedBuyersJob`.

Checks asserted: a buyer with **no failure row at all** is reported (the case the existing job structurally cannot see); the block date is named; under-threshold, too-recent, free-only, and chargeback-carrying buyers are skipped; a reversed chargeback still reports; human-written, cleared, and expired blocks are skipped; guid and domain blocks are skipped; legacy mixed-case history joins; oldest-first ordering; truncation wording in both the found-something and found-nothing cases; and silence when nothing qualifies on a complete scan.

## QA steps (RUN — production, read-only)

Dry-ran the job's exact predicates against production via the audited console (request
`20260803T0208`, read-only, replica). Not a prediction — this is what came back:

```
GP1746DRY gate: min_purchases=3 min_age=60 days
GP1746DRY candidates_scanned=5001 truncated=true
GP1746DRY oldest_block=2021-04-29 07:05:07 UTC
GP1746DRY STALE_FOUND=1178
GP1746DRY [1] se***@icloud.com n=3  since=2021-04-29
GP1746DRY [2] tr***@gmail.com  n=6  since=2021-04-30
GP1746DRY [3] an***@hotmail.com n=6 since=2021-04-30
GP1746DRY [4] le***@gmail.com  n=3  since=2021-04-30
GP1746DRY [5] al***@gmail.com  n=12 since=2021-04-30
```

**1,178 of the first 5,000 candidate blocks (23.6%) are holding an established buyer** — in line
with the 18% sample estimate in the issue, and higher because oldest-first ordering front-loads the
worst of the backlog. The oldest is from **2021-04-29**; entry 5 is a buyer with **12 settled
purchases** blocked for over four years.

Also confirms the mechanics: the gate resolves to the live constants (3 purchases / 60 days),
`truncated: true` fires as designed at this population size, and oldest-first ordering holds across
the report.

Emails are masked here only for the PR; the alert itself needs the full address to be actionable.

## Not in this PR

- **Auto-clearing.** Deliberately a human decision; see above.
- **Non-email block types.** They need a failure row to attribute a person, which is the existing job's territory.
- **A durable `can_contact`-style reason column on `PlatformBlock`** so staleness stops being inferred from `blocked_by: nil`. Worth doing, out of scope here.


---

AI disclosure: written by Gumclaw (Hermes Agent, `claude-opus-5`) against antiwork/gumroad-private#1746 — find stale platform blocks by enumerating the blocks themselves rather than by who happened to retry recently. The production dry-run numbers above are real read-only replica reads, not estimates.
