### PR TITLE
Tell a visitor a deleted account is holding their email, instead of a dead-end loop

### DIFF
--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -39,7 +39,7 @@ class LoginsController < Devise::SessionsController
 
     return redirect_with_login_error("Please try another password. The one you entered was incorrect.") unless @user.valid_password?(password)
 
-    return redirect_with_login_error("You cannot log in because your account was permanently deleted. Please sign up for a new account to start selling!") if @user.deleted?
+    return redirect_with_login_error(User::DELETED_ACCOUNT_LOGIN_ERROR) if @user.deleted?
 
     @user.remember_me = true # Always "remember" user sessions
 

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -140,9 +140,10 @@ class SignupController < Devise::RegistrationsController
           format.json { render json: { success: true, redirect_location: login_path_for(user) } }
         end
       else
+        message = user.deleted? ? User::DELETED_ACCOUNT_HOLDS_EMAIL_ERROR : "An account already exists with this email."
         respond_to do |format|
-          format.html { redirect_with_signup_error("An account already exists with this email.") }
-          format.json { render json: { success: false, error_message: "An account already exists with this email." } }
+          format.html { redirect_with_signup_error(message) }
+          format.json { render json: { success: false, error_message: message } }
         end
       end
     end

--- a/app/controllers/user/omniauth_callbacks_controller.rb
+++ b/app/controllers/user/omniauth_callbacks_controller.rb
@@ -32,7 +32,7 @@ class User::OmniauthCallbacksController < Devise::OmniauthCallbacksController
         flash[:alert] = "You're an admin, you can't login with Twitter."
         redirect_to login_path
       elsif @user.deleted?
-        flash[:alert] = "You cannot log in because your account was permanently deleted. Please sign up for a new account to start selling!"
+        flash[:alert] = User::DELETED_ACCOUNT_LOGIN_ERROR
         redirect_to login_path
       elsif @user.email.present?
         sign_in_or_prepare_for_two_factor_auth(@user)
@@ -94,7 +94,7 @@ class User::OmniauthCallbacksController < Devise::OmniauthCallbacksController
         flash[:alert] = "An account already exists with this email."
         return safe_redirect_to referer
       elsif user.deleted?
-        flash[:alert] = "You cannot log in because your account was permanently deleted. Please sign up for a new account to start selling!"
+        flash[:alert] = User::DELETED_ACCOUNT_LOGIN_ERROR
         return safe_redirect_to referer
       end
 
@@ -154,7 +154,7 @@ class User::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     def sign_in_with_oauth(provider_name)
       if @user&.persisted?
         if @user.deleted?
-          flash[:alert] = "You cannot log in because your account was permanently deleted. Please sign up for a new account to start selling!"
+          flash[:alert] = User::DELETED_ACCOUNT_LOGIN_ERROR
           redirect_to login_path
         else
           sign_in @user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,6 +32,15 @@ class User < ApplicationRecord
 
   INVALID_NAME_FOR_EMAIL_DELIVERY_REGEX = /:/
 
+  # Soft deletion keeps the row's email set, so a deleted account goes on
+  # reserving its address while `by_email` still finds it and login refuses it.
+  # Both surfaces must name that state: telling a returning visitor an account
+  # "already exists" or to "sign up for a new account" sends them round a loop
+  # neither surface can end, because releasing the address is a support write.
+  DELETED_ACCOUNT_HOLDS_EMAIL_ERROR = "This email address belonged to a Gumroad account that was deleted, so it can't be used for a new account yet. Email support@gumroad.com and we'll free it up for you."
+
+  DELETED_ACCOUNT_LOGIN_ERROR = "You cannot log in because your account was deleted. Email support@gumroad.com if you'd like to use this email address for a new account."
+
   MIN_AU_BACKTAX_OWED_CENTS_FOR_CONTACT = 100_00
 
   MIN_AGE_FOR_SERVICE_PRODUCTS = 30.days

--- a/app/modules/user/validations.rb
+++ b/app/modules/user/validations.rb
@@ -21,9 +21,12 @@ module User::Validations
     end
 
     def email_almost_unique
-      return if !email_changed? || email.blank? || User.by_email(email).empty?
+      return if !email_changed? || email.blank?
 
-      errors.add(:base, "An account already exists with this email.")
+      holders = User.by_email(email)
+      return if holders.empty?
+
+      errors.add(:base, holders.all?(&:deleted?) ? User::DELETED_ACCOUNT_HOLDS_EMAIL_ERROR : "An account already exists with this email.")
     end
 
     def account_created_email_domain_is_not_blocked

--- a/spec/controllers/logins_controller_spec.rb
+++ b/spec/controllers/logins_controller_spec.rb
@@ -218,14 +218,16 @@ describe LoginsController, type: :controller, inertia: true do
       expect(response).to redirect_to("https://username.test.gumroad.com")
     end
 
-    it "disallows logging in if the user has been deleted" do
+    it "disallows logging in if the user has been deleted, and points them at support" do
       @user.deleted_at = Time.current
       @user.save!
 
       post "create", params: { user: { login_identifier: @user.email, password: "password" } }
 
       expect(response).to redirect_to(login_path)
-      expect(flash[:warning]).to eq("You cannot log in because your account was permanently deleted. Please sign up for a new account to start selling!")
+      expect(flash[:warning]).to eq(User::DELETED_ACCOUNT_LOGIN_ERROR)
+      expect(flash[:warning]).to include("support@gumroad.com")
+      expect(flash[:warning]).to_not include("sign up for a new account")
     end
 
     # Login reCAPTCHA was removed with the disable_login_recaptcha flag (100% on in prod

--- a/spec/controllers/signup_controller_spec.rb
+++ b/spec/controllers/signup_controller_spec.rb
@@ -143,6 +143,38 @@ describe SignupController, type: :controller, inertia: true do
       end
     end
 
+    describe "the only account holding the email was deleted" do
+      before do
+        @deleted = create(:user, password: "password")
+        @deleted.update!(deleted_at: Time.current)
+      end
+
+      it "names the deleted account and routes to support instead of claiming the account exists" do
+        post "create", params: { user: { email: @deleted.email, password: "password" } }
+
+        expect(response).to redirect_to(signup_path)
+        expect(flash[:warning]).to eq(User::DELETED_ACCOUNT_HOLDS_EMAIL_ERROR)
+        expect(flash[:warning]).to include("support@gumroad.com")
+        expect(flash[:warning]).to_not include("An account already exists")
+        expect(controller.user_signed_in?).to eq false
+      end
+
+      it "returns the same message over json" do
+        post "create", params: { user: { email: @deleted.email, password: "password" } }, format: :json
+
+        expect(response.parsed_body["success"]).to be(false)
+        expect(response.parsed_body["error_message"]).to eq(User::DELETED_ACCOUNT_HOLDS_EMAIL_ERROR)
+      end
+
+      it "still says the account already exists when a live account holds the email" do
+        live = create(:user, password: "password")
+
+        post "create", params: { user: { email: live.email, password: "wrongpassword" } }
+
+        expect(flash[:warning]).to eq("An account already exists with this email.")
+      end
+    end
+
     it "creates a user" do
       user = build(:user, password: "password")
       post "create", params: { user: { email: user.email, password: "password" } }

--- a/spec/controllers/user/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/user/omniauth_callbacks_controller_spec.rb
@@ -3,8 +3,7 @@
 require "spec_helper"
 
 describe User::OmniauthCallbacksController do
-  ACCOUNT_DELETION_ERROR_MSG = "You cannot log in because your account was permanently deleted. "\
-                               "Please sign up for a new account to start selling!"
+  ACCOUNT_DELETION_ERROR_MSG = User::DELETED_ACCOUNT_LOGIN_ERROR
 
   before do
     request.env["devise.mapping"] = Devise.mappings[:user]

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1212,6 +1212,42 @@ describe User, :vcr do
       (1..n).map { ("a".."z").to_a.sample }.join
     end
 
+    describe "email_almost_unique" do
+      it "tells a signup that the address is held by a deleted account, not that an account exists" do
+        create(:user, email: "taken@example.com").update!(deleted_at: Time.current)
+
+        user = build(:user, email: "taken@example.com")
+
+        expect(user).to_not be_valid
+        expect(user.errors[:base]).to eq([User::DELETED_ACCOUNT_HOLDS_EMAIL_ERROR])
+      end
+
+      it "keeps the generic message when a live account holds the address" do
+        create(:user, email: "live@example.com")
+
+        user = build(:user, email: "live@example.com")
+
+        expect(user).to_not be_valid
+        expect(user.errors[:base]).to eq(["An account already exists with this email."])
+      end
+
+      # The live holder is created FIRST so a predicate that only inspects the first row
+      # would report "deleted" and hand the wrong message to someone who really is
+      # colliding with a live account. The second holder needs update_columns because
+      # the validation under test is what would otherwise refuse to create it.
+      it "keeps the generic message when a live and a deleted account both hold the address" do
+        create(:user, email: "shared@example.com")
+        second = create(:user, email: "other@example.com")
+        second.update_columns(email: "shared@example.com", deleted_at: Time.current)
+        expect(User.by_email("shared@example.com").order(:id).pluck(:deleted_at).map(&:present?)).to eq([false, true])
+
+        user = build(:user, email: "shared@example.com")
+
+        expect(user).to_not be_valid
+        expect(user.errors[:base]).to eq(["An account already exists with this email."])
+      end
+    end
+
     describe "google_analytics_id" do
       [
         { id: nil, valid: true },


### PR DESCRIPTION
## What

Both ends of the signup/login pair now name the one state they were silent about: **the email address is held by an account that was deleted.** Previously they gave contradictory instructions and neither could be acted on.

Two constants on `User`, used by every surface that can hit this:

| constant | shown when | text |
|---|---|---|
| `DELETED_ACCOUNT_HOLDS_EMAIL_ERROR` | a signup collides with an address whose only holders are deleted | "This email address belonged to a Gumroad account that was deleted, so it can't be used for a new account yet. Email support@gumroad.com and we'll free it up for you." |
| `DELETED_ACCOUNT_LOGIN_ERROR` | login/OAuth on a deleted account | "You cannot log in because your account was deleted. Email support@gumroad.com if you'd like to use this email address for a new account." |

## Why

Soft deletion (`User#deactivate!`) clears `username`, `credit_card_id` and the child records, but leaves `email` set. `User.by_email` has no `alive` scope, so a deleted row keeps reserving the address — while `LoginsController#create` refuses it as deleted. The two surfaces then said:

- signup → *"An account already exists with this email."* → so the visitor goes to log in
- login → *"…permanently deleted. **Please sign up for a new account** to start selling!"* → so the visitor goes back to signup

That is a closed loop, and the second message instructs the exact action the first one blocks. Google sign-up has the same shape: `find_or_create_for_google_oauth2` matches the deleted row by email, and `sign_in_with_oauth` bounces it to `/login`.

Releasing the address is a support-side console write (`update_columns(email: "…-freed-<pk>@deleted.invalid")`), so no code path can end the loop on the visitor's behalf. The honest fix is to say so and route them to the one channel that can.

Reported via gumroad-private#1758 (`janakisunil00@gmail.com` — deleted an account 9 minutes after creating it, then could neither sign up nor log in). That ticket's remaining half is the prod write itself, still blocked on gumroad-private#1752 (console access), and this PR does **not** narrow it.

## Before / After

Generated from the two refs, so the columns differ only by this branch:

| Surface | Before | After |
|---|---|---|
| Email signup, deleted holder | "An account already exists with this email." | `DELETED_ACCOUNT_HOLDS_EMAIL_ERROR` |
| Email signup, **live** holder | "An account already exists with this email." | unchanged |
| Password login, deleted account | "…permanently deleted. Please sign up for a new account to start selling!" | `DELETED_ACCOUNT_LOGIN_ERROR` |
| Google / Apple / Twitter / Stripe OAuth, deleted account | same "sign up for a new account" text | `DELETED_ACCOUNT_LOGIN_ERROR` |
| `save_to_library` + settings email change, deleted holder | "An account already exists with this email." | `DELETED_ACCOUNT_HOLDS_EMAIL_ERROR` |

The model-level change is what covers the last row: `email_almost_unique` branches on the holders, so every caller of the validation gets the right message without repeating the condition.

**`all?` not `any?` is the load-bearing choice.** An address can be held by a live account *and* a deleted one (the deleted row was never released). Only the all-deleted case may claim the address is free-able; anything else must keep the generic message, or someone colliding with a live account gets told to email support about a non-problem.

### No preview screenshots — the preview tier is down

Every branch preview host is unreachable, so there is no hosted app to capture this on:

```
gp1755-seller-ip-carveout.apps.staging.gumroad.org        000   (TLS handshake fails)
gp1751-stripe-intervention-remediation…                   000
gp1750-transient-esp-retry…                               000
staging.gumroad.com                                       503
gumroad.com  (control arm, same machine)                  200
```

Prod answering 200 from the same client rules out a local routing fault. This is the platform outage tracked in gumroad-private#1699 (Nomad placement), not a failure of this branch — no `preview/gp1758…` deployment exists because no deploy has succeeded. The surface matrix above is the substitute evidence; it is derived mechanically from both refs rather than asserted. I will attach preview captures when the tier is back.

## Test Results

Run locally in a dedicated worktree at head `234baf833244` (`DISABLE_SPRING=1`):

- `spec/models/user_spec.rb -e "email_almost_unique"` — **3 examples, 0 failures** (new)
- `spec/controllers/signup_controller_spec.rb -e "the only account holding the email was deleted"` — **3 examples, 0 failures** (new)
- `spec/controllers/logins_controller_spec.rb -e "deleted"` — **1 example, 0 failures** (updated)
- `spec/controllers/user/omniauth_callbacks_controller_spec.rb` — 48 examples, 2 failures, both `create(:purchase)` factory failures on `origin/main` in this worktree, unrelated to the diff and untouched by it
- `spec/controllers/signup_controller_spec.rb` (whole file) — 45 examples, 18 failures, all environmental in this worktree: 6 vite manifest (`resolve_entries`) on `GET new`, the rest `create(:purchase)`. None in the examples this PR adds or changes.

**Mutation proof — all three mutants red, each on its own assertion:**

| Mutant | Result |
|---|---|
| validation drops the deleted-holder branch | 3 examples, **1 failure** — `expected [DELETED_ACCOUNT_HOLDS_EMAIL_ERROR]` |
| validation reads `any?(&:deleted?)` instead of `all?` | 3 examples, **1 failure** — the mixed live+deleted holder case |
| signup controller drops the deleted branch | 3 examples, **2 failures** — html and json legs |

The mixed-holder spec creates the **live** holder first and asserts the row order, so a first-row-only predicate has somewhere wrong to land. Tree verified restored after each mutant (`grep -c` of the guard back to 1).

### Stale-test sweep

Behaviour-change sweep across `spec/` and `test/` for the old strings, the constants, and the outcome:

- `spec/controllers/logins_controller_spec.rb:228` pinned the literal "sign up for a new account" text → rewritten to assert the new message **and** that the retired instruction is gone
- `spec/controllers/user/omniauth_callbacks_controller_spec.rb:6` hardcoded the same string in `ACCOUNT_DELETION_ERROR_MSG` → now reads the constant, so its 3 call sites move with it
- No spec pinned the signup side of the loop as intended behaviour — that path had no deleted-holder coverage at all before this PR

## Status

- [x] **Scope** — the shippable half of gumroad-private#1758 (messaging). The prod-console write that actually frees the address is the other half and stays on #1758, blocked on gumroad-private#1752.
- [x] **Design** — branch inside `email_almost_unique` so every caller of the validation gets the right message; `all?` not `any?` for mixed live+deleted holders.
- [x] **Build** — two constants, one validation branch, signup + login + OAuth surfaces; stale-test sweep done.
- [x] **QA** — Test Results below; three mutants killed, each on its own assertion. No pixel obligation beyond copy, and the preview tier is down (probed live, gumroad-private#1699).
- [ ] **Review** — Greptile clean at this head; the adversarial (fable-5) pre-merge round is **still owed**. That is why this PR keeps the `working` label and has no review request yet: it is mine to finish, not a human's queue item.
- [ ] **Shipped** — not merged. CI is green at `234baf833`: 79 checks SUCCESS, 0 failures. The one red is `buildkite/gumroad`, the cluster-wide Nomad preview-placement failure tracked in gumroad-private#1699 — failing on `main` too, not a defect in this branch.

## QA steps

Reviewer path, no preview needed:

1. `rails c` → `u = create(:user); u.update!(deleted_at: Time.current)`
2. `User.new(email: u.email).tap(&:valid?).errors[:base]` → the deleted-holder message
3. `create(:user, email: "x@y.com"); User.new(email: "x@y.com").tap(&:valid?).errors[:base]` → unchanged generic message
4. `POST /signup` with the deleted user's email → redirected to `/signup` with the support-routing warning, not signed in
5. `POST /login` with that user's credentials → the new login message, no "sign up for a new account"

---

🤖 This PR was written by Gumclaw, an AI agent (model: `claude-opus-5`), running autonomously.

**Instructions given:** standing order to drain the gumroad-private backlog — take the simplest open issue with no PR, verify the defect still exists at `origin/main`, build the smallest complete fix, open a draft PR with evidence.

**What the agent decided on its own:** that gumroad-private#1758 splits into a prod-console write (human, blocked on #1752) and a shippable messaging defect (this PR); to branch inside `email_almost_unique` rather than at each call site; to use `all?` rather than `any?` for mixed holders; to route to `support@gumroad.com` rather than invent a self-service release; and to ship without preview captures, with the outage probed live rather than quoted.

**Human review requested for:** the exact wording of both messages, and whether a deleted-holder collision should eventually get a self-service release path instead of a support hop.

