### PR TITLE
Stop a seller's own self-QA arming the IP card-testing block

### DIFF
--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -915,9 +915,14 @@ module Purchase::Blockable
     def block_ip_address_based_on_recent_failures!
       return if PlatformBlock.ip_address.active.find_by(object_value: ip_address).present?
 
+      # Excludes the seller testing their own paid flow (gumroad-private#1755): several
+      # self-purchases on new cards is the documented way to verify checkout, and it should not
+      # arm a threshold meant for a stranger card-testing the storefront.
       recent_failures = countable_card_testing_failures
                           .where("ip_address = ?", ip_address)
                           .where(created_at: CARD_TESTING_IP_ADDRESS_WATCH_PERIOD.ago..)
+                          .where("purchaser_id IS NULL OR purchaser_id != ?", seller.id)
+                          .where("email IS NULL OR email != ?", seller.email)
 
       return if distinct_card_count(recent_failures) < MAX_NUMBER_OF_FAILED_FINGERPRINTS
 

--- a/spec/models/concerns/purchase/blockable_velocity_noise_spec.rb
+++ b/spec/models/concerns/purchase/blockable_velocity_noise_spec.rb
@@ -57,6 +57,49 @@ RSpec.describe Purchase::Blockable do
       end
     end
 
+    context "when the seller is testing their own paid flow (gumroad-private#1755)" do
+      def self_purchase(fingerprint:, seller:)
+        create(:failed_purchase, link: create(:product, user: seller), seller:,
+                                 purchaser: seller, email: seller.email,
+                                 browser_guid: guid, ip_address: ip,
+                                 stripe_fingerprint: fingerprint,
+                                 stripe_error_code: PurchaseErrorCode::CARD_DECLINED_FRAUDULENT)
+      end
+
+      it "does not block the ip address on four self-purchase declines alone" do
+        seller = create(:user)
+        4.times { |i| self_purchase(fingerprint: "self#{i}", seller:) }
+
+        create(:failed_purchase, link: create(:product, user: seller), seller:,
+                                 browser_guid: SecureRandom.uuid, ip_address: ip,
+                                 stripe_fingerprint: "live-self",
+                                 stripe_error_code: PurchaseErrorCode::CARD_DECLINED_FRAUDULENT)
+              .send(:block_ip_address_based_on_recent_failures!)
+
+        expect(PlatformBlock.active.find_by(object_value: ip)).to be_nil
+      end
+
+      it "still blocks the ip when a stranger's four cards join a self-purchase" do
+        seller = create(:user)
+        self_purchase(fingerprint: "self0", seller:)
+        3.times do |i|
+          create(:failed_purchase, link: create(:product, user: seller), seller:,
+                                   email: "stranger-#{SecureRandom.hex(4)}@example.com",
+                                   browser_guid: guid, ip_address: ip,
+                                   stripe_fingerprint: "stranger#{i}",
+                                   stripe_error_code: PurchaseErrorCode::CARD_DECLINED_FRAUDULENT)
+        end
+
+        create(:failed_purchase, link: create(:product, user: seller), seller:,
+                                 browser_guid: guid, ip_address: ip,
+                                 stripe_fingerprint: "live-mixed",
+                                 stripe_error_code: PurchaseErrorCode::CARD_DECLINED_FRAUDULENT)
+              .send(:block_ip_address_based_on_recent_failures!)
+
+        expect(PlatformBlock.active.find_by(object_value: ip)).to be_present
+      end
+    end
+
     context "when the issuer answered about the card" do
       # The attacker picks the amount and the card, so exempting an issuer-answered decline hands
       # them a velocity-free oracle for validating a stolen list.


### PR DESCRIPTION
- [x] Scope — gumroad-private#1755 decision 4: a seller's own pre-launch self-QA can arm the IP card-testing block against themselves
- [x] Design — n/a: exempt self-purchases from `block_ip_address_based_on_recent_failures!`'s recent-failures scan, as decision 4 specified
- [x] Build — b6b8ca4b8
- [ ] QA
- [ ] Ship
- [x] Market — n/a
- [x] Sell — n/a

## What

`block_ip_address_based_on_recent_failures!` no longer counts a seller's own self-purchase declines toward the 4-distinct-card threshold on their own IP.

```ruby
recent_failures = countable_card_testing_failures
                    .where("ip_address = ?", ip_address)
                    .where(created_at: CARD_TESTING_IP_ADDRESS_WATCH_PERIOD.ago..)
                    .where("purchaser_id IS NULL OR purchaser_id != ?", seller.id)
                    .where("email IS NULL OR email != ?", seller.email)
```

Stranger failures on the same IP still count normally, and still trip the block.

## Why

gumroad-private#1755 (decisions 1 and 3 already merged as #6905/#6915) documented the confirmed case: seller ran several $1 self-purchases from his own IP to test the paid flow before launch, four distinct declined-card fingerprints tripped `MAX_NUMBER_OF_FAILED_FINGERPRINTS`, and `block_ip_address_based_on_recent_failures!` wrote a `PlatformBlock` on his own IP — locking out real buyers until support intervened.

Decisions 1/3 stopped that block from rejecting *buyers*; decision 4 stops the seller's own testing from *arming* the block in the first place, per the issue's own proposed fix: "Excluding purchases where `email == seller.email` (or where the buyer is the seller's own account)."

## Before / after

| Scenario | Before | After |
|---|---|---|
| Seller self-purchases 4 declined test cards from their own IP | IP block written | Not counted, no block |
| A stranger's 4 declined cards on the same IP as a seller's self-test | IP block written | Still written (stranger rows still count) |
| A stranger's 4 declined cards, unrelated to any seller | IP block written | Unchanged |

## Test Results

`bundle exec rspec spec/models/concerns/purchase/blockable_velocity_noise_spec.rb` (lane0 env, dedicated worktree): 15 examples, 0 failures.

Two new examples added under "when the seller is testing their own paid flow (gumroad-private#1755)":
- Four self-purchase declines alone do not arm the IP block.
- A stranger's four declined cards on the same IP still arm the block even alongside a self-purchase.

Mutation-verified: reverted the two new `.where` exclusion clauses and reran the two new specs — the first ("does not block... alone") went red (`PlatformBlock` was present when it should be nil), the second (mixed population) stayed green as expected, since it only asserts strangers still count. Confirmed the fix file byte-for-byte identical to the mutation-tested version before committing.

## QA steps

Same spec run above exercises both branches directly against the model method (no UI surface — backend-only fraud-rule change).

---

AI disclosure: this PR was written with the assistance of claude-sonnet-5, operating autonomously per `gumroad-private#1755` decision 4.
