### PR TITLE
Validate the whole collaborator product set before changing any revenue share

### DIFF
--- a/app/services/collaborator/update_service.rb
+++ b/app/services/collaborator/update_service.rb
@@ -8,35 +8,48 @@ class Collaborator::UpdateService
   end
 
   def process
+    # Resolve the whole requested product set before touching anything: a bad or unowned id used to
+    # raise partway through, after the rows for de-selected products had already been destroyed, so
+    # the collaborator was left on a revenue share nobody asked for.
+    requested_products = params[:products].map do |product_params|
+      [seller.products.find_by_external_id!(product_params[:id]), product_params]
+    end
+
     default_basis_points = params[:percent_commission].presence&.to_i&.*(100)
     collaborator.affiliate_basis_points = default_basis_points if default_basis_points.present?
     collaborator.apply_to_all_products = params[:apply_to_all_products]
     collaborator.dont_show_as_co_creator = params[:dont_show_as_co_creator]
 
-    enabled_product_ids = params[:products].map { _1[:id] }
-    collaborator.product_affiliates.map do |pa|
-      product_id = ObfuscateIds.encrypt(pa.link_id)
-      pa.destroy! unless enabled_product_ids.include?(product_id)
+    result = nil
+
+    ActiveRecord::Base.transaction do
+      enabled_product_ids = params[:products].map { _1[:id] }
+      collaborator.product_affiliates.each do |pa|
+        product_id = ObfuscateIds.encrypt(pa.link_id)
+        pa.destroy! unless enabled_product_ids.include?(product_id)
+      end
+
+      collaborator.product_affiliates = requested_products.map do |product, product_params|
+        product_affiliate = collaborator.product_affiliates.find_or_initialize_by(product:)
+        product_affiliate.dont_show_as_co_creator = collaborator.apply_to_all_products ?
+          collaborator.dont_show_as_co_creator :
+          product_params[:dont_show_as_co_creator]
+        percent_commission = collaborator.apply_to_all_products ? collaborator.affiliate_percentage : product_params[:percent_commission]
+        product_affiliate.affiliate_basis_points = percent_commission.to_i * 100
+        product_affiliate
+      end
+
+      if collaborator.save
+        result = { success: true }
+      else
+        collaborator.errors.add(:base, collaborator.errors.full_messages.first) if collaborator.errors[:base].blank? && collaborator.errors.any?
+        result = { success: false, collaborator: }
+        raise ActiveRecord::Rollback
+      end
     end
 
-    collaborator.product_affiliates = params[:products].map do |product_params|
-      product = seller.products.find_by_external_id!(product_params[:id])
-      product_affiliate = collaborator.product_affiliates.find_or_initialize_by(product:)
-      product_affiliate.dont_show_as_co_creator = collaborator.apply_to_all_products ?
-        collaborator.dont_show_as_co_creator :
-        product_params[:dont_show_as_co_creator]
-      percent_commission = collaborator.apply_to_all_products ? collaborator.affiliate_percentage : product_params[:percent_commission]
-      product_affiliate.affiliate_basis_points = percent_commission.to_i * 100
-      product_affiliate
-    end
-
-    if collaborator.save
-      AffiliateMailer.collaborator_update(collaborator.id).deliver_later
-      { success: true }
-    else
-      collaborator.errors.add(:base, collaborator.errors.full_messages.first) if collaborator.errors[:base].blank? && collaborator.errors.any?
-      { success: false, collaborator: collaborator }
-    end
+    AffiliateMailer.collaborator_update(collaborator.id).deliver_later if result[:success]
+    result
   end
 
   private

--- a/spec/services/collaborator/update_service_spec.rb
+++ b/spec/services/collaborator/update_service_spec.rb
@@ -80,5 +80,48 @@ describe Collaborator::UpdateService do
         described_class.new(seller:, collaborator_id: collaborator.external_id, params:).process
       end.to raise_error ActiveRecord::RecordNotFound
     end
+
+    context "when one product in the requested set is invalid" do
+      before do
+        params[:products] = [{ id: product2.external_id }, { id: SecureRandom.hex }]
+      end
+
+      it "leaves the existing revenue share untouched" do
+        expect do
+          described_class.new(seller:, collaborator_id: collaborator.external_id, params:).process
+        end.to raise_error ActiveRecord::RecordNotFound
+
+        collaborator.reload
+        expect(collaborator.products).to match_array [product1, product2]
+        expect(collaborator.product_affiliates.find_by(product: product1).affiliate_basis_points).to eq 30_00
+        expect(collaborator.product_affiliates.find_by(product: product2).affiliate_basis_points).to eq 30_00
+        expect(product1.reload.is_collab).to eq true
+      end
+
+      it "does not email the collaborator about a change that did not happen" do
+        expect do
+          described_class.new(seller:, collaborator_id: collaborator.external_id, params:).process
+        rescue ActiveRecord::RecordNotFound
+          nil
+        end.not_to have_enqueued_mail(AffiliateMailer, :collaborator_update)
+      end
+    end
+
+    context "when a product belongs to another seller" do
+      let(:other_sellers_product) { create(:product) }
+
+      before do
+        params[:products] = [{ id: product2.external_id }, { id: other_sellers_product.external_id }]
+      end
+
+      it "leaves the existing revenue share untouched" do
+        expect do
+          described_class.new(seller:, collaborator_id: collaborator.external_id, params:).process
+        end.to raise_error ActiveRecord::RecordNotFound
+
+        collaborator.reload
+        expect(collaborator.products).to match_array [product1, product2]
+      end
+    end
   end
 end

--- a/spec/services/collaborator/update_service_spec.rb
+++ b/spec/services/collaborator/update_service_spec.rb
@@ -107,6 +107,34 @@ describe Collaborator::UpdateService do
       end
     end
 
+    # The rollback itself, rather than the pre-flight resolve: here every product id is real, so the
+    # destroys and the re-assignment do run, and only `collaborator.save` refuses. Without the
+    # transaction the de-selected row would already be gone by then.
+    context "when the collaborator itself fails validation" do
+      before do
+        params[:percent_commission] = Collaborator::MAX_PERCENT_COMMISSION + 10
+      end
+
+      it "returns the invalid collaborator and leaves the existing revenue share untouched" do
+        result = nil
+
+        expect do
+          result = described_class.new(seller:, collaborator_id: collaborator.external_id, params:).process
+        end.not_to have_enqueued_mail(AffiliateMailer, :collaborator_update)
+
+        expect(result[:success]).to eq false
+        expect(result[:collaborator].errors[:base]).to be_present
+
+        collaborator.reload
+        expect(collaborator.affiliate_basis_points).to eq 40_00
+        expect(collaborator.apply_to_all_products).to eq false
+        expect(collaborator.products).to match_array [product1, product2]
+        expect(collaborator.product_affiliates.find_by(product: product1).affiliate_basis_points).to eq 30_00
+        expect(collaborator.product_affiliates.find_by(product: product2).affiliate_basis_points).to eq 30_00
+        expect(product1.reload.is_collab).to eq true
+      end
+    end
+
     context "when a product belongs to another seller" do
       let(:other_sellers_product) { create(:product) }
 


### PR DESCRIPTION
## Scope

`Collaborator::UpdateService` destroyed the `ProductAffiliate` rows for de-selected products *before* it had resolved the requested product set. `seller.products.find_by_external_id!` then raised on the first bad or unowned id, leaving the collaborator on a revenue share the seller never asked for, with the removals already committed and nothing surfaced in the UI to explain it.

Reported by a seller-facing correspondent reviewing the public codebase (Helper `422bb37544404a1182e54763eeb5e38b`).

## Design

Resolve every requested product up front, then perform the destroys and the save inside one transaction. A failed `save` rolls back and the collaborator-update email only fires on success, so a rejected change no longer tells the collaborator their split moved.

## Build

- `app/services/collaborator/update_service.rb` — pre-resolve the product set; wrap mutations in `ActiveRecord::Base.transaction`; move `AffiliateMailer.collaborator_update` behind the success branch.

## QA

Failing-first, run locally against an isolated test DB (`gumroad_test_collab1152`).

**RED** (fix reverted, new specs only): `7 examples, 2 failures` — both new "leaves the existing revenue share untouched" examples failed. On the unfixed code the collaborator came back holding only `product2`; `product1`'s revenue-share row was already gone.

```
rspec ./spec/services/collaborator/update_service_spec.rb:89 # when one product in the requested set is invalid leaves the existing revenue share untouched
rspec ./spec/services/collaborator/update_service_spec.rb:119 # when a product belongs to another seller leaves the existing revenue share untouched
```

**GREEN** (fix applied):
- `spec/services/collaborator/update_service_spec.rb` — 7 examples, 0 failures
- `spec/services/collaborator/update_service_spec.rb` + `create_service_spec.rb` — 23 examples, 0 failures
- `bundle exec rubocop app/services/collaborator/ spec/services/collaborator/` — 4 files, no offenses

Checks run: invalid product id mid-set leaves both original product rows and their basis points intact and keeps `is_collab` set on the untouched product; a product owned by another seller does the same; the collaborator-update email is not enqueued for a change that did not happen; both pre-existing update paths and all create-service examples still pass.
