### PR TITLE
Stop telling blocked payers to switch browser or network when they cannot

### DIFF
--- a/app/modules/purchase/risk.rb
+++ b/app/modules/purchase/risk.rb
@@ -6,6 +6,12 @@ module Purchase::Risk
   CHARGEBACK_GRACE_PERIOD = 1.year
   CHARGEBACK_GRACE_LIMIT = 1
 
+  # Shown when an identifier-level block stopped the purchase. Deliberately suggests nothing the
+  # payer can change themselves: we cannot see from here which identifiers are blocked, and every
+  # self-service suggestion we have tried sent people around a loop that could not end
+  # (gumroad-private#1480, gumroad-private#1755). Support is the only route that always works.
+  BLOCKED_IDENTIFIER_ERROR = "Your card was not charged. This payment could not be completed — please contact support@gumroad.com for help."
+
   def check_for_fraud
     Timeout.timeout(CHECK_FOR_FRAUD_TIMEOUT_SECONDS) do
       check_for_past_blocked_email_domains
@@ -62,13 +68,9 @@ module Purchase::Risk
       return unless past_blocked_object(browser_guid)
 
       self.error_code = PurchaseErrorCode::BLOCKED_BROWSER_GUID
-      # Do not suggest another browser or connection here. A browser block may have been written
-      # alongside a block on the buyer's email address (#block_buyer! does both), in which case
-      # switching browser, network or payment method changes nothing — and the old wording sent
-      # blocked buyers around that loop until they gave up (gumroad-private#1480). We cannot tell
-      # from here which blocks exist, so point at the one route that always works: only support can
-      # look at the block and lift it.
-      errors.add :base, "Your card was not charged. This payment could not be completed — please contact support@gumroad.com for help."
+      # A browser block is usually written alongside a block on the buyer's email address
+      # (#block_buyer! does both), so switching browser, network or payment method changes nothing.
+      errors.add :base, BLOCKED_IDENTIFIER_ERROR
     end
 
     def check_for_past_chargebacks
@@ -122,7 +124,10 @@ module Purchase::Risk
       return if (blocked_ip_addresses & buyer_side_ip_addresses).empty?
 
       self.error_code = PurchaseErrorCode::BLOCKED_IP_ADDRESS
-      errors.add :base, "Your card was not charged. Please try again on a different browser and/or internet connection."
+      # The blocked address may be the buyer's account IP rather than the one this request came
+      # from, and a browser switch never moves an IP at all, so the old "different browser and/or
+      # internet connection" wording was advice that frequently could not work.
+      errors.add :base, BLOCKED_IDENTIFIER_ERROR
     end
 
     def past_blocked_object(object)

--- a/spec/modules/purchase/risk_spec.rb
+++ b/spec/modules/purchase/risk_spec.rb
@@ -3,6 +3,16 @@
 require "spec_helper"
 
 describe Purchase::Risk do
+  describe "BLOCKED_IDENTIFIER_ERROR" do
+    # The two blocks it covers can sit on an identifier the payer cannot change from the checkout
+    # they are looking at (an account IP, or an email block written beside a browser block), so any
+    # self-service instruction here is a loop with no exit. Both prior wordings were one.
+    it "routes the payer to support and suggests nothing they could change themselves" do
+      expect(Purchase::Risk::BLOCKED_IDENTIFIER_ERROR).to include("support@gumroad.com")
+      expect(Purchase::Risk::BLOCKED_IDENTIFIER_ERROR).to_not match(/browser|internet connection|different card|another/i)
+    end
+  end
+
   describe "check purchase for previous chargebacks" do
     it "returns errors if the email has charged-back" do
       product = create(:product)
@@ -230,7 +240,8 @@ describe Purchase::Risk do
       bad_purchase = build(:purchase, link: @product, ip_address: "192.378.12.1")
       bad_purchase.send(:check_for_fraud)
       expect(bad_purchase.errors.empty?).to be(false)
-      expect(bad_purchase.errors.full_messages).to eq ["Your card was not charged. Please try again on a different browser and/or internet connection."]
+      expect(bad_purchase.error_code).to eq PurchaseErrorCode::BLOCKED_IP_ADDRESS
+      expect(bad_purchase.errors.full_messages).to eq [Purchase::Risk::BLOCKED_IDENTIFIER_ERROR]
     end
 
     it "returns errors if the buyer browser_guid has been blocked" do
@@ -240,7 +251,8 @@ describe Purchase::Risk do
       bad_purchase = build(:purchase, link: @product, browser_guid:)
       bad_purchase.send(:check_for_fraud)
       expect(bad_purchase.errors.empty?).to be(false)
-      expect(bad_purchase.errors.full_messages).to eq ["Your card was not charged. This payment could not be completed — please contact support@gumroad.com for help."]
+      expect(bad_purchase.error_code).to eq PurchaseErrorCode::BLOCKED_BROWSER_GUID
+      expect(bad_purchase.errors.full_messages).to eq [Purchase::Risk::BLOCKED_IDENTIFIER_ERROR]
     end
 
     it "does not return errors if only the seller's account_created_ip has been blocked" do
@@ -266,7 +278,7 @@ describe Purchase::Risk do
         end.to change { purchase.error_code }
           .from(nil).to(PurchaseErrorCode::BLOCKED_IP_ADDRESS)
           .and change { purchase.errors.empty? }.from(true).to(false)
-          .and change { purchase.errors.full_messages }.from([]).to(["Your card was not charged. Please try again on a different browser and/or internet connection."])
+          .and change { purchase.errors.full_messages }.from([]).to([Purchase::Risk::BLOCKED_IDENTIFIER_ERROR])
       end
 
       it "blocks even with purchase_check_for_fraudulent_ips explicitly off, because the flag no longer gates the check" do
@@ -329,7 +341,7 @@ describe Purchase::Risk do
             purchase = build(:membership_purchase, is_original_subscription_purchase: true, ip_address: blocked_ip_address, subscription:)
             purchase.send(:check_for_fraud)
             expect(purchase.errors.empty?).to be(false)
-            expect(purchase.errors.full_messages).to eq ["Your card was not charged. Please try again on a different browser and/or internet connection."]
+            expect(purchase.errors.full_messages).to eq [Purchase::Risk::BLOCKED_IDENTIFIER_ERROR]
           end
         end
 


### PR DESCRIPTION
## What

The `blocked_ip_address` checkout error stops telling the payer to switch browser or network, and instead points them at support — the same treatment gumroad-private#1480 gave the browser-guid branch. Both branches now read one shared constant, `Purchase::Risk::BLOCKED_IDENTIFIER_ERROR`, so the two cannot drift apart again.

```ruby
# before
errors.add :base, "Your card was not charged. Please try again on a different browser and/or internet connection."
# after
errors.add :base, BLOCKED_IDENTIFIER_ERROR
#  => "Your card was not charged. This payment could not be completed — please contact support@gumroad.com for help."
```

## Why

The advice frequently cannot work, and the person receiving it has no way to know that.

`check_for_past_fraudulent_ips` blocks on `blocked_ip_addresses & buyer_side_ip_addresses`, and `buyer_side_ip_addresses` is the request IP **plus** the buyer account's `current_sign_in_ip` / `last_sign_in_ip` / `account_created_ip`. So the blocked address is often not the network the payer is sitting on — changing network moves one of four values and leaves the match intact. And "different browser" never moves an IP at all, in any of the four cases.

This is decision 3 of gumroad-private#1755. Decision 1 shipped as #6905. On #1755's confirmed case the seller and his buyers both received this string; he had no way to act on it and only wrote in because he happened to find an unrelated help article. The identical loop is what #1480 removed from `check_for_past_blocked_guids`, and the reasoning transfers verbatim: we cannot tell from inside the check which identifiers carry a block, so the only instruction that is always true is "contact support".

## Before-After

Backend-only, no rendered surface changed by this diff — the string is composed in `Purchase::Risk` and surfaced by the existing checkout error path. The before/after is the string itself:

| Branch | error_code | Message before | Message after |
|---|---|---|---|
| `check_for_past_fraudulent_ips` | `blocked_ip_address` | Your card was not charged. Please try again on a different browser and/or internet connection. | Your card was not charged. This payment could not be completed — please contact support@gumroad.com for help. |
| `check_for_past_blocked_guids` | `blocked_browser_guid` | Your card was not charged. This payment could not be completed — please contact support@gumroad.com for help. | *unchanged* (now the same constant) |

The second row is the point of the shared constant: the guid branch already had the right copy, and holding both in one place is what stops the next copy edit fixing only one of them.

## Test Results

Ran locally in a dedicated worktree at load ~36 (probed rather than assumed — this file boots Rails and exits, so the lane gate is irrelevant to it):

`bundle exec rspec spec/modules/purchase/risk_spec.rb` — **47 examples, 18 failures**, and every one of the 5 examples this PR touches or adds passed (lines 12, 243, 253, 280, 343).

The 18 failures are pre-existing and environmental, in examples this diff does not touch: all of them die inside `create(:purchase, ...)` with `ActiveRecord::RecordInvalid: We couldn't charge your card. Try again or use a different card.` — the local `MerchantAccount` preamble this machine needs for the purchase factory. Every failing line is in the `#check_for_past_chargebacks` group or a subscription/free-purchase example that asserts no message at all. Kept them visible rather than filtering to a green subset; CI runs the same file with a provisioned merchant account.

Stale-pin sweep before the first push, per the behaviour-change rule:

- `grep "different browser and/or internet connection"` across the repo — 4 hits, 1 production, **3 spec assertions** pinning the retired copy (`risk_spec.rb:233`, `:269`, `:332`). All three now assert the shared constant, so they move with the copy instead of pinning a literal.
- Grepped the same literal across `*.ts` / `*.tsx` / `*.erb` / `*.yml` / `*.json` — no frontend or fixture copy of the string, so the server message is the only surface.
- Grepped `BLOCKED_IP_ADDRESS` / `blocked_ip_address` across `app spec test lib` — only `risk.rb`, `purchase_error_code.rb`, `risk_spec.rb`. No `it`-name or `context`-name pin naming the retired advice.
- Added two `error_code` assertions to the two pre-existing message examples: with both branches emitting the same string, the message alone no longer identifies which branch fired, and without the code assertion a mutant swapping the branches would pass.

### Mutation proof — both mutants died

Ran in the same worktree, reverting the file to HEAD between legs (`git status --short` empty afterwards, `BLOCKED_IDENTIFIER_ERROR` still present 3x):

| Mutant | Result |
|---|---|
| Restore the old browser/network string on the IP branch only (leaves the constant intact) | **RED** — `risk_spec.rb:235` and `:272` both fail |
| Revert the constant itself to the retired copy (both branches regress together) | **RED** — `risk_spec.rb:10`, the new constant example, fails |

The two legs kill different things on purpose. Mutant 1 proves the two converted assertions still bind the IP branch's own output rather than just comparing a constant to itself. Mutant 2 proves the new constant example is what catches a regression that moves *both* branches at once — which is exactly the failure a shared constant makes possible and the per-branch assertions cannot see, since they would both still match.


## QA steps

Reviewer path, no preview surface needed:

1. Read `app/modules/purchase/risk.rb` — one constant, two call sites, no control-flow change (`git diff origin/main -- app` touches only string literals and comments).
2. `bundle exec rspec spec/modules/purchase/risk_spec.rb` — the three converted assertions exercise the real `check_for_fraud` path against a live `PlatformBlock` row.
3. Optional negative check that the copy cannot regress: `grep -rn "different browser" app/` returns nothing.

Enforcement behaviour is untouched by design: who gets blocked is decided before the `errors.add`, so this diff cannot change any admission decision. Decision 1 of #1755 (#6905, merged) is what changed that.

## Not in this PR

- #1755 decision 2 (back out sellers whose own IP carries a block) — a production data operation, blocked on gumroad-private#1752 and human-owned.
- #1755 decision 4 (stop a seller's own self-QA arming `block_ip_address_based_on_recent_failures!`) — narrows a fraud threshold, so it wants its own PR and its own overlap-case specs.

---

🤖 This PR was written by Hermes Agent (gumclaw), model `claude-opus-5`.

Instructions given: autonomous dispatcher standing order to drain qualifying gumroad-private issues to open PRs; this is decision 3 of gumroad-private#1755, which @slavingia's thread on that issue left unbuilt after decision 1 shipped.

---

## Ball: mine — waiting on my own CI

Label is `working`, not `awaiting-human`. @nyomanjyotisa stays assignee and owns the outcome, but **nothing is on him right now** — do not review yet.

What I owe before hand-off: all 89 checks are still in flight (`Test Fast 0-17`, `Test Slow 0-49`, `Test Minitest 0`, `Greptile Review`, `buildkite/gumroad`). I settle CI first, then flip to `awaiting-human` with an explicit review ask.
