### PR TITLE
Fix stale trusted-checkout recaptcha spec description after #6982

### DIFF
--- a/spec/controllers/concerns/validate_recaptcha_spec.rb
+++ b/spec/controllers/concerns/validate_recaptcha_spec.rb
@@ -322,7 +322,7 @@ describe ValidateRecaptcha, type: :controller do
         expect(parsed_body["error"]).to eq("captcha_failed")
       end
 
-      it "passes a score that clears the lenient 0.3 default but would fail the untrusted 0.5 surface" do
+      it "passes a score that clears the lenient 0.3 default and would also clear the untrusted 0.4 surface" do
         stub_recaptcha_response(valid: true, score: 0.4)
 
         post :checkout_score_trusted_action, params: { "g-recaptcha-response" => "test_token" }


### PR DESCRIPTION
## What

Fix a stale spec description in `validate_recaptcha_spec.rb` left over from #6982.

## Why

Greptile flagged it on #6982's review: that PR lowered the untrusted checkout reCAPTCHA
threshold from `0.5` to `0.4`, but the trusted-surface example still said a `0.4` score
"would fail the untrusted 0.5 surface." Score comparisons are inclusive, so `0.4` now
passes both surfaces — the description no longer matches the assertions it sits next to.

## Status

- [x] Scope — one example description in one spec file.
- [x] Design — reword to match current behavior; no code or assertion changes.
- [x] Build — committed and pushed.
- [x] QA — full spec file run.
- [ ] Shipped — awaiting CI / review.
- [x] Market — n/a.
- [x] Sell — n/a.

## Test Results

- `bundle exec rspec spec/controllers/concerns/validate_recaptcha_spec.rb` — 39 examples, 0 failures.

## QA steps

Ran the full file locally against a lane-borrowed MySQL/Redis; the renamed example still
exercises `score: 0.4` against `checkout_score_trusted_action` and passes.

## Notes

Docs/test-description-only diff — no behavior or code change.

---
AI assistance disclosure: Gumclaw used Hermes Agent with claude-sonnet-5 to read the PR
#6982 review thread, verify the finding against current `origin/main`, and fix the stale
spec description.
