### PR TITLE
Document why offer code lookups tolerate unnormalized buyer input

### DIFF
--- a/app/services/offer_code_discount_computing_service.rb
+++ b/app/services/offer_code_discount_computing_service.rb
@@ -167,6 +167,11 @@ class OfferCodeDiscountComputingService
       end
     end
 
+    # Callers may pass the buyer's code as typed (OfferCodesController and
+    # CartPresenter do). That is safe: the code is used only in this lookup,
+    # where utf8mb4_unicode_ci already equates NFD/NFC forms, case, and
+    # trailing spaces — the same rows Order::CreateService#normalize_discount_code
+    # would match — and results are keyed by permalink, never by the code string.
     def offer_codes
       return OfferCode.none if code.blank? && offer_code_id.blank?
 

--- a/spec/services/offer_code_discount_computing_service_spec.rb
+++ b/spec/services/offer_code_discount_computing_service_spec.rb
@@ -78,6 +78,15 @@ describe OfferCodeDiscountComputingService do
     expect(result[:error_code]).to eq(:invalid_offer)
   end
 
+  it "matches a code submitted in decomposed unicode form, as checkout passes it unnormalized" do
+    offer_code.update!(code: "caf\u00E9")
+
+    result = OfferCodeDiscountComputingService.new("cafe\u0301", products_data).process
+
+    expect(result[:error_code]).to be_nil
+    expect(result[:products_data][product.unique_permalink][:discount]).to include(type: "percent", percents: 100)
+  end
+
   it "returns invalid error_code in result when products is nil" do
     result = OfferCodeDiscountComputingService.new(offer_code.code, nil).process
 


### PR DESCRIPTION
## What

Adds a comment on the offer code lookup in `OfferCodeDiscountComputingService` explaining why callers can pass the buyer's discount code as typed, and a spec that locks the behavior by submitting a decomposed unicode form of a stored code.

## Why

Checkout's discount endpoint and the cart presenter pass the raw code into the service, while order creation first normalizes it (NFC, strip, downcase). We investigated whether that asymmetry could make the cart and the order disagree about a discount. It cannot: the service only uses the code in a `where(code:)` lookup, the `offer_codes` table's `utf8mb4_unicode_ci` collation already treats decomposed and composed unicode forms, letter case, and trailing spaces as equal, and results are keyed by product permalink rather than the code string. The comment and the spec record that conclusion so a future change to the lookup or the collation surfaces it immediately.

## Before/After

No behavior change — comment and spec only, so there is nothing to capture visually.

## Test Results

- `bundle exec rspec spec/services/offer_code_discount_computing_service_spec.rb` — 55 examples, 0 failures
- `bundle exec rubocop` on both changed files — no offenses

---

AI disclosure: written with Claude Fable 5.