### PR TITLE
Make the review notification survive a retry and stop expiring into a duplicate

### DIFF
--- a/app/mailers/contacting_creator_mailer.rb
+++ b/app/mailers/contacting_creator_mailer.rb
@@ -24,6 +24,7 @@ class ContactingCreatorMailer < ApplicationMailer
   # here would be accepted and silently ignored, since deliver callbacks take `:if`/`:unless` only.
   around_deliver :settle_undeliverable_ping_subscription_notice
   around_deliver :settle_undelivered_receipts_notice
+  around_deliver :settle_review_notification
 
   layout "layouts/email"
 
@@ -689,12 +690,16 @@ class ContactingCreatorMailer < ApplicationMailer
 
   # A review notifies the seller at most once (immediately if the buyer typed before submitting,
   # otherwise via whichever of the delayed message-less render or the blank→present arrival fires
-  # first). The claim is the enforcement: without it, the delayed job's read of `message` and its
-  # eventual delivery straddle the buyer's commit, so both paths can decide to send.
+  # first). Two things enforce that: `seller_notified_at` for a send that already happened, however
+  # long ago, and the claim for the overlap the marker cannot see — the delayed job's read of
+  # `message` and its eventual delivery straddle the buyer's commit, so without it both paths can
+  # decide to send before either has recorded one.
+  #
+  # The claim is taken last, so an ordinary rejection does not have to give one back.
   def review_submitted(review_id)
     @review = ProductReview.includes(:purchase, link: :user).find(review_id)
     return do_not_send if @review.deleted?
-    return do_not_send unless claim_review_notification(@review.id)
+    return do_not_send if @review.seller_notified?
 
     @product = @review.link
     @seller = @product.user
@@ -702,6 +707,9 @@ class ContactingCreatorMailer < ApplicationMailer
     # sitting in the queue when the seller flips this off, and the job's own preference
     # check at enqueue time can't see a later change.
     return do_not_send if @seller.disable_reviews_email?
+    @review_notification_claim = @review.claim_seller_notification
+    return do_not_send if @review_notification_claim.nil?
+
     full_name = @review.purchase.full_name
     email = @review.purchase.email
     @buyer = full_name.present? ? "#{full_name} (#{email})" : email
@@ -793,16 +801,6 @@ class ContactingCreatorMailer < ApplicationMailer
       @do_not_send = true
     end
 
-    # Atomic claim so the delayed message-less render and the blank→present arrival notify can't
-    # both win: whichever commits its render first (not whichever fires first) gets the seller's
-    # one email. TTL covers rendering + delivery, not the review's whole life — a lost claim after
-    # that just means a review-created-then-immediately-deleted row leaves no dangling key.
-    REVIEW_NOTIFICATION_CLAIM_TTL = 1.hour
-
-    def claim_review_notification(review_id)
-      $redis.set(RedisKey.product_review_seller_notified(review_id), Time.current.to_i, nx: true, ex: REVIEW_NOTIFICATION_CLAIM_TTL.to_i)
-    end
-
     def format_dispute_evidence_due_at(due_at)
       due_at.in_time_zone(@seller.timezone.presence || Time.zone).strftime("%B %-d, %Y at %-l:%M %p %Z")
     end
@@ -865,6 +863,26 @@ class ContactingCreatorMailer < ApplicationMailer
           settle, @resource_subscription.id, @undeliverable_ping_subscription_reason,
           @undeliverable_ping_subscription_claim_token
         )
+      end
+    end
+
+    # The render claimed the seller's one notice for a review; this decides whether it was spent.
+    # Mirrors `settle_undeliverable_ping_subscription_notice`, including why the claim has to be
+    # given back rather than left to expire: `MailDeliveryJob` retries a transient SMTP failure by
+    # re-rendering the same mailer action, so a claim still held on the retry turns a delivery worth
+    # retrying into a notice the seller never gets.
+    def settle_review_notification
+      delivered = false
+      yield
+      delivered = message.to.present? && message.perform_deliveries
+    ensure
+      # `ensure` rather than an after callback, so a raised delivery settles too.
+      unless @review_notification_claim.nil?
+        if delivered
+          @review.record_seller_notified!
+        else
+          @review.release_seller_notification_claim(@review_notification_claim)
+        end
       end
     end
 

--- a/app/models/product_review.rb
+++ b/app/models/product_review.rb
@@ -9,9 +9,26 @@ class ProductReview < ApplicationRecord
   # How long a message-less review waits before the seller is told about it. The rating autosave
   # creates the row the moment a star is tapped, usually a minute or two before the buyer submits
   # their text (gumroad-private#1783) — notifying on create meant the email routinely quoted
-  # nothing. The window only has to cover taps that never become a submit; a message arriving at
-  # any point emails immediately and cancels the delayed render.
+  # nothing. The window only has to cover taps that never become a submit; a message arriving
+  # before the seller has been told emails immediately and cancels the delayed render.
   SELLER_NOTIFICATION_DELAY = 5.minutes
+
+  # How long a render holds the seller's notice before it has to say what happened to it. It only has
+  # to cover handing one message to the delivery method; expiring is the backstop for a render that
+  # dies before it can settle. It is not evidence the seller was told — `seller_notified_at` is —
+  # which is why a claim can expire without costing the notice.
+  SELLER_NOTIFICATION_CLAIM_TTL = 10.minutes
+
+  # Release only the claim this render holds. An absent key means ours already expired, so a DEL
+  # would be a no-op; a different value means a successor claimed behind us and deleting it would
+  # let a third render send a duplicate.
+  RELEASE_SELLER_NOTIFICATION_IF_HELD = <<~LUA
+    if redis.call('GET', KEYS[1]) == ARGV[1] then
+      return redis.call('DEL', KEYS[1])
+    end
+    return 0
+  LUA
+
   RestrictedOperationError = Class.new(StandardError)
 
   belongs_to :link, optional: true
@@ -58,7 +75,36 @@ class ProductReview < ApplicationRecord
   # silently replace it.
   after_update_commit :notify_seller_of_arrived_message, if: -> { saved_change_to_message? && saved_change_to_message.first.blank? && message.present? }
 
+  def seller_notified? = seller_notified_at.present?
+
+  # Takes the seller's one notice for this review and returns the token proving this render holds
+  # it, or nil when another render does. One write rather than a read followed by one: the delayed
+  # message-less render and the blank→present arrival can overlap, and both reading an absent claim
+  # would both send.
+  def claim_seller_notification
+    token = SecureRandom.hex(16)
+    claimed = $redis.set(seller_notification_claim_key, token, nx: true, ex: SELLER_NOTIFICATION_CLAIM_TTL.to_i)
+    claimed ? token : nil
+  end
+
+  # Gives back a claim this render took and did not spend, so a retry of the same delivery — or the
+  # other path, if it is still to come — can report the review instead of the notice being lost.
+  def release_seller_notification_claim(token)
+    return if token.blank?
+
+    $redis.eval(RELEASE_SELLER_NOTIFICATION_IF_HELD, keys: [seller_notification_claim_key], argv: [token])
+  end
+
+  # Written once a message has actually been transmitted. Durable rather than a Redis key with a
+  # lifetime, because the buyer can add their text at any point after the message-less render
+  # already told the seller — an hour later or a week later — and that must not be a second email.
+  def record_seller_notified!
+    self.class.where(id:, seller_notified_at: nil).update_all(seller_notified_at: Time.current)
+  end
+
   private
+    def seller_notification_claim_key = RedisKey.product_review_seller_notified(id)
+
     def update_product_review_stat
       return if rating_previous_change.nil?
       link.update_review_stat_via_rating_change(*rating_previous_change)
@@ -84,6 +130,10 @@ class ProductReview < ApplicationRecord
 
     def notify_seller_of_arrived_message
       return if link.user.disable_reviews_email?
+      # A buyer who comes back well after the message-less render already reported the review is
+      # editing a review the seller has been told about, not submitting a new one. The render
+      # re-checks this too; this only saves enqueuing a job that would decide the same thing.
+      return if seller_notified?
 
       ContactingCreatorMailer.review_submitted(id).deliver_later
     end

--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -95,8 +95,9 @@ class RedisKey
     # email_infos rows, so this set is the only thing that brings them back.
     def undelivered_receipt_pending_retry = "undelivered_receipt_sweep:pending_retry"
     # Claims the seller notification for a review so the message-less delayed render and the
-    # blank→present immediate send can't both deliver when the buyer's text lands mid-flight.
-    # See ContactingCreatorMailer#review_submitted.
+    # blank→present immediate send can't both deliver when the buyer's text lands mid-flight. Held
+    # only for the length of one render; `product_reviews.seller_notified_at` is what records that
+    # the seller was told. See ContactingCreatorMailer#review_submitted.
     def product_review_seller_notified(review_id) = "product_review_seller_notified:#{review_id}"
   end
 end

--- a/db/migrate/20261206171842_add_seller_notified_at_to_product_reviews.rb
+++ b/db/migrate/20261206171842_add_seller_notified_at_to_product_reviews.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSellerNotifiedAtToProductReviews < ActiveRecord::Migration[7.1]
+  def change
+    add_column :product_reviews, :seller_notified_at, :datetime, precision: 6
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_12_06_163724) do
+ActiveRecord::Schema[7.1].define(version: 2026_12_06_171842) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -1820,6 +1820,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_12_06_163724) do
     t.text "message"
     t.virtual "has_message", type: :boolean, null: false, as: "if((`message` is null),false,true)", stored: true
     t.datetime "deleted_at"
+    t.datetime "seller_notified_at"
     t.index ["link_id", "has_message", "created_at"], name: "idx_on_link_id_has_message_created_at_2fcf6c0c64"
     t.index ["purchase_id"], name: "index_product_reviews_on_purchase_id", unique: true
   end

--- a/spec/mailers/contacting_creator_mailer_spec.rb
+++ b/spec/mailers/contacting_creator_mailer_spec.rb
@@ -2709,6 +2709,47 @@ describe ContactingCreatorMailer do
         mail = ContactingCreatorMailer.review_submitted(review.id)
         expect(mail.to).to eq([review.link.user.email])
       end
+
+      it "does not send once a delivered render has recorded the seller as notified" do
+        review.update_columns(seller_notified_at: Time.current)
+
+        mail = ContactingCreatorMailer.review_submitted(review.id)
+        expect(mail.message).to be_a(ActionMailer::Base::NullMail)
+      end
+
+      it "does not send again once the claim has expired, because the record of the send outlives it" do
+        ContactingCreatorMailer.review_submitted(review.id).deliver_now
+        $redis.del(RedisKey.product_review_seller_notified(review.id))
+
+        mail = ContactingCreatorMailer.review_submitted(review.id)
+        expect(mail.message).to be_a(ActionMailer::Base::NullMail)
+      end
+
+      it "records the seller as notified once the message is delivered" do
+        expect do
+          ContactingCreatorMailer.review_submitted(review.id).deliver_now
+        end.to change { review.reload.seller_notified_at }.from(nil)
+      end
+
+      it "gives the claim back when delivery raises, so the retry still sends" do
+        allow_any_instance_of(Mail::Message).to receive(:do_delivery).and_raise(Net::SMTPServerBusy, "451 try again later")
+
+        expect do
+          ContactingCreatorMailer.review_submitted(review.id).deliver_now
+        end.to raise_error(Net::SMTPServerBusy)
+
+        expect(review.reload.seller_notified_at).to be_nil
+        expect($redis.get(RedisKey.product_review_seller_notified(review.id))).to be_nil
+      end
+
+      it "leaves nothing claimed when the render decides not to send" do
+        review.link.user.update!(disable_reviews_email: true)
+
+        ContactingCreatorMailer.review_submitted(review.id).deliver_now
+
+        expect($redis.get(RedisKey.product_review_seller_notified(review.id))).to be_nil
+        expect(review.reload.seller_notified_at).to be_nil
+      end
     end
 
     it "does not send for a deleted review" do

--- a/spec/models/product_review_spec.rb
+++ b/spec/models/product_review_spec.rb
@@ -175,6 +175,20 @@ describe ProductReview do
       end.to have_enqueued_mail(ContactingCreatorMailer, :review_submitted).with(product_review.id)
     end
 
+    it "doesn't send when the message arrives after the seller was already told about the review" do
+      # The buyer tapped stars, the delayed render reported the rating-only review, and they came
+      # back later to write the text. That is an edit of a review the seller has seen, not a
+      # submission they haven't.
+      product.user.update!(disable_reviews_email: false)
+      product_review.message = nil
+      product_review.save!
+      product_review.update_columns(seller_notified_at: Time.current)
+
+      expect do
+        product_review.update!(message: "Exactly what I needed")
+      end.not_to have_enqueued_mail(ContactingCreatorMailer, :review_submitted)
+    end
+
     it "doesn't send when an existing message is edited" do
       product.user.update!(disable_reviews_email: false)
 


### PR DESCRIPTION
Follow-up to #6953, which introduced the seller review notification claim. Two of the four P1s the bot review raised on that PR are still live on `main`; this fixes both.

## What

The claim that decides whether a review notifies the seller was a single Redis key with a one-hour TTL, taken at render and never given back. That key was doing two jobs it can't both do, so this splits them:

- **`product_reviews.seller_notified_at`** (new column) records that the seller was told, and outlives any TTL.
- **The Redis key** goes back to being a short lease over one render, released when nothing was delivered.

The lease is settled in an `around_deliver`, the same way the two other notices in this mailer already work.

## Why

**A transient SMTP failure lost the notification.** `MailDeliveryJob` retries by re-rendering the mailer action. The retry found the claim its own failed attempt had taken, returned `do_not_send`, and the job succeeded having sent nothing. The retry that exists to save the email was the thing that discarded it.

**Past the TTL the claim stopped deduplicating.** A buyer who taps stars and comes back more than an hour later to write their review got the seller a second email; the same buyer returning within the hour got none. Which one happened depended on queue timing rather than on anything about the review, and the mailer's own comment promised at-most-once either way. With a durable marker, a message arriving later is an edit of a review the seller has already seen.

Storing the "already told them" fact in the database rather than a longer-lived Redis key is what makes that true for any gap, and it mirrors `SubscriptionPlanChange#notified_subscriber_at`, which solves the same problem the same way.

The other two P1s on #6953 don't need anything: the stale opt-in was fixed before merge by the mailer's own `disable_reviews_email?` re-check, and the double-send race is what the claim already prevents. The fifth finding was T-Rex reporting it couldn't boot Ruby 3.4.3, not a defect in the code.

## Before / After

| | Before | After |
|---|---|---|
| Transient SMTP failure, then retry | Retry sees its own claim, sends nothing, job goes green | Claim released, retry sends |
| Buyer adds text 30 min after the rating-only email | No email | No email |
| Buyer adds text 2 hours after the rating-only email | Second email | No email |
| Two renders racing | One email | One email |

No user-visible surface changes — the template is untouched, and what moves is which render delivers and whether a failed one can try again.

## Test Results

- `spec/models/product_review_spec.rb` — 20 examples, 0 failures
- `spec/mailers/contacting_creator_mailer_spec.rb` — 230 examples, 0 failures
- `spec/services/product_review/update_service_spec.rb` — 4 examples, 0 failures
- `bundle exec rubocop` on all changed files — no offenses
- `bin/check-migration-versions` — clean against `origin/main`

Each new test was checked against a reverted fix:

| Reverted | Test that goes red |
|---|---|
| release-on-failure in `settle_review_notification` | gives the claim back when delivery raises, so the retry still sends |
| `seller_notified?` guard in the mailer | does not send once a delivered render has recorded the seller as notified · does not send again once the claim has expired |
| `seller_notified?` guard in the model callback | doesn't send when the message arrives after the seller was already told |

## QA steps

1. Create a review with no message; let the delayed render deliver. `product_reviews.seller_notified_at` is set.
2. Add text to that review. No second email is enqueued.
3. Delete the `product_review_seller_notified:<id>` key to simulate expiry and add text again. Still no email — the marker, not the key, is what decides.
4. Stub the delivery to raise `Net::SMTPServerBusy` on a fresh review. The key is gone afterwards and `seller_notified_at` is still nil, so the retry sends.
