### PR TITLE
Stop guest checkouts spoofing the seller email to dodge the IP card-testing block

### DIFF
--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -917,12 +917,14 @@ module Purchase::Blockable
 
       # Excludes the seller testing their own paid flow (gumroad-private#1755): several
       # self-purchases on new cards is the documented way to verify checkout, and it should not
-      # arm a threshold meant for a stranger card-testing the storefront.
+      # arm a threshold meant for a stranger card-testing the storefront. Only a confirmed
+      # `purchaser_id` match proves the seller made the purchase — a guest checkout's typed-in
+      # email is unauthenticated and a card tester can set it to the seller's own address to
+      # dodge the threshold entirely, so email alone must never exempt a row.
       recent_failures = countable_card_testing_failures
                           .where("ip_address = ?", ip_address)
                           .where(created_at: CARD_TESTING_IP_ADDRESS_WATCH_PERIOD.ago..)
                           .where("purchaser_id IS NULL OR purchaser_id != ?", seller.id)
-                          .where("email IS NULL OR email != ?", seller.email)
 
       return if distinct_card_count(recent_failures) < MAX_NUMBER_OF_FAILED_FINGERPRINTS
 

--- a/spec/models/concerns/purchase/blockable_velocity_noise_spec.rb
+++ b/spec/models/concerns/purchase/blockable_velocity_noise_spec.rb
@@ -98,6 +98,25 @@ RSpec.describe Purchase::Blockable do
 
         expect(PlatformBlock.active.find_by(object_value: ip)).to be_present
       end
+
+      it "still blocks the ip when a guest checkout merely types the seller's email (gp#1755 review)" do
+        seller = create(:user)
+        4.times do |i|
+          create(:failed_purchase, link: create(:product, user: seller), seller:,
+                                   purchaser: nil, email: seller.email,
+                                   browser_guid: guid, ip_address: ip,
+                                   stripe_fingerprint: "spoof#{i}",
+                                   stripe_error_code: PurchaseErrorCode::CARD_DECLINED_FRAUDULENT)
+        end
+
+        create(:failed_purchase, link: create(:product, user: seller), seller:,
+                                 browser_guid: guid, ip_address: ip,
+                                 stripe_fingerprint: "live-spoof",
+                                 stripe_error_code: PurchaseErrorCode::CARD_DECLINED_FRAUDULENT)
+              .send(:block_ip_address_based_on_recent_failures!)
+
+        expect(PlatformBlock.active.find_by(object_value: ip)).to be_present
+      end
     end
 
     context "when the issuer answered about the card" do


### PR DESCRIPTION
- [x] Scope — Greptile P1 finding on merged #6960: the self-purchase exemption keyed off email alone, letting a guest checkout spoof the seller's email to dodge the IP card-testing threshold.
- [x] Design — n/a: require `purchaser_id == seller.id`, drop the standalone email exclusion.
- [x] Build — c792bfb1d
- [ ] QA
- [ ] Ship
- [x] Market — n/a
- [x] Sell — n/a

## What

`block_ip_address_based_on_recent_failures!`'s self-purchase exemption no longer exempts a row on checkout email alone. Only a confirmed `purchaser_id == seller.id` proves the seller made the purchase.

## Why

#6960 (merged) exempted self-QA declines from arming the IP card-testing block by excluding rows where `purchaser_id != seller.id` **or** `email != seller.email`. Greptile's post-merge review found the email clause is a fraud bypass: checkout email is buyer-controlled and unauthenticated on a guest row, so a card tester could set it to the seller's own email on every failed guest attempt and have those declines excluded from the IP scan — letting repeated declines from one IP dodge the 4-distinct-card threshold entirely.

## Before / after

| Scenario | Before | After |
|---|---|---|
| Confirmed self-purchase (`purchaser_id == seller.id`), 4 declines | Not counted, no block | Unchanged — still not counted |
| Guest checkout typing the seller's email, 4 declines, no `purchaser_id` | **Not counted, no block (bypass)** | Counted — IP block written |
| Stranger's declines on the same IP | Still counted | Unchanged |

## Test Results

`bundle exec rspec spec/models/concerns/purchase/blockable_velocity_noise_spec.rb` (lane0 env borrowed via `lane_alloc.sh env 0`, dedicated worktree): 16 examples, 0 failures.

New example: "still blocks the ip when a guest checkout merely types the seller's email (gp#1755 review)".

Mutation-verified: reverted the fix (re-added the `email != seller.email` clause) and reran the new example alone — it went red (`Expected nil to return a truthy result for present?`), confirming it actually exercises the bypass. Restored the fix and confirmed `grep -c 'email IS NULL OR email != ?'` is 0 in the shipped file.

## QA steps

Same spec run above exercises both branches directly against the model method — backend-only fraud-rule change, no UI surface.

---

AI disclosure: this PR was written with the assistance of claude-sonnet-5, fixing a Greptile finding on merged PR #6960.
