### PR TITLE
Expose the sale's listed currency on the Sales API v2 sale object

### DIFF
--- a/app/javascript/components/ApiDocumentation/Endpoints/Sales.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/Sales.tsx
@@ -96,6 +96,7 @@ export const GetSales = () => (
       "formatted_display_price": "$10 a month",
       "formatted_total_price": "$10 a month",
       "currency_symbol": "$",
+      "currency": "usd",
       "amount_refundable_in_currency": "0",
       "product_id": "32-nPainqpLj1B_WIwVlMw==",
       "product_permalink": "XCBbJ",
@@ -209,6 +210,7 @@ export const GetSale = () => (
     "formatted_display_price": "$10 a month",
     "formatted_total_price": "$10 a month",
     "currency_symbol": "$",
+    "currency": "usd",
     "amount_refundable_in_currency": "0",
     "product_id": "32-nPainqpLj1B_WIwVlMw==",
     "product_permalink": "XCBbJ",
@@ -304,6 +306,7 @@ export const MarkSaleAsShipped = () => (
     "formatted_display_price": "$22",
     "formatted_total_price": "$22",
     "currency_symbol": "$",
+    "currency": "usd",
     "amount_refundable_in_currency": "22",
     "product_id": "CCQadnagaqfmKxdHaG5AKQ==",
     "product_permalink": "KHc",
@@ -374,7 +377,7 @@ export const RefundSale = () => (
     <ApiParameters>
       <ApiParameter
         name="amount_cents"
-        description="(optional) - Amount in cents (in currency of the sale) to be refunded. If set, issue partial refund by this amount. If not set, issue full refund. You can issue multiple partial refunds per sale until it is fully refunded."
+        description="(optional) - Amount to refund, in minor units of the sale's listed currency — the `currency` field on the sale object, not the buyer's local currency. Most currencies have 100 minor units, so 200 means $2.00; zero-decimal currencies have none, so for a JPY sale 200 means ¥200. If set, issue partial refund by this amount. If not set, issue full refund. You can issue multiple partial refunds per sale until it is fully refunded."
       />
     </ApiParameters>
     <SaleResponseFields />
@@ -402,6 +405,7 @@ export const RefundSale = () => (
     "formatted_display_price": "$10",
     "formatted_total_price": "$10",
     "currency_symbol": "$",
+    "currency": "usd",
     "amount_refundable_in_currency": "8",
     "product_id": "e7xqFa2WL0E-qJlQ4WYJxA==",
     "product_permalink": "RSE",

--- a/app/javascript/components/ApiDocumentation/Endpoints/Sales.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/Sales.tsx
@@ -377,7 +377,7 @@ export const RefundSale = () => (
     <ApiParameters>
       <ApiParameter
         name="amount_cents"
-        description="(optional) - Amount to refund, in minor units of the sale's listed currency — the `currency` field on the sale object, not the buyer's local currency. Most currencies have 100 minor units, so 200 means $2.00; zero-decimal currencies have none, so for a JPY sale 200 means ¥200. If set, issue partial refund by this amount. If not set, issue full refund. You can issue multiple partial refunds per sale until it is fully refunded."
+        description="(optional) - Amount to refund, in minor units of the sale's listed currency — the `currency` field on the sale object, not the buyer's local currency. Most currencies have 100 minor units, so 200 means 2.00 of that currency; zero-decimal currencies have none, so for a JPY sale 200 means ¥200. If set, issue partial refund by this amount. If not set, issue full refund. You can issue multiple partial refunds per sale until it is fully refunded."
       />
     </ApiParameters>
     <SaleResponseFields />

--- a/app/javascript/components/ApiDocumentation/responseFieldDefinitions.ts
+++ b/app/javascript/components/ApiDocumentation/responseFieldDefinitions.ts
@@ -426,6 +426,12 @@ export const SALE_FIELDS: FieldDefinition[] = [
   { name: "formatted_total_price", type: "string", description: "Human-readable total price" },
   { name: "currency_symbol", type: "string", description: 'Currency symbol (e.g. "$")' },
   {
+    name: "currency",
+    type: "string",
+    description:
+      'ISO code of the currency the sale is denominated in (e.g. "usd", "jpy"). This is the currency `amount_cents` is read in when refunding, so it also tells you how many minor units an amount has — JPY has none, so `amount_cents=25` refunds ¥25.',
+  },
+  {
     name: "amount_refundable_in_currency",
     type: "string",
     description: "Amount still refundable in the sale's currency",

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -984,6 +984,10 @@ class Purchase < ApplicationRecord
       transaction_url_for_seller:,
       formatted_total_price:,
       currency_symbol: symbol_for(displayed_price_currency_type),
+      # ISO code of the currency this sale is denominated in — the same currency
+      # the refund endpoint reads amount_cents in. Callers need it to know how
+      # many minor units an amount has: JPY has none, so 25 means ¥25, not ¥0.25.
+      currency: (displayed_price_currency_type.to_s if version == 2),
       amount_refundable_in_currency:,
       link_id: (link.unique_permalink if version == 1),
       product_id: link.external_id,

--- a/spec/controllers/api/v2/sales_controller_spec.rb
+++ b/spec/controllers/api/v2/sales_controller_spec.rb
@@ -420,6 +420,25 @@ describe Api::V2::SalesController do
         expect(response.parsed_body["sale"]).not_to have_key("buyer_presentment")
       end
 
+      it "returns the sale's listed currency, which is the currency a refund amount_cents is read in" do
+        get :show, params: @params
+
+        expect(response.parsed_body["sale"]["currency"]).to eq "usd"
+      end
+
+      it "returns the listed currency for a sale priced in a zero-decimal currency" do
+        jpy_product = create(:product, user: @seller, price_currency_type: "jpy", price_cents: 3_000)
+        jpy_purchase = create(:purchase, link: jpy_product, seller: @seller, displayed_price_currency_type: "jpy")
+
+        get :show, params: @params.merge(id: jpy_purchase.external_id)
+
+        expect(response.parsed_body["sale"]["currency"]).to eq "jpy"
+      end
+
+      it "omits the currency field from version 1 serializations" do
+        expect(@purchase.as_json).not_to have_key(:currency)
+      end
+
       it "includes buyer_presentment fields when the purchase has a presentment record" do
         # Values reconcile with the documented fx_rate direction (USD per 1 CAD;
         # canonical USD divided by the rate gives buyer-currency amounts): the

--- a/spec/controllers/api/v2/sales_controller_spec.rb
+++ b/spec/controllers/api/v2/sales_controller_spec.rb
@@ -435,6 +435,22 @@ describe Api::V2::SalesController do
         expect(response.parsed_body["sale"]["currency"]).to eq "jpy"
       end
 
+      # The refund endpoint scales amount_cents by the currency recorded on the
+      # PURCHASE, so a seller who relists the product in another currency must not
+      # change what an old sale reports — the product's current currency would
+      # scale a refund on this sale by 100 instead of 1.
+      it "reports the currency recorded on the sale, not the product's current one" do
+        jpy_product = create(:product, user: @seller, price_currency_type: "jpy", price_cents: 3_000)
+        jpy_purchase = create(:purchase, link: jpy_product, seller: @seller, displayed_price_currency_type: "jpy")
+        jpy_product.update_columns(price_currency_type: "usd")
+
+        expect(jpy_purchase.reload.link.price_currency_type).to eq "usd"
+
+        get :show, params: @params.merge(id: jpy_purchase.external_id)
+
+        expect(response.parsed_body["sale"]["currency"]).to eq "jpy"
+      end
+
       it "omits the currency field from version 1 serializations" do
         expect(@purchase.as_json).not_to have_key(:currency)
       end


### PR DESCRIPTION
## What

Adds `currency` — the ISO code of the currency a sale is priced in — to the Sales API v2 sale object, and makes the refund endpoint's `amount_cents` documentation say which currency that amount is read in.

No behaviour change to the refund endpoint itself. This is the server half of gumroad-private#1782; the client half is the gumroad-cli PR linked from that issue.

## Why

`PUT /v2/sales/:id/refund` reads `amount_cents` in the sale's **listed** currency (`displayed_price_currency_type`), dividing by that currency's unit scaling factor. For JPY that factor is `1`, for everything else it is `100`.

A caller therefore has to know the sale's currency before it can send an amount — and the sale object never told it. It exposes `currency_symbol` (`"¥"`) and `amount_refundable_in_currency` (a formatted string), but no ISO code. `Purchase#as_json` version 2 was the only serialization on this endpoint without one, while the products endpoint has had `currency` for years.

That gap is what produced the reported defect: the Gumroad CLI scaled `--amount` by a hardcoded ×100 because it had nothing to scale by, so on a JPY-listed sale `--amount 25` requested a **¥2500** refund. The server was right; the caller had no way to be.

The refund parameter's own docs said only *"Amount in cents (in currency of the sale)"*, which reads as "cents" — the wrong mental model for a zero-decimal currency, and silent about the listed-vs-presentment distinction the controller's comment spells out precisely.

## Before / after

`GET /v2/sales/:id` for a sale on a JPY-listed product:

| field | before | after |
| --- | --- | --- |
| `currency_symbol` | `"¥"` | `"¥"` |
| `currency` | *absent* | `"jpy"` |
| `amount_refundable_in_currency` | `"3000"` | `"3000"` |

The value is read from the **sale** (`displayed_price_currency_type`), not from the product's current listing, so relisting a product does not retroactively change what its existing sales report.

A caller reading `currency: "jpy"` knows `amount_cents=25` means ¥25. Before, `"¥"` and `"3000"` were all it had, and neither distinguishes ¥3000 from $30.00.

Version 1 serializations are unchanged — the field is gated on `version == 2`, matching how `link_id`, `web_csv_parity_fields`, and `buyer_presentment` are gated in the same hash.

## Test Results

- `bundle exec rspec spec/controllers/api/v2/sales_controller_spec.rb -e "GET 'show'"` — **13 examples, 0 failures** (34.5s)
- `ruby -c app/models/purchase.rb` — Syntax OK
- `ruby -c spec/controllers/api/v2/sales_controller_spec.rb` — Syntax OK
- `bundle exec rspec spec/controllers/api/v2/sales_controller_spec.rb -e "GET 'show'"` after the review fixes — **14 examples, 0 failures**
- Full `spec/controllers/api/v2/sales_controller_spec.rb` — **81 examples, 0 failures** (at `d864c6c1f`; the fix round only adds one example and edits doc copy)

Four examples are new: the USD read, the JPY read, the relist case, and the version-1 omission. Mutation proof that they bite — three mutants, each killed by a **different** example:

| mutant | result |
| --- | --- |
| `currency: ("usd" if version == 2)` (hardcode the common case) | RED — *returns the listed currency for a sale priced in a zero-decimal currency* |
| `currency: displayed_price_currency_type.to_s` (drop the version gate) | RED — *omits the currency field from version 1 serializations* |
| `currency: (link.price_currency_type.to_s if version == 2)` (read the product instead of the sale) | RED — *reports the currency recorded on the sale, not the product's current one* |

**The third mutant survived the first version of this spec set**, which is worth recording rather than hiding: the JPY example built its purchase under a JPY-listed product, so both currency sources agreed and the assertion could not tell them apart. The relist example fixes that by changing the product's currency after the sale exists, which is the case that actually matters — the refund endpoint scales by the sale's own recorded currency, so a product relisted from JPY to USD would otherwise make the API report `usd` for an old yen sale and scale its refund by 100.

That example needs `update_columns`: `update!(price_currency_type: "usd")` is rejected by the product's own validation (`Default price cents can't be blank`), so the state has to be written past it.

The USD read and the version-1 omission are the baseline and the gate; no mutant above targets the USD read alone, since it is what catches the field being dropped entirely.

## QA steps

Not applicable as a click-path — this is an API field plus documentation copy. Verified via the specs above, which exercise the real controller through `GET :show`, and by reading the rendered parameter text in `Sales.tsx`.

The API documentation page changes are copy-only: the `amount_cents` parameter description, a `currency` entry in `SALE_FIELDS`, and `"currency": "usd"` added to the four example response payloads that already show `currency_symbol`.

## Deploy ordering

This PR deploys first. The CLI change tolerates its absence — it falls back to `currency_type` / `price_currency_type` and refuses `--amount` outright rather than guessing — so merging the CLI PR first is safe, but a CLI *release* should follow this deploy.

## Status

- [x] Scope — server-side half of gumroad-private#1782: expose the currency, document the parameter
- [x] Design — additive field, version-2 gated, named `currency` to match `PRODUCT_FIELDS` and the CLI's existing fallback chain
- [x] Build — `d864c6c1f`, review fixes in `e612950a5` and `61d563d6b`
- [x] QA — full sales controller spec green; API field plus copy, no click-path to record
- [ ] Ship — not merged
- [ ] Market — n/a
- [ ] Sell — n/a

---

🤖 Written with claude-opus-5 via Hermes Agent.
