### PR TITLE
Stop telling sellers a buyer paid them for a free download

### DIFF
--- a/app/services/undelivered_receipt_notifier.rb
+++ b/app/services/undelivered_receipt_notifier.rb
@@ -2,7 +2,8 @@
 
 # Tells a seller when a buyer paid and there is no evidence the receipt ever reached them, because
 # nothing else does: a receipt whose delivery is never confirmed sits in `email_infos` forever and
-# notifies nobody, while a bounced row is another no-delivery signal for the seller
+# notifies nobody, and a bounced one silently sets `can_contact: false` for that buyer across all of
+# the seller's sales, so the seller loses the channel at the same moment they need it
 # (gumroad-private#1635).
 #
 # The seller is the recipient rather than our own error reporting for the reason established in
@@ -120,6 +121,8 @@ class UndeliveredReceiptNotifier
   #
   # Re-resolved at render, not trusted from the sweep: the buyer can open their content in the gap.
   def self.undelivered?(purchase)
+    return false unless paid?(purchase)
+
     email_info = purchase.receipt_email_info
     return false if email_info.nil?
     return false if email_info.sent_at.blank? || email_info.sent_at > SETTLE_GRACE.ago
@@ -129,14 +132,30 @@ class UndeliveredReceiptNotifier
     !accessed_content?(purchase)
   end
 
+  # Free downloads are excluded because every action this notice prescribes assumes money changed
+  # hands: there is nothing to refund, and a free-checkout address the buyer typed wrong is not a
+  # customer waiting on the seller. It is also where the bounce volume lives — one suspended account
+  # produced 143,746 bounces in a day from automated $0 checkouts to scraped addresses
+  # (gumroad-private#1397), so including them would bury the paid buyers who can actually be helped.
+  def self.paid?(purchase)
+    order_purchases(purchase).any? { |p| p.price_cents.to_i.positive? }
+  end
+  private_class_method :paid?
+
   # A charge receipt covers every purchase in the order, so any one of them being opened means the
   # buyer got the email. Checking only the representative purchase would report a buyer who is
   # demonstrably reading their content.
   def self.accessed_content?(purchase)
-    purchases = purchase.uses_charge_receipt? ? purchase.charge.purchases.to_a : [purchase]
-    purchases.any? { |p| p.url_redirect.present? && p.url_redirect.uses.to_i.positive? }
+    order_purchases(purchase).any? { |p| p.url_redirect.present? && p.url_redirect.uses.to_i.positive? }
   end
   private_class_method :accessed_content?
+
+  # Everything one receipt covers. A charge receipt stands for the whole order, so judging the
+  # representative purchase alone would answer for one line of a cart.
+  def self.order_purchases(purchase)
+    purchase.uses_charge_receipt? ? purchase.charge.purchases.to_a : [purchase]
+  end
+  private_class_method :order_purchases
 
   def self.report(error)
     ErrorNotifier.notify(error)

--- a/spec/services/undelivered_receipt_notifier_spec.rb
+++ b/spec/services/undelivered_receipt_notifier_spec.rb
@@ -68,6 +68,15 @@ describe UndeliveredReceiptNotifier do
       expect(described_class.undelivered?(purchase)).to eq(true)
     end
 
+    # Nothing this notice prescribes applies to a free download: there is no payment to refund, and it
+    # told sellers a buyer "paid you" for a $0 checkout (gumroad-private#1635 follow-up).
+    it "is false for a free purchase" do
+      free_purchase = create(:purchase, link: create(:product, price_cents: 0), price_cents: 0)
+      create(:customer_email_info, purchase: free_purchase, state: "bounced", sent_at: 3.days.ago)
+
+      expect(described_class.undelivered?(free_purchase)).to eq(false)
+    end
+
     context "with a charge receipt covering several purchases" do
       let(:seller) { create(:user) }
       let(:charge) { create(:charge, seller:) }
@@ -95,6 +104,24 @@ describe UndeliveredReceiptNotifier do
         create(:url_redirect, purchase: second_purchase, link: second_purchase.link, uses: 0)
 
         expect(described_class.undelivered?(first_purchase)).to eq(true)
+      end
+
+      # A paid line makes the whole order actionable: the seller can refund it, so the free companion
+      # item must not suppress the notice.
+      it "is true when only one purchase in the charge was paid" do
+        first_purchase.update_columns(price_cents: 0)
+        create(:url_redirect, purchase: first_purchase, link: first_purchase.link, uses: 0)
+        create(:url_redirect, purchase: second_purchase, link: second_purchase.link, uses: 0)
+
+        expect(described_class.undelivered?(first_purchase)).to eq(true)
+      end
+
+      it "is false when every purchase in the charge was free" do
+        first_purchase.update_columns(price_cents: 0)
+        second_purchase.update_columns(price_cents: 0)
+        create(:url_redirect, purchase: first_purchase, link: first_purchase.link, uses: 0)
+
+        expect(described_class.undelivered?(first_purchase)).to eq(false)
       end
     end
   end


### PR DESCRIPTION
The nightly undelivered-receipt notice judged every receipt regardless of what the buyer paid. A bounced receipt on a **$0 free download** therefore emailed the seller "A buyer paid you and we have no confirmation that their receipt reached them" and told them that "reaching them another way, or refunding, is the only thing that will resolve it."

None of that applies to a free download. There is no payment to refund, and a free-checkout address the buyer mistyped is not a customer waiting on the seller. A seller wrote in this morning saying they had never taken a payment, the product named is free, and they could not work out what was being asked of them — all correct.

### Verified on production

Purchase `348299739` (free product): `price_cents: 0`, `purchase_state: successful`, receipt `EmailInfo.state: bounced` (buyer typed `naver.con`), `url_redirect.uses: 0` — and `UndeliveredReceiptNotifier.undelivered?` returned `true`. The notice fired correctly by its own rules; the rules were wrong.

Sizing over a settled window (2026-07-25 → 2026-07-30, 4,000-row samples per side, `undelivered?` evaluated per row): **7 of 4,000 free** purchases would notify vs **17 of 4,000 paid** — about 29% of the cohort is unactionable. The tail is worse: gumroad-private#1397 recorded one account producing 150,529 automated $0 checkouts to scraped addresses in four days, which is exactly the shape that mass-bounces on free rows and would bury the paid buyers who can actually be helped.

### Change

`undelivered?` now returns false unless some purchase the receipt covers was paid. Because a charge receipt stands for a whole order, the price check runs at order granularity (extracted alongside the existing content-access check as `order_purchases`), so a cart with one paid line still notifies and an all-free cart does not.

### Verification

- `51 examples, 0 failures` — `spec/services/undelivered_receipt_notifier_spec.rb` + `spec/sidekiq/alert_sellers_of_undelivered_receipts_job_spec.rb`
- `15 examples, 0 failures` — `ContactingCreatorMailer` `undelivered_receipts` group
- Mutation check: deleting the new guard line reddens exactly the two new free-purchase examples and nothing else, so the specs pin the behaviour rather than merely covering it.
- `rubocop` clean on both touched files.
