### PR TITLE
Add genre and content-type facets to Music and sound design

### DIFF
--- a/app/models/taxonomy_attribute_definitions.rb
+++ b/app/models/taxonomy_attribute_definitions.rb
@@ -12,11 +12,16 @@
 # permanent once products carry values for it; `label` and `values` are display-side and may
 # be edited freely.
 class TaxonomyAttributeDefinitions
+  # `genre` and `content_type` were added after the initial ship (gumroad-private#1799 follow-up):
+  # sample-pack marketplaces like Splice and Loopmasters organize primarily by genre and content
+  # type, ahead of tempo bucket, so those were the real gap in the original facet set.
   MUSIC_DEFINITIONS = [
-    { name: "format", label: "Format", value_type: "enum", values: ["WAV", "MP3", "AIFF", "MIDI", "Stems"], position: 0 },
-    { name: "tempo", label: "Tempo", value_type: "enum", values: ["Under 90 BPM", "90–120 BPM", "120–140 BPM", "Over 140 BPM"], position: 1 },
-    { name: "loopable", label: "Loopable", value_type: "boolean", values: [], position: 2 },
-    { name: "license", label: "License", value_type: "enum", values: ["Personal", "Commercial", "Royalty-free"], position: 3 },
+    { name: "genre", label: "Genre", value_type: "enum", values: ["Hip-Hop", "House", "Techno", "Trap", "Pop", "R&B", "Lo-fi", "EDM", "Ambient", "Cinematic"], position: 0 },
+    { name: "content_type", label: "Content type", value_type: "enum", values: ["Loop", "One-shot", "MIDI", "Preset", "Stem", "Full track"], position: 1 },
+    { name: "format", label: "Format", value_type: "enum", values: ["WAV", "MP3", "AIFF", "MIDI", "Stems"], position: 2 },
+    { name: "tempo", label: "Tempo", value_type: "enum", values: ["Under 90 BPM", "90–120 BPM", "120–140 BPM", "Over 140 BPM"], position: 3 },
+    { name: "loopable", label: "Loopable", value_type: "boolean", values: [], position: 4 },
+    { name: "license", label: "License", value_type: "enum", values: ["Personal", "Commercial", "Royalty-free"], position: 5 },
   ].freeze
 
   DEFINITIONS = {


### PR DESCRIPTION
## What changed

Adds two new Discover facets to the Music and sound design taxonomy in `app/models/taxonomy_attribute_definitions.rb`:

- **`genre`** (enum): Hip-Hop, House, Techno, Trap, Pop, R&B, Lo-fi, EDM, Ambient, Cinematic
- **`content_type`** (enum): Loop, One-shot, MIDI, Preset, Stem, Full track

Both are positioned before `format`, keeping `format`/`tempo`/`loopable`/`license` unchanged. Applies to the `music-and-sound-design` root and its `dance-and-theater`/`instruments`/`sound-design`/`vocal` children, same scope as the existing `MUSIC_DEFINITIONS`.

## Why

Follow-up to #6949 (merged), which shipped `format`, `tempo`, `loopable`, `license` facets for gumroad-private#1799.

Looking at how real sample-pack/loop marketplaces organize buyer filters:
- **Splice** and **Loopmasters** both put **genre** and **content type** (loop / one-shot / MIDI / preset / stem / full track) front-and-center — these are the dominant facets buyers filter by, ahead of BPM range.
- Tempo bucketing exists on those sites too, but as a secondary/refinement filter, not the primary way buyers narrow results.

That means the facet set that shipped in #6949 was missing the two filters that matter most for this category. This PR closes that gap without touching what already merged.

## Before / after

**Before** (`MUSIC_DEFINITIONS`, live on main):
```ruby
format, tempo, loopable, license
```

**After:**
```ruby
genre, content_type, format, tempo, loopable, license
```

## Test results

```
$ bundle exec rspec spec/models/taxonomy_attribute_definitions_spec.rb
7 examples, 0 failures

$ bundle exec rubocop app/models/taxonomy_attribute_definitions.rb
1 file inspected, no offenses detected
```

Verified against `TaxonomyAttribute` constraints:
- `name` matches `/\A[a-z0-9_]+\z/` (`genre`, `content_type`)
- unique within the category's definition list
- both use `enum`, which is in `TaxonomyAttribute::FILTERABLE_VALUE_TYPES`

## QA steps

1. Run `Onetime::SeedTaxonomyAttributes` (or the dev/staging/test seed) against a local DB.
2. Visit Discover for `music-and-sound-design` (and its `instruments`/`vocal`/`dance-and-theater`/`sound-design` children).
3. Confirm `Genre` and `Content type` filters appear ahead of `Format`, with the listed enum options, and that filtering by them narrows the product listing.
4. Confirm existing `Format`/`Tempo`/`Loopable`/`License` filters are unchanged.

Refs: #6949, gumroad-private#1799
