### PR TITLE
Find a membership in Customers search by the member's current email

### DIFF
--- a/app/models/concerns/purchase/searchable.rb
+++ b/app/models/concerns/purchase/searchable.rb
@@ -66,6 +66,10 @@ module Purchase::Searchable
         indexes :raw, type: :keyword
       end
       indexes :email_domain, type: :text, analyzer: :email, search_analyzer: :search_email
+      indexes :subscription_current_email, type: :text, analyzer: :email, search_analyzer: :search_email do
+        indexes :raw, type: :keyword
+      end
+      indexes :subscription_current_email_domain, type: :text, analyzer: :email, search_analyzer: :search_email
       indexes :paypal_email, type: :text, analyzer: :email, search_analyzer: :search_email do
         indexes :raw, type: :keyword
       end
@@ -123,7 +127,7 @@ module Purchase::Searchable
       ],
       "country" => "country_or_ip_country",
       "created_at" => "created_at",
-      "email" => ["email", "email_domain"],
+      "email" => ["email", "email_domain", "subscription_current_email", "subscription_current_email_domain"],
       "fee_cents" => "fee_cents",
       "flags" => %w[
         selected_flags
@@ -163,6 +167,10 @@ module Purchase::Searchable
         email&.downcase
       when "email_domain"
         email.downcase.split("@")[1] if email.present?
+      when "subscription_current_email"
+        subscription.email&.downcase if is_original_subscription_purchase? && subscription.present?
+      when "subscription_current_email_domain"
+        subscription.email.downcase.split("@")[1] if is_original_subscription_purchase? && subscription.present? && subscription.email.present?
       when "selected_flags"
         selected_flags.map(&:to_s)
       when "stripe_refunded"
@@ -254,6 +262,30 @@ module Purchase::Searchable
         end
       end
     end
+  end
+
+  module BuyerEmailCallbacks
+    extend ActiveSupport::Concern
+
+    included do
+      after_commit :update_original_subscription_purchase_documents_email, on: :update,
+                                                                           if: -> { email_previously_changed? || unconfirmed_email_previously_changed? }
+    end
+
+    private
+      def update_original_subscription_purchase_documents_email
+        Purchase.is_original_subscription_purchase
+                .where(subscription_id: subscriptions.select(:id))
+                .select(:id)
+                .find_each do |purchase|
+          options = {
+            "record_id" => purchase.id,
+            "class_name" => "Purchase",
+            "fields" => ["subscription_current_email", "subscription_current_email_domain"]
+          }
+          ElasticsearchIndexerWorker.perform_in(2.seconds, "update", options)
+        end
+      end
   end
 
   module RelatedPurchaseCallbacks

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,7 @@ class User < ApplicationRecord
           TwoFactorAuthentication, Versionable, Comments, VipCreator, SignedUrlHelper, Purchases, SecureExternalId,
           AttributeBlockable, PayoutInfo, EmailNormalization, SingleUseResetPasswordToken,
           DashboardNavItems, ReputationSummary
+  include Purchase::Searchable::BuyerEmailCallbacks
 
   has_many :user_external_authentications, dependent: :destroy
 

--- a/app/services/purchase_search_service.rb
+++ b/app/services/purchase_search_service.rb
@@ -451,11 +451,12 @@ class PurchaseSearchService
         shoulds << {
           multi_match: {
             query: query_string,
-            fields: ["email", "email_domain", "full_name"]
+            fields: ["email", "email_domain", "full_name", "subscription_current_email", "subscription_current_email_domain"]
           }
         }
         if query_string.include?("@")
           shoulds << { term: { "email.raw" => query_string } }
+          shoulds << { term: { "subscription_current_email.raw" => query_string } }
           shoulds << { term: { "paypal_email.raw" => query_string } }
         end
         if query_string.match?(/\A[a-f0-9]{8}-[a-f0-9]{8}-[a-f0-9]{8}-[a-f0-9]{8}\z/)

--- a/db/migrate/20261206190000_add_subscription_current_email_to_purchases_index.rb
+++ b/db/migrate/20261206190000_add_subscription_current_email_to_purchases_index.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class AddSubscriptionCurrentEmailToPurchasesIndex < ActiveRecord::Migration[7.1]
+  def up
+    EsClient.indices.put_mapping(
+      index: Purchase.index_name,
+      body: {
+        properties: {
+          subscription_current_email: {
+            type: "text",
+            analyzer: "email",
+            search_analyzer: "search_email",
+            fields: {
+              raw: { type: "keyword" }
+            }
+          },
+          subscription_current_email_domain: {
+            type: "text",
+            analyzer: "email",
+            search_analyzer: "search_email"
+          }
+        }
+      }
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_12_06_171842) do
+ActiveRecord::Schema[7.1].define(version: 2026_12_06_190000) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false

--- a/spec/models/concerns/purchase/searchable_spec.rb
+++ b/spec/models/concerns/purchase/searchable_spec.rb
@@ -39,6 +39,8 @@ describe Purchase::Searchable do
         "latest_charge_date" => nil,
         "email" => "buyer1@gmail.com",
         "email_domain" => "gmail.com",
+        "subscription_current_email" => nil,
+        "subscription_current_email_domain" => nil,
         "paypal_email" => "buyer1@paypal.com",
         "fee_cents" => 93, # 100 * 0.129 + 50 + 30
         "full_name" => "Joe Buyer",
@@ -91,6 +93,8 @@ describe Purchase::Searchable do
         "subscription_id" => @purchase.subscription.id,
         "subscription_cancelled_at" => "2018-01-01T00:00:00Z",
         "subscription_deactivated_at" => "2018-01-01T00:00:00Z",
+        "subscription_current_email" => @purchase.subscription.user.email,
+        "subscription_current_email_domain" => @purchase.subscription.user.email.split("@")[1],
         "monthly_recurring_revenue" => 100.0 / 12,
         "not_refunded_except_subscriptions" => true,
         "not_subscription_or_original_subscription_purchase" => true,
@@ -282,6 +286,56 @@ describe Purchase::Searchable do
       @subscription.save!
 
       expect(ElasticsearchIndexerWorker.jobs.size).to eq(0)
+    end
+  end
+
+  describe "BuyerEmail Callbacks" do
+    before do
+      @member = create(:user, email: "member@example.com")
+      @subscription = create(:subscription, user: @member)
+      @original_purchase = create(:purchase, subscription: @subscription, is_original_subscription_purchase: true, purchaser: @member)
+      @recurring_purchase = create(:purchase, subscription: @subscription, purchaser: @member)
+      ElasticsearchIndexerWorker.jobs.clear
+    end
+
+    def current_email_reindex_jobs
+      ElasticsearchIndexerWorker.jobs.select do |job|
+        job["args"][1]["class_name"] == "Purchase" &&
+          job["args"][1]["fields"] == ["subscription_current_email", "subscription_current_email_domain"]
+      end
+    end
+
+    it "reindexes the original subscription purchase when the member's email changes" do
+      @member.update!(email: "new-member@example.com")
+
+      expect(ElasticsearchIndexerWorker).to have_enqueued_sidekiq_job("update", "record_id" => @original_purchase.id, "class_name" => "Purchase", "fields" => ["subscription_current_email", "subscription_current_email_domain"])
+      expect(current_email_reindex_jobs.size).to eq(1)
+    end
+
+    it "reindexes the original subscription purchase when the member's email change is confirmed" do
+      @member.update!(email: "new-member@example.com")
+      ElasticsearchIndexerWorker.jobs.clear
+
+      @member.confirm
+
+      expect(ElasticsearchIndexerWorker).to have_enqueued_sidekiq_job("update", "record_id" => @original_purchase.id, "class_name" => "Purchase", "fields" => ["subscription_current_email", "subscription_current_email_domain"])
+    end
+
+    it "does not reindex when unrelated attributes change" do
+      @member.update!(name: "New Name")
+
+      expect(current_email_reindex_jobs.size).to eq(0)
+    end
+
+    it "updates the indexed current email", :sidekiq_inline, :elasticsearch_wait_for_refresh do
+      index_model_records(Purchase)
+
+      @member.update!(email: "new-member@example.com")
+
+      document = get_document_attributes(@original_purchase)
+      expect(document["subscription_current_email"]).to eq("new-member@example.com")
+      expect(document["subscription_current_email_domain"]).to eq("example.com")
+      expect(document["email"]).to eq(@original_purchase.email)
     end
   end
 

--- a/spec/services/purchase_search_service_spec.rb
+++ b/spec/services/purchase_search_service_spec.rb
@@ -499,6 +499,27 @@ describe PurchaseSearchService do
       expect(get_records(seller_query: purchase_6.license.serial)).to match_array([purchase_6])
     end
 
+    it "finds a membership by the member's current email after an account email change" do
+      member = create(:user, email: "signup-address@example.com")
+      product = create(:membership_product)
+      subscription = create(:subscription, link: product, user: member)
+      purchase = create(:membership_purchase, email: "signup-address@example.com", link: product, subscription:, purchaser: member)
+      index_model_records(Purchase)
+
+      expect(get_records(seller_query: "current-address@example.org")).to be_empty
+
+      member.update!(email: "current-address@example.org")
+      index_model_records(Purchase)
+
+      # findable by the current email: exact match, autocomplete prefix, and domain
+      expect(get_records(seller_query: "current-address@example.org")).to match_array([purchase])
+      expect(get_records(seller_query: "Current-Address@example.org")).to match_array([purchase])
+      expect(get_records(seller_query: "current-addr")).to match_array([purchase])
+      expect(get_records(seller_query: "example.org")).to match_array([purchase])
+      # still findable by the email the subscription signed up with
+      expect(get_records(seller_query: "signup-address@example.com")).to match_array([purchase])
+    end
+
     it "supports fulltext/autocomplete search as a buyer" do
       seller_1 = create(:user, name: "Daniel Vassallo")
       product_1 = create(:product, name: "Everyone Can Build a Twitter Audience", user: seller_1, description: "Last year I left a cushy job at <strong>Amazon</strong> to work for myself.")


### PR DESCRIPTION
## What

Makes the seller-facing Customers search find a membership by the member's **current** email after the buyer changes their account email, while remaining findable by the signup-time purchase email.

- Indexes two new fields on the `purchases` Elasticsearch index: `subscription_current_email` (with a `.raw` keyword subfield) and `subscription_current_email_domain`, populated from `Subscription#email` on original subscription purchases only — the one row Customers search can reach for a membership.
- Adds both fields to `PurchaseSearchService#build_body_fulltext_search`: the `multi_match` fields (autocomplete + domain search) and an exact `subscription_current_email.raw` term branch for full addresses beyond the 20-char edge-ngram limit.
- Reindexes the fields when the buyer's account email changes: `Purchase::Searchable::BuyerEmailCallbacks` (included into `User`) enqueues an `ElasticsearchIndexerWorker` update for each of the user's original subscription purchases when `email` **or** `unconfirmed_email` changes. It deliberately covers the unconfirmed case: `User#form_email` prefers `unconfirmed_email`, so `Subscription#email` (and every recurring charge receipt) switches to the new address immediately, while the existing `UpdatePurchaseEmailToMatchAccountWorker` only runs once the address is confirmed — exactly the window in which the seller cannot find the member.
- Maps the purchase `email` column to the new fields in `ATTRIBUTE_TO_SEARCH_FIELDS`, so flows that rewrite the original purchase row's email (e.g. `Purchase::ReassignByEmailService` on subscription reassignment) refresh them for free.
- Adds the fields to the live `purchases` mapping via an ES migration (`AddSubscriptionCurrentEmailToPurchasesIndex`), following the existing pattern (`AddEmailDomainToPurchasesIndex`, `AddTaxonomyIdToPurchaseIndex`). The mapping is `dynamic: :strict`, so this must deploy before any write of the new fields. The migration is numbered above main's current schema version so that `db:prepare`/`schema:load` environments never mark it applied without running it.

## Why (root cause)

Reported in antiwork/gumroad-private#1771: a seller could not find a member by the address the member was writing in from, because two behaviors combine into a dead end:

1. Customers search runs `PurchaseSearchService` with `exclude_non_original_subscription_purchases: true` (`customers_controller.rb`), so for a membership exactly one row is searchable: the original subscription purchase.
2. `Subscription#email` resolves the buyer's current account email (`User#form_email`) and stamps it onto each *new* recurring charge (`subscription.rb` `build_purchase`), but the original subscription purchase row keeps the signup email forever.

So the row holding the current email is excluded from search, and the searchable row holds a stale email — zero results for the current address.

This takes option 1 from the issue (index the current email as an additional field) rather than option 2 (rewrite the original purchase's `email` on change), because the original row's `email` is what receipts and audience membership key off; an extra search-only field has no blast radius outside search.

Relationship to #6925: that PR builds the same option 1 with a wider footprint (a dedicated reindex worker, subscription `user_id` reassignment tracking, and a `Onetime` backfill service). This PR is the minimal slice — the field, the query, and reindex wiring that reuses the established `ElasticsearchIndexerWorker` "update" pattern from `Purchase::Searchable::SubscriptionCallbacks`, with no new Sidekiq class.

**Historical documents:** the new fields populate on the next reindex of a document or on the next email change. Members whose email changed *before* this ships stay unfindable until their documents are reindexed. That backfill should use the existing `Onetime` pattern (`app/services/onetime`, per CONTRIBUTING "Feature development") in a follow-up — #6925's `Onetime::BackfillSubscriptionCurrentEmail` is a ready-made candidate, scoped to memberships whose indexed email already differs from the member's current account email.

## Before/After

| | Seller searches the member's current address in Customers |
|---|---|
| Before | 0 results — only the signup-time address matches |
| After | The membership is found by current address (exact, autocomplete prefix, and domain), and still found by the signup address |

A walkthrough of the Customers search will follow — the change adds no new UI surface (it changes which rows the existing search box reaches), so the visual evidence is the same search box returning the member where it previously returned nothing.

## Test Results

Run locally (Ruby 3.4.3, MySQL + Elasticsearch test env):

- `bundle exec rspec spec/services/purchase_search_service_spec.rb spec/models/concerns/purchase/searchable_spec.rb` — **68 examples, 0 failures**
- Revert check: with the application code reverted (specs kept), the acceptance example fails — `1 example, 1 failure` — so the new specs are load-bearing.
- `bundle exec rubocop` on all changed files — 1 offense auto-corrected, 0 remaining

New coverage:

- `purchase_search_service_spec.rb`: acceptance test from the issue — a membership is findable by the member's current email after an account email change (exact, prefix, and domain queries) and still findable by the original purchase email; the current address returns nothing before the change.
- `searchable_spec.rb` "BuyerEmail Callbacks": the original subscription purchase is reindexed when the member's email changes (unconfirmed and on confirm), not on unrelated attribute changes; plus an inline-Sidekiq end-to-end example asserting the ES document carries the new current email while `email` keeps the signup address.
- `searchable_spec.rb` `#indexed_json`: the new fields are nil for non-membership purchases and populated from the subscription's user for original subscription purchases.

The acceptance specs fail with the fix reverted (the new fields disappear from the mapping and query, so the current-address searches return nothing).

## QA steps

1. Log in as a seller with a membership product, open **Customers**.
2. As the member, change the account email (Settings) — no need to confirm it.
3. Back on the seller dashboard, search the member's new address: the membership appears. Search the signup address: it still appears.

Fixes antiwork/gumroad-private#1771.

---

*AI disclosure: written by Claude Fable 5 (subagent), driven by Claude Code. Prompt: fix antiwork/gumroad-private#1771 (Customers search cannot find a member by their current email after an email change) with the smallest change that indexes and searches the member's current email, reusing existing reindex patterns and deferring the historical backfill to the established Onetime mechanism.*
