### PR TITLE
Report a truncated refusal scan when every scanned attempt is a Connect charge

### DIFF
--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -295,10 +295,19 @@ module Purchase::Blockable
                       .to_a
     eligible = scanned.reject { |purchase| purchase.merchant_account&.is_a_stripe_connect_account? }
     candidates = eligible.first(PROCESSOR_REFUSAL_MAX_READS)
-    return if candidates.empty?
 
     # A full scan may be hiding eligible rows behind the bound, so it counts as capped too.
     capped = eligible.size > candidates.size || scanned.size == PROCESSOR_REFUSAL_MAX_SCAN
+
+    # Ordered before the empty-candidates exit: a page that is entirely Connect rows leaves every
+    # eligible attempt behind the bound, and a bare nil there is the truncated-scan-reads-as-clean
+    # silence this method exists to end.
+    if candidates.empty?
+      return { incomplete: true, truncated_by: :read_cap } if capped
+
+      return
+    end
+
     ran_out_of_time = false
     deadline = Time.current + PROCESSOR_REFUSAL_TIME_BUDGET
 

--- a/spec/models/concerns/purchase/blockable_spec.rb
+++ b/spec/models/concerns/purchase/blockable_spec.rb
@@ -691,9 +691,13 @@ describe Purchase::Blockable do
       it "reports an incomplete scan when a full page of scanned attempts is all Connect charges" do
         connect_account = create(:merchant_account, user: create(:user), charge_processor_id: StripeChargeProcessor.charge_processor_id)
         connect_account.update!(json_data: { "meta" => { "stripe_connect" => "true" } })
-        create_list(:purchase, Purchase::Blockable::PROCESSOR_REFUSAL_MAX_SCAN, link: product, email: buyer_email, purchaser: buyer, created_at: 1.hour.ago)
-          .each { |record| record.update_columns(stripe_transaction_id: "ch_connect", merchant_account_id: connect_account.id) }
-        refused_purchase.update_column(:created_at, 3.hours.ago)
+        # Unambiguously newer than the context's `ch_newer` row, which also sits at 1.hour.ago: the
+        # scan orders created_at DESC and takes a page of MAX_SCAN, so a tie there would let the one
+        # eligible row win the page at random and the assertion below would flake.
+        Purchase::Blockable::PROCESSOR_REFUSAL_MAX_SCAN.times do |offset|
+          create(:purchase, link: product, email: buyer_email, purchaser: buyer, created_at: (offset + 1).minutes.ago)
+            .update_columns(stripe_transaction_id: "ch_connect", merchant_account_id: connect_account.id)
+        end
         expect(Stripe::Charge).not_to receive(:retrieve)
 
         refusal = refused_purchase.processor_rule_refusal

--- a/spec/models/concerns/purchase/blockable_spec.rb
+++ b/spec/models/concerns/purchase/blockable_spec.rb
@@ -685,6 +685,23 @@ describe Purchase::Blockable do
         expect(refused_purchase.processor_rule_refusal_note(refusal)).to include("more attempts in the last day")
       end
 
+      # The same silence, reached without a single read: when a full page of scanned attempts is all
+      # Connect charges there is nothing eligible to read, and the eligible attempts that would have
+      # answered the question sit behind the bound.
+      it "reports an incomplete scan when a full page of scanned attempts is all Connect charges" do
+        connect_account = create(:merchant_account, user: create(:user), charge_processor_id: StripeChargeProcessor.charge_processor_id)
+        connect_account.update!(json_data: { "meta" => { "stripe_connect" => "true" } })
+        create_list(:purchase, Purchase::Blockable::PROCESSOR_REFUSAL_MAX_SCAN, link: product, email: buyer_email, purchaser: buyer, created_at: 1.hour.ago)
+          .each { |record| record.update_columns(stripe_transaction_id: "ch_connect", merchant_account_id: connect_account.id) }
+        refused_purchase.update_column(:created_at, 3.hours.ago)
+        expect(Stripe::Charge).not_to receive(:retrieve)
+
+        refusal = refused_purchase.processor_rule_refusal
+
+        expect(refusal).to eq({ incomplete: true, truncated_by: :read_cap })
+        expect(refused_purchase.processor_rule_refusal_note(refusal)).to include("more attempts in the last day")
+      end
+
       # The two truncation exits are not interchangeable: telling the agent there were more attempts
       # than we read, when the scan actually timed out, is a reason they cannot act on.
       it "reports an incomplete scan when the time budget runs out before every attempt is read" do


### PR DESCRIPTION
Follow-up to #6916, which merged before its adversarial review finished. The review found one P1 in the code that shipped, so this is a fix to `main` rather than a pre-merge note.

## What

`processor_rule_refusal` returns a bare `nil` — read as "nothing is holding this buyer" — when a full page of scanned attempts is entirely Connect charges.

`return if candidates.empty?` sat *before* `capped` was computed, so the truncation signal could not be reached from that exit. The method's own doc comment three lines above promises the opposite:

> Returns nil only when the whole window was read and nothing is holding them; a scan that ran out of reads or budget returns `incomplete` instead, because a nil there is indistinguishable from "clean" to the callers and that silence is the bug this method exists to end.

## Why it is reachable

`eligible` drops charges on a creator's own Connect account, because those refusals come from the creator's Radar rules rather than ours. If all `PROCESSOR_REFUSAL_MAX_SCAN` (40) newest rows are Connect rows, `eligible` is empty and the method returns `nil` — while `scanned.size == 40` proves eligible platform-account attempts may sit behind the bound, unread.

A buyer hammering a Connect storefront produces exactly that page shape. It is the same "no results" vs "we stopped looking" conflation gp#1739 was filed for, reached through a path #6916 did not cover: the earlier fix guarded the read cap and the time budget, both of which are evaluated *after* at least one candidate exists.

## The fix

Compute `capped` before the empty-candidates exit and route that exit through it, so an all-Connect full page returns `{ incomplete: true, truncated_by: :read_cap }`. A genuinely short scan with no eligible rows still returns `nil`, which is correct — the window really was read.

No behaviour change for any case that reads at least one candidate.

## Test Results

- Added a spec asserting the all-Connect full page reports `truncated_by: :read_cap` and produces the "more attempts in the last day" note, with `expect(Stripe::Charge).not_to receive(:retrieve)` pinning that it never spends a read.
- `rubocop` clean on both touched files.
- **Local RSpec cannot verify this in my worktree and CI is the verifier.** A *pre-existing* test in the same `describe` block — "finds a rule refusal sitting behind a newer ordinary decline" — fails identically on unmodified `main` here, in the shared `before` block, with `ActiveRecord::RecordInvalid: We couldn't charge your card` from `create(:purchase, ...)`. That is a local charge-stub environment failure, not a regression: I confirmed it by reverting my change and re-running. So I could not demonstrate local RED→GREEN, and I am not claiming it.

## QA steps

Backend-only change to an admin-facing diagnostic string; no UI surface. Verified by the spec above plus CI.

## Status

- [x] Scope — the P1 from the #6916 adversarial review
- [x] Design — order `capped` before the empty-candidates exit; preserve `nil` for a genuinely complete short scan
- [x] Build — one ordering change, one spec
- [x] QA — **CI green at `96945f9b3`: 79 checks SUCCESS, 0 failures**, which verifies the new spec (local suite blocked by the pre-existing flake documented above)
- [ ] Ship — not merged
- [x] Market — n/a, internal diagnostic
- [x] Sell — n/a, no seller-facing surface