### PR TITLE
Alert on email blasts that started sending and never completed

### DIFF
--- a/app/sidekiq/alert_on_stalled_post_email_blasts_job.rb
+++ b/app/sidekiq/alert_on_stalled_post_email_blasts_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Reports email blasts that started sending and never finished (gumroad-private#1750).
+# Reports email blasts that were requested and never finished sending (gumroad-private#1750).
 #
 # A killed SendPostBlastEmailsJob leaves `completed_at` nil forever, while the seller's dashboard
 # shows a plausible non-zero delivered count — so the only detection channel was a seller who knew
@@ -24,54 +24,68 @@ class AlertOnStalledPostEmailBlastsJob
   # Report at most this many. The alert exists to be read.
   MAX_REPORTED = 25
 
-  def perform
-    stalled = scan_for_stalled_blasts
-    return if stalled.empty?
+  # The bound on the work: incomplete rows past this stay unscanned and the report says so rather
+  # than presenting its count as the total.
+  MAX_CANDIDATES_SCANNED = 500
 
-    InternalNotificationWorker.perform_async("payments", "Stalled post email blasts", message_for(stalled))
+  def perform
+    scan = scan_for_stalled_blasts
+    return if scan[:stalled].empty? && !scan[:truncated]
+
+    InternalNotificationWorker.perform_async("payments", "Stalled post email blasts", message_for(scan))
   end
 
   private
+    # Windowed on `requested_at`, which is indexed (through post_id it is not — the standalone
+    # window read still walks the index-less columns, but requested_at is set at creation and NOT
+    # NULL for every real blast) and, unlike `started_at`, is present even when the send job never
+    # ran at all — a blast whose enqueue was lost is precisely the row this alert must not skip.
     def scan_for_stalled_blasts
       candidates = PostEmailBlast
         .where(completed_at: nil)
-        .where("started_at < ?", STALL_THRESHOLD.ago)
-        .where("started_at > ?", LOOKBACK.ago)
-        .order(started_at: :desc)
+        .where(requested_at: LOOKBACK.ago..STALL_THRESHOLD.ago)
+        .order(requested_at: :desc)
+        .limit(MAX_CANDIDATES_SCANNED + 1)
         .to_a
-      return [] if candidates.empty?
+      truncated = candidates.size > MAX_CANDIDATES_SCANNED
+      candidates = candidates.first(MAX_CANDIDATES_SCANNED)
+      return { stalled: [], truncated: } if candidates.empty?
 
       dead = dead_blast_ids
       busy = busy_blast_ids
       retrying = retrying_blast_ids
+      queued = queued_blast_ids
 
-      candidates.map do |blast|
+      stalled = candidates.map do |blast|
         disposition =
           if busy.include?(blast.id) then :running
+          elsif queued.include?(blast.id) then :queued
           elsif retrying.include?(blast.id) then :retrying
           elsif dead.include?(blast.id) then :dead
           else :unaccounted
           end
 
-        {
-          blast:,
-          disposition:,
-          sent: SentPostEmail.where(post_id: blast.post_id).count,
-        }
+        { blast:, disposition: }
       end
+
+      { stalled:, truncated: }
     end
 
     def dead_blast_ids
-      ids = []
-      Sidekiq::DeadSet.new.scan("SendPostBlastEmailsJob") do |job|
-        ids << job.args[0] if job.klass == "SendPostBlastEmailsJob"
-      end
-      ids
+      collect_set_blast_ids(Sidekiq::DeadSet.new)
     end
 
     def retrying_blast_ids
+      collect_set_blast_ids(Sidekiq::RetrySet.new)
+    end
+
+    def queued_blast_ids
+      Sidekiq::Queue.new("default").filter_map { |job| job.args[0] if job.klass == "SendPostBlastEmailsJob" }
+    end
+
+    def collect_set_blast_ids(set)
       ids = []
-      Sidekiq::RetrySet.new.scan("SendPostBlastEmailsJob") do |job|
+      set.scan("SendPostBlastEmailsJob") do |job|
         ids << job.args[0] if job.klass == "SendPostBlastEmailsJob"
       end
       ids
@@ -84,36 +98,45 @@ class AlertOnStalledPostEmailBlastsJob
         payload = work["payload"]
         payload = JSON.parse(payload) if payload.is_a?(String)
         ids << payload["args"][0] if payload && payload["class"] == "SendPostBlastEmailsJob"
-      rescue StandardError
+      rescue JSON::ParserError
         next
       end
       ids
     end
 
-    def message_for(stalled)
+    def message_for(scan)
+      stalled = scan[:stalled]
       lines = stalled.first(MAX_REPORTED).map { |entry| line_for(entry) }
       omitted = stalled.size - lines.size
 
       [
-        "#{stalled.size} email blast#{"s" if stalled.size != 1} started sending more than " \
-          "#{STALL_THRESHOLD.inspect} ago and never completed.",
+        headline(stalled.size, scan[:truncated]),
+        (scan[:truncated] ? "The scan stopped at #{MAX_CANDIDATES_SCANNED} incomplete blasts, so others are not counted here." : nil),
         "",
         *lines,
         (omitted.positive? ? "…and #{omitted} more." : nil),
         "",
-        "RUNNING may just be a very large blast mid-pass; DEAD and UNACCOUNTED are stranded — " \
-          "every audience member past the sent count silently got nothing. To resume, retry the " \
-          "dead-set entry (`job.retry`), NOT `perform_async`: the job's `lock: :until_executed` " \
-          "uniqueness lock is still held by the dead entry, so a fresh enqueue is silently " \
-          "suppressed. Confirm with the seller first when the blast is time-boxed. " \
-          "See gumroad-private#1750 for a worked run.",
+        "RUNNING/QUEUED may just be a very large blast mid-pass; DEAD and UNACCOUNTED are stranded — " \
+          "every audience member past the delivered count silently got nothing. Resume a DEAD blast by " \
+          "retrying its dead-set entry (`job.retry`). For UNACCOUNTED (hard-killed worker, no dead " \
+          "entry), the job's `lock: :until_executed` digest can still be held, silently suppressing a " \
+          "fresh `perform_async` — check and clear the SidekiqUniqueJobs digest first. Confirm with the " \
+          "seller before resuming a time-boxed blast. See gumroad-private#1750 for a worked run.",
       ].compact.join("\n")
     end
 
     def line_for(entry)
       blast = entry[:blast]
-      hours = ((Time.current - blast.started_at) / 1.hour).round(1)
+      hours = ((Time.current - blast.requested_at) / 1.hour).round(1)
+      started = blast.started_at ? "" : " [never started]"
       "• blast #{blast.id} (post #{blast.post_id}, seller #{blast.seller_id}) — " \
-        "started #{hours}h ago, #{entry[:sent]} sent, #{entry[:disposition].to_s.upcase}"
+        "requested #{hours}h ago#{started}, #{blast.delivery_count} delivered, #{entry[:disposition].to_s.upcase}"
+    end
+
+    def headline(count, truncated)
+      return "No incomplete blast qualified on the scanned page, but the scan was truncated, so this is not evidence that none did." if count.zero?
+
+      "#{truncated ? "At least " : ""}#{count} email blast#{"s" if count != 1} " \
+        "requested more than #{STALL_THRESHOLD.inspect} ago #{count == 1 ? "has" : "have"} not completed."
     end
 end

--- a/app/sidekiq/alert_on_stalled_post_email_blasts_job.rb
+++ b/app/sidekiq/alert_on_stalled_post_email_blasts_job.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+# Reports email blasts that started sending and never finished (gumroad-private#1750).
+#
+# A killed SendPostBlastEmailsJob leaves `completed_at` nil forever, while the seller's dashboard
+# shows a plausible non-zero delivered count — so the only detection channel was a seller who knew
+# their own audience size writing in. 11 blasts / ~1.6M undelivered emails accrued that way over
+# ten days before anyone noticed.
+#
+# Reports; resuming a blast is a per-seller human call, because several stalled blasts are
+# time-boxed sale announcements that may be worse delivered late than not at all.
+class AlertOnStalledPostEmailBlastsJob
+  include Sidekiq::Job
+  sidekiq_options retry: 2, queue: :low
+
+  # Large resumed blasts legitimately run for a couple of hours (~4k sends/min against six-figure
+  # audiences), so anything under this is treated as still in flight.
+  STALL_THRESHOLD = 4.hours
+
+  # Blasts older than this were already stalled before this alert existed; re-reporting the same
+  # historical rows every run buries the new ones the alert exists to catch.
+  LOOKBACK = 14.days
+
+  # Report at most this many. The alert exists to be read.
+  MAX_REPORTED = 25
+
+  def perform
+    stalled = scan_for_stalled_blasts
+    return if stalled.empty?
+
+    InternalNotificationWorker.perform_async("payments", "Stalled post email blasts", message_for(stalled))
+  end
+
+  private
+    def scan_for_stalled_blasts
+      candidates = PostEmailBlast
+        .where(completed_at: nil)
+        .where("started_at < ?", STALL_THRESHOLD.ago)
+        .where("started_at > ?", LOOKBACK.ago)
+        .order(started_at: :desc)
+        .to_a
+      return [] if candidates.empty?
+
+      dead = dead_blast_ids
+      busy = busy_blast_ids
+      retrying = retrying_blast_ids
+
+      candidates.map do |blast|
+        disposition =
+          if busy.include?(blast.id) then :running
+          elsif retrying.include?(blast.id) then :retrying
+          elsif dead.include?(blast.id) then :dead
+          else :unaccounted
+          end
+
+        {
+          blast:,
+          disposition:,
+          sent: SentPostEmail.where(post_id: blast.post_id).count,
+        }
+      end
+    end
+
+    def dead_blast_ids
+      ids = []
+      Sidekiq::DeadSet.new.scan("SendPostBlastEmailsJob") do |job|
+        ids << job.args[0] if job.klass == "SendPostBlastEmailsJob"
+      end
+      ids
+    end
+
+    def retrying_blast_ids
+      ids = []
+      Sidekiq::RetrySet.new.scan("SendPostBlastEmailsJob") do |job|
+        ids << job.args[0] if job.klass == "SendPostBlastEmailsJob"
+      end
+      ids
+    end
+
+    def busy_blast_ids
+      ids = []
+      Sidekiq::Workers.new.each do |_process_id, _thread_id, work|
+        # Sidekiq 7 hands the payload back as a JSON string here, not a parsed hash.
+        payload = work["payload"]
+        payload = JSON.parse(payload) if payload.is_a?(String)
+        ids << payload["args"][0] if payload && payload["class"] == "SendPostBlastEmailsJob"
+      rescue StandardError
+        next
+      end
+      ids
+    end
+
+    def message_for(stalled)
+      lines = stalled.first(MAX_REPORTED).map { |entry| line_for(entry) }
+      omitted = stalled.size - lines.size
+
+      [
+        "#{stalled.size} email blast#{"s" if stalled.size != 1} started sending more than " \
+          "#{STALL_THRESHOLD.inspect} ago and never completed.",
+        "",
+        *lines,
+        (omitted.positive? ? "…and #{omitted} more." : nil),
+        "",
+        "RUNNING may just be a very large blast mid-pass; DEAD and UNACCOUNTED are stranded — " \
+          "every audience member past the sent count silently got nothing. To resume, retry the " \
+          "dead-set entry (`job.retry`), NOT `perform_async`: the job's `lock: :until_executed` " \
+          "uniqueness lock is still held by the dead entry, so a fresh enqueue is silently " \
+          "suppressed. Confirm with the seller first when the blast is time-boxed. " \
+          "See gumroad-private#1750 for a worked run.",
+      ].compact.join("\n")
+    end
+
+    def line_for(entry)
+      blast = entry[:blast]
+      hours = ((Time.current - blast.started_at) / 1.hour).round(1)
+      "• blast #{blast.id} (post #{blast.post_id}, seller #{blast.seller_id}) — " \
+        "started #{hours}h ago, #{entry[:sent]} sent, #{entry[:disposition].to_s.upcase}"
+    end
+end

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -191,6 +191,11 @@ alert_on_negative_destination_balances:
   class: AlertOnNegativeDestinationBalancesJob
   queue: low
   description: Reports payable sellers whose Gumroad-managed Stripe account carries a negative destination ledger from FX residue
+alert_on_stalled_post_email_blasts:
+  cron: "40 11 * * *" # UTC 11:40
+  class: AlertOnStalledPostEmailBlastsJob
+  queue: low
+  description: Reports email blasts that started sending hours ago and never completed, so a killed blast job is found before a seller writes in
 alert_on_stripe_dob_drift:
   cron: "30 12 * * 1" # UTC 12:30 Monday
   class: AlertOnStripeDobDriftJob

--- a/spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb
+++ b/spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb
@@ -5,11 +5,13 @@ require "spec_helper"
 describe AlertOnStalledPostEmailBlastsJob do
   let(:post) { create(:installment) }
 
-  def stalled_blast(started_hours_ago: 6, post: self.post)
-    create(:post_email_blast, post:, started_at: started_hours_ago.hours.ago, completed_at: nil)
+  def stalled_blast(requested_hours_ago: 6, post: self.post, delivery_count: 0, started: true)
+    requested_at = requested_hours_ago.hours.ago
+    create(:post_email_blast, post:, requested_at:, started_at: started ? requested_at + 1.minute : nil,
+                              completed_at: nil, delivery_count:)
   end
 
-  def stub_sidekiq(dead: [], retrying: [], busy: [])
+  def stub_sidekiq(dead: [], retrying: [], busy: [], queued: [])
     dead_set = instance_double(Sidekiq::DeadSet)
     allow(Sidekiq::DeadSet).to receive(:new).and_return(dead_set)
     allow(dead_set).to receive(:scan) do |_match, &block|
@@ -21,6 +23,9 @@ describe AlertOnStalledPostEmailBlastsJob do
     allow(retry_set).to receive(:scan) do |_match, &block|
       retrying.each { |id| block.call(fake_sidekiq_job(id)) }
     end
+
+    queue = queued.map { |id| fake_sidekiq_job(id) }
+    allow(Sidekiq::Queue).to receive(:new).with("default").and_return(queue)
 
     workers = instance_double(Sidekiq::Workers)
     allow(Sidekiq::Workers).to receive(:new).and_return(workers)
@@ -40,10 +45,8 @@ describe AlertOnStalledPostEmailBlastsJob do
     allow(InternalNotificationWorker).to receive(:perform_async)
   end
 
-  it "reports a stalled blast with its dead-set disposition and sent count" do
-    blast = stalled_blast
-    create(:sent_post_email, post:, email: "a@example.com")
-    create(:sent_post_email, post:, email: "b@example.com")
+  it "reports a stalled blast with its dead-set disposition and per-blast delivered count" do
+    blast = stalled_blast(delivery_count: 6800)
     stub_sidekiq(dead: [blast.id])
 
     described_class.new.perform
@@ -51,15 +54,15 @@ describe AlertOnStalledPostEmailBlastsJob do
     expect(InternalNotificationWorker).to have_received(:perform_async) do |room, subject, message|
       expect(room).to eq("payments")
       expect(subject).to eq("Stalled post email blasts")
-      expect(message).to include("1 email blast started sending")
+      expect(message).to include("1 email blast requested more than")
       expect(message).to include("blast #{blast.id}")
-      expect(message).to include("2 sent, DEAD")
+      expect(message).to include("6800 delivered, DEAD")
     end
   end
 
-  it "stays silent when every started blast completed or is under the stall threshold" do
-    create(:post_email_blast, post:, started_at: 6.hours.ago, completed_at: 5.hours.ago)
-    create(:post_email_blast, post:, started_at: 1.hour.ago, completed_at: nil)
+  it "stays silent when every blast completed or is under the stall threshold" do
+    create(:post_email_blast, post:, requested_at: 6.hours.ago, started_at: 6.hours.ago, completed_at: 5.hours.ago)
+    create(:post_email_blast, post:, requested_at: 1.hour.ago, started_at: 1.hour.ago, completed_at: nil)
     stub_sidekiq
 
     described_class.new.perform
@@ -68,7 +71,7 @@ describe AlertOnStalledPostEmailBlastsJob do
   end
 
   it "ignores stalls older than the lookback so historical rows do not bury new ones" do
-    stalled_blast(started_hours_ago: 15 * 24)
+    stalled_blast(requested_hours_ago: 15 * 24)
     stub_sidekiq
 
     described_class.new.perform
@@ -76,18 +79,45 @@ describe AlertOnStalledPostEmailBlastsJob do
     expect(InternalNotificationWorker).not_to have_received(:perform_async)
   end
 
-  it "distinguishes running, retrying and unaccounted blasts" do
+  it "reports a blast whose send job never ran at all" do
+    blast = stalled_blast(started: false)
+    stub_sidekiq
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
+      expect(message).to match(/blast #{blast.id}.*\[never started\].*UNACCOUNTED/)
+    end
+  end
+
+  it "distinguishes running, queued, retrying and unaccounted blasts" do
     running = stalled_blast
+    queued = stalled_blast(post: create(:installment))
     retrying = stalled_blast(post: create(:installment))
     lost = stalled_blast(post: create(:installment))
-    stub_sidekiq(busy: [running.id], retrying: [retrying.id])
+    stub_sidekiq(busy: [running.id], queued: [queued.id], retrying: [retrying.id])
 
     described_class.new.perform
 
     expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
       expect(message).to match(/blast #{running.id}.*RUNNING/)
+      expect(message).to match(/blast #{queued.id}.*QUEUED/)
       expect(message).to match(/blast #{retrying.id}.*RETRYING/)
       expect(message).to match(/blast #{lost.id}.*UNACCOUNTED/)
+    end
+  end
+
+  it "says the scan was truncated instead of presenting a cut page as the total" do
+    stub_const("#{described_class}::MAX_CANDIDATES_SCANNED", 1)
+    stalled_blast
+    stalled_blast(post: create(:installment))
+    stub_sidekiq
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
+      expect(message).to include("At least 1 email blast")
+      expect(message).to include("The scan stopped at 1 incomplete blasts")
     end
   end
 end

--- a/spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb
+++ b/spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe AlertOnStalledPostEmailBlastsJob do
+  let(:post) { create(:installment) }
+
+  def stalled_blast(started_hours_ago: 6, post: self.post)
+    create(:post_email_blast, post:, started_at: started_hours_ago.hours.ago, completed_at: nil)
+  end
+
+  def stub_sidekiq(dead: [], retrying: [], busy: [])
+    dead_set = instance_double(Sidekiq::DeadSet)
+    allow(Sidekiq::DeadSet).to receive(:new).and_return(dead_set)
+    allow(dead_set).to receive(:scan) do |_match, &block|
+      dead.each { |id| block.call(fake_sidekiq_job(id)) }
+    end
+
+    retry_set = instance_double(Sidekiq::RetrySet)
+    allow(Sidekiq::RetrySet).to receive(:new).and_return(retry_set)
+    allow(retry_set).to receive(:scan) do |_match, &block|
+      retrying.each { |id| block.call(fake_sidekiq_job(id)) }
+    end
+
+    workers = instance_double(Sidekiq::Workers)
+    allow(Sidekiq::Workers).to receive(:new).and_return(workers)
+    allow(workers).to receive(:each) do |&block|
+      busy.each do |id|
+        # Production hands the payload back as a JSON string, so the fixture does too.
+        block.call("pid", "tid", { "payload" => { "class" => "SendPostBlastEmailsJob", "args" => [id] }.to_json })
+      end
+    end
+  end
+
+  def fake_sidekiq_job(blast_id)
+    instance_double(Sidekiq::SortedEntry, klass: "SendPostBlastEmailsJob", args: [blast_id])
+  end
+
+  before do
+    allow(InternalNotificationWorker).to receive(:perform_async)
+  end
+
+  it "reports a stalled blast with its dead-set disposition and sent count" do
+    blast = stalled_blast
+    create(:sent_post_email, post:, email: "a@example.com")
+    create(:sent_post_email, post:, email: "b@example.com")
+    stub_sidekiq(dead: [blast.id])
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).to have_received(:perform_async) do |room, subject, message|
+      expect(room).to eq("payments")
+      expect(subject).to eq("Stalled post email blasts")
+      expect(message).to include("1 email blast started sending")
+      expect(message).to include("blast #{blast.id}")
+      expect(message).to include("2 sent, DEAD")
+    end
+  end
+
+  it "stays silent when every started blast completed or is under the stall threshold" do
+    create(:post_email_blast, post:, started_at: 6.hours.ago, completed_at: 5.hours.ago)
+    create(:post_email_blast, post:, started_at: 1.hour.ago, completed_at: nil)
+    stub_sidekiq
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).not_to have_received(:perform_async)
+  end
+
+  it "ignores stalls older than the lookback so historical rows do not bury new ones" do
+    stalled_blast(started_hours_ago: 15 * 24)
+    stub_sidekiq
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).not_to have_received(:perform_async)
+  end
+
+  it "distinguishes running, retrying and unaccounted blasts" do
+    running = stalled_blast
+    retrying = stalled_blast(post: create(:installment))
+    lost = stalled_blast(post: create(:installment))
+    stub_sidekiq(busy: [running.id], retrying: [retrying.id])
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
+      expect(message).to match(/blast #{running.id}.*RUNNING/)
+      expect(message).to match(/blast #{retrying.id}.*RETRYING/)
+      expect(message).to match(/blast #{lost.id}.*UNACCOUNTED/)
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds `AlertOnStalledPostEmailBlastsJob` (daily, 11:40 UTC): reports `PostEmailBlast` rows requested more than 4 hours ago whose `completed_at` is still nil, within a 14-day lookback and a 500-row scan bound (truncation is said out loud). Each line carries the blast/post/seller ids, hours since request, the row's own `delivery_count`, and a Sidekiq disposition — RUNNING / QUEUED / RETRYING / DEAD / UNACCOUNTED — read from the live workers, default queue, retry set and dead set. Report goes to the `payments` room via `InternalNotificationWorker`.

## Why

gumroad-private#1750: `SendPostBlastEmailsJob` dying mid-pass (in-pod DNS failures to the ESPs, plus deploy kills) left **11 blasts / ~1.6M undelivered emails across 9 sellers** stranded over ten days with zero detection — `completed_at` stays nil forever, the dashboard shows a plausible non-zero delivered count, and the only alarm was a seller who knew his own audience size writing in. This is ask 3 of that issue. Reporting only: resuming is a per-seller human call (several stalled blasts were time-boxed sale announcements).

## Design notes (post-review)

- Windowed on **`requested_at`** (indexed, set at creation), not `started_at`: a blast whose send job never got enqueued has `started_at` nil and is exactly the row the alert must not skip — those render as `[never started]`.
- Per-blast progress is **`delivery_count`** on the row itself, not a `SentPostEmail` count: `SentPostEmail` is per-post (a resend would double-count the original blast's rows) and non-opener resends don't write it at all.
- The remediation text distinguishes DEAD (resume via dead-set `job.retry`) from UNACCOUNTED (hard-killed worker — no dead entry; the `until_executed` digest can still be held and must be checked/cleared before a fresh enqueue). Reaching the dead set fires the SidekiqUniqueJobs death handler, which releases the lock, so the two cases need opposite instructions.

## Before → After

| | Before | After |
|---|---|---|
| Killed or never-enqueued blast job | Silent — `completed_at` nil forever, dashboard shows a plausible count | Named in a daily `payments` alert with disposition + delivered count |
| Detection latency | Days-to-never (seller-reported; 8 of 9 affected sellers never wrote in) | ≤ ~28h (4h stall threshold + daily cadence) |

The same `completed_at IS NULL` + requested-window read on the prod console is what produced gp#1750's 11-blast evidence table (2026-08-03).

## Test Results

- `bundle exec rspec spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb` — 6 examples, 0 failures (lane-0 env; final run 22:20Z at head `074e71de3`).
- Mutation checks, each mutant killed by exactly its intended example:
  - Round 1 (pre-review head): drop the stall-threshold filter → red on the silence example only; collapse disposition to dead-only → red on the disposition example only.
  - Round 2 (this head): widen the `requested_at` window past the stall threshold → red on "stays silent…" only; delete the `:queued` branch → red on "distinguishes running, queued, retrying and unaccounted" only. Restore verified byte-identical to HEAD after each round.
- `ruby -c` both files; sidekiq_schedule.yml YAML-clean.
- Adversarial (fable-5) review ran on the first head; all six findings fixed in `074e71de3` (per-blast `delivery_count`, `requested_at` window + never-started coverage, QUEUED disposition, scan bound + truncation headline, narrowed `JSON::ParserError` rescue, corrected DEAD/UNACCOUNTED remediation text — the original text had the uniqueness-lock claim inverted).

## QA steps

Backend-only, no rendered surface. Reviewer path: read the job, run the spec file, check the message text against the SidekiqUniqueJobs death-handler registration in `config/initializers/sidekiq.rb`. Post-deploy watch point: first tick at 11:40 UTC should be quiet or name only genuinely stalled blasts; the gp#1750 cohort was resumed 2026-08-03 21:34Z so it should not re-fire on those.

## Not in this PR

Asks 1 (in-pod DNS root cause — infra) and 2 (per-slice ESP retry — open as #6898) of gp#1750.

---

🤖 AI-generated (claude-sonnet-5, Hermes Agent). Instructions: autonomous dev dispatcher standing order + Sahil's "fix all" on gp#1750; ask 3 (alerting) built after the 10 stranded blasts were resumed via audited console.
