### PR TITLE
Normalize discount codes the same way across checkout, recovery, and the cart

### DIFF
--- a/app/javascript/data/order.test.ts
+++ b/app/javascript/data/order.test.ts
@@ -188,6 +188,15 @@ describe("mergeOfferCodes", () => {
       ),
     ).toMatchObject([{ code: "SAVE", products: { first: { cents: 100 }, second: { cents: 0 } } }]);
   });
+
+  it("merges codes that differ only in unicode normalization", () => {
+    expect(
+      mergeOfferCodes(
+        [{ code: "éclair".normalize("NFC"), products: { first: fixedDiscount(100) } }],
+        [{ code: "éclair".normalize("NFD"), products: { second: fixedDiscount(0) } }],
+      ),
+    ).toMatchObject([{ products: { first: { cents: 100 }, second: { cents: 0 } } }]);
+  });
 });
 
 describe("startOrderCreation", () => {

--- a/app/javascript/data/order.ts
+++ b/app/javascript/data/order.ts
@@ -50,7 +50,7 @@ export const mergeOfferCodes = (...groups: OfferCodes[]): OfferCodes =>
     groups
       .flat()
       .reduce((merged, offerCode) => {
-        const key = offerCode.code.trim().toLowerCase();
+        const key = offerCode.code.normalize("NFC").trim().toLowerCase();
         const current = merged.get(key);
         merged.set(key, current ? { ...current, products: { ...current.products, ...offerCode.products } } : offerCode);
         return merged;

--- a/app/models/offer_code.rb
+++ b/app/models/offer_code.rb
@@ -78,6 +78,12 @@ class OfferCode < ApplicationRecord
     where("NOT EXISTS (SELECT 1 FROM offer_codes_excluded_products WHERE offer_codes_excluded_products.offer_code_id = offer_codes.id AND offer_codes_excluded_products.product_id = ?)", product.id)
   }
 
+  # Codes may contain accented Latin characters (see the format validation above), so NFC-normalize
+  # before comparing — a decomposed client submission must match its precomposed stored form.
+  def self.normalize_code(code)
+    code.to_s.unicode_normalize(:nfc).strip.downcase
+  end
+
   def is_valid_for_purchase?(purchase_quantity: 1, excluding_purchase: nil)
     return true if max_purchase_count.nil?
 

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -5104,19 +5104,26 @@ class Purchase < ApplicationRecord
     def offer_code_usage_available?(offer_code, lock: false)
       return true if offer_code.max_purchase_count.nil?
 
+      units = offer_code_applied_once_per_cart?(offer_code) ? 1 : quantity
+      offer_code_quantity_left(offer_code, lock:) >= units
+    end
+
+    def offer_code_applied_once_per_cart?(offer_code)
       discount = purchase_offer_code_discount
-      once_per_cart = discount.present? ? discount.once_per_cart? && !discount.offer_code_is_percent : offer_code.is_cents? && offer_code.once_per_cart?
-      allocation_ids = [discount&.once_per_cart_allocation_id].compact if once_per_cart
-      units = once_per_cart ? 1 : quantity
+      discount.present? ? discount.once_per_cart? && !discount.offer_code_is_percent : offer_code.is_cents? && offer_code.once_per_cart?
+    end
+
+    def offer_code_quantity_left(offer_code, lock: false)
+      allocation_ids = [purchase_offer_code_discount&.once_per_cart_allocation_id].compact if offer_code_applied_once_per_cart?(offer_code)
       offer_code.quantity_left(
         excluding_purchase: self,
         excluding_once_per_cart_allocation_ids: allocation_ids,
         lock:
-      ) >= units
+      )
     end
 
     def add_offer_code_usage_error(offer_code, lock: false)
-      if offer_code.quantity_left(excluding_purchase: self, lock:).positive?
+      if offer_code_quantity_left(offer_code, lock:).positive?
         self.error_code = PurchaseErrorCode::EXCEEDING_OFFER_CODE_QUANTITY
         errors.add :base, "Sorry, the discount code you are using is invalid for the quantity you have selected."
       else

--- a/app/services/order/create_service.rb
+++ b/app/services/order/create_service.rb
@@ -397,7 +397,7 @@ class Order::CreateService
     end
 
     def normalize_discount_code(code)
-      code.to_s.unicode_normalize(:nfc).strip.downcase
+      OfferCode.normalize_code(code)
     end
 
     def build_purchase_params(product, purchase_params)

--- a/app/services/order/offer_code_recovery_service.rb
+++ b/app/services/order/offer_code_recovery_service.rb
@@ -8,7 +8,7 @@ class Order::OfferCodeRecoveryService
 
   def self.merge_responses(*response_groups)
     response_groups.flatten.each_with_object({}) do |response, merged|
-      key = response[:code].to_s.strip.downcase
+      key = OfferCode.normalize_code(response[:code])
       if merged.key?(key)
         merged[key][:products].merge!(response[:products])
       else
@@ -32,7 +32,7 @@ class Order::OfferCodeRecoveryService
     candidates.each_with_object([]) do |candidate, sanitized|
       return [] unless candidate.respond_to?(:key?) && candidate.respond_to?(:[])
 
-      code = candidate[:code].to_s.strip.downcase
+      code = OfferCode.normalize_code(candidate[:code])
       product_params = candidate[:products]
       return [] if code.blank? || code.bytesize > MAX_RETRY_OFFER_CODE_FIELD_BYTES
       return [] unless product_params.respond_to?(:each_pair) && product_params.respond_to?(:size)

--- a/spec/models/purchase/purchase_offer_code_spec.rb
+++ b/spec/models/purchase/purchase_offer_code_spec.rb
@@ -46,6 +46,47 @@ describe Purchase, "offer-code capacity" do
     expect(purchase.error_code).to eq(PurchaseErrorCode::OFFER_CODE_SOLD_OUT)
   end
 
+  it "excludes its own once-per-cart allocation when picking the usage error" do
+    product = create(:product)
+    offer_code = create(
+      :offer_code,
+      products: [product],
+      amount_cents: 100,
+      once_per_cart: true,
+      max_purchase_count: 1
+    )
+    completed_purchase = create(:purchase, link: product, seller: product.user, offer_code:, purchaser: nil)
+    completed_purchase.create_purchase_offer_code_discount!(
+      offer_code:,
+      offer_code_amount: 100,
+      offer_code_is_percent: false,
+      once_per_cart: true,
+      once_per_cart_allocation_id: SecureRandom.uuid,
+      pre_discount_minimum_price_cents: product.price_cents
+    )
+
+    allocation_id = SecureRandom.uuid
+    purchase = build(:purchase_in_progress, link: product, seller: product.user, offer_code:)
+    purchase.build_purchase_offer_code_discount(
+      offer_code:,
+      offer_code_amount: 100,
+      offer_code_is_percent: false,
+      once_per_cart: true,
+      once_per_cart_allocation_id: allocation_id,
+      pre_discount_minimum_price_cents: product.price_cents
+    )
+
+    # The error branch must read capacity with the same exclusions as the
+    # availability check, or the two usage messages can disagree.
+    expect(offer_code).to receive(:quantity_left)
+      .with(hash_including(excluding_once_per_cart_allocation_ids: [allocation_id]))
+      .and_call_original
+
+    purchase.send(:add_offer_code_usage_error, offer_code)
+
+    expect(purchase.error_code).to eq(PurchaseErrorCode::OFFER_CODE_SOLD_OUT)
+  end
+
   it "sizes a temporary-discount mandate from the saved PWYW total" do
     product = create(:membership_product, price_cents: 10_00, customizable_price: true)
     offer_code = create(:offer_code, products: [product], amount_cents: 5_00, once_per_cart: true)

--- a/spec/services/order/offer_code_recovery_service_spec.rb
+++ b/spec/services/order/offer_code_recovery_service_spec.rb
@@ -155,4 +155,25 @@ describe Order::OfferCodeRecoveryService do
     expect(merged.first[:code]).to eq("SAVE")
     expect(merged.first[:products].keys).to contain_exactly(product_1.unique_permalink, product_2.unique_permalink)
   end
+
+  it "merges responses whose codes differ only in unicode normalization" do
+    merged = described_class.merge_responses(
+      [{ code: "éclair".unicode_normalize(:nfc), products: { product_1.unique_permalink => { cents: 100 } } }],
+      [{ code: "éclair".unicode_normalize(:nfd), products: { product_2.unique_permalink => { cents: 0 } } }],
+    )
+
+    expect(merged.one?).to be(true)
+    expect(merged.first[:products].keys).to contain_exactly(product_1.unique_permalink, product_2.unique_permalink)
+  end
+
+  it "sanitizes retry candidate codes to their precomposed form" do
+    candidates = described_class.sanitize_retry_candidates(
+      [{
+        code: "ÉCLAIR".unicode_normalize(:nfd),
+        products: { "retry-line" => { permalink: product_1.unique_permalink, quantity: 1 } },
+      }]
+    )
+
+    expect(candidates.first[:code]).to eq("éclair".unicode_normalize(:nfc))
+  end
 end


### PR DESCRIPTION
## What

Two follow-ups to #6750, both found while re-reading that change:

- Discount code normalization now lives in one place. `OfferCode.normalize_code` applies unicode NFC normalization, strips whitespace, and downcases. Order creation already normalized this way; the server's retry and recovery paths and the cart's frontend merge now use the same helper.
- The two capacity reads in `Purchase` share one helper. The check that decides whether a discount code still has room, and the branch that picks which error message to show, now both exclude the purchase's own cart-level allocation.

## Why

Discount codes accept accented characters. A browser can submit `éclair` in decomposed form while the stored code is precomposed, and the two forms are different strings in Ruby and JavaScript even though MySQL treats them as equal. The recovery path merged cart responses by lowercased code alone, so one discount could come back as two entries and show up twice in the cart. Routing every comparison through one helper keeps the frontend, order creation, and recovery on the same footing.

The capacity change is hardening rather than a live fix. `add_offer_code_usage_error` recomputed the remaining quantity without the allocation exclusion that the availability check applies, so in principle the "exceeds quantity" and "usage limit reached" messages could disagree with the check that just ran. That is unreachable today: the error branch runs only after availability fails, and for a cart-level discount that means the excluded reading is already below one, which puts the unexcluded reading there too. Both paths pick "usage limit reached". Sharing one helper means the messages stay correct without depending on that reasoning holding as the surrounding code changes.

## Before/After

Nothing to show. Neither change alters what a buyer or seller sees today: the message branch is unreachable, and the normalization fix only bites on input a normal keyboard doesn't produce. Staging a video would mean hand-crafting decomposed unicode into a cart request, which demonstrates the unit tests rather than the product.

## Test Results

- `bundle exec rspec spec/models/purchase/purchase_offer_code_spec.rb spec/services/order/offer_code_recovery_service_spec.rb` — 12 examples, 0 failures
- `npx vitest run app/javascript/data/order.test.ts` — 28 tests, 0 failures
- All three new Ruby examples and the new vitest case fail when the app code is reverted
- `bundle exec rubocop`, `DISABLE_TYPE_CHECKED=1 npx eslint`, `npm run typecheck` — clean

No end-to-end tests were added. The recovery and merge paths this touches are driven by a partial cart failure followed by an SCA retry, which the suite covers at the controller, service, and frontend unit levels rather than in the browser. The remaining gap is buyer-facing browser coverage for cart-level fixed-amount discounts in general, which predates this change and is worth its own PR.

---

Written with Claude Fable 5. Reviewed with Claude Opus 5 at xhigh reasoning effort, which confirmed both changes preserve behavior and caught the frontend half of the normalization fix.
