### PR TITLE
Stop requiring a beneficial owner's ID number on edit when the server does not

### DIFF
--- a/app/javascript/components/Settings/PaymentsPage/BeneficialOwnersSection.test.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/BeneficialOwnersSection.test.tsx
@@ -28,7 +28,14 @@ const ownerWithoutIdNumber = {
   phone: null,
   dob: { day: null, month: null, year: null },
   address: { line1: null, city: null, postal_code: null, state: null, country: "GB" },
-  relationship: { owner: true, director: true, executive: true, representative: false, title: null, percent_ownership: 25 },
+  relationship: {
+    owner: true,
+    director: true,
+    executive: true,
+    representative: false,
+    title: null,
+    percent_ownership: 25,
+  },
   id_number_provided: false,
   ssn_last_4_provided: false,
   nationality: null,
@@ -59,7 +66,8 @@ const renderSection = (owners: unknown[]) => {
   );
 };
 
-const idNumberInput = () => screen.getByLabelText(/tax ID number|ID number/iu);
+// GB has no country-specific config, so the field carries the fallback "Personal ID number" label.
+const idNumberInput = () => screen.getByLabelText("Personal ID number");
 
 describe("BeneficialOwnersSection ID number requirement", () => {
   // The server requires an ID number only when creating an owner
@@ -71,14 +79,14 @@ describe("BeneficialOwnersSection ID number requirement", () => {
 
     fireEvent.click(await screen.findByRole("button", { name: "Edit Chloe Flexman" }));
 
-    await waitFor(() => expect(idNumberInput()).not.toBeRequired());
+    await waitFor(() => expect(idNumberInput().hasAttribute("required")).toBe(false));
   });
 
   it("still requires an ID number when adding a new owner", async () => {
     renderSection([]);
 
-    fireEvent.click(await screen.findByRole("button", { name: /add owner/iu }));
+    fireEvent.click(await screen.findByRole("button", { name: "Add beneficial owner" }));
 
-    await waitFor(() => expect(idNumberInput()).toBeRequired());
+    await waitFor(() => expect(idNumberInput().hasAttribute("required")).toBe(true));
   });
 });

--- a/app/javascript/components/Settings/PaymentsPage/BeneficialOwnersSection.test.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/BeneficialOwnersSection.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import BeneficialOwnersSection from "$app/components/Settings/PaymentsPage/BeneficialOwnersSection";
+
+beforeAll(() => {
+  Object.assign(globalThis, {
+    Routes: new Proxy(
+      {},
+      {
+        get: (_target, name: string) => () => `/${String(name).replace(/_path$|_url$/u, "")}`,
+      },
+    ),
+  });
+});
+
+afterEach(cleanup);
+
+// A co-director with no ID number on file: exactly the shape Stripe asks us to complete with a DOB,
+// an address and a title, and never asks for an ID number for.
+const ownerWithoutIdNumber = {
+  id: "person_1",
+  first_name: "Chloe",
+  last_name: "Flexman",
+  email: null,
+  phone: null,
+  dob: { day: null, month: null, year: null },
+  address: { line1: null, city: null, postal_code: null, state: null, country: "GB" },
+  relationship: { owner: true, director: true, executive: true, representative: false, title: null, percent_ownership: 25 },
+  id_number_provided: false,
+  ssn_last_4_provided: false,
+  nationality: null,
+  verification_status: "unverified",
+  requirements_currently_due: ["dob.day", "dob.month", "dob.year", "address.line1", "relationship.title"],
+};
+
+const renderSection = (owners: unknown[]) => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ beneficial_owners: owners }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    ),
+  );
+  return render(
+    <BeneficialOwnersSection
+      countries={{ GB: "United Kingdom" }}
+      states={{ us: [], ca: [], au: [], mx: [], ae: [], ir: [], br: [], jp: [] }}
+      defaultCountry="GB"
+      minDobYear={1900}
+      isFormDisabled={false}
+    />,
+  );
+};
+
+const idNumberInput = () => screen.getByLabelText(/tax ID number|ID number/iu);
+
+describe("BeneficialOwnersSection ID number requirement", () => {
+  // The server requires an ID number only when creating an owner
+  // (StripeBeneficialOwnersManager::REQUIRED_CREATE_ONLY_FIELDS), so requiring it on edit blocked a
+  // save the server would have accepted and stranded the seller in a verification loop
+  // (gumroad-private#1776).
+  it("does not require an ID number when editing an owner who has none on file", async () => {
+    renderSection([ownerWithoutIdNumber]);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Edit Chloe Flexman" }));
+
+    await waitFor(() => expect(idNumberInput()).not.toBeRequired());
+  });
+
+  it("still requires an ID number when adding a new owner", async () => {
+    renderSection([]);
+
+    fireEvent.click(await screen.findByRole("button", { name: /add owner/iu }));
+
+    await waitFor(() => expect(idNumberInput()).toBeRequired());
+  });
+});

--- a/app/javascript/components/Settings/PaymentsPage/BeneficialOwnersSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/BeneficialOwnersSection.tsx
@@ -1171,6 +1171,11 @@ const BeneficialOwnersSection = ({
                   const isUs = defaultCountry === "US";
                   const taxIdConfig =
                     isUs && useGovernmentIdForUs ? PERSONAL_ID_NUMBER_CONFIG : taxIdConfigFor(defaultCountry);
+                  // Only creating an owner requires an ID number (the server enforces it via
+                  // REQUIRED_CREATE_ONLY_FIELDS). Requiring it on edit stranded sellers completing a
+                  // co-director's DOB and address — a third party's ID number they cannot obtain, for
+                  // a field Stripe never asked for (gumroad-private#1776).
+                  const isCreatingOwner = editState.mode !== "edit";
                   const hasTaxIdOnFile =
                     editState.mode === "edit" &&
                     (editState.owner.id_number_provided || editState.owner.ssn_last_4_provided);
@@ -1209,7 +1214,7 @@ const BeneficialOwnersSection = ({
                               minLength={taxIdConfig.minLength}
                               maxLength={taxIdConfig.maxLength}
                               placeholder={taxIdConfig.placeholder}
-                              required={!hasTaxIdOnFile}
+                              required={isCreatingOwner}
                               disabled={isFormDisabled}
                               value={formState.id_number}
                               onChange={(event) => updateForm({ id_number: event.target.value })}


### PR DESCRIPTION
## What

On **Settings → Payments → Beneficial owners**, the "Personal ID number" field is no longer `required` when *editing* an existing owner. It stays required when *adding* one, which is the only case the server actually enforces.

One line changes behaviour:

```diff
-  required={!hasTaxIdOnFile}
+  required={isCreatingOwner}
```

## Why

gumroad-private#1776. `StripeBeneficialOwnersManager::REQUIRED_CREATE_ONLY_FIELDS` puts `id_number` behind `action == :create`, so the update path accepts a save without one. The client did not agree: `hasTaxIdOnFile` is `editState.mode === "edit" && (owner.id_number_provided || owner.ssn_last_4_provided)`, so for an existing owner with **neither** on file it is `false` in edit mode too, and the browser's own `required` attribute blocked a submission the server would have taken.

Measured on the reported account (Buff Motion Limited, GB company, `acct_1SHmAs2nk6IfrQdc`, audited console read `20260803T115549Z-e7a94d3f`): `charges_enabled` true, `requirements.errors` empty, and `currently_due` is exactly seven fields on one person — `person_1Tt3yI….{address.city, address.line1, address.postal_code, dob.day, dob.month, dob.year, relationship.title}`. That person (Chloe Flexman, co-director) has `id_number_provided: false`, and **Stripe is not asking for her ID number.** Our form was.

So the only route through the form was for the seller to obtain and type a third party's passport or licence number, for a field nobody requested — while "Action Required" verification emails kept arriving, because the DOB and address Stripe *did* want could not be saved.

## Before / After

| | Before | After |
|---|---|---|
| Edit an owner with no ID number on file | "Personal ID number" required; browser blocks Save changes; DOB/address/title cannot be completed | field optional; save goes through and Stripe's `currently_due` clears |
| Edit an owner **with** an ID number on file | masked value + "Change" link, not required | unchanged |
| Add a new owner | required | required — the server rejects a create without one, so this must stay |

Server-side validation is unchanged, so nothing here relaxes what we actually enforce; it stops the client enforcing more than the server.

## Test Results

| Check | Result |
|---|---|
| `npx vitest run app/javascript/components/Settings/PaymentsPage/BeneficialOwnersSection.test.tsx` (new file) | **2 passed** (2) |
| `npx prettier --write` on the test file | clean |
| `Lint JS/TS` / `Typecheck TS` on CI | red on the first push, fixed — see below |

Two CI failures on the first push, both real and both in the new test rather than the fix: prettier wanted the `relationship` literal expanded, and `expect(...).toBeRequired()` does not exist here because **jest-dom is not loaded in this repo's vitest setup** (`error TS2339: Property 'toBeRequired' does not exist on type 'Assertion<HTMLElement>'`). Assertions are now `hasAttribute("required")`, which is also closer to what the bug actually was.

Two selector corrections while getting the harness to run, worth knowing for the next test in this file: GB has no entry in `TAX_ID_CONFIGS`, so the field renders the fallback label **"Personal ID number"**; and the create button's accessible name is **"Add beneficial owner"**, not "Add owner" (that string is the *submit* button inside the sheet).

### Mutation proof

Fix committed first, then reverted in place and restored from `HEAD` via an `EXIT` trap:

| Mutant | Result |
|---|---|
| `required={isCreatingOwner}` → `required={!hasTaxIdOnFile}` (i.e. main's behaviour) | **1 failed \| 1 passed** ✅ |
| control — restored tree, guard grep 1 | 2 passed ✅ |

One of two examples dying is the correct outcome, not a weak proof: the mutant only changes the *edit* arm, so the create-arm example must keep passing. If both had reddened, the create guard would have been asserting nothing.

## QA steps

Frontend, but the changed state is an HTML `required` attribute rather than a rendered pixel, so the durable artifact is the two-arm test above. Click-path on the preview app:

1. As a company-account seller with an existing beneficial owner who has no ID number on file, open Settings → Payments → Beneficial owners.
2. Click Edit on that person. Fill DOB, address and title. Leave "Personal ID number" empty.
3. Save changes — before this the browser refused with its own required-field message; now it saves, and the server accepts it (`REQUIRED_CREATE_ONLY_FIELDS` is create-only).
4. Click "Add beneficial owner" and try to save with the ID number empty — still refused, because the server does require it on create.

## Status

- [x] Scope — client/server disagreement confirmed in both files
- [x] Build — one line plus a two-arm regression test
- [x] Tests — 2 passed; mutant proven red on the edit arm only
- [x] QA — component-level; the changed state is an attribute, not a pixel
- [ ] Shipped — awaiting CI + review

---

🤖 Written by [Hermes Agent](https://github.com/NousResearch/hermes-agent) (claude-opus-5) on gumclaw's instruction. Instructions given: drain the gumroad-private backlog, taking the simplest open issue with no PR against it.
