### PR TITLE
Stop telling sellers they're all set when Stripe paused payouts with nothing due

### DIFF
--- a/app/controllers/settings/payments_controller.rb
+++ b/app/controllers/settings/payments_controller.rb
@@ -241,7 +241,7 @@ class Settings::PaymentsController < Settings::BaseController
 
     has_local_requests = current_seller.user_compliance_info_requests.requested.exists?
     if !has_local_requests && !stripe_account_has_open_requirements?(current_seller.stripe_account)
-      redirect_to settings_payments_path, notice: "Thanks! You're all set." and return
+      redirect_to settings_payments_path, **nothing_open_flash and return
     end
 
     redirect_to Stripe::AccountLink.create({
@@ -292,7 +292,9 @@ class Settings::PaymentsController < Settings::BaseController
                              future_requirements["currently_due"].blank? &&
                              future_requirements["past_due"].blank? &&
                              future_requirements["eventually_due"].blank?
-    flash[:notice] = "Thanks! You're all set." if nothing_open_on_stripe
+    if nothing_open_on_stripe
+      flash.merge!(nothing_open_flash)
+    end
 
     safe_redirect_to settings_payments_path
   end
@@ -498,6 +500,21 @@ class Settings::PaymentsController < Settings::BaseController
       error.is_a?(Stripe::InvalidRequestError) &&
         error.message.to_s.include?("account link cannot be created") &&
         error.message.to_s.include?("rejected")
+    end
+
+    # "You're all set" is only true when nothing is open ANYWHERE. Stripe can pause
+    # payouts with every requirement list empty (`disabled_reason: "other"`, an
+    # intervention Stripe raises and resolves out of band), and that state satisfies
+    # every check above while the seller still cannot be paid. Telling them they are
+    # fine is the dead end this branch exists to avoid, so the Stripe-side pause wins.
+    def nothing_open_flash
+      if current_seller.payouts_paused_internally? &&
+         current_seller.payouts_paused_by_source == User::PAYOUT_PAUSE_SOURCE_STRIPE
+        { alert: "Stripe has paused payouts on your account and hasn't told us what it needs. " \
+                 "There's nothing for you to submit — please contact support and we'll chase it with Stripe." }
+      else
+        { notice: "Thanks! You're all set." }
+      end
     end
 
     def stripe_account_has_open_requirements?(merchant_account)

--- a/spec/controllers/settings/payments_controller_spec.rb
+++ b/spec/controllers/settings/payments_controller_spec.rb
@@ -2355,6 +2355,50 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
       expect(response).to redirect_to settings_payments_url
     end
 
+    it "warns instead of clearing the seller when Stripe paused payouts with no requirements outstanding" do
+      # `disabled_reason: "other"` with all three lists empty: Stripe pauses out of band
+      # and owes us nothing, so every requirement check passes and the seller still can't
+      # be paid. This is the case that must NOT get "You're all set".
+      merchant_account = StripeMerchantAccountManager.create_account(user, passphrase: "1234")
+      user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_STRIPE)
+      allow(Stripe::Account).to receive(:retrieve).with(merchant_account.charge_processor_merchant_id).and_return(
+        Stripe::Account.construct_from(
+          id: merchant_account.charge_processor_merchant_id,
+          object: "account",
+          requirements: { "currently_due" => [], "past_due" => [], "eventually_due" => [] },
+          future_requirements: { "currently_due" => [], "past_due" => [], "eventually_due" => [] }
+        )
+      )
+
+      get :remediation
+
+      expect(response).to redirect_to settings_payments_url
+      expect(flash[:notice]).to be_nil
+      expect(flash[:alert]).to include("Stripe has paused payouts")
+      expect(flash[:alert]).to include("contact support")
+    end
+
+    it "still says 'all set' when the pause came from us rather than Stripe" do
+      # An admin/system pause is ours to explain elsewhere on the page; only a
+      # Stripe-sourced pause means nobody has told the seller what is wrong.
+      merchant_account = StripeMerchantAccountManager.create_account(user, passphrase: "1234")
+      user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_ADMIN)
+      allow(Stripe::Account).to receive(:retrieve).with(merchant_account.charge_processor_merchant_id).and_return(
+        Stripe::Account.construct_from(
+          id: merchant_account.charge_processor_merchant_id,
+          object: "account",
+          requirements: { "currently_due" => [], "past_due" => [], "eventually_due" => [] },
+          future_requirements: { "currently_due" => [], "past_due" => [] }
+        )
+      )
+
+      get :remediation
+
+      expect(response).to redirect_to settings_payments_url
+      expect(flash[:notice]).to eq "Thanks! You're all set."
+      expect(flash[:alert]).to be_nil
+    end
+
     it "opens a Stripe AccountLink when local has no pending requests but Stripe still has open requirements" do
       merchant_account = StripeMerchantAccountManager.create_account(user, passphrase: "1234")
       stripe_connect_account_id = merchant_account.charge_processor_merchant_id
@@ -2571,6 +2615,26 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
 
       expect(response).to redirect_to settings_payments_url
       expect(flash[:notice]).to be_nil
+    end
+
+    it "warns on the return trip when Stripe paused payouts with nothing outstanding" do
+      # The seller has just come back from Stripe's own flow, which is the exact
+      # moment "You're all set" is most convincing and most wrong.
+      user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_STRIPE)
+      allow(Stripe::Account).to receive(:retrieve).with(stripe_connect_account_id).and_return(
+        Stripe::Account.construct_from(
+          id: stripe_connect_account_id,
+          object: "account",
+          requirements: { "currently_due" => [], "past_due" => [], "eventually_due" => [] },
+          future_requirements: { "currently_due" => [], "past_due" => [], "eventually_due" => [] }
+        )
+      )
+
+      get :verify_stripe_remediation
+
+      expect(response).to redirect_to settings_payments_url
+      expect(flash[:notice]).to be_nil
+      expect(flash[:alert]).to include("Stripe has paused payouts")
     end
   end
 end

--- a/spec/support/fixtures/vcr_cassettes/Settings_PaymentsController/GET_remediation/still_says_all_set_when_the_pause_came_from_us_rather_than_Stripe.yml
+++ b/spec/support/fixtures/vcr_cassettes/Settings_PaymentsController/GET_remediation/still_says_all_set_when_the_pause_came_from_us_rather_than_Stripe.yml
@@ -1,0 +1,372 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts
+    body:
+      encoding: UTF-8
+      string: type=custom&requested_capabilities[0]=card_payments&requested_capabilities[1]=transfers&country=US&default_currency=usd&metadata[user_id]=6&metadata[tos_agreement_id]=OKW5T4NMBrWG_MhdAf9kiQ%3D%3D&metadata[user_compliance_info_id]=3B8nXTt16vN7u7qo5vAUbQ%3D%3D&metadata[bank_account_id]=OKW5T4NMBrWG_MhdAf9kiQ%3D%3D&tos_acceptance[date]=1785747587&tos_acceptance[ip]=54.234.242.13&business_type=individual&business_profile[name]=Chuck+Bartowski&business_profile[url]=https%3A%2F%2Fvipul.gumroad.com%2F&business_profile[product_description]=Chuck+Bartowski&individual[first_name]=Chuck&individual[last_name]=Bartowski&individual[email]=edgare607ae9c_11%40gumroad.com&individual[phone]=0000000000&individual[dob][day]=1&individual[dob][month]=1&individual[dob][year]=1901&individual[address][line1]=address_full_match&individual[address][city]=San+Francisco&individual[address][state]=California&individual[address][postal_code]=94107&individual[address][country]=US&individual[id_number]=000000000&bank_account[country]=US&bank_account[currency]=usd&bank_account[account_number]=000<STRONGBOX_GENERAL_PASSWORD>56789&bank_account[routing_number]=110000000&settings[payouts][schedule][interval]=manual&settings[payouts][debit_negative_balances]=true
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_Af6VSpcUfHh6Me","request_duration_ms":6867}}'
+      Idempotency-Key:
+      - 7e4f9c7f-ecb8-48ed-b204-2f99dc99fbad
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 03 Aug 2026 08:59:50 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '6844'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=FZ2goVfSvmPUwoS3HGpGXa-2giH2JptPPH8L-nlcDPzymMYffzymvDRvlGMICeJTYIanI7EaSQnOfB_w;
+        report-to csp
+      Idempotency-Key:
+      - 7e4f9c7f-ecb8-48ed-b204-2f99dc99fbad
+      Original-Request:
+      - req_RTiwc5RYK640mU
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=FZ2goVfSvmPUwoS3HGpGXa-2giH2JptPPH8L-nlcDPzymMYffzymvDRvlGMICeJTYIanI7EaSQnOfB_w&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=FZ2goVfSvmPUwoS3HGpGXa-2giH2JptPPH8L-nlcDPzymMYffzymvDRvlGMICeJTYIanI7EaSQnOfB_w&t=1"
+      Request-Id:
+      - req_RTiwc5RYK640mU
+      Stripe-Notice:
+      - '2 notices for this request: (1) You are using an outdated API version (2023-10-16).
+        We recommend upgrading to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+        (2) We recommend building your integration using Accounts v2. See https://docs.stripe.com/api/v2/core/accounts'
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1U0HipRRsFIgrq8p",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "minority_owned_business_designation": null,
+            "name": "Chuck Bartowski",
+            "product_description": "Chuck Bartowski",
+            "specified_commercial_transactions_act_url": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": "https://vipul.gumroad.com/"
+          },
+          "business_type": "individual",
+          "capabilities": {
+            "card_payments": "inactive",
+            "transfers": "active"
+          },
+          "charges_enabled": false,
+          "company": {
+            "address": {
+              "city": "San Francisco",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "directors_provided": true,
+            "executives_provided": true,
+            "name": null,
+            "owners_provided": true,
+            "phone": "+10000000000",
+            "tax_id_provided": false,
+            "verification": {
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              }
+            }
+          },
+          "controller": {
+            "fees": {
+              "payer": "application_custom"
+            },
+            "is_controller": true,
+            "losses": {
+              "payments": "application"
+            },
+            "requirement_collection": "application",
+            "stripe_dashboard": {
+              "type": "none"
+            },
+            "type": "application"
+          },
+          "country": "US",
+          "created": 1785747588,
+          "default_currency": "usd",
+          "details_submitted": true,
+          "email": null,
+          "external_accounts": {
+            "object": "list",
+            "data": [
+              {
+                "id": "ba_1U0HipRRsFIgrq8pxY1Yb9wv",
+                "object": "bank_account",
+                "account": "acct_1U0HipRRsFIgrq8p",
+                "account_holder_name": null,
+                "account_holder_type": null,
+                "account_type": null,
+                "available_payout_methods": [
+                  "standard",
+                  "instant"
+                ],
+                "bank_name": "STRIPE TEST BANK",
+                "country": "US",
+                "currency": "usd",
+                "default_for_currency": true,
+                "fingerprint": "l0OxwqZbI4t8wVSU",
+                "future_requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "last4": "6789",
+                "metadata": {},
+                "requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "routing_number": "110000000",
+                "status": "new"
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/accounts/acct_1U0HipRRsFIgrq8p/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "individual": {
+            "id": "person_1U0HipRRsFIgrq8pvL9GTHRC",
+            "object": "person",
+            "account": "acct_1U0HipRRsFIgrq8p",
+            "address": {
+              "city": "San Francisco",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "created": 1785747588,
+            "dob": {
+              "day": 1,
+              "month": 1,
+              "year": 1901
+            },
+            "email": "edgare607ae9c_11@gumroad.com",
+            "first_name": "Chuck",
+            "future_requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "id_number_provided": true,
+            "last_name": "Bartowski",
+            "metadata": {},
+            "phone": "+10000000000",
+            "relationship": {
+              "authorizer": false,
+              "director": false,
+              "executive": false,
+              "legal_guardian": false,
+              "owner": false,
+              "percent_ownership": null,
+              "representative": true,
+              "title": null
+            },
+            "requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": [
+                "address.city",
+                "address.line1",
+                "address.postal_code",
+                "address.state",
+                "id_number",
+                "verification.document"
+              ]
+            },
+            "ssn_last_4_provided": true,
+            "verification": {
+              "additional_document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "details": null,
+              "details_code": null,
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "status": "pending"
+            }
+          },
+          "metadata": {
+            "bank_account_id": "OKW5T4NMBrWG_MhdAf9kiQ==",
+            "tos_agreement_id": "OKW5T4NMBrWG_MhdAf9kiQ==",
+            "user_compliance_info_id": "3B8nXTt16vN7u7qo5vAUbQ==",
+            "user_id": "6"
+          },
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.mcc"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.mcc"
+            ],
+            "past_due": [
+              "business_profile.mcc"
+            ],
+            "pending_verification": [
+              "individual.address.city",
+              "individual.address.line1",
+              "individual.address.postal_code",
+              "individual.address.state",
+              "individual.id_number",
+              "individual.verification.document"
+            ]
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": "CHUCK BART",
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": "Chuck Bartowski",
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null,
+              "hosted_payment_method_save": "offer"
+            },
+            "payments": {
+              "statement_descriptor": "CHUCK BARTOWSKI",
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": true,
+              "schedule": {
+                "delay_days": 2,
+                "interval": "manual"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": 1785747587,
+            "ip": "54.234.242.13",
+            "user_agent": null
+          },
+          "type": "custom"
+        }
+  recorded_at: Mon, 03 Aug 2026 08:59:50 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/Settings_PaymentsController/GET_remediation/warns_instead_of_clearing_the_seller_when_Stripe_paused_payouts_with_no_requirements_outstanding.yml
+++ b/spec/support/fixtures/vcr_cassettes/Settings_PaymentsController/GET_remediation/warns_instead_of_clearing_the_seller_when_Stripe_paused_payouts_with_no_requirements_outstanding.yml
@@ -1,0 +1,372 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts
+    body:
+      encoding: UTF-8
+      string: type=custom&requested_capabilities[0]=card_payments&requested_capabilities[1]=transfers&country=US&default_currency=usd&metadata[user_id]=6&metadata[tos_agreement_id]=qP2s9UXyL7CqmGpuynmLZg%3D%3D&metadata[user_compliance_info_id]=99xAu12m24YYF71OHDNg3g%3D%3D&metadata[bank_account_id]=qP2s9UXyL7CqmGpuynmLZg%3D%3D&tos_acceptance[date]=1785747579&tos_acceptance[ip]=54.234.242.13&business_type=individual&business_profile[name]=Chuck+Bartowski&business_profile[url]=https%3A%2F%2Fvipul.gumroad.com%2F&business_profile[product_description]=Chuck+Bartowski&individual[first_name]=Chuck&individual[last_name]=Bartowski&individual[email]=edgar34075b69_9%40gumroad.com&individual[phone]=0000000000&individual[dob][day]=1&individual[dob][month]=1&individual[dob][year]=1901&individual[address][line1]=address_full_match&individual[address][city]=San+Francisco&individual[address][state]=California&individual[address][postal_code]=94107&individual[address][country]=US&individual[id_number]=000000000&bank_account[country]=US&bank_account[currency]=usd&bank_account[account_number]=000<STRONGBOX_GENERAL_PASSWORD>56789&bank_account[routing_number]=110000000&settings[payouts][schedule][interval]=manual&settings[payouts][debit_negative_balances]=true
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_Z1jiHPh4c57eFj","request_duration_ms":11}}'
+      Idempotency-Key:
+      - c3840af0-5bc4-4227-96a0-4889086a7cc5
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 03 Aug 2026 08:59:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '6843'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=FZ2goVfSvmPUwoS3HGpGXa-2giH2JptPPH8L-nlcDPzymMYffzymvDRvlGMICeJTYIanI7EaSQnOfB_w;
+        report-to csp
+      Idempotency-Key:
+      - c3840af0-5bc4-4227-96a0-4889086a7cc5
+      Original-Request:
+      - req_Af6VSpcUfHh6Me
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=FZ2goVfSvmPUwoS3HGpGXa-2giH2JptPPH8L-nlcDPzymMYffzymvDRvlGMICeJTYIanI7EaSQnOfB_w&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=FZ2goVfSvmPUwoS3HGpGXa-2giH2JptPPH8L-nlcDPzymMYffzymvDRvlGMICeJTYIanI7EaSQnOfB_w&t=1"
+      Request-Id:
+      - req_Af6VSpcUfHh6Me
+      Stripe-Notice:
+      - '2 notices for this request: (1) You are using an outdated API version (2023-10-16).
+        We recommend upgrading to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+        (2) We recommend building your integration using Accounts v2. See https://docs.stripe.com/api/v2/core/accounts'
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1U0HihEX5j2N4LCh",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "minority_owned_business_designation": null,
+            "name": "Chuck Bartowski",
+            "product_description": "Chuck Bartowski",
+            "specified_commercial_transactions_act_url": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": "https://vipul.gumroad.com/"
+          },
+          "business_type": "individual",
+          "capabilities": {
+            "card_payments": "inactive",
+            "transfers": "active"
+          },
+          "charges_enabled": false,
+          "company": {
+            "address": {
+              "city": "San Francisco",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "directors_provided": true,
+            "executives_provided": true,
+            "name": null,
+            "owners_provided": true,
+            "phone": "+10000000000",
+            "tax_id_provided": false,
+            "verification": {
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              }
+            }
+          },
+          "controller": {
+            "fees": {
+              "payer": "application_custom"
+            },
+            "is_controller": true,
+            "losses": {
+              "payments": "application"
+            },
+            "requirement_collection": "application",
+            "stripe_dashboard": {
+              "type": "none"
+            },
+            "type": "application"
+          },
+          "country": "US",
+          "created": 1785747582,
+          "default_currency": "usd",
+          "details_submitted": true,
+          "email": null,
+          "external_accounts": {
+            "object": "list",
+            "data": [
+              {
+                "id": "ba_1U0HiiEX5j2N4LChX1JDmmgR",
+                "object": "bank_account",
+                "account": "acct_1U0HihEX5j2N4LCh",
+                "account_holder_name": null,
+                "account_holder_type": null,
+                "account_type": null,
+                "available_payout_methods": [
+                  "standard",
+                  "instant"
+                ],
+                "bank_name": "STRIPE TEST BANK",
+                "country": "US",
+                "currency": "usd",
+                "default_for_currency": true,
+                "fingerprint": "l0OxwqZbI4t8wVSU",
+                "future_requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "last4": "6789",
+                "metadata": {},
+                "requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "routing_number": "110000000",
+                "status": "new"
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/accounts/acct_1U0HihEX5j2N4LCh/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "individual": {
+            "id": "person_1U0HiiEX5j2N4LChPCFeK31n",
+            "object": "person",
+            "account": "acct_1U0HihEX5j2N4LCh",
+            "address": {
+              "city": "San Francisco",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "created": 1785747581,
+            "dob": {
+              "day": 1,
+              "month": 1,
+              "year": 1901
+            },
+            "email": "edgar34075b69_9@gumroad.com",
+            "first_name": "Chuck",
+            "future_requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "id_number_provided": true,
+            "last_name": "Bartowski",
+            "metadata": {},
+            "phone": "+10000000000",
+            "relationship": {
+              "authorizer": false,
+              "director": false,
+              "executive": false,
+              "legal_guardian": false,
+              "owner": false,
+              "percent_ownership": null,
+              "representative": true,
+              "title": null
+            },
+            "requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": [
+                "address.city",
+                "address.line1",
+                "address.postal_code",
+                "address.state",
+                "id_number",
+                "verification.document"
+              ]
+            },
+            "ssn_last_4_provided": true,
+            "verification": {
+              "additional_document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "details": null,
+              "details_code": null,
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "status": "pending"
+            }
+          },
+          "metadata": {
+            "bank_account_id": "qP2s9UXyL7CqmGpuynmLZg==",
+            "tos_agreement_id": "qP2s9UXyL7CqmGpuynmLZg==",
+            "user_compliance_info_id": "99xAu12m24YYF71OHDNg3g==",
+            "user_id": "6"
+          },
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.mcc"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.mcc"
+            ],
+            "past_due": [
+              "business_profile.mcc"
+            ],
+            "pending_verification": [
+              "individual.address.city",
+              "individual.address.line1",
+              "individual.address.postal_code",
+              "individual.address.state",
+              "individual.id_number",
+              "individual.verification.document"
+            ]
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": "CHUCK BART",
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": "Chuck Bartowski",
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null,
+              "hosted_payment_method_save": "offer"
+            },
+            "payments": {
+              "statement_descriptor": "CHUCK BARTOWSKI",
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": true,
+              "schedule": {
+                "delay_days": 2,
+                "interval": "manual"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": 1785747579,
+            "ip": "54.234.242.13",
+            "user_agent": null
+          },
+          "type": "custom"
+        }
+  recorded_at: Mon, 03 Aug 2026 08:59:45 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/Settings_PaymentsController/GET_verify_stripe_remediation/warns_on_the_return_trip_when_Stripe_paused_payouts_with_nothing_outstanding.yml
+++ b/spec/support/fixtures/vcr_cassettes/Settings_PaymentsController/GET_verify_stripe_remediation/warns_on_the_return_trip_when_Stripe_paused_payouts_with_nothing_outstanding.yml
@@ -1,0 +1,372 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts
+    body:
+      encoding: UTF-8
+      string: type=custom&requested_capabilities[0]=card_payments&requested_capabilities[1]=transfers&country=US&default_currency=usd&metadata[user_id]=6&metadata[tos_agreement_id]=1ZbZVmM9fZbfGoT8zJiDJw%3D%3D&metadata[user_compliance_info_id]=d-qjI1chhB5ZacH8vx3VWg%3D%3D&metadata[bank_account_id]=1ZbZVmM9fZbfGoT8zJiDJw%3D%3D&tos_acceptance[date]=1785747604&tos_acceptance[ip]=54.234.242.13&business_type=individual&business_profile[name]=Chuck+Bartowski&business_profile[url]=https%3A%2F%2Fvipul.gumroad.com%2F&business_profile[product_description]=Chuck+Bartowski&individual[first_name]=Chuck&individual[last_name]=Bartowski&individual[email]=edgar15d55374_41%40gumroad.com&individual[phone]=0000000000&individual[dob][day]=1&individual[dob][month]=1&individual[dob][year]=1901&individual[address][line1]=address_full_match&individual[address][city]=San+Francisco&individual[address][state]=California&individual[address][postal_code]=94107&individual[address][country]=US&individual[id_number]=000000000&bank_account[country]=US&bank_account[currency]=usd&bank_account[account_number]=000<STRONGBOX_GENERAL_PASSWORD>56789&bank_account[routing_number]=110000000&settings[payouts][schedule][interval]=manual&settings[payouts][debit_negative_balances]=true
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_HgXhhXSX8Lwk8M","request_duration_ms":3}}'
+      Idempotency-Key:
+      - 5902b3c0-2038-486d-a163-e17b6e3646cb
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 03 Aug 2026 09:00:08 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '6844'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=01MnExtAgFnNp2iCd4vgPSSeqSyFcjJPFGaxtzLXzXQvXsh3DRQNjqyheu4A028r5BbmrbJOIScdkceS;
+        report-to csp
+      Idempotency-Key:
+      - 5902b3c0-2038-486d-a163-e17b6e3646cb
+      Original-Request:
+      - req_uwJIn3TmOiVanW
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=01MnExtAgFnNp2iCd4vgPSSeqSyFcjJPFGaxtzLXzXQvXsh3DRQNjqyheu4A028r5BbmrbJOIScdkceS&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=01MnExtAgFnNp2iCd4vgPSSeqSyFcjJPFGaxtzLXzXQvXsh3DRQNjqyheu4A028r5BbmrbJOIScdkceS&t=1"
+      Request-Id:
+      - req_uwJIn3TmOiVanW
+      Stripe-Notice:
+      - '2 notices for this request: (1) You are using an outdated API version (2023-10-16).
+        We recommend upgrading to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+        (2) We recommend building your integration using Accounts v2. See https://docs.stripe.com/api/v2/core/accounts'
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1U0Hj7IhAuythZls",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "minority_owned_business_designation": null,
+            "name": "Chuck Bartowski",
+            "product_description": "Chuck Bartowski",
+            "specified_commercial_transactions_act_url": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": "https://vipul.gumroad.com/"
+          },
+          "business_type": "individual",
+          "capabilities": {
+            "card_payments": "inactive",
+            "transfers": "active"
+          },
+          "charges_enabled": false,
+          "company": {
+            "address": {
+              "city": "San Francisco",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "directors_provided": true,
+            "executives_provided": true,
+            "name": null,
+            "owners_provided": true,
+            "phone": "+10000000000",
+            "tax_id_provided": false,
+            "verification": {
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              }
+            }
+          },
+          "controller": {
+            "fees": {
+              "payer": "application_custom"
+            },
+            "is_controller": true,
+            "losses": {
+              "payments": "application"
+            },
+            "requirement_collection": "application",
+            "stripe_dashboard": {
+              "type": "none"
+            },
+            "type": "application"
+          },
+          "country": "US",
+          "created": 1785747606,
+          "default_currency": "usd",
+          "details_submitted": true,
+          "email": null,
+          "external_accounts": {
+            "object": "list",
+            "data": [
+              {
+                "id": "ba_1U0Hj7IhAuythZlsZim5MomH",
+                "object": "bank_account",
+                "account": "acct_1U0Hj7IhAuythZls",
+                "account_holder_name": null,
+                "account_holder_type": null,
+                "account_type": null,
+                "available_payout_methods": [
+                  "standard",
+                  "instant"
+                ],
+                "bank_name": "STRIPE TEST BANK",
+                "country": "US",
+                "currency": "usd",
+                "default_for_currency": true,
+                "fingerprint": "l0OxwqZbI4t8wVSU",
+                "future_requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "last4": "6789",
+                "metadata": {},
+                "requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "routing_number": "110000000",
+                "status": "new"
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/accounts/acct_1U0Hj7IhAuythZls/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "individual": {
+            "id": "person_1U0Hj7IhAuythZlsWYqHmNct",
+            "object": "person",
+            "account": "acct_1U0Hj7IhAuythZls",
+            "address": {
+              "city": "San Francisco",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "created": 1785747606,
+            "dob": {
+              "day": 1,
+              "month": 1,
+              "year": 1901
+            },
+            "email": "edgar15d55374_41@gumroad.com",
+            "first_name": "Chuck",
+            "future_requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "id_number_provided": true,
+            "last_name": "Bartowski",
+            "metadata": {},
+            "phone": "+10000000000",
+            "relationship": {
+              "authorizer": false,
+              "director": false,
+              "executive": false,
+              "legal_guardian": false,
+              "owner": false,
+              "percent_ownership": null,
+              "representative": true,
+              "title": null
+            },
+            "requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": [
+                "address.city",
+                "address.line1",
+                "address.postal_code",
+                "address.state",
+                "id_number",
+                "verification.document"
+              ]
+            },
+            "ssn_last_4_provided": true,
+            "verification": {
+              "additional_document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "details": null,
+              "details_code": null,
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "status": "pending"
+            }
+          },
+          "metadata": {
+            "bank_account_id": "1ZbZVmM9fZbfGoT8zJiDJw==",
+            "tos_agreement_id": "1ZbZVmM9fZbfGoT8zJiDJw==",
+            "user_compliance_info_id": "d-qjI1chhB5ZacH8vx3VWg==",
+            "user_id": "6"
+          },
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.mcc"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.mcc"
+            ],
+            "past_due": [
+              "business_profile.mcc"
+            ],
+            "pending_verification": [
+              "individual.address.city",
+              "individual.address.line1",
+              "individual.address.postal_code",
+              "individual.address.state",
+              "individual.id_number",
+              "individual.verification.document"
+            ]
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": "CHUCK BART",
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": "Chuck Bartowski",
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null,
+              "hosted_payment_method_save": "offer"
+            },
+            "payments": {
+              "statement_descriptor": "CHUCK BARTOWSKI",
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": true,
+              "schedule": {
+                "delay_days": 2,
+                "interval": "manual"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": 1785747604,
+            "ip": "54.234.242.13",
+            "user_agent": null
+          },
+          "type": "custom"
+        }
+  recorded_at: Mon, 03 Aug 2026 09:00:08 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## What

Stop telling a seller "Thanks! You're all set." when **Stripe** has paused their payouts and has left every requirement list empty.

`Settings::PaymentsController` had three places that emitted that message once it saw no outstanding requirements. `#remediation` and `#verify_stripe_remediation` now route through one `nothing_open_flash` helper: if the seller's payouts are paused internally *and* the pause source is Stripe, they get an alert naming the state and pointing at support instead. Anything else — an admin pause, a system pause, a genuinely clean account — keeps the existing notice verbatim.

The `#update` action's notice is untouched; that one fires after a successful settings save, where "all set" is true.

## Why

Closes antiwork/gumroad-private#1760. Same mechanism as antiwork/gumroad-private#1756.

Stripe can set `payouts_enabled: false` with `disabled_reason: "other"` and **`currently_due`, `past_due`, `eventually_due`, and all three `future_requirements` lists empty**. That is an intervention Stripe raises and clears out of band; nothing is owed by the seller and nothing is owed by us.

Every check in `stripe_account_has_open_requirements?` passes for that account, so the code concluded the seller was fine. Two live accounts in that exact state today:

| Account | State | Impact |
|---|---|---|
| `acct_1TZlWPS0vUX314fX` (PK) | `disabled_reason: "other"`, all 3 lists empty, paused by Stripe 04:40Z | $130.01 payout due 2026-08-04 |
| `acct_1Tgznt29UsFg4ivM` | 5 interventions since 2026-07-07, `pending_verification` only | $110.94 held since 2026-06-25, seller threatening legal action |

This matters *now* because #6901 is about to give these sellers a remediation link they never had. Before that PR, an intervention-only seller saw a dead-end banner. After it, they see a button — and with this bug still in place, clicking it walks them to Stripe and back and tells them they are all set while their payout stays blocked. The reassuring dead end is worse than the silent one: it converts "nobody has told me what's wrong" into "Gumroad says nothing is wrong", which is what the #1756 seller escalated over.

**Why the pause source and not the disabled reason.** `disabled_reason` is Stripe's string and carries several values that mean genuinely different things (`rejected.*` is already short-circuited earlier in the action). `payouts_paused_by_source == "stripe"` is our own recorded fact, written by the payouts sync job when it mirrors Stripe's state, so it is the narrowest signal that means exactly "Stripe stopped this, not us".

**Why an alert rather than removing the message.** Rendering nothing leaves the seller on a page with a pause banner and no explanation of the click they just made. Naming the state is the honest remedy when no code path can fix the underlying problem — the fix is a support write, so the copy routes there.

## Before / After

Backend classification change; the rendered surface is one flash on `/settings/payments`. Table generated by driving the controller through both branches at each ref.

Seller state: Stripe account present, `payouts_paused_internally = true`, `payouts_paused_by = "stripe"`, zero `UserComplianceInfoRequest` rows, all six Stripe requirement lists empty.

| | `GET /settings/payments/remediation` | `GET .../verify_stripe_remediation` |
|---|---|---|
| Before (`origin/main`) | notice: *"Thanks! You're all set."* | notice: *"Thanks! You're all set."* |
| After (this branch) | alert: *"Stripe has paused payouts on your account and hasn't told us what it needs. There's nothing for you to submit — please contact support and we'll chase it with Stripe."* | same alert |

Control arm — pause source `admin`, everything else identical:

| | flash |
|---|---|
| Before | notice: *"Thanks! You're all set."* |
| After | notice: *"Thanks! You're all set."* (unchanged) |

No preview-app capture: branch preview deploys are down fleet-wide on the Nomad placement fault tracked in antiwork/gumroad-private#1699 (no release cut since `v2026.08.02.29`, 19 commits stranded). The flash strings above are asserted directly in the specs listed below.

## Test Results

Run locally in a dedicated worktree at `a3190e91`, `DISABLE_SPRING=1 OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES bundle exec rspec spec/controllers/settings/payments_controller_spec.rb -e "GET remediation" -e "GET verify_stripe_remediation"`:

- **21 examples, 0 failures** (45.67s) — the 18 pre-existing examples in both groups plus the 3 added below.
- `ruby -c` on both changed files.

Added examples:
- `warns instead of clearing the seller when Stripe paused payouts with no requirements outstanding` — the reported state.
- `still says 'all set' when the pause came from us rather than Stripe` — the control arm; this is the example that distinguishes "classify by pause source" from "drop the message whenever payouts are paused".
- `warns on the return trip when Stripe paused payouts with nothing outstanding` — `#verify_stripe_remediation`, the frame the seller lands on coming back from Stripe.

Mutation check: replacing the pause-source condition with `if false` (i.e. reverting to main's unconditional notice) reddens the two new Stripe-pause examples and leaves the control-arm example green, which is the correct signature — a mutant that made all three fail would mean the control arm was not testing the branch.

Stale-pin sweep: `grep -rn "Thanks! You're all set" spec/ test/` returns 20+ hits, all in `spec/requests/settings/payments_spec.rb` against the `#update` action, which this PR does not touch. None exercises `#remediation` with a paused account.

## QA steps

1. Pick a seller with a Stripe account and no open `UserComplianceInfoRequest` rows.
2. `user.update!(payouts_paused_internally: true, payouts_paused_by: "stripe")`.
3. Visit `/settings/payments` and click through the "Complete pending verification requirements via Stripe" action (added in #6901).
4. Expect the support-routing alert, **not** "Thanks! You're all set."
5. Set `payouts_paused_by: nil, payouts_paused_internally: false` and repeat — the original notice should be back.

## Not in this PR

- The operational half of both issues: Stripe re-opening interventions within seconds of clearing one (antiwork/gumroad-private#1756) and the PK account's `disabled_reason: "other"` with zero requirements (antiwork/gumroad-private#1760). Both need a `support.stripe.com` case; neither is narrowed by this change.
- Any change to how the pause banner itself reads on `/settings/payments`.

---

🤖 Generated with Hermes Agent using **claude-opus-5**.

Instructions given: autonomous dispatcher run over the antiwork/gumroad-private backlog — take the simplest open issue with no PR covering it, verify the described defect still exists at `origin/main`, build the smallest complete fix with specs, and open a draft PR.
