### PR TITLE
Tell library buyers removal is reversible, because it is

### DIFF
--- a/app/controllers/library_controller.rb
+++ b/app/controllers/library_controller.rb
@@ -54,7 +54,7 @@ class LibraryController < Sellers::BaseController
 
     @purchase.update!(is_deleted_by_buyer: true)
 
-    redirect_to library_path, notice: "Product deleted!", status: :see_other
+    redirect_to library_path, notice: "Removed from your library!", status: :see_other
   end
 
   private

--- a/app/javascript/components/DownloadPage/Layout.tsx
+++ b/app/javascript/components/DownloadPage/Layout.tsx
@@ -377,7 +377,7 @@ const PurchaseDeleteButton = ({
           <>
             <Button onClick={() => setIsDeleteModalOpen(false)}>Cancel</Button>
             <Button color="danger" onClick={handleDelete}>
-              {isDeleting ? "Deleting..." : "Confirm"}
+              {isDeleting ? "Removing..." : "Confirm"}
             </Button>
           </>
         }

--- a/app/javascript/components/DownloadPage/Layout.tsx
+++ b/app/javascript/components/DownloadPage/Layout.tsx
@@ -355,7 +355,7 @@ const PurchaseDeleteButton = ({
     setIsDeleting(true);
     try {
       await deletePurchasedProduct({ purchase_id });
-      showAlert("Product deleted!", "success");
+      showAlert("Removed from your library!", "success");
       window.location.href = Routes.library_path();
     } catch (e) {
       assertResponseError(e);
@@ -367,12 +367,12 @@ const PurchaseDeleteButton = ({
   return (
     <>
       <Button color="danger" onClick={() => setIsDeleteModalOpen(true)}>
-        Delete permanently
+        Remove from library
       </Button>
       <Modal
         open={isDeleteModalOpen}
         onClose={() => setIsDeleteModalOpen(false)}
-        title="Delete Product"
+        title="Remove from library"
         footer={
           <>
             <Button onClick={() => setIsDeleteModalOpen(false)}>Cancel</Button>
@@ -382,9 +382,15 @@ const PurchaseDeleteButton = ({
           </>
         }
       >
-        <span className="inline">
-          Are you sure you want to delete <b>{product_name ?? ""}</b>?
-        </span>
+        <div>
+          <span className="inline">
+            Remove <b>{product_name ?? ""}</b> from your library?
+          </span>
+          <p>
+            You keep access through this page's link, and our support team can put the card back if you change your
+            mind.
+          </p>
+        </div>
       </Modal>
     </>
   );

--- a/app/javascript/pages/Library/Index.test.tsx
+++ b/app/javascript/pages/Library/Index.test.tsx
@@ -259,3 +259,22 @@ describe("LibraryPage", () => {
     expect(lastGetParams()).toEqual({ sort: "purchase_date" });
   });
 });
+
+describe("removal copy", () => {
+  it("offers removal rather than permanent deletion, and says the card can come back", () => {
+    renderPage();
+
+    const card = screen.getAllByRole("button", { name: "Open product action menu" })[0];
+    if (!card) throw new Error("expected a product card menu");
+    fireEvent.click(card);
+
+    fireEvent.click(screen.getByText("Remove from library"));
+
+    expect(screen.getByText(/from your library\?/u)).toBeTruthy();
+    expect(screen.getByText(/our support team can put the card back/u)).toBeTruthy();
+    // `is_deleted_by_buyer` is reversible, so copy claiming otherwise is the defect
+    // (gumroad-private#1762).
+    expect(screen.queryByText(/permanently/iu)).toBeNull();
+    expect(screen.queryByText(/cannot be undone/iu)).toBeNull();
+  });
+});

--- a/app/javascript/pages/Library/Index.tsx
+++ b/app/javascript/pages/Library/Index.tsx
@@ -120,7 +120,7 @@ export const Card = ({
                 </MenuItem>
                 <MenuItem variant="danger" onClick={() => onDelete()}>
                   <Trash className="size-5" />
-                  Delete permanently
+                  Remove from library
                 </MenuItem>
               </Menu>
             </PopoverContent>
@@ -144,7 +144,7 @@ export const DeleteProductModal = ({
     try {
       await deletePurchasedProduct({ purchase_id: result.purchase.id });
       onDelete(result);
-      showAlert("Product deleted!", "success");
+      showAlert("Removed from your library!", "success");
     } catch (e) {
       assertResponseError(e);
       showAlert("Something went wrong.", "error");
@@ -155,7 +155,7 @@ export const DeleteProductModal = ({
     <Modal
       open={!!deleting}
       onClose={onCancel}
-      title="Delete Product"
+      title="Remove from library"
       footer={
         <>
           <Button onClick={onCancel}>Cancel</Button>
@@ -165,7 +165,11 @@ export const DeleteProductModal = ({
         </>
       }
     >
-      <h4>Are you sure you want to delete {deleting?.product.name ?? ""}?</h4>
+      <h4>Remove {deleting?.product.name ?? ""} from your library?</h4>
+      <p>
+        You keep access through your original download link, and our support team can put the card back if you change
+        your mind.
+      </p>
     </Modal>
   );
 };
@@ -282,7 +286,7 @@ export default function LibraryPage() {
     try {
       await deletePurchasedProduct({ purchase_id: result.purchase.id });
       router.reload();
-      showAlert("Product deleted!", "success");
+      showAlert("Removed from your library!", "success");
     } catch (e) {
       assertResponseError(e);
       showAlert("Something went wrong.", "error");

--- a/app/views/help_center/articles/contents/_198-your-gumroad-library.html.erb
+++ b/app/views/help_center/articles/contents/_198-your-gumroad-library.html.erb
@@ -6,7 +6,7 @@
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/64b7bbd9d48f7f58ce212b7b/file-PJ51jIBfWe.png" %></figure>
   <h3>Removing and restoring products</h3>
   <p>In your Gumroad library, simply scroll to the product that you want to archive or delete and click the three dots on the bottom-right that appear when you hover over the product.</p>
-  <p>If you want to permanently remove the product, click "Delete permanently".</p>
+  <p>If you want to take the product's card out of your library, click "Remove from library". You keep access through your original download link, and our support team can put the card back if you change your mind — <a href="https://help.gumroad.com/">contact us</a> and tell us which product it was.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/64b7bc68c2f5ed048130c845/file-vA9IglTFdv.gif" %></figure>
   <p>If you simply don't want to see the product in your library but might want to access it later, archive it. </p>
   <p>You can easily see your archived products again by clicking “Show archived only” on the left side of your screen, and unarchive them again from the three-dots menu.</p>

--- a/app/views/help_center/articles/contents/_198-your-gumroad-library.html.erb
+++ b/app/views/help_center/articles/contents/_198-your-gumroad-library.html.erb
@@ -5,7 +5,7 @@
   <p><a href="https://gumroad.com/signup">If you create a new Gumroad account</a>, you can access your library immediately from <a href="https://gumroad.com/library">here</a>. Be sure to sign up with the same email address you used to buy products, so your purchases can be automatically synced with your new account.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/64b7bbd9d48f7f58ce212b7b/file-PJ51jIBfWe.png" %></figure>
   <h3>Removing and restoring products</h3>
-  <p>In your Gumroad library, simply scroll to the product that you want to archive or delete and click the three dots on the bottom-right that appear when you hover over the product.</p>
+  <p>In your Gumroad library, simply scroll to the product that you want to archive or remove and click the three dots on the bottom-right that appear when you hover over the product.</p>
   <p>If you want to take the product's card out of your library, click "Remove from library". You keep access through your original download link, and our support team can put the card back if you change your mind — <a href="https://help.gumroad.com/">contact us</a> and tell us which product it was.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/64b7bc68c2f5ed048130c845/file-vA9IglTFdv.gif" %></figure>
   <p>If you simply don't want to see the product in your library but might want to access it later, archive it. </p>

--- a/spec/controllers/library_controller_spec.rb
+++ b/spec/controllers/library_controller_spec.rb
@@ -316,13 +316,20 @@ describe LibraryController, :vcr, type: :controller, inertia: true do
       let(:request_params) { { id: purchase.external_id } }
     end
 
-    it "deletes the purchase" do
+    it "hides the purchase from the library without deleting the row" do
       expect do
         patch :delete, params: { id: purchase.external_id }
 
         expect(response).to redirect_to(library_path)
-        expect(flash[:notice]).to eq("Product deleted!")
+        expect(flash[:notice]).to eq("Removed from your library!")
       end.to change { purchase.reload.is_deleted_by_buyer }.from(false).to(true)
+
+      # The copy promises the buyer keeps access and support can restore the card, so removal must
+      # stay a reversible flag flip (gumroad-private#1762).
+      expect(Purchase.exists?(purchase.id)).to be(true)
+      expect(purchase.reload.purchase_state).to eq("successful")
+      purchase.update!(is_deleted_by_buyer: false)
+      expect(user.purchases.visible_in_library).to include(purchase)
     end
   end
 end

--- a/spec/requests/library_spec.rb
+++ b/spec/requests/library_spec.rb
@@ -526,12 +526,16 @@ describe("Library Scenario", type: :system, js: true) do
     within find_product_card(purchase.link).hover do
       find_and_click "[aria-label='Open product action menu']"
     end
-    click_on "Delete permanently"
-    expect(page).to have_text("Are you sure you want to delete #{purchase.link_name}?")
+    click_on "Remove from library"
+    expect(page).to have_text("Remove #{purchase.link_name} from your library?")
+    # The buyer is told removal is reversible, because it is: the row survives and support can
+    # clear the flag (gumroad-private#1762).
+    expect(page).to have_text("our support team can put the card back")
     click_on "Confirm"
 
     wait_for_ajax
     expect(page).to_not have_product_card(purchase.link)
+    expect(purchase.reload.is_deleted_by_buyer).to be(true)
   end
 
   it "paginates results and shows the next page when a page link is clicked" do


### PR DESCRIPTION
## What

The library card's removal action is renamed from **Delete permanently** to **Remove from library**, and its confirmation now tells the buyer what actually happens: they keep access through their download link, and support can put the card back.

Five surfaces, all describing the same `is_deleted_by_buyer` flag flip:

| Surface | Before | After |
|---|---|---|
| Library card menu item (`pages/Library/Index.tsx`) | `Delete permanently` | `Remove from library` |
| Library confirm modal title | `Delete Product` | `Remove from library` |
| Library confirm modal body | `Are you sure you want to delete <name>?` | `Remove <name> from your library?` + the reversibility line |
| Download-page button + modal (`DownloadPage/Layout.tsx`) | `Delete permanently` / `Delete Product` / `Are you sure you want to delete <name>?` | same wording as the library |
| Server flash (`LibraryController#delete`) | `Product deleted!` | `Removed from your library!` |
| Help center article 198 | `click "Delete permanently"` | names the new label and says support can restore the card |

No behaviour change: the route, the controller write, and the flag are untouched.

## Why

`LibraryController#delete` sets `is_deleted_by_buyer` (flag bit 20), and `Purchase.visible_in_library` filters `.not_is_deleted_by_buyer`. The purchase row survives intact — `Admin::PurchasesController#undelete` exists precisely to clear the flag, and `Purchase::ReassignByEmailService` clears it too. `UrlRedirectsController#check_permissions` never consults it, so the buyer's download link keeps working after removal.

So the word *permanently* was false on every one of those surfaces, and it was false in the direction that costs the most: a buyer who removes a card and wants it back has no self-serve path, and the only remedy is a support ticket that a prod-console write closes.

Found while working the cluster of ops tickets filed against that lane. gumroad-private#1762 is the second instance of the identical request from the *same buyer* inside a week (the first, four Zoltium purchases, was restored by console on 2026-07-30). The pattern the tickets share is not a code bug in the flag — it is that the UI told the buyer the action was irreversible, so nobody expected to be able to undo it and nobody was offered a way.

This does not close #1762 or its siblings (#1757, #1759, #1758 are prod-console writes blocked on #1752) and it does not narrow them. It stops the lane refilling.

### Not in this PR

- **A "Removed" tab on the library**, mirroring the existing Archived tab, which would make this fully self-serve and retire the support lane. That is a real feature (presenter scope, filter state, counts, an unremove route) and wants its own issue — happy to open it.
- The mobile API's `Api::Mobile::PurchasesController#destroy` sets the same flag but returns JSON with no user-facing copy, so there is nothing to reword there.
- No change to product *deletion* by sellers (`ProductsPage/ActionsPopover.tsx`, help article 248) — that one genuinely is permanent, and its copy is correct.

## Before-After

The change is copy on rendered surfaces. The decisive artifact is the source-level assertion added to `pages/Library/Index.test.tsx`, which drives the real component, opens the real modal, and asserts the reversibility sentence is present and that no `permanently` / `cannot be undone` string survives anywhere in the dialog. That is what stops the old framing coming back in a future edit, which a screenshot cannot do.

Preview-app captures are owed. Preview infra was down earlier this morning (gumroad-private#1699) but has **partially recovered**: sweeping all 50 recent preview deployments this run, 5 hosts return 200 with certificates issued 08:23–08:34Z, 4 fail the TLS handshake, 1 returns 500, and every deployment older than ~08:20Z reports `failure` with no `environment_url` at all. This branch has no preview deployment yet. The PR stays **draft** until one lands and the two modals are captured.

## Test Results

Run locally in a dedicated worktree at `d1e304e`, load average 74–85:

- `npx vitest run app/javascript/pages/Library/Index.test.tsx` — **11 passed (11)**, 157.3s. Includes the new `removal copy` example.
- **Mutation proof**: reverting the menu item to `Delete permanently` reddens exactly the new example — `Tests 1 failed | 10 passed (11)`, `Unable to find an element with the text: Remove from library` — while the other 10 stay green. The assertion has teeth and is scoped to the copy under change.
- `ruby -c` on `library_controller.rb`, `library_controller_spec.rb`, `library_spec.rb` — Syntax OK.
- ERB parse of `_198-your-gumroad-library.html.erb` — OK.
- Not run locally: `spec/requests/library_spec.rb` (system spec — needs a lane's MySQL/Redis/Chrome, and the lane allocator refuses above load 35; measured 74+ this run). It is updated in this diff and the `Tests` workflow covers it.

### Stale test pins swept and inverted

Three assertions pinned the retired copy. Sweeping the literal, not just the symbol:

- `spec/requests/library_spec.rb:529-530` — clicked `"Delete permanently"` and asserted `"Are you sure you want to delete …"`. Rewritten to the new labels, plus an assertion that the reversibility sentence renders and that `is_deleted_by_buyer` is what actually flipped.
- `spec/controllers/library_controller_spec.rb:324` — asserted the `"Product deleted!"` flash. Retitled from `"deletes the purchase"` (which named the retired framing) to `"hides the purchase from the library without deleting the row"`, and extended to prove the row survives and re-clearing the flag brings it back through `visible_in_library` — the exact restore support performs.
- `spec/requests/products/index_spec.rb` also matches `"Product deleted!"` but that is the seller-side product deletion, a different and genuinely permanent action. Left alone.

## QA steps

Executed this run against the code:

1. `git grep -n "Delete permanently" origin/main -- app` → the library card, the download page, and help article 248. Confirmed 248 is the seller flow and out of scope.
2. Read `Admin::PurchasesController#undelete` (`app/controllers/admin/purchases_controller.rb:133`) — clears `is_deleted_by_buyer` and writes an audit comment. This is the code path the new copy promises exists.
3. Read `UrlRedirectsController#check_permissions` — does not consult the flag, so "you keep access through your download link" is accurate.
4. Confirmed `Purchase` has no `deleted_at` column, so removal cannot be a row delete under any code path.

Owed once previews are reachable: open `/library`, hover a card, open the ⋯ menu, click **Remove from library**, capture the modal; then the same on a `/d/<token>` download page.

---

## AI disclosure

Written by Hermes Agent (`claude-opus-5`) running autonomously as gumclaw's dev dispatcher.

Instructions given: drain the qualifying gumroad-private backlog issue → PR; on an ops ticket, read the root-cause section as a build brief and ship the code half while the ops half stays parked.
