### PR TITLE
Send the store agent the whole request the creator just typed

### DIFF
--- a/app/services/ai/store_agent_service.rb
+++ b/app/services/ai/store_agent_service.rb
@@ -39,7 +39,13 @@ class Ai::StoreAgentService
   # of a runaway tool loop. A late phantom-staging claim can reserve the two tightly scoped turns
   # below when the normal budget no longer has room for them.
   MAX_TOOL_ITERATIONS = 25
+  # History budget per PRIOR message, so twenty turns of recap cannot crowd out the system prompt.
   MAX_MESSAGE_LENGTH = 2_000
+  # The turn being answered gets its own budget: it is the request, not a recap, and trimming it
+  # drops the instructions the model needs. Gumroad's own Share tab → Landing page → "Copy prompt"
+  # emits ~4,900 characters, so at the history budget every creator who pasted it lost most of it
+  # before the model saw it and was told the request was too large.
+  MAX_CURRENT_MESSAGE_LENGTH = 20_000
   MISSING_REQUIRED_READ_MESSAGE = "Store agent write proposal blocked by missing required full read"
   # Anthropic requires max_tokens on every request. This cap has to fit more than a brief chat
   # reply: when the agent edits a product, the model must emit the ENTIRE new value (for example a
@@ -1121,7 +1127,10 @@ class Ai::StoreAgentService
     # Build the Anthropic message array from the client-supplied history. The system prompt is passed
     # separately (Anthropic's top-level `system` param), so it is NOT included here.
     def build_conversation(messages)
-      history = Array(messages).last(MAX_HISTORY_MESSAGES).filter_map do |msg|
+      window = Array(messages).last(MAX_HISTORY_MESSAGES)
+      current_message_index = window.rindex { |msg| (msg[:role] || msg["role"]) == "user" && (msg[:content] || msg["content"]).to_s.strip.present? }
+
+      history = window.each_with_index.filter_map do |msg, index|
         role = msg[:role] || msg["role"]
         content = (msg[:content] || msg["content"]).to_s.strip
         next if content.blank?
@@ -1134,7 +1143,8 @@ class Ai::StoreAgentService
           else
             ""
           end
-        content = content.truncate(MAX_MESSAGE_LENGTH - state_suffix.length, omission: "...")
+        limit = index == current_message_index ? MAX_CURRENT_MESSAGE_LENGTH : MAX_MESSAGE_LENGTH
+        content = content.truncate(limit - state_suffix.length, omission: "...")
         { role:, content: "#{content}#{state_suffix}" }
       end
 

--- a/spec/services/ai/store_agent_service_spec.rb
+++ b/spec/services/ai/store_agent_service_spec.rb
@@ -126,6 +126,55 @@ describe Ai::StoreAgentService do
       expect(assistant_message[:content]).to end_with("\n\n[Server proposal state: #{proposal_state}]")
     end
 
+    it "sends the whole request the creator just typed, and still trims their earlier turns" do
+      captured = nil
+      allow(client).to receive(:messages) do |args|
+        captured = args
+        text_result("ok")
+      end
+      earlier_request = "e" * (described_class::MAX_MESSAGE_LENGTH + 500)
+      current_request = "c" * (described_class::MAX_MESSAGE_LENGTH + 500)
+
+      service.respond(messages: [
+                        { role: "user", content: earlier_request },
+                        { role: "assistant", content: "Done." },
+                        { role: "user", content: current_request },
+                      ])
+
+      # The decoy is a user message of the SAME oversized length, so a limit applied to every user
+      # message alike cannot pass this: the earlier turn must still be cut and the last one must not.
+      expect(captured[:messages].first[:content].length).to eq(described_class::MAX_MESSAGE_LENGTH)
+      expect(captured[:messages].last[:content]).to eq(current_request)
+    end
+
+    it "trims a current message past the current-message budget" do
+      captured = nil
+      allow(client).to receive(:messages) do |args|
+        captured = args
+        text_result("ok")
+      end
+
+      service.respond(messages: [{ role: "user", content: "c" * (described_class::MAX_CURRENT_MESSAGE_LENGTH + 100) }])
+
+      expect(captured[:messages].last[:content].length).to eq(described_class::MAX_CURRENT_MESSAGE_LENGTH)
+    end
+
+    it "treats the last non-blank user turn as the current message when blank turns trail it" do
+      captured = nil
+      allow(client).to receive(:messages) do |args|
+        captured = args
+        text_result("ok")
+      end
+      current_request = "c" * (described_class::MAX_MESSAGE_LENGTH + 500)
+
+      service.respond(messages: [
+                        { role: "user", content: current_request },
+                        { role: "user", content: "   " },
+                      ])
+
+      expect(captured[:messages].last[:content]).to eq(current_request)
+    end
+
     context "when the model completes a turn" do
       it "rejects an untyped staging claim that the prose backstop does not recognize" do
         false_claim = "Your edit is waiting in the action panel. Use the button there."


### PR DESCRIPTION
## What

Gives the turn the creator is actually asking about its own character budget (`MAX_CURRENT_MESSAGE_LENGTH = 20_000`), instead of trimming it to the 2,000-character budget that exists to keep twenty turns of *history* from crowding out the system prompt.

Prior messages are unchanged and still trimmed to `MAX_MESSAGE_LENGTH = 2_000`.

## Why

Gumroad's own **Share tab → Landing page → "Copy prompt"** button emits a 4,987-character prompt and tells the creator to hand it to an AI agent. Paste it into the Agent tab and `build_conversation` cut it to 2,000 characters before the model ever saw it — so the model received an instruction block that ends mid-sentence in `...`, and the creator got told the request was too big. That is the ticket behind #6363.

The 2,000 budget is right for history: it bounds the recap. It is wrong for the request, because trimming the request drops the instructions the reply depends on, and no amount of "ask me for a smaller section" helps a creator whose whole request is one pasted block.

This is one of the smaller, separate changes @gianfrancopiana asked for when closing #6363 ("We can address message limits, profile-page generation, and product landing-page support as smaller, separate changes"). It carries none of #6363's token-cap or retry-budget changes — `MAX_REPLY_TOKENS` is untouched at 8,192, no per-request budget, no replay changes.

## Before / after

Measured by reading the real `agentPrompt` string out of `LandingPageEditor.tsx` and capturing what `Ai::AnthropicClient#messages` is handed. Same probe, base vs branch:

| | Pasted by creator | Reaches the model | Truncated |
|---|---|---|---|
| Before (`origin/main`) | 4,987 chars | **2,000** | yes (`...`) |
| After (this branch) | 4,987 chars | **4,987** | no |

## Test Results

- `bundle exec rspec spec/services/ai/store_agent_service_spec.rb` — 100 examples, 0 failures (14.63s).
- `ruby -c` on both changed files.
- Mutation check on the three new examples, each mutant run against the full file:
  - `limit = MAX_CURRENT_MESSAGE_LENGTH` for every message (drops the history bound) → **2 failures**.
  - `limit = MAX_MESSAGE_LENGTH` for every message (reverts to `main`) → **3 failures**.
  - `rindex` without the blank-content guard → **1 failure**.

The first spec's decoy is a user message of the *same* oversized length as the current one, so a single limit applied to every user message alike cannot pass it — that is what the first mutant proves.

## QA steps

Executed, as a probe rather than a click-path (this is a server-side budget with no UI):

1. Read the exact `agentPrompt` template literal out of `app/javascript/components/ProductEdit/ShareTab/LandingPageEditor.tsx` — the same string the "Copy prompt" button copies.
2. Stubbed `Ai::AnthropicClient` and called `Ai::StoreAgentService#respond` with that string as the only user message.
3. Printed the length of the content actually placed in `messages`: 4,987 on this branch, 2,000 with the limit line reverted, per the table above.

## Status

- [x] Scope — one of the three smaller changes named on #6363; message limits only.
- [x] Design — separate budget for the turn being answered; history budget unchanged.
- [x] Build — pushed, local suite green, three mutants killed.
- [x] QA — the probe above is done. Greptile returned 5/5 with no blocking findings at this head (`9439e42e`); still owed is the adversarial (fable-5) pre-merge review.
- [ ] Shipped — **CI is green at this head**: 80 checks SUCCESS, 10 skipped, 0 failures on `9439e42e`. The single red is `buildkite/gumroad`, which is the cluster-wide Nomad preview-placement failure tracked in gumroad-private#1699 — it is failing on `main` too and is not a defect in this branch. Stays draft only for the fable-5 review.

---

🤖 Written by Hermes Agent (claude-opus-5).

