### PR TITLE
Pin that the Stripe refusal read does not retry

### DIFF
--- a/spec/models/concerns/purchase/blockable_spec.rb
+++ b/spec/models/concerns/purchase/blockable_spec.rb
@@ -719,6 +719,20 @@ describe Purchase::Blockable do
         expect(@observed.last.sum).to be <= 2
       end
 
+      # Without this the client falls back to the global Stripe.max_network_retries of 3, which would
+      # let one slow read spend the whole budget three times over.
+      it "does not retry a read, so a slow Stripe cannot multiply the budget" do
+        allow(Stripe::Charge).to receive(:retrieve) do |_params, opts|
+          @retries = opts[:client].config.max_network_retries
+          outcome_for(type: "issuer_declined", reason: "generic_decline")
+        end
+
+        refused_purchase.processor_rule_refusal
+
+        expect(@retries).to eq(0)
+        expect(Stripe.max_network_retries).to be > 0
+      end
+
       # stripe-ruby forwards any opts key outside Util::OPTS_USER_SPECIFIED as an HTTP header, so
       # passing the timeouts as per-request opts raised before the request was made and every scan
       # reported "could not read" — invisible to the other examples, which stub `retrieve` away.


### PR DESCRIPTION
## Status

- [x] Scope — the adversarial review of #6890 raised one P2. #6890 merged before that commit landed, so the pin is orphaned; this carries it to main.
- [x] Design — assert the client the scan builds reports `max_network_retries == 0` while the global setting is still non-zero, so the spec fails if the key is ever dropped.
- [x] Build — one spec, no production code change.
- [x] QA — executed, below.
- [ ] Ship — not merged; @nyomanjyotisa reviews.
- [x] Market — n/a, test-only.
- [x] Sell — n/a, test-only.

## What

Test-only. Adds one example to the `#processor_rule_refusal` group pinning that the `Stripe::StripeClient` it builds carries `max_network_retries: 0`.

## Why

`PROCESSOR_REFUSAL_READ_OPTS` sets `max_network_retries: 0`, and that value is load-bearing. `config/initializers/003_stripe.rb` sets `Stripe.max_network_retries = 3` globally, so if the key were ever dropped from the client construction the scan would silently inherit 3 retries — one slow charge lookup could then spend the 8-second scan budget three times over, on an admin request whose unblock has **already committed** to the database. That is the exact failure the budget exists to prevent.

Nothing pinned it: the adversarial review on #6890 removed the key with `PROCESSOR_REFUSAL_READ_OPTS.except(:max_network_retries)` and all 17 examples stayed green. This closes that hole.

The example also asserts `Stripe.max_network_retries` is greater than zero, so it cannot pass vacuously by the global happening to be 0 — the point is that the client *diverges* from the global.

## Before / After

| | Before | After |
| --- | --- | --- |
| Client built with `max_network_retries: 0` | green | green |
| Key dropped, client inherits global 3 retries | **green** — the regression ships unnoticed | **red** |

No production behaviour changes; the value being asserted is already what main does.

## Test Results

Checks run:

- `ruby -c spec/models/concerns/purchase/blockable_spec.rb` — Syntax OK
- `bundle exec rubocop spec/models/concerns/purchase/blockable_spec.rb` — 1 file inspected, no offenses
- Mutation check, run on the #6890 branch before that PR merged: constructing the client with `PROCESSOR_REFUSAL_READ_OPTS.except(:max_network_retries)` turns this example RED, and every other example in the group stays green — which is why the gap existed.
- CI on this PR is the authority for the suite run; see checks.

Local full-group runs on this machine go red inside `create(:purchase)` with "We couldn't charge your card" — the purchase factory needs Stripe test credentials this box does not hold. That is environmental and predates the change; the same group was green here earlier in the session against a warmed cassette.

## QA steps

Executed at `71e36ff`:

1. Confirmed the assertion is true of main as shipped: `git show origin/main:app/models/concerns/purchase/blockable.rb` builds the client from `PROCESSOR_REFUSAL_READ_OPTS`, which contains `max_network_retries: 0`.
2. Confirmed the global it diverges from is really set: `config/initializers/003_stripe.rb:5` → `Stripe.max_network_retries = 3`.
3. Confirmed the example was not already present on main (`grep -c "does not retry a read"` → 0), i.e. this is a genuine orphan and not a duplicate.
4. Ran the mutation described above and watched this example fail while the rest of the group passed.

---

AI disclosure: authored by Hermes Agent (claude-opus-5). Follow-up to #6890, carrying over the one P2 from its pre-merge review after that PR was merged at an earlier commit.
