### PR TITLE
Seed a mobile fixture with a third-party video embed

### DIFF
--- a/db/seeds/030_development/mobile_app_test_data.rb
+++ b/db/seeds/030_development/mobile_app_test_data.rb
@@ -86,6 +86,29 @@ def create_mobile_product_file(product:, fixture_name:, file_name:)
   product_file
 end
 
+# A third-party embed, not an uploaded file: `create_mobile_product_file` covers the native
+# player, and nothing here exercised the WebView the embed renders in. The URL has to be a real
+# HTTPS one — the content page turns `attrs.url` into an anchor href and RichContent rejects the
+# script-bearing schemes, so a placeholder like "embed://x" would not save.
+def create_mobile_embed_page(product:, title:)
+  existing = product.alive_rich_contents.find_by(title:)
+  return existing if existing.present?
+
+  product.alive_rich_contents.create!(
+    title:,
+    description: [
+      {
+        "type" => "mediaEmbed",
+        "attrs" => {
+          "url" => "https://www.youtube.com/watch?v=YE7VzlLtp-4",
+          "title" => "Big Buck Bunny",
+          "html" => '<iframe src="https://cdn.iframe.ly/api/iframe?url=https%3A%2F%2Fyoutu.be%2FYE7VzlLtp-4&key=31708e31359468f73bc5b03e9dcab7da" style="top: 0; left: 0; width: 100%; height: 100%; position: absolute; border: 0;" allowfullscreen scrolling="no" allow="accelerometer *; clipboard-write *; encrypted-media *; gyroscope *; picture-in-picture *; web-share *;"></iframe>'
+        }
+      }
+    ]
+  )
+end
+
 seller1 = create_mobile_user(
   email: "mobile_seller1_do_not_edit@gumroad.com",
   name: "Mobile Seller 1",
@@ -138,3 +161,14 @@ create_mobile_purchase(seller: seller2, buyer: seller1, product: product2)
 
 create_mobile_purchase(seller: seller1, buyer: buyer, product: product1)
 create_mobile_purchase(seller: seller2, buyer: buyer, product: product2)
+
+embed_course = create_mobile_product(
+  user: seller1,
+  name: "Mobile Embed Video Course",
+  price_cents: 500,
+  permalink: "embedvideocourse"
+)
+
+create_mobile_embed_page(product: embed_course, title: "Lesson 1")
+
+create_mobile_purchase(seller: seller1, buyer: buyer, product: embed_course)


### PR DESCRIPTION
## Scope

Adds a deterministic mobile e2e fixture to `db/seeds/030_development/mobile_app_test_data.rb`:
`Mobile Embed Video Course` (permalink `embedvideocourse`), a `Lesson 1` content page holding a
real `mediaEmbed` node, and a successful purchase by the existing `mobile_buyer_do_not_edit@`
buyer.

antiwork/gumroad-mobile#342 adds a Maestro flow asserting a third-party video embed plays *inside*
the purchase-content WebView instead of iOS taking playback over. Nothing in this seed file
exercised the embed path — `create_mobile_product_file` creates uploaded mp3/mp4/pdf files and the
existing `video-playback.yaml` drives the *native* player via `id: video-player`. So the flow had
nothing to point at outside a dev's local DB. This is the seed half of that flow.

## Design

Two notes worth a reviewer's eye:

- **The embed URL is a real HTTPS YouTube/Iframely pair, not a placeholder.** `RichContent`'s
  `link_hrefs_use_permitted_schemes` validation reads `attrs.url` for `mediaEmbed`
  (`URL_ATTRS_BY_NODE_TYPE`) because the content page renders that value as an anchor href, so a
  fake scheme won't save. The `html` keeps `allowfullscreen` — that attribute is what #341/#6012
  are about, and a fixture that dropped it would test the opposite of the intended behaviour.
- **Re-runnable, like the rest of the file.** `create_mobile_embed_page` returns any existing page
  with the same title rather than appending a second one, matching how
  `create_mobile_product`/`create_mobile_purchase` already guard.

## QA

Exercised against the local dev DB, not predicted. First run was against a DB where I'd previously
hand-seeded this product; that short-circuited the new code and proved nothing, so I deleted the
prior rows and re-ran from scratch.

Checks run after a clean-slate run:

- Seed completes with no error; product created (`Mobile Embed Video Course`, 500 cents).
- Content page `Lesson 1` exists with node list exactly `["mediaEmbed"]`.
- `attrs.url` reads back `https://www.youtube.com/watch?v=YE7VzlLtp-4` — i.e. the row passed the
  scheme validation rather than being silently rejected.
- `html` still contains `allowfullscreen`.
- Purchase for `mobile_buyer_do_not_edit@gumroad.com` is `successful` and has a url_redirect, so
  the mobile content page has something to render.
- Second consecutive seed run: still 1 rich content, 1 purchase — no duplicates.

## Status

Draft: the consuming Maestro flow in gumroad-mobile#342 is not yet green end to end (its
`utils/sign-in.yaml` logout path fails from the seller-authenticated entry state), so this
fixture's real consumer can't confirm it in CI yet. The fixture itself is verified above and
lands independently.

---

## Ball: mine — still a draft

Label is `working`, not `awaiting-human`. @nyomanjyotisa stays assignee; **nothing is on him yet.**

What I owe before hand-off:
1. Take this out of draft.
2. Close Greptile's real finding: the seed is not idempotent for the fixture's whole point — a pre-existing `Lesson 1` page keeps its stale content on re-run, so the required `mediaEmbed` node can silently vanish and the Maestro flow in antiwork/gumroad-mobile#342 stops exercising WebView playback. The page content needs to be upserted, not created-if-missing.
3. Green CI (89 checks still running).
