### PR TITLE
Stop claiming payment in the undelivered-receipt notice for free downloads

### DIFF
--- a/app/mailers/contacting_creator_mailer.rb
+++ b/app/mailers/contacting_creator_mailer.rb
@@ -447,6 +447,10 @@ class ContactingCreatorMailer < ApplicationMailer
     # The count is what the seller acts on: it counts everyone this email stands behind, listed or
     # summarized, and never the sweep's figure from before the recheck.
     @total = still_affected.size
+    # Free downloads enter the sweep on equal footing with paid sales, and the paid framing
+    # ("paid you", "or refunding") is false for them — a free-catalogue seller reads the notice
+    # as phishing (gumroad-private#1780). The copy branches on this count.
+    @paid_count = still_affected.count { _1.price_cents.positive? }
     @purchases = still_affected.first(UndeliveredReceiptNotifier::MAX_LISTED_PER_SELLER)
     @undisclosed_count = @total - @purchases.size
     @subject = "#{@total == 1 ? "A buyer" : "#{@total} buyers"} may not have received their receipt"

--- a/app/views/contacting_creator_mailer/undelivered_receipts.html.erb
+++ b/app/views/contacting_creator_mailer/undelivered_receipts.html.erb
@@ -2,12 +2,26 @@
 <div>
   <p>
     <% if @total == 1 %>
-      A buyer paid you and we have no confirmation that their receipt reached them. They have not
-      opened what they bought either, so they may be waiting on you without knowing to ask.
-    <% else %>
+      <% if @paid_count == 1 %>
+        A buyer paid you and we have no confirmation that their receipt reached them. They have not
+        opened what they bought either, so they may be waiting on you without knowing to ask.
+      <% else %>
+        A buyer picked up one of your free products and we have no confirmation that their receipt
+        reached them. They have not opened what they got either, so they may be waiting on you
+        without knowing to ask.
+      <% end %>
+    <% elsif @paid_count == @total %>
       <%= @total %> of your buyers paid you and we have no confirmation that their receipts reached
       them. None of them have opened what they bought either, so they may be waiting on you without
       knowing to ask.
+    <% elsif @paid_count.zero? %>
+      <%= @total %> of your buyers picked up free products and we have no confirmation that their
+      receipts reached them. None of them have opened what they got either, so they may be waiting
+      on you without knowing to ask.
+    <% else %>
+      <%= @total %> of your buyers completed a purchase and we have no confirmation that their
+      receipts reached them. None of them have opened what they got either, so they may be waiting
+      on you without knowing to ask.
     <% end %>
   </p>
   <%# The email layout collapses a bare table to display:block, which stacks every cell into its own
@@ -38,8 +52,8 @@
   <% end %>
   <p>
     You can resend a receipt from that buyer's sale page. If a resend does not reach them either, the
-    address is likely wrong or their mail provider is refusing our mail — reaching them another way,
-    or refunding, is the only thing that will resolve it.
+    address is likely wrong or their mail provider is refusing our mail — reaching them another
+    way<%= ", or refunding," if @paid_count.positive? %> is the only thing that will resolve it.
   </p>
   <p>
     We send this once per buyer, so you will not hear about these again.

--- a/spec/mailers/contacting_creator_mailer_spec.rb
+++ b/spec/mailers/contacting_creator_mailer_spec.rb
@@ -1677,6 +1677,46 @@ describe ContactingCreatorMailer do
       expect(mail.body.encoded).to include purchase.email
       expect(mail.body.encoded).to include "Terraforming Guide"
       expect(mail.body.encoded).to include "A buyer paid you and we have no confirmation"
+      expect(mail.body.encoded).to include "or refunding,"
+    end
+
+    # A free download generates the same receipt row as a paid sale, so it enters the sweep — but
+    # "paid you" and "or refunding" are false for it, and a free-catalogue seller reads the notice
+    # as phishing (gumroad-private#1780).
+    it "does not claim payment or offer a refund for a free download" do
+      purchase = create(:free_purchase, seller:, link: product)
+      create(:customer_email_info, purchase:, state: "sent", sent_at: 3.days.ago)
+
+      mail = ContactingCreatorMailer.undelivered_receipts(seller.id, [purchase.id])
+
+      expect(mail.body.encoded).to include "A buyer picked up one of your free products"
+      expect(mail.body.encoded).not_to include "paid you"
+      expect(mail.body.encoded).not_to include "refunding"
+    end
+
+    it "uses payment-neutral wording for a mixed paid and free digest" do
+      paid = undelivered_purchase
+      free = create(:free_purchase, seller:, link: product)
+      create(:customer_email_info, purchase: free, state: "sent", sent_at: 3.days.ago)
+
+      mail = ContactingCreatorMailer.undelivered_receipts(seller.id, [paid.id, free.id])
+
+      expect(mail.body.encoded).to include "2 of your buyers completed a purchase"
+      expect(mail.body.encoded).not_to include "paid you"
+      expect(mail.body.encoded).to include "or refunding,"
+    end
+
+    it "uses free wording when every affected sale is free" do
+      purchases = Array.new(2) do
+        purchase = create(:free_purchase, seller:, link: product)
+        create(:customer_email_info, purchase:, state: "sent", sent_at: 3.days.ago)
+        purchase
+      end
+
+      mail = ContactingCreatorMailer.undelivered_receipts(seller.id, purchases.map(&:id))
+
+      expect(mail.body.encoded).to include "2 of your buyers picked up free products"
+      expect(mail.body.encoded).not_to include "refunding"
     end
 
     it "pluralizes the subject and body for several affected sales" do


### PR DESCRIPTION
Fixes the undelivered-receipt notice asserting a payment that never happened on free ($0) purchases.

A seller with a largely-free catalogue (10,557 sales / $163 lifetime) wrote in reading the notice as a bug or a phishing attempt:

> "To my knowledge, I have never received any payments from Gumroad or from any customers, especially not for a free product. Since the product mentioned is free, there should not have been any payment involved in the first place."

The cohort logic was correct — the receipt genuinely could not be delivered (buyer typo'd `.con`, `url_redirect.uses = 0`). Only the copy was wrong: `undelivered_receipts.html.erb` hardcoded "A buyer **paid you**" and closed by offering **refunding** as the remedy, neither of which exists for a $0 row.

## What changed

`@paid_count` on the mailer, and the copy branches on it:

| digest | wording | refund sentence |
|---|---|---|
| all paid | "paid you" (unchanged) | shown |
| all free | "picked up one of your free products" / "picked up free products" | suppressed |
| mixed | "completed a purchase" (payment-neutral) | shown |

This is option 1 from gumroad-private#1780 — it preserves the signal rather than dropping free purchases from the sweep. The bounce still costs a free-product seller the contact channel (gp#1635), which is the notice's real value here; only the money claims were false.

Four mailer specs cover all three shapes plus the existing paid case.

Closes antiwork/gumroad-private#1780

## Test Results

Full CI green on `5b2e52b1` — 29/29 checks success, 1 skipped, 0 failures, including all 48 `Test Slow` spec shards. Verified via `gh api repos/antiwork/gumroad/commits/5b2e52b1/check-runs`.

New specs in `spec/mailers/contacting_creator_mailer_spec.rb`:
- `does not claim payment or offer a refund for a free download` — asserts `not_to include "paid you"` and `not_to include "refunding"`
- `uses payment-neutral wording for a mixed paid and free digest`
- `uses free wording when every affected sale is free`
- existing all-paid case extended to assert `"or refunding,"` still renders

## QA steps

Mailer-only change; no UI route. Reviewer click-path is the mailer preview:

1. `bin/rails s`, open `/rails/mailers/contacting_creator/undelivered_receipts`
2. Body should read "A buyer **picked up one of your free products**" for a $0 fixture and must not contain the word "refunding"
3. Swap the fixture to a paid purchase — the original "A buyer paid you …" and "or refunding," copy must both come back unchanged

The three copy branches are exhaustively asserted by the specs above, which is the reviewable evidence here — the render has no visual change beyond the sentence text, so before/after screenshots would show only the two strings already quoted in the table.

---

Authored by Gumclaw (Claude Opus 4.5 via Hermes Agent). The diagnosis in gumroad-private#1780 came from a live prod console read of purchase 348299739 (audit `20260803T125836Z-06b2f70b`); the fix and specs were written from that investigation, and the option-1-vs-2 product call is stated in the issue.
