### PR TITLE
Evaluate store Agent eligibility on every authorization check

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1382,23 +1382,19 @@ class User < ApplicationRecord
   # earned-your-way-in bar as AI product generation: real money in, and a payout that
   # proves the account is a going concern rather than a fresh signup experimenting.
   #
-  # Unlike eligible_for_ai_product_generation?, this is evaluated on EVERY Inertia render
-  # (the Agent nav tab reads it out of policies_props), so it is ordered and memoized for
-  # that path. sales_cents_total is an Elasticsearch aggregation, while has_completed_payouts?
-  # is an indexed exists? — checking the payout first means a seller who has never been paid
-  # out short-circuits without touching ES, which is exactly the pre-launch account this
-  # gate exists to stop.
+  # Never memoize: this backs an authorization check on a long-lived SSE stream, so a
+  # suspension mid-conversation has to revoke access on the next check rather than at the
+  # next object load.
+  #
+  # The ordering is what keeps it cheap. sales_cents_total is an Elasticsearch aggregation
+  # while has_completed_payouts? is an indexed exists?, so testing the payout first means a
+  # seller who has never been paid out short-circuits without touching ES — exactly the
+  # pre-launch account this gate exists to stop.
   def eligible_for_store_agent?
-    return @eligible_for_store_agent if defined?(@eligible_for_store_agent)
+    return true if Rails.env.development?
+    return false if !confirmed? || suspended? || !has_completed_payouts?
 
-    @eligible_for_store_agent =
-      if Rails.env.development?
-        true
-      elsif !confirmed? || suspended? || !has_completed_payouts?
-        false
-      else
-        sales_cents_total >= MIN_SALES_CENTS_VALUE_FOR_STORE_AGENT
-      end
+    sales_cents_total >= MIN_SALES_CENTS_VALUE_FOR_STORE_AGENT
   end
 
   # Devise routes every confirmation *resend* through this method — the public

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4456,11 +4456,21 @@ describe User, :vcr do
       expect(user.eligible_for_store_agent?).to eq(false)
     end
 
-    it "memoizes the result so one render does not re-query Elasticsearch" do
+    it "re-evaluates on every call so a suspension revokes access on the same object" do
       create(:payment_completed, user:)
-      expect(user).to receive(:sales_cents_total).once.and_return(15_000)
+      expect(user.eligible_for_store_agent?).to eq(true)
 
-      3.times { expect(user.eligible_for_store_agent?).to eq(true) }
+      user.update!(user_risk_state: :suspended_for_fraud)
+
+      expect(user.eligible_for_store_agent?).to eq(false)
+    end
+
+    it "re-evaluates on every call so a newly eligible seller is not held to an earlier denial" do
+      expect(user.eligible_for_store_agent?).to eq(false)
+
+      create(:payment_completed, user:)
+
+      expect(user.eligible_for_store_agent?).to eq(true)
     end
   end
 

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -117,20 +117,35 @@ describe UserPolicy do
   end
 
   permissions :use_store_agent? do
+    # Stub the operated seller, never any_instance: the acting team member and the seller are
+    # both Users, and an any_instance stub makes a `user.eligible_for_store_agent?` typo pass.
     before do
-      allow_any_instance_of(User).to receive(:eligible_for_store_agent?).and_return(true)
+      allow(seller).to receive(:eligible_for_store_agent?).and_return(true)
     end
 
     it "denies access to the owner of a seller that has not earned the agent yet" do
-      allow_any_instance_of(User).to receive(:eligible_for_store_agent?).and_return(false)
+      allow(seller).to receive(:eligible_for_store_agent?).and_return(false)
       seller_context = SellerContext.new(user: seller, seller:)
       expect(subject).to_not permit(seller_context, seller)
     end
 
     it "denies access to an admin when the seller has not earned the agent yet" do
-      allow_any_instance_of(User).to receive(:eligible_for_store_agent?).and_return(false)
+      allow(seller).to receive(:eligible_for_store_agent?).and_return(false)
       seller_context = SellerContext.new(user: admin_for_seller, seller:)
       expect(subject).to_not permit(seller_context, seller)
+    end
+
+    it "reads eligibility off the seller, not the acting team member" do
+      allow(seller).to receive(:eligible_for_store_agent?).and_return(false)
+      allow(admin_for_seller).to receive(:eligible_for_store_agent?).and_return(true)
+      seller_context = SellerContext.new(user: admin_for_seller, seller:)
+      expect(subject).to_not permit(seller_context, seller)
+    end
+
+    it "grants an admin acting for an eligible seller who is not themselves eligible" do
+      allow(admin_for_seller).to receive(:eligible_for_store_agent?).and_return(false)
+      seller_context = SellerContext.new(user: admin_for_seller, seller:)
+      expect(subject).to permit(seller_context, seller)
     end
 
     it "grants access to owner" do


### PR DESCRIPTION
Follow-up to #6903 (merged `829c102`). Greptile's review landed after that merge with two findings; both reproduce on `origin/main`, so they are fixed here rather than on the deleted branch.

## What changed

`User#eligible_for_store_agent?` no longer memoizes. #6903 cached the first result in `@eligible_for_store_agent` for the lifetime of the `User` object, so:

- a seller authorized at the start of a request stayed authorized after being **suspended** on that same object, and
- a seller denied before their first completed payout stayed **denied** after becoming eligible.

The memoization was justified in a comment as protecting the Inertia render path, but `use_store_agent?` is the only caller of the predicate and `policies_props` invokes it exactly **once per render** — so the cache bought nothing on the path it was written for, while the real exposure is `Api::Internal::AgentMessageStreamsController`, where the authorization check sits on a long-lived SSE stream that can outlive a suspension. The ordering (indexed `has_completed_payouts?` exists? before the `sales_cents_total` Elasticsearch aggregation) is what keeps the predicate cheap and is preserved; that ordering is separately pinned by the existing "does not touch sales_cents_total" example. The shape now matches its sibling `eligible_for_ai_product_generation?`, which was never memoized.

`spec/policies/user_policy_spec.rb` stops stubbing eligibility with `allow_any_instance_of(User)`. The seller and the acting team member are both `User`s, so an any-instance stub returned the same value for both and every role example passed even if `use_store_agent?` read `user.eligible_for_store_agent?` instead of `seller.eligible_for_store_agent?`. The stub is now on the operated `seller`, plus two new examples that separate the two receivers: an eligible admin acting for an ineligible seller is denied, and an ineligible admin acting for an eligible seller is granted.

## Why

`use_store_agent?` authorizes actions that rewrite a seller's live storefront. An authorization predicate that answers from a cache can only fail in the direction of granting access that current state forbids.

## Before / after

| Sequence on one `User` object | Before (`main` @ `829c102`) | After |
| --- | --- | --- |
| eligible → `suspended_for_fraud` → re-check | `true` (stale grant) | `false` |
| ineligible → completed payout recorded → re-check | `false` (stale denial) | `true` |
| Admin eligible, seller not | policy spec passes either receiver | denied, and a `user.`-receiver mutant fails |

## Test Results

Run in a dedicated worktree at `e95a468`, load average 41 (these are model/policy specs — they boot Rails and exit, so no lane state is needed):

- `bundle exec rspec spec/policies/user_policy_spec.rb spec/models/user_spec.rb -e "use_store_agent" -e "eligible_for_store_agent"` — **20 examples, 0 failures** in 17.65s. Covers the two new transition examples, the two new receiver examples, and the eleven pre-existing boundary/gate/role examples.
- Mutation check, receiver mutant — `seller.eligible_for_store_agent?` → `user.eligible_for_store_agent?` in `UserPolicy#use_store_agent?`: **3 examples red**, including the new "grants an admin acting for an eligible seller who is not themselves eligible". Under the old any-instance stub this mutant survived.
- Mutation check, cache mutant — `User#eligible_for_store_agent?` restored byte-for-byte to the memoized shape merged in #6903: **2 examples red**, exactly the two new transition examples. Both directions of the stale cache are pinned, not just the suspension one.
- `ruby -c` on `app/models/user.rb`, `spec/models/user_spec.rb`, `spec/policies/user_policy_spec.rb`.

The pre-existing "does not touch sales_cents_total when the seller has no completed payout" example still passes, so removing the cache did not cost the Elasticsearch short-circuit.

## QA steps

Backend-only predicate with no visual surface; the artifact is the transition table above, produced by the two new model examples driving a real suspension and a real `payment_completed` on one loaded `User`, rather than a screenshot.

## Status

- [x] Scope — two Greptile findings on #6903, both reproduced against `origin/main`
- [x] Design — drop the memoization outright (single caller, one call per render, sibling predicate is unmemoized) rather than adding invalidation hooks
- [x] Build — `e95a468`
- [x] QA — spec + mutation runs recorded above, both mutants killed
- [ ] Shipped — merged ≠ deployed; confirmed from the first release tag containing the merge commit
- [ ] Market — n/a, internal authorization hardening with no seller-facing change to announce
- [ ] Sell — n/a, no pricing or packaging surface

---

Written by Hermes Agent (claude-opus-5) under gumclaw, reviewed before opening.
