### PR TITLE
Release the buyer library's optimistic filter state on any settled navigation

### DIFF
--- a/app/javascript/pages/Library/Index.test.tsx
+++ b/app/javascript/pages/Library/Index.test.tsx
@@ -101,8 +101,7 @@ const creatorCheckbox = (name: string): HTMLInputElement => {
   return input;
 };
 
-type VisitOutcome = { cancelled: boolean; interrupted: boolean };
-type OnFinish = (visit: VisitOutcome) => void;
+type OnFinish = () => void;
 
 // router.get is a vi.fn, so its recorded options are untyped; narrow rather than assert.
 const isOnFinish = (value: unknown): value is OnFinish => typeof value === "function";
@@ -118,8 +117,8 @@ const lastOnFinish = (): OnFinish => {
   return onFinish;
 };
 
-const settleLastVisit = (visit: VisitOutcome = { cancelled: false, interrupted: false }) => {
-  lastOnFinish()(visit);
+const settleLastVisit = () => {
+  lastOnFinish()();
 };
 
 const lastGetParams = (): Record<string, string> => {
@@ -215,6 +214,32 @@ describe("LibraryPage", () => {
     expect(creatorCheckbox("Zoe").checked).toBe(false);
   });
 
+  it("releases the optimistic filter state when an archive reload displaces the visit", () => {
+    renderPage();
+
+    fireEvent.click(creatorCheckbox("Zoe"));
+    expect(creatorCheckbox("Zoe").checked).toBe(true);
+
+    // router.reload() from an archive/delete interrupts the filter visit and echoes the old
+    // search, so the only settle signal is this one — the checkbox must not stay stranded.
+    act(() => settleLastVisit());
+    expect(creatorCheckbox("Zoe").checked).toBe(false);
+  });
+
+  it("hides the archived-purchases banner as soon as the archived filter is clicked", () => {
+    renderPage();
+
+    expect(screen.getByRole("status").textContent).toContain("You have 2 archived purchases");
+
+    const archivedLabel = screen.getByText("Show archived only").closest("label");
+    if (!archivedLabel) throw new Error("expected the archived filter label");
+    fireEvent.click(archivedLabel.querySelector("input") ?? archivedLabel);
+
+    // The banner invites you into the archive, so it must not survive alongside a ticked
+    // "Show archived only" while the request is in flight.
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
   it("keeps the newer click's params when a superseded visit settles", () => {
     renderPage();
 
@@ -224,7 +249,7 @@ describe("LibraryPage", () => {
 
     // Inertia fires onFinish for the visit the second click interrupted; honouring it would
     // discard Ann and put us back at the bug.
-    act(() => supersededVisit({ cancelled: false, interrupted: true }));
+    act(() => supersededVisit());
     expect(creatorCheckbox("Ann").checked).toBe(true);
 
     fireEvent.click(creatorCheckbox("Zoe"));

--- a/app/javascript/pages/Library/Index.tsx
+++ b/app/javascript/pages/Library/Index.tsx
@@ -220,6 +220,11 @@ export default function LibraryPage() {
   // toggles derive their next value from what is rendered.
   const [pendingSearch, setPendingSearch] = React.useState<SearchParams | null>(null);
   const activeSearch = pendingSearch ?? search;
+  // Counts only the visits navigate() started. An interrupted filter visit must keep the
+  // optimistic state when a newer filter click displaced it, but drop it when something
+  // else did — router.reload() from an archive/delete also interrupts, and echoes the old
+  // search, so trusting the interrupted flag alone would strand the controls permanently.
+  const inFlightNavigations = React.useRef(0);
 
   const navigate = ({ page, ...updates }: Partial<SearchParams> & { page?: number }) => {
     const next = { ...activeSearch, ...updates };
@@ -230,16 +235,15 @@ export default function LibraryPage() {
     if (next.bundles.length > 0) data.bundles = next.bundles.join(",");
     if (next.show_archived_only) data.show_archived_only = "true";
     if (page !== undefined && page > 1) data.page = page.toString();
+    inFlightNavigations.current += 1;
     router.get(Routes.library_path(), data, {
       preserveState: true,
       preserveScroll: page === undefined,
-      onFinish: (visit) => {
-        // Inertia fires this for superseded visits too. Clearing there would drop a newer
-        // click's params and reinstate exactly the bug this fixes, so only a visit that
-        // ran to its own end hands control back to the server's props — which is also what
-        // snaps the controls back when the request failed.
-        if (visit.cancelled || visit.interrupted) return;
-        setPendingSearch(null);
+      onFinish: () => {
+        inFlightNavigations.current -= 1;
+        // The last navigation to settle hands the controls back to the server's props,
+        // whether it succeeded, failed or was displaced by a reload.
+        if (inFlightNavigations.current === 0) setPendingSearch(null);
       },
     });
   };
@@ -359,7 +363,7 @@ export default function LibraryPage() {
             )}
           </Placeholder>
         ) : null}
-        {archivedCount > 0 && !search.show_archived_only && !showArchivedNotice ? (
+        {archivedCount > 0 && !activeSearch.show_archived_only && !showArchivedNotice ? (
           <Alert role="status" variant="info" className="mb-5">
             You have {archivedCount} archived purchase{archivedCount === 1 ? "" : "s"}.{" "}
             <button


### PR DESCRIPTION
- [x] Scope — two review findings against my own #6884, one of them a bug that PR introduced
- [x] Design — n/a: bug fix on an existing surface, no new UI
- [x] Build — `Index.tsx` in-flight counter + banner fix, 2 new vitest examples
- [x] QA — 12 vitest examples green, all three guards mutation-verified individually (below)
- [ ] Shipped
- [ ] Market — n/a
- [ ] Sell — n/a

## What

Follow-up to [#6884](https://github.com/antiwork/gumroad/pull/6884). The adversarial review of that PR finished after it had already merged, and two of its findings are real. Fixing forward.

**1. The `interrupted` guard I shipped can strand the filter controls permanently.** #6884 clears the optimistic filter state from the visit's own `onFinish`, skipping `cancelled`/`interrupted` visits — necessary, because Inertia fires `onFinish` for a visit that a *newer filter click* displaced, and clearing there would discard the newer click's params and reinstate the bug #6884 fixed.

The guard assumed a newer filter click is the only thing that can displace a filter visit. It is not. `refreshAfterArchiveChange` and `deletePurchase` call `router.reload()`, and Inertia's sync request stream is `{ maxConcurrent: 1, interruptible: true }` — so archiving or deleting a card within the round-trip of a filter click interrupts that filter visit too. The reload then echoes the *old* committed `search`, and because my guard skips interrupted visits, nothing ever clears `pendingSearch`. The checkbox stays ticked, permanently, next to a grid that contradicts it — and since the toggles derive from `activeSearch`, the user's instinctive "click it again to fix it" sends the *opposite* of what they want.

`navigate` now counts its own in-flight visits and the last one to settle releases the optimistic state, whatever the reason it settled. That keeps the supersede protection (an earlier visit settling while a newer one is outstanding leaves the count non-zero, so the newer click's params survive) without depending on *why* a visit ended. It also covers the plain failure case — network drop or 500 — which the previous shape only covered incidentally.

**2. The archived banner contradicted its own checkbox mid-flight.** "You have N archived purchases. Click here to view" was keyed to props `search.show_archived_only` while the "Show archived only" checkbox reads `activeSearch`, so for one round-trip after ticking it the page showed a ticked archived filter *and* a banner inviting you into the archive. The banner now reads the same optimistic flag. Its text uses `archivedCount`, which does not change meaning mid-flight, so there is no stale-count hazard here — unlike `showArchivedNotice` and `refreshAfterArchiveChange`, which stay on props `search` deliberately because they pair with counts only the server can update.

Ref antiwork/gumroad-private#1668

## Why

Both are the same class of defect as the original Greptile P1: the buyer's filter shows one thing and the results are another, with no error to explain it. The first one is strictly worse than the bug it came from — the original lost a selection on a fast double-click and self-corrected on the next click, whereas a stranded `pendingSearch` does not self-correct at all and actively inverts the retry.

I shipped that guard, so this is mine to clean up rather than file.

## Before / After

Each guard mutated separately; every mutant reddens only the example that owns it:

```
revert to the interrupted-flag guard   -> FAIL releases the optimistic filter state when an archive reload displaces the visit
clear on every settle (ignore counter) -> FAIL keeps the newer click's params when a superseded visit settles
never decrement the counter            -> FAIL hands the filter controls back to the server's props once the visit settles
banner back on props search            -> FAIL hides the archived-purchases banner as soon as the archived filter is clicked
```

The first line is the regression this PR exists for: the code #6884 merged fails the new archive-reload example.

## Test Results

- `npx vitest run app/javascript/pages/Library/Index.test.tsx` — 12 passed (10 from #6884, 2 new)
- `npx eslint`, `npx prettier --check`, `npx tsc --noEmit` — clean on both touched files

No new system spec: both behaviours are sub-round-trip interleavings that Capybara cannot stage deterministically, which is what the vitest layer is for. The `server-side pagination` group from #6884 is untouched.

One environment note for anyone reproducing locally: `app/javascript/utils/routes.d.ts` is generated and gitignored, so a fresh worktree lints with three phantom `Routes.library_path` errors until you copy it in from a built checkout. Not a code issue.

## QA steps

@nyomanjyotisa — same account as #6884 (products from 6+ creators, plus at least one archived purchase):

1. **The stranding case.** Tick a creator filter and, in the same second, archive one of the visible cards. When the grid settles, the creator checkbox must agree with the products shown — not stay ticked over an unfiltered grid. Then click that checkbox once and confirm it does the obvious thing.
2. **The banner.** With at least one archived purchase, tick "Show archived only" and watch the top of the page during the refresh: the "You have N archived purchases" banner must disappear immediately, not linger next to the ticked box.
3. **Regression guard for #6884.** Tick two creators as fast as you can; both must stay ticked and the results must be the union. This is the behaviour #6884 fixed and this PR must not undo.

Step 1 is the load-bearing one.

## AI disclosure

Written by gumclaw, an AI agent (claude-opus-5), fixing findings from an adversarial review of its own previous PR. A human owns the merge.
