### PR TITLE
Screen the buyer's IP, not the seller's, when blocking a purchase

### DIFF
--- a/app/modules/purchase/risk.rb
+++ b/app/modules/purchase/risk.rb
@@ -104,10 +104,18 @@ module Purchase::Risk
       buyer_ip_addresses = User.where(email: blockable_emails_if_fraudulent_transaction).pluck(:current_sign_in_ip, :last_sign_in_ip, :account_created_ip).flatten.compact.uniq
       seller_ip_addresses = [seller.current_sign_in_ip, seller.last_sign_in_ip, seller.account_created_ip].compact
       ip_addresses_to_check = (seller_ip_addresses + [ip_address].compact).concat(buyer_ip_addresses)
-      return if PlatformBlock.active.where(object_value: ip_addresses_to_check).count == 0
-      # Compacting before slicing let a nil seller slot pull the buyer's IP into the first three
-      # positions, so a blocked buyer satisfied the seller's own carve-out and checked out.
-      return if PlatformBlock.active.where(object_value: seller_ip_addresses).present? && seller.compliant?
+      blocked_ip_addresses = PlatformBlock.active.where(object_value: ip_addresses_to_check).pluck(:object_value)
+      return if blocked_ip_addresses.empty?
+
+      # Screen the buyer, never the seller. A block on the seller's own IP rejects every paid
+      # purchase on their whole storefront, from any buyer on any network, and surfaces as a
+      # card error the buyer cannot act on — so subtract the seller's addresses and block only
+      # on what is left. If the seller is the problem, that is a flag or a suspension.
+      #
+      # Subtracting rather than short-circuiting on "a seller IP is blocked" matters in both
+      # directions: the old carve-out returned even when the buyer's own IP was separately
+      # blocked, and it was gated on compliant?, which excluded every never-reviewed seller.
+      return if (blocked_ip_addresses - seller_ip_addresses).empty?
 
       self.error_code = PurchaseErrorCode::BLOCKED_IP_ADDRESS
       errors.add :base, "Your card was not charged. Please try again on a different browser and/or internet connection."

--- a/app/modules/purchase/risk.rb
+++ b/app/modules/purchase/risk.rb
@@ -103,19 +103,23 @@ module Purchase::Risk
 
       buyer_ip_addresses = User.where(email: blockable_emails_if_fraudulent_transaction).pluck(:current_sign_in_ip, :last_sign_in_ip, :account_created_ip).flatten.compact.uniq
       seller_ip_addresses = [seller.current_sign_in_ip, seller.last_sign_in_ip, seller.account_created_ip].compact
-      ip_addresses_to_check = (seller_ip_addresses + [ip_address].compact).concat(buyer_ip_addresses)
+      buyer_side_ip_addresses = ([ip_address].compact + buyer_ip_addresses).uniq
+      ip_addresses_to_check = seller_ip_addresses + buyer_side_ip_addresses
       blocked_ip_addresses = PlatformBlock.active.where(object_value: ip_addresses_to_check).pluck(:object_value)
       return if blocked_ip_addresses.empty?
 
       # Screen the buyer, never the seller. A block on the seller's own IP rejects every paid
-      # purchase on their whole storefront, from any buyer on any network, and surfaces as a
-      # card error the buyer cannot act on — so subtract the seller's addresses and block only
-      # on what is left. If the seller is the problem, that is a flag or a suspension.
+      # purchase on their whole storefront, from any buyer on any network, and surfaces as a card
+      # error the buyer cannot act on. If the seller is the problem, that is a flag or a suspension.
       #
-      # Subtracting rather than short-circuiting on "a seller IP is blocked" matters in both
-      # directions: the old carve-out returned even when the buyer's own IP was separately
-      # blocked, and it was gated on compliant?, which excluded every never-reviewed seller.
-      return if (blocked_ip_addresses - seller_ip_addresses).empty?
+      # Matched by SOURCE, not by subtracting the seller's values: an address can be both, and a
+      # buyer sitting on a blocked IP still has to be blocked when the seller happens to share it
+      # (same office, same CGNAT, seller buying their own product). Subtracting would drop it.
+      #
+      # The previous carve-out short-circuited on "any seller IP is blocked" and was gated on
+      # compliant?, so it both skipped the buyer check outright and excluded every never-reviewed
+      # seller — not_reviewed being the initial risk state (gumroad-private#1755).
+      return if (blocked_ip_addresses & buyer_side_ip_addresses).empty?
 
       self.error_code = PurchaseErrorCode::BLOCKED_IP_ADDRESS
       errors.add :base, "Your card was not charged. Please try again on a different browser and/or internet connection."

--- a/spec/modules/purchase/risk_spec.rb
+++ b/spec/modules/purchase/risk_spec.rb
@@ -311,6 +311,16 @@ describe Purchase::Risk do
           .from(nil).to(PurchaseErrorCode::BLOCKED_IP_ADDRESS)
       end
 
+      it "still blocks a buyer sitting on a blocked ip_address the seller also uses" do
+        seller = create(:user, current_sign_in_ip: blocked_ip_address, user_risk_state: "compliant")
+        purchase = build(:purchase, link: create(:product, user: seller), seller:, ip_address: blocked_ip_address)
+
+        expect do
+          purchase.check_for_fraud
+        end.to change { purchase.error_code }
+          .from(nil).to(PurchaseErrorCode::BLOCKED_IP_ADDRESS)
+      end
+
       describe "subscription purchase" do
         let(:subscription) { create(:subscription) }
 

--- a/spec/modules/purchase/risk_spec.rb
+++ b/spec/modules/purchase/risk_spec.rb
@@ -282,7 +282,6 @@ describe Purchase::Risk do
       it "returns error when a blocked buyer ip_address lands in the seller's slots because the seller has none" do
         seller = create(:user, current_sign_in_ip: nil, last_sign_in_ip: nil, account_created_ip: nil)
         purchase = build(:purchase, link: create(:product, user: seller), seller:, ip_address: blocked_ip_address)
-        allow(seller).to receive(:compliant?).and_return(true)
 
         expect do
           purchase.check_for_fraud
@@ -290,13 +289,26 @@ describe Purchase::Risk do
           .from(nil).to(PurchaseErrorCode::BLOCKED_IP_ADDRESS)
       end
 
-      it "still lets a compliant seller sell when it is the seller's own ip_address that is blocked" do
-        seller = create(:user, current_sign_in_ip: blocked_ip_address)
-        purchase = build(:purchase, link: create(:product, user: seller), seller:)
-        allow(seller).to receive(:compliant?).and_return(true)
+      %w[compliant not_reviewed].each do |risk_state|
+        it "lets a #{risk_state} seller sell when it is the seller's own ip_address that is blocked" do
+          seller = create(:user, current_sign_in_ip: blocked_ip_address, user_risk_state: risk_state)
+          purchase = build(:purchase, link: create(:product, user: seller), seller:)
 
-        purchase.check_for_fraud
-        expect(purchase.error_code).to be_nil
+          purchase.check_for_fraud
+          expect(purchase.error_code).to be_nil
+        end
+      end
+
+      it "still blocks the buyer's own blocked ip_address when the seller's is blocked too" do
+        buyer_ip_address = "198.51.100.7"
+        PlatformBlock.add!(object_type: PlatformBlock::TYPES[:ip_address], object_value: buyer_ip_address, expires_in: 1.hour)
+        seller = create(:user, current_sign_in_ip: blocked_ip_address, user_risk_state: "compliant")
+        purchase = build(:purchase, link: create(:product, user: seller), seller:, ip_address: buyer_ip_address)
+
+        expect do
+          purchase.check_for_fraud
+        end.to change { purchase.error_code }
+          .from(nil).to(PurchaseErrorCode::BLOCKED_IP_ADDRESS)
       end
 
       describe "subscription purchase" do

--- a/spec/modules/purchase/risk_spec.rb
+++ b/spec/modules/purchase/risk_spec.rb
@@ -243,11 +243,11 @@ describe Purchase::Risk do
       expect(bad_purchase.errors.full_messages).to eq ["Your card was not charged. This payment could not be completed — please contact support@gumroad.com for help."]
     end
 
-    it "returns errors if the seller ip_address has been blocked" do
+    it "does not return errors if only the seller's account_created_ip has been blocked" do
       PlatformBlock.add!(object_type: PlatformBlock::TYPES[:ip_address], object_value: "123.121.11.1", expires_in: 1.hour)
-      bad_purchase = build(:purchase, link: @product, seller: @user)
-      bad_purchase.send(:check_for_fraud)
-      expect(bad_purchase.errors.empty?).to be(false)
+      purchase = build(:purchase, link: @product, seller: @user)
+      purchase.send(:check_for_fraud)
+      expect(purchase.errors.empty?).to be(true)
     end
 
     describe "ip_address check" do
@@ -355,7 +355,7 @@ describe Purchase::Risk do
       end
     end
 
-    context "when the creator's ip_address has been blocked but the seller is compliant" do
+    context "when the creator's ip_address has been blocked" do
       let(:seller) { @product.user }
 
       before do


### PR DESCRIPTION
## What

`check_for_past_fraudulent_ips` now screens the **buyer's** IP addresses only. A `PlatformBlock` on one of the *seller's* own IPs no longer rejects purchases on that seller's storefront, for any seller review state.

Fixes gumroad-private#1755.

```ruby
buyer_side_ip_addresses = ([ip_address].compact + buyer_ip_addresses).uniq
ip_addresses_to_check = seller_ip_addresses + buyer_side_ip_addresses
blocked_ip_addresses = PlatformBlock.active.where(object_value: ip_addresses_to_check).pluck(:object_value)
return if blocked_ip_addresses.empty?
return if (blocked_ip_addresses & buyer_side_ip_addresses).empty?
```

The match is by **source**, not by subtracting the seller's values. An address can be both the seller's and the buyer's, and a buyer on a blocked IP must still be blocked when the seller happens to share it.

## Why

#6868 turned IP `PlatformBlock` enforcement on in production (live in `v2026.08.02.25`, 2026-08-02 22:14Z). `ip_addresses_to_check` includes the seller's `current_sign_in_ip` / `last_sign_in_ip` / `account_created_ip`, so a block written against a seller-owned IP fails **every paid purchase on that seller's entire storefront**, from any buyer on any network — the block never has to touch the buyer.

The carve-out that exists to prevent exactly this was gated on `seller.compliant?`:

```ruby
return if PlatformBlock.active.where(object_value: seller_ip_addresses).present? && seller.compliant?
```

`not_reviewed` is the **initial** state of the `user_risk_state` machine (`app/models/user.rb:386`) and only a human `mark_compliant` leaves it. So the protection was absent for exactly the population most likely to trip an automated IP block: a new seller running pre-launch QA. Four distinct failed card fingerprints from one IP inside the watch window is `MAX_NUMBER_OF_FAILED_FINGERPRINTS` (`app/models/concerns/purchase/blockable.rb:26`), and `block_ip_address_based_on_recent_failures!` then writes a block on the seller's own address. First confirmed casualty in gumroad-private#1755 arrived ~8h after the deploy.

The buyer-facing copy makes it worse — "try again on a different browser and/or internet connection" is unactionable when the block is on the seller's IP, so both parties debug the wrong thing.

### This also closes a second hole the issue did not name

Screening by source is not the same change as dropping `&& seller.compliant?`. The old line short-circuited on *"is any seller IP blocked"*, so once a seller had a blocked IP, a compliant seller's storefront also stopped screening the **buyer's** IP — a genuinely blocked buyer checked out freely. Pinned by `still blocks the buyer's own blocked ip_address when the seller's is blocked too`.

### Alternatives considered

The issue proposed the one-line `&& seller.compliant?` deletion. That fixes the reported outage but preserves the short-circuit above, and it states the semantics as "a blocked seller IP is a reason to skip the check" rather than "the seller is not who we are screening".

Set **subtraction** (`blocked - seller_ip_addresses`) was the first shape pushed here and is wrong: when a blocked address is *both* the seller's and the buyer's — shared office, CGNAT, seller buying their own product — subtraction drops it and the blocked buyer checks out. Greptile flagged this as a P1 on `417dac39` and it is fixed in `429cb39d`. Intersecting against the buyer-side sources keeps the value when it arrives from the buyer, whatever the seller also uses. `still blocks a buyer sitting on a blocked ip_address the seller also uses` pins it.

### Not in this PR

Points 2-4 of gumroad-private#1755 are deliberately out of scope and **not narrowed by this change**: backing out the already-written seller-IP blocks (a bulk production data op), the misleading error copy, and excluding seller self-QA from `block_ip_address_based_on_recent_failures!` in the first place. This PR stops the bleeding; it does not clear sellers already blocked.

## Before / After

| Scenario | Before | After |
|---|---|---|
| `not_reviewed` seller, block on seller's own IP, unrelated buyer | ❌ `blocked_ip_address`, whole storefront dead | ✅ purchase proceeds |
| `compliant` seller, block on seller's own IP, unrelated buyer | ✅ proceeds | ✅ proceeds (unchanged) |
| Blocked **buyer** IP, seller's IP separately blocked | ❌ buyer let through (hole) | ✅ buyer correctly blocked |
| Blocked IP that is **both** the buyer's and the seller's | ❌ buyer let through | ✅ buyer correctly blocked |
| Blocked buyer IP, seller clean | ✅ blocked | ✅ blocked (unchanged) |
| Seller has no IPs recorded, buyer IP blocked | ✅ blocked | ✅ blocked (unchanged) |
| Free purchase / recurring charge | exempt | exempt (unchanged) |

Rows 1, 3 and 4 are the behaviour change; every other row is a regression guard.

## Test Results

All measured at head `f53625f418` in a review worktree (`~/repos/gumroad-review-gp1755-seller-ip-carveout`):

- `bundle exec rspec spec/modules/purchase/risk_spec.rb` — **46 examples, 0 failures**
- `bundle exec rubocop app/modules/purchase/risk.rb spec/modules/purchase/risk_spec.rb` — no offenses
- `ruby -c` on both files — Syntax OK

### Mutation proof

The new examples are not vacuous. Two mutants, whole-file run each time, file restored and diffed against pristine afterwards:

**Mutant 1 — revert `check_for_past_fraudulent_ips` to `origin/main` (i.e. reintroduce the bug): 46 examples, 4 failures**

1. `does not return errors if only the seller's account_created_ip has been blocked`
2. `lets a not_reviewed seller sell when it is the seller's own ip_address that is blocked`
3. `still blocks the buyer's own blocked ip_address when the seller's is blocked too`
4. `still blocks a buyer sitting on a blocked ip_address the seller also uses`

**Mutant 2 — swap the intersection for the subtraction that shipped in `417dac39` (the Greptile P1): 46 examples, 1 failure**

- `still blocks a buyer sitting on a blocked ip_address the seller also uses`

Mutant 2 failing *only* that example is the point: it is the one example that distinguishes source-matching from value-subtraction, and it would not exist without the review round.

### Stale pins found and inverted

`risk_spec.rb:246` — `returns errors if the seller ip_address has been blocked` — **encoded the outage as intended behaviour**. The seller's `account_created_ip` is blocked and the spec asserted the purchase must fail, which is precisely the storefront-wide rejection gumroad-private#1755 reports. Inverted to `does not return errors if only the seller's account_created_ip has been blocked`.

It survived my first sweep because I grepped for `compliant?` and this spec never mentions it — it depended on the behaviour without naming the gate. Flagged independently by the adversarial review as a P2 and by a real spec failure.

Two now-misleading `allow(seller).to receive(:compliant?)` stubs were also removed, and the context `when the creator's ip_address has been blocked but the seller is compliant` retitled, since compliance is no longer what decides it. No minitest (`test/`) coverage touches this path.

### Adversarial review (fable-5)

Run against `417dac39`: **P1:1 P2:1 P3:0** — both fixed in `429cb39d` / `f53625f418` and both pinned by the specs above. Greptile flagged the same P1 independently.

## QA steps

**One thing is genuinely owed: the blast-radius measurement.** The query below was written and attempted this run; the audited prod console failed the hop — every candidate instance in `production-web_cluster_green` failed the health probe. That is the live credential loss tracked in gumroad-private#1752 (bastion allowlist fingerprint `SHA256:hcZOBvPj…` not recoverable from 1Password), not a transient. So **how many sellers are currently affected is unknown**, and I have not guessed at it.

Query, ready to run the moment the hop is restored:

```ruby
rows = Purchase.unscoped.where(error_code: "blocked_ip_address")
               .where("created_at > ?", Time.utc(2026, 8, 2, 21, 41))
by_seller = rows.group(:seller_id).count
# then, per seller: are any of their own IPs in PlatformBlock.active?
# split the result by user_risk_state to size the not_reviewed defect population
```

Reviewer path meanwhile:

1. Read `app/modules/purchase/risk.rb#check_for_past_fraudulent_ips` — the whole change is three lines.
2. `bundle exec rspec spec/modules/purchase/risk_spec.rb -e "ip_address check"`.
3. Re-run the mutation proof above if you want it first-hand — both mutants are one-line edits.

There is no preview surface: the change is a server-side guard, and the buyer-visible artifact is the *absence* of a card error.

## Ask

@slavingia — gumroad-private#1755 decision 1 was explicitly yours: this narrows a control #6868 just widened. My read is that a block on a seller's own IP should never reject that seller's buyers regardless of review state; if the seller is the problem, the answer is a flag or a suspension, not a silent storefront-wide payment failure that reads to the buyer as a card error. Holding this draft for your call rather than arming auto-merge — it is a checkout/purchases surface either way.

---

🤖 Written by Hermes Agent (`claude-opus-5`) on gumclaw's workstation, from gumroad-private#1755. Instructions given: autonomous dispatcher standing order — pick up qualifying open issues and take them to an open PR. The fix, the second-hole finding, and the spec design are mine; the defect report and the four numbered decisions are the issue's.
