### PR TITLE
Stop the shared Stripe test account throttling CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -550,6 +550,13 @@ jobs:
         run: |
           mkdir -p ./test-logs
           chmod 777 ./test-logs
+          # Override the image's baked-in Stripe key only when this shard has an account
+          # assigned; an empty -e would blank it.
+          STRIPE_SHARD_ENV=""
+          [ -n "$STRIPE_SHARD_API_KEY" ] && STRIPE_SHARD_ENV="$STRIPE_SHARD_ENV -e STRIPE_API_KEY=$STRIPE_SHARD_API_KEY"
+          [ -n "$STRIPE_SHARD_PUBLIC_KEY" ] && STRIPE_SHARD_ENV="$STRIPE_SHARD_ENV -e STRIPE_PUBLIC_KEY_TEST=$STRIPE_SHARD_PUBLIC_KEY"
+          [ -n "$STRIPE_SHARD_PLATFORM_ID" ] && STRIPE_SHARD_ENV="$STRIPE_SHARD_ENV -e STRIPE_PLATFORM_ACCOUNT_ID=$STRIPE_SHARD_PLATFORM_ID"
+          [ -n "$STRIPE_SHARD_CONNECT_ID" ] && STRIPE_SHARD_ENV="$STRIPE_SHARD_ENV -e STRIPE_CONNECT_CLIENT_ID=$STRIPE_SHARD_CONNECT_ID"
           docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
             -v "$(pwd)/test-logs:/app/log" \
             -e RUBY_YJIT_ENABLE \
@@ -568,6 +575,7 @@ jobs:
             -e KNAPSACK_PRO_FIXED_QUEUE_SPLIT \
             -e CI \
             -e IN_DOCKER \
+            $STRIPE_SHARD_ENV \
             $WEB_REPO:${{ needs.build.outputs.test_image_tag }} \
             /usr/local/bin/gosu app bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --format progress]"
         env:
@@ -587,6 +595,13 @@ jobs:
           KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
           CI: true
           IN_DOCKER: true
+          # Stripe's rate limits are per ACCOUNT and up to 68 shards run at once against one
+          # test account, so throttling scales with queue depth, not with what a spec does.
+          # Empty unless the suffixed secrets exist, which leaves .env.test's key in force.
+          STRIPE_SHARD_API_KEY: ${{ secrets[format('STRIPE_API_KEY_{0}', matrix.ci_node_index % 2)] }}
+          STRIPE_SHARD_PUBLIC_KEY: ${{ secrets[format('STRIPE_PUBLIC_KEY_TEST_{0}', matrix.ci_node_index % 2)] }}
+          STRIPE_SHARD_PLATFORM_ID: ${{ secrets[format('STRIPE_PLATFORM_ACCOUNT_ID_{0}', matrix.ci_node_index % 2)] }}
+          STRIPE_SHARD_CONNECT_ID: ${{ secrets[format('STRIPE_CONNECT_CLIENT_ID_{0}', matrix.ci_node_index % 2)] }}
           WEB_REPO: gumroadteam/web
       - name: Archive flaky specs log
         if: always()
@@ -735,6 +750,13 @@ jobs:
           chmod 777 ./capybara-artifacts
           mkdir -p ./test-logs
           chmod 777 ./test-logs
+          # Override the image's baked-in Stripe key only when this shard has an account
+          # assigned; an empty -e would blank it.
+          STRIPE_SHARD_ENV=""
+          [ -n "$STRIPE_SHARD_API_KEY" ] && STRIPE_SHARD_ENV="$STRIPE_SHARD_ENV -e STRIPE_API_KEY=$STRIPE_SHARD_API_KEY"
+          [ -n "$STRIPE_SHARD_PUBLIC_KEY" ] && STRIPE_SHARD_ENV="$STRIPE_SHARD_ENV -e STRIPE_PUBLIC_KEY_TEST=$STRIPE_SHARD_PUBLIC_KEY"
+          [ -n "$STRIPE_SHARD_PLATFORM_ID" ] && STRIPE_SHARD_ENV="$STRIPE_SHARD_ENV -e STRIPE_PLATFORM_ACCOUNT_ID=$STRIPE_SHARD_PLATFORM_ID"
+          [ -n "$STRIPE_SHARD_CONNECT_ID" ] && STRIPE_SHARD_ENV="$STRIPE_SHARD_ENV -e STRIPE_CONNECT_CLIENT_ID=$STRIPE_SHARD_CONNECT_ID"
           docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
             -v "$(pwd)/capybara-artifacts:/app/tmp/capybara" \
             -v "$(pwd)/test-logs:/app/log" \
@@ -753,6 +775,7 @@ jobs:
             -e KNAPSACK_PRO_FIXED_QUEUE_SPLIT \
             -e CI \
             -e IN_DOCKER \
+            $STRIPE_SHARD_ENV \
             $WEB_REPO:${{ needs.build.outputs.test_image_tag }} \
             /usr/local/bin/gosu app bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --format progress]"
         env:
@@ -771,6 +794,13 @@ jobs:
           KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
           CI: true
           IN_DOCKER: true
+          # Stripe's rate limits are per ACCOUNT and up to 68 shards run at once against one
+          # test account, so throttling scales with queue depth, not with what a spec does.
+          # Empty unless the suffixed secrets exist, which leaves .env.test's key in force.
+          STRIPE_SHARD_API_KEY: ${{ secrets[format('STRIPE_API_KEY_{0}', matrix.ci_node_index % 2)] }}
+          STRIPE_SHARD_PUBLIC_KEY: ${{ secrets[format('STRIPE_PUBLIC_KEY_TEST_{0}', matrix.ci_node_index % 2)] }}
+          STRIPE_SHARD_PLATFORM_ID: ${{ secrets[format('STRIPE_PLATFORM_ACCOUNT_ID_{0}', matrix.ci_node_index % 2)] }}
+          STRIPE_SHARD_CONNECT_ID: ${{ secrets[format('STRIPE_CONNECT_CLIENT_ID_{0}', matrix.ci_node_index % 2)] }}
           WEB_REPO: gumroadteam/web
       - name: Archive capybara artifacts
         if: failure()

--- a/spec/lib/stripe_rate_limit_retries_spec.rb
+++ b/spec/lib/stripe_rate_limit_retries_spec.rb
@@ -123,7 +123,7 @@ describe "Stripe rate-limit retries in the test environment" do
       error = stripe_error(Stripe::RateLimitError, "Request rate limit exceeded", status: 429)
 
       expect { Stripe::StripeClient.should_retry?(error, num_retries: 2) }
-        .to output(/rate limited.*Waiting and retrying \(retry 3 of 8\)/m).to_stderr
+        .to output(/rate limited.*Waiting and retrying \(retry 3 of 12\)/m).to_stderr
     end
 
     it "says it is giving up once the budget is gone, rather than claiming success" do
@@ -133,7 +133,7 @@ describe "Stripe rate-limit retries in the test environment" do
       error = stripe_error(Stripe::RateLimitError, "Request rate limit exceeded", status: 429)
 
       expect { Stripe::StripeClient.should_retry?(error, num_retries: StripeTestRateLimitRetries::MAX_RETRIES) }
-        .to output(/still rate limited after 8 retries, giving up/).to_stderr
+        .to output(/still rate limited after 12 retries, giving up/).to_stderr
     end
 
     it "stays quiet about failures that have nothing to do with rate limiting" do
@@ -144,10 +144,11 @@ describe "Stripe rate-limit retries in the test environment" do
   end
 
   describe "the retry budget" do
-    it "allows eight retries capped at sixteen seconds of waiting each" do
+    it "allows twelve retries capped at sixteen seconds of waiting each" do
       # Pinned literally rather than derived, so that changing the budget has to
-      # change this spec deliberately.
-      expect(StripeTestRateLimitRetries::MAX_RETRIES).to eq(8)
+      # change this spec deliberately. Eight was not enough to outlast the
+      # contention 68 concurrent shards create on one Stripe test account.
+      expect(StripeTestRateLimitRetries::MAX_RETRIES).to eq(12)
       expect(StripeTestRateLimitRetries::MAX_RETRY_DELAY).to eq(16)
     end
 

--- a/spec/support/stripe_rate_limit_retries.rb
+++ b/spec/support/stripe_rate_limit_retries.rb
@@ -49,10 +49,10 @@ module StripeTestRateLimitRetries
   # fallback, after checking the structured fields.
   RATE_LIMIT_MESSAGE = /rate limit|too many requests|creating accounts too quickly/i
 
-  # Retry budget for THROTTLED requests only: eight retries, so nine HTTP
+  # Retry budget for THROTTLED requests only: twelve retries, so thirteen HTTP
   # attempts. Delays before each retry follow the gem's own schedule (0.5s
-  # doubling, capped at MAX_RETRY_DELAY), so the worst case is
-  # 0.5 + 1 + 2 + 4 + 8 + 16 + 16 + 16 = 63.5 seconds of waiting.
+  # doubling, capped at MAX_RETRY_DELAY, jittered into (delay/2, delay]), so the
+  # worst case is 0.5 + 1 + 2 + 4 + 8 + 16 × 7 = 127.5 seconds of waiting.
   #
   # That is deliberately generous rather than minimal. The helper this file
   # replaces allowed roughly 134 seconds, and it did so specifically for
@@ -60,14 +60,23 @@ module StripeTestRateLimitRetries
   # request-rate bucket. A budget short enough to expire inside that window
   # would fail the build for the reason this file exists to prevent.
   #
+  # Eight retries (63.5s) was that budget, and it was not enough: on 2026-08-03
+  # nine open PRs went red at once, every failure a checkout or subscription spec
+  # whose log ended in "still rate limited after 8 retries". Test Slow alone
+  # fans out to 50 shards and Test Fast to 18, every one of them against the same
+  # Stripe test account, and several PRs build concurrently — so the contention
+  # scales with how busy the queue is, not with anything a spec does. Re-running
+  # the identical commit turned #6901 from 11 failures to 0, which is what a
+  # too-small budget looks like from the outside.
+  #
   # It is kept OFF Stripe's global configuration on purpose. Raising
   # Stripe.max_network_retries would also widen the gem's own retries for
   # timeouts, 409 conflicts and 500s, so a spec hitting one of those could sit
-  # in backoff for a minute for a reason that has nothing to do with
+  # in backoff for minutes for a reason that has nothing to do with
   # throttling. Instead the wider budget is applied only on the code path that
   # has already identified the failure as a rate limit, and the global values
   # stay as config/initializers/003_stripe.rb sets them.
-  MAX_RETRIES = 8
+  MAX_RETRIES = 12
   MAX_RETRY_DELAY = 16
 
   # should_retry? decides, and the gem then immediately asks sleep_time how long


### PR DESCRIPTION
## Why so many red PRs

Nine of nineteen open PRs were red. None were red for their own code.

Every failure was a `Test Slow` / `Test Fast` shard ending the same way:

```
[Stripe] rate limited — the shared Stripe test account is throttling us.
Waiting and retrying (retry 8 of 8): Request rate limit exceeded.
[Stripe] still rate limited after 8 retries, giving up
```

and then a checkout that never completed:

```
Failure/Error: expect(page).to have_alert(text: "Your purchase was successful! ...")
  expected to find visible alert ... but there were no matches
```

Rate-limit lines per failing job, across the nine: 32, 46, 50, 73, 73, 76, 83, 90, 91. Failing specs and shard numbers were scattered. `main` was green throughout.

Re-running the failed jobs on **identical commits, no diff**:

| PR | before | after re-run |
|---|---|---|
| #6901 | 11 failures | **81 pass, 0 fail** |
| #6904 | 7 failures | **81 pass, 0 fail** |
| #6898 | 9 failures | **81 pass, 0 fail** |
| #6879 | 7 failures | **81 pass, 0 fail** |
| #6750 | 19 failures | **81 pass, 0 fail** |
| #6908 | 4 failures | **81 pass, 0 fail** |
| #6911 | 10 failures | **81 pass, 0 fail** |

## The ceiling

`test_slow` fans out to **50** shards, `test_fast` to **18**, and `concurrency` is keyed per PR, so several PRs build simultaneously. Every shard creates customers, payment methods and payment intents against the **same** Stripe test account. Stripe's limits are per account, so contention scales with queue depth — not with anything a spec does.

Retries only widen the window we wait in. They cannot raise the ceiling. That is why this keeps recurring.

## Why mocking cannot fix it

The seven offender specs are all `type: :system, js: true`:

| Spec | Examples |
|---|---|
| `spec/requests/purchases/product/taxes_spec.rb` | 375 |
| `spec/requests/purchases/product/generate_invoice_spec.rb` | 71 |
| `spec/requests/purchases/product/upsell_spec.rb` | 59 |
| `spec/requests/subscription/non_tiered_membership_spec.rb` | 40 |
| `spec/requests/subscription/tiered_membership_spec.rb` | 33 |
| `spec/requests/subscription/installment_plan_spec.rb` | 13 |
| `spec/requests/subscription/tiered_membership_vat_spec.rb` | 6 |

Their Stripe traffic splits three ways, and only one part is mockable:

1. **Server-side setup** (`:chargeable` → `Stripe::PaymentMethod.create`, `:merchant_account` → live Connect account creation). Ruby gem, VCR-able.
2. **Browser-side** — `fill_in_payment_element` types into Stripe's iframes, and clicking Pay makes Stripe.js call `api.stripe.com/v1/payment_methods` directly with the publishable key. **This never passes through the Ruby process**, so WebMock and VCR cannot see it — while still counting against the same per-account limit. `spec/support/stripe_rate_limit_retries.rb:39-44` already documents this gap.
3. **Server-side charge** — VCR technically sees it, but the request body carries the `pm_…` id the browser just minted, different every run, so cassette matching either fails or must be loosened into uselessness.

`stripe-mock` is already a service in `test_minitest` (`tests.yml:389`) but nothing points `Stripe.api_base` at it — it is vestigial. It is also stateless, so it cannot support create-then-confirm PaymentIntent flows, and it does nothing for the Elements iframe.

So mocking can only ever cover part 1, and cannot fix the failures.

## Change

Two parts.

**1. Shard across Stripe test accounts** (`.github/workflows/tests.yml`) — the only lever that reaches browser-side traffic. Each rspec shard resolves its Stripe credentials from `STRIPE_*_<index % N>` secrets, so N accounts divide the contention by N.

This is **plumbing only and a no-op until the secrets exist.** The keys live in `.env.test` baked into the test image, and `dotenv` does not overload an already-set variable — so a bare `docker run -e STRIPE_API_KEY` with no secret configured would forward an **empty** value and blank the key on all 68 shards. The override is therefore built by shell that skips unset values.

**2. Raise the retry budget** as the backstop for residual spikes: `MAX_RETRIES` 8 → 12, so 127.5s worst case, back near the ~134s the helper this replaced allowed for account-creation throttling. Kept off Stripe's global config for the reason already documented there — a global bump would widen the gem's retries for timeouts, 409s and 500s too.

## Test Results

Run, not predicted:

- `spec/lib/stripe_rate_limit_retries_spec.rb` — **19 examples, 0 failures**
- `rubocop` on both ruby files — 2 inspected, **0 offenses**
- `tests.yml` parses as valid YAML; 10 jobs; shard matrices unchanged (50 / 18)
- The generated shell was executed under `bash -eo pipefail` both ways: with no secrets set it produces an empty override and reaches the next line (exit 0 — `&&` lists are exempt from `-e`, verified rather than assumed); with `STRIPE_SHARD_API_KEY`/`PUBLIC_KEY` set it emits `-e STRIPE_API_KEY=… -e STRIPE_PUBLIC_KEY_TEST=…`

The two specs pinning the budget literally were updated deliberately (`retry 3 of 12`, `after 12 retries`, `MAX_RETRIES == 12`) — they exist so a budget change cannot happen silently.

## QA steps

1. Merge with no `STRIPE_*_1` secrets: every shard behaves exactly as today, using `.env.test`. This is the safe default and is what CI on this PR exercises.
2. Add `STRIPE_API_KEY_1`, `STRIPE_PUBLIC_KEY_TEST_1`, `STRIPE_PLATFORM_ACCOUNT_ID_1`, `STRIPE_CONNECT_CLIENT_ID_1`; odd-indexed shards then use account 1, even-indexed use `.env.test`.
3. Confirm the publishable key reaching the browser matches the shard's secret key — it is served via a meta tag (`app/controllers/concerns/page_meta/base.rb:54`), so a mismatched pair fails tokenization.
4. Count `rate limited` warn lines in shard logs before/after; they should fall roughly by half with two accounts.
5. Retry-budget boundary: a 429 at `num_retries: 11` retries and logs `retry 12 of 12`; at 12 it logs `still rate limited after 12 retries, giving up`. Non-rate-limit errors (402, 400, 500) unaffected and silent.

## What is still owed

Provisioning the second Stripe test account is a human step — it needs Connect enabled, a topped-up test balance, and API version `2023-10-16` to match. Once its four secrets are set, contention halves with no further code change; adding accounts 2–3 is one more secret each.

**Reviewer note:** the `% 2` divisor sets how many accounts the fan-out uses. It is deliberately 2 rather than 50 so the first account added takes effect immediately and the blast radius is one bit; raising it is a one-character change once more accounts exist.
