### PR TITLE
Clear PWYW when a $0-base product has a paid version

### DIFF
--- a/app/models/variant.rb
+++ b/app/models/variant.rb
@@ -17,6 +17,7 @@ class Variant < BaseVariant
 
   before_create :set_position
   after_save :set_customizable_price
+  after_save :sync_product_customizable_price
 
   delegate :link, to: :variant_category
   delegate :user, to: :link

--- a/app/modules/product/prices.rb
+++ b/app/modules/product/prices.rb
@@ -61,10 +61,14 @@ module Product::Prices
   def set_customizable_price
     return if is_tiered_membership
     return unless default_price_cents == 0
-    # Clearing, not returning: a $0-base product that gains a paid variant keeps the
-    # stale `true` otherwise, and no editor control switches PWYW off on a $0 base — so
-    # checkout offers a free-entry amount box whose minimum on the free option is 0 and
-    # a buyer can pay full price for the free tier (gumroad-private#1660).
+    # Coffee is deliberately $0-base with paid "Suggested Amounts" variants and a free-entry
+    # box — initialize_suggested_amount_if_needed! sets both in one save, so clearing here
+    # would undo it on creation.
+    return if native_type == Link::NATIVE_TYPE_COFFEE
+    # Clearing, not returning: a $0-base product that gains a paid variant keeps the stale
+    # `true` otherwise, and no editor control switches PWYW off on a $0 base — so checkout
+    # offers a free-entry amount box whose minimum on the free option is 0 and a buyer can
+    # pay full price for the free tier (gumroad-private#1660).
     if variant_categories_alive.joins(:variants).merge(BaseVariant.alive).sum("base_variants.price_difference_cents") > 0
       update_column(:customizable_price, false) if customizable_price?
       return

--- a/app/modules/product/prices.rb
+++ b/app/modules/product/prices.rb
@@ -61,7 +61,14 @@ module Product::Prices
   def set_customizable_price
     return if is_tiered_membership
     return unless default_price_cents == 0
-    return if variant_categories_alive.joins(:variants).merge(BaseVariant.alive).sum("base_variants.price_difference_cents") > 0
+    # Clearing, not returning: a $0-base product that gains a paid variant keeps the
+    # stale `true` otherwise, and no editor control switches PWYW off on a $0 base — so
+    # checkout offers a free-entry amount box whose minimum on the free option is 0 and
+    # a buyer can pay full price for the free tier (gumroad-private#1660).
+    if variant_categories_alive.joins(:variants).merge(BaseVariant.alive).sum("base_variants.price_difference_cents") > 0
+      update_column(:customizable_price, false) if customizable_price?
+      return
+    end
     update_column(:customizable_price, true)
   end
 

--- a/app/modules/product/prices.rb
+++ b/app/modules/product/prices.rb
@@ -61,15 +61,15 @@ module Product::Prices
   def set_customizable_price
     return if is_tiered_membership
     return unless default_price_cents == 0
-    # Coffee is deliberately $0-base with paid "Suggested Amounts" variants and a free-entry
-    # box — initialize_suggested_amount_if_needed! sets both in one save, so clearing here
-    # would undo it on creation.
-    return if native_type == Link::NATIVE_TYPE_COFFEE
-    # Clearing, not returning: a $0-base product that gains a paid variant keeps the stale
-    # `true` otherwise, and no editor control switches PWYW off on a $0 base — so checkout
-    # offers a free-entry amount box whose minimum on the free option is 0 and a buyer can
-    # pay full price for the free tier (gumroad-private#1660).
     if variant_categories_alive.joins(:variants).merge(BaseVariant.alive).sum("base_variants.price_difference_cents") > 0
+      # Coffee is deliberately $0-base with paid "Suggested Amounts" variants and a free-entry
+      # box (initialize_suggested_amount_if_needed! sets both in one write), so it is exempt
+      # from the clear — but not from the set below, which is its self-heal.
+      return if native_type == Link::NATIVE_TYPE_COFFEE
+      # Clearing, not returning: a $0-base product that gains a paid variant keeps the stale
+      # `true` otherwise, and no editor control switches PWYW off on a $0 base — so checkout
+      # offers a free-entry amount box whose minimum on the free option is 0 and a buyer can
+      # pay full price for the free tier (gumroad-private#1660).
       write_customizable_price_column(false)
       return
     end

--- a/app/modules/product/prices.rb
+++ b/app/modules/product/prices.rb
@@ -70,10 +70,10 @@ module Product::Prices
     # offers a free-entry amount box whose minimum on the free option is 0 and a buyer can
     # pay full price for the free tier (gumroad-private#1660).
     if variant_categories_alive.joins(:variants).merge(BaseVariant.alive).sum("base_variants.price_difference_cents") > 0
-      update_column(:customizable_price, false) if customizable_price?
+      write_customizable_price_column(false)
       return
     end
-    update_column(:customizable_price, true)
+    write_customizable_price_column(true)
   end
 
   def price_range=(price)
@@ -326,6 +326,15 @@ module Product::Prices
       else
         alive_prices.where(currency: price_currency_type)
       end
+    end
+
+    def write_customizable_price_column(value)
+      return if customizable_price? == value
+      # update_column skips the before_update hook that refreshes the search index, and
+      # customizable_price is an indexed field PriceCheckerService filters on — so the
+      # refresh has to be requested by hand.
+      update_column(:customizable_price, value)
+      enqueue_index_update_for(["customizable_price"])
     end
 
     # Private: Called only on create to instantiate Price object(s) and associate it to the newly created product.

--- a/app/modules/product/prices.rb
+++ b/app/modules/product/prices.rb
@@ -61,15 +61,16 @@ module Product::Prices
   def set_customizable_price
     return if is_tiered_membership
     return unless default_price_cents == 0
+    # Coffee is deliberately $0-base with paid "Suggested Amounts" variants and a free-entry box
+    # (initialize_suggested_amount_if_needed! sets both in one write), so the clear below would
+    # undo it. Above the paid-variant branch, matching the pre-existing behaviour: coffee always
+    # trips that branch, so it never reached the set either.
+    return if native_type == Link::NATIVE_TYPE_COFFEE
+    # Clearing, not returning: a $0-base product that gains a paid variant keeps the stale
+    # `true` otherwise, and no editor control switches PWYW off on a $0 base — so checkout
+    # offers a free-entry amount box whose minimum on the free option is 0 and a buyer can
+    # pay full price for the free tier (gumroad-private#1660).
     if variant_categories_alive.joins(:variants).merge(BaseVariant.alive).sum("base_variants.price_difference_cents") > 0
-      # Coffee is deliberately $0-base with paid "Suggested Amounts" variants and a free-entry
-      # box (initialize_suggested_amount_if_needed! sets both in one write), so it is exempt
-      # from the clear — but not from the set below, which is its self-heal.
-      return if native_type == Link::NATIVE_TYPE_COFFEE
-      # Clearing, not returning: a $0-base product that gains a paid variant keeps the stale
-      # `true` otherwise, and no editor control switches PWYW off on a $0 base — so checkout
-      # offers a free-entry amount box whose minimum on the free option is 0 and a buyer can
-      # pay full price for the free tier (gumroad-private#1660).
       write_customizable_price_column(false)
       return
     end

--- a/app/modules/variant/prices.rb
+++ b/app/modules/variant/prices.rb
@@ -31,6 +31,15 @@ module Variant::Prices
     update_column(:customizable_price, true)
   end
 
+  # A variant save is the other way the product-level PWYW flag goes stale: the editor path
+  # reaches Product::Prices#set_customizable_price because LinksController#update saves the
+  # product after update_variants, but Api::V2::VariantsController#create only saves the
+  # variant — so without this the API can still leave a $0-base product PWYW with a paid
+  # option (gumroad-private#1660).
+  def sync_product_customizable_price
+    link&.set_customizable_price
+  end
+
   def price_must_be_within_range
     return unless variant_category.present? && link.present?
     super

--- a/spec/modules/product/prices_spec.rb
+++ b/spec/modules/product/prices_spec.rb
@@ -196,9 +196,10 @@ describe Product::Prices do
         expect(product.reload.customizable_price).to be(false)
       end
 
-      it "keeps customizable_price when the paid version is deleted again" do
+      it "restores customizable_price once the paid version is deleted and a free one remains" do
         product = create(:product, price_cents: 0)
         category = create(:variant_category, title: "versions", link: product)
+        category.variants.create!(name: "Free Version", price_difference_cents: 0)
         paid = category.variants.create!(name: "premium version", price_difference_cents: 10_00)
         product.save!
         expect(product.reload.customizable_price).to be(false)
@@ -220,7 +221,8 @@ describe Product::Prices do
       end
 
       it "keeps a coffee product customizable despite its paid suggested amounts" do
-        product = create(:product, native_type: Link::NATIVE_TYPE_COFFEE, price_cents: 5_00)
+        seller = create(:user, created_at: 2.months.ago)
+        product = create(:product, user: seller, native_type: Link::NATIVE_TYPE_COFFEE, price_cents: 5_00)
         product.initialize_suggested_amount_if_needed!
         expect(product.reload.customizable_price).to be(true)
         expect(product.variant_categories_alive.joins(:variants).merge(BaseVariant.alive)

--- a/spec/modules/product/prices_spec.rb
+++ b/spec/modules/product/prices_spec.rb
@@ -218,6 +218,18 @@ describe Product::Prices do
 
         expect(product.reload.customizable_price).to be(true)
       end
+
+      it "keeps a coffee product customizable despite its paid suggested amounts" do
+        product = create(:product, native_type: Link::NATIVE_TYPE_COFFEE, price_cents: 5_00)
+        product.initialize_suggested_amount_if_needed!
+        expect(product.reload.customizable_price).to be(true)
+        expect(product.variant_categories_alive.joins(:variants).merge(BaseVariant.alive)
+                 .sum("base_variants.price_difference_cents")).to be > 0
+
+        product.save!
+
+        expect(product.reload.customizable_price).to be(true)
+      end
     end
   end
 

--- a/spec/modules/product/prices_spec.rb
+++ b/spec/modules/product/prices_spec.rb
@@ -172,6 +172,52 @@ describe Product::Prices do
         expect(product.customizable_price).to be(false)
         expect(product.price_cents).to eq(0)
       end
+
+      it "clears a stale customizable_price when a paid version is added later" do
+        product = create(:product, price_cents: 0)
+        expect(product.customizable_price).to be(true)
+
+        create(:variant_category, title: "versions", link: product)
+        product.variant_categories.first.variants.create!(name: "premium version", price_difference_cents: 10_00)
+        product.save!
+
+        expect(product.reload.customizable_price).to be(false)
+      end
+
+      it "clears the flag when the only free version sits beside a paid one" do
+        product = create(:product, price_cents: 0)
+        category = create(:variant_category, title: "versions", link: product)
+        category.variants.create!(name: "Free Version", price_difference_cents: 0)
+        category.variants.create!(name: "Full Version", price_difference_cents: 10_00)
+        product.update_column(:customizable_price, true)
+
+        product.save!
+
+        expect(product.reload.customizable_price).to be(false)
+      end
+
+      it "keeps customizable_price when the paid version is deleted again" do
+        product = create(:product, price_cents: 0)
+        category = create(:variant_category, title: "versions", link: product)
+        paid = category.variants.create!(name: "premium version", price_difference_cents: 10_00)
+        product.save!
+        expect(product.reload.customizable_price).to be(false)
+
+        paid.mark_deleted!
+        product.save!
+
+        expect(product.reload.customizable_price).to be(true)
+      end
+
+      it "leaves a paid product's PWYW flag alone" do
+        product = create(:product, price_cents: 5_00, customizable_price: true)
+        category = create(:variant_category, title: "versions", link: product)
+        category.variants.create!(name: "premium version", price_difference_cents: 10_00)
+
+        product.save!
+
+        expect(product.reload.customizable_price).to be(true)
+      end
     end
   end
 

--- a/spec/modules/product/prices_spec.rb
+++ b/spec/modules/product/prices_spec.rb
@@ -222,11 +222,12 @@ describe Product::Prices do
 
       it "keeps a coffee product customizable despite its paid suggested amounts" do
         seller = create(:user, created_at: 2.months.ago)
+        # after_create :initialize_suggested_amount_if_needed! has already moved the price onto a
+        # paid "Suggested Amounts" variant and set the flag — the exact shape the clear would undo.
         product = create(:product, user: seller, native_type: Link::NATIVE_TYPE_COFFEE, price_cents: 5_00)
-        product.initialize_suggested_amount_if_needed!
         expect(product.reload.customizable_price).to be(true)
         expect(product.variant_categories_alive.joins(:variants).merge(BaseVariant.alive)
-                 .sum("base_variants.price_difference_cents")).to be > 0
+                 .sum("base_variants.price_difference_cents")).to eq(5_00)
 
         product.save!
 

--- a/spec/modules/product/prices_spec.rb
+++ b/spec/modules/product/prices_spec.rb
@@ -223,10 +223,13 @@ describe Product::Prices do
       it "refreshes the search index when it clears the flag" do
         product = create(:product, price_cents: 0)
         category = create(:variant_category, title: "versions", link: product)
-
-        expect_any_instance_of(Link).to receive(:enqueue_index_update_for).with(["customizable_price"])
-
         category.variants.create!(name: "premium version", price_difference_cents: 10_00)
+        # The variant save above already cleared it; put it back so this save has work to do.
+        product.update_column(:customizable_price, true)
+
+        expect(product).to receive(:enqueue_index_update_for).with(["customizable_price"])
+
+        product.save!
       end
 
       it "does not re-enqueue an index update when the flag is already right" do

--- a/spec/modules/product/prices_spec.rb
+++ b/spec/modules/product/prices_spec.rb
@@ -223,18 +223,16 @@ describe Product::Prices do
       it "refreshes the search index when it clears the flag" do
         product = create(:product, price_cents: 0)
         category = create(:variant_category, title: "versions", link: product)
+
+        expect_any_instance_of(Link).to receive(:enqueue_index_update_for).with(["customizable_price"])
+
         category.variants.create!(name: "premium version", price_difference_cents: 10_00)
-
-        expect(product).to receive(:enqueue_index_update_for).with(["customizable_price"])
-
-        product.save!
       end
 
       it "does not re-enqueue an index update when the flag is already right" do
         product = create(:product, price_cents: 0)
         category = create(:variant_category, title: "versions", link: product)
         category.variants.create!(name: "premium version", price_difference_cents: 10_00)
-        product.save!
         expect(product.reload.customizable_price).to be(false)
 
         expect(product).not_to receive(:enqueue_index_update_for).with(["customizable_price"])
@@ -250,16 +248,6 @@ describe Product::Prices do
         expect(product.reload.customizable_price).to be(true)
         expect(product.variant_categories_alive.joins(:variants).merge(BaseVariant.alive)
                  .sum("base_variants.price_difference_cents")).to eq(5_00)
-
-        product.save!
-
-        expect(product.reload.customizable_price).to be(true)
-      end
-
-      it "still re-sets a coffee product whose flag was lost" do
-        seller = create(:user, created_at: 2.months.ago)
-        product = create(:product, user: seller, native_type: Link::NATIVE_TYPE_COFFEE, price_cents: 5_00)
-        product.update_column(:customizable_price, false)
 
         product.save!
 

--- a/spec/modules/product/prices_spec.rb
+++ b/spec/modules/product/prices_spec.rb
@@ -220,6 +220,16 @@ describe Product::Prices do
         expect(product.reload.customizable_price).to be(true)
       end
 
+      it "refreshes the search index when it clears the flag" do
+        product = create(:product, price_cents: 0)
+        category = create(:variant_category, title: "versions", link: product)
+        category.variants.create!(name: "premium version", price_difference_cents: 10_00)
+
+        expect(product).to receive(:enqueue_index_update_for).with(["customizable_price"])
+
+        product.save!
+      end
+
       it "keeps a coffee product customizable despite its paid suggested amounts" do
         seller = create(:user, created_at: 2.months.ago)
         # after_create :initialize_suggested_amount_if_needed! has already moved the price onto a

--- a/spec/modules/product/prices_spec.rb
+++ b/spec/modules/product/prices_spec.rb
@@ -230,6 +230,18 @@ describe Product::Prices do
         product.save!
       end
 
+      it "does not re-enqueue an index update when the flag is already right" do
+        product = create(:product, price_cents: 0)
+        category = create(:variant_category, title: "versions", link: product)
+        category.variants.create!(name: "premium version", price_difference_cents: 10_00)
+        product.save!
+        expect(product.reload.customizable_price).to be(false)
+
+        expect(product).not_to receive(:enqueue_index_update_for).with(["customizable_price"])
+
+        product.save!
+      end
+
       it "keeps a coffee product customizable despite its paid suggested amounts" do
         seller = create(:user, created_at: 2.months.ago)
         # after_create :initialize_suggested_amount_if_needed! has already moved the price onto a

--- a/spec/modules/product/prices_spec.rb
+++ b/spec/modules/product/prices_spec.rb
@@ -255,6 +255,39 @@ describe Product::Prices do
 
         expect(product.reload.customizable_price).to be(true)
       end
+
+      it "still re-sets a coffee product whose flag was lost" do
+        seller = create(:user, created_at: 2.months.ago)
+        product = create(:product, user: seller, native_type: Link::NATIVE_TYPE_COFFEE, price_cents: 5_00)
+        product.update_column(:customizable_price, false)
+
+        product.save!
+
+        expect(product.reload.customizable_price).to be(true)
+      end
+
+      it "clears the flag when the paid variant is saved without the product" do
+        product = create(:product, price_cents: 0)
+        expect(product.customizable_price).to be(true)
+        category = create(:variant_category, title: "versions", link: product)
+
+        # Api::V2::VariantsController#create saves only the variant.
+        category.variants.create!(name: "premium version", price_difference_cents: 10_00)
+
+        expect(product.reload.customizable_price).to be(false)
+      end
+
+      it "restores the flag when the paid variant is deleted without the product" do
+        product = create(:product, price_cents: 0)
+        category = create(:variant_category, title: "versions", link: product)
+        category.variants.create!(name: "Free Version", price_difference_cents: 0)
+        paid = category.variants.create!(name: "premium version", price_difference_cents: 10_00)
+        expect(product.reload.customizable_price).to be(false)
+
+        paid.mark_deleted!
+
+        expect(product.reload.customizable_price).to be(true)
+      end
     end
   end
 

--- a/spec/requests/products/show/show_spec.rb
+++ b/spec/requests/products/show/show_spec.rb
@@ -577,11 +577,11 @@ describe("ProductShowScenario", type: :system, js: true) do
           product.alive_variants.each_with_index { _1.update(price_difference_cents: (_2 + 1) * 100) }
         end
 
-        it "sets the PWYW input placeholder value correctly" do
+        it "does not show the PWYW input" do
           visit product.long_url
-          expect(page).to have_field("Name a fair price:", with: "", placeholder: "1+")
+          expect(page).not_to have_field("Name a fair price:")
           choose "Untitled 2"
-          expect(page).to have_field("Name a fair price:", with: "", placeholder: "2+")
+          expect(page).not_to have_field("Name a fair price:")
         end
       end
 

--- a/spec/requests/purchases/product/stripejs_purchase_spec.rb
+++ b/spec/requests/purchases/product/stripejs_purchase_spec.rb
@@ -584,53 +584,34 @@ describe("PurchaseScenario using StripeJs", type: :system, js: true) do
       end
     end
 
-    describe "multiple variants: 0+ and non-0+" do
+    describe "multiple variants: $0 and paid" do
       before do
-        @pwyw_product.price_range = "0+"
-        @pwyw_product.customizable_price = true
-        @pwyw_product.save!
+        @pwyw_product.update!(price_cents: 0, customizable_price: true)
 
         @variant_category = create(:variant_category, link: @pwyw_product, title: "type")
         @var_zero_plus = create(:variant, variant_category: @variant_category, name: "Zero-plus", price_difference_cents: 0)
         @var_paid = create(:variant, variant_category: @variant_category, name: "Paid", price_difference_cents: 500)
       end
 
-      it "lets to purchase the zero-plus variant for free" do
+      it "lets the zero variant be added for free" do
         visit "/l/#{@pwyw_product.unique_permalink}"
 
-        add_to_cart(@pwyw_product, pwyw_price: 0, option: "Zero-plus")
+        expect(page).not_to have_field("Name a fair price")
+        add_to_cart(@pwyw_product, option: "Zero-plus")
 
-        check_out(@pwyw_product, is_free: true)
+        expect(page).to have_text("Zero-plus")
+        expect(page).to have_text("US$0")
       end
 
-      it "does not let to purchase the paid variant for free, shows PWYW error instead of going to CC form" do
+      it "prices the paid variant at its fixed amount" do
         visit "/l/#{@pwyw_product.unique_permalink}"
 
-        choose "Paid"
-        fill_in "Name a fair price", with: 0
-        click_on "I want this!"
-        expect(find_field("Name a fair price")["aria-invalid"]).to eq("true")
-        expect(page).not_to have_button("Pay")
-
-        fill_in "Name a fair price", with: 4
-        click_on "I want this!"
-        expect(find_field("Name a fair price")["aria-invalid"]).to eq("true")
-        expect(page).not_to have_button("Pay")
-
-        add_to_cart(@pwyw_product, pwyw_price: 6, option: "Paid")
+        expect(page).not_to have_field("Name a fair price")
+        add_to_cart(@pwyw_product, option: "Paid")
 
         expect(page).to have_button("Pay")
 
-        expect(page).to have_text("Total US$6", normalize_ws: true)
-
-        check_out(@pwyw_product)
-
-        purchase = Purchase.last
-        expect(purchase.card_type).to eq "visa"
-        expect(purchase.card_country).to eq "US"
-        expect(purchase.card_country_source).to eq Purchase::CardCountrySource::STRIPE
-        expect(purchase.card_visual).to eq "**** **** **** 4242"
-        expect(purchase.price_cents).to eq(6_00)
+        expect(page).to have_text("Total US$5", normalize_ws: true)
       end
     end
 


### PR DESCRIPTION
## Status

- [x] **Scope** — @slavingia decided Ask A on gumroad-private#1660 at 2026-08-02 20:00Z: *"I think clearing is good and if sellers ask we can make it an option."* Ask 1 (license on swap) shipped in #6822; Ask B (keyless-swap scan) returned zero orphans.
- [x] **Design** — option 1 of the two on the issue: clear the stored flag whenever a $0-base product has paid alive variants. No new editor control, per the decision.
- [x] **Build** — `app/modules/product/prices.rb`, `app/modules/variant/prices.rb`, `app/models/variant.rb`, plus model/request specs.
- [x] **QA** — focused specs green, stale request specs updated, five mutants killed, fable fix-round approved, CI green at head. Details below.
- [ ] **Ship** — not merged.
- [ ] **Market** — n/a, a wrong-flag fix with no announcement.
- [ ] **Sell** — n/a.

## What

`Product::Prices#set_customizable_price` now **clears** `customizable_price` when a $0-base product has a paid alive variant, instead of returning and leaving a stale `true`. Variant-only saves also trigger the recompute, so the public API path cannot leave the stale flag behind.

## Why

The callback only ever set the flag to `true`. Its own guard already computed the condition under which PWYW should be off:

```ruby
return if variant_categories_alive.joins(:variants).merge(BaseVariant.alive)
            .sum("base_variants.price_difference_cents") > 0
```

but hitting that guard just returned, so a product that was $0 with no paid version (flag set `true`) and later gained a paid version kept the `true` forever. There is no editor control that switches PWYW off on a $0-base product, so the seller could not fix it either.

Consequence on the reporting seller's product (`Link` 13471676): `price_cents = 0`, alive variants `Free Version` (0) and `Full Version` (1000), so the guard's own rule says not-PWYW — yet the public page served `pwyw: {suggested_price_cents: 1000}`. Checkout therefore offered a free-entry amount box whose minimum on the **Free Version** option is 0, and a buyer typed €13.02 with the free tier selected and was charged (`Purchase` 348721370).

## Before / after

Same product, `price_cents = 0`, alive variants `Free Version` (0) + `Full Version` (1000), on its next product or variant save:

| | `customizable_price` | product page `pwyw` |
|---|---|---|
| before | `true` (stale) | `{suggested_price_cents: 1000}` |
| after | `false` | `nil` |

The three presenters that gate on the flag (`checkout_presenter.rb:429`, `product_presenter/product_props.rb:54`, `purchase_product_presenter.rb:35`) all read `product.customizable_price ? {...} : nil`, so clearing the flag is what removes the amount box.

## Important edge cases

- **Coffee is exempt.** Coffee products are deliberately $0-base with paid `"Suggested Amounts"` variants and a free-entry box: `Link#initialize_suggested_amount_if_needed!` moves the price onto a variant and sets `customizable_price: true` in the same write. Removing the exemption is mutation-tested and fails the coffee spec.
- **Tiered memberships are untouched.** Product-level `set_customizable_price` returns immediately for tiered memberships, and the tier-level `Variant::Prices#set_customizable_price` still owns tier PWYW.
- **API variant creates/updates/deletes are covered.** `Variant after_save :sync_product_customizable_price` calls the product-level recompute. This closes the path where `Api::V2::VariantsController#create` saves only the variant and never saves the product.
- **Search gets refreshed.** The callback still uses `update_column`, so the normal `before_update` delta hook does not run; the new helper explicitly calls `enqueue_index_update_for(["customizable_price"])` after an actual flip. The no-op guard is spec-pinned so normal saves do not enqueue duplicate index updates.

## Test Results

Local lane at final head `a756d727`:

- `bundle exec rspec spec/modules/product/prices_spec.rb spec/models/variant_spec.rb spec/models/product_installment_plan_spec.rb` → **182 examples, 0 failures**.
- Focused request specs that CI caught as stale pins after the behavior change:
  - `spec/requests/products/show/show_spec.rb:580`
  - `spec/requests/purchases/product/stripejs_purchase_spec.rb:596`
  - `spec/requests/purchases/product/stripejs_purchase_spec.rb:605`
  → **3 examples, 0 failures** after updating them to the new fixed-price behavior.
- Pre-existing system red baselined earlier: `spec/requests/products/edit/pwyw_spec.rb` is **3/3 red on this branch and identically 3/3 red on `origin/main`** (`find_field(... disabled: true)` / missing copy), so it is not caused by this diff.

Mutation checks at head:

| mutant | result |
|---|---|
| clear leg removed (back to main's bare `return`) | 13 examples, **7 failures** |
| coffee exemption removed | 13 examples, **1 failure** |
| index refresh removed | 13 examples, **1 failure** |
| no-op guard removed | 13 examples, **1 failure** |
| variant-save sync hook removed | 13 examples, **3 failures** |

Fable/adversarial review:

- Round 1 found two P2s: the API variant-only save path and the skipped search-index refresh. Both fixed.
- Fix-round review at `510495d6` verdict: **APPROVE — prior P2s fixed, no new P1/P2 found**. The final request-spec updates after that were stale-test expectation changes only; the code under review did not change.

GitHub CI at final head `a756d727`:

- `Tests` push workflow run `30797625890` → **76 success, 1 skipped, 0 failures**.
- `Preview app` push workflow run `30797625846` → success.
- `Tests` pull_request_target run `30797628020` → success.

## QA steps

Executed in lane worktrees:

1. Verified the model-level state transitions with `spec/modules/product/prices_spec.rb`: stale `true` clears when a paid variant exists; the flag restores when the paid variant is deleted and a free option remains; paid-base products stay unchanged; coffee stays PWYW.
2. Verified the API-equivalent path by saving variants without saving the product — both create and delete recompute the product flag.
3. Verified stale request specs now match the decision: a `$0` digital product with paid variants does **not** render `Name a fair price`; the free option adds as `US$0`, and the paid option adds as `US$5`.
4. Verified CI green at the pushed head.

No hosted browser checkout QA: the branch-preview tier is still unreliable/down (gumroad-private#1699), so the executed QA is local request/model specs plus CI.

---

AI disclosure: authored by Hermes Agent (claude-opus-5).