### PR TITLE
Quote pay-in-full carts of installment-offering products in the buyer's currency

### DIFF
--- a/app/presenters/checkout/stripe_payment_presenter.rb
+++ b/app/presenters/checkout/stripe_payment_presenter.rb
@@ -452,14 +452,12 @@ class Checkout::StripePaymentPresenter
         # shape (1) runs in live mode only when the resolver exposes a launched local method
         # whose Connect-account capabilities can accept the product's forced currency.
         #
-        # Shape 1 is still reachable even though props now always hands a quoted cart to the
-        # buyer-currency element. The gap between "is a candidate" and "gets the element" is a
-        # product that OFFERS an installment plan: it is a candidate (the display converts) but
-        # the element shape rejects it, because quote creation cannot see whether the buyer
-        # picked installments. Such a cart is never quoted either — quotable_product? rejects
-        # installment-plan products — so it carries no token and the client-confirm lane can
-        # charge it safely. Keeping shape 1 listed means it keeps the local-method tabs instead
-        # of being kicked back to CardElement.
+        # Shape 1 stays listed even though props now always hands a quoted cart to the
+        # buyer-currency element. Candidates the element shape still refuses — ramped
+        # sellers' recurring, preorder and commission items, whose charge differs from the
+        # locked cart total (gumroad-private#1737) — are never quoted as plain carts, so
+        # when such a cart is method-forced the client-confirm lane can charge it safely,
+        # keeping its local-method tabs instead of being kicked back to CardElement.
         supported = (method_forced_shape?(items) && client_confirm_eligible?) ||
           buyer_currency_presentment_element_shape?(items)
         return "buyer_currency_presentment_unsupported" unless supported
@@ -471,9 +469,12 @@ class Checkout::StripePaymentPresenter
     # The cart shape whose buyer-currency presentment the CARD charge path supports, mirroring
     # the gates of Checkout::BuyerCurrencyEligibility#decision that are knowable at render time:
     # one-time, non-commission items that are each a presentment candidate (candidate? already
-    # covers the seller's flags and an active buyer-local display). Products that offer
-    # installments stay on CardElement even when the buyer chooses a one-time purchase because
-    # quote creation cannot see that choice and rejects the product.
+    # covers the seller's flags and an active buyer-local display). A product that merely
+    # OFFERS an installment plan is accepted when the buyer pays in full: its display only
+    # converts for sellers in the subscription ramp (CurrencyHelper#buyer_currency_unquotable_product?),
+    # and for those sellers the quote signs it like any one-time item — the surcharge request
+    # carries the buyer's actual choice, so a selected installment is rejected on
+    # `pay_in_installments` below rather than on what the product could have offered.
     #
     # A cart may span several sellers. The order pipeline turns it into one charge per seller,
     # and the surcharge endpoint locks one quote per prospective charge before the buyer is
@@ -514,7 +515,7 @@ class Checkout::StripePaymentPresenter
       items.all? do |item|
         buyer_currency_presentment_candidate?(item) &&
           item[:recurrence].blank? &&
-          !item[:pay_in_installments] && !item[:offers_installment_plan] &&
+          !item[:pay_in_installments] &&
           !item[:is_preorder] && !item[:has_free_trial] &&
           item[:native_type] != Link::NATIVE_TYPE_COMMISSION
       end
@@ -597,7 +598,6 @@ class Checkout::StripePaymentPresenter
           quantity: cart_product.quantity,
           recurrence: cart_product.recurrence,
           pay_in_installments: cart_product.pay_in_installments,
-          offers_installment_plan: product.installment_plan.present?,
           is_preorder: product.is_in_preorder_state,
           has_free_trial: product.free_trial_enabled,
           native_type: product.native_type,
@@ -621,7 +621,6 @@ class Checkout::StripePaymentPresenter
           quantity: checkout_product[:quantity],
           recurrence: checkout_product[:recurrence],
           pay_in_installments: checkout_product[:pay_in_installments],
-          offers_installment_plan: product[:installment_plan].present?,
           is_preorder: product[:is_preorder],
           has_free_trial: product[:free_trial].present?,
           native_type: product[:native_type],
@@ -710,14 +709,13 @@ class Checkout::StripePaymentPresenter
 
     # quantity defaults to 1: price_cents is always the per-unit price, and the only current
     # consumer of quantity (the Klarna amount-window total) must not undercount multi-unit carts.
-    def item(seller:, price_cents:, recurrence:, pay_in_installments:, offers_installment_plan:, is_preorder:, has_free_trial:, native_type:, buyer_currency_display:, quantity: 1, product_currency: nil, ppp_discounted: false, has_customizable_price: false)
+    def item(seller:, price_cents:, recurrence:, pay_in_installments:, is_preorder:, has_free_trial:, native_type:, buyer_currency_display:, quantity: 1, product_currency: nil, ppp_discounted: false, has_customizable_price: false)
       {
         seller:,
         price_cents:,
         quantity:,
         recurrence:,
         pay_in_installments:,
-        offers_installment_plan:,
         is_preorder:,
         has_free_trial:,
         native_type:,

--- a/app/presenters/checkout/stripe_payment_presenter.rb
+++ b/app/presenters/checkout/stripe_payment_presenter.rb
@@ -452,12 +452,10 @@ class Checkout::StripePaymentPresenter
         # shape (1) runs in live mode only when the resolver exposes a launched local method
         # whose Connect-account capabilities can accept the product's forced currency.
         #
-        # Shape 1 stays listed even though props now always hands a quoted cart to the
-        # buyer-currency element. Candidates the element shape still refuses — ramped
-        # sellers' recurring, preorder and commission items, whose charge differs from the
-        # locked cart total (gumroad-private#1737) — are never quoted as plain carts, so
-        # when such a cart is method-forced the client-confirm lane can charge it safely,
-        # keeping its local-method tabs instead of being kicked back to CardElement.
+        # Shape 1 stays listed so that a candidate cart the element shape refuses (recurring,
+        # preorder or commission items) keeps its local-method tabs when the resolver accepts
+        # it, instead of being kicked back to CardElement — the resolver independently rejects
+        # the shapes whose charge could disagree with a mounted element's amount.
         supported = (method_forced_shape?(items) && client_confirm_eligible?) ||
           buyer_currency_presentment_element_shape?(items)
         return "buyer_currency_presentment_unsupported" unless supported

--- a/spec/presenters/checkout/stripe_payment_presenter_spec.rb
+++ b/spec/presenters/checkout/stripe_payment_presenter_spec.rb
@@ -455,7 +455,7 @@ describe Checkout::StripePaymentPresenter do
     Feature.deactivate_user(Checkout::BuyerCurrencyEligibility::FEATURE_NAME, seller) if seller
   end
 
-  it "falls back to CardElement when a one-time purchase offers an installment plan" do
+  it "selects the buyer-currency presentment Payment Element when a one-time purchase offers an installment plan" do
     seller = create(:user, disable_buyer_local_currency: false)
     product = create(:product, user: seller, price_cents: 1234)
     create(:product_installment_plan, link: product)
@@ -463,6 +463,10 @@ describe Checkout::StripePaymentPresenter do
     Feature.activate_user(described_class::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, seller)
     Feature.activate_user(:buyer_local_currency, seller)
     Feature.activate_user(Checkout::BuyerCurrencyEligibility::FEATURE_NAME, seller)
+    # The subscription ramp is what turns the buyer-local display on for a product offering
+    # installments (CurrencyHelper#buyer_currency_unquotable_product?), so this cart only
+    # becomes a presentment candidate for a ramped seller.
+    Feature.activate_user(Checkout::BuyerCurrencyEligibility::SUBSCRIPTION_FEATURE_NAME, seller)
     add_products = [
       checkout_product_for(
         product,
@@ -474,18 +478,19 @@ describe Checkout::StripePaymentPresenter do
       )
     ]
 
-    expect(stripe_payment_props(add_products:)).to eq(
-      integration: described_class::STRIPE_CARD_ELEMENT_INTEGRATION,
-      fallback_reason: "buyer_currency_presentment_unsupported",
-      disable_wallets: true,
-      request_apple_pay_merchant_tokens: false,
-      payment_element_wallets: false,
-      flat_payment_methods: false,
-      elements_options: nil,
-    )
+    props = stripe_payment_props(add_products:)
+
+    # Offering a plan is not choosing one: the surcharge request carries the buyer's actual
+    # selection, so a pay-in-full cart is quoted and charged like any one-time item. The
+    # selected-installment cart still falls back — covered by the pay_in_installments
+    # examples asserting "setup_or_installment_flow".
+    expect(props[:integration]).to eq(described_class::STRIPE_PAYMENT_ELEMENT_INTEGRATION)
+    expect(props[:fallback_reason]).to be_nil
+    expect(props[:elements_options][:buyer_currency_presentment]).to be(true)
   ensure
     Feature.deactivate_user(:buyer_local_currency, seller) if seller
     Feature.deactivate_user(Checkout::BuyerCurrencyEligibility::FEATURE_NAME, seller) if seller
+    Feature.deactivate_user(Checkout::BuyerCurrencyEligibility::SUBSCRIPTION_FEATURE_NAME, seller) if seller
   end
 
   it "falls back to CardElement when the presentment candidate item is recurring" do


### PR DESCRIPTION
# Quote pay-in-full carts of installment-offering products in the buyer's currency

## What

Removes the presenter-side `offers_installment_plan` rejection from `Checkout::StripePaymentPresenter#buyer_currency_presentment_element_shape?`, and the item field itself (this gate was its only reader). A cart whose product merely **offers** an installment plan — with the buyer paying in full — now mounts the buyer-currency Payment Element instead of falling back to CardElement in canonical USD. A cart where the buyer **selects** installments still falls back, on the existing `pay_in_installments` check (and earlier, on `setup_or_installment_flow`).

## Why

Sahil on gumroad-private#1312 (2026-08-03): *"Open PRs to get us to 0% on cardelement"*, and on the "excluded by design" framing: *"No 'by design' all product types should be multi currency and payment element now."* The 24h residual read on that issue attributes **5 successful purchases / $50.24 GMV** to "product offers an installment plan".

The gate was stale, not protective. Its comment said "quote creation cannot see that choice and rejects the product" — that was true before gp#1322 shipped, but today:

- The surcharge request carries the buyer's actual choice: `CustomerSurchargeController#buyer_currency_charge_details` only takes the installment branch when `item[:pay_in_installments]` is set, otherwise the line is built as a plain one-time item.
- `Checkout::BuyerCurrencyQuote#quotable_line_item?` accepts an installment-offering product for a subscription-ramped seller (the `installment_plan.present?` arm gates on `subscriptions_enabled?`, not a blanket reject).
- The charge-time mirror `BuyerCurrencyEligibility#unquotable_purchase?` keys on `purchase.is_installment_payment?` — the buyer's selection — not on what the product offers, and `#unquotable_product?`'s comment states it directly: "A product that merely offers installments remains quotable."
- The product page already shows the buyer's local price for these products when the seller is in the subscription ramp (`CurrencyHelper#buyer_currency_unquotable_product?`), so the presenter gate was the one layer still disagreeing: local price on the page, USD CardElement at the till.

## Before / After

| Cart | Before | After |
|---|---|---|
| One-time purchase of a product offering an installment plan (seller in subscription ramp) | CardElement, canonical USD (`buyer_currency_presentment_unsupported`) | Buyer-currency Payment Element |
| Same product, seller **not** in subscription ramp | CardElement | unchanged — display stays "default", never a candidate |
| Buyer selects pay-in-installments | CardElement (`setup_or_installment_flow`) | unchanged |
| Product with no installment plan | unchanged | unchanged |

The rendered surfaces on both sides are the existing checkout surfaces; the diff moves which one mounts for one cart shape.

## What still gates the lane

Seller flags (`buyer_currency_charging`, `buyer_local_currency`, Payment Element flag), the subscription ramp (which is what turns the buyer-local display on for these products), `MAX_QUOTED_CHARGES`, and all quote/charge-time verification. The quote and charge layers were already correct for this cart; only the render-time mirror moved.

## Test Results

Run locally in a lane-envd worktree (`DISABLE_SPRING=1 bundle exec rspec`):

- `spec/presenters/checkout/stripe_payment_presenter_spec.rb` — targeted runs of the changed example plus all examples that failed in a load-59 full-file run: 9 examples, 0 failures, then 4 examples, 0 failures on the residual set (full-file failures at load 49–58 moved between runs and all pass individually — load-induced, per the lane-contention rule; the `Tests` CI run at head is the authoritative full-file result).
- Mutation proof: reverted `stripe_payment_presenter.rb` to `origin/main` in place — the rewritten example (`:458`) reddens on `expect(props[:integration]).to eq(STRIPE_PAYMENT_ELEMENT_INTEGRATION)`; restored from HEAD and verified `git status` clean, `grep -c offers_installment_plan` = 0.
- Spec sweep for pins: the one example pinning the old fallback (`"falls back to CardElement when a one-time purchase offers an installment plan"`) is inverted and now pins the new behavior with the subscription ramp active; `pay_in_installments`-selected examples asserting `setup_or_installment_flow` are untouched (4 of them) and keep the selected-installment fallback pinned. `grep -rn offers_installment_plan app/ spec/` → zero hits.

## QA steps

Backend lane-selection change with no new rendered surface. Reviewer path: read the `stripe_payment_presenter.rb` diff (one condition, one dead field, two comments); run `spec/presenters/checkout/stripe_payment_presenter_spec.rb:458`. The quote/charge behavior for this cart is already covered on main by `buyer_currency_quote_spec.rb`'s ramped-seller installment examples and `buyer_currency_eligibility_spec.rb`'s "allows pay-in-full purchases of products offering an installment plan".

## Status

- [x] Scope — gumroad-private#1312, "product offers an installment plan" residual bucket (5 purchases/$50.24 per day)
- [x] Build
- [x] Local spec runs — changed + previously-failing examples green (see Test Results)
- [x] Mutation proof — example reddens against main's presenter
- [ ] CI green at head — `Tests` run pending
- [ ] Fable-5 adversarial review
- [x] QA recorded — spec-based, no rendered surface
- [ ] Shipped

Not armed for auto-merge: checkout/payments surface — merge decision is human (@rmarescu).

---

## AI disclosure

Built by gumclaw (Hermes Agent, model `claude-sonnet-5`) on the dispatcher standing order for gumroad-private#1312, following Sahil's "Open PRs to get us to 0% on cardelement" and "No 'by design'" directions on that issue.
