### PR TITLE
Say a Stripe date of birth was unreadable rather than absent when it will not parse

### DIFF
--- a/app/sidekiq/alert_on_stripe_dob_drift_job.rb
+++ b/app/sidekiq/alert_on_stripe_dob_drift_job.rb
@@ -140,10 +140,11 @@ class AlertOnStripeDobDriftJob
       ErrorNotifier.notify(e)
     end
 
-    # Stripe's copy as a Date, `nil` when the account holds no date of birth, or `:unreadable` when
-    # the read itself failed. The three are deliberately distinct: a missing dob on Stripe IS drift
-    # against a birthday we hold, while a failed read establishes nothing and must not be reported as
-    # agreement or as drift.
+    # Stripe's copy as a Date; `nil` when the account holds no date of birth; `:unparseable` when it
+    # holds something that is not a date; `:unreadable` when the read itself failed. All four are
+    # deliberately distinct. A missing dob IS drift against a birthday we hold, and so is a garbled
+    # one — but they are different findings, and calling a garbled date "no date of birth on file"
+    # would be a false statement in a report whose only job is to say which copy holds what.
     #
     # Read with `[]` rather than `dig`: `Stripe::Account` is a `Stripe::StripeObject`, which does not
     # implement `dig` at all (it wraps a values hash and exposes `[]`), so `dig` raises NoMethodError
@@ -155,13 +156,14 @@ class AlertOnStripeDobDriftJob
       return nil if dob.nil?
 
       year, month, day = dob["year"], dob["month"], dob["day"]
-      return nil if year.blank? || month.blank? || day.blank?
+      return nil if [year, month, day].all?(&:blank?)
+      # Some parts present and some missing is a date Stripe holds and we cannot compare — not an
+      # absent one.
+      return :unparseable if year.blank? || month.blank? || day.blank?
 
       Date.new(year.to_i, month.to_i, day.to_i)
     rescue Date::Error
-      # A partial or impossible date on Stripe's side is not something this report can resolve into a
-      # comparison, and it is not a read failure either.
-      nil
+      :unparseable
     rescue Stripe::StripeError => e
       Rails.logger.warn "Could not read the Stripe date of birth for merchant account #{merchant_account.id}: #{e.class}: #{e.message}"
       :unreadable
@@ -191,16 +193,21 @@ class AlertOnStripeDobDriftJob
     end
 
     # Under-18-on-our-side first, then widest gap first. What ranks a line is whether money is
-    # already being held on the strength of the disagreement.
+    # already being held on the strength of the disagreement. A date we could not compare at all
+    # sorts as the widest gap: it is the least resolved, not the least important.
     def report_order(drifted)
       drifted.sort_by do |entry|
-        gap = entry[:theirs] ? (entry[:theirs] - entry[:ours]).to_i.abs : Float::INFINITY
+        gap = entry[:theirs].is_a?(Date) ? (entry[:theirs] - entry[:ours]).to_i.abs : Float::INFINITY
         [entry[:ours] > UserComplianceInfo::GUARDIAN_REQUIRED_BELOW_AGE.years.ago.to_date ? 0 : 1, -gap]
       end
     end
 
     def line_for(entry)
-      theirs = entry[:theirs] || "no date of birth on file"
+      theirs = case entry[:theirs]
+               when nil then "no date of birth on file"
+               when :unparseable then "a date of birth we could not read as a date"
+               else entry[:theirs]
+      end
       gated = entry[:ours] > UserComplianceInfo::GUARDIAN_REQUIRED_BELOW_AGE.years.ago.to_date ? " [under 18 on our side — payouts gated]" : ""
       "• #{entry[:user].email} (user #{entry[:user].id}) — we hold #{entry[:ours]}, Stripe holds #{theirs} " \
         "on #{entry[:merchant_account].charge_processor_merchant_id}#{gated}, " \

--- a/spec/sidekiq/alert_on_stripe_dob_drift_job_spec.rb
+++ b/spec/sidekiq/alert_on_stripe_dob_drift_job_spec.rb
@@ -205,6 +205,69 @@ describe AlertOnStripeDobDriftJob do
     expect(message).to include(drifted_seller.email)
   end
 
+  # A garbled date is drift too, but reporting it as "no date of birth on file" would be a false
+  # statement about what Stripe holds — in a report whose only job is to say which copy holds what.
+  it "distinguishes a date of birth it could not parse from one that is absent" do
+    account = gumroad_managed_account
+    compliance_info(birthday: Date.new(2010, 4, 27))
+    allow(Stripe::Account).to receive(:retrieve).with(account.charge_processor_merchant_id).and_return(
+      Stripe::StripeObject.construct_from(individual: { dob: { year: 2005, month: 2, day: 31 } })
+    )
+
+    body = message
+    expect(body).to include("Stripe holds a date of birth we could not read as a date")
+    expect(body).not_to include("no date of birth on file")
+  end
+
+  # Some parts present and some missing is a date Stripe holds, not an absent one.
+  it "treats a partially populated date of birth as unparseable rather than absent" do
+    account = gumroad_managed_account
+    compliance_info(birthday: Date.new(2010, 4, 27))
+    allow(Stripe::Account).to receive(:retrieve).with(account.charge_processor_merchant_id).and_return(
+      Stripe::StripeObject.construct_from(individual: { dob: { year: 2005, month: nil, day: nil } })
+    )
+
+    body = message
+    expect(body).to include("could not read as a date")
+    expect(body).not_to include("no date of birth on file")
+  end
+
+  # An all-blank dob hash is Stripe's shape for "never supplied", which stays the absent case.
+  it "still reports an all-blank date of birth as absent" do
+    account = gumroad_managed_account
+    compliance_info(birthday: Date.new(2010, 4, 27))
+    allow(Stripe::Account).to receive(:retrieve).with(account.charge_processor_merchant_id).and_return(
+      Stripe::StripeObject.construct_from(individual: { dob: { year: nil, month: nil, day: nil } })
+    )
+
+    body = message
+    expect(body).to include("Stripe holds no date of birth on file")
+    expect(body).not_to include("could not read as a date")
+  end
+
+  # An unparseable date must not raise in the ranking, which does date arithmetic on the pair.
+  it "ranks an unparseable date alongside comparable ones without raising" do
+    unparseable_seller = create(:user)
+    unparseable_account = gumroad_managed_account(user: unparseable_seller)
+    compliance_info(birthday: 16.years.ago.to_date, user: unparseable_seller)
+
+    comparable_account = gumroad_managed_account
+    expect(comparable_account).to be_present
+    compliance_info(birthday: 16.years.ago.to_date)
+
+    allow(Stripe::Account).to receive(:retrieve) do |account_id|
+      if account_id == unparseable_account.charge_processor_merchant_id
+        Stripe::StripeObject.construct_from(individual: { dob: { year: 2005, month: 2, day: 31 } })
+      else
+        Stripe::StripeObject.construct_from(individual: { dob: { year: 2004, month: 8, day: 27 } })
+      end
+    end
+
+    lines = message.lines.select { |line| line.start_with?("•") }
+    expect(lines.size).to eq(2)
+    expect(lines.first).to include(unparseable_seller.email)
+  end
+
   describe "sweeping the population across runs" do
     it "resumes after the account the previous run compared last" do
       first_account = gumroad_managed_account


### PR DESCRIPTION
## What

Follow-up to #6902 (merged). When Stripe holds a date of birth that will not parse, the drift report described it as **"no date of birth on file"** — a false statement about what Stripe holds, in a report whose only job is to say which copy holds what.

`stripe_dob` now returns four distinct outcomes instead of three: a `Date`, `nil` (absent), `:unparseable` (Stripe holds something that is not a date), and `:unreadable` (the read itself failed).

## Why

Two ways to reach it, both real:

1. An impossible date — `{year: 2005, month: 2, day: 31}` — raised `Date::Error`, which was rescued to `nil`.
2. A partially populated date — year present, month and day missing — hit `return nil if year.blank? || month.blank? || day.blank?`.

Either way the line read "Stripe holds no date of birth on file". Someone acting on that would go looking for an empty field and find a populated, malformed one. An all-blank dob hash *is* Stripe's shape for "never supplied", so that case stays the absent one — the new branch fires only when some parts are present and some are not.

Two call sites needed the same care. `report_order` computed `entry[:theirs] - entry[:ours]`, guarded only by truthiness, so a `:unparseable` symbol would have reached `Symbol - Date` and raised — taking down the whole report rather than one line. It now type-checks for `Date` and sorts an uncomparable date as the widest gap: least resolved, not least important.

Found by the adversarial review round on #6902, filed as a P2 there and not fixed before that PR merged.

## Test Results

- `bundle exec rspec spec/sidekiq/alert_on_stripe_dob_drift_job_spec.rb` — **22 examples, 0 failures** (27.46s)
- `bundle exec rubocop` on both changed files — no offenses
- CI at `3d13096e`: **81 checks pass, 0 fail** — all 18 `Test Fast` and both `Test Minitest` shards, `ci/green` = "Test suite passed", `buildkite/gumroad` green, Greptile clean with no findings.

Four new examples, each mutation-checked:

| mutant | verdict |
|---|---|
| M1 rescue `Date::Error` back to `nil` (impossible date reads as absent) | KILLED |
| M2 revert the partial-date branch (some parts missing reads as absent) | KILLED |
| M3 drop the `:unparseable` label from `line_for` | KILLED |
| M4 rank without the `Date` type check | KILLED |

M4 is the one worth noting: without the type check the ranking raises on a symbol, so it fails loudly rather than mis-sorting.

## QA steps

Same standing blocker as #6902: the production dry run needs audited console access this machine has lost (the bastion refuses its key while EC2 discovery works — tracked on gumroad-private#1695). This change is reachable only when Stripe holds a malformed date, which is exactly what has not been measured yet, so the honest statement is that its frequency is unknown. The job still only reads and notifies.

## Status

- [x] **Scope** — one report-copy correctness bug from #6902's review, plus the latent raise its fix would otherwise have introduced.
- [x] **Design** — four-way read outcome; absent and unparseable stay distinct; uncomparable sorts as widest gap.
- [x] **Build** — head `3d13096e`.
- [x] **Review** — 4 of 4 mutants killed; Greptile clean.
- [ ] **QA** — production dry run still blocked (above).
- [ ] **Ship** — ready for review; payout-gate-adjacent reporting, so a human merges.
- [ ] **Shipped** — not merged, not deployed.
- [ ] **Market** — internal detector; nothing to announce.
- [ ] **Sell** — n/a.

---

🤖 Written by Hermes Agent (claude-opus-5), following up gumroad-private#1726.
