### PR TITLE
Sweep a variant grouping's versions together with the grouping in the editor save

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1469,11 +1469,10 @@ class LinksController < ApplicationController
     end
 
     # Survivors are looked up by the requested id rather than by walking the
-    # product's live parents. Deleting a grouping does not soft-delete the
-    # versions inside it, so a version (or its page) whose grouping went away in
-    # this same save is still alive and still unapplied, while being unreachable
-    # through `current_base_variants` — exactly the rows this report exists to
-    # name.
+    # product's live parents. A version that survived under a grouping this
+    # save deleted (the API's category destroy leaves live children; older
+    # editor saves did too, gumroad-private#1784) is unreachable through
+    # `current_base_variants` — exactly the rows this report exists to name.
     def surviving_variant_ids(requested_ids)
       return [] if requested_ids.empty?
 

--- a/app/models/product_variant_deletion_audit.rb
+++ b/app/models/product_variant_deletion_audit.rb
@@ -97,12 +97,14 @@ class ProductVariantDeletionAudit < ApplicationRecord
   #   Not what it proposed to delete — a version an earlier save already deleted
   #   must not be attributed to this one.
   # - `affected_variant_external_ids`: versions whose removal this operation
-  #   AUTHORISED, which is what intent is judged against. Usually the same as the
-  #   deleted set, but not for a category sweep: marking a category deleted
-  #   removes the grouping without soft-deleting its rows (no `dependent:` on the
-  #   association), so the deleted set is empty while the seller may still have
-  #   explicitly confirmed every child. Judging intent from the deleted set there
-  #   reports a fully confirmed removal as `payload_omission`.
+  #   AUTHORISED, which is what intent is judged against. Usually the same as
+  #   the deleted set, but not always: a version an earlier save already
+  #   removed is authorised but not deleted here, and the API's category
+  #   destroy (`Api::V2::VariantCategoriesController`) removes the grouping
+  #   without soft-deleting its rows (no `dependent:` on the association), so
+  #   its deleted set is empty while the seller may still have explicitly
+  #   confirmed every child. Judging intent from the deleted set there reports
+  #   a fully confirmed removal as `payload_omission`.
   # - `confirmed_removed_variant_ids`: the raw confirmation list off the request.
   #   Only its intersection with the affected set is stored, because the list can
   #   name rows this request never touched.

--- a/app/services/product/variant_category_updater_service.rb
+++ b/app/services/product/variant_category_updater_service.rb
@@ -123,6 +123,42 @@ class Product::VariantCategoryUpdaterService
       (variant.respond_to?(:prices) && variant.prices.alive.where("price_cents > 0").exists?)
   end
 
+  # Soft-deletes variants and schedules the cleanup of their pages and
+  # archives. Returns the external ids of the variants this call actually
+  # deleted — narrower than +variants+, because a variant an earlier save
+  # already deleted keeps its original deletion timestamp (support uses that
+  # timestamp to find which rows a bad save wiped).
+  #
+  # A class method because both this service (versions omitted from a
+  # submitted grouping) and Product::VariantsUpdaterService (a whole grouping
+  # swept because the payload never mentioned it) delete versions and must do
+  # it the same way — the sweep used to mark only the grouping deleted, which
+  # left its versions alive under a deleted parent (gumroad-private#1784).
+  def self.batch_delete_variants(product:, variants:)
+    variant_ids = variants.respond_to?(:pluck) ? variants.pluck(:id) : variants.map(&:id)
+    return [] if variant_ids.empty?
+
+    now = Time.current
+    newly_deleted = BaseVariant.where(id: variant_ids).alive.to_a
+    BaseVariant.where(id: newly_deleted.map(&:id)).update_all(deleted_at: now, updated_at: now) if newly_deleted.any?
+
+    # Cleanup runs for every id, including ones deleted earlier: an earlier
+    # delete may not have finished cleaning up, and both workers are safe to
+    # run twice.
+    variant_ids.each do |variant_id|
+      DeleteProductRichContentWorker.perform_async(product.id, variant_id)
+      DeleteProductFilesArchivesWorker.perform_async(product.id, variant_id)
+    end
+
+    product.invalidate_cache
+    # `update_all` above skips callbacks, so TouchesProductForPriceCache never fires and
+    # `invalidate_cache` does not write `links`. Deleting the cheapest tier would otherwise
+    # leave the storefront advertising its price (Pages::ProfileData keys on links.updated_at).
+    product.touch if newly_deleted.any?
+
+    newly_deleted.map(&:external_id)
+  end
+
   def perform
     if category_params[:id].present?
       self.variant_category = variant_categories.find_by_external_id(category_params[:id])
@@ -314,37 +350,8 @@ class Product::VariantCategoryUpdaterService
       )
     end
 
-    # Returns the external ids of the variants this call actually soft-deleted,
-    # which the deletion audit records. That is narrower than `variants`: a
-    # variant an earlier save already deleted stays deleted with its original
-    # timestamp (see below), and attributing it to this request would overstate
-    # what this save removed.
     def batch_delete_variants(variants)
-      variant_ids = variants.respond_to?(:pluck) ? variants.pluck(:id) : variants.map(&:id)
-      return [] if variant_ids.empty?
-
-      # Only stamp variants that aren't already deleted, so a variant keeps the
-      # timestamp from the save that actually deleted it. Support uses that
-      # timestamp to find which rows a bad save wiped.
-      now = Time.current
-      newly_deleted = BaseVariant.where(id: variant_ids).alive.to_a
-      BaseVariant.where(id: newly_deleted.map(&:id)).update_all(deleted_at: now, updated_at: now) if newly_deleted.any?
-
-      # Cleanup runs for every id, including ones deleted earlier: an earlier
-      # delete may not have finished cleaning up, and both workers are safe to
-      # run twice.
-      variant_ids.each do |variant_id|
-        DeleteProductRichContentWorker.perform_async(product.id, variant_id)
-        DeleteProductFilesArchivesWorker.perform_async(product.id, variant_id)
-      end
-
-      product.invalidate_cache
-      # `update_all` above skips callbacks, so TouchesProductForPriceCache never fires and
-      # `invalidate_cache` does not write `links`. Deleting the cheapest tier would otherwise
-      # leave the storefront advertising its price (Pages::ProfileData keys on links.updated_at).
-      product.touch if newly_deleted.any?
-
-      newly_deleted.map(&:external_id)
+      self.class.batch_delete_variants(product:, variants:)
     end
 
     def create_or_update_variant!(external_id, params)

--- a/app/services/product/variants_updater_service.rb
+++ b/app/services/product/variants_updater_service.rb
@@ -101,35 +101,39 @@ class Product::VariantsUpdaterService
       next if grouping_protected_from_sweep?(variant_category)
 
       # Captured before the sweep: these are the versions whose removal this
-      # operation authorises, and the same list the guard checks. Read afterwards
-      # it would still be accurate today (the sweep does not soft-delete them)
-      # but that is an accident of the missing `dependent:` option, not something
-      # the audit should rely on.
-      affected_variant_external_ids = variant_category.alive_variants.map(&:external_id)
+      # operation authorises, and the same list the guard checks.
+      variants_to_sweep = variant_category.alive_variants.to_a
+      affected_variant_external_ids = variants_to_sweep.map(&:external_id)
 
       Product::VariantCategoryUpdaterService.ensure_deletion_intent!(
         product:,
-        variants: variant_category.alive_variants.to_a,
+        variants: variants_to_sweep,
         confirmed_removed_variant_ids:,
         diagnostics: deletion_guard_diagnostics
       )
+      # The versions go with their grouping. VariantCategory's `has_many
+      # :variants` has no `dependent:` option, so `mark_deleted!` alone leaves
+      # them alive under a deleted grouping — a state no editor query expects,
+      # which broke both loading and saving the product carrying it
+      # (gumroad-private#1784). The guard above authorised removing exactly
+      # this list, and the shared deletion path also schedules the cleanup of
+      # their pages, so nothing live is left hanging off the dead grouping.
+      deleted_variant_external_ids = Product::VariantCategoryUpdaterService.batch_delete_variants(
+        product:,
+        variants: variants_to_sweep
+      )
       variant_category.mark_deleted!
 
-      # Marking the grouping deleted does NOT soft-delete its versions —
-      # VariantCategory's `has_many :variants` has no `dependent:` option — so
-      # any versions alive here stay alive under a deleted grouping. Two
-      # consequences for the audit:
-      #
-      # 1. `alive_child_variant_count` records that, so the no-cascade behaviour
-      #    is visible in data rather than something you have to know to look for.
-      # 2. Intent has to be judged against the versions this sweep AUTHORISED
-      #    removing (`affected_variant_external_ids`), not against soft-deleted
-      #    rows — there are none here. Judging it from the deleted set would
-      #    report a sweep the seller explicitly confirmed as omission-driven.
+      # `alive_child_variant_count` predates the version sweep above and now
+      # records 0 for new rows; kept so old audit rows stay interpretable.
+      # Intent is judged against the versions this sweep AUTHORISED removing
+      # (`affected_variant_external_ids`) — a version an earlier save already
+      # deleted is not attributed to this request.
       ProductVariantDeletionAudit.record_deletion(
         actor_user_id: deletion_audit_context[:actor_user_id],
         product_id: product.id,
         route: ProductVariantDeletionAudit::EDITOR_CATEGORY_SWEPT,
+        deleted_variant_external_ids:,
         deleted_variant_category_external_ids: [variant_category.external_id],
         affected_variant_external_ids: affected_variant_external_ids,
         confirmed_removed_variant_ids:,

--- a/spec/controllers/links_controller_update_orphaned_variants_spec.rb
+++ b/spec/controllers/links_controller_update_orphaned_variants_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Regression coverage for gumroad-private#1784.
+#
+# When an editor save's payload doesn't mention a variant grouping at all, the
+# save sweeps that grouping. The sweep used to mark only the grouping deleted:
+# its versions (and their pages) stayed alive under a soft-deleted parent, a
+# state the editor can neither display nor save back. These specs pin that a
+# swept grouping takes its versions down with it, so that state can no longer
+# be produced by the editor.
+describe LinksController, type: :controller do
+  let(:seller) { create(:user) }
+  let(:product) { create(:product, user: seller) }
+
+  before { sign_in seller }
+
+  def file_embed_page(file)
+    [{ "type" => "fileEmbed", "attrs" => { "id" => file.external_id, "uid" => SecureRandom.uuid } }]
+  end
+
+  def paragraph(text)
+    [{ "type" => "paragraph", "content" => [{ "type" => "text", "text" => text }] }]
+  end
+
+  def editor_save_params(variants_params)
+    {
+      id: product.unique_permalink,
+      name: product.name,
+      description: "A description",
+      price_currency_type: "usd",
+      price_cents: product.price_cents,
+      customizable_price: false,
+      covers: [],
+      files: [],
+      has_same_rich_content_for_all_variants: false,
+      rich_content: [],
+      variants: variants_params,
+      confirmed_removed_variant_ids: [],
+      confirmed_removed_rich_content_ids: [],
+      preserved_rich_content_ids: [],
+      rich_content_provenance_version: 1,
+    }
+  end
+
+  it "sweeps an unsubmitted grouping's versions together with the grouping instead of leaving them alive under it" do
+    # The production shape behind gumroad-private#1784: a duplicate "Version"
+    # grouping whose versions carry file-embed pages. The editor only ever
+    # addresses the first alive grouping, so the duplicate is absent from the
+    # payload and gets swept. The seller confirmed removing its versions — but
+    # the sweep left the versions and their pages alive under the soft-deleted
+    # grouping, and that state broke every later editor load and save.
+    file = create(:product_file, link: product)
+    live_category = create(:variant_category, link: product, title: "Version")
+    live_variant = create(:variant, variant_category: live_category, name: "Free Trial")
+    live_page = create(:rich_content, entity: live_variant, title: "Download", description: paragraph("Download instructions"))
+
+    old_category = create(:variant_category, link: product, title: "Version")
+    old_variants = ["1 Mac", "2 Macs"].map { |name| create(:variant, variant_category: old_category, name: name) }
+    old_variants.each { |variant| create(:rich_content, entity: variant, title: nil, description: file_embed_page(file)) }
+
+    params = editor_save_params(
+      [
+        {
+          id: live_variant.external_id,
+          name: live_variant.name,
+          price_difference_cents: 0,
+          rich_content: [
+            {
+              id: live_page.external_id,
+              title: live_page.title,
+              description: { type: "doc", content: paragraph("Edited instructions") },
+            }
+          ],
+        }
+      ]
+    )
+    params[:confirmed_removed_variant_ids] = old_variants.map(&:external_id)
+
+    post :update, params: params, as: :json
+
+    expect(response).to be_successful
+    expect(live_page.reload.description).to eq(paragraph("Edited instructions"))
+    expect(old_category.reload).to be_deleted
+    old_variants.each { |variant| expect(variant.reload).to be_deleted }
+    expect(BaseVariant.alive.where(variant_category_id: product.variant_categories.deleted.select(:id))).to be_empty
+    expect(DeleteProductRichContentWorker.jobs.map { _1["args"] }).to include(*old_variants.map { [product.id, _1.id] })
+  end
+end

--- a/spec/services/product/variants_updater_service_spec.rb
+++ b/spec/services/product/variants_updater_service_spec.rb
@@ -242,6 +242,25 @@ describe Product::VariantsUpdaterService do
         expect(@size_category.reload).not_to be_alive
       end
 
+      it "soft-deletes the swept category's variants and schedules their content cleanup" do
+        # Regression for gumroad-private#1784: the sweep marked only the
+        # category deleted, leaving its variants (and their pages) alive under
+        # a soft-deleted parent — a state the editor cannot load or save back.
+        small = create(:variant, variant_category: @size_category, name: "Small")
+        medium = create(:variant, variant_category: @size_category, name: "Medium")
+
+        Product::VariantsUpdaterService.new(
+          product: @product,
+          variants_params: @variant_categories
+        ).perform
+
+        expect(@size_category.reload).not_to be_alive
+        expect(small.reload).to be_deleted
+        expect(medium.reload).to be_deleted
+        expect(DeleteProductRichContentWorker.jobs.map { _1["args"] }).to include([@product.id, small.id], [@product.id, medium.id])
+        expect(DeleteProductFilesArchivesWorker.jobs.map { _1["args"] }).to include([@product.id, small.id], [@product.id, medium.id])
+      end
+
       it "does not mark a category deleted if it has purchases and files" do
         small_variant = create(:variant, :with_product_file, variant_category: @size_category, name: "Small")
         create(:purchase, link: @product, variant_attributes: [small_variant])

--- a/test/controllers/links_controller_test.rb
+++ b/test/controllers/links_controller_test.rb
@@ -6611,10 +6611,11 @@ class LinksControllerDeletionAuditTest < ActionController::TestCase
   # --- the outer category sweep (Product::VariantsUpdaterService) ---
   #
   # A whole grouping absent from the payload is swept after each submitted
-  # grouping is processed. Marking it deleted does NOT soft-delete its versions,
-  # so intent must be judged against the versions the sweep authorised removing.
-  # Judging it from the (empty) deleted set reported every sweep as
-  # omission-driven, including fully confirmed ones.
+  # grouping is processed. The sweep soft-deletes the grouping's versions with
+  # it (gumroad-private#1784 — leaving them alive under a deleted grouping is a
+  # state the editor cannot load or save back). Intent is still judged against
+  # the versions the sweep authorised removing: judging it from the deleted set
+  # would misreport a version an earlier save had already removed.
 
   test "a swept category whose children were all confirmed records intent as confirmed ids" do
     swept = create_variant_category(link: @product, title: "Swept")
@@ -6631,10 +6632,12 @@ class LinksControllerDeletionAuditTest < ActionController::TestCase
     assert_not_nil audit, "expected an audit for the swept category"
     assert_equal [swept.external_id], audit.deleted_variant_category_external_ids
     assert_equal [child.external_id], audit.affected_variant_external_ids
+    assert_equal [child.external_id], audit.deleted_variant_external_ids
     assert_equal ProductVariantDeletionAudit::CONFIRMED_IDS, audit.intent_source
     assert_equal 0, audit.unconfirmed_affected_variant_count
-    # The no-cascade behaviour is recorded rather than left to be discovered.
-    assert_equal 1, audit.alive_child_variant_count
+    # The sweep takes the versions with the grouping, so none stay alive under it.
+    assert_equal 0, audit.alive_child_variant_count
+    assert_equal true, child.reload.deleted?
   end
 
   test "a swept category with some children confirmed records intent as mixed" do
@@ -7212,9 +7215,8 @@ class LinksControllerSaveContractTest < ActionController::TestCase
 
     assert_not other_category.reload.alive?
     assert kept.reload.alive?
-    # Sweeping a grouping does not cascade to its versions (VariantCategory's
-    # `has_many :variants` has no `dependent:` option), so aliveness alone cannot
-    # say WHICH route deleted the grouping. The audit row names it.
+    # Aliveness alone cannot say WHICH route deleted the grouping; the audit
+    # row names it.
     audit = ProductVariantDeletionAudit.where(route: ProductVariantDeletionAudit::EDITOR_CATEGORY_SWEPT).last
     assert_not_nil audit, "the grouping should have been deleted by the named-grouping sweep"
     assert_includes audit.deleted_variant_category_external_ids, other_category.external_id


### PR DESCRIPTION
## What

Makes the product editor's variant-grouping sweep delete the grouping's versions together with the grouping. When a save payload doesn't mention a grouping at all, `Product::VariantsUpdaterService` sweeps it — but the sweep only called `mark_deleted!` on the `VariantCategory` row. Its versions (and their rich content pages) stayed alive under a soft-deleted parent. The sweep now routes those versions through the same shared deletion path the per-version diff route already uses (extracted to `Product::VariantCategoryUpdaterService.batch_delete_variants`), which soft-deletes them, schedules `DeleteProductRichContentWorker` / `DeleteProductFilesArchivesWorker` cleanup for their pages and archives, and records the deleted ids on the existing `EDITOR_CATEGORY_SWEPT` audit row.

Fixes the code side of antiwork/gumroad-private#1784.

## Why

That issue's product carried two `variant_categories` rows both titled "Version" — one soft-deleted with four **alive** `BaseVariant` rows and live per-variant `RichContent` still hanging off it. Root cause of how that invalid state occurs: the editor only ever addresses the product's first alive grouping, so a duplicate grouping is never in the payload and gets swept on the next ordinary save; `VariantCategory`'s `has_many :variants` has no `dependent:` option, so `mark_deleted!` orphans the live versions and their pages. (The API's `variant_categories#destroy` can produce the same shape, but that endpoint documents it as an explicit caller decision; the editor sweep is the path a seller hits by just pressing "Save changes".)

Once the state exists, alive-scoped editor queries can't see the orphans, but any save session that still lists them is permanently rejected by the deletion guards: reproduced locally, a save whose payload omits the duplicate grouping's content-bearing versions fails 422 with "This save would remove versions that still have content… please refresh the page and try again" on every retry, and a session that resubmits an orphan's page while a duplicate live `RichContent` row exists fails 422 the same way — the seller experiences a save that never persists. Making the sweep take its versions down deterministically (still behind the existing deletion-intent guard, so only versions the seller confirmed removing or blank ones are affected) prevents the state from being minted by the editor at all. A blocked sweep still blocks the save exactly as before.

Deliberately out of scope: repairing rows that already carry the degenerate state in production. That is a separate onetime task if still needed (the issue's product was already cleaned up by support via console).

## Before/After

Before: an editor save that sweeps an unsubmitted grouping leaves that grouping's versions alive under the soft-deleted category — `BaseVariant.alive.where(variant_category_id: <deleted category>)` is non-empty, their `RichContent` rows stay alive, and no cleanup jobs are enqueued. After: the same save soft-deletes the versions with their grouping and enqueues the content/archive cleanup jobs; the audit row now also records the deleted variant ids and reports `alive_child_variant_count: 0`.

This is a non-user-visible server-side change (the editor UI flow is unchanged); a walkthrough video of the relevant editor save behavior will follow separately — not attaching one preemptively rather than fabricating it.

## Test Results

New regression coverage, verified to fail without the fix and pass with it:

- `spec/controllers/links_controller_update_orphaned_variants_spec.rb` — full editor-shaped save over the issue's exact data shape (duplicate "Version" groupings, file-embed pages, confirmed removals). Without the fix: fails on `expect(variant.reload).to be_deleted` (versions left alive under the deleted grouping). With the fix: passes.
- `spec/services/product/variants_updater_service_spec.rb` — "soft-deletes the swept category's variants and schedules their content cleanup". Without the fix: fails on `expect(small.reload).to be_deleted`. With the fix: passes.

Suites run locally (MySQL/ES test env):

- `bundle exec rspec spec/controllers/links_controller_update_orphaned_variants_spec.rb spec/services/product/variants_updater_service_spec.rb spec/services/product/variant_category_updater_service_spec.rb spec/services/product/variant_category_updater_service_contract_spec.rb` — 60 examples, 1 failure: `does not mark a category deleted if it has purchases and files` fails locally in `create(:purchase, …)` setup on the shared card fixtures (pre-existing local-environment caveat, unrelated to this change — needs CI to confirm).
- `bundle exec rspec spec/controllers/api/v2/variant_categories_controller_spec.rb spec/controllers/api/v2/variants_controller_spec.rb` — 84 examples, 0 failures.
- `bin/rails test test/controllers/links_controller_test.rb -n "/grouping|category|deletion|contract/"` — 40 runs, 0 failures (includes the `EDITOR_CATEGORY_SWEPT` audit tests, updated for the sweep now cascading).
- `bin/rails test test/controllers/links_controller_test.rb -n "/variant|version/"` — 71 runs, 0 failures.
- `bin/rails test test/integration/product_variant_deletion_audit_request_id_test.rb` — 2 runs, 0 failures.
- `bundle exec rubocop` on all changed files — no offenses.

---

**AI disclosure:** Written by Claude Fable 5 (subagent), directed by @slavingia. Prompt: fix the bug in antiwork/gumroad-private#1784 (product content editor save hangs and silently discards changes when a product has duplicate variant categories and orphaned live variants) — reproduce the failure shape in a spec first, pick the smallest safe server-side fix, no data-repair migrations.
