### PR TITLE
Measure the chargeback payout gate over a trailing year at 1.5%

### DIFF
--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -519,7 +519,7 @@ module Purchase::Blockable
     return unless seller.present?
     return if [User::PAYOUT_PAUSE_SOURCE_ADMIN, User::PAYOUT_PAUSE_SOURCE_SYSTEM].include?(seller.payouts_paused_by_source)
 
-    chargeback_stats = seller.lost_chargebacks
+    chargeback_stats = seller.lost_chargebacks_for_payout_gate
     chargeback_volume_percentage = chargeback_stats[:volume]
     return if chargeback_volume_percentage == "NA"
 
@@ -532,7 +532,7 @@ module Purchase::Blockable
     User.transaction do
       seller.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_SYSTEM)
       seller.comments.create(
-        content: "Payouts automatically paused due to chargeback rate (#{chargeback_volume_percentage}) exceeding #{User::MAX_CHARGEBACK_RATE_ALLOWED_FOR_PAYOUTS}% volume.",
+        content: "Payouts automatically paused due to chargeback rate (#{chargeback_volume_percentage}) exceeding #{User::MAX_CHARGEBACK_RATE_ALLOWED_FOR_PAYOUTS}% volume over the last #{User::PAYOUT_CHARGEBACK_RATE_WINDOW.inspect}.",
         comment_type: Comment::COMMENT_TYPE_ON_PROBATION,
         author_name: User::SYSTEM_PAYOUT_PAUSE_COMMENT_AUTHORS[:high_chargeback_rate]
       )

--- a/app/modules/user/risk.rb
+++ b/app/modules/user/risk.rb
@@ -20,7 +20,19 @@ module User::Risk
   #
   # This is the same 1% used for automatic refund-policy enforcement below, but measured
   # differently: this one is a share of DOLLAR VOLUME, that one is a share of unique BUYERS.
-  MAX_CHARGEBACK_RATE_ALLOWED_FOR_PAYOUTS = 1.0
+  #
+  # 1.5% over a trailing year, rather than 1% over lifetime (2026-08-03, Sahil). The old pairing
+  # made the hold hard to exit on exactly the accounts most worth keeping: measured over lifetime,
+  # a four-year seller's denominator is so large that a clean quarter barely moves the ratio, so a
+  # seller who has already fixed the behaviour stays paused on history they cannot change. A
+  # trailing window lets recent selling actually count, and the threshold moves up with it so the
+  # change is a genuine loosening rather than a reshuffle.
+  MAX_CHARGEBACK_RATE_ALLOWED_FOR_PAYOUTS = 1.5
+
+  # Only sales inside this trailing window count toward the payout gate's chargeback rate. Keep the
+  # pause and the release measuring the identical window — a release that reads a different span
+  # than the pause either re-pauses immediately or never fires.
+  PAYOUT_CHARGEBACK_RATE_WINDOW = 365.days
 
   # Thresholds for automatically forcing a buyer-friendly refund policy on a seller.
   # The dispute rate here is a rate of UNIQUE BUYERS (buyers with a standing chargeback /

--- a/app/modules/user/stats.rb
+++ b/app/modules/user/stats.rb
@@ -242,6 +242,18 @@ module User::Stats
 
   # Admin use only
   def lost_chargebacks # returns `{ volume: String, count: String }`
+    chargeback_rates
+  end
+
+  # The payout gate's view of the same ratio, restricted to the trailing
+  # PAYOUT_CHARGEBACK_RATE_WINDOW. Lifetime is the wrong measure for a hold a seller is supposed to
+  # be able to work their way out of: on a long-lived account the denominator is so large that
+  # months of clean selling barely move it, so the hold outlives the behaviour that caused it.
+  def lost_chargebacks_for_payout_gate # returns `{ volume: String, count: String }`
+    chargeback_rates(created_on_or_after: User::PAYOUT_CHARGEBACK_RATE_WINDOW.ago)
+  end
+
+  def chargeback_rates(created_on_or_after: nil) # returns `{ volume: String, count: String }`
     search_params = {
       seller: self,
       state: "successful",
@@ -263,6 +275,7 @@ module User::Stats
         }
       }
     }
+    search_params[:created_on_or_after] = created_on_or_after if created_on_or_after
     search_result = PurchaseSearchService.search(search_params)
     count_denominator = search_result.response.hits.total.value.to_f
     volume_denominator = search_result.aggregations["price_cents_total"]["value"]

--- a/app/sidekiq/release_chargeback_rate_payout_pause_for_seller_job.rb
+++ b/app/sidekiq/release_chargeback_rate_payout_pause_for_seller_job.rb
@@ -3,9 +3,10 @@
 # Re-checks one seller who is under an automatic chargeback-rate payout hold, and lifts the hold if
 # their rate is back within the allowed range.
 #
-# The release deliberately mirrors the pause: same rate (the lifetime unrefunded-sales volume ratio
-# from User#lost_chargebacks), same threshold constant, and an audit comment on the account so the
-# release is as traceable as the pause was.
+# The release deliberately mirrors the pause: same rate (the trailing-window unrefunded-sales volume
+# ratio from User#lost_chargebacks_for_payout_gate), same threshold constant, same window, and an
+# audit comment on the account so the release is as traceable as the pause was. Reading a different
+# span than the pause would either re-pause the seller immediately or never fire at all.
 #
 # Accounts that are suspended or flagged are left alone. Those are risk decisions made about the
 # account as a whole, and a recovered chargeback rate is not a reason to undo them — releasing there
@@ -19,7 +20,7 @@ class ReleaseChargebackRatePayoutPauseForSellerJob
     return if user.nil?
     return unless releasable?(user)
 
-    volume_percentage = user.lost_chargebacks[:volume]
+    volume_percentage = user.lost_chargebacks_for_payout_gate[:volume]
     # "NA" means the seller has no settled sales volume to divide by, so there is no rate to
     # compare. Leave the hold in place rather than guessing.
     return if volume_percentage == "NA"
@@ -50,7 +51,8 @@ class ReleaseChargebackRatePayoutPauseForSellerJob
     # contradicts the account's real state — same shape the Stripe resume path uses.
     def resume_comment_content(user, volume_percentage)
       recovered = "chargeback rate (#{volume_percentage}) is back within the " \
-                  "#{User::MAX_CHARGEBACK_RATE_ALLOWED_FOR_PAYOUTS}% volume limit"
+                  "#{User::MAX_CHARGEBACK_RATE_ALLOWED_FOR_PAYOUTS}% volume limit over the last " \
+                  "#{User::PAYOUT_CHARGEBACK_RATE_WINDOW.inspect}"
 
       if user.payouts_paused_by_user?
         "Automatic chargeback-rate hold lifted: #{recovered}. Payouts remain paused by the creator."

--- a/spec/models/concerns/purchase/blockable_spec.rb
+++ b/spec/models/concerns/purchase/blockable_spec.rb
@@ -1888,7 +1888,7 @@ describe Purchase::Blockable do
     context "when seller payouts are already paused internally" do
       before do
         seller.update!(payouts_paused_internally: true)
-        allow(seller).to receive(:lost_chargebacks).and_return({ volume: "4.2%", count: "15.0%" })
+        allow(seller).to receive(:lost_chargebacks_for_payout_gate).and_return({ volume: "4.2%", count: "15.0%" })
       end
 
       it "does not change the payout pause source" do
@@ -1905,7 +1905,7 @@ describe Purchase::Blockable do
 
     context "when chargeback volume is 'NA'" do
       before do
-        allow(seller).to receive(:lost_chargebacks).and_return({ volume: "NA", count: "0.0%" })
+        allow(seller).to receive(:lost_chargebacks_for_payout_gate).and_return({ volume: "NA", count: "0.0%" })
       end
 
       it "does not pause payouts" do
@@ -1927,7 +1927,7 @@ describe Purchase::Blockable do
     # policy should not need this file edited to keep the boundary covered.
     context "when chargeback volume is exactly at the threshold" do
       before do
-        allow(seller).to receive(:lost_chargebacks)
+        allow(seller).to receive(:lost_chargebacks_for_payout_gate)
           .and_return({ volume: "#{User::MAX_CHARGEBACK_RATE_ALLOWED_FOR_PAYOUTS}%", count: "10.0%" })
       end
 
@@ -1947,7 +1947,7 @@ describe Purchase::Blockable do
 
     context "when chargeback volume is below the threshold" do
       before do
-        allow(seller).to receive(:lost_chargebacks)
+        allow(seller).to receive(:lost_chargebacks_for_payout_gate)
           .and_return({ volume: "#{User::MAX_CHARGEBACK_RATE_ALLOWED_FOR_PAYOUTS - 0.5}%", count: "5.0%" })
       end
 
@@ -1969,7 +1969,7 @@ describe Purchase::Blockable do
     # actually distinguishes the 1% policy from the 3% one.
     context "when chargeback volume is 2.5%, which the old 3% threshold allowed" do
       before do
-        allow(seller).to receive(:lost_chargebacks).and_return({ volume: "2.5%", count: "5.0%" })
+        allow(seller).to receive(:lost_chargebacks_for_payout_gate).and_return({ volume: "2.5%", count: "5.0%" })
       end
 
       it "pauses payouts internally" do
@@ -1983,13 +1983,13 @@ describe Purchase::Blockable do
         purchase.pause_payouts_for_seller_based_on_chargeback_rate!
 
         expect(seller.comments.last.content)
-          .to eq("Payouts automatically paused due to chargeback rate (2.5%) exceeding 1.0% volume.")
+          .to eq("Payouts automatically paused due to chargeback rate (2.5%) exceeding #{User::MAX_CHARGEBACK_RATE_ALLOWED_FOR_PAYOUTS}% volume over the last #{User::PAYOUT_CHARGEBACK_RATE_WINDOW.inspect}.")
       end
     end
 
     context "when chargeback volume exceeds the threshold" do
       before do
-        allow(seller).to receive(:lost_chargebacks).and_return({ volume: "4.2%", count: "15.0%" })
+        allow(seller).to receive(:lost_chargebacks_for_payout_gate).and_return({ volume: "4.2%", count: "15.0%" })
       end
 
       it "pauses payouts internally" do
@@ -2003,7 +2003,7 @@ describe Purchase::Blockable do
         purchase.pause_payouts_for_seller_based_on_chargeback_rate!
 
         comment = seller.comments.last
-        expect(comment.content).to eq("Payouts automatically paused due to chargeback rate (4.2%) exceeding 1.0% volume.")
+        expect(comment.content).to eq("Payouts automatically paused due to chargeback rate (4.2%) exceeding #{User::MAX_CHARGEBACK_RATE_ALLOWED_FOR_PAYOUTS}% volume over the last #{User::PAYOUT_CHARGEBACK_RATE_WINDOW.inspect}.")
         expect(comment.comment_type).to eq(Comment::COMMENT_TYPE_ON_PROBATION)
         expect(comment.author_name).to eq("pause_payouts_for_seller_based_on_chargeback_rate")
       end
@@ -2027,7 +2027,7 @@ describe Purchase::Blockable do
 
     context "when chargeback volume is far above the threshold" do
       before do
-        allow(seller).to receive(:lost_chargebacks).and_return({ volume: "15.7%", count: "25.0%" })
+        allow(seller).to receive(:lost_chargebacks_for_payout_gate).and_return({ volume: "15.7%", count: "25.0%" })
       end
 
       it "pauses payouts internally" do
@@ -2041,15 +2041,19 @@ describe Purchase::Blockable do
         purchase.pause_payouts_for_seller_based_on_chargeback_rate!
 
         comment = seller.comments.last
-        expect(comment.content).to eq("Payouts automatically paused due to chargeback rate (15.7%) exceeding 1.0% volume.")
+        expect(comment.content).to eq("Payouts automatically paused due to chargeback rate (15.7%) exceeding #{User::MAX_CHARGEBACK_RATE_ALLOWED_FOR_PAYOUTS}% volume over the last #{User::PAYOUT_CHARGEBACK_RATE_WINDOW.inspect}.")
         expect(comment.comment_type).to eq(Comment::COMMENT_TYPE_ON_PROBATION)
         expect(comment.author_name).to eq("pause_payouts_for_seller_based_on_chargeback_rate")
       end
     end
 
     context "edge case: when chargeback volume is just above the threshold" do
+      # Derived from the constant: a literal stops testing the boundary the moment the threshold
+      # moves, which is what a hardcoded 1.1% did when the gate went to 1.5.
+      let(:just_above) { format("%.1f%%", User::MAX_CHARGEBACK_RATE_ALLOWED_FOR_PAYOUTS + 0.1) }
+
       before do
-        allow(seller).to receive(:lost_chargebacks).and_return({ volume: "1.1%", count: "8.0%" })
+        allow(seller).to receive(:lost_chargebacks_for_payout_gate).and_return({ volume: just_above, count: "8.0%" })
       end
 
       it "pauses payouts internally" do
@@ -2063,7 +2067,7 @@ describe Purchase::Blockable do
         purchase.pause_payouts_for_seller_based_on_chargeback_rate!
 
         comment = seller.comments.last
-        expect(comment.content).to eq("Payouts automatically paused due to chargeback rate (1.1%) exceeding 1.0% volume.")
+        expect(comment.content).to eq("Payouts automatically paused due to chargeback rate (#{just_above}) exceeding #{User::MAX_CHARGEBACK_RATE_ALLOWED_FOR_PAYOUTS}% volume over the last #{User::PAYOUT_CHARGEBACK_RATE_WINDOW.inspect}.")
         expect(comment.comment_type).to eq(Comment::COMMENT_TYPE_ON_PROBATION)
         expect(comment.author_name).to eq("pause_payouts_for_seller_based_on_chargeback_rate")
       end

--- a/spec/modules/user/stats_spec.rb
+++ b/spec/modules/user/stats_spec.rb
@@ -1650,6 +1650,42 @@ describe User::Stats, :vcr do
     end
   end
 
+  describe "#lost_chargebacks_for_payout_gate", :sidekiq_inline, :elasticsearch_wait_for_refresh do
+    # The whole point of the windowed variant: an old dispute must stop counting against the seller
+    # once it ages out, so a hold can actually be exited by selling cleanly.
+    it "ignores sales and chargebacks older than the window while #lost_chargebacks still counts them" do
+      product = create(:product, price_cents: 1000, user: @user)
+      travel_to(User::PAYOUT_CHARGEBACK_RATE_WINDOW.ago - 30.days) do
+        create(:disputed_purchase, link: product)
+      end
+      create(:purchase, link: create(:product, price_cents: 9000, user: @user))
+
+      aggregate_failures do
+        # Lifetime still sees the aged dispute: 1000 / (1000 + 9000).
+        expect(@user.lost_chargebacks[:volume]).to eq("10.0%")
+        # The gate does not — the only sale inside the window is the clean one.
+        expect(@user.lost_chargebacks_for_payout_gate[:volume]).to eq("0.0%")
+        expect(@user.lost_chargebacks_for_payout_gate[:count]).to eq("0.0%")
+      end
+    end
+
+    it "still counts a chargeback inside the window" do
+      product = create(:product, price_cents: 1000, user: @user)
+      create(:disputed_purchase, link: product)
+      create(:purchase, link: create(:product, price_cents: 9000, user: @user))
+
+      expect(@user.lost_chargebacks_for_payout_gate[:volume]).to eq("10.0%")
+    end
+
+    it "returns 'NA' when the window holds no paid sales, so the gate leaves the hold alone" do
+      travel_to(User::PAYOUT_CHARGEBACK_RATE_WINDOW.ago - 30.days) do
+        create(:purchase, link: create(:product, price_cents: 5000, user: @user))
+      end
+
+      expect(@user.lost_chargebacks_for_payout_gate[:volume]).to eq("NA")
+    end
+  end
+
   describe "#all_sales_count" do
     it "returns the number of unique customers" do
       product_1 = create(:product, user: @user)

--- a/spec/sidekiq/release_chargeback_rate_payout_pause_for_seller_job_spec.rb
+++ b/spec/sidekiq/release_chargeback_rate_payout_pause_for_seller_job_spec.rb
@@ -19,14 +19,14 @@ describe ReleaseChargebackRatePayoutPauseForSellerJob do
   def pause_for_chargeback_rate!(user = seller)
     user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_SYSTEM)
     user.comments.create!(
-      content: "Payouts automatically paused due to chargeback rate (#{still_high_rate}) exceeding #{User::MAX_CHARGEBACK_RATE_ALLOWED_FOR_PAYOUTS}% volume.",
+      content: "Payouts automatically paused due to chargeback rate (#{still_high_rate}) exceeding #{User::MAX_CHARGEBACK_RATE_ALLOWED_FOR_PAYOUTS}% volume over the last #{User::PAYOUT_CHARGEBACK_RATE_WINDOW.inspect}.",
       comment_type: Comment::COMMENT_TYPE_ON_PROBATION,
       author_name: User::SYSTEM_PAYOUT_PAUSE_COMMENT_AUTHORS[:high_chargeback_rate]
     )
   end
 
   def stub_rate(volume)
-    allow_any_instance_of(User).to receive(:lost_chargebacks).and_return({ volume:, count: "0.0%" })
+    allow_any_instance_of(User).to receive(:lost_chargebacks_for_payout_gate).and_return({ volume:, count: "0.0%" })
   end
 
   context "when the rate has recovered" do
@@ -219,7 +219,7 @@ describe ReleaseChargebackRatePayoutPauseForSellerJob do
     pause_for_chargeback_rate!
     admin_id = create(:user).id
     # The rate lookup is the slow part; simulate an admin pausing the account during it.
-    allow_any_instance_of(User).to receive(:lost_chargebacks) do
+    allow_any_instance_of(User).to receive(:lost_chargebacks_for_payout_gate) do
       seller.update!(payouts_paused_internally: true, payouts_paused_by: admin_id)
       { volume: "0.5%", count: "0.0%" }
     end

--- a/spec/sidekiq/release_chargeback_rate_payout_pauses_job_spec.rb
+++ b/spec/sidekiq/release_chargeback_rate_payout_pauses_job_spec.rb
@@ -6,7 +6,7 @@ describe ReleaseChargebackRatePayoutPausesJob do
   def pause_for_chargeback_rate!(user)
     user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_SYSTEM)
     user.comments.create!(
-      content: "Payouts automatically paused due to chargeback rate (#{User::MAX_CHARGEBACK_RATE_ALLOWED_FOR_PAYOUTS * 4}%) exceeding #{User::MAX_CHARGEBACK_RATE_ALLOWED_FOR_PAYOUTS}% volume.",
+      content: "Payouts automatically paused due to chargeback rate (#{User::MAX_CHARGEBACK_RATE_ALLOWED_FOR_PAYOUTS * 4}%) exceeding #{User::MAX_CHARGEBACK_RATE_ALLOWED_FOR_PAYOUTS}% volume over the last #{User::PAYOUT_CHARGEBACK_RATE_WINDOW.inspect}.",
       comment_type: Comment::COMMENT_TYPE_ON_PROBATION,
       author_name: User::SYSTEM_PAYOUT_PAUSE_COMMENT_AUTHORS[:high_chargeback_rate]
     )

--- a/spec/support/fixtures/vcr_cassettes/User_Stats/_lost_chargebacks_for_payout_gate/ignores_sales_and_chargebacks_older_than_the_window_while_lost_chargebacks_still_counts_them.yml
+++ b/spec/support/fixtures/vcr_cassettes/User_Stats/_lost_chargebacks_for_payout_gate/ignores_sales_and_chargebacks_older_than_the_window_while_lost_chargebacks_still_counts_them.yml
@@ -1,0 +1,145 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_createDispute
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_UDAH0KszdJfZo2","request_duration_ms":24}}'
+      Idempotency-Key:
+      - 1c21aabd-05fc-4aef-ba7c-97edcb7e034f
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 03 Aug 2026 13:11:35 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=KZrKaWtwmcMrGOoBTmyx4jz1rsZIG80tBL0m9_87bcgSt5gHYsT6VvcM9bb_pCmTYR6p7e-___jsQR3I;
+        report-to csp
+      Idempotency-Key:
+      - 1c21aabd-05fc-4aef-ba7c-97edcb7e034f
+      Original-Request:
+      - req_kJk6njNGNL99pH
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=KZrKaWtwmcMrGOoBTmyx4jz1rsZIG80tBL0m9_87bcgSt5gHYsT6VvcM9bb_pCmTYR6p7e-___jsQR3I&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=KZrKaWtwmcMrGOoBTmyx4jz1rsZIG80tBL0m9_87bcgSt5gHYsT6VvcM9bb_pCmTYR6p7e-___jsQR3I&t=1"
+      Request-Id:
+      - req_kJk6njNGNL99pH
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1U0LeVIBOqvOFDrfpWzYSjO7",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "xhj6XkBnqmm1SCzj",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "0259",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1785762695,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Fri, 04 Jul 2025 13:11:34 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/User_Stats/_lost_chargebacks_for_payout_gate/still_counts_a_chargeback_inside_the_window.yml
+++ b/spec/support/fixtures/vcr_cassettes/User_Stats/_lost_chargebacks_for_payout_gate/still_counts_a_chargeback_inside_the_window.yml
@@ -1,0 +1,145 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_createDispute
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_kJk6njNGNL99pH","request_duration_ms":551}}'
+      Idempotency-Key:
+      - 622a444c-c5c6-49d5-b6a3-d2e9650b6a26
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 03 Aug 2026 13:11:41 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=KZrKaWtwmcMrGOoBTmyx4jz1rsZIG80tBL0m9_87bcgSt5gHYsT6VvcM9bb_pCmTYR6p7e-___jsQR3I;
+        report-to csp
+      Idempotency-Key:
+      - 622a444c-c5c6-49d5-b6a3-d2e9650b6a26
+      Original-Request:
+      - req_e12NFhjkeWbjnQ
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=KZrKaWtwmcMrGOoBTmyx4jz1rsZIG80tBL0m9_87bcgSt5gHYsT6VvcM9bb_pCmTYR6p7e-___jsQR3I&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=KZrKaWtwmcMrGOoBTmyx4jz1rsZIG80tBL0m9_87bcgSt5gHYsT6VvcM9bb_pCmTYR6p7e-___jsQR3I&t=1"
+      Request-Id:
+      - req_e12NFhjkeWbjnQ
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1U0LeaIBOqvOFDrfot07k1mC",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "xhj6XkBnqmm1SCzj",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "0259",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1785762700,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Mon, 03 Aug 2026 13:11:41 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
Sellers under the automatic chargeback-rate payout hold could not realistically get out of it.

The gate compared **lifetime** chargeback volume against 1%. On a long-lived account the lifetime denominator is so large that months of clean selling barely move the ratio — so a seller who has already fixed the behaviour stays paused on history they cannot change. The hold outlived the problem it was created for.

This measures the same ratio over a **trailing 365 days** and raises the threshold to **1.5%**.

## Scope / Design

`User#lost_chargebacks` (lifetime) is unchanged and still backs the admin stats panel, where a lifetime view is the right one. The payout gate now calls a new `#lost_chargebacks_for_payout_gate`, which is the same aggregation with `created_on_or_after` applied. Both share one private implementation so the two can't drift apart in how they count.

Both sites that consume the gate moved together — the pause in `Purchase::Blockable` and the release in `ReleaseChargebackRatePayoutPauseForSellerJob`. That pairing matters: if the release read a different window than the pause, it would either re-pause the seller instantly or never fire at all. The window is a named constant for the same reason.

Pause and resume comments now state the window, so an account's history says what was actually measured rather than leaving a bare percentage.

## Build

- `MAX_CHARGEBACK_RATE_ALLOWED_FOR_PAYOUTS` 1.0 → 1.5
- `PAYOUT_CHARGEBACK_RATE_WINDOW` = 365 days (new)
- `User::Stats#lost_chargebacks_for_payout_gate` (new); `#lost_chargebacks` behaviour preserved
- Pause + release both read the windowed rate

## QA

46 examples, 0 failures, run locally:

- `spec/modules/user/stats_spec.rb -e lost_chargebacks` — **6 examples, 0 failures**
- `spec/sidekiq/release_chargeback_rate_payout_pause_for_seller_job_spec.rb` + `..._pauses_job_spec.rb` — **23 examples, 0 failures**
- `spec/models/concerns/purchase/blockable_spec.rb -e pause_payouts_for_seller_based_on_chargeback_rate` — **17 examples, 0 failures**
- rubocop, 8 files, no offenses

New specs pin the behaviour the change exists for: a chargeback older than the window stops counting against the gate while `#lost_chargebacks` still reports it (10.0% lifetime vs 0.0% windowed), a chargeback inside the window still counts, and an all-stale window returns `"NA"` so the gate leaves the hold alone rather than guessing.

**One spec was silently rotting** and is fixed here: the "just above the threshold" boundary case hardcoded 1.1%, which is *below* the new 1.5 gate — it would have kept passing while testing nothing. It now derives from the constant.

## Measured impact

Verified on production data for the account that prompted this (audit `20260803T124559Z-1f6481eb`, `-306ba6b6`):

| Window | Volume rate | Against gate |
|---|---|---|
| Lifetime (old gate) | **1.5%** | fails 1.0% |
| 365 days (new gate) | **1.4%** | passes 1.5% |
| 90 days | 0.3% | passes |
| 30 days | 0.7% | passes |

The lifetime figure is dominated by 2022–2024 disputes on a four-year, 8,543-sale account. Recent behaviour is comfortably clean, and the new gate reflects that while still catching a seller whose *current* selling is disputed.

⚠️ **Not measured: the platform-wide population.** Counting how many sellers this releases needs a scan of `users.flags` bit 20, which is unindexed — the read timed out twice on the replica at 120s. So I can confirm the direction (strictly looser: higher threshold *and* a smaller denominator window) but not the count of affected accounts. If we want that number before rollout, it needs an offline/analytics query rather than a console read.

## Risk

Strictly a loosening — no seller who passes today starts failing. The reverse is possible in one narrow case: a seller whose disputes are *concentrated in the last year* while their lifetime rate was diluted below 1% by clean older volume. That seller now correctly fails a gate they previously slipped through, which is the intended behaviour of a recency-weighted measure.

Fixes the structural half of gumroad-private#1763.
