### PR TITLE
Clear stale accepted cross-sell offer on cart update

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -71,6 +71,12 @@ class CheckoutController < ApplicationController
             original_product_id: accepted_offer[:original_product_id],
             original_variant_id: accepted_offer[:original_variant_id],
           }
+        else
+          # A cart item that no longer carries an accepted offer must clear any offer left on the
+          # existing row. This happens when a buyer removes the product that triggered a cross-sell;
+          # retaining the association makes a later cart reload resurrect the discount and upsell.
+          cart_product.accepted_offer = nil
+          cart_product.accepted_offer_details = {}
         end
         cart_product.price = item[:price]
         cart_product.quantity = item[:quantity]

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -645,6 +645,45 @@ describe CheckoutController, type: :controller, inertia: true do
         )
       end
 
+      it "clears a stale accepted offer when the cart item is submitted without one" do
+        original_product = create(:product, user: seller)
+        offered_product = create(:product, user: seller)
+        cross_sell = create(
+          :upsell,
+          seller:,
+          product: offered_product,
+          selected_products: [original_product],
+          cross_sell: true
+        )
+        cart = create(:cart, user: controller.logged_in_user)
+        cart_product = create(
+          :cart_product,
+          cart:,
+          product: offered_product,
+          accepted_offer: cross_sell,
+          accepted_offer_details: { original_product_id: original_product.external_id, original_variant_id: nil }
+        )
+
+        patch :update, params: {
+          cart: {
+            items: [{
+              product: { id: offered_product.external_id },
+              price: offered_product.price_cents,
+              quantity: 1,
+              rent: false,
+              referrer: "direct",
+              url_parameters: {},
+              accepted_offer: nil
+            }],
+            discountCodes: []
+          }
+        }, as: :json
+
+        expect(response).to have_http_status(:see_other)
+        expect(response).to redirect_to(checkout_path)
+        expect(cart_product.reload).to have_attributes(accepted_offer: nil, accepted_offer_details: {})
+      end
+
       it "forces the cart email to the signed-in user's email regardless of the submitted email" do
         cart = create(:cart, user: seller, email: "stale@example.com")
 


### PR DESCRIPTION
Imports the fix from an external contributor PR (RealBhupesh/gumroad#4), reduced to the code change plus a regression spec.

## Problem

`CheckoutController#update` only wrote `accepted_offer` when the submitted cart item carried one. When an item arrived **without** an offer, the existing `CartProduct` row kept its previous `accepted_offer` association and `accepted_offer_details`.

Buyer-visible effect: a buyer accepts a cross-sell, then removes the product that triggered it. The frontend stops sending the offer, but the row keeps it, so the next cart reload resurrects the removed cross-sell discount and upsell.

## Fix

Add the missing `else` branch in the item loop: when no `accepted_offer` is submitted, clear `accepted_offer` and reset `accepted_offer_details` to `{}`.

```ruby
else
  cart_product.accepted_offer = nil
  cart_product.accepted_offer_details = {}
end
```

## Verification (local, `spec/controllers/checkout_controller_spec.rb:648`)

Failing-first confirmed against the real controller, not a mock:

- On `origin/main` (fix reverted, spec kept) → **RED**
  `Failure/Error: expect(cart_product.reload).to have_attributes(accepted_offer: nil, accepted_offer_details: {})` — 1 example, 1 failure.
- With the fix applied → **GREEN**
  1 example, 0 failures.

The spec seeds a `CartProduct` carrying an accepted offer, PATCHes the cart with the same item and no `accepted_offer`, and asserts the association and details are cleared.

## Scope

Two files, +45 lines, no schema or API-shape change. The contributor's branch also carried screen-recording media, excluded here. Nothing else in the loop's behavior changes — the offer-present path is untouched.

Co-authored-by: RealBhupesh <RealBhupesh@users.noreply.github.com>


## Test Results

Recorded above under *Verification* — restating under the conventional heading so the gate is machine-checkable:

- `spec/controllers/checkout_controller_spec.rb` — the new example at `:648`: **1 example, 0 failures** with the fix applied.
- **Mutation proof / failing-first:** reverting the `else` branch on `origin/main` while keeping the spec reddens exactly that example — `expect(cart_product.reload).to have_attributes(accepted_offer: nil, accepted_offer_details: {})` fails, 1 example / 1 failure. The assertion drives the real controller through a PATCH, not a mock, so it has teeth.

## QA steps

No hosted-preview capture is owed here. The change is a server-side association clear inside `CheckoutController#update`'s item loop; it renders no new pixel and alters no layout, so a screenshot would show an unchanged cart either way. The decisive artifact is the failing-first spec above.

Click-path for a reviewer who wants it by hand:

1. As a buyer, add a product that triggers a cross-sell and accept the offer.
2. Remove the triggering product from the cart.
3. Reload the cart — the cross-sell discount and upsell must **not** reappear. Before this fix they did, because the `CartProduct` row kept its stale `accepted_offer`.

## AI disclosure

Imported and prepared by gumclaw, an AI agent (Hermes Agent, `claude-opus-5`), running autonomously. The code change originates with an external human contributor (@RealBhupesh, RealBhupesh/gumroad#4) and is credited via the `Co-authored-by` trailer; the regression spec, the failing-first verification and this description are the agent's. A human owns the merge.
