### PR TITLE
Drop the unqueried recency claim from the stale-block report's per-buyer line

### DIFF
--- a/app/sidekiq/alert_on_stale_blocks_holding_established_buyers_job.rb
+++ b/app/sidekiq/alert_on_stale_blocks_holding_established_buyers_job.rb
@@ -87,12 +87,13 @@ class AlertOnStaleBlocksHoldingEstablishedBuyersJob
       { stale: report_order(stale), truncated: }
     end
 
-    # Active email blocks nobody is named on, oldest first, one over the candidate budget so that
-    # exhausting it is distinguishable from a table holding exactly that many.
+    # Active email blocks nobody is named on, one over the candidate budget so that exhausting it is
+    # distinguishable from a table holding exactly that many.
     #
-    # Oldest first because age is the whole complaint: a block written years ago that still refuses a
-    # long-standing customer is the one a human should see, and a recent row is more likely to be a
-    # velocity rule firing for cause.
+    # Ordered by id, not age: id is the keyset the cursor resumes from, and `blocked_at` is not
+    # monotonic in id because PlatformBlock.add! reuses the row and rewrites blocked_at on re-block.
+    # Age-ranking happens per page in `report_order`, so a run reports its own page oldest-first
+    # rather than the backlog's oldest rows.
     #
     # `blocked_by: nil` keeps this to unattended rows. A named block is a decision about this buyer,
     # not a rule that outlived itself. Not airtight — PlatformBlock.add! overwrites blocked_by on
@@ -188,7 +189,7 @@ class AlertOnStaleBlocksHoldingEstablishedBuyersJob
     end
 
     # Oldest block first. Age is what makes a line worth reading here: unlike the failure-keyed
-    # report there is no recent attempt to rank by, and the buyer stuck since 2021 is the one whose
+    # report there is no attempt recency to rank by, and the buyer stuck since 2021 is the one whose
     # block is least likely to still be justified.
     def report_order(stale)
       stale.sort_by { |entry| [entry[:blocked_at].to_i, -entry[:settled_purchases]] }
@@ -196,7 +197,7 @@ class AlertOnStaleBlocksHoldingEstablishedBuyersJob
 
     def line_for(entry)
       "• #{entry[:email]} — #{entry[:settled_purchases]} settled purchases, " \
-        "blocked by email since #{entry[:blocked_at].to_date} (no recent attempt)"
+        "blocked by email since #{entry[:blocked_at].to_date}"
     end
 
     def headline(count, truncated)

--- a/spec/sidekiq/alert_on_stale_blocks_holding_established_buyers_job_spec.rb
+++ b/spec/sidekiq/alert_on_stale_blocks_holding_established_buyers_job_spec.rb
@@ -43,7 +43,7 @@ describe AlertOnStaleBlocksHoldingEstablishedBuyersJob do
     settled_purchases(established_count)
     block_email
 
-    expect(message).to include(email, "#{established_count} settled purchases", "no recent attempt")
+    expect(message).to include(email, "#{established_count} settled purchases")
   end
 
   it "names the date the block was written" do
@@ -211,6 +211,7 @@ describe AlertOnStaleBlocksHoldingEstablishedBuyersJob do
     expect(body).to include("does NOT query attempts")
     expect(body).not_to include("have NOT tried recently")
     expect(body).not_to include("has not tried to check out recently")
+    expect(body).not_to include("no recent attempt")
   end
 
   # A truncated scan that found nothing must still report: otherwise the bound, not the platform,


### PR DESCRIPTION
## What

Removes `(no recent attempt)` from the per-buyer line in
`AlertOnStaleBlocksHoldingEstablishedBuyersJob`, and corrects two comments the cursor
change left stale.

## Why

[#6895](https://github.com/antiwork/gumroad/pull/6895) set out to remove a claim the report
makes but never queries — that these buyers had stopped retrying. Its description says the
claim appeared "in three places — the footer, the headline, and the per-buyer wording". It
fixed two. `line_for` still printed `(no recent attempt)` on **every** reported line, and
the spec at line 46 pinned that wording with `expect(message).to include(..., "no recent
attempt")`, so the guard example added in the same PR could not catch it — it asserted only
that the *other* two strings were absent.

The job reads blocks, settled purchases and chargebacks. It never reads checkout attempts.
That is the original Greptile P1 on [#6889](https://github.com/antiwork/gumroad/pull/6889),
and it is live on `main` now that #6895 has merged.

Found by an adversarial pre-merge review of #6895 that finished after Sahil merged it, so
this ships the remainder as its own change rather than amending merged work.

Second, smaller correction: `candidate_blocks` still documented itself as returning rows
"oldest first", which stopped being true when the query moved to an `id` keyset. These are
not equivalent — `PlatformBlock.add!` reuses the existing row and rewrites `blocked_at` on
re-block, so a low-id row can carry a recent date. Age-ranking now happens per page in
`report_order`, and the comment says so.

## Before / After

One reported line, for a buyer the job has no attempt data about:

| | line |
|---|---|
| Before | `• buyer@example.com — 4 settled purchases, blocked by email since 2021-04-29 (no recent attempt)` |
| After | `• buyer@example.com — 4 settled purchases, blocked by email since 2021-04-29` |

The footer already explains that the scan keys on blocks rather than failures and does not
query attempts, so the reader still knows what the line does and does not establish.

## Test Results

Checks run:

- `bundle exec rspec spec/sidekiq/alert_on_stale_blocks_holding_established_buyers_job_spec.rb`
  → **20 examples, 0 failures** (run on this branch, rebased on `main` at `0868efbd4`)
- `bundle exec rubocop` on both changed files → no offenses
- `ruby -c` on both changed files → Syntax OK
- **Mutation check:** re-adding `(no recent attempt)` to `line_for` turns the run RED
  (`20 examples, 1 failure`, exit 1), so the new negative assertion is load-bearing rather
  than vacuous. Restored and re-verified clean afterwards.

The guard example now asserts all three strings are absent:

```ruby
expect(body).to include("does NOT query attempts")
expect(body).not_to include("have NOT tried recently")
expect(body).not_to include("has not tried to check out recently")
expect(body).not_to include("no recent attempt")   # added here
```

## QA steps

No rendered surface — this is the text of a Slack/alert message produced by a weekly cron.
The evidence is the message body itself, asserted in the spec above rather than screenshotted.

To read it by hand:

```ruby
AlertOnStaleBlocksHoldingEstablishedBuyersJob.new.send(:report)
```

on a console with candidate rows present; every `•` line should end at the block date.

## Not in this PR

The review also raised three P3s on the merged cursor design, all judged acceptable and left
alone: a mid-run failure means the Sidekiq retry scans the *next* page rather than re-scanning
the failed one (deliberate — the alternative pins the sweep); a non-truncated mid-sweep run
gives a bare count without noting how much of the backlog sat before the cursor; and the new
`RedisKey` entry is placed between two lines of an existing group. None change what the job
reports.

---

🤖 Written by [Hermes Agent](https://github.com/NousResearch/hermes-agent) (`claude-opus-5`) as gumclaw.

**Instructions given:** standing autonomous dispatcher order on antiwork/gumroad-private; completes the third site of the unqueried-recency claim that #6895 set out to remove.
