### PR TITLE
Drop the presenter's per-item product-shape gates from buyer-currency presentment

### DIFF
--- a/app/presenters/checkout/stripe_payment_presenter.rb
+++ b/app/presenters/checkout/stripe_payment_presenter.rb
@@ -62,6 +62,15 @@ class Checkout::StripePaymentPresenter
     fallback_reason = fallback_reason_for(checkout_items)
     return card_element_props(fallback_reason, disable_wallets:) if fallback_reason.present?
 
+    # Setup carts (every item a preorder or free trial) charge nothing today, so there is no
+    # amount to present in the buyer's currency — they keep the SetupIntent-mode element even
+    # when every item is a presentment candidate. Checked before the presentment branch so
+    # removing the per-item shape conditions cannot mount a payment-mode element on a cart
+    # with no charge.
+    if setup_for_future_charges_without_charging?(checkout_items)
+      return payment_element_props(STRIPE_ELEMENTS_MODE_FOR_SETUP_INTENT)
+    end
+
     # FX-quoted buyer-currency candidates use server-confirm because the deferred-intent path does
     # not consume their locked quote token. Its currency-less PaymentMethod lets the charge path
     # price the intent from the verified quote after the Element displays that same amount.
@@ -114,16 +123,11 @@ class Checkout::StripePaymentPresenter
       )
     end
 
-    # Client-confirm eligible carts are always one-time charges, so check them before setup mode.
+    # Client-confirm eligible carts are always one-time charges, so the setup branch above can
+    # never have claimed one (the resolver rejects setup_for_future carts).
     return client_confirm_props if client_confirm_eligible?
 
-    stripe_elements_mode =
-      if setup_for_future_charges_without_charging?(checkout_items)
-        STRIPE_ELEMENTS_MODE_FOR_SETUP_INTENT
-      else
-        STRIPE_ELEMENTS_MODE_FOR_PAYMENT_INTENT
-      end
-    payment_element_props(stripe_elements_mode)
+    payment_element_props(STRIPE_ELEMENTS_MODE_FOR_PAYMENT_INTENT)
   end
 
   private
@@ -409,33 +413,14 @@ class Checkout::StripePaymentPresenter
         return "stripe_payment_element_amount_below_minimum"
       end
       if items.any? { buyer_currency_presentment_candidate?(_1) }
-        # PR-1 safety gate, progressively narrowed: presentment candidates originally rode
-        # CardElement because the canonical USD Payment Element couldn't carry buyer-currency
-        # presentment. Two shapes now stay on the Payment Element:
-        #   1. The method-forced shape (a single item priced in a forced currency with a
-        #      resolver-available local method) when the cart is client-confirm eligible — that path handles
-        #      presentment end-to-end (forced-currency element in client_confirm_props,
-        #      forced-currency intent in Order::PreparePaymentIntentService); kicking it back
-        #      to CardElement would make the iDEAL/Bancontact tabs unreachable for any tester
-        #      whose GeoIP currency differs from the product's.
-        #   2. The buyer-currency card shape (one seller's one-time items, each priced in a
-        #      currency other than the buyer's own — the same cart shape the eligibility
-        #      service's card mode accepts), which mounts the
-        #      server-confirm Payment Element in the buyer's quote currency (see props).
-        # Non-flagged sellers never produce a candidate (buyer_presentment_candidate? checks
-        # the seller flags), so neither branch changes behavior for unflagged checkouts. The
-        # card shape (2) runs in live mode since the production rollout; the method-forced
-        # shape (1) runs in live mode only when the resolver exposes a launched local method
-        # whose Connect-account capabilities can accept the product's forced currency.
-        #
-        # Shape 1 is still reachable even though props now always hands a quoted cart to the
-        # buyer-currency element. The gap between "is a candidate" and "gets the element" is a
-        # product that OFFERS an installment plan: it is a candidate (the display converts) but
-        # the element shape rejects it, because quote creation cannot see whether the buyer
-        # picked installments. Such a cart is never quoted either — quotable_product? rejects
-        # installment-plan products — so it carries no token and the client-confirm lane can
-        # charge it safely. Keeping shape 1 listed means it keeps the local-method tabs instead
-        # of being kicked back to CardElement.
+        # A candidate cart must mount a lane that can honor an FX quote (the buyer-currency
+        # element, or CardElement via this fallback) — the client-confirm lane fails a quoted
+        # payment closed. The only candidate carts still kicked back to CardElement are the
+        # ones the element shape cannot represent: carts mixing candidate and non-candidate
+        # items (a partial quote would mix local-currency and dollar lines, so the quote
+        # service refuses them) and carts past the quote's seller cap. The method-forced arm
+        # keeps uniform forced-currency carts on their local-method element when a
+        # non-candidate line breaks the presentment shape.
         supported = (method_forced_shape?(items) && client_confirm_eligible?) ||
           buyer_currency_presentment_element_shape?(items)
         return "buyer_currency_presentment_unsupported" unless supported
@@ -444,52 +429,24 @@ class Checkout::StripePaymentPresenter
       nil
     end
 
-    # The cart shape whose buyer-currency presentment the CARD charge path supports, mirroring
-    # the gates of Checkout::BuyerCurrencyEligibility#decision that are knowable at render time:
-    # one-time, non-commission items that are each a presentment candidate (candidate? already
-    # covers the seller's flags and an active buyer-local display). Products that offer
-    # installments stay on CardElement even when the buyer chooses a one-time purchase because
-    # quote creation cannot see that choice and rejects the product.
+    # Whether every item is a presentment candidate (candidate? covers the seller's flags and
+    # an active buyer-local display), within the number of charges the quote service prices
+    # (Checkout::BuyerCurrencyQuote::MAX_QUOTED_CHARGES — past it the endpoint withholds the
+    # quote, and the element would just fall back to dollars a moment later).
     #
-    # A cart may span several sellers. The order pipeline turns it into one charge per seller,
-    # and the surcharge endpoint locks one quote per prospective charge before the buyer is
-    # shown a total, so each charge is priced from its own locked amount and the cart total is
-    # their sum — no locked figure is ever split across intents.
-    #
-    # The seller count is capped for the same reason the quote service caps it
-    # (Checkout::BuyerCurrencyQuote::MAX_QUOTED_CHARGES): past that many sellers the endpoint
-    # withholds the quote, and mounting the element for a currency no quote will arrive for
-    # would only make the browser fall back to canonical US dollars a moment later.
-    #
-    # There is deliberately no condition on the currency the SELLER priced in. The quote
-    # converts the cart's canonical USD total into the buyer's currency, which works the same
-    # whether the seller listed in dollars, euros or reais. The one
-    # excluded case — a product priced in the buyer's own currency, which is withheld from
-    # quoting so an FX round trip cannot misprice it — is already excluded by
-    # buyer_currency_presentment_candidate?: the buyer-local display only turns on when the
-    # buyer's currency differs from the product's. The direct-listed client-confirm surface
-    # handles that cart when its ramp is enabled; otherwise it stays canonical USD.
-    #
-    # Charge-time-only gates (merchant account model, wallet params, GeoIP re-check, quote
-    # verification) stay in the eligibility service — when any of them falls back, the charge
-    # simply runs canonical USD, which the currency-less card PaymentMethod the server-confirm
-    # element mints supports just as well.
+    # There are deliberately no product-shape conditions here. The buyer-local display and the
+    # quote service own that policy (CurrencyHelper#buyer_currency_unquotable_product? and
+    # BuyerCurrencyQuote#quotable_line_item?, kept in lockstep), and a cart the quote service
+    # declines is safe on this element: no quote arrives, no token is minted, and the browser
+    # mounts canonical USD. Charge-time-only gates (merchant account model, GeoIP re-check,
+    # quote verification) stay in the eligibility service for the same reason.
     def buyer_currency_presentment_element_shape?(items)
       return false if items.empty?
 
       cart_sellers = items.map { _1[:seller] }.uniq
       return false if cart_sellers.length > Checkout::BuyerCurrencyQuote::MAX_QUOTED_CHARGES
 
-      # Each charge's quote locks that charge's total, so every item must individually pass the
-      # presentment gates: one unsupported item means the charge path could not honor its
-      # locked total, and the whole cart falls back.
-      items.all? do |item|
-        buyer_currency_presentment_candidate?(item) &&
-          item[:recurrence].blank? &&
-          !item[:pay_in_installments] && !item[:offers_installment_plan] &&
-          !item[:is_preorder] && !item[:has_free_trial] &&
-          item[:native_type] != Link::NATIVE_TYPE_COMMISSION
-      end
+      items.all? { buyer_currency_presentment_candidate?(_1) }
     end
 
     # The method-forced cart shape, mirroring the gates under which
@@ -576,7 +533,7 @@ class Checkout::StripePaymentPresenter
     def cart_items
       return [] if cart.blank?
 
-      cart.alive_cart_products.joins(:product).merge(Link.not_archived).includes(:option, product: [:user, :installment_plan]).map do |cart_product|
+      cart.alive_cart_products.joins(:product).merge(Link.not_archived).includes(:option, product: :user).map do |cart_product|
         product = cart_product.product
         item(
           seller: product.user,
@@ -584,7 +541,6 @@ class Checkout::StripePaymentPresenter
           quantity: cart_product.quantity,
           recurrence: cart_product.recurrence,
           pay_in_installments: cart_product.pay_in_installments,
-          offers_installment_plan: product.installment_plan.present?,
           is_preorder: product.is_in_preorder_state,
           has_free_trial: product.free_trial_enabled,
           native_type: product.native_type,
@@ -608,7 +564,6 @@ class Checkout::StripePaymentPresenter
           quantity: checkout_product[:quantity],
           recurrence: checkout_product[:recurrence],
           pay_in_installments: checkout_product[:pay_in_installments],
-          offers_installment_plan: product[:installment_plan].present?,
           is_preorder: product[:is_preorder],
           has_free_trial: product[:free_trial].present?,
           native_type: product[:native_type],
@@ -697,14 +652,13 @@ class Checkout::StripePaymentPresenter
 
     # quantity defaults to 1: price_cents is always the per-unit price, and the only current
     # consumer of quantity (the Klarna amount-window total) must not undercount multi-unit carts.
-    def item(seller:, price_cents:, recurrence:, pay_in_installments:, offers_installment_plan:, is_preorder:, has_free_trial:, native_type:, buyer_currency_display:, quantity: 1, product_currency: nil, ppp_discounted: false, has_customizable_price: false)
+    def item(seller:, price_cents:, recurrence:, pay_in_installments:, is_preorder:, has_free_trial:, native_type:, buyer_currency_display:, quantity: 1, product_currency: nil, ppp_discounted: false, has_customizable_price: false)
       {
         seller:,
         price_cents:,
         quantity:,
         recurrence:,
         pay_in_installments:,
-        offers_installment_plan:,
         is_preorder:,
         has_free_trial:,
         native_type:,

--- a/spec/presenters/checkout/stripe_payment_presenter_spec.rb
+++ b/spec/presenters/checkout/stripe_payment_presenter_spec.rb
@@ -282,14 +282,13 @@ describe Checkout::StripePaymentPresenter do
     it "keeps wallets suppressed on a CardElement-fallback presentment cart with both flags on" do
       Feature.activate_user(described_class::PAYMENT_ELEMENT_WALLETS_FEATURE_NAME, presentment_seller)
       Feature.activate_user(described_class::BUYER_CURRENCY_WALLETS_FEATURE_NAME, presentment_seller)
-      # A recurring item is a presentment candidate but not a supported element shape.
-      recurring_product = create(:membership_product, user: presentment_seller)
-      add_products = [
+      # A cart mixing a candidate with a non-candidate line (here: a product already priced in
+      # the buyer's own currency, whose display stays "default") is not a supported element shape.
+      cad_product = create(:product, user: presentment_seller, price_currency_type: "cad", price_cents: 500)
+      add_products = presentment_add_products + [
         checkout_product_for(
-          recurring_product,
-          price: 500,
-          recurrence: "monthly",
-          buyer_currency_display: { display_mode: "buyer_local", buyer_currency_shown: Currency::CAD }
+          cad_product,
+          buyer_currency_display: { display_mode: "default", buyer_currency_shown: Currency::CAD }
         )
       ]
 
@@ -419,7 +418,10 @@ describe Checkout::StripePaymentPresenter do
     Feature.deactivate_user(Checkout::BuyerCurrencyEligibility::FEATURE_NAME, seller) if seller
   end
 
-  it "falls back to CardElement when a one-time purchase offers an installment plan" do
+  it "mounts the buyer-currency element for a one-time purchase of a product offering an installment plan" do
+    # Whether the quote layer will actually quote this cart is its own policy (the display and
+    # quote service gate installment-offering products on the subscription ramp); the presenter
+    # only needs every line to be a candidate. An unquoted cart mounts canonical USD.
     seller = create(:user, disable_buyer_local_currency: false)
     product = create(:product, user: seller, price_cents: 1234)
     create(:product_installment_plan, link: product)
@@ -439,20 +441,14 @@ describe Checkout::StripePaymentPresenter do
     ]
 
     expect(stripe_payment_props(add_products:)).to eq(
-      integration: described_class::STRIPE_CARD_ELEMENT_INTEGRATION,
-      fallback_reason: "buyer_currency_presentment_unsupported",
-      disable_wallets: true,
-      request_apple_pay_merchant_tokens: false,
-      payment_element_wallets: false,
-      flat_payment_methods: false,
-      elements_options: nil,
+      payment_element_props(buyer_currency_presentment: true, disable_wallets: true)
     )
   ensure
     Feature.deactivate_user(:buyer_local_currency, seller) if seller
     Feature.deactivate_user(Checkout::BuyerCurrencyEligibility::FEATURE_NAME, seller) if seller
   end
 
-  it "falls back to CardElement when the presentment candidate item is recurring" do
+  it "mounts the buyer-currency element for a recurring presentment candidate" do
     seller = create(:user, disable_buyer_local_currency: false)
     product = create(:membership_product, user: seller, price_cents: 1234)
     allow(Stripe).to receive(:api_key).and_return("sk_test_currency")
@@ -475,13 +471,62 @@ describe Checkout::StripePaymentPresenter do
     ]
 
     expect(stripe_payment_props(add_products:)).to eq(
-      integration: described_class::STRIPE_CARD_ELEMENT_INTEGRATION,
-      fallback_reason: "buyer_currency_presentment_unsupported",
-      disable_wallets: true,
-      request_apple_pay_merchant_tokens: false,
-      payment_element_wallets: false,
-      flat_payment_methods: false,
-      elements_options: nil,
+      payment_element_props(buyer_currency_presentment: true, disable_wallets: true)
+    )
+  ensure
+    Feature.deactivate_user(:buyer_local_currency, seller) if seller
+    Feature.deactivate_user(Checkout::BuyerCurrencyEligibility::FEATURE_NAME, seller) if seller
+  end
+
+  it "mounts the buyer-currency element for a commission presentment candidate" do
+    seller = create(:user, disable_buyer_local_currency: false)
+    product = create(:product, user: seller, price_cents: 1234)
+    allow(Stripe).to receive(:api_key).and_return("sk_test_currency")
+    Feature.activate_user(described_class::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, seller)
+    Feature.activate_user(:buyer_local_currency, seller)
+    Feature.activate_user(Checkout::BuyerCurrencyEligibility::FEATURE_NAME, seller)
+    add_products = [
+      checkout_product_for(
+        product,
+        native_type: Link::NATIVE_TYPE_COMMISSION,
+        buyer_currency_display: {
+          display_mode: "buyer_local",
+          buyer_currency_shown: Currency::CAD,
+        }
+      )
+    ]
+
+    expect(stripe_payment_props(add_products:)).to eq(
+      payment_element_props(buyer_currency_presentment: true, disable_wallets: true)
+    )
+  ensure
+    Feature.deactivate_user(:buyer_local_currency, seller) if seller
+    Feature.deactivate_user(Checkout::BuyerCurrencyEligibility::FEATURE_NAME, seller) if seller
+  end
+
+  it "keeps SetupIntent mode for a preorder presentment candidate" do
+    # A setup cart charges nothing today, so there is no amount to present in the buyer's
+    # currency; the setup branch must claim it before the presentment branch or it would mount
+    # a payment-mode element on a cart with no charge.
+    seller = create(:user, disable_buyer_local_currency: false)
+    product = create(:product, user: seller, price_cents: 1234)
+    allow(Stripe).to receive(:api_key).and_return("sk_test_currency")
+    Feature.activate_user(described_class::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, seller)
+    Feature.activate_user(:buyer_local_currency, seller)
+    Feature.activate_user(Checkout::BuyerCurrencyEligibility::FEATURE_NAME, seller)
+    add_products = [
+      checkout_product_for(
+        product,
+        is_preorder: true,
+        buyer_currency_display: {
+          display_mode: "buyer_local",
+          buyer_currency_shown: Currency::CAD,
+        }
+      )
+    ]
+
+    expect(stripe_payment_props(add_products:)).to eq(
+      payment_element_props(stripe_elements_mode: described_class::STRIPE_ELEMENTS_MODE_FOR_SETUP_INTENT)
     )
   ensure
     Feature.deactivate_user(:buyer_local_currency, seller) if seller
@@ -513,14 +558,7 @@ describe Checkout::StripePaymentPresenter do
     Feature.deactivate_user(Checkout::BuyerCurrencyEligibility::FEATURE_NAME, seller) if seller
   end
 
-  it "falls back to CardElement for a flag-on seller's unsupported presentment shape in live mode" do
-    # Lifting the test-mode gate makes every buyer-local-display cart from a double-flagged
-    # seller a presentment candidate in live, not just the supported card shape. Unsupported
-    # shapes (here: a recurring membership) get the safety posture — CardElement with wallets
-    # disabled — instead of the full Payment Element, because a wallet or multi-method charge
-    # would collect canonical USD while the cart displays buyer-currency totals. This example
-    # pins that live-mode downgrade so the flag ramp is done knowing a seller's whole catalog
-    # changes checkout surface, not only their USD one-time products.
+  it "mounts the buyer-currency element for a recurring presentment candidate in live mode" do
     seller = create(:user, disable_buyer_local_currency: false)
     product = create(:membership_product, user: seller, price_cents: 1234)
     allow(Stripe).to receive(:api_key).and_return("sk_live_currency")
@@ -543,15 +581,7 @@ describe Checkout::StripePaymentPresenter do
     ]
 
     expect(stripe_payment_props(add_products:)).to eq(
-      integration: described_class::STRIPE_CARD_ELEMENT_INTEGRATION,
-      fallback_reason: "buyer_currency_presentment_unsupported",
-      disable_wallets: true,
-      request_apple_pay_merchant_tokens: false,
-      # CardElement fallbacks never mount a Payment Element, so the wallets-in-the-element
-      # rollout flag can't apply — this branch's presenter reports the surface as off.
-      payment_element_wallets: false,
-      flat_payment_methods: false,
-      elements_options: nil,
+      payment_element_props(buyer_currency_presentment: true, disable_wallets: true)
     )
   ensure
     Feature.deactivate_user(:buyer_local_currency, seller) if seller
@@ -1904,12 +1934,12 @@ describe Checkout::StripePaymentPresenter do
         .to eq(payment_element_client_confirm_props)
     end
 
-    it "falls back to CardElement for a recurring EUR-priced presentment candidate instead of crashing" do
+    it "mounts the buyer-currency element for a recurring EUR-priced presentment candidate instead of crashing" do
       # A recurring cart is rejected by the payment method resolver (client-confirm only
       # covers one-time purchases), so its resolution carries a nil method list. The
-      # method-forced shape check must consult the resolver's eligibility verdict before
-      # scanning the method list — otherwise this cart raises instead of returning the
-      # buyer_currency_presentment_unsupported fallback.
+      # method-forced shape check — evaluated before the presentment shape in the supported
+      # check — must consult the resolver's eligibility verdict before scanning the method
+      # list, or this cart raises instead of mounting the element.
       seller = create(:user, disable_buyer_local_currency: false)
       product = create(:membership_product, user: seller, price_currency_type: "eur", price_cents: 1500)
       Feature.activate_user(described_class::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, seller)
@@ -1932,13 +1962,7 @@ describe Checkout::StripePaymentPresenter do
       ]
 
       expect(stripe_payment_props(add_products:)).to eq(
-        integration: described_class::STRIPE_CARD_ELEMENT_INTEGRATION,
-        fallback_reason: "buyer_currency_presentment_unsupported",
-        disable_wallets: true,
-        request_apple_pay_merchant_tokens: false,
-        payment_element_wallets: false,
-        flat_payment_methods: false,
-        elements_options: nil,
+        payment_element_props(buyer_currency_presentment: true, disable_wallets: true)
       )
     ensure
       deactivate_buyer_currency_flags(seller) if seller


### PR DESCRIPTION
# Drop the presenter's per-item product-shape gates from buyer-currency presentment

## What

Removes every per-item product-shape condition from `Checkout::StripePaymentPresenter#buyer_currency_presentment_element_shape?` — `recurrence`, `pay_in_installments`, `offers_installment_plan`, `is_preorder`, `has_free_trial`, and the commission `native_type` check. The shape is now just "every item is a presentment candidate, within the quote's seller cap." The `offers_installment_plan` item field dies with its only reader (and the `:installment_plan` include with it).

One structural guard replaces the per-item conditions: the SetupIntent-mode branch is hoisted above the presentment branch in `props`, so a single-seller all-preorder/free-trial cart (which charges nothing today) keeps its setup-mode element instead of being pulled into a payment-mode element with no amount to mount.

## Why

Sahil on this block: "open a separate PR that removes all this so we get presentment on EVERY SINGLE PURCHASE on gumroad no exceptions" — continuing gumroad-private#1312's "0% on CardElement" push after #6958 removed the `offers_installment_plan` gate alone. This PR supersedes the presenter portion of #6958.

The conditions were a third copy of policy that two other layers already own, and both fail safe:

- The buyer-local display (`CurrencyHelper#buyer_currency_unquotable_product?`) refuses to turn on for free trials, and gates recurring/preorder/commission/installment-plan products on the `subscriptions_enabled?` ramp — so a non-ramped seller's product of these shapes never becomes a candidate and never reaches the shape check at all.
- The quote service (`Checkout::BuyerCurrencyQuote#quotable_line_item?`) re-applies the same list at quote time. A cart it declines gets no quote and no token, and the browser mounts the element in canonical USD — the same posture USD-GeoIP buyers already exercise on this lane every day.

So the only thing the presenter's copy did was kick carts the pipeline supports (ramped-seller memberships, commissions, installment-offering products) back to CardElement, and silently drift as the other two layers ramped forward. `pay_in_installments` was double-dead: the `setup_or_installment_flow` fallback fires before the shape is ever consulted.

## Before / After

| Cart (all items candidates: seller flags on, buyer-local display active) | Before | After |
|---|---|---|
| Recurring membership (seller in subscription ramp) | CardElement, `buyer_currency_presentment_unsupported` | Buyer-currency Payment Element |
| Commission, installment-offering one-time purchase | CardElement | Buyer-currency Payment Element |
| Single-seller all-preorder/free-trial cart | Setup-mode Payment Element | unchanged (hoisted branch) |
| Buyer selects pay-in-installments | CardElement (`setup_or_installment_flow`) | unchanged |
| Mixed candidate/non-candidate cart, or > `MAX_QUOTED_CHARGES` sellers | CardElement | unchanged |
| Non-flagged sellers | never candidates | unchanged |

## What still gates the lane

Seller flags (`buyer_currency_charging`, `buyer_local_currency`, Payment Element flag), the subscription ramp (via the display — a non-ramped seller's recurring/commission/installment/preorder products are never candidates), the quote service's own shape policy at quote time, `MAX_QUOTED_CHARGES`, and all charge-time verification. The presenter no longer carries a copy of any of it.

## Test Results

Run locally in an RVM-envd worktree (`DISABLE_SPRING=1 bundle exec rspec`):

- `spec/presenters/checkout/stripe_payment_presenter_spec.rb` — full file: **121 examples, 0 failures**.
- `spec/presenters/checkout_presenter_spec.rb -e "#checkout_payment_props"` (exercises the modified `cart_items` path and the kept seller cap): **4 examples, 0 failures**.
- Mutation proof: with `stripe_payment_presenter.rb` reverted to `origin/main`, the four inverted examples redden (`:421` installment-offering, `:451` recurring, `:481` commission, `:561` recurring live-mode); restored and re-ran full file green.
- `bundle exec rubocop -a` on both changed files: no offenses.

Spec changes: four CardElement-fallback pins inverted to pin the element; the wallet-suppression fallback example now uses a mixed candidate/non-candidate cart (the remaining fallback shape); new examples pin the commission shape and the preorder SetupIntent-mode hoist. `grep -rn offers_installment_plan app/ spec/` → zero hits.

## QA steps

Backend lane-selection change with no new rendered surface — both element variants this PR routes between are existing checkout surfaces. Reviewer path: read the presenter diff (one `items.all?` body, one hoisted branch, one dead field), then run `spec/presenters/checkout/stripe_payment_presenter_spec.rb`. End-to-end quote/charge behavior for the newly-routed shapes is already covered on main by `buyer_currency_quote_spec.rb` (ramped-seller membership/commission/installment examples) and `buyer_currency_eligibility_spec.rb`.

## Status

- [x] Scope — gumroad-private#1312 "0% on CardElement"; supersedes the presenter half of #6958
- [x] Build + local spec runs green (see Test Results)
- [x] Mutation proof — inverted examples redden against main's presenter
- [ ] CI green at head
- [x] QA recorded — spec-based, no rendered surface

Not armed for auto-merge: checkout/payments surface — merge decision is human (@rmarescu).

---

## AI disclosure

Built with Claude Code (model `claude-fable-5`) from Sahil's prompt on the shape gate: "open a separate PR that removes all this so we get presentment on EVERY SINGLE PURCHASE on gumroad no exceptions."
