### PR TITLE
Fix stale Fonts seed spec assertion after #6962

### DIFF
--- a/spec/services/onetime/seed_taxonomy_attributes_spec.rb
+++ b/spec/services/onetime/seed_taxonomy_attributes_spec.rb
@@ -15,8 +15,8 @@ describe Onetime::SeedTaxonomyAttributes do
   it "creates the registry's definitions for the matched taxonomy" do
     result = described_class.process(dry_run: false)
 
-    expect(result[:created]).to eq(4)
-    expect(TaxonomyAttribute.where(taxonomy: fonts).pluck(:name)).to match_array(%w[format license variable_font styles])
+    expect(result[:created]).to eq(6)
+    expect(TaxonomyAttribute.where(taxonomy: fonts).pluck(:name)).to match_array(%w[classification format license variable_font has_multiple_weights styles])
 
     format = TaxonomyAttribute.find_by(taxonomy: fonts, name: "format")
     expect(format.label).to eq("Format")


### PR DESCRIPTION
## What

Fixes `spec/services/onetime/seed_taxonomy_attributes_spec.rb`, which still asserted the pre-#6962 4-attribute result for `design/fonts`.

## Why

#6962 (merged) expanded the `design/fonts` registry from 4 to 6 attributes (`classification`, `has_multiple_weights` added). Greptile flagged post-merge that the spec's "creates the registry's definitions" example was stale — it asserted `result[:created]).to eq(4)` and the old 4-name set, both now wrong against `origin/main`. Confirmed the spec was red before this fix by reading it against the current registry.

## Before / After

- Before: `expect(result[:created]).to eq(4)` / `match_array(%w[format license variable_font styles])`
- After: `expect(result[:created]).to eq(6)` / `match_array(%w[classification format license variable_font has_multiple_weights styles])`

## Test Results

- `bundle exec rspec spec/services/onetime/seed_taxonomy_attributes_spec.rb` (lane 0, `origin/main` HEAD 1b5c1afc5) — 5 examples, 0 failures.

## QA steps

N/A — test-only fix, no runtime behavior change. Verified the corrected assertion matches `TaxonomyAttributeDefinitions::DEFINITIONS["design/fonts"]` on `origin/main`.

## Status

- [x] Scope — one stale assertion in one spec file, confirmed against `origin/main`'s current registry.
- [x] Design — mirror the shipped `TaxonomyAttributeDefinitions::DEFINITIONS["design/fonts"]` names/count, no other change.
- [x] Build — spec updated.
- [x] QA — n/a (test-only, no runtime behavior).
- [x] Shipped — CI pending on this PR.
- [x] Market/Sell — n/a, internal test fix.

---

AI disclosure: Implemented by Hermes Agent. Prompt: fix a Greptile-flagged stale test assertion left behind by merged PR #6962.
