### PR TITLE
Harden sensitive logging and bundle redirects

### DIFF
--- a/app/controllers/api/v2/licenses_controller.rb
+++ b/app/controllers/api/v2/licenses_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class Api::V2::LicensesController < Api::V2::BaseController
-  before_action :log_params, only: [:verify]
   before_action :clean_params, only: [:verify]
   before_action(only: [:enable, :disable, :decrement_uses_count, :rotate]) { doorkeeper_authorize! :edit_products }
   before_action :fetch_valid_license
@@ -93,7 +92,6 @@ class Api::V2::LicensesController < Api::V2::BaseController
     end
 
     def success_with_license
-      Rails.logger.info("License information for #{@license.serial} , license.purchase: #{@license.purchase&.id} , license.imported_customer: #{@license.imported_customer&.id}")
       json = { success: true }.merge(@license.as_json(only: [:uses]))
       if @license.purchase.present?
         purchase = @license.purchase
@@ -123,11 +121,6 @@ class Api::V2::LicensesController < Api::V2::BaseController
       json = purchase.as_json_for_license
       json.keep_if { |key, _| WHITELIST_PURCHASE_ATTRIBUTES.include? key }
       json
-    end
-
-    # Temporary debug output
-    def log_params
-      logger.info "Verify license API request: #{params.inspect}"
     end
 
     def redis_namespace

--- a/app/controllers/bundles/content_controller.rb
+++ b/app/controllers/bundles/content_controller.rb
@@ -32,7 +32,7 @@ class Bundles::ContentController < Bundles::BaseController
     elsif should_unpublish
       redirect_back fallback_location: edit_bundle_content_path(bundle.external_id), notice: "Unpublished!", status: :see_other
     elsif params[:redirect_to].present?
-      redirect_to params[:redirect_to], notice: "Changes saved!", status: :see_other
+      redirect_to safe_redirect_path(params[:redirect_to]), allow_other_host: true, notice: "Changes saved!", status: :see_other
     else
       redirect_back fallback_location: edit_bundle_content_path(bundle.external_id), notice: "Changes saved!", status: :see_other
     end

--- a/app/controllers/bundles/product_controller.rb
+++ b/app/controllers/bundles/product_controller.rb
@@ -79,7 +79,7 @@ class Bundles::ProductController < Bundles::BaseController
     if should_unpublish
       redirect_back fallback_location: edit_bundle_product_path(@bundle.external_id), notice: "Unpublished!", status: :see_other
     elsif params[:redirect_to].present?
-      redirect_to params[:redirect_to], notice:, status: :see_other
+      redirect_to safe_redirect_path(params[:redirect_to]), allow_other_host: true, notice:, status: :see_other
     elsif was_published
       redirect_back fallback_location: edit_bundle_product_path(@bundle.external_id), notice:, status: :see_other
     else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -750,7 +750,7 @@ class User < ApplicationRecord
   def valid_password?(password)
     super(password)
   rescue BCrypt::Errors::InvalidHash
-    logger.info "Account with sha256 password: #{inspect}"
+    logger.info "Account with legacy sha256 password user_id=#{id}"
     false
   end
 

--- a/app/modules/purchase/ping_notification.rb
+++ b/app/modules/purchase/ping_notification.rb
@@ -78,8 +78,6 @@ module Purchase::PingNotification
     payload[:disputed] = chargedback?
     payload[:dispute_won] = chargeback_reversed?
 
-    Rails.logger.info("payload_for_ping_notification #{payload.inspect}")
-
     payload
   end
 end

--- a/app/sidekiq/post_to_individual_ping_endpoint_worker.rb
+++ b/app/sidekiq/post_to_individual_ping_endpoint_worker.rb
@@ -20,7 +20,7 @@ class PostToIndividualPingEndpointWorker
 
     response = HTTParty.post(post_url, body:, timeout: 5, headers: { "Content-Type" => content_type })
 
-    Rails.logger.info("PostToIndividualPingEndpointWorker response=#{response.code} url=#{post_url} content_type=#{content_type} params=#{params.inspect}")
+    Rails.logger.info("PostToIndividualPingEndpointWorker response=#{response.code} content_type=#{content_type} user_id=#{user_id}")
 
     unless response.success?
       if ERROR_CODES_TO_RETRY.include?(response.code) && retry_count < (BACKOFF_STRATEGY.length - 1)
@@ -31,7 +31,7 @@ class PostToIndividualPingEndpointWorker
   # rescue clause to handle connection errors. Without this, the job
   # would fail if the user inputted post_url is invalid.
   rescue *INTERNET_EXCEPTIONS => e
-    Rails.logger.info("[#{e.class}] PostToIndividualPingEndpointWorker error=\"#{e.message}\" url=#{post_url} content_type=#{content_type} params=#{params.inspect}")
+    Rails.logger.info("[#{e.class}] PostToIndividualPingEndpointWorker error content_type=#{content_type} user_id=#{user_id}")
   end
 
   private

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -7,4 +7,4 @@
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += %i[password cc_number number expiry_date cc_expiry cvc account_number account_number_repeated passphrase
                                                  chargeable tax_id individual_tax_id business_tax_id ssn_first_three ssn_middle_two ssn_last_four
-                                                 access_token mobile_token device_code user_code client_secret]
+                                                 access_token mobile_token device_code user_code client_secret license_key]

--- a/spec/config/initializers/filter_parameter_logging_spec.rb
+++ b/spec/config/initializers/filter_parameter_logging_spec.rb
@@ -3,12 +3,13 @@
 require "spec_helper"
 
 describe "filter parameter logging configuration" do
-  it "filters OAuth device flow bearer secrets" do
+  it "filters OAuth device flow and license bearer secrets" do
     filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
     parameters = {
       client_secret: "secret",
       device_code: "device-code",
       user_code: "user-code",
+      license_key: "license-key",
       visible: "safe",
       nested: { "client_secret" => "nested-secret" },
     }
@@ -16,6 +17,7 @@ describe "filter parameter logging configuration" do
       client_secret: "[FILTERED]",
       device_code: "[FILTERED]",
       user_code: "[FILTERED]",
+      license_key: "[FILTERED]",
       visible: "safe",
       nested: { "client_secret" => "[FILTERED]" },
     }

--- a/spec/controllers/api/v2/licenses_controller_spec.rb
+++ b/spec/controllers/api/v2/licenses_controller_spec.rb
@@ -253,6 +253,15 @@ describe Api::V2::LicensesController do
   end
 
   describe "POST 'verify'" do
+    it "does not write license keys to the application log" do
+      messages = []
+      allow(Rails.logger).to receive(:info) { |message| messages << message }
+
+      post :verify, params: { product_id: @product.external_id, license_key: @purchase.license.serial }
+
+      expect(messages.join("\n")).not_to include(@purchase.license.serial)
+    end
+
     shared_examples_for "verify license" do |product_identifier_key, product_identifier_value|
       before do
         @product_identifier = { product_identifier_key => @product.send(product_identifier_value) }

--- a/spec/controllers/bundles/content_controller_spec.rb
+++ b/spec/controllers/bundles/content_controller_spec.rb
@@ -90,6 +90,16 @@ describe Bundles::ContentController, inertia: true do
       expect(new_bundle_products.third.deleted_at).to be_nil
     end
 
+    it "keeps a supplied redirect on the Gumroad host" do
+      put :update, params: {
+        bundle_id: bundle.external_id,
+        redirect_to: "https://evil.example/phish",
+        products: [{ product_id: bundle.bundle_products.first.product.external_id, quantity: 1 }]
+      }
+
+      expect(response).to redirect_to("/phish")
+    end
+
     context "adding a call to a bundle" do
       let(:call_product) { create(:call_product, user: seller) }
 

--- a/spec/controllers/bundles/product_controller_spec.rb
+++ b/spec/controllers/bundles/product_controller_spec.rb
@@ -147,6 +147,12 @@ describe Bundles::ProductController, inertia: true do
       expect(flash[:notice]).to eq("Changes saved!")
     end
 
+    it "keeps a supplied redirect on the Gumroad host" do
+      put :update, params: { bundle_id: bundle.external_id, redirect_to: "https://evil.example/phish", price_cents: 2000 }
+
+      expect(response).to redirect_to("/phish")
+    end
+
     # An unsupported currency is caught by the model's own
     # `price_must_be_within_range`, not by anything added here — these pin that
     # it surfaces to the seller as a flash alert and rolls the whole update back.

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1995,6 +1995,18 @@ describe User, :vcr do
       expect(user).to be_valid_password("password")
       expect(user).to_not be_valid_password("INVALD")
     end
+
+    it "does not log password data when a legacy hash is encountered" do
+      user = build(:user, password: "password")
+      user.encrypted_password = "sha256$legacy"
+      messages = []
+      allow(Rails.logger).to receive(:info) { |message| messages << message }
+
+      expect(user.valid_password?("password")).to be(false)
+
+      expect(messages).to include("Account with legacy sha256 password user_id=")
+      expect(messages.join("\n")).not_to include(user.encrypted_password, user.email)
+    end
   end
 
   describe "#clear_products_cache" do

--- a/spec/sidekiq/post_to_individual_ping_endpoint_worker_spec.rb
+++ b/spec/sidekiq/post_to_individual_ping_endpoint_worker_spec.rb
@@ -60,10 +60,13 @@ describe PostToIndividualPingEndpointWorker do
 
   it "does not raise when it encounters an internet error" do
     allow(HTTParty).to receive(:post).and_raise(SocketError.new("socket error message"))
-    expect(Rails.logger).to receive(:info).with("[SocketError] PostToIndividualPingEndpointWorker error=\"socket error message\" url=http://example.com content_type=#{Mime[:url_encoded_form]} params={\"q\" => 47}")
+    messages = []
+    allow(Rails.logger).to receive(:info) { |message| messages << message }
     expect(HTTParty).to receive(:post).exactly(1).times
 
     PostToIndividualPingEndpointWorker.new.perform("http://example.com", { "q" => 47 })
+
+    expect(messages).to include("[SocketError] PostToIndividualPingEndpointWorker error content_type=#{Mime[:url_encoded_form]} user_id=")
   end
 
   it "re-raises a non-internet error" do
@@ -91,11 +94,27 @@ describe PostToIndividualPingEndpointWorker do
   end
 
   describe "logging" do
-    it "logs url, response code and params" do
+    it "does not log the endpoint URL or payload" do
       expect(HTTParty).to receive(:post).with("https://notification.com", timeout: 5, body: { "a" => 1 }, headers: { "Content-Type" => Mime[:url_encoded_form] }).and_return(@http_double)
-      expect(Rails.logger).to receive(:info).with("PostToIndividualPingEndpointWorker response=200 url=https://notification.com content_type=#{Mime[:url_encoded_form]} params={\"a\" => 1}")
+      messages = []
+      allow(Rails.logger).to receive(:info) { |message| messages << message }
 
       PostToIndividualPingEndpointWorker.new.perform("https://notification.com", { "a" => 1 })
+
+      expect(messages.join("\n")).not_to include("https://notification.com", '"a" => 1')
+    end
+
+    it "does not log license keys or webhook credentials" do
+      endpoint = "https://notification.com/webhook?token=endpoint-secret"
+      payload = { "license_key" => "license-secret", "email" => "buyer@example.com" }
+      expect(HTTParty).to receive(:post).with(endpoint, timeout: 5, body: payload, headers: { "Content-Type" => Mime[:url_encoded_form] }).and_return(@http_double)
+      messages = []
+      allow(Rails.logger).to receive(:info) { |message| messages << message }
+
+      PostToIndividualPingEndpointWorker.new.perform(endpoint, payload)
+
+      logged = messages.join("\n")
+      expect(logged).not_to include(endpoint, "endpoint-secret", "license-secret", "buyer@example.com")
     end
   end
 end


### PR DESCRIPTION
# What

Harden four security-sensitive logging paths and the two bundle-editor redirects.

# Why

- The public license verification endpoint logged the full request param hash (`log_params`) and the license serial on every `verify` call, so plaintext license keys landed in the application log.
- Ping payload generation and `PostToIndividualPingEndpointWorker` logged the entire payload plus the seller-supplied endpoint URL. That payload carries license keys and buyer email addresses, and the URL carries whatever credential the seller put in its query string.
- The legacy sha256 fallback in `User#valid_password?` logged `inspect` on the whole record, dumping account attributes on a failed login.
- `Bundles::ContentController#update` and `Bundles::ProductController#update` passed `params[:redirect_to]` straight to `redirect_to`.

# Changes

- Removed the license param/serial log lines, and added `license_key` to `config.filter_parameters` so it stays redacted anywhere else params get logged.
- Reduced the ping worker's log lines to response code, content type, and user id; removed the payload log in `payload_for_ping_notification`.
- Replaced the full-record inspect in the legacy password fallback with `user_id=` only.
- Normalized both bundle redirect targets through the existing `SafeRedirectPathService`, which keeps same-host and relative paths and rewrites an external target to its local path.
- Added regression coverage for each redaction and both redirect boundaries.

Backend only. No UI, product behavior, or design change.

# Approach notes

The redirect fix uses the service already in `ApplicationController` rather than dropping the parameter or whitelisting paths, so the feature keeps working: both call sites are fed by `saveBeforeNavigate` in `pages/Bundles/{Content,Product}/Edit.tsx`, which passes an in-app path, and `SafeRedirectPathService#process` returns same-host and subdomain-host values untouched. Only a crafted external host degrades, and it degrades to the local path instead of raising `UnsafeRedirectError`.

`allow_other_host: true` is required alongside it because the service legitimately returns subdomain hosts (seller custom domains under `ROOT_DOMAIN`); host validation has moved into the service rather than being removed.

On the worker, dropping `post_url` and `params` from the log leaves `user_id` as the correlation key, which is the seller whose endpoint is being called — enough to debug a seller's failing webhook without holding their payload in the log.

# Test results

Verified in a clean worktree off `origin/main`, failing-first (code reverted, contributed specs kept):

- `bundles/product_controller_spec.rb:150` RED with `ActionController::Redirecting::UnsafeRedirectError: Unsafe redirect to "https://evil.example/phish"`.
- `post_to_individual_ping_endpoint_worker_spec.rb` RED on both new examples, the log line containing `url=https://notification.com/webhook?token=endpoint-secret ... license_key" => "license-secret", "email" => "buyer@example.com"`.
- `filter_parameter_logging_spec.rb` RED with `license_key: "license-key"` instead of `[FILTERED]`.

With the fixes restored: **26 examples, 0 failures** across `bundles/product_controller_spec.rb`, `post_to_individual_ping_endpoint_worker_spec.rb`, `filter_parameter_logging_spec.rb`, and the new `user_spec.rb` password example.

RuboCop on all 13 changed files: no offenses.

`bundles/content_controller_spec.rb` has pre-existing failures on this machine from its `let!(:purchase)` factory (`Validation failed: We couldn't charge your card`); the same 5 reproduce on unmodified `origin/main` in the same worktree, so they are environmental and not from this change.

---

Based on https://github.com/RealBhupesh/gumroad/pull/6 by @RealBhupesh.

Visual/QA evidence lives on the source PR (test-output screenshot and a terminal walkthrough recording); the `qa-media/` binaries were deliberately not imported so blobs stay out of this repo.

AI Disclosure: Claude Opus 4.6 (1M context) was used to review the original PR and import the changes.
