### PR TITLE
Deep-freeze shared taxonomy facet definitions (follow-up to #6948)

### DIFF
--- a/app/models/taxonomy_attribute_definitions.rb
+++ b/app/models/taxonomy_attribute_definitions.rb
@@ -12,6 +12,18 @@
 # permanent once products carry values for it; `label` and `values` are display-side and may
 # be edited freely.
 class TaxonomyAttributeDefinitions
+  # Freezing the outer array only stops reassignment — the nested hashes and `values` arrays stay
+  # mutable, and every DEFINITIONS path sharing one of these constants points at the same objects.
+  # A caller mutating one path's definition (e.g. tailoring a facet in place) would silently alter
+  # every other taxonomy mapped to the same constant.
+  def self.deep_freeze(definitions)
+    definitions.each do |definition|
+      definition[:values].freeze
+      definition.freeze
+    end
+    definitions.freeze
+  end
+
   # `genre` and `content_type` were added after the initial ship (gumroad-private#1799 follow-up):
   # sample-pack marketplaces like Splice and Loopmasters organize primarily by genre and content
   # type, ahead of tempo bucket, so those were the real gap in the original facet set.
@@ -22,7 +34,8 @@ class TaxonomyAttributeDefinitions
     { name: "tempo", label: "Tempo", value_type: "enum", values: ["Under 90 BPM", "90–120 BPM", "120–140 BPM", "Over 140 BPM"], position: 3 },
     { name: "loopable", label: "Loopable", value_type: "boolean", values: [], position: 4 },
     { name: "license", label: "License", value_type: "enum", values: ["Personal", "Commercial", "Royalty-free"], position: 5 },
-  ].freeze
+  ]
+  deep_freeze(MUSIC_DEFINITIONS)
 
   # VRChat buyers don't shop on generic 3D-asset axes (engine/file format) — everything here is a
   # Unity upload by definition. What actually gates a purchase: what kind of item it is, which
@@ -35,7 +48,8 @@ class TaxonomyAttributeDefinitions
     { name: "performance_rank", label: "Performance rank", value_type: "enum", values: ["Excellent", "Good", "Medium", "Poor"], position: 2 },
     { name: "rigged", label: "Rigged", value_type: "boolean", values: [], position: 3 },
     { name: "license", label: "License", value_type: "enum", values: ["Personal", "Commercial", "Extended commercial"], position: 4 },
-  ].freeze
+  ]
+  deep_freeze(VRCHAT_DEFINITIONS)
 
   # Generic 3D-model marketplace facets (gumroad-private#1796), modeled on how TurboSquid,
   # CGTrader, and Sketchfab actually let buyers narrow a catalog: subject category first
@@ -50,7 +64,8 @@ class TaxonomyAttributeDefinitions
     { name: "animated", label: "Animated", value_type: "boolean", values: [], position: 4 },
     { name: "poly_count", label: "Poly count", value_type: "enum", values: ["Low-poly (under 10k)", "Mid-poly (10k-50k)", "High-poly (over 50k)"], position: 5 },
     { name: "license", label: "License", value_type: "enum", values: ["Personal", "Commercial", "Extended commercial"], position: 6 },
-  ].freeze
+  ]
+  deep_freeze(THREE_D_ASSETS_DEFINITIONS)
 
   SOFTWARE_DEVELOPMENT_DEFINITIONS = [
     # Product type comes first: code/plugin marketplaces (CodeCanyon, GitHub Marketplace, VS Code
@@ -61,7 +76,8 @@ class TaxonomyAttributeDefinitions
     { name: "framework", label: "Framework", value_type: "enum", values: ["React", "Next.js", "Vue", "Rails", "Django", "Laravel", "Flutter", "Node.js"], position: 2 },
     { name: "includes_source", label: "Includes source code", value_type: "boolean", values: [], position: 3 },
     { name: "license", label: "License", value_type: "enum", values: ["Personal", "Commercial", "Extended commercial"], position: 4 },
-  ].freeze
+  ]
+  deep_freeze(SOFTWARE_DEVELOPMENT_DEFINITIONS)
 
   DEFINITIONS = {
     # Generic 3D assets (game-dev models, environments, props not tied to VRChat's avatar system)


### PR DESCRIPTION
## What

Deep-freeze the shared `TaxonomyAttributeDefinitions` constants — `SOFTWARE_DEVELOPMENT_DEFINITIONS` (6 taxonomy paths), `MUSIC_DEFINITIONS` (5 paths), `VRCHAT_DEFINITIONS` (2 paths), and `THREE_D_ASSETS_DEFINITIONS` — so the nested hashes and their `values` arrays are actually immutable, not just the outer array.

## Why

Follow-up to a Greptile P2 posted on #6948 (merged) — `.freeze` on the outer array only stops reassignment; the nested hashes and `values` arrays inside stayed mutable and are shared by reference across every taxonomy path mapped to the same constant. Greptile's executable probe mutated one nested value through one path and observed the change through all six software-development paths. Any caller that tailors a definition for one taxonomy (in a script, a console session, a future feature) would silently corrupt the facets used by every other taxonomy sharing that constant.

Added `TaxonomyAttributeDefinitions.deep_freeze` (freezes each definition hash, its `values` array, and the outer array) and applied it to every constant currently reused across multiple `DEFINITIONS` entries, plus `THREE_D_ASSETS_DEFINITIONS` for consistency since it's the same shape.

## Before / After

Before: `defn[:values] << "x"` on any shared constant succeeds silently.
After: same call raises `FrozenError`.

## Status

- [x] Scope — data-only immutability fix on one file, no schema/behavior change; scope is the Greptile finding on #6948.
- [x] Design — deep-freeze helper applied to every shared constant; no alternative design considered (freezing is the standard Ruby fix for this class of bug).
- [x] Build — committed, pushed.
- [x] QA — `bin/rails runner` probe on this branch: mutating a shared definition's `values` array, a definition hash's field, and pushing onto the shared outer array each now raise `FrozenError` (previously succeeded silently); `DEFINITIONS.keys.size` unchanged at 16, confirming no behavior change to path resolution.
- [ ] Shipped — awaiting CI + merge.
- [ ] Market — n/a, internal registry fix.
- [ ] Sell — n/a.

## Test Results

- `ruby -c app/models/taxonomy_attribute_definitions.rb`: Syntax OK.
- `bundle exec rubocop app/models/taxonomy_attribute_definitions.rb`: no offenses.
- `bin/rails runner` probe against the live class on this branch (real Rails boot): confirmed above.
- No spec file exists for this registry in the repo (`spec/models/taxonomy_attribute_definitions_spec.rb`, referenced in #6948's body, does not exist on `main`) — nothing to run there.

## QA steps

Ran the mutation-reproduction probe directly against `TaxonomyAttributeDefinitions` in a `bin/rails runner` session on this branch — confirms the fix without needing a DB-backed spec.

---

AI disclosure: opened autonomously by Hermes Agent (claude-sonnet-5) in response to Greptile's P2 finding on #6948.


## Watcher re-verification (2026-08-03)

Re-ran the mutation probe directly on the hosted preview
(`gp1798-software-facet-deep-freez.apps.staging.gumroad.org`), confirmed at the app's live
`ENV["REVISION"] == fbc235237e75` (matches this PR's head):

```ruby
d = TaxonomyAttributeDefinitions::MUSIC_DEFINITIONS
d.first[:values] << "x"   # => FrozenError (previously succeeded silently)
```

No rendered surface exists for this change (an internal Ruby constant registry with no
controller/view reader), so a Rails-console mutation probe against the deployed image is the
correct evidence class rather than a screenshot — consistent with the PR's own QA section.
