### PR TITLE
Re-verify the chargeback and suspension vetoes at the unblock write

### DIFF
--- a/app/sidekiq/alert_on_stale_blocks_holding_established_buyers_job.rb
+++ b/app/sidekiq/alert_on_stale_blocks_holding_established_buyers_job.rb
@@ -92,12 +92,13 @@ class AlertOnStaleBlocksHoldingEstablishedBuyersJob
           if suspended.include?(email)
             held << entry
           else
-            # Re-checked here, immediately before the write, rather than trusting the candidate
-            # query's snapshot — a concurrent admin block or an intervening chargeback would
-            # otherwise get cleared by a run that started before either landed.
+            # Re-checked here, immediately before the write, rather than trusting the batch's
+            # snapshot — a concurrent admin block, a newly-suspended account, or a chargeback
+            # recorded after the batch queries ran would otherwise get cleared by a decision that
+            # was already stale by the time it reached this line.
             block.reload
             still_active = block.blocked_at.present? && (block.expires_at.nil? || block.expires_at > Time.current)
-            if still_active && block.blocked_by.nil?
+            if still_active && block.blocked_by.nil? && !newly_disputed_or_suspended?(email)
               block.unblock!
               cleared << entry
             else
@@ -206,6 +207,15 @@ class AlertOnStaleBlocksHoldingEstablishedBuyersJob
                             .distinct.pluck(:email).map(&:downcase).to_set
 
       by_login | by_purchaser
+    end
+
+    # The batch-level `reject_disputed` and `linked_to_suspended_account` queries ran once, before
+    # this row's write. A chargeback recorded, or an account suspended, in the gap between that
+    # query and this `unblock!` would otherwise slip through unnoticed — re-deriving both from a
+    # single email, right at the write, is what closes that gap rather than trusting a snapshot the
+    # rest of the batch already moved past.
+    def newly_disputed_or_suspended?(email)
+      reject_disputed({ email => 1 }).empty? || linked_to_suspended_account([email]).any?
     end
 
     def message_for(scan)

--- a/spec/sidekiq/alert_on_stale_blocks_holding_established_buyers_job_spec.rb
+++ b/spec/sidekiq/alert_on_stale_blocks_holding_established_buyers_job_spec.rb
@@ -235,6 +235,39 @@ describe AlertOnStaleBlocksHoldingEstablishedBuyersJob do
       expect(message).to include(email, "held")
       expect(block.reload.blocked_by).to eq(admin_id)
     end
+
+    # reject_disputed and linked_to_suspended_account both run once per batch, before any row's
+    # write — a chargeback recorded (or an account suspended) in that gap must still be caught at
+    # the write, not just at enumeration time.
+    it "does not clear a block whose buyer got a chargeback after the batch's dispute check ran" do
+      purchases = settled_purchases(established_count)
+      block = block_email
+
+      original_reload = PlatformBlock.instance_method(:reload)
+      allow_any_instance_of(PlatformBlock).to receive(:reload) do |instance|
+        purchases.first.update!(chargeback_date: Time.current) if instance.id == block.id
+        original_reload.bind_call(instance)
+      end
+
+      expect(message).to include(email, "held")
+      expect(block.reload.blocked_at).to be_present
+    end
+
+    it "does not clear a block whose account got suspended after the batch's suspension check ran" do
+      settled_purchases(established_count)
+      block = block_email
+
+      original_reload = PlatformBlock.instance_method(:reload)
+      allow_any_instance_of(PlatformBlock).to receive(:reload) do |instance|
+        if instance.id == block.id && !User.exists?(email:)
+          create(:user, email:, user_risk_state: "suspended_for_fraud")
+        end
+        original_reload.bind_call(instance)
+      end
+
+      expect(message).to include(email, "held")
+      expect(block.reload.blocked_at).to be_present
+    end
   end
 
   describe "sweeping the backlog across runs" do


### PR DESCRIPTION
## What

Adds a fresh-read re-verification of the chargeback and suspension vetoes at the moment `alert_on_stale_blocks_holding_established_buyers_job` writes an auto-clear (`unblock!`), not just at the batch-query stage earlier in the run. Also adds two spec examples covering the new veto path.

## Why

The job batches its "eligible to clear" candidates from an earlier query, then writes `unblock!` later in the same run. Between those two points, a buyer's chargeback or suspension state can change — a chargeback filed after the batch scan but before the write would otherwise slip through and get auto-cleared on stale data. This re-checks both vetoes with a fresh read immediately before the write.

## Test Results

Fable-5 adversarial review verdict at `/Users/gumclaw/reviews/gp1746-autoclear-v2/verdict.md`:

- **Guard-guarantee (holds)**: `newly_disputed_or_suspended?` issues genuinely fresh reads — no memoization, no preloaded association — and `block.reload` immediately before the check clears the Rails 7.1 AR query cache (`persistence.rb:1070`), so a cache hit reading stale data is impossible. A residual microsecond window between the fresh SELECT and the UPDATE remains (no row locking), which is inherent to this class of check, not a flaw introduced here.
- **Boolean/boundary walk (holds)**: verified `reject_disputed({email => 1}).empty?` is an exact complement of the existing `not_chargedback_or_chargedback_reversed` check, never returns nil, and the batch-shaped helpers behave correctly at n=1 (no threshold/percentile assumptions that change meaning for a single-row check).
- **Reachability (confirmed)**: scheduled weekly (`config/sidekiq_schedule.yml`, `0 12 * * 1`), and the auto-clear write is live in the code path (not report-only).
- Non-blocking P3s noted in the verdict: the report line for held-and-newly-flagged rows reuses generic "held — linked to a suspended account" phrasing even when the actual reason is a fresh chargeback/suspension caught by this change (pre-existing pattern, this change just adds new cases that hit it); per-row fresh queries add bounded N+1 load (capped by `MAX_CANDIDATES_SCANNED=5000`/run, weekly, low queue — acceptable for this volume); one new spec's message-content assertion is non-discriminating on its own (the `blocked_at` assertion in the same example is what actually pins the behavior).

Local spec run for `spec/sidekiq/alert_on_stale_blocks_holding_established_buyers_job_spec.rb` was still completing under heavy concurrent Rails-boot load on this host at PR-open time — CI will provide the authoritative pass/fail; flagging this explicitly rather than asserting a result I didn't observe.

## QA steps

This is a fraud-enforcement write path (auto-clearing buyer blocks). Reviewer path:
1. Read `newly_disputed_or_suspended?` in the sidekiq job — confirm both checks are genuinely fresh reads (no memoized/preloaded state) and fire strictly before the `unblock!` write.
2. Run `bundle exec rspec spec/sidekiq/alert_on_stale_blocks_holding_established_buyers_job_spec.rb` — the two new examples should be the only new coverage, both testing the veto (one for a fresh chargeback, one for fresh suspension) fires and blocks the clear.
3. Confirm via CI that the full spec file is green.

## Status

- [x] Scope — re-verify vetoes at write time only; no other behavior touched
- [x] Design — fresh read immediately before write, reusing existing `reject_disputed` / `linked_to_suspended_account` helpers rather than inventing new ones
- [x] Build — cherry-picked cleanly onto a fresh branch off current `origin/main`
- [x] QA — fable-5 adversarial review (verdict above), guard-guarantee and boundary checks confirmed by static trace; local spec run did not finish before this PR opened — CI will confirm
- [ ] Shipped — this is a fraud/suspension-adjacent write path; **do not self-merge**, needs a human's QA sign-off given the direct effect on buyer block state

---

AI disclosure: built and reviewed by Hermes Agent (Claude) running autonomously as gumclaw. Cherry-picked and reworked from a prior branch's post-merge commit (never shipped, never reviewed) after PR #6943 merged without it.
