### PR TITLE
The Stripe refusal read has never run: pass its timeouts as a StripeClient

### DIFF
--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -239,6 +239,11 @@ module Purchase::Blockable
 
   # An informational read on an admin request that has already committed its unblock, so it gets a
   # tight budget and never retries: a slow processor must not turn a done unblock into a timeout.
+  #
+  # Passed as a StripeClient, never as per-request opts: stripe-ruby forwards any opts key outside
+  # `Util::OPTS_USER_SPECIFIED` as an HTTP header, so an Integer timeout raises `NoMethodError:
+  # undefined method 'strip' for an instance of Integer` before the request leaves the process —
+  # which the rescue below then reports as "could not read the processor outcome" on every call.
   PROCESSOR_REFUSAL_READ_OPTS = { read_timeout: 5, open_timeout: 2, max_network_retries: 0 }.freeze
 
   # A refusal can sit behind newer attempts that failed for unrelated reasons (an issuer decline, a
@@ -300,12 +305,14 @@ module Purchase::Blockable
       # Clamped together, because a connect and a read both spend this budget: leaving open_timeout
       # at its default lets a late read outlive the deadline by the whole connect phase.
       open_timeout = [PROCESSOR_REFUSAL_READ_OPTS[:open_timeout], remaining - 1].min
-      read_opts = PROCESSOR_REFUSAL_READ_OPTS.merge(
-        open_timeout:,
-        read_timeout: [PROCESSOR_REFUSAL_READ_OPTS[:read_timeout], remaining - open_timeout].min
+      read_client = Stripe::StripeClient.new(
+        PROCESSOR_REFUSAL_READ_OPTS.merge(
+          open_timeout:,
+          read_timeout: [PROCESSOR_REFUSAL_READ_OPTS[:read_timeout], remaining - open_timeout].min
+        )
       )
       charge = Stripe::Charge.retrieve({ id: candidate.stripe_transaction_id, expand: %w[outcome.rule] },
-                                       read_opts)
+                                       { client: read_client })
       outcome = charge["outcome"] || {}
 
       # A later authorised attempt means the buyer already got through, so an earlier refusal in the

--- a/spec/models/concerns/purchase/blockable_spec.rb
+++ b/spec/models/concerns/purchase/blockable_spec.rb
@@ -707,7 +707,8 @@ describe Purchase::Blockable do
       it "shortens both per-read timeouts to what is left of the budget" do
         allow(Stripe::Charge).to receive(:retrieve) do |_params, opts|
           travel Purchase::Blockable::PROCESSOR_REFUSAL_TIME_BUDGET - 2.seconds
-          @observed = (@observed || []) << [opts[:open_timeout], opts[:read_timeout]]
+          config = opts[:client].config
+          @observed = (@observed || []) << [config.open_timeout, config.read_timeout]
           outcome_for(type: "issuer_declined", reason: "generic_decline")
         end
 
@@ -716,6 +717,21 @@ describe Purchase::Blockable do
         defaults = Purchase::Blockable::PROCESSOR_REFUSAL_READ_OPTS
         expect(@observed).to eq([[defaults[:open_timeout], defaults[:read_timeout]], [1, 1]])
         expect(@observed.last.sum).to be <= 2
+      end
+
+      # stripe-ruby forwards any opts key outside Util::OPTS_USER_SPECIFIED as an HTTP header, so
+      # passing the timeouts as per-request opts raised before the request was made and every scan
+      # reported "could not read" — invisible to the other examples, which stub `retrieve` away.
+      it "carries the timeouts in a way the Stripe client actually accepts" do
+        allow(Stripe::Charge).to receive(:retrieve) do |_params, opts|
+          rejected = opts.keys - Stripe::Util::OPTS_USER_SPECIFIED.to_a - [:client]
+          raise ArgumentError, "opts#{rejected.inspect} would be sent to Stripe as HTTP headers" if rejected.any?
+
+          outcome_for(type: "issuer_declined", reason: "generic_decline")
+        end
+
+        # nil, not the {error:} hash the rescue produces when the call raises.
+        expect(refused_purchase.processor_rule_refusal).to be_nil
       end
 
       # With less than a connect-plus-read left there is no timeout pair that fits, so the read is


### PR DESCRIPTION
## Status

- [x] Scope — adversarial review of #6886 found a P1 that predates it: the Stripe read in `processor_rule_refusal` has never actually run. Verified against `origin/main` and against stripe-ruby 12.5.0 directly.
- [x] Design — the timeouts must travel on a `Stripe::StripeClient`, which is the only place the gem reads them.
- [x] Build — one call site changed, plus a regression spec that goes RED against main's shipped code, plus the review's P2 retries pin.
- [x] QA — executed, below. Adversarial review clean (no P1; its P2 fixed in `6d63a79`).
- [ ] Ship — not merged; @nyomanjyotisa reviews.
- [x] Market — n/a, internal admin response.
- [x] Sell — n/a, no seller-facing surface.

## What

`processor_rule_refusal` passed its timeouts as per-request opts:

```ruby
Stripe::Charge.retrieve({ id: ..., expand: %w[outcome.rule] },
                        { read_timeout: 5, open_timeout: 2, max_network_retries: 0 })
```

stripe-ruby only recognises `Stripe::Util::OPTS_USER_SPECIFIED` (`api_key`, `idempotency_key`, `stripe_account`, `stripe_version`) in that hash and forwards **everything else to the request as an HTTP header**. An Integer header value raises inside `Net::HTTPHeader#initialize_http_header` before any request is made:

```
NoMethodError: undefined method 'strip' for an instance of Integer
```

The method's `rescue StandardError` then returns `{ error: "could not read the processor outcome" }`. So since #6874 shipped, **every** admin unblock has reported "Could not check whether Stripe is still refusing this buyer" — the check has never read a charge, and neither the truncation work in #6886 nor the rule/predicate branching in #6874 has ever executed in production.

This PR moves the timeouts onto a `Stripe::StripeClient` passed as `opts[:client]`, which is the supported route and is where `StripeConfiguration` actually reads them.

## Why the specs missed it

Every existing example stubs `Stripe::Charge.retrieve` wholesale, so the opts hash was never handed to the real gem. That is the coverage gap, so the added spec closes it by rejecting any opts key the gem would turn into a header, rather than by asserting on values the stub invents.

## Before / After

Probed with `bundle exec ruby` against stripe 12.5.0 in this worktree, using a deliberately invalid API key so the failure mode is visible:

| Call | Result |
| --- | --- |
| `Charge.retrieve(params, { read_timeout: 5, open_timeout: 2, max_network_retries: 0 })` | `NoMethodError: undefined method 'strip' for an instance of Integer` — raised locally, no request attempted |
| `Charge.retrieve(params)` (control) | `Stripe::AuthenticationError: Invalid API Key` — request attempted |
| `Charge.retrieve(params, { api_key: ... })` (control, allowed key) | `Stripe::AuthenticationError` — request attempted |
| `Charge.retrieve(params, { client: StripeClient.new(read_timeout: 5, open_timeout: 2, max_network_retries: 0) })` **(this PR)** | `Stripe::AuthenticationError` — request attempted, and `client.config` reports `read_timeout=5 open_timeout=2 retries=0` |

Reaching authentication is the pass condition: it proves the request left the process with the timeouts attached.

Admin-visible effect: the unblock response stops saying "Could not check whether Stripe is still refusing this buyer" on every single unblock and starts reporting the real outcome — the velocity-rule / just-cleared-block distinction #6874 built, and the truncation warning #6886 built.

## Test Results

Checks run:

- `bundle exec rspec spec/models/concerns/purchase/blockable_spec.rb -e "#processor_rule_refusal"` — 17 examples, 0 failures at `16d0c1a`
- `bundle exec rubocop` on both changed files — no offenses
- `ruby -c` on both changed files — Syntax OK
- Mutation check, run and restored: reverting the call site to main's per-request opts turns the new spec RED (`blockable_spec.rb:739`). The spec pins the actual defect, not a restatement of the fix.
- Second mutation check: dropping `max_network_retries` from the client turns the retries spec RED.
- CI: **Tests green at head `6d63a791`** (81 checks pass, 0 fail).
- The pre-existing timeout-clamp example was updated to read `opts[:client].config` and still pins the clamped pair `[1, 1]` with `sum <= 2`, so the budget clamping from #6886 is still covered.

Adversarial review found no P1. Its one P2 — `max_network_retries: 0` was load-bearing but unpinned, so dropping it would silently fall back to the global `Stripe.max_network_retries = 3` and let one slow read spend the budget three times over — is fixed in `6d63a79` with a spec that asserts the client's value is `0` while the global is still greater than zero.

Note on local runs: the 18-example run in this worktree goes red in `create(:purchase)` with "We couldn't charge your card", which is the factory needing Stripe test credentials this machine does not hold — not the diff. CI is the authority and is green.

## QA steps

Executed at `6d63a79`:

1. Ran the four-case gem probe in the table above via `bundle exec ruby` — confirmed the shipped form raises locally and the client form reaches Stripe.
2. Confirmed `Stripe::Util::OPTS_USER_SPECIFIED` in stripe 12.5.0 contains only the four auth/version keys, i.e. this is the gem's contract and not a local misconfiguration.
3. Confirmed the repo already uses this pattern elsewhere: `app/business/payments/charging/implementations/stripe/stripe_fx_quote.rb:89` builds a `Stripe::StripeClient.new(open_timeout:, read_timeout:, write_timeout:)`. This fix matches the established convention rather than inventing one.
4. Ran the full `#processor_rule_refusal` group green at `16d0c1a`, then mutated the call site back to main's form and confirmed the new spec fails; then mutated `max_network_retries` away and confirmed the retries spec fails.
5. Confirmed the worktree was restored clean (`git status --porcelain` empty) after each mutation run.
6. Confirmed the Tests workflow is green at the current head SHA, not at a stale one.

Not QA'd against a real Stripe key — that needs production credentials. The probe deliberately uses an invalid key, so it proves the request is *made*, not that a specific charge reads back. First real-world confirmation will be the next admin unblock reporting an actual outcome instead of "could not check".

---

AI disclosure: authored by Hermes Agent (claude-opus-5). Found while running the mandatory adversarial pre-merge review on #6886; the finding turned out to predate it and to be live on `main`, so it is split out here.
