### PR TITLE
Fail loudly instead of hanging on an unresolvable variant id during save (gumroad-private#1784)

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -667,6 +667,22 @@ class LinksController < ApplicationController
         error_message = @product.errors.full_messages.first || e.message
       end
       return render json: { error_message: }, status: :unprocessable_entity
+    rescue => e
+      # Defense in depth for gumroad-private#1784: every guard above this line
+      # translates its own failure mode into a specific rescue with a seller-
+      # readable message. Anything NOT already one of those — a bug in a
+      # service this save flow calls, a transient DB error, anything we
+      # haven't anticipated — used to propagate straight out of this method as
+      # a bare 500. The transaction still rolls back either way (nothing is
+      # ever half-persisted), but an uncaught exception here previously left
+      # the editor's save request with no readable JSON body: from the
+      # browser that is indistinguishable from a hang, which is exactly what
+      # gp1784 reported ("Saving changes..." never resolves, nothing
+      # persists, no visible error). Mirrors the existing catch-all in
+      # `publish` above. Every branch of this method must end in an
+      # unambiguous "saved" or "here's why not" — never a bare timeout.
+      ErrorNotifier.notify(e)
+      return render json: { error_message: "Something went wrong while saving your changes. Please refresh the page and try again — if the problem continues, contact support." }, status: :unprocessable_entity
     end
     report_unapplied_deletions!
     report_unstated_confirmed_removals!

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -668,19 +668,9 @@ class LinksController < ApplicationController
       end
       return render json: { error_message: }, status: :unprocessable_entity
     rescue => e
-      # Defense in depth for gumroad-private#1784: every guard above this line
-      # translates its own failure mode into a specific rescue with a seller-
-      # readable message. Anything NOT already one of those — a bug in a
-      # service this save flow calls, a transient DB error, anything we
-      # haven't anticipated — used to propagate straight out of this method as
-      # a bare 500. The transaction still rolls back either way (nothing is
-      # ever half-persisted), but an uncaught exception here previously left
-      # the editor's save request with no readable JSON body: from the
-      # browser that is indistinguishable from a hang, which is exactly what
-      # gp1784 reported ("Saving changes..." never resolves, nothing
-      # persists, no visible error). Mirrors the existing catch-all in
-      # `publish` above. Every branch of this method must end in an
-      # unambiguous "saved" or "here's why not" — never a bare timeout.
+      # Catch-all so an unanticipated failure never leaves the editor's save
+      # request with no JSON body (gumroad-private#1784) — mirrors `publish`
+      # above.
       ErrorNotifier.notify(e)
       return render json: { error_message: "Something went wrong while saving your changes. Please refresh the page and try again — if the problem continues, contact support." }, status: :unprocessable_entity
     end

--- a/app/services/product/variant_category_updater_service.rb
+++ b/app/services/product/variant_category_updater_service.rb
@@ -206,21 +206,36 @@ class Product::VariantCategoryUpdaterService
       validate_variant_recurrences!(category_params[:options])
       category_params[:options].each_with_index do |option, index|
         begin
-          variant = create_or_update_variant!(option[:id],
-                                              name: option[:name],
-                                              description: option[:description],
-                                              duration_in_minutes: option[:duration_in_minutes],
-                                              price_difference_cents: string_to_price_cents(
-                                                price_currency_type.to_sym,
-                                                option[:price_difference].to_s
-                                              ),
-                                              customizable_price: option[:customizable_price],
-                                              max_purchase_count: option[:max_purchase_count],
-                                              position_in_category: index,
-                                              variant_category:,
-                                              apply_price_changes_to_existing_memberships: !!option[:apply_price_changes_to_existing_memberships],
-                                              subscription_price_change_effective_date: option[:subscription_price_change_effective_date],
-                                              subscription_price_change_message: option[:subscription_price_change_message])
+          variant =
+            begin
+              create_or_update_variant!(option[:id],
+                                        name: option[:name],
+                                        description: option[:description],
+                                        duration_in_minutes: option[:duration_in_minutes],
+                                        price_difference_cents: string_to_price_cents(
+                                          price_currency_type.to_sym,
+                                          option[:price_difference].to_s
+                                        ),
+                                        customizable_price: option[:customizable_price],
+                                        max_purchase_count: option[:max_purchase_count],
+                                        position_in_category: index,
+                                        variant_category:,
+                                        apply_price_changes_to_existing_memberships: !!option[:apply_price_changes_to_existing_memberships],
+                                        subscription_price_change_effective_date: option[:subscription_price_change_effective_date],
+                                        subscription_price_change_message: option[:subscription_price_change_message])
+            rescue ActiveRecord::RecordNotFound
+              # Scoped to the lookup inside `create_or_update_variant!` (via
+              # `find_by_external_id!`) so it only fires when the submitted
+              # variant id itself no longer resolves under this product — e.g.
+              # the editor's in-memory snapshot still references a version
+              # another session (or an earlier save in the SAME request) has
+              # since deleted. A `RecordNotFound` from anything downstream
+              # (like a missing `ProductFile`) is a different failure and must
+              # fall through to the generic rescue below instead of being
+              # mislabeled as a stale variant.
+              errors.add(:base, "This save would remove content pages that weren't explicitly deleted. The content shown in the editor may be out of date — please refresh the page and try again.")
+              raise Link::LinkInvalid
+            end
           save_integrations(variant, option)
           visited_variant_external_ids << variant.external_id
           save_rich_content(variant, option)
@@ -231,24 +246,6 @@ class Product::VariantCategoryUpdaterService
           # editor needs to offer the seller an explicit choice. The generic
           # re-raise below would flatten it into a plain Link::LinkInvalid.
           raise
-        rescue ActiveRecord::RecordNotFound
-          # `create_or_update_variant!` raises this (via `find_by_external_id!`)
-          # when the submitted variant id no longer resolves to a live variant
-          # under this product — e.g. the editor's in-memory snapshot still
-          # references a version another session (or an earlier save in the
-          # SAME request) has since deleted. Left unrescued this propagated all
-          # the way out of the `ActiveRecord::Base.transaction` in
-          # `LinksController#update` as a bare 500: the transaction rolled back
-          # (so nothing was silently half-saved), but the response was neither
-          # the JSON error shape the editor's save handler expects nor a
-          # message a seller could read — from the browser it looked exactly
-          # like the hang gumroad-private#1784 reported ("Saving changes..."
-          # never resolves, nothing persists, no visible error). Converting it
-          # here to the same `Link::LinkInvalid` path every other per-variant
-          # failure already uses gives the seller an actual message and asks
-          # them to refresh, instead of letting the request die silently.
-          errors.add(:base, "This save would remove content pages that weren't explicitly deleted. The content shown in the editor may be out of date — please refresh the page and try again.")
-          raise Link::LinkInvalid
         rescue ActiveRecord::RecordInvalid, Link::LinkInvalid, ArgumentError => e
           error_message = variant.present? ? variant.errors.full_messages.to_sentence : e.message
           errors.add(:base, error_message)

--- a/app/services/product/variant_category_updater_service.rb
+++ b/app/services/product/variant_category_updater_service.rb
@@ -3,6 +3,11 @@
 class Product::VariantCategoryUpdaterService
   include CurrencyHelper
 
+  # Distinct from ActiveRecord::RecordNotFound so the per-variant rescue in
+  # `perform` can't also catch a downstream missing-record failure (e.g. a
+  # missing ProductFile) raised later in the same begin block.
+  StaleVariantReferenceError = Class.new(StandardError)
+
   attr_reader :product, :category_params, :confirmed_removed_variant_ids, :payload_page_ids, :confirmed_removed_rich_content_ids, :preserved_rich_content_ids, :rewrite_budget, :deletion_guard_diagnostics, :id_mappings, :legacy_dead_file_embed_ids_by_rich_content_id, :deletion_audit_context, :contract
   attr_accessor :variant_category
 
@@ -223,16 +228,13 @@ class Product::VariantCategoryUpdaterService
                                         apply_price_changes_to_existing_memberships: !!option[:apply_price_changes_to_existing_memberships],
                                         subscription_price_change_effective_date: option[:subscription_price_change_effective_date],
                                         subscription_price_change_message: option[:subscription_price_change_message])
-            rescue ActiveRecord::RecordNotFound
-              # Scoped to the lookup inside `create_or_update_variant!` (via
-              # `find_by_external_id!`) so it only fires when the submitted
-              # variant id itself no longer resolves under this product — e.g.
-              # the editor's in-memory snapshot still references a version
-              # another session (or an earlier save in the SAME request) has
-              # since deleted. A `RecordNotFound` from anything downstream
-              # (like a missing `ProductFile`) is a different failure and must
-              # fall through to the generic rescue below instead of being
-              # mislabeled as a stale variant.
+            rescue StaleVariantReferenceError
+              # Raised only by the lookup inside `create_or_update_variant!`
+              # (via `find_by_external_id!`), never by anything downstream —
+              # see that method for why a plain `ActiveRecord::RecordNotFound`
+              # can't be rescued here without also mislabeling a later
+              # missing-record failure (e.g. a missing `ProductFile`) as a
+              # stale variant.
               errors.add(:base, "This save would remove content pages that weren't explicitly deleted. The content shown in the editor may be out of date — please refresh the page and try again.")
               raise Link::LinkInvalid
             end
@@ -372,7 +374,17 @@ class Product::VariantCategoryUpdaterService
     def create_or_update_variant!(external_id, params)
       return Variant.create!(params.slice(*ALLOWED_ATTRIBUTES)) if external_id.blank?
 
-      variant = product.variants.find_by_external_id!(external_id)
+      begin
+        variant = product.variants.find_by_external_id!(external_id)
+      rescue ActiveRecord::RecordNotFound
+        # The submitted variant id no longer resolves under this product —
+        # e.g. the editor's in-memory snapshot still references a version
+        # another session (or an earlier variant in the SAME save request,
+        # via the deletion-audit/keep-variants bookkeeping) has since
+        # deleted. Wrapped in its own class so callers can't also catch a
+        # RecordNotFound raised later by save!/assign_attributes below.
+        raise StaleVariantReferenceError
+      end
       variant.assign_attributes(params.slice(*ALLOWED_ATTRIBUTES))
 
       if variant.apply_price_changes_to_existing_memberships_changed? && !variant.apply_price_changes_to_existing_memberships?

--- a/app/services/product/variant_category_updater_service.rb
+++ b/app/services/product/variant_category_updater_service.rb
@@ -231,6 +231,24 @@ class Product::VariantCategoryUpdaterService
           # editor needs to offer the seller an explicit choice. The generic
           # re-raise below would flatten it into a plain Link::LinkInvalid.
           raise
+        rescue ActiveRecord::RecordNotFound
+          # `create_or_update_variant!` raises this (via `find_by_external_id!`)
+          # when the submitted variant id no longer resolves to a live variant
+          # under this product — e.g. the editor's in-memory snapshot still
+          # references a version another session (or an earlier save in the
+          # SAME request) has since deleted. Left unrescued this propagated all
+          # the way out of the `ActiveRecord::Base.transaction` in
+          # `LinksController#update` as a bare 500: the transaction rolled back
+          # (so nothing was silently half-saved), but the response was neither
+          # the JSON error shape the editor's save handler expects nor a
+          # message a seller could read — from the browser it looked exactly
+          # like the hang gumroad-private#1784 reported ("Saving changes..."
+          # never resolves, nothing persists, no visible error). Converting it
+          # here to the same `Link::LinkInvalid` path every other per-variant
+          # failure already uses gives the seller an actual message and asks
+          # them to refresh, instead of letting the request die silently.
+          errors.add(:base, "This save would remove content pages that weren't explicitly deleted. The content shown in the editor may be out of date — please refresh the page and try again.")
+          raise Link::LinkInvalid
         rescue ActiveRecord::RecordInvalid, Link::LinkInvalid, ArgumentError => e
           error_message = variant.present? ? variant.errors.full_messages.to_sentence : e.message
           errors.add(:base, error_message)

--- a/spec/services/product/variant_category_updater_service_spec.rb
+++ b/spec/services/product/variant_category_updater_service_spec.rb
@@ -21,8 +21,15 @@ describe Product::VariantCategoryUpdaterService do
         }
       end
 
-      it "raises an error and does not update the variant" do
-        expect { Product::VariantCategoryUpdaterService.new(product: product, category_params: variant_category_params).perform }.to raise_error(ActiveRecord::RecordNotFound)
+      # An id that doesn't resolve under this product used to escape as a bare
+      # ActiveRecord::RecordNotFound, which reached the editor as a 500 with no
+      # JSON body (gumroad-private#1784). It is now translated into the same
+      # Link::LinkInvalid every other save failure uses, carrying a message the
+      # seller can act on.
+      it "raises a seller-readable error and does not update the variant" do
+        expect { Product::VariantCategoryUpdaterService.new(product: product, category_params: variant_category_params).perform }
+          .to raise_error(Link::LinkInvalid)
+        expect(product.errors.full_messages).to include(a_string_matching(/content shown in the editor may be out of date/))
         expect(variant.reload.name).not_to eq other_variant.name
       end
     end

--- a/test/controllers/links_controller_gp1784_rich_content_save_test.rb
+++ b/test/controllers/links_controller_gp1784_rich_content_save_test.rb
@@ -133,6 +133,34 @@ class LinksControllerGp1784RichContentSaveTest < ActionController::TestCase
     assert_response :unprocessable_entity
   end
 
+  test "a RecordNotFound raised after variant lookup (e.g. a missing ProductFile) is not mislabeled as a stale variant" do
+    # Pins the Greptile P1 finding: only the `find_by_external_id!` lookup
+    # inside `create_or_update_variant!` should map to the stale-variant
+    # message. A RecordNotFound from anything downstream of that lookup is a
+    # different failure and must fall through to the generic catch-all
+    # instead of being reported to the seller as "content pages were removed".
+    Product::VariantCategoryUpdaterService.any_instance.stubs(:save_rich_content).raises(ActiveRecord::RecordNotFound, "Couldn't find ProductFile with 'id'=999999999")
+    rich_content_before = @free_trial_rich_content.updated_at
+
+    ErrorNotifier.expects(:notify).with(instance_of(ActiveRecord::RecordNotFound))
+
+    put :update, params: @base_params.merge(
+      variants: @variants.map do |variant|
+        rich_content = variant.alive_rich_contents.sole
+        {
+          id: variant.external_id,
+          name: variant.name,
+          rich_content: [{ id: rich_content.external_id, title: rich_content.title, description: rich_content.description }],
+        }
+      end
+    ), as: :json
+
+    assert_response :unprocessable_entity
+    assert_not_equal "This save would remove content pages that weren't explicitly deleted. The content shown in the editor may be out of date — please refresh the page and try again.",
+                     response.parsed_body["error_message"]
+    assert_equal rich_content_before, @free_trial_rich_content.reload.updated_at
+  end
+
   test "an entirely unanticipated exception during save also fails loudly instead of propagating as a bare 500" do
     # Defense in depth: even a failure mode nobody wrote a specific rescue for
     # must still surface as a readable JSON error, not an unhandled 500 that

--- a/test/controllers/links_controller_gp1784_rich_content_save_test.rb
+++ b/test/controllers/links_controller_gp1784_rich_content_save_test.rb
@@ -98,11 +98,39 @@ class LinksControllerGp1784RichContentSaveTest < ActionController::TestCase
     # could read — indistinguishable, from the browser, from a hang.
     assert_response :unprocessable_entity
     body = response.parsed_body
-    assert body["error_message"].present?, "expected a seller-readable error_message, got: #{response.body}"
+    # Pin the SERVICE-level rescue specifically: the controller's catch-all
+    # would also render 422, but with a generic message and an ErrorNotifier
+    # report. Asserting the service's refresh message (and no error report,
+    # below) means this test fails if the targeted rescue is removed and the
+    # failure merely falls through to defense-in-depth.
+    assert_includes body["error_message"].to_s, "may be out of date — please refresh",
+                    "expected the variant-not-found seller message from " \
+                    "VariantCategoryUpdaterService, got: #{response.body}"
 
     # The whole transaction rolled back: the unrelated Free Trial edit in the
     # SAME request must NOT have been silently partially applied.
     assert_equal rich_content_before, @free_trial_rich_content.reload.updated_at
+  end
+
+  test "a stale variant id takes the anticipated service rescue, not the catch-all (no error report for an expected editor-staleness case)" do
+    stale_variant = @variants.last
+    stale_variant_id = ObfuscateIds.encrypt(stale_variant.id + 999_999_999)
+    stale_variant.mark_deleted!
+
+    ErrorNotifier.expects(:notify).never
+
+    put :update, params: @base_params.merge(
+      variants: (@variants - [stale_variant]).map do |variant|
+        rich_content = variant.alive_rich_contents.sole
+        {
+          id: variant.external_id,
+          name: variant.name,
+          rich_content: [{ id: rich_content.external_id, title: rich_content.title, description: rich_content.description }],
+        }
+      end + [{ id: stale_variant_id, name: stale_variant.name }]
+    ), as: :json
+
+    assert_response :unprocessable_entity
   end
 
   test "an entirely unanticipated exception during save also fails loudly instead of propagating as a bare 500" do
@@ -111,6 +139,11 @@ class LinksControllerGp1784RichContentSaveTest < ActionController::TestCase
     # looks like a hang from the browser.
     Product::VariantCategoryUpdaterService.any_instance.stubs(:save_rich_content).raises(RuntimeError, "boom")
     rich_content_before = @free_trial_rich_content.updated_at
+
+    # The catch-all's contract is fail-loudly-BOTH-ways: readable JSON for the
+    # seller AND a report for on-call. Without this expectation, removing the
+    # ErrorNotifier call would silently regress 500-visibility to nothing.
+    ErrorNotifier.expects(:notify).with(instance_of(RuntimeError))
 
     put :update, params: @base_params.merge(
       variants: @variants.map do |variant|

--- a/test/controllers/links_controller_gp1784_rich_content_save_test.rb
+++ b/test/controllers/links_controller_gp1784_rich_content_save_test.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Pins gumroad-private#1784, item 2: on a versioned product where one submitted
+# variant id no longer resolves (already deleted by a concurrent save, or by an
+# earlier iteration within the SAME save — see VariantCategoryUpdaterService),
+# `Product::VariantCategoryUpdaterService#create_or_update_variant!` raised a bare
+# `ActiveRecord::RecordNotFound` that unwound straight out of the `update`
+# transaction. `LinksController#update`'s rescue clauses only handle
+# StaleContentConflict/StaleDeletionConflict/HiddenVariantContentConflict/
+# RecordNotSaved/RecordInvalid/LinkInvalid, so RecordNotFound was never one of
+# them — the controller returned a bare 500, the transaction rolled back
+# (nothing persisted), and from the editor's "Save changes" button this looked
+# exactly like the reported symptom: a save that neither persists nor surfaces
+# any error, hanging on "Saving changes...".
+#
+# The shape here mirrors the reporter's product qushdj (link 13633998): a
+# versioned product with several variants including one literally named
+# "Free Trial", each variant with exactly one live RichContent row and no
+# Link-level RichContent. The variant name "Free Trial" is included and
+# asserted on to rule out (not invoke) any accidental interaction with
+# subscription free-trial plumbing — the bug is purely about a stale/missing
+# variant id, unrelated to what any variant happens to be named.
+class LinksControllerGp1784RichContentSaveTest < ActionController::TestCase
+  tests LinksController
+
+  setup do
+    @seller = create_user(name: "Seller", payment_address: "seller-pay-#{SecureRandom.hex(4)}@example.com")
+    @logged_in_user = create_user
+    create_team_membership(user: @logged_in_user, seller: @seller, role: TeamMembership::ROLE_ADMIN)
+    cookies.encrypted[:current_seller_id] = @seller.id
+    sign_in @logged_in_user
+
+    @product = create_product(user: @seller)
+    @category = create_variant_category(link: @product, title: "Version")
+
+    # Five live variants, one named exactly "Free Trial", matching the
+    # reporter's product shape. Each gets exactly one live RichContent row;
+    # the product itself has no Link-level RichContent.
+    @variants = ["Free Trial", "1 Mac", "2 Macs", "3 Macs", "5 Macs"].map do |name|
+      create_variant(variant_category: @category, name:)
+    end
+    @rich_contents = @variants.map do |variant|
+      create_rich_content(entity: variant, title: "Download", description: [{ "type" => "paragraph" }])
+    end
+    @free_trial_variant = @variants.first
+    @free_trial_rich_content = @rich_contents.first
+
+    @base_params = { id: @product.unique_permalink, name: @product.name }
+  end
+
+  test "editing a RichContent row on the 'Free Trial' variant persists (rules out a name collision with subscription free-trial plumbing)" do
+    put :update, params: @base_params.merge(
+      variants: @variants.map do |variant|
+        rich_content = variant.alive_rich_contents.sole
+        {
+          id: variant.external_id,
+          name: variant.name,
+          rich_content: [{
+            id: rich_content.external_id,
+            title: rich_content.title,
+            description: variant == @free_trial_variant ? { type: "doc", content: [{ "type" => "paragraph", "content" => [{ "type" => "text", "text" => "Edited" }] }] } : rich_content.description,
+          }],
+        }
+      end
+    ), as: :json
+
+    assert_response :success
+    assert_equal [{ "type" => "paragraph", "content" => [{ "type" => "text", "text" => "Edited" }] }],
+                 @free_trial_rich_content.reload.description
+  end
+
+  test "a save naming a variant id that no longer resolves fails loudly with a JSON error instead of a bare 500 / silent no-op" do
+    stale_variant = @variants.last
+    stale_variant_id = ObfuscateIds.encrypt(stale_variant.id + 999_999_999)
+    stale_variant.mark_deleted!
+
+    rich_content_before = @free_trial_rich_content.updated_at
+
+    put :update, params: @base_params.merge(
+      variants: (@variants - [stale_variant]).map do |variant|
+        rich_content = variant.alive_rich_contents.sole
+        {
+          id: variant.external_id,
+          name: variant.name,
+          rich_content: [{
+            id: rich_content.external_id,
+            title: rich_content.title,
+            description: variant == @free_trial_variant ? { type: "doc", content: [{ "type" => "paragraph", "content" => [{ "type" => "text", "text" => "Edited" }] }] } : rich_content.description,
+          }],
+        }
+      end + [{ id: stale_variant_id, name: stale_variant.name }]
+    ), as: :json
+
+    # Before the fix this was a bare 500 (ActiveRecord::RecordNotFound
+    # escaping the transaction) with no JSON body the editor's save handler
+    # could read — indistinguishable, from the browser, from a hang.
+    assert_response :unprocessable_entity
+    body = response.parsed_body
+    assert body["error_message"].present?, "expected a seller-readable error_message, got: #{response.body}"
+
+    # The whole transaction rolled back: the unrelated Free Trial edit in the
+    # SAME request must NOT have been silently partially applied.
+    assert_equal rich_content_before, @free_trial_rich_content.reload.updated_at
+  end
+
+  test "an entirely unanticipated exception during save also fails loudly instead of propagating as a bare 500" do
+    # Defense in depth: even a failure mode nobody wrote a specific rescue for
+    # must still surface as a readable JSON error, not an unhandled 500 that
+    # looks like a hang from the browser.
+    Product::VariantCategoryUpdaterService.any_instance.stubs(:save_rich_content).raises(RuntimeError, "boom")
+    rich_content_before = @free_trial_rich_content.updated_at
+
+    put :update, params: @base_params.merge(
+      variants: @variants.map do |variant|
+        rich_content = variant.alive_rich_contents.sole
+        {
+          id: variant.external_id,
+          name: variant.name,
+          rich_content: [{ id: rich_content.external_id, title: rich_content.title, description: rich_content.description }],
+        }
+      end
+    ), as: :json
+
+    assert_response :unprocessable_entity
+    assert response.parsed_body["error_message"].present?
+    assert_equal rich_content_before, @free_trial_rich_content.reload.updated_at
+  end
+end


### PR DESCRIPTION
## Status

- [x] Scope
- [x] Design
- [x] Build
- [ ] QA
- [ ] Shipped (human merge decision required — draft, not auto-mergeable)

Continues **gumroad-private#1784, item 2** (the code fix). Item 1 (unblocking the
seller via prod-console data cleanup — duplicate live `variant_categories`,
orphaned live `BaseVariant` rows, duplicate live per-variant `RichContent`) is
already done and verified stable; this PR is the remaining open item, filed
after the customer re-tested **on cleaned-up data** and content-editor Save
**still hung silently** — proving this is a real code defect in the save path,
not just a symptom of the corrupt data state.

## What was wrong

`LinksController#update`'s per-variant save loop
(`Product::VariantCategoryUpdaterService#perform`) rescues several specific
exception classes per variant (`HiddenVariantContentConflict`,
`RecordInvalid`, `Link::LinkInvalid`, `ArgumentError`) and turns each into a
seller-readable JSON error. It did **not** rescue
`ActiveRecord::RecordNotFound`, which `create_or_update_variant!` raises (via
`find_by_external_id!`) whenever a submitted variant id no longer resolves to
a live variant under the product — e.g. the editor's in-memory snapshot still
references a version another session (or an earlier variant in the *same*
save request, via the deletion-audit/keep-variants bookkeeping) has since
deleted.

Left unrescued, that exception propagated straight out of the enclosing
`ActiveRecord::Base.transaction` in `LinksController#update` as a bare 500.
The transaction rolled back correctly (nothing was ever half-persisted), but
the HTTP response carried none of the JSON error shapes the editor's save
handler (`saveProductError` / `ResponseError` in `product_edit.ts`) expects —
so from the browser this was indistinguishable from a hang: "Saving
changes..." never resolved, nothing persisted, and no error was ever shown.
That is exactly the symptom reported against product `qushdj` (link
13633998) — a versioned product with 5 variants (incl. one named "Free
Trial"), one live RichContent row per variant, no Link-level RichContent —
even after the underlying corrupt-data state (duplicate categories, orphaned
variants) had already been cleaned up.

**The "Free Trial" name was checked explicitly and ruled out** as a factor:
there is no code path where a variant literally named "Free Trial" collides
with subscription free-trial plumbing (`has_free_trial`, etc.) — the failure
is purely about a variant id that no longer resolves, independent of what any
variant is named. A pinning spec below asserts this directly.

## Fix

1. **`Product::VariantCategoryUpdaterService#perform`**: rescue
   `ActiveRecord::RecordNotFound` in the same per-variant `begin/rescue`
   block, converting it into the existing `Link::LinkInvalid` path (same as
   every other per-variant failure in that method) with a message asking the
   seller to refresh — this is the specific, well-targeted fix for the
   reproduced defect.
2. **`LinksController#update`**: add a catch-all `rescue => e` (mirroring the
   existing one in `#publish` just below it) so that *any other*
   unanticipated exception in this save path also renders a readable JSON
   error instead of propagating as a bare 500. This is defense-in-depth per
   the issue's own ask — "make the editor either reconcile or fail loudly
   instead of hanging... A save that neither persists nor errors is the part
   the seller actually experienced" — so a *future*, still-unknown failure
   mode in this path can't reproduce the same silent-hang UX.

Neither branch of the fix changes the transaction's rollback behavior — a
failed save was never silently half-persisted either before or after this
change. The change is entirely about the response the editor gets back.

## Pinning specs

`test/controllers/links_controller_gp1784_rich_content_save_test.rb` (new):

1. Editing the RichContent on the variant literally named "Free Trial"
   persists correctly (rules out the name-collision hypothesis).
2. A save naming a variant id that no longer resolves fails with a readable
   `422` + `error_message` instead of a bare `500` / silent no-op, and the
   whole transaction rolls back (an unrelated edit in the same request is
   NOT partially applied).
3. An entirely unrelated/unanticipated exception injected into the save path
   also fails loudly via the new catch-all, instead of propagating as a bare
   500 (defense-in-depth check).

**Mutation-checked**: reverted both fixes locally and confirmed specs 2 and 3
reddened with the exact `ActiveRecord::RecordNotFound` / `RuntimeError` stack
traces this PR fixes, then restored the fixes and confirmed green again.

Ran the full existing `test/controllers/links_controller_test.rb` suite
locally against these changes to check for regressions in the surrounding
save/update flow.

## Pre-merge review (autoreview panel, codex gpt-5.6-sol + claude fable-5, P1 bar)

**Round 1** at `be5301f3` — 3 P1 findings; dispositions:

1. **Accepted (fable-5): spec vacuity.** The stale-variant spec's assertions
   were all satisfiable by the controller catch-all alone, so deleting the
   targeted service rescue survived the suite. Fixed in `a6df38d1`: the spec
   now asserts the service's specific refresh message, a new spec pins
   `ErrorNotifier.expects(:notify).never` on the anticipated path, and the
   catch-all spec requires `ErrorNotifier.notify(RuntimeError)`. Re-run
   mutation table: service rescue deleted → 2 failures; `ErrorNotifier.notify`
   deleted → 1 failure; restored → 4 runs, 12 assertions, 0 failures.
2. **Declined (codex): "non-local return inside the transaction can COMMIT
   prior writes."** Verified against Rails 7.1 semantics: the new rescues sit
   OUTSIDE the `ActiveRecord::Base.transaction do ... end` block (transaction
   opens at controller line 400 and closes at 608; the rescue clauses are
   clauses of the surrounding `begin` at 609+, same shape as every
   pre-existing rescue in this method). An exception raised inside the block
   therefore aborts the transaction BEFORE any rescue runs; the
   `return render` happens after rollback. `commit_transaction_on_non_local_return`
   is not in play because control leaves the block by exception, not by
   `return`/`throw`. Spec 2's cross-variant assertion (unrelated edit in the
   same request not applied) exercises exactly this rollback.
3. **Declined (codex): same claim for the service-level translation** — same
   analysis; `Link::LinkInvalid` raised in the service propagates out of the
   transaction block to the controller rescue, aborting the transaction first.

**Round 2** at `a6df38d1` — panel clean, 0 findings, exit 0
("patch is correct, 0.86").

## QA

- [ ] Human: confirm the seller on product `qushdj` (link 13633998) can now
      save content-editor changes successfully, or — if some other variant
      of the bug remains — gets an actual, readable error instead of a
      silent hang.
- [ ] Human: merge decision. This touches the core product-editing save path
      on a live, money-adjacent surface — intentionally left as a **draft**,
      not marked ready, no auto-merge armed.

## Notes for reviewers

- This PR does **not** touch the prod data cleanup (item 1) — that was
  already executed and verified via the audited prod console per the issue
  thread; no code in this repo is responsible for that step.
- Happy to add a broader regression test sweep (e.g. duplicate live
  RichContent rows arriving in a single payload) if reviewers want deeper
  coverage of the historical corrupt-data shapes, but the two exception
  paths fixed here are the ones actually reproduced and traced to a specific
  raise.

