### PR TITLE
Detect when a seller's date of birth on Stripe stops agreeing with ours

### DIFF
--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -87,6 +87,8 @@ class RedisKey
     # High-water mark for AlertSellersOfUndeliveredReceiptsJob: the last email_infos id it judged.
     def undelivered_receipt_sweep_cursor = "undelivered_receipt_sweep:cursor"
     def stale_block_sweep_cursor = "stale_block_sweep:cursor"
+    # High-water mark for AlertOnStripeDobDriftJob: the last merchant_accounts id it compared.
+    def stripe_dob_drift_sweep_cursor = "stripe_dob_drift_sweep:cursor"
     # Purchases whose notice was claimed but never transmitted. The cursor is already past their
     # email_infos rows, so this set is the only thing that brings them back.
     def undelivered_receipt_pending_retry = "undelivered_receipt_sweep:pending_retry"

--- a/app/sidekiq/alert_on_stripe_dob_drift_job.rb
+++ b/app/sidekiq/alert_on_stripe_dob_drift_job.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+# Reports sellers whose live `UserComplianceInfo#birthday` no longer agrees with the `individual.dob`
+# their Gumroad-managed Stripe account holds (gumroad-private#1726).
+#
+# The two copies drive different live decisions and neither reads the other: the under-18 payout gate
+# reads ours, Stripe's identity verification reads theirs. So a correction that never propagated is
+# invisible until someone reads both side by side — which is how the reported case surfaced, on a
+# support ticket about something else. Nothing today detects it.
+#
+# Reports only. Which of the two dates is true is exactly what a drift row leaves unestablished, so
+# writing a date of birth onto a KYC record is a human decision in either direction.
+class AlertOnStripeDobDriftJob
+  include Sidekiq::Job
+  sidekiq_options retry: 2, queue: :low
+
+  # Report at most this many. The alert exists to be read.
+  MAX_REPORTED = 25
+
+  # The bound on the work: how many accounts get a Stripe read per run. Each candidate costs one
+  # `Stripe::Account.retrieve`, so this is a rate budget, not a database one. Successive runs resume
+  # from a saved cursor and wrap, so the population is covered across runs rather than the same page
+  # being re-read forever.
+  MAX_CANDIDATES_SCANNED = 400
+
+  def perform
+    scan = scan_for_drift
+    # Truncation with nothing qualifying still has to go out: it means the scan bound, not the
+    # platform, decided the report was empty.
+    return if scan[:drifted].empty? && !scan[:truncated]
+
+    InternalNotificationWorker.perform_async("payouts", "Stripe date-of-birth drift", message_for(scan))
+  end
+
+  private
+    def scan_for_drift
+      after_id = current_cursor
+      candidates = candidate_accounts(after_id)
+
+      # Exhausted the population: wrap to the beginning so the sweep is a loop rather than a dead end.
+      if candidates.empty? && after_id.positive?
+        save_cursor(0)
+        candidates = candidate_accounts(0)
+      end
+
+      truncated = candidates.size > MAX_CANDIDATES_SCANNED
+      candidates = candidates.first(MAX_CANDIDATES_SCANNED)
+      # Advance past what this run judged, before the Stripe reads, so a later failure cannot pin the
+      # cursor and re-scan the same page forever.
+      save_cursor(candidates.last.id) if candidates.any?
+
+      drifted = []
+      unreadable = 0
+
+      candidates.each do |merchant_account|
+        user = merchant_account.user
+        next if user.nil?
+
+        compliance_info = user.alive_user_compliance_info
+        next if compliance_info.nil?
+        # A business account's date of birth belongs to its representative and is synced through
+        # `update_person`, not `individual`, so comparing it against `individual.dob` would report
+        # every one of them.
+        next unless compliance_info.is_individual?
+
+        ours = compliance_info.birthday
+        next if ours.blank?
+
+        theirs = stripe_dob(merchant_account)
+        if theirs == :unreadable
+          unreadable += 1
+          next
+        end
+        next if theirs == ours
+
+        drifted << {
+          user:,
+          merchant_account:,
+          ours:,
+          theirs:,
+          compliance_info_id: compliance_info.id,
+        }
+      end
+
+      { drifted: report_order(drifted), unreadable:, truncated: }
+    end
+
+    # Live Gumroad-managed Stripe accounts, oldest id first, one over the budget so that exhausting
+    # the population is distinguishable from it holding exactly that many.
+    #
+    # Ordered by id rather than by anything drift-related because the ordering IS the resume cursor,
+    # and no column records when the two copies last agreed.
+    def candidate_accounts(after_id)
+      MerchantAccount.alive
+                     .charge_processor_alive
+                     .stripe
+                     .where.not(user_id: nil)
+                     .where("merchant_accounts.id > ?", after_id)
+                     .where("json_data->>'$.meta.stripe_connect' IS NULL OR json_data->>'$.meta.stripe_connect' != 'true'")
+                     .order(id: :asc)
+                     .limit(MAX_CANDIDATES_SCANNED + 1)
+                     .to_a
+    end
+
+    def current_cursor
+      $redis.get(RedisKey.stripe_dob_drift_sweep_cursor).to_i
+    rescue => e
+      # A lost cursor re-scans the first page, which costs Stripe reads but reports the truth.
+      # Losing the run is worse.
+      ErrorNotifier.notify(e)
+      0
+    end
+
+    def save_cursor(cursor_id)
+      $redis.set(RedisKey.stripe_dob_drift_sweep_cursor, cursor_id)
+    rescue => e
+      ErrorNotifier.notify(e)
+    end
+
+    # Stripe's copy as a Date, `nil` when the account holds no date of birth, or `:unreadable` when
+    # the read itself failed. The three are deliberately distinct: a missing dob on Stripe IS drift
+    # against a birthday we hold, while a failed read establishes nothing and must not be reported as
+    # agreement or as drift.
+    def stripe_dob(merchant_account)
+      account = Stripe::Account.retrieve(merchant_account.charge_processor_merchant_id)
+      dob = account.dig(:individual, :dob)
+      return nil if dob.blank?
+
+      year, month, day = dob[:year], dob[:month], dob[:day]
+      return nil if year.blank? || month.blank? || day.blank?
+
+      Date.new(year.to_i, month.to_i, day.to_i)
+    rescue Date::Error
+      # A partial or impossible date on Stripe's side is not something this report can resolve into a
+      # comparison, and it is not a read failure either.
+      nil
+    rescue Stripe::StripeError => e
+      Rails.logger.warn "Could not read the Stripe date of birth for merchant account #{merchant_account.id}: #{e.class}: #{e.message}"
+      :unreadable
+    end
+
+    def message_for(scan)
+      drifted = scan[:drifted]
+      lines = drifted.first(MAX_REPORTED).map { |entry| line_for(entry) }
+      omitted = drifted.size - lines.size
+
+      [
+        headline(drifted.size, scan[:truncated]),
+        (scan[:truncated] ? "The scan stopped at #{MAX_CANDIDATES_SCANNED} accounts, so this is a floor — the population is larger than the count above." : nil),
+        (scan[:unreadable].positive? ? "#{scan[:unreadable]} more could not be read from Stripe this run, so they are neither clear nor drifted." : nil),
+        "",
+        *lines,
+        (omitted.positive? ? "…and #{omitted} more." : nil),
+        "",
+        "The two copies drive different decisions: the under-18 payout gate reads ours, Stripe's " \
+          "identity verification reads theirs. A younger date on our side holds payouts while " \
+          "Stripe runs an adult records check that cannot match; an older date on our side means " \
+          "the gate does not engage for someone Stripe holds as a minor. " \
+          "Do not correct either copy from this report — which date is true is what a line here " \
+          "leaves open, and the seller's own later revision is evidence, not proof. " \
+          "See gumroad-private#1726.",
+      ].compact.join("\n")
+    end
+
+    # Under-18-on-our-side first, then by how far apart the two dates are. What ranks a line is
+    # whether money is already being held on the strength of the disagreement.
+    def report_order(drifted)
+      drifted.sort_by do |entry|
+        [entry[:ours] > UserComplianceInfo::GUARDIAN_REQUIRED_BELOW_AGE.years.ago.to_date ? 0 : 1,
+         -((entry[:theirs] || Date.new(1900, 1, 1)) - entry[:ours]).to_i.abs]
+      end
+    end
+
+    def line_for(entry)
+      theirs = entry[:theirs] || "no date of birth on file"
+      gated = entry[:ours] > UserComplianceInfo::GUARDIAN_REQUIRED_BELOW_AGE.years.ago.to_date ? " [under 18 on our side — payouts gated]" : ""
+      "• #{entry[:user].email} (user #{entry[:user].id}) — we hold #{entry[:ours]}, Stripe holds #{theirs} " \
+        "on #{entry[:merchant_account].charge_processor_merchant_id}#{gated}, " \
+        "live compliance record #{entry[:compliance_info_id]}"
+    end
+
+    def headline(count, truncated)
+      return "No live Gumroad-managed Stripe account on the scanned page disagrees with our date of birth, but the scan was truncated, so this is not evidence that none do." if count.zero?
+
+      "#{truncated ? "At least " : ""}#{count} seller#{"s" if count != 1} " \
+        "#{count == 1 ? "has" : "have"} a date of birth on Stripe that disagrees with ours."
+    end
+end

--- a/app/sidekiq/alert_on_stripe_dob_drift_job.rb
+++ b/app/sidekiq/alert_on_stripe_dob_drift_job.rb
@@ -25,9 +25,10 @@ class AlertOnStripeDobDriftJob
 
   def perform
     scan = scan_for_drift
-    # Truncation with nothing qualifying still has to go out: it means the scan bound, not the
-    # platform, decided the report was empty.
-    return if scan[:drifted].empty? && !scan[:truncated]
+    # Nothing qualifying is only silence when the run actually established that. A truncated scan
+    # means the bound decided the report was empty, and unreadable accounts mean Stripe did — both
+    # are results, and neither is evidence the platform is clean.
+    return if scan[:drifted].empty? && !scan[:truncated] && scan[:unreadable].zero?
 
     InternalNotificationWorker.perform_async("payouts", "Stripe date-of-birth drift", message_for(scan))
   end
@@ -156,7 +157,7 @@ class AlertOnStripeDobDriftJob
       omitted = drifted.size - lines.size
 
       [
-        headline(drifted.size, scan[:truncated]),
+        headline(drifted.size, scan[:truncated], scan[:unreadable]),
         (scan[:truncated] ? "The scan stopped at #{MAX_CANDIDATES_SCANNED} accounts, so this is a floor — the population is larger than the count above." : nil),
         (scan[:unreadable].positive? ? "#{scan[:unreadable]} more could not be read from Stripe this run, so they are neither clear nor drifted." : nil),
         "",
@@ -190,8 +191,19 @@ class AlertOnStripeDobDriftJob
         "live compliance record #{entry[:compliance_info_id]}"
     end
 
-    def headline(count, truncated)
-      return "No live Gumroad-managed Stripe account on the scanned page disagrees with our date of birth, but the scan was truncated, so this is not evidence that none do." if count.zero?
+    def headline(count, truncated, unreadable)
+      if count.zero?
+        # Name the reason the page came back empty, because "none found" and "none established" are
+        # different facts and only one of them is reassuring.
+        reason = if truncated && unreadable.positive?
+          "but the scan was truncated and #{unreadable} account#{"s" if unreadable != 1} could not be read"
+        elsif truncated
+          "but the scan was truncated"
+        else
+          "but #{unreadable} account#{"s" if unreadable != 1} could not be read"
+        end
+        return "No live Gumroad-managed Stripe account on the scanned page disagrees with our date of birth, #{reason}, so this is not evidence that none do."
+      end
 
       "#{truncated ? "At least " : ""}#{count} seller#{"s" if count != 1} " \
         "#{count == 1 ? "has" : "have"} a date of birth on Stripe that disagrees with ours."

--- a/app/sidekiq/alert_on_stripe_dob_drift_job.rb
+++ b/app/sidekiq/alert_on_stripe_dob_drift_job.rb
@@ -12,9 +12,16 @@
 # writing a date of birth onto a KYC record is a human decision in either direction.
 class AlertOnStripeDobDriftJob
   include Sidekiq::Job
+  include RecurringLockTtl
+
   # Serialized: the Redis cursor is read, used, and written back in separate steps, so two overlapping
   # runs would claim the same page, spend the Stripe budget twice and send the report twice.
   sidekiq_options retry: 2, queue: :low, lock: :until_executed
+  # Worst case is the read budget, not the database: MAX_CANDIDATES_SCANNED sequential
+  # `Stripe::Account.retrieve` calls. At a pessimistic ~2s each — a Stripe timeout rather than a
+  # normal round trip — 400 accounts is ~13 minutes, so 30 gives the budget room to grow without
+  # the declaration going stale silently.
+  recurring_lock_ttl max_attempt: 30.minutes
 
   # Report at most this many. The alert exists to be read.
   MAX_REPORTED = 25

--- a/app/sidekiq/alert_on_stripe_dob_drift_job.rb
+++ b/app/sidekiq/alert_on_stripe_dob_drift_job.rb
@@ -53,6 +53,12 @@ class AlertOnStripeDobDriftJob
       unreadable = 0
 
       candidates.each do |merchant_account|
+        # The model's own predicate rather than a SQL rewrite of it, the same way
+        # AlertOnNegativeDestinationBalancesJob does: a Stripe Connect account's legal entity is the
+        # seller's own to maintain, we push nothing onto it, and a hand-written
+        # `json_data->>'$.meta.stripe_connect'` filter is a second copy of a rule that already exists.
+        next unless merchant_account.is_a_gumroad_managed_stripe_account?
+
         user = merchant_account.user
         next if user.nil?
 
@@ -85,8 +91,9 @@ class AlertOnStripeDobDriftJob
       { drifted: report_order(drifted), unreadable:, truncated: }
     end
 
-    # Live Gumroad-managed Stripe accounts, oldest id first, one over the budget so that exhausting
-    # the population is distinguishable from it holding exactly that many.
+    # Live Stripe merchant accounts, oldest id first, one over the budget so that exhausting the
+    # population is distinguishable from it holding exactly that many. Stripe Connect accounts are
+    # filtered out by the caller using the model's own predicate.
     #
     # Ordered by id rather than by anything drift-related because the ordering IS the resume cursor,
     # and no column records when the two copies last agreed.
@@ -96,7 +103,6 @@ class AlertOnStripeDobDriftJob
                      .stripe
                      .where.not(user_id: nil)
                      .where("merchant_accounts.id > ?", after_id)
-                     .where("json_data->>'$.meta.stripe_connect' IS NULL OR json_data->>'$.meta.stripe_connect' != 'true'")
                      .order(id: :asc)
                      .limit(MAX_CANDIDATES_SCANNED + 1)
                      .to_a
@@ -121,12 +127,17 @@ class AlertOnStripeDobDriftJob
     # the read itself failed. The three are deliberately distinct: a missing dob on Stripe IS drift
     # against a birthday we hold, while a failed read establishes nothing and must not be reported as
     # agreement or as drift.
+    #
+    # Read with `[]` rather than `dig`: `Stripe::Account` is a `Stripe::StripeObject`, which does not
+    # implement `dig` at all (it wraps a values hash and exposes `[]`), so `dig` raises NoMethodError
+    # on every account. A stubbed plain Hash in a spec hides that, because Hash does implement it.
     def stripe_dob(merchant_account)
       account = Stripe::Account.retrieve(merchant_account.charge_processor_merchant_id)
-      dob = account.dig(:individual, :dob)
-      return nil if dob.blank?
+      individual = account["individual"]
+      dob = individual && individual["dob"]
+      return nil if dob.nil?
 
-      year, month, day = dob[:year], dob[:month], dob[:day]
+      year, month, day = dob["year"], dob["month"], dob["day"]
       return nil if year.blank? || month.blank? || day.blank?
 
       Date.new(year.to_i, month.to_i, day.to_i)
@@ -162,12 +173,12 @@ class AlertOnStripeDobDriftJob
       ].compact.join("\n")
     end
 
-    # Under-18-on-our-side first, then by how far apart the two dates are. What ranks a line is
-    # whether money is already being held on the strength of the disagreement.
+    # Under-18-on-our-side first, then widest gap first. What ranks a line is whether money is
+    # already being held on the strength of the disagreement.
     def report_order(drifted)
       drifted.sort_by do |entry|
-        [entry[:ours] > UserComplianceInfo::GUARDIAN_REQUIRED_BELOW_AGE.years.ago.to_date ? 0 : 1,
-         -((entry[:theirs] || Date.new(1900, 1, 1)) - entry[:ours]).to_i.abs]
+        gap = entry[:theirs] ? (entry[:theirs] - entry[:ours]).to_i.abs : Float::INFINITY
+        [entry[:ours] > UserComplianceInfo::GUARDIAN_REQUIRED_BELOW_AGE.years.ago.to_date ? 0 : 1, -gap]
       end
     end
 

--- a/app/sidekiq/alert_on_stripe_dob_drift_job.rb
+++ b/app/sidekiq/alert_on_stripe_dob_drift_job.rb
@@ -12,7 +12,9 @@
 # writing a date of birth onto a KYC record is a human decision in either direction.
 class AlertOnStripeDobDriftJob
   include Sidekiq::Job
-  sidekiq_options retry: 2, queue: :low
+  # Serialized: the Redis cursor is read, used, and written back in separate steps, so two overlapping
+  # runs would claim the same page, spend the Stripe budget twice and send the report twice.
+  sidekiq_options retry: 2, queue: :low, lock: :until_executed
 
   # Report at most this many. The alert exists to be read.
   MAX_REPORTED = 25
@@ -92,9 +94,15 @@ class AlertOnStripeDobDriftJob
       { drifted: report_order(drifted), unreadable:, truncated: }
     end
 
-    # Live Stripe merchant accounts, oldest id first, one over the budget so that exhausting the
-    # population is distinguishable from it holding exactly that many. Stripe Connect accounts are
-    # filtered out by the caller using the model's own predicate.
+    # Live Stripe merchant accounts we manage the legal entity on, oldest id first, one over the
+    # budget so that exhausting the population is distinguishable from it holding exactly that many.
+    #
+    # Connect accounts are excluded here via the model's own `stripe_connect` scope rather than a
+    # hand-written `json_data->>` predicate, so there is still one definition of that rule. Excluding
+    # them in SQL rather than only in the loop matters for the BUDGET: filtered in Ruby, a page that
+    # happens to start with 400 Connect rows would spend the whole budget, advance the cursor past
+    # them, and report no drift without having read a single managed account. The loop keeps the
+    # model predicate as the authority anyway.
     #
     # Ordered by id rather than by anything drift-related because the ordering IS the resume cursor,
     # and no column records when the two copies last agreed.
@@ -104,6 +112,7 @@ class AlertOnStripeDobDriftJob
                      .stripe
                      .where.not(user_id: nil)
                      .where("merchant_accounts.id > ?", after_id)
+                     .where.not(id: MerchantAccount.stripe_connect.select(:id))
                      .order(id: :asc)
                      .limit(MAX_CANDIDATES_SCANNED + 1)
                      .to_a

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -187,6 +187,11 @@ alert_on_negative_destination_balances:
   class: AlertOnNegativeDestinationBalancesJob
   queue: low
   description: Reports payable sellers whose Gumroad-managed Stripe account carries a negative destination ledger from FX residue
+alert_on_stripe_dob_drift:
+  cron: "30 12 * * 1" # UTC 12:30 Monday
+  class: AlertOnStripeDobDriftJob
+  queue: low
+  description: Reports sellers whose date of birth on Stripe disagrees with the one the under-18 payout gate reads
 alert_sellers_of_undelivered_receipts:
   cron: "30 11 * * *" # UTC 11:30
   class: AlertSellersOfUndeliveredReceiptsJob

--- a/spec/sidekiq/alert_on_stripe_dob_drift_job_spec.rb
+++ b/spec/sidekiq/alert_on_stripe_dob_drift_job_spec.rb
@@ -110,7 +110,8 @@ describe AlertOnStripeDobDriftJob do
   end
 
   # A failed read establishes nothing. Counting it as agreement hides drift; counting it as drift
-  # invents it.
+  # invents it. And a run whose ONLY outcome is unreadable accounts must still send — otherwise
+  # Stripe being unreachable is indistinguishable from a clean platform.
   it "counts an unreadable Stripe account separately instead of calling it clear or drifted" do
     account = gumroad_managed_account
     compliance_info(birthday: Date.new(2010, 4, 27))
@@ -119,6 +120,8 @@ describe AlertOnStripeDobDriftJob do
 
     body = message
     expect(body).to include("1 more could not be read from Stripe this run")
+    expect(body).to include("1 account could not be read")
+    expect(body).to include("not evidence that none do")
     expect(body).not_to include(seller.email)
   end
 

--- a/spec/sidekiq/alert_on_stripe_dob_drift_job_spec.rb
+++ b/spec/sidekiq/alert_on_stripe_dob_drift_job_spec.rb
@@ -188,6 +188,23 @@ describe AlertOnStripeDobDriftJob do
     expect(message).to include("we hold 2010-04-27, Stripe holds 2005-04-27")
   end
 
+  # The budget is a Stripe-read budget, so Connect accounts must not consume it. Filtered only inside
+  # the loop, a page that happens to begin with budget-many Connect rows would spend the whole run on
+  # accounts it never reads, advance the cursor past them, and report no drift while a managed account
+  # one row later is drifted.
+  it "does not let Stripe Connect accounts consume the scan budget" do
+    create(:merchant_account_stripe_connect, user: create(:user))
+
+    drifted_seller = create(:user)
+    account = gumroad_managed_account(user: drifted_seller)
+    compliance_info(birthday: Date.new(2010, 4, 27), user: drifted_seller)
+    stub_stripe_dobs(account.charge_processor_merchant_id => Date.new(2005, 4, 27))
+
+    stub_const("#{described_class}::MAX_CANDIDATES_SCANNED", 1)
+
+    expect(message).to include(drifted_seller.email)
+  end
+
   describe "sweeping the population across runs" do
     it "resumes after the account the previous run compared last" do
       first_account = gumroad_managed_account

--- a/spec/sidekiq/alert_on_stripe_dob_drift_job_spec.rb
+++ b/spec/sidekiq/alert_on_stripe_dob_drift_job_spec.rb
@@ -18,12 +18,18 @@ describe AlertOnStripeDobDriftJob do
   end
 
   # Stripe's answer keyed by account id, so one example can hold different dates per account.
+  #
+  # Built as a real `Stripe::StripeObject`, not a Hash. The two are not interchangeable here: a
+  # StripeObject exposes `[]` but no `dig`, so a Hash stub silently passes code that would raise
+  # NoMethodError against every live account.
   def stub_stripe_dobs(by_account_id)
     allow(Stripe::Account).to receive(:retrieve) do |account_id|
       raise Stripe::InvalidRequestError.new("no such account", nil) unless by_account_id.key?(account_id)
 
       dob = by_account_id[account_id]
-      { individual: { dob: dob && { year: dob.year, month: dob.month, day: dob.day } } }.with_indifferent_access
+      Stripe::StripeObject.construct_from(
+        individual: dob && { dob: { year: dob.year, month: dob.month, day: dob.day } }
+      )
     end
   end
 
@@ -129,7 +135,9 @@ describe AlertOnStripeDobDriftJob do
   it "skips a Stripe Connect account, whose legal entity is the seller's own to maintain" do
     create(:merchant_account_stripe_connect, user: seller)
     compliance_info(birthday: Date.new(2010, 4, 27))
-    allow(Stripe::Account).to receive(:retrieve).and_return({ individual: { dob: { year: 2005, month: 4, day: 27 } } }.with_indifferent_access)
+    allow(Stripe::Account).to receive(:retrieve).and_return(
+      Stripe::StripeObject.construct_from(individual: { dob: { year: 2005, month: 4, day: 27 } })
+    )
 
     described_class.new.perform
 
@@ -159,6 +167,22 @@ describe AlertOnStripeDobDriftJob do
     lines = message.lines.select { |line| line.start_with?("•") }
     expect(lines.first).to include(seller.email)
     expect(lines.second).to include(adult_seller.email)
+  end
+
+  # Regression pin for the defect the adversarial review round found: the first version read the dob
+  # with `account.dig(:individual, :dob)`, which raises NoMethodError on every live account because
+  # `Stripe::Account` is a `Stripe::StripeObject` and StripeObject has no `dig`. A Hash stub passed it.
+  # This example asserts against the real return type, so a `dig` regression is red rather than green.
+  it "reads the date of birth off a real Stripe object, which has no #dig" do
+    gumroad_managed_account
+    compliance_info(birthday: Date.new(2010, 4, 27))
+    stripe_account = Stripe::StripeObject.construct_from(
+      individual: { dob: { year: 2005, month: 4, day: 27 } }
+    )
+    expect(stripe_account).not_to respond_to(:dig)
+    allow(Stripe::Account).to receive(:retrieve).and_return(stripe_account)
+
+    expect(message).to include("we hold 2010-04-27, Stripe holds 2005-04-27")
   end
 
   describe "sweeping the population across runs" do

--- a/spec/sidekiq/alert_on_stripe_dob_drift_job_spec.rb
+++ b/spec/sidekiq/alert_on_stripe_dob_drift_job_spec.rb
@@ -1,0 +1,232 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe AlertOnStripeDobDriftJob do
+  let(:seller) { create(:user) }
+
+  def gumroad_managed_account(user: seller)
+    create(:merchant_account, user:,
+                              charge_processor_id: StripeChargeProcessor.charge_processor_id,
+                              charge_processor_merchant_id: "acct_dobdrift_#{SecureRandom.hex(6)}",
+                              country: "RO")
+  end
+
+  def compliance_info(birthday:, user: seller, business: false)
+    factory = business ? :user_compliance_info_business : :user_compliance_info
+    create(factory, user:, birthday:, skip_stripe_job_on_create: true)
+  end
+
+  # Stripe's answer keyed by account id, so one example can hold different dates per account.
+  def stub_stripe_dobs(by_account_id)
+    allow(Stripe::Account).to receive(:retrieve) do |account_id|
+      raise Stripe::InvalidRequestError.new("no such account", nil) unless by_account_id.key?(account_id)
+
+      dob = by_account_id[account_id]
+      { individual: { dob: dob && { year: dob.year, month: dob.month, day: dob.day } } }.with_indifferent_access
+    end
+  end
+
+  def message
+    captured = nil
+    allow(InternalNotificationWorker).to receive(:perform_async) { |_room, _subject, body| captured = body }
+    described_class.new.perform
+    captured
+  end
+
+  before do
+    allow(InternalNotificationWorker).to receive(:perform_async)
+    $redis.del(RedisKey.stripe_dob_drift_sweep_cursor)
+  end
+
+  it "reports a seller whose Stripe date of birth disagrees with ours" do
+    account = gumroad_managed_account
+    compliance_info(birthday: Date.new(2010, 4, 27))
+    stub_stripe_dobs(account.charge_processor_merchant_id => Date.new(2005, 4, 27))
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).to have_received(:perform_async) do |room, subject, body|
+      expect(room).to eq("payouts")
+      expect(subject).to eq("Stripe date-of-birth drift")
+      expect(body).to include("1 seller has a date of birth on Stripe that disagrees with ours")
+      expect(body).to include(seller.email)
+      expect(body).to include("we hold 2010-04-27, Stripe holds 2005-04-27")
+      expect(body).to include(account.charge_processor_merchant_id)
+    end
+  end
+
+  it "stays silent when the two copies agree" do
+    account = gumroad_managed_account
+    compliance_info(birthday: Date.new(2005, 4, 27))
+    stub_stripe_dobs(account.charge_processor_merchant_id => Date.new(2005, 4, 27))
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).not_to have_received(:perform_async)
+  end
+
+  # The year is the field that decides whether someone may be paid at all, and the reported cases all
+  # matched on day and month — a comparison that only looked at the year, or only at the whole string
+  # loosely, would miss or invent drift.
+  it "reports a year-only disagreement on an otherwise identical date" do
+    account = gumroad_managed_account
+    compliance_info(birthday: Date.new(2009, 8, 27))
+    stub_stripe_dobs(account.charge_processor_merchant_id => Date.new(2004, 8, 27))
+
+    expect(message).to include("we hold 2009-08-27, Stripe holds 2004-08-27")
+  end
+
+  it "flags a seller our own gate holds as under 18, because that is the money-holding direction" do
+    account = gumroad_managed_account
+    compliance_info(birthday: 16.years.ago.to_date)
+    stub_stripe_dobs(account.charge_processor_merchant_id => 21.years.ago.to_date)
+
+    expect(message).to include("[under 18 on our side — payouts gated]")
+  end
+
+  it "does not flag the gate marker for a seller we hold as an adult" do
+    account = gumroad_managed_account
+    compliance_info(birthday: 30.years.ago.to_date)
+    stub_stripe_dobs(account.charge_processor_merchant_id => 25.years.ago.to_date)
+
+    expect(message).not_to include("payouts gated")
+  end
+
+  # An absent date on Stripe is a real disagreement with a birthday we hold — that account cannot be
+  # verified against anything — so it must not be filtered out with the agreements.
+  it "reports an account holding no date of birth at all" do
+    account = gumroad_managed_account
+    compliance_info(birthday: Date.new(2010, 4, 27))
+    stub_stripe_dobs(account.charge_processor_merchant_id => nil)
+
+    expect(message).to include("Stripe holds no date of birth on file")
+  end
+
+  # A failed read establishes nothing. Counting it as agreement hides drift; counting it as drift
+  # invents it.
+  it "counts an unreadable Stripe account separately instead of calling it clear or drifted" do
+    account = gumroad_managed_account
+    compliance_info(birthday: Date.new(2010, 4, 27))
+    allow(Stripe::Account).to receive(:retrieve).with(account.charge_processor_merchant_id)
+                                               .and_raise(Stripe::APIConnectionError.new("timeout"))
+
+    body = message
+    expect(body).to include("1 more could not be read from Stripe this run")
+    expect(body).not_to include(seller.email)
+  end
+
+  it "skips a business record, whose date of birth belongs to the representative Stripe syncs separately" do
+    account = gumroad_managed_account
+    compliance_info(birthday: Date.new(2010, 4, 27), business: true)
+    stub_stripe_dobs(account.charge_processor_merchant_id => Date.new(2005, 4, 27))
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).not_to have_received(:perform_async)
+  end
+
+  it "skips a Stripe Connect account, whose legal entity is the seller's own to maintain" do
+    create(:merchant_account_stripe_connect, user: seller)
+    compliance_info(birthday: Date.new(2010, 4, 27))
+    allow(Stripe::Account).to receive(:retrieve).and_return({ individual: { dob: { year: 2005, month: 4, day: 27 } } }.with_indifferent_access)
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).not_to have_received(:perform_async)
+  end
+
+  it "skips a seller with no live compliance record, since there is nothing to compare" do
+    account = gumroad_managed_account
+    stub_stripe_dobs(account.charge_processor_merchant_id => Date.new(2005, 4, 27))
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).not_to have_received(:perform_async)
+  end
+
+  it "ranks the under-18 seller above an adult one, because the gate is already holding their money" do
+    adult_seller = create(:user)
+    adult_account = gumroad_managed_account(user: adult_seller)
+    compliance_info(birthday: 30.years.ago.to_date, user: adult_seller)
+
+    minor_account = gumroad_managed_account
+    compliance_info(birthday: 16.years.ago.to_date)
+
+    stub_stripe_dobs(adult_account.charge_processor_merchant_id => 40.years.ago.to_date,
+                     minor_account.charge_processor_merchant_id => 21.years.ago.to_date)
+
+    lines = message.lines.select { |line| line.start_with?("•") }
+    expect(lines.first).to include(seller.email)
+    expect(lines.second).to include(adult_seller.email)
+  end
+
+  describe "sweeping the population across runs" do
+    it "resumes after the account the previous run compared last" do
+      first_account = gumroad_managed_account
+      compliance_info(birthday: Date.new(2010, 4, 27))
+
+      second_seller = create(:user)
+      second_account = gumroad_managed_account(user: second_seller)
+      compliance_info(birthday: Date.new(2009, 8, 27), user: second_seller)
+
+      stub_stripe_dobs(first_account.charge_processor_merchant_id => Date.new(2005, 4, 27),
+                       second_account.charge_processor_merchant_id => Date.new(2004, 8, 27))
+      stub_const("#{described_class}::MAX_CANDIDATES_SCANNED", 1)
+
+      expect(message).to include(seller.email)
+      expect($redis.get(RedisKey.stripe_dob_drift_sweep_cursor).to_i).to eq(first_account.id)
+
+      second_message = message
+      expect(second_message).to include(second_seller.email)
+      expect(second_message).not_to include(seller.email)
+    end
+
+    it "wraps to the start once it runs out of accounts" do
+      account = gumroad_managed_account
+      compliance_info(birthday: Date.new(2010, 4, 27))
+      stub_stripe_dobs(account.charge_processor_merchant_id => Date.new(2005, 4, 27))
+      $redis.set(RedisKey.stripe_dob_drift_sweep_cursor, account.id)
+
+      expect(message).to include(seller.email)
+    end
+  end
+
+  # A bound that silently decides the report is empty is indistinguishable from a clean platform, so
+  # a truncated scan has to send even with nothing to show.
+  it "sends a truncated scan that found nothing, so the bound cannot pass for a clean result" do
+    account = gumroad_managed_account
+    compliance_info(birthday: Date.new(2005, 4, 27))
+
+    other = create(:user)
+    other_account = gumroad_managed_account(user: other)
+    compliance_info(birthday: Date.new(2005, 4, 27), user: other)
+
+    stub_stripe_dobs(account.charge_processor_merchant_id => Date.new(2005, 4, 27),
+                     other_account.charge_processor_merchant_id => Date.new(2005, 4, 27))
+    stub_const("#{described_class}::MAX_CANDIDATES_SCANNED", 1)
+
+    body = message
+    expect(body).to include("not evidence that none do")
+    expect(body).to include("this is a floor")
+  end
+
+  it "stays silent when the scan completed and found nothing" do
+    account = gumroad_managed_account
+    compliance_info(birthday: Date.new(2005, 4, 27))
+    stub_stripe_dobs(account.charge_processor_merchant_id => Date.new(2005, 4, 27))
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).not_to have_received(:perform_async)
+  end
+
+  # Nothing here may write a date of birth: which copy is true is what a drift row leaves open.
+  it "tells its reader not to correct either copy from the report" do
+    account = gumroad_managed_account
+    compliance_info(birthday: Date.new(2010, 4, 27))
+    stub_stripe_dobs(account.charge_processor_merchant_id => Date.new(2005, 4, 27))
+
+    expect(message).to include("Do not correct either copy from this report")
+  end
+end


### PR DESCRIPTION
## What

Adds `AlertOnStripeDobDriftJob` — a weekly report of sellers whose live `UserComplianceInfo#birthday` no longer agrees with the `individual.dob` their Gumroad-managed Stripe account holds. Reports only; nothing writes a date of birth.

Closes the third ask of gumroad-private#1726 ("decide the reconciliation rule and make it explicit"). Its first production run is also the measurement the first ask wants — the 2-in-25 figure in the issue is a sample, and this job's headline is a floor over the real population.

## Why

The two copies drive different live decisions and neither reads the other:

- the under-18 payout gate reads **ours** (`UserComplianceInfo#birthday`, via `has_completed_payout_compliance_info?` → `requires_legal_guardian?`),
- Stripe's identity verification reads **theirs**.

When they disagree, it resolves in whichever direction hurts. Younger on our side holds payouts while Stripe runs an adult records check that cannot match; older on our side means the gate does not engage for someone Stripe holds as a minor. Nothing today detects either. The reported case surfaced only because a support agent happened to read both dates side by side on a ticket about something else.

### Design decisions

- **Report, do not correct.** Which of the two dates is true is exactly what a drift row leaves open. The seller's own later revision is evidence, not proof, and the opposite direction would un-gate a minor's payouts. The alert body says so explicitly, and a spec pins that sentence.
- **Individual records only.** A business record's date of birth belongs to its representative and syncs through `update_person`, not `individual` — comparing it against `individual.dob` would report every business account.
- **Gumroad-managed accounts only**, filtered with the model's own `is_a_gumroad_managed_stripe_account?` rather than a hand-written `json_data->>'$.meta.stripe_connect'` predicate. A Connect account's legal entity is the seller's own to maintain, and a second SQL copy of an existing rule drifts from it.
- **Three-way read result.** `Date` / `nil` / `:unreadable` are distinct. A missing dob on Stripe *is* drift against a birthday we hold (that account cannot be verified against anything), while a failed read establishes nothing and is counted separately rather than passing for agreement.
- **Cursor sweep, loud truncation.** Each candidate costs one `Stripe::Account.retrieve`, so the run is rate-bounded at 400 accounts and resumes from a Redis cursor, wrapping at the end. Connect accounts are excluded in SQL so they cannot consume that read budget, and the job is `lock: :until_executed` so two overlapping runs cannot claim the same page. A scan that finds nothing still sends when it was truncated *or* when any account was unreadable — otherwise the bound, or Stripe being unreachable, silently decides the report is empty and that is indistinguishable from a clean platform. The empty-page headline names which of the two happened.
- **Ranking.** Under-18-on-our-side first, then widest gap first: what makes a line worth reading is whether the gate is already holding money on the strength of the disagreement.

### Five real defects the review rounds caught

All found, fixed in-branch, and pinned by specs:

1. **`account.dig(:individual, :dob)` raises `NoMethodError` on every live account.** `Stripe::Account.retrieve` returns a `Stripe::StripeObject`, which exposes `[]` and implements no `dig` at all — so the job would have crashed on its first candidate and never sent anything. The first version of the spec stubbed a plain Hash, which *does* implement `dig`, so the suite was green against a job that could not run. Fixed to `[]` reads; the spec now stubs a real `Stripe::StripeObject` and asserts `not_to respond_to(:dig)`, so the regression is red rather than green.
2. **A run whose only outcome was unreadable accounts sent nothing.** The count was reachable only alongside a drifted row, so a Stripe outage looked exactly like a clean platform. Fixed in the send condition and in the empty-page headline.
3. **Connect accounts could consume the whole Stripe-read budget.** Self-inflicted: fixing the duplicated-SQL-predicate finding by moving the Connect filter into the loop meant a page beginning with budget-many Connect rows would spend the run reading nothing, advance the cursor past them, and report no drift. The exclusion is back in SQL — via the model's own `stripe_connect` scope, so the rule still has one definition — with the in-loop predicate kept as the authority.
4. **Two overlapping runs could claim the same page**, spending the Stripe budget twice and sending the report twice, since the cursor is read and written in separate steps. Serialized with `lock: :until_executed`.
5. **That lock was unbounded.** Caught by CI, not by me: `spec/models/concerns/recurring_lock_ttl_spec.rb` is a repo-wide contract requiring every *scheduled* `until_executed` job to declare a worst-case attempt, because a cron entry's lock digest is constant and one SIGKILL would mute every later enqueue forever — silently, with cron still reporting success. Fixed with `include RecurringLockTtl` and `recurring_lock_ttl max_attempt: 30.minutes`, sized off the read budget (400 sequential Stripe reads at a pessimistic 2s each ≈ 13 min). Yields a 90-minute TTL, which clears all four of the contract's bounds.

### What this does not cover

- **Ask 2 (why the correction did not propagate) is not answered here.** The re-send branch at `stripe_merchant_account_manager.rb:379` is correct, as the issue says; establishing whether a resync ran for the reported revision and whether the DOB was in its diff needs production data. This job makes the *class* visible going forward; it does not diagnose the individual failure.
- **No bulk correction**, per the issue's fourth ask.

## Before / After

| | before | after |
|---|---|---|
| Gumroad DOB vs Stripe DOB disagreement | detected by nobody; surfaces only if a human reads both copies on an unrelated ticket | weekly alert to `payouts`, most-gated and widest-gap first, with the live compliance record id |
| Stripe holds no DOB while we hold one | indistinguishable from agreement | reported as drift |
| Stripe read fails | n/a | counted separately, reported as neither clear nor drifted, and the run still sends |

## Test Results

Checks run at `2c092120`:

- `bundle exec rspec spec/sidekiq/alert_on_stripe_dob_drift_job_spec.rb spec/models/concerns/recurring_lock_ttl_spec.rb` — **160 examples, 0 failures, 4 pending** (53.05s): the job's own 18 plus the whole repo-wide lock-TTL contract
- `bundle exec rspec spec/models/concerns/recurring_lock_ttl_spec.rb -e AlertOnStripeDobDriftJob` — 4 examples, 0 failures (the three this job first broke, plus the recovery bound)
- `bundle exec rubocop` on the three changed Ruby files — 3 files inspected, no offenses
- `ruby -c` on all three changed Ruby files — Syntax OK
- `config/sidekiq_schedule.yml` parses and the new entry resolves
- CI at head: **80 checks pass, 0 fail**, including all 18 `Test Fast` and both `Test Minitest` shards; `ci/green` = "Test suite passed". `buildkite/gumroad` is red, and is red identically on sibling PRs #6889 and #6898 — the preview-app infra fault, not this diff.

Mutation check — the smallest edit that should break each new guard, full spec file per mutant:

| mutant | verdict |
|---|---|
| M1 delete the `is_individual?` guard | KILLED (1 failure) |
| M2 delete the Gumroad-managed-account filter | KILLED (1 failure) |
| M3 stop counting `:unreadable` | KILLED (1 failure) |
| M4 drop `unreadable` from the send condition | KILLED (1 failure) |
| M5 drop `truncated` from the send condition | KILLED (1 failure) |
| M6 treat a missing Stripe dob as agreement | KILLED (1 failure) |
| M7 invert the under-18-first ranking | KILLED (1 failure) |
| M8 reintroduce `account.dig` | KILLED (**13 failures**) |
| M9 revert the SQL Connect-budget exclusion | KILLED (1 failure) |
| M10 drop both Connect filters | KILLED (2 failures) |

10 of 10 killed. M8 taking down 13 of 17 examples is the measure of the fixture fix: under the original Hash stub the same mutant was invisible. M3 was **unkillable** before defect 2 was fixed — its only guard was the example that was itself red — which is why every fix round was re-mutated rather than assumed. M9/M10 are the fix-round mutants for defects 3 and 4.

## QA steps

⚠️ **Owed.** For a report-only backend job the QA artifact is a read-only dry run of the job's own predicates against production, as with `AlertOnStaleBlocksHoldingEstablishedBuyersJob` (gumroad-private#1746) — and that run is also the answer to ask 1.

Blocker, measured this session: the audited production console is unreachable. The bastion refuses this machine's key on every instance in the web cluster while EC2 discovery works, so it is a rotated console key rather than a cluster outage. Tracked on gumroad-private#1695. **No number from gumroad-private#1726 is restated here as if measured** — the 2-in-25 figure remains that issue's sample, not a population count.

Planned QA once the console is reachable:
1. Read-only dry run of `scan_for_drift`'s predicates over the first candidate page: candidate count, drifted count, unreadable count, oldest and newest account id.
2. Confirm the three accounts named in gumroad-private#1726 appear once the cursor reaches them.
3. Confirm `truncated` fires and the cursor advances across two consecutive runs.

## Status

- [x] **Scope** — asks 1 and 3 of gumroad-private#1726. Ask 2 needs production forensics; ask 4 is explicitly not built.
- [x] **Design** — report-only, cursor-swept, three-way read result. Rationale above.
- [x] **Build** — job, Redis cursor key, schedule entry, 18 specs. Head `2c092120`.
- [x] **Review** — adversarial round, Greptile, and CI's own lock-TTL contract: 4 P1s and 1 P2, all fixed in-branch and pinned, each review thread answered. Two of them were introduced by *earlier fix rounds*, which is why each round was re-run and re-mutated rather than assumed: 10 of 10 mutants killed, CI green at head.
- [ ] **QA** — owed; blocked on console access (above).
- [ ] **Ship** — held. Payout-gate-adjacent, so no auto-merge: one human reviews.
- [ ] **Shipped** — not merged, not deployed.
- [ ] **Market** — internal detector; nothing to announce.
- [ ] **Sell** — n/a.

The remaining gap is the production dry run, not the code: the job only reads and notifies, so the first scheduled Monday run is itself a valid measurement if the dry run stays blocked.

---

🤖 Written by Hermes Agent (claude-opus-5) on behalf of @slavingia, who asked to continue gumroad-private#1726.
