### PR TITLE
Lower checkout reCAPTCHA score threshold

### DIFF
--- a/app/controllers/concerns/validate_recaptcha.rb
+++ b/app/controllers/concerns/validate_recaptcha.rb
@@ -41,12 +41,12 @@ module ValidateRecaptcha
   # Default score thresholds used when the per-surface Redis key is unset.
   # Surfaces not listed here default to nil (no score gating — token validity
   # alone). The score-based checkout key returns a score for ~every valid token,
-  # so it gates at 0.5 out of the box; trusted buyers (see CheckoutRecaptcha) get
+  # so it gates at 0.4 out of the box; trusted buyers (see CheckoutRecaptcha) get
   # a more lenient 0.3 bar. Override at runtime per surface by setting
   # RedisKey.recaptcha_score_threshold(surface), e.g.
   # $redis.set(RedisKey.recaptcha_score_threshold(:checkout_score), "0.4").
   RECAPTCHA_SCORE_THRESHOLD_DEFAULTS = {
-    checkout_score: 0.5,
+    checkout_score: 0.4,
     checkout_score_trusted: 0.3,
   }.freeze
   RECAPTCHA_SCORE_LOG_PREFIX = "[recaptcha_score]"

--- a/spec/controllers/concerns/validate_recaptcha_spec.rb
+++ b/spec/controllers/concerns/validate_recaptcha_spec.rb
@@ -219,7 +219,7 @@ describe ValidateRecaptcha, type: :controller do
         expect(parsed_body["success"]).to be true
       end
 
-      it "rejects a low score using the default 0.5 threshold when Redis is unset" do
+      it "rejects a low score using the default 0.4 threshold when Redis is unset" do
         stub_recaptcha_response(valid: true, score: 0.1)
 
         post :checkout_score_action, params: { "g-recaptcha-response" => "test_token" }
@@ -228,8 +228,8 @@ describe ValidateRecaptcha, type: :controller do
         expect(parsed_body["error"]).to eq("captcha_failed")
       end
 
-      it "passes a score at or above the default 0.5 threshold when Redis is unset" do
-        stub_recaptcha_response(valid: true, score: 0.7)
+      it "passes a score at or above the default 0.4 threshold when Redis is unset" do
+        stub_recaptcha_response(valid: true, score: 0.4)
 
         post :checkout_score_action, params: { "g-recaptcha-response" => "test_token" }
 
@@ -249,7 +249,7 @@ describe ValidateRecaptcha, type: :controller do
 
       describe "#recaptcha_failure_message" do
         it "does not blame ad blockers when a genuine, correctly-hosted token failed on score alone" do
-          stub_recaptcha_response(valid: true, score: 0.4)
+          stub_recaptcha_response(valid: true, score: 0.3)
 
           post :checkout_score_message_action, params: { "g-recaptcha-response" => "test_token" }
 


### PR DESCRIPTION
## What

Lower the default score-based checkout reCAPTCHA threshold for the untrusted checkout surface from `0.5` to `0.4`.

Trusted checkout stays at `0.3`, and explicit Redis overrides still win.

## Why

Ref antiwork/gumroad-private#1590. Sahil asked to “lower the bar a notch to start.” Production measurements on the issue showed the single largest rejected-on-score bucket was `0.4`, one notch below the old `0.5` bar. This lets those valid, correctly-hosted tokens proceed while preserving score gating below `0.4`.

This is intentionally separate from #6810’s larger challenge-fallback approach.

## Status

- [x] Scope — one default threshold plus matching focused specs.
- [x] Design — lower only `checkout_score`; leave trusted `checkout_score_trusted` and Redis override behavior unchanged.
- [x] Build — committed and pushed.
- [x] QA — focused controller specs and rubocop clean locally.
- [ ] Shipped — awaiting CI / review.
- [x] Market — n/a.
- [x] Sell — n/a.

## Test Results

- `./bin/bundle exec rspec spec/controllers/concerns/validate_recaptcha_spec.rb` — 39 examples, 0 failures.
- `./bin/bundle exec rubocop app/controllers/concerns/validate_recaptcha.rb spec/controllers/concerns/validate_recaptcha_spec.rb` — 2 files inspected, no offenses detected.
- Autoreview panel (`codex` + `claude`, `--max-priority P1`) — clean, 0 findings.

## Notes

No UI media: this changes a server-side fraud threshold. The behavior is pinned by focused controller specs: score `0.4` now passes by default on `checkout_score`, while lower scores still fail and Redis override behavior remains covered.

---
AI assistance disclosure: Gumclaw used Hermes Agent with GPT-5.5 to inspect the issue, implement Sahil’s requested threshold change, and run focused verification.

