### PR TITLE
Seed taxonomy attributes in every environment, not just dev

### DIFF
--- a/app/models/taxonomy_attribute_definitions.rb
+++ b/app/models/taxonomy_attribute_definitions.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Canonical per-category attribute definitions for faceted Discover filtering.
+#
+# These have to live in code rather than only in `db/seeds`, because the seed file that
+# introduced them sits under `010_development_staging_test/` and never runs in production —
+# so the Fonts facets shipped with no rows behind them on prod. `Onetime::SeedTaxonomyAttributes`
+# applies this registry to any environment; the dev/staging/test seed reads the same source so
+# the two cannot drift.
+#
+# Adding a category is a data-only change here. `name` is the ES filter-token prefix and is
+# permanent once products carry values for it; `label` and `values` are display-side and may
+# be edited freely.
+class TaxonomyAttributeDefinitions
+  DEFINITIONS = {
+    "design/fonts" => [
+      { name: "format", label: "Format", value_type: "enum", values: ["OTF", "TTF", "WOFF2"], position: 0 },
+      { name: "license", label: "License", value_type: "enum", values: ["Personal", "Commercial", "App embedding"], position: 1 },
+      { name: "variable_font", label: "Variable font", value_type: "boolean", values: [], position: 2 },
+      { name: "styles", label: "Styles", value_type: "number", values: [], position: 3 },
+    ],
+  }.freeze
+
+  # Maps each configured slug path to its Taxonomy, skipping paths whose taxonomy is absent.
+  def self.each_taxonomy_with_definitions
+    return to_enum(:each_taxonomy_with_definitions) unless block_given?
+
+    DEFINITIONS.each do |slug_path, definitions|
+      taxonomy = taxonomy_for(slug_path)
+      next if taxonomy.nil?
+
+      yield taxonomy, definitions
+    end
+  end
+
+  # Walks the slug path so "design/fonts" cannot match a same-named leaf under another parent
+  # (`photoshop` and `canva` each appear under several branches).
+  def self.taxonomy_for(slug_path)
+    slug_path.split("/").reduce(nil) do |parent, slug|
+      taxonomy = Taxonomy.find_by(slug:, parent:)
+      return nil if taxonomy.nil?
+
+      taxonomy
+    end
+  end
+end

--- a/app/services/onetime/seed_taxonomy_attributes.rb
+++ b/app/services/onetime/seed_taxonomy_attributes.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Applies `TaxonomyAttributeDefinitions` to whatever environment it runs in.
+#
+# Existing rows are updated in place rather than recreated: `TaxonomyAttribute#name` is the ES
+# filter-token prefix, so destroying and re-inserting a row would orphan every product value
+# already indexed under it. Rows present in the DB but absent from the registry are deactivated,
+# not deleted, for the same reason.
+module Onetime
+  class SeedTaxonomyAttributes
+    def self.process(dry_run: true)
+      new.process(dry_run:)
+    end
+
+    def process(dry_run: true)
+      created = 0
+      updated = 0
+      deactivated = 0
+
+      TaxonomyAttributeDefinitions.each_taxonomy_with_definitions do |taxonomy, definitions|
+        definitions.each do |definition|
+          attribute = TaxonomyAttribute.find_by(taxonomy:, name: definition[:name])
+
+          if attribute.nil?
+            created += 1
+            puts "CREATE #{taxonomy.slug}/#{definition[:name]}"
+            TaxonomyAttribute.create!(definition.merge(taxonomy:, active: true)) unless dry_run
+            next
+          end
+
+          attribute.assign_attributes(definition.merge(active: true))
+          next unless attribute.changed?
+
+          updated += 1
+          puts "UPDATE #{taxonomy.slug}/#{definition[:name]} #{attribute.changes.inspect}"
+          attribute.save! unless dry_run
+        end
+
+        stale = TaxonomyAttribute.where(taxonomy:, active: true).where.not(name: definitions.map { _1[:name] })
+        stale.each do |attribute|
+          deactivated += 1
+          puts "DEACTIVATE #{taxonomy.slug}/#{attribute.name}"
+          attribute.update!(active: false) unless dry_run
+        end
+      end
+
+      puts "#{dry_run ? 'DRY RUN' : 'APPLIED'} created=#{created} updated=#{updated} deactivated=#{deactivated}"
+      { created:, updated:, deactivated: }
+    end
+  end
+end

--- a/db/seeds/010_development_staging_test/taxonomy_create.rb
+++ b/db/seeds/010_development_staging_test/taxonomy_create.rb
@@ -53,17 +53,7 @@ Taxonomy.find_or_create_by!(slug: "photoshop", parent: mockups)
 Taxonomy.find_or_create_by!(slug: "illustrator", parent: mockups)
 Taxonomy.find_or_create_by!(slug: "canva", parent: mockups)
 Taxonomy.find_or_create_by!(slug: "indesign", parent: mockups)
-fonts = Taxonomy.find_or_create_by!(slug: "fonts", parent: design)
-[
-  { name: "format", label: "Format", value_type: "enum", values: ["OTF", "TTF", "WOFF2"], position: 0 },
-  { name: "license", label: "License", value_type: "enum", values: ["Personal", "Commercial", "App embedding"], position: 1 },
-  { name: "variable_font", label: "Variable font", value_type: "boolean", values: [], position: 2 },
-  { name: "styles", label: "Styles", value_type: "number", values: [], position: 3 },
-].each do |definition|
-  TaxonomyAttribute.find_or_create_by!(taxonomy: fonts, name: definition[:name]) do |attribute|
-    attribute.assign_attributes(definition)
-  end
-end
+Taxonomy.find_or_create_by!(slug: "fonts", parent: design)
 branding = Taxonomy.find_or_create_by!(slug: "branding", parent: design)
 Taxonomy.find_or_create_by!(slug: "logos", parent: branding)
 Taxonomy.find_or_create_by!(slug: "business-cards", parent: branding)
@@ -410,3 +400,6 @@ Taxonomy.find_or_create_by!(slug: "pbr", parent: textures)
 Taxonomy.find_or_create_by!(slug: "tattoos", parent: textures)
 
 Taxonomy.find_or_create_by!(slug: "other")
+
+# Same registry the production backfill applies, so the two cannot drift.
+Onetime::SeedTaxonomyAttributes.process(dry_run: false)

--- a/spec/models/taxonomy_attribute_definitions_spec.rb
+++ b/spec/models/taxonomy_attribute_definitions_spec.rb
@@ -12,12 +12,14 @@ describe TaxonomyAttributeDefinitions do
     end
 
     it "does not match a same-named leaf under a different parent" do
-      design = Taxonomy.find_or_create_by!(slug: "design")
-      Taxonomy.find_or_create_by!(slug: "fonts", parent: design)
-      other = Taxonomy.find_or_create_by!(slug: "three-d")
-      decoy = Taxonomy.find_or_create_by!(slug: "fonts", parent: other)
+      # Decoy first, so a lookup that ignores the parent returns it by insertion order.
+      decoy_parent = Taxonomy.create!(slug: "zz-decoy-parent")
+      decoy = Taxonomy.create!(slug: "zz-shared-leaf", parent: decoy_parent)
+      wanted_parent = Taxonomy.create!(slug: "zz-wanted-parent")
+      wanted = Taxonomy.create!(slug: "zz-shared-leaf", parent: wanted_parent)
 
-      expect(described_class.taxonomy_for("design/fonts")).not_to eq(decoy)
+      expect(Taxonomy.where(slug: "zz-shared-leaf").order(:id).first).to eq(decoy)
+      expect(described_class.taxonomy_for("zz-wanted-parent/zz-shared-leaf")).to eq(wanted)
     end
 
     it "returns nil when any segment is missing" do

--- a/spec/models/taxonomy_attribute_definitions_spec.rb
+++ b/spec/models/taxonomy_attribute_definitions_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe TaxonomyAttributeDefinitions do
+  describe ".taxonomy_for" do
+    it "resolves a nested slug path" do
+      design = Taxonomy.find_or_create_by!(slug: "design")
+      fonts = Taxonomy.find_or_create_by!(slug: "fonts", parent: design)
+
+      expect(described_class.taxonomy_for("design/fonts")).to eq(fonts)
+    end
+
+    it "does not match a same-named leaf under a different parent" do
+      design = Taxonomy.find_or_create_by!(slug: "design")
+      Taxonomy.find_or_create_by!(slug: "fonts", parent: design)
+      other = Taxonomy.find_or_create_by!(slug: "three-d")
+      decoy = Taxonomy.find_or_create_by!(slug: "fonts", parent: other)
+
+      expect(described_class.taxonomy_for("design/fonts")).not_to eq(decoy)
+    end
+
+    it "returns nil when any segment is missing" do
+      expect(described_class.taxonomy_for("design/nonexistent-category")).to be_nil
+    end
+  end
+
+  describe "DEFINITIONS" do
+    it "only uses value types the model accepts" do
+      types = described_class::DEFINITIONS.values.flatten.map { _1[:value_type] }.uniq
+
+      expect(types - TaxonomyAttribute::VALUE_TYPES).to be_empty
+    end
+
+    it "uses names the model's format validation accepts, unique within a category" do
+      described_class::DEFINITIONS.each do |slug_path, definitions|
+        names = definitions.map { _1[:name] }
+
+        expect(names.uniq.size).to eq(names.size), "duplicate attribute name in #{slug_path}"
+        names.each { expect(_1).to match(/\A[a-z0-9_]+\z/) }
+      end
+    end
+  end
+
+  describe ".each_taxonomy_with_definitions" do
+    it "skips configured paths whose taxonomy does not exist" do
+      Taxonomy.where(slug: "fonts").destroy_all
+
+      expect(described_class.each_taxonomy_with_definitions.to_a).to be_empty
+    end
+  end
+end

--- a/spec/services/onetime/seed_taxonomy_attributes_spec.rb
+++ b/spec/services/onetime/seed_taxonomy_attributes_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Onetime::SeedTaxonomyAttributes do
+  let!(:design) { Taxonomy.find_or_create_by!(slug: "design") }
+  let!(:fonts) { Taxonomy.find_or_create_by!(slug: "fonts", parent: design) }
+
+  before { TaxonomyAttribute.where(taxonomy: fonts).delete_all }
+
+  it "does not write anything on a dry run" do
+    expect { described_class.process(dry_run: true) }.not_to change { TaxonomyAttribute.count }
+  end
+
+  it "creates the registry's definitions for the matched taxonomy" do
+    result = described_class.process(dry_run: false)
+
+    expect(result[:created]).to eq(4)
+    expect(TaxonomyAttribute.where(taxonomy: fonts).pluck(:name)).to match_array(%w[format license variable_font styles])
+
+    format = TaxonomyAttribute.find_by(taxonomy: fonts, name: "format")
+    expect(format.label).to eq("Format")
+    expect(format.value_type).to eq("enum")
+    expect(format.values).to eq(["OTF", "TTF", "WOFF2"])
+    expect(format.active).to eq(true)
+  end
+
+  it "is idempotent" do
+    described_class.process(dry_run: false)
+
+    expect { described_class.process(dry_run: false) }.not_to change { TaxonomyAttribute.count }
+  end
+
+  it "updates a drifted row in place so its id and indexed filter tokens survive" do
+    described_class.process(dry_run: false)
+    format = TaxonomyAttribute.find_by(taxonomy: fonts, name: "format")
+    format.update!(label: "Old label", values: ["OTF"], active: false)
+
+    described_class.process(dry_run: false)
+
+    format.reload
+    expect(format.label).to eq("Format")
+    expect(format.values).to eq(["OTF", "TTF", "WOFF2"])
+    expect(format.active).to eq(true)
+  end
+
+  it "deactivates a row the registry no longer defines instead of deleting it" do
+    described_class.process(dry_run: false)
+    orphan = TaxonomyAttribute.create!(taxonomy: fonts, name: "retired_facet", label: "Retired", value_type: "enum", values: ["A"], position: 9, active: true)
+
+    described_class.process(dry_run: false)
+
+    expect(orphan.reload.active).to eq(false)
+    expect(TaxonomyAttribute.exists?(orphan.id)).to eq(true)
+  end
+end


### PR DESCRIPTION
## What

Moves the per-category faceted-attribute definitions out of the dev-only seed file into a code registry (`TaxonomyAttributeDefinitions`) plus a backfill (`Onetime::SeedTaxonomyAttributes`) that can run in any environment, including production.

## Why

#6858 shipped structured Fonts attributes for Discover — the editor inputs, the ES filter tokens, the sidebar facets. The four `TaxonomyAttribute` rows they read were created in `db/seeds/010_development_staging_test/taxonomy_create.rb`, and that directory name means the file loads in development, staging and test only. Production has never run it.

Confirmed against the production replica (audited read `20260803T031929Z-a30ed738`): `TaxonomyAttribute` is not yet a deployed constant, and once #6858 does deploy the table will be empty, because nothing in the release path creates those rows. `Link#taxonomy_attributes_for_current_taxonomy` returns `TaxonomyAttribute.none`, `taxonomy_attribute_filter_tokens` returns `[]`, and `taxonomy_attributes_data` returns `[]`. So the feature deploys and renders nothing: no attribute inputs in the Share tab, no facets in the Discover sidebar, for all 18,683 live Fonts products.

The registry is also what makes the follow-up ask on gumroad-private#1670 ("do the same for many top categories") a data-only change: adding a category becomes one entry in `DEFINITIONS`, not a new seed file plus a new backfill.

## Design notes

- **Rows are updated in place, never recreated.** `TaxonomyAttribute#name` is the prefix of the ES filter token (`format:otf`), so destroying and re-inserting a row would orphan every product value already indexed under it.
- **Unknown rows are deactivated, not deleted**, for the same reason — `active_ordered` and `filterable?` already gate on `active`.
- **Slug paths are resolved segment by segment.** `photoshop`, `canva` and `illustrator` each exist under several parents in the taxonomy tree, so a bare `find_by(slug:)` would be ambiguous; `design/fonts` walks the parent chain.
- The dev/staging/test seed now calls the same service, so the two definitions cannot drift.

## Before-After

| | `TaxonomyAttribute` rows for `design/fonts` | Discover sidebar facets | Share-tab attribute inputs |
|---|---|---|---|
| Before (production, after #6858 deploys) | 0 | none rendered | none rendered |
| After (`Onetime::SeedTaxonomyAttributes.process(dry_run: false)`) | 4 (format, license, variable_font, styles) | Format / License / Variable font | same four inputs |

The visual surface itself is unchanged by this PR — the facet and editor UI both shipped in #6858, and its screenshots are the rendered evidence for them (`qa-media/pr-6858-discover-fonts-facets.png`, `qa-media/pr-6858-editor-structured-attributes.png`). This PR only decides whether the rows behind that UI exist in production. There is no pixel diff to add: the difference is zero facets versus four, and the facets' appearance is already evidenced.

## Test Results

- `spec/services/onetime/seed_taxonomy_attributes_spec.rb` — 5 examples: dry run writes nothing, creates the registry's four definitions with correct type/values/active, idempotent on a second run, repairs a drifted row **in place** (same id, so indexed tokens survive), deactivates rather than deletes a row the registry no longer defines.
- `spec/models/taxonomy_attribute_definitions_spec.rb` — 6 examples: nested slug-path resolution, the same-named-leaf-under-a-different-parent decoy, nil on a missing segment, every configured `value_type` is in `TaxonomyAttribute::VALUE_TYPES`, every name passes the model's `/\A[a-z0-9_]+\z/` format validation and is unique within its category, and configured paths with no taxonomy are skipped rather than raising.
- **Mutation-checked**, both new spec files. Reverting the deactivation branch to a bare counter reddens `seed_taxonomy_attributes_spec` (5 examples, 1 failure). Dropping `parent:` from the slug lookup reddens `taxonomy_attribute_definitions_spec` (6 examples, 1 failure) — the first version of that decoy *survived* the mutant, because `find_or_create_by!` ordering returned the right row by luck; the fixture now creates the decoy first and asserts an unscoped lookup would pick it (`f9333eb`).
- `rubocop` on all four changed/added Ruby files: no offenses.
- `ruby -c` on the edited seed file.

## QA steps

1. `bin/rails db:seed` on a fresh dev DB, then `TaxonomyAttribute.count` → 4 (the seed now routes through the service).
2. On production, after #6858 deploys: `Onetime::SeedTaxonomyAttributes.process` (dry run — prints four `CREATE` lines, writes nothing), then `Onetime::SeedTaxonomyAttributes.process(dry_run: false)`.
3. Verify: `Taxonomy.find_by(slug: "fonts").taxonomy_attributes.count` → 4.
4. Load `/discover?taxonomy=design/fonts` and confirm the Format / License / Variable font facets appear with counts. Counts populate as products are reindexed; a seller saving Share-tab attributes triggers `enqueue_index_update_for(["taxonomy_attribute_filters"])` for their product immediately.

This is a data write against production, so step 2 is a human's call, not an auto-merge — assigned for that reason.

---

🤖 Written by [Hermes Agent](https://github.com/NousResearch/hermes-agent) (`claude-opus-5`) as gumclaw.

**Instructions given:** standing autonomous dispatcher order on antiwork/gumroad-private; @slavingia on gumroad-private#1670: *"Once live, track success/lift and suggest doing the same for many top categories etc"* — verifying "live" surfaced that the rows behind the feature do not exist in production.
