### PR TITLE
Wait out the shared Stripe test account longer than eight retries

### DIFF
--- a/spec/lib/stripe_rate_limit_retries_spec.rb
+++ b/spec/lib/stripe_rate_limit_retries_spec.rb
@@ -123,7 +123,7 @@ describe "Stripe rate-limit retries in the test environment" do
       error = stripe_error(Stripe::RateLimitError, "Request rate limit exceeded", status: 429)
 
       expect { Stripe::StripeClient.should_retry?(error, num_retries: 2) }
-        .to output(/rate limited.*Waiting and retrying \(retry 3 of 8\)/m).to_stderr
+        .to output(/rate limited.*Waiting and retrying \(retry 3 of 12\)/m).to_stderr
     end
 
     it "says it is giving up once the budget is gone, rather than claiming success" do
@@ -133,7 +133,7 @@ describe "Stripe rate-limit retries in the test environment" do
       error = stripe_error(Stripe::RateLimitError, "Request rate limit exceeded", status: 429)
 
       expect { Stripe::StripeClient.should_retry?(error, num_retries: StripeTestRateLimitRetries::MAX_RETRIES) }
-        .to output(/still rate limited after 8 retries, giving up/).to_stderr
+        .to output(/still rate limited after 12 retries, giving up/).to_stderr
     end
 
     it "stays quiet about failures that have nothing to do with rate limiting" do
@@ -144,10 +144,11 @@ describe "Stripe rate-limit retries in the test environment" do
   end
 
   describe "the retry budget" do
-    it "allows eight retries capped at sixteen seconds of waiting each" do
+    it "allows twelve retries capped at sixteen seconds of waiting each" do
       # Pinned literally rather than derived, so that changing the budget has to
-      # change this spec deliberately.
-      expect(StripeTestRateLimitRetries::MAX_RETRIES).to eq(8)
+      # change this spec deliberately. Eight was not enough to outlast the
+      # contention 68 concurrent shards create on one Stripe test account.
+      expect(StripeTestRateLimitRetries::MAX_RETRIES).to eq(12)
       expect(StripeTestRateLimitRetries::MAX_RETRY_DELAY).to eq(16)
     end
 

--- a/spec/support/stripe_rate_limit_retries.rb
+++ b/spec/support/stripe_rate_limit_retries.rb
@@ -49,10 +49,10 @@ module StripeTestRateLimitRetries
   # fallback, after checking the structured fields.
   RATE_LIMIT_MESSAGE = /rate limit|too many requests|creating accounts too quickly/i
 
-  # Retry budget for THROTTLED requests only: eight retries, so nine HTTP
+  # Retry budget for THROTTLED requests only: twelve retries, so thirteen HTTP
   # attempts. Delays before each retry follow the gem's own schedule (0.5s
-  # doubling, capped at MAX_RETRY_DELAY), so the worst case is
-  # 0.5 + 1 + 2 + 4 + 8 + 16 + 16 + 16 = 63.5 seconds of waiting.
+  # doubling, capped at MAX_RETRY_DELAY, jittered into (delay/2, delay]), so the
+  # worst case is 0.5 + 1 + 2 + 4 + 8 + 16 × 7 = 127.5 seconds of waiting.
   #
   # That is deliberately generous rather than minimal. The helper this file
   # replaces allowed roughly 134 seconds, and it did so specifically for
@@ -60,14 +60,23 @@ module StripeTestRateLimitRetries
   # request-rate bucket. A budget short enough to expire inside that window
   # would fail the build for the reason this file exists to prevent.
   #
+  # Eight retries (63.5s) was that budget, and it was not enough: on 2026-08-03
+  # nine open PRs went red at once, every failure a checkout or subscription spec
+  # whose log ended in "still rate limited after 8 retries". Test Slow alone
+  # fans out to 50 shards and Test Fast to 18, every one of them against the same
+  # Stripe test account, and several PRs build concurrently — so the contention
+  # scales with how busy the queue is, not with anything a spec does. Re-running
+  # the identical commit turned #6901 from 11 failures to 0, which is what a
+  # too-small budget looks like from the outside.
+  #
   # It is kept OFF Stripe's global configuration on purpose. Raising
   # Stripe.max_network_retries would also widen the gem's own retries for
   # timeouts, 409 conflicts and 500s, so a spec hitting one of those could sit
-  # in backoff for a minute for a reason that has nothing to do with
+  # in backoff for minutes for a reason that has nothing to do with
   # throttling. Instead the wider budget is applied only on the code path that
   # has already identified the failure as a rate limit, and the global values
   # stay as config/initializers/003_stripe.rb sets them.
-  MAX_RETRIES = 8
+  MAX_RETRIES = 12
   MAX_RETRY_DELAY = 16
 
   # should_retry? decides, and the gem then immediately asks sleep_time how long


### PR DESCRIPTION
## What

Raises the test-only Stripe rate-limit retry budget (`StripeTestRateLimitRetries::MAX_RETRIES`) from 8 to 12 retries (63.5s → 127.5s worst case), and updates the pinning spec to match.

This is the narrow half of what was proposed in #6919 (closed). That PR also tried to shard CI across multiple Stripe test accounts via a GitHub Actions matrix; Greptile correctly flagged two P1s in that half — an unsupported `%` modulo expression that would break workflow parsing entirely, and a partial-secret-override path that could mix credentials from different Stripe accounts. Both problematic commits are excluded here; this branch is only the retry-budget bump, cherry-picked clean onto a fresh branch off main.

## Why

CI runs many parallel shards (Test Slow fans out to 50, Test Fast to 18) against the **same** shared Stripe test account. Contention scales with queue depth, not with anything a spec does. On 2026-08-03, nine open PRs went red at once on the same signature — a 429 after exhausting the 8-retry budget, followed by a checkout that never completed. Re-running the identical commits on affected PRs turned every one of them green with zero code changes, confirming the failures were budget exhaustion, not real regressions.

This stays off Stripe's global retry config (`Stripe.max_network_retries`) deliberately — a global bump would also widen retries for timeouts, 409s and 500s, for reasons unrelated to shared-account throttling. Only the code path that has already identified a failure as rate-limit-shaped gets the wider budget.

## Test Results

Real runs, on this branch's head (`39d82a383`):

```
$ bundle exec rspec spec/lib/stripe_rate_limit_retries_spec.rb
19 examples, 0 failures

$ bundle exec rubocop spec/support/stripe_rate_limit_retries.rb spec/lib/stripe_rate_limit_retries_spec.rb
2 files inspected, no offenses detected
```

Mutation-verified pinning (fable-5 adversarial review): reverting `MAX_RETRIES` 12 → 8 in a pristine worktree fails 3 of 19 examples — the literal `eq(12)` pin and both retry-count log-message assertions — so this cannot silently regress.

Confirmed the excluded #6919 P1s did not leak back in: `git diff origin/main..HEAD -- .github/workflows/tests.yml` is empty, and no `%` modulo GH Actions expression or `STRIPE_SHARD_*` reference exists anywhere in this diff.

Full fable-5 verdict (5/5, one non-blocking P3 on comment verbosity) recorded at `/Users/gumclaw/reviews/stripe-retry-budget-bump/verdict.md`.

## QA steps

Test-infrastructure-only change, no rendered surface. Reviewer path:

1. Read `spec/support/stripe_rate_limit_retries.rb` around `MAX_RETRIES` — confirm it's the only Stripe-retry constant that changed, and that `Stripe.max_network_retries`/`max_network_retry_delay` are untouched.
2. Run `bundle exec rspec spec/lib/stripe_rate_limit_retries_spec.rb` — expect 19 examples, 0 failures.
3. Optionally watch the next batch of concurrent PR builds for `still rate limited after 12 retries` vs the old `after 8 retries` in shard logs.

## Status

- [x] Scope — retry-budget bump only; the GH Actions sharding half of #6919 is deliberately excluded (two Greptile P1s)
- [x] Design — widen only the rate-limit-specific retry path, leave Stripe's global retry config alone
- [x] Build — cherry-picked `39d82a383` onto a fresh branch off `origin/main`
- [x] QA — real spec run (19/19), rubocop clean, mutation-verified pin, fable-5 adversarial review (5/5)
- [ ] Shipped — no live money path touched (test-only file), but leaving for a human's call on CI cost since it will slow down failing builds by up to 64s more before they fail

---

AI disclosure: built and reviewed by Hermes Agent (Claude) running autonomously as gumclaw. This PR was cherry-picked from the test-infra half of a previously-closed PR (#6919) after separating out the parts Greptile flagged as broken.
