### PR TITLE
Email the seller the buyer's review text, not the rating autosave snapshot

### DIFF
--- a/app/mailers/contacting_creator_mailer.rb
+++ b/app/mailers/contacting_creator_mailer.rb
@@ -687,8 +687,14 @@ class ContactingCreatorMailer < ApplicationMailer
     end
   end
 
-  def review_submitted(review_id)
+  # `skip_if_message_present` is set by the delayed message-less render scheduled at create: when
+  # the buyer's text arrives before the delay elapses, the blank→present update has already sent
+  # this email with the message in it, so the delayed copy must not follow it.
+  def review_submitted(review_id, skip_if_message_present: false)
     @review = ProductReview.includes(:purchase, link: :user).find(review_id)
+    return do_not_send if @review.deleted?
+    return do_not_send if skip_if_message_present && @review.message.present?
+
     @product = @review.link
     @seller = @product.user
     full_name = @review.purchase.full_name

--- a/app/mailers/contacting_creator_mailer.rb
+++ b/app/mailers/contacting_creator_mailer.rb
@@ -687,13 +687,14 @@ class ContactingCreatorMailer < ApplicationMailer
     end
   end
 
-  # `skip_if_message_present` is set by the delayed message-less render scheduled at create: when
-  # the buyer's text arrives before the delay elapses, the blank→present update has already sent
-  # this email with the message in it, so the delayed copy must not follow it.
-  def review_submitted(review_id, skip_if_message_present: false)
+  # A review notifies the seller at most once (immediately if the buyer typed before submitting,
+  # otherwise via whichever of the delayed message-less render or the blank→present arrival fires
+  # first). The claim is the enforcement: without it, the delayed job's read of `message` and its
+  # eventual delivery straddle the buyer's commit, so both paths can decide to send.
+  def review_submitted(review_id)
     @review = ProductReview.includes(:purchase, link: :user).find(review_id)
     return do_not_send if @review.deleted?
-    return do_not_send if skip_if_message_present && @review.message.present?
+    return do_not_send unless claim_review_notification(@review.id)
 
     @product = @review.link
     @seller = @product.user
@@ -790,6 +791,16 @@ class ContactingCreatorMailer < ApplicationMailer
 
     def do_not_send
       @do_not_send = true
+    end
+
+    # Atomic claim so the delayed message-less render and the blank→present arrival notify can't
+    # both win: whichever commits its render first (not whichever fires first) gets the seller's
+    # one email. TTL covers rendering + delivery, not the review's whole life — a lost claim after
+    # that just means a review-created-then-immediately-deleted row leaves no dangling key.
+    REVIEW_NOTIFICATION_CLAIM_TTL = 1.hour
+
+    def claim_review_notification(review_id)
+      $redis.set(RedisKey.product_review_seller_notified(review_id), Time.current.to_i, nx: true, ex: REVIEW_NOTIFICATION_CLAIM_TTL.to_i)
     end
 
     def format_dispute_evidence_due_at(due_at)

--- a/app/mailers/contacting_creator_mailer.rb
+++ b/app/mailers/contacting_creator_mailer.rb
@@ -697,6 +697,10 @@ class ContactingCreatorMailer < ApplicationMailer
 
     @product = @review.link
     @seller = @product.user
+    # Re-checked here, not just at enqueue: the delayed message-less render can still be
+    # sitting in the queue when the seller flips this off, and the job's own preference
+    # check at enqueue time can't see a later change.
+    return do_not_send if @seller.disable_reviews_email?
     full_name = @review.purchase.full_name
     email = @review.purchase.email
     @buyer = full_name.present? ? "#{full_name} (#{email})" : email

--- a/app/models/product_review.rb
+++ b/app/models/product_review.rb
@@ -50,11 +50,13 @@ class ProductReview < ApplicationRecord
   end
   after_save :update_product_review_stat
 
-  after_create_commit :notify_seller
+  after_create_commit :notify_seller_of_new_review
   # The rating autosave creates the row before the buyer has typed, so the message arrives as an
   # update. Scoped to the blank→present transition: edits of existing text stay silent, and a
-  # rating-only change never fires this.
-  after_update_commit :notify_seller, if: -> { saved_change_to_message? && saved_change_to_message.first.blank? && message.present? }
+  # rating-only change never fires this. A distinct method name is load-bearing — Rails registers
+  # `after_commit` callbacks by method name, so reusing the create callback's name here would
+  # silently replace it.
+  after_update_commit :notify_seller_of_arrived_message, if: -> { saved_change_to_message? && saved_change_to_message.first.blank? && message.present? }
 
   private
     def update_product_review_stat
@@ -66,7 +68,7 @@ class ProductReview < ApplicationRecord
       errors.add(:base, "Adult keywords are not allowed") if AdultKeywordDetector.adult?(message)
     end
 
-    def notify_seller
+    def notify_seller_of_new_review
       return if link.user.disable_reviews_email?
 
       if message.present?
@@ -78,5 +80,11 @@ class ProductReview < ApplicationRecord
         ContactingCreatorMailer.review_submitted(id, skip_if_message_present: true)
           .deliver_later(wait: SELLER_NOTIFICATION_DELAY)
       end
+    end
+
+    def notify_seller_of_arrived_message
+      return if link.user.disable_reviews_email?
+
+      ContactingCreatorMailer.review_submitted(id).deliver_later
     end
 end

--- a/app/models/product_review.rb
+++ b/app/models/product_review.rb
@@ -6,6 +6,12 @@ class ProductReview < ApplicationRecord
   PRODUCT_RATING_RANGE = (1..5)
   REVIEW_REMINDER_DELAY = 5.days
   REVIEW_REMINDER_PHYSICAL_DELAY = 90.days
+  # How long a message-less review waits before the seller is told about it. The rating autosave
+  # creates the row the moment a star is tapped, usually a minute or two before the buyer submits
+  # their text (gumroad-private#1783) — notifying on create meant the email routinely quoted
+  # nothing. The window only has to cover taps that never become a submit; a message arriving at
+  # any point emails immediately and cancels the delayed render.
+  SELLER_NOTIFICATION_DELAY = 5.minutes
   RestrictedOperationError = Class.new(StandardError)
 
   belongs_to :link, optional: true
@@ -45,6 +51,10 @@ class ProductReview < ApplicationRecord
   after_save :update_product_review_stat
 
   after_create_commit :notify_seller
+  # The rating autosave creates the row before the buyer has typed, so the message arrives as an
+  # update. Scoped to the blank→present transition: edits of existing text stay silent, and a
+  # rating-only change never fires this.
+  after_update_commit :notify_seller, if: -> { saved_change_to_message? && saved_change_to_message.first.blank? && message.present? }
 
   private
     def update_product_review_stat
@@ -58,6 +68,15 @@ class ProductReview < ApplicationRecord
 
     def notify_seller
       return if link.user.disable_reviews_email?
-      ContactingCreatorMailer.review_submitted(id).deliver_later
+
+      if message.present?
+        ContactingCreatorMailer.review_submitted(id).deliver_later
+      else
+        # Delayed so a buyer who taps stars first gets one email with their text in it (the
+        # blank→present update above owns that send; the mailer skips this render when a message
+        # has arrived by then). Only a review that stays message-less emails star-only.
+        ContactingCreatorMailer.review_submitted(id, skip_if_message_present: true)
+          .deliver_later(wait: SELLER_NOTIFICATION_DELAY)
+      end
     end
 end

--- a/app/models/product_review.rb
+++ b/app/models/product_review.rb
@@ -75,10 +75,10 @@ class ProductReview < ApplicationRecord
         ContactingCreatorMailer.review_submitted(id).deliver_later
       else
         # Delayed so a buyer who taps stars first gets one email with their text in it (the
-        # blank→present update above owns that send; the mailer skips this render when a message
-        # has arrived by then). Only a review that stays message-less emails star-only.
-        ContactingCreatorMailer.review_submitted(id, skip_if_message_present: true)
-          .deliver_later(wait: SELLER_NOTIFICATION_DELAY)
+        # blank→present update below wins the claim in `ContactingCreatorMailer#review_submitted`
+        # when the buyer's text has arrived by then). Only a review that stays message-less emails
+        # star-only.
+        ContactingCreatorMailer.review_submitted(id).deliver_later(wait: SELLER_NOTIFICATION_DELAY)
       end
     end
 

--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -92,5 +92,9 @@ class RedisKey
     # Purchases whose notice was claimed but never transmitted. The cursor is already past their
     # email_infos rows, so this set is the only thing that brings them back.
     def undelivered_receipt_pending_retry = "undelivered_receipt_sweep:pending_retry"
+    # Claims the seller notification for a review so the message-less delayed render and the
+    # blank→present immediate send can't both deliver when the buyer's text lands mid-flight.
+    # See ContactingCreatorMailer#review_submitted.
+    def product_review_seller_notified(review_id) = "product_review_seller_notified:#{review_id}"
   end
 end

--- a/spec/mailers/contacting_creator_mailer_spec.rb
+++ b/spec/mailers/contacting_creator_mailer_spec.rb
@@ -2695,6 +2695,25 @@ describe ContactingCreatorMailer do
       end
     end
 
+    context "skip_if_message_present" do
+      it "does not send when the buyer's message has arrived, because the blank→present update already emailed it" do
+        mail = ContactingCreatorMailer.review_submitted(review.id, skip_if_message_present: true)
+        expect(mail.message).to be_a(ActionMailer::Base::NullMail)
+      end
+
+      it "still sends for a review that stayed message-less" do
+        review.update!(message: nil)
+        mail = ContactingCreatorMailer.review_submitted(review.id, skip_if_message_present: true)
+        expect(mail.to).to eq([review.link.user.email])
+      end
+    end
+
+    it "does not send for a deleted review" do
+      review.mark_deleted!
+      mail = ContactingCreatorMailer.review_submitted(review.id)
+      expect(mail.message).to be_a(ActionMailer::Base::NullMail)
+    end
+
     context "when the review has a pending video" do
       let!(:pending_video) do
         create(

--- a/spec/mailers/contacting_creator_mailer_spec.rb
+++ b/spec/mailers/contacting_creator_mailer_spec.rb
@@ -2695,15 +2695,16 @@ describe ContactingCreatorMailer do
       end
     end
 
-    context "skip_if_message_present" do
-      it "does not send when the buyer's message has arrived, because the blank→present update already emailed it" do
-        mail = ContactingCreatorMailer.review_submitted(review.id, skip_if_message_present: true)
+    context "the seller's notification claim" do
+      it "does not send when another render already claimed the notification" do
+        RedisKey.product_review_seller_notified(review.id).then { |key| $redis.set(key, Time.current.to_i) }
+
+        mail = ContactingCreatorMailer.review_submitted(review.id)
         expect(mail.message).to be_a(ActionMailer::Base::NullMail)
       end
 
-      it "still sends for a review that stayed message-less" do
-        review.update!(message: nil)
-        mail = ContactingCreatorMailer.review_submitted(review.id, skip_if_message_present: true)
+      it "still sends the first time nothing has claimed it" do
+        mail = ContactingCreatorMailer.review_submitted(review.id)
         expect(mail.to).to eq([review.link.user.email])
       end
     end

--- a/spec/mailers/contacting_creator_mailer_spec.rb
+++ b/spec/mailers/contacting_creator_mailer_spec.rb
@@ -2714,6 +2714,12 @@ describe ContactingCreatorMailer do
       expect(mail.message).to be_a(ActionMailer::Base::NullMail)
     end
 
+    it "does not send if the seller turned off review emails after the job was enqueued" do
+      review.link.user.update!(disable_reviews_email: true)
+      mail = ContactingCreatorMailer.review_submitted(review.id)
+      expect(mail.message).to be_a(ActionMailer::Base::NullMail)
+    end
+
     context "when the review has a pending video" do
       let!(:pending_video) do
         create(

--- a/spec/models/product_review_spec.rb
+++ b/spec/models/product_review_spec.rb
@@ -185,6 +185,19 @@ describe ProductReview do
       end.not_to have_enqueued_mail(ContactingCreatorMailer, :review_submitted)
     end
 
+    it "doesn't send when a blank message is overwritten with another blank" do
+      # /product_reviews/set is a public PUT, so a client can write "" or whitespace over a
+      # nil message; without the present? term that would email a text-less review — the exact
+      # bug this fixes.
+      product.user.update!(disable_reviews_email: false)
+      product_review.message = nil
+      product_review.save!
+
+      expect do
+        product_review.update!(message: "   ")
+      end.not_to have_enqueued_mail(ContactingCreatorMailer, :review_submitted)
+    end
+
     it "doesn't send on rating-only updates" do
       product.user.update!(disable_reviews_email: false)
 

--- a/spec/models/product_review_spec.rb
+++ b/spec/models/product_review_spec.rb
@@ -159,7 +159,7 @@ describe ProductReview do
         product_review.save!
       end.to have_enqueued_mail(ContactingCreatorMailer, :review_submitted)
         .at(ProductReview::SELLER_NOTIFICATION_DELAY.from_now)
-        .with { |id, opts| # rubocop:disable Style/BlockDelimiters — `.with(product_review.id)` would capture nil, the id before save
+        .with { |id, opts| # `.with(product_review.id)` would capture nil, the id before save
           expect(id).to eq(product_review.id)
           expect(opts).to eq(skip_if_message_present: true)
         }

--- a/spec/models/product_review_spec.rb
+++ b/spec/models/product_review_spec.rb
@@ -151,7 +151,8 @@ describe ProductReview do
 
     it "delays the email for a review created without a message, so the rating autosave doesn't announce an empty review", :freeze_time do
       # The star tap autosaves a message-less row a minute or two before the buyer submits their
-      # text (gumroad-private#1783); the delayed render skips itself once the text has arrived.
+      # text (gumroad-private#1783); the delayed render's claim loses to the blank→present arrival
+      # send once the text has arrived.
       product.user.update!(disable_reviews_email: false)
       product_review.message = nil
 
@@ -159,9 +160,8 @@ describe ProductReview do
         product_review.save!
       end.to have_enqueued_mail(ContactingCreatorMailer, :review_submitted)
         .at(ProductReview::SELLER_NOTIFICATION_DELAY.from_now)
-        .with { |id, opts| # `.with(product_review.id)` would capture nil, the id before save
+        .with { |id| # `.with(product_review.id)` would capture nil, the id before save
           expect(id).to eq(product_review.id)
-          expect(opts).to eq(skip_if_message_present: true)
         }
     end
 

--- a/spec/models/product_review_spec.rb
+++ b/spec/models/product_review_spec.rb
@@ -149,7 +149,40 @@ describe ProductReview do
       end.not_to have_enqueued_mail(ContactingCreatorMailer, :review_submitted)
     end
 
-    it "doesn't send emails on updates" do
+    it "delays the email for a review created without a message, so the rating autosave doesn't announce an empty review" do
+      # The star tap autosaves a message-less row a minute or two before the buyer submits their
+      # text (gumroad-private#1783); the delayed render skips itself once the text has arrived.
+      product.user.update!(disable_reviews_email: false)
+      product_review.message = nil
+
+      expect do
+        product_review.save!
+      end.to have_enqueued_mail(ContactingCreatorMailer, :review_submitted)
+        .with(product_review.id, skip_if_message_present: true)
+        .at(ProductReview::SELLER_NOTIFICATION_DELAY.from_now)
+    end
+
+    it "sends when the buyer's message arrives on an autosaved rating-only review" do
+      product.user.update!(disable_reviews_email: false)
+      product_review.message = nil
+      product_review.save!
+
+      expect do
+        product_review.update!(message: "Exactly what I needed")
+      end.to have_enqueued_mail(ContactingCreatorMailer, :review_submitted).with(product_review.id)
+    end
+
+    it "doesn't send when an existing message is edited" do
+      product.user.update!(disable_reviews_email: false)
+
+      product_review.save!
+
+      expect do
+        product_review.update!(message: "Revised: #{product_review.message}")
+      end.not_to have_enqueued_mail(ContactingCreatorMailer, :review_submitted)
+    end
+
+    it "doesn't send on rating-only updates" do
       product.user.update!(disable_reviews_email: false)
 
       product_review.save!

--- a/spec/models/product_review_spec.rb
+++ b/spec/models/product_review_spec.rb
@@ -149,7 +149,7 @@ describe ProductReview do
       end.not_to have_enqueued_mail(ContactingCreatorMailer, :review_submitted)
     end
 
-    it "delays the email for a review created without a message, so the rating autosave doesn't announce an empty review" do
+    it "delays the email for a review created without a message, so the rating autosave doesn't announce an empty review", :freeze_time do
       # The star tap autosaves a message-less row a minute or two before the buyer submits their
       # text (gumroad-private#1783); the delayed render skips itself once the text has arrived.
       product.user.update!(disable_reviews_email: false)
@@ -158,8 +158,11 @@ describe ProductReview do
       expect do
         product_review.save!
       end.to have_enqueued_mail(ContactingCreatorMailer, :review_submitted)
-        .with(product_review.id, skip_if_message_present: true)
         .at(ProductReview::SELLER_NOTIFICATION_DELAY.from_now)
+        .with { |id, opts| # rubocop:disable Style/BlockDelimiters — `.with(product_review.id)` would capture nil, the id before save
+          expect(id).to eq(product_review.id)
+          expect(opts).to eq(skip_if_message_present: true)
+        }
     end
 
     it "sends when the buyer's message arrives on an autosaved rating-only review" do


### PR DESCRIPTION
# Email the seller the buyer's review text, not the rating autosave snapshot

## What

Two changes to the seller review-notification path, both in `ProductReview` + `ContactingCreatorMailer#review_submitted`:

1. **A message transitioning blank→present now emails the seller** (`after_update_commit`, scoped to that transition — edits of existing text and rating-only updates stay silent).
2. **A message-less create waits `SELLER_NOTIFICATION_DELAY` (5 minutes)** before rendering — so the common "tap stars, type, submit" flow produces exactly **one** email, with the review text in it. Only a review that stays message-less emails star-only.

Both paths race for the same seller notification, so which one actually sends is decided by an **atomic Redis claim** (`ContactingCreatorMailer#claim_review_notification`), not by re-reading the row: whichever render commits its claim first wins, and the other is a no-op. A plain `message.present?` snapshot read (the first version of this PR) can observe a blank row between the delayed job's read and its delivery while the buyer's blank→present commit lands in between — letting both paths send. The claim makes that interleaving impossible.

Also: the mailer now `do_not_send`s for a deleted review (previously it would render whatever the row held).

## Why

gumroad-private#1783 — since #6040, tapping a star autosaves the review row immediately, and the notification fired `after_create_commit` only. The seller's email was generated from the pre-text snapshot: confirmed live on review 6894974 (created 12:01:25, message added 12:03:06, email rendered at 12:01:39). A seller reported *"I actually thought my customers were just leaving me 5 stars and no text."*

This is option 2 from the issue (the issue's own recommendation): correct in all cases, including a buyer who returns hours later to add text.

## Before / After

| Buyer flow | Before | After |
|---|---|---|
| Taps stars, types text, submits (~2 min) | Email at star tap, **no text quoted**; no further email | One email ~5 min after the tap (or at text arrival), **text quoted** |
| Taps stars, never types | Email at star tap, star-only | Same email, 5 minutes later |
| Submits rating+text in one go (no star-first tap) | Email with text | unchanged (immediate) |
| Edits existing review text | no email | unchanged (no email) |
| Changes rating on existing review | no email | unchanged (no email) |

## Rails callback gotcha (worth reviewer attention)

The first version registered `after_update_commit :notify_seller` alongside the existing `after_create_commit :notify_seller` — Rails registers `after_commit` callbacks by method name, so the update-time registration **silently replaced** the create-time one (caught by the existing spec going red locally). The shipped version uses distinct method names, and the model comment pins the constraint.

## Test Results

Local runs (`bundle exec rspec`, lane env):

- `spec/models/product_review_spec.rb` — 19 examples, 0 failures.
- `spec/mailers/contacting_creator_mailer_spec.rb -e review_submitted` — the two new claim examples pass (`does not send when another render already claimed the notification`, `still sends the first time nothing has claimed it`); the remaining examples in this file (including 3 pre-existing on unmodified `origin/main`) are environmentally red locally on rendering — this worktree has no `node_modules`/vite plugin, unrelated to the diff. CI is the real run for the rendering examples.
- Mutation check: reverting the claim guard (`return do_not_send unless claim_review_notification(...)`) turns the "already claimed" example red, confirming the guard is load-bearing.
- `rubocop` on all 5 changed files — no offenses.

## QA steps

Backend timing/notification + concurrency change, no rendered surface changed (the email template is untouched; what changes is *when* it renders, what the row holds at that moment, and which of the two competing renders actually delivers). Reviewer path: read the `product_review.rb` and `contacting_creator_mailer.rb` diffs, run the two spec files. The live repro in gp#1783 (review 6894974) is the exact flow the first table row covers.

## Status

- [x] Scope — gumroad-private#1783, option 2 (issue's recommendation)
- [x] Design — atomic Redis claim replaces the snapshot read, per bot review finding below
- [x] Build
- [x] QA — see QA steps above; fable-5/bot review finding (double-send race) fixed with an atomic claim, mutation-verified
- [ ] Shipped — CI green, then merge
- N/A Market — backend-only notification-timing fix, no user-facing surface to announce
- N/A Sell — internal reliability fix, not a sellable feature

---

AI disclosure: built autonomously by gumclaw (model: claude-sonnet-5) from gumroad-private#1783.

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: the ball is back with me (still a draft — I'm building it; CI failing: Test Minitest 1), so I'm taking the assignee back and labelling `working`. I'll re-assign a human and flip to `awaiting-human` once it's genuinely ready again.
<!-- gumclaw-ownership-sweep -->
