### PR TITLE
Tell a seller which field Stripe refused when payout setup is rejected

### DIFF
--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -61,6 +61,10 @@ module StripeMerchantAccountManager
   # for a reason we do not handle specifically. See record_account_rejection_note below.
   ACCOUNT_REJECTION_NOTE_PREFIX = "Stripe rejected payout setup"
 
+  # Marks the seller-facing half of an account-rejection breadcrumb, so the publish block can point
+  # at that specific note rather than whatever seller-visible payout note happens to be newest.
+  PAYOUT_SETUP_REJECTION_NOTE_FLAG = "payout_setup_rejection"
+
   # Prefix for the breadcrumb left when Stripe refuses the service agreement we derived from the
   # seller's legal-entity country. See update_account_attributes below.
   SERVICE_AGREEMENT_REJECTION_NOTE_PREFIX = "Stripe rejected service agreement"
@@ -324,6 +328,60 @@ module StripeMerchantAccountManager
 
     !postal_code_invalid_error?(error) && !bank_account_invalid_error?(error)
   end
+
+  # Our own words for the fields Stripe names in `param`. Stripe's paths ("individual[id_number]")
+  # are not what the settings form calls them, and its messages quote the value it refused without
+  # ever stating the rule it applied.
+  PAYOUT_SETUP_REJECTED_FIELD_LABELS = {
+    "phone" => "phone number",
+    "support_phone" => "business phone number",
+    "id_number" => "Tax ID",
+    "tax_id" => "business tax ID",
+    "dob" => "date of birth",
+    "first_name" => "first name",
+    "last_name" => "last name",
+  }.freeze
+  private_constant :PAYOUT_SETUP_REJECTED_FIELD_LABELS
+
+  # Seller-facing copy for the payout-setup rejections that have no dedicated lane of their own —
+  # everything undiagnosed_stripe_rejection? covers. Without it these fall through to Stripe's raw
+  # message or nothing at all, and a seller ends up with a saved-looking settings page, no payout
+  # rail, and a publish button that blames a missing payment method (gumroad-private#1777).
+  #
+  # nil for the rejections that are already handled specifically, so a caller can fall through to
+  # the postal-code and bank-directory branches without ordering the checks by hand.
+  def self.payout_setup_rejection_seller_message(error, user)
+    return unless undiagnosed_stripe_rejection?(error)
+
+    field = PAYOUT_SETUP_REJECTED_FIELD_LABELS[stripe_rejected_field(error)]
+    [
+      field ? "Our payment partner couldn't accept the #{field} you entered." : "Our payment partner couldn't accept the details you entered.",
+      us_individual_phone_rule_note(error, user),
+      "Please correct it here and save again — until it goes through you have no payout method, which also stops you publishing new products.",
+    ].compact.join(" ")
+  end
+
+  # Stripe requires the representative's phone to be a US number on a US individual or
+  # sole-proprietorship account, and its rejection quotes the number without saying so. Some
+  # foreign landlines are accepted, so a seller cannot infer the rule from a retry either.
+  def self.us_individual_phone_rule_note(error, user)
+    return unless phone_number_invalid_error?(error)
+
+    compliance_info = user&.alive_user_compliance_info
+    return unless compliance_info&.legal_entity_country_code == Compliance::Countries::USA.alpha2
+    # legal_entity_business_type falls back to sole proprietorship for a non-business account, so
+    # this one comparison covers both the individual and the sole-prop cases Stripe applies it to.
+    return unless compliance_info.legal_entity_business_type == UserComplianceInfo::BusinessTypes::SOLE_PROPRIETORSHIP
+
+    "For a US individual or sole-proprietorship account it has to be a US number, even if you live elsewhere."
+  end
+  private_class_method :us_individual_phone_rule_note
+
+  def self.stripe_rejected_field(error)
+    param = error.respond_to?(:param) ? error.param.to_s : ""
+    param.split("[").last.to_s.delete("]").presence
+  end
+  private_class_method :stripe_rejected_field
 
   def self.delete_account(merchant_account)
     stripe_account = Stripe::Account.retrieve(merchant_account.charge_processor_merchant_id)
@@ -1638,8 +1696,10 @@ module StripeMerchantAccountManager
   # recorded. `param` is the field name Stripe objected to; that single value is normally
   # enough to identify the problem without reproducing the failure.
   #
-  # Not seller-visible: the seller already saw Stripe's message, and the raw parameter path
-  # is internal vocabulary that would confuse more than it helps.
+  # Seller-visible, so a seller who navigates away from the inline error still has a way to find
+  # out. It carries our own wording rather than the raw parameter path: these rejections are not
+  # auto-retryable (RetryStripeRejectedPayoutSetupsJob only picks up the postal-code and bank-sync
+  # prefixes), so the seller has to act, and previously the one durable record was support-only.
   def self.record_account_rejection_note(user, error)
     return if user.blank?
 
@@ -1651,6 +1711,11 @@ module StripeMerchantAccountManager
     user.add_payout_note(
       content: "#{ACCOUNT_REJECTION_NOTE_PREFIX}: #{details.join(' ')} — #{error.message.to_s.truncate(300)}",
       seller_visible: false
+    )
+    user.add_payout_note(
+      content: payout_setup_rejection_seller_message(error, user),
+      seller_visible: true,
+      json_data: { PAYOUT_SETUP_REJECTION_NOTE_FLAG => true }
     )
   rescue => e
     # A missing breadcrumb must never turn into a second failure on top of the original

--- a/app/controllers/settings/payments_controller.rb
+++ b/app/controllers/settings/payments_controller.rb
@@ -147,6 +147,11 @@ class Settings::PaymentsController < Settings::BaseController
         # came from, and this is the path a first-time payout setup fails on.
         directory_miss = StripeMerchantAccountManager.bank_directory_miss_seller_message(e, current_seller.active_bank_account)
         return redirect_with_error(directory_miss) if directory_miss
+        # Everything else Stripe refuses at account-creation time used to fall through to its raw
+        # message, which quotes the value without naming the rule — or to nothing at all, leaving a
+        # "Thanks! You're all set." page with no payout rail behind it (gumroad-private#1777).
+        rejection_message = StripeMerchantAccountManager.payout_setup_rejection_seller_message(e, current_seller)
+        return redirect_with_error(rejection_message) if rejection_message
         return redirect_with_error(e.try(:message) || "Something went wrong.")
       end
     end

--- a/app/models/concerns/user/comments.rb
+++ b/app/models/concerns/user/comments.rb
@@ -33,6 +33,13 @@ module User::Comments
     recent_payout_notes.find { |note| PayoutNoteVisibility.seller_visible?(note) }
   end
 
+  # The newest payout note recorded because Stripe rejected the seller's payout setup, or nil.
+  # Marked with StripeMerchantAccountManager::PAYOUT_SETUP_REJECTION_NOTE_FLAG when written, so a
+  # reader that needs this specific note is not left guessing from the newest visible one.
+  def latest_payout_setup_rejection_note
+    recent_payout_notes.find { |note| note.json_data[StripeMerchantAccountManager::PAYOUT_SETUP_REJECTION_NOTE_FLAG] == true }
+  end
+
   # The newest payout note on the account, seller-facing or internal.
   #
   # Same scoping and ordering as latest_seller_visible_payout_note on purpose — the payout pipeline

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1640,8 +1640,22 @@ class Link < ApplicationRecord
     def enforce_merchant_account_exits_for_new_users!
       return if publishable?
 
-      errors.add(:base, "You must connect at least one payment method before you can publish this product for sale.")
-      raise LinkInvalid, "You must connect at least one payment method before you can publish this product for sale."
+      errors.add(:base, publish_blocked_message)
+      raise LinkInvalid, publish_blocked_message
+    end
+
+    # A seller whose payout setup Stripe rejected has a saved bank account and no rail, so telling
+    # them to connect a payment method sends them looking for something that is already there. Point
+    # at the rejection instead — the seller-visible note recorded when Stripe refused the account
+    # (gumroad-private#1777).
+    #
+    # Keyed on the note's own marker rather than on the newest seller-visible payout note, which is
+    # usually an unrelated skipped-payout explanation.
+    def publish_blocked_message
+      rejection = user.latest_payout_setup_rejection_note
+      return "You must connect at least one payment method before you can publish this product for sale." if rejection.blank?
+
+      "Your payout setup hasn't gone through yet, so you can't publish this product for sale. #{rejection.content}"
     end
 
     def free_trial_only_enabled_if_recurring_billing

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_rejection_message_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_rejection_message_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Stripe's rejections quote the value they refused without ever naming the rule, and everything
+# outside the postal-code and bank-directory lanes used to reach the seller as that raw message or
+# not at all (gumroad-private#1777).
+describe StripeMerchantAccountManager, ".payout_setup_rejection_seller_message" do
+  let(:user) { create(:user) }
+
+  def rejection(message, param, code: nil)
+    Stripe::InvalidRequestError.new(message, param, code:)
+  end
+
+  it "names the field in the settings form's own words, not Stripe's parameter path" do
+    create(:user_compliance_info, user:, country: "Colombia")
+
+    message = described_class.payout_setup_rejection_seller_message(
+      rejection("Invalid value for individual[id_number]", "individual[id_number]"), user
+    )
+
+    expect(message).to include("couldn't accept the Tax ID you entered")
+    expect(message).not_to include("individual[id_number]")
+    expect(message).to include("stops you publishing new products")
+  end
+
+  it "states the US-number rule for a US individual account, which Stripe's own message omits" do
+    create(:user_compliance_info, user:, country: "United States")
+
+    message = described_class.payout_setup_rejection_seller_message(
+      rejection('"+573006330866" is not a valid phone number', "individual[phone]"), user
+    )
+
+    expect(message).to include("couldn't accept the phone number you entered")
+    expect(message).to include("has to be a US number")
+  end
+
+  # The rule is Stripe's, and it only applies to US individual and sole-proprietorship accounts, so
+  # asserting it anywhere else would send the seller to change a field that was already correct.
+  it "does not state the US-number rule for a non-US account" do
+    create(:user_compliance_info, user:, country: "Colombia")
+
+    message = described_class.payout_setup_rejection_seller_message(
+      rejection('"+573006330866" is not a valid phone number', "individual[phone]"), user
+    )
+
+    expect(message).to include("couldn't accept the phone number you entered")
+    expect(message).not_to include("US number")
+  end
+
+  it "does not state the US-number rule for a US company, which Stripe does not apply it to" do
+    create(:user_compliance_info_business, user:, country: "United States",
+                                           business_type: UserComplianceInfo::BusinessTypes::LLC)
+
+    message = described_class.payout_setup_rejection_seller_message(
+      rejection('"+573006330866" is not a valid phone number', "individual[phone]"), user
+    )
+
+    expect(message).not_to include("US number")
+  end
+
+  it "falls back to a generic sentence for a rejection carrying no param" do
+    create(:user_compliance_info, user:)
+
+    message = described_class.payout_setup_rejection_seller_message(
+      rejection("Something is wrong. Please contact us if this continues.", nil), user
+    )
+
+    expect(message).to include("couldn't accept the details you entered")
+  end
+
+  # These two already have dedicated seller-facing copy and their own retry loops; a second message
+  # here would compete with the branch the controller checks first.
+  it "returns nothing for a postal-code rejection" do
+    expect(
+      described_class.payout_setup_rejection_seller_message(
+        rejection("Invalid postal code", "individual[address][postal_code]", code: "postal_code_invalid"), user
+      )
+    ).to be_nil
+  end
+
+  it "returns nothing for a bank-account rejection" do
+    expect(
+      described_class.payout_setup_rejection_seller_message(
+        rejection("We couldn't find the bank for that BIC", "bank_account[routing_number]"), user
+      )
+    ).to be_nil
+  end
+
+  # An APIConnectionError means Stripe never reached a verdict, so blaming the seller's data would
+  # send them editing a field that is fine.
+  it "returns nothing for an error that is not a rejection of the seller's input" do
+    expect(
+      described_class.payout_setup_rejection_seller_message(
+        Stripe::APIConnectionError.new("connection failed"), user
+      )
+    ).to be_nil
+  end
+end

--- a/spec/models/link_publish_payout_block_spec.rb
+++ b/spec/models/link_publish_payout_block_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# A seller whose Stripe payout setup was rejected has a saved bank account and no rail, so the
+# generic "connect a payment method" wall sent them looking for something that was already there —
+# one seller stayed blocked for a month (gumroad-private#1777).
+describe Link, "#publish! when the seller cannot be paid out" do
+  let(:seller) { create(:user) }
+  let(:product) { create(:product, user: seller, draft: true, purchase_disabled_at: Time.current) }
+
+  def publish_error
+    product.publish!
+    nil
+  rescue Link::LinkInvalid => e
+    e.message
+  end
+
+  it "points at the rejected field when Stripe refused the seller's payout setup" do
+    seller.add_payout_note(
+      content: "Our payment partner couldn't accept the phone number you entered. For a US individual or sole-proprietorship account it has to be a US number, even if you live elsewhere.",
+      seller_visible: true,
+      json_data: { StripeMerchantAccountManager::PAYOUT_SETUP_REJECTION_NOTE_FLAG => true }
+    )
+
+    expect(publish_error).to eq(
+      "Your payout setup hasn't gone through yet, so you can't publish this product for sale. " \
+      "Our payment partner couldn't accept the phone number you entered. For a US individual or sole-proprietorship account it has to be a US number, even if you live elsewhere."
+    )
+  end
+
+  it "keeps the generic message for a seller who never started payout setup" do
+    expect(publish_error).to eq("You must connect at least one payment method before you can publish this product for sale.")
+  end
+
+  # Keyed on the rejection note's own marker: a skipped-payout explanation is the note most sellers
+  # have, and reading whichever seller-visible note is newest would blame a rejection that never
+  # happened.
+  it "keeps the generic message when the newest seller-visible note is an unrelated payout explanation" do
+    seller.add_payout_note(content: "Your payout was skipped because your balance was below the minimum.", seller_visible: true)
+
+    expect(publish_error).to eq("You must connect at least one payment method before you can publish this product for sale.")
+  end
+
+  it "does not block a seller who has a payout rail, rejection note or not" do
+    seller.add_payout_note(
+      content: "Our payment partner couldn't accept the Tax ID you entered.",
+      seller_visible: true,
+      json_data: { StripeMerchantAccountManager::PAYOUT_SETUP_REJECTION_NOTE_FLAG => true }
+    )
+    create(:merchant_account_stripe_connect, user: seller)
+
+    expect(publish_error).to be_nil
+    expect(product.reload.published?).to be(true)
+  end
+end

--- a/spec/models/link_publish_payout_block_spec.rb
+++ b/spec/models/link_publish_payout_block_spec.rb
@@ -6,7 +6,9 @@ require "spec_helper"
 # generic "connect a payment method" wall sent them looking for something that was already there —
 # one seller stayed blocked for a month (gumroad-private#1777).
 describe Link, "#publish! when the seller cannot be paid out" do
-  let(:seller) { create(:user) }
+  # payment_address is populated by the factory, and it alone satisfies can_publish_products?, so a
+  # seller with no payout rail has to be built explicitly.
+  let(:seller) { create(:user, payment_address: nil) }
   let(:product) { create(:product, user: seller, draft: true, purchase_disabled_at: Time.current) }
 
   def publish_error

--- a/spec/services/update_user_compliance_info_spec.rb
+++ b/spec/services/update_user_compliance_info_spec.rb
@@ -1042,12 +1042,26 @@ describe UpdateUserComplianceInfo do
 
         expect(result[:success]).to be false
 
-        note = user.reload.comments.with_type_payout_note.alive.last
+        note = user.reload.comments.with_type_payout_note.alive.find { |c| c.content.include?("Stripe rejected payout setup") }
         expect(note).to be_present
-        expect(note.content).to include("Stripe rejected payout setup")
         expect(note.content).to include("code=invalid_request_error")
         expect(note.content).to include("param=individual[id_number]")
         expect(note.content).to include("Invalid value for individual[id_number]")
+      end
+
+      it "also tells the seller which field was refused, in a note they can read later" do
+        # The internal breadcrumb is support-only, so before this a seller who left the page had no
+        # way to find out why they had no payout rail (gumroad-private#1777).
+        error = Stripe::InvalidRequestError.new("Invalid value for individual[id_number]", "individual[id_number]", code: "invalid_request_error")
+        allow(StripeMerchantAccountManager).to receive(:handle_new_user_compliance_info).and_raise(error)
+
+        described_class.new(compliance_params: params, user:).process
+
+        note = user.reload.latest_payout_setup_rejection_note
+        expect(note).to be_present
+        expect(PayoutNoteVisibility.seller_visible?(note)).to be true
+        expect(note.content).to include("couldn't accept the Tax ID you entered")
+        expect(note.content).not_to include("individual[id_number]")
       end
 
       it "still returns Stripe's message to the seller" do


### PR DESCRIPTION
## What

When Stripe rejects a seller's payout-setup for anything other than a postal code or bank-details miss, the seller now finds out — inline on `/settings/payments`, in a durable note they can read later, and in the publish error that used to blame the wrong thing.

Three surfaces:

1. **`Settings::PaymentsController#update`** — a new branch for the remaining `Stripe::InvalidRequestError` cases, named in the settings form's own vocabulary rather than Stripe's parameter path (`individual[id_number]` → "the Tax ID you entered").
2. **`StripeMerchantAccountManager.record_account_rejection_note`** — the support-only breadcrumb from #6476 stays exactly as it is; a second, seller-visible note is written alongside it, marked with `PAYOUT_SETUP_REJECTION_NOTE_FLAG` so a reader that needs *this* note is not guessing from whichever note is newest.
3. **`Link#enforce_merchant_account_exits_for_new_users!`** — when that marked note exists, the publish wall says the payout setup was rejected and repeats the reason, instead of "You must connect at least one payment method", which is false for a seller who has a bank account saved.

For `individual[phone]` on a US individual or sole-proprietorship account it also states the rule Stripe applies and never mentions: the representative phone must be a US number. Stripe accepts some foreign landlines and rejects every foreign mobile, so a seller cannot infer it by retrying.

## Why

gumroad-private#1777. A seller switches payout method to a bank account, Stripe refuses account creation, the rejection is swallowed, the page says "Thanks! You're all set." — and the only symptom appears a month later on a different page: *"You must connect at least one payment method before you can publish this product for sale."*

Measured on the reported seller (user 23146962): one alive `AchAccount` with `stripe_bank_account_id` nil, a Stripe merchant account created and soft-deleted in the same second, `can_publish_products?` false, one product saved and unpublishable. Replaying his exact params showed the phone was the only blocker — same params with a US phone passed with `currently_due: ["external_account"]` and no errors.

Not one seller: `Stripe rejected payout setup` notes since #6476 shipped hit a 60-row cap in under six days. `individual[phone]` accounts for 15 distinct users, `individual[id_number]` for 5 — one of whom retried **21 times in 16 minutes**, which is the signature of a seller with no feedback. Several of the phone values are malformed `+1`-prefixed foreign numbers (`+11423309901`, `+10000000000`), i.e. sellers guessing at a format after a rejection they were never shown.

## Before / After

| Surface | Before | After |
|---|---|---|
| `/settings/payments` save, `individual[phone]` refused | Stripe's raw `"+573006330866" is not a valid phone number`, or nothing at all | "Our payment partner couldn't accept the phone number you entered. For a US individual or sole-proprietorship account it has to be a US number, even if you live elsewhere. Please correct it here and save again — until it goes through you have no payout method, which also stops you publishing new products." |
| `/settings/payments` save, `individual[id_number]` refused | Stripe's message quoting the parameter path | "Our payment partner couldn't accept the Tax ID you entered. Please correct it here and save again — …" |
| Durable record on the account | one note, `seller_visible: false` — support-only | that note unchanged, plus a seller-visible one in our words |
| Publish attempt afterwards | "You must connect at least one payment method before you can publish this product for sale." — false, the bank account is saved | "Your payout setup hasn't gone through yet, so you can't publish this product for sale. Our payment partner couldn't accept the phone number you entered. …" |
| Postal-code / bank-directory rejections | dedicated copy + weekly retry | unchanged — `payout_setup_rejection_seller_message` returns nil for both, so the existing branches still win |

## Test Results

Run locally in a dedicated worktree at load ~30-70 (`DISABLE_SPRING=1 bundle exec rspec`):

| Check | Result |
|---|---|
| `spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_rejection_message_spec.rb` (new) | 8 examples, 0 failures |
| `spec/models/link_publish_payout_block_spec.rb` (new) | 4 examples, 0 failures |
| Both together | **12 examples, 0 failures** in 58.9s |
| `ruby -c` on all four changed files | Syntax OK |

`spec/services/update_user_compliance_info_spec.rb` — updated (its `…alive.last` read now returns the new seller-visible note, so it was a real stale pin, plus one added example) — is owed a run; the file's other examples call live Stripe stubs and it is queued behind CI rather than measured here.

### Mutation proof — every new spec group reddens when its guard is reverted

Fix committed first, mutation applied in place, restored from `HEAD` via an `EXIT` trap:

| Mutant | Effect | Result |
|---|---|---|
| `rejection = user.latest_payout_setup_rejection_note` → `rejection = nil` | publish block falls back to the generic message | `4 examples, 1 failure` ✅ |
| `us_individual_phone_rule_note(error, user),` line deleted | the US-number rule is never stated | `8 examples, 1 failure` ✅ |
| `field = PAYOUT_SETUP_REJECTED_FIELD_LABELS[…]` → `field = nil` | every rejection gets the generic sentence | `8 examples, 3 failures` ✅ |
| control — restored tree | | `12 examples, 0 failures`, guard greps 1/1 ✅ |

Mutant 3 killing **3** examples rather than 1 is the correct result: the field label is what three separate examples assert on (Tax ID, phone number, and the "does not mention US number" negative arm), so dropping the lookup is a wider break than dropping the phone-rule sentence.

## QA steps

Backend only; the changed strings are flash copy, a payout note and a validation message — no new rendered surface. Reviewer path:

1. Read the four call sites in the diff.
2. `bundle exec rspec spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_rejection_message_spec.rb spec/models/link_publish_payout_block_spec.rb` → 12 examples, 0 failures.
3. Optional console probe: `StripeMerchantAccountManager.payout_setup_rejection_seller_message(Stripe::InvalidRequestError.new('"+573006330866" is not a valid phone number', "individual[phone]"), User.find(<us_individual_seller>))`

## Not in this PR

Ask 4 of the issue — validating the US-individual phone rule client-side in `Show.tsx`, where `country` and `business_type` are already known. Cheapest possible catch, but it duplicates a Stripe rule in TypeScript and needs its own decision about how strictly to enforce something Stripe itself applies unevenly (foreign landlines pass). Say the word and I will open it.

Asks 1-3 do not narrow the postal-code or bank-directory lanes: `payout_setup_rejection_seller_message` returns nil for both, so their existing branches still win in the controller.

## Status

- [x] Scope — issue asks 1, 2 and 3
- [x] Design — seller-visible note marked with its own flag rather than reusing "newest visible note"
- [x] Build — four call sites, two new spec files, one stale pin repaired
- [x] Tests — 12 examples green, three mutants proven red (table above)
- [x] QA — spec-level; no rendered surface to capture
- [ ] Shipped — awaiting CI + review

---

🤖 Written by [Hermes Agent](https://github.com/NousResearch/hermes-agent) (claude-opus-5) on gumclaw's instruction. Instructions given: drain the gumroad-private backlog, build the simplest open issue with no PR against it; on this issue, implement asks 1-3 and leave ask 4 as a named follow-up.
