### PR TITLE
Lift the frontend payInInstallments exclusion for the buyer-currency presentment lane

### DIFF
--- a/app/javascript/components/Checkout/payment.test.ts
+++ b/app/javascript/components/Checkout/payment.test.ts
@@ -250,6 +250,32 @@ describe("canUseStripePaymentElement", () => {
     expect(canUseStripePaymentElement(state({ products: [product({ hasFreeTrial: true })] }))).toBe(false);
   });
 
+  it("allows pay-in-installments on the buyer-currency (FX-quoted) presentment lane", () => {
+    // gumroad-private#1312/#1322 + #6981: the server only sets buyer_currency_presentment on a
+    // pay_in_installments cart once Checkout::StripePaymentPresenter has already proven the cart
+    // is a presentment candidate whose seller is in the later-charge ramp — see
+    // Checkout::BuyerCurrencyEligibility#later_charge_purchase_in_ramp?. Trusting the flag here
+    // cannot widen eligibility past what the server decided.
+    expect(
+      canUseStripePaymentElement(
+        state({
+          checkoutPayment: buyerCurrencyPresentmentPaymentElementConfig,
+          products: [product({ payInInstallments: true })],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("still falls back for pay-in-installments on the canonical (non-presentment) server-confirm lane", () => {
+    // An unramped seller's cart never actually mounts integration "payment_element" for
+    // pay_in_installments per stripe_payment_presenter_spec (the server routes it to
+    // CardElement instead), but the client guard must independently refuse to widen past what
+    // buyer_currency_presentment says, regardless of how it got here.
+    expect(
+      canUseStripePaymentElement(state({ products: [product({ payInInstallments: true, hasFreeTrial: false })] })),
+    ).toBe(false);
+  });
+
   it("allows setup-mode checkout for preorder and free-trial flows", () => {
     expect(
       canUseStripePaymentElement(

--- a/app/javascript/components/Checkout/payment.ts
+++ b/app/javascript/components/Checkout/payment.ts
@@ -395,7 +395,20 @@ export function canUseStripePaymentElement(state: State): state is StateWithPaym
     if (total === null || total < STRIPE_PAYMENT_ELEMENT_MINIMUM_USD_CHARGE_CENTS) return false;
   }
 
-  return !state.products.some((product) => product.payInInstallments || product.hasFreeTrial || product.isPreorder);
+  // pay_in_installments is excluded UNLESS the server put this cart on the buyer-currency
+  // (FX-quoted) presentment lane — the one server-confirm shape that can honor it (see
+  // Checkout::StripePaymentPresenter#fallback_reason_for, gumroad-private#1312/#1322). That
+  // element charges the quote's locked first-installment amount, the same figure a plain USD
+  // installment checkout charges today, so quoting it changes only the currency, not what is
+  // billed. A cart whose seller is not in the later-charge ramp never gets
+  // buyer_currency_presentment: true for an installment purchase — the server keeps it on
+  // CardElement (fallback_reason "setup_or_installment_flow") — so trusting this flag here
+  // cannot widen eligibility past what the server already decided.
+  if (state.products.some((product) => product.payInInstallments)) {
+    return !!state.checkoutPayment.elements_options.buyer_currency_presentment;
+  }
+
+  return !state.products.some((product) => product.hasFreeTrial || product.isPreorder);
 }
 
 // The browser must not widen server eligibility for client-confirm: single-seller,


### PR DESCRIPTION
# Lift the frontend `payInInstallments` exclusion for the buyer-currency presentment lane

## What

Phase 1 of closing the #1322 installment later-charge gap: once the seller is in the later-charge ramp, route pay-in-installments checkouts through the buyer-currency (FX-quoted) Payment Element instead of unconditionally falling back to CardElement client-side.

## Relationship to #6981

**Builds directly on #6981** ("Route pay-in-installments through the buyer-currency Payment Element too") — this branch is stacked on top of it (base: `gp1312-installments-payment-element`), not independent and not main-based. #6981 fixed the **server** side: `Checkout::StripePaymentPresenter#fallback_reason_for` now lets an installment purchase mount `integration: "payment_element"` with `buyer_currency_presentment: true` once the cart is a presentment candidate. But the **frontend** guard, `canUseStripePaymentElement` in `payment.ts`, still unconditionally excluded `product.payInInstallments` — so even with #6981 merged, the browser would still refuse to mount the Payment Element for an installment purchase and silently fall back to CardElement, defeating the backend fix. This PR is the piece that actually lets a buyer see it.

**This PR should not be merged before #6981.** If #6981 lands first, this rebases cleanly onto main. If this needs to go first for review reasons, the frontend lift is a no-op until #6981's presenter change ships (the server would never set `buyer_currency_presentment: true` for an installment cart yet), so ordering is not a correctness risk either way — but merging #6981 first keeps the diffs easy to review independently.

## Why this is safe

`canUseStripePaymentElement` now checks the server's own `buyer_currency_presentment` flag before allowing `payInInstallments` through:

```ts
if (state.products.some((product) => product.payInInstallments)) {
  return !!state.checkoutPayment.elements_options.buyer_currency_presentment;
}
```

That flag is **only ever `true`** when `Checkout::StripePaymentPresenter` has already proven, server-side, that:
1. The cart is a buyer-currency presentment candidate (`buyer_currency_presentment_candidate?` — seller flags + active buyer-local display), AND
2. Per #6981, the installment purchase specifically is allowed through that candidate branch (previously it was kicked to CardElement unconditionally before the candidate check ran).

There is no path where a seller **not** in the later-charge ramp (`Checkout::BuyerCurrencyEligibility.subscriptions_enabled?` — the flag `later_charge_purchase_in_ramp?` gates on) produces `buyer_currency_presentment: true` for an installment item; such a cart still gets `fallback_reason: "setup_or_installment_flow"` → `integration: "card_element"`, and this frontend change does not touch that path at all. So the frontend guard cannot widen eligibility past what the server already decided — it just stops actively narrowing it back down once the server has opened the door.

`canUseStripePaymentElementClientConfirm` (the deferred-PaymentIntent lane) is **untouched** and still unconditionally excludes `payInInstallments`. That lane genuinely cannot take an installment purchase today: `Order::PreparePaymentIntentService#payment_method_resolution` resolves it as a recurring/future-charge cart, and `StripePaymentPresenter`'s own resolver call does not pass `recurring:` for a `pay_in_installments` item, so the two would resolve different method sets and Stripe would reject the mismatched ConfirmationToken (this is the exact gap #6981's own PR body calls out as staying out of scope). Widening the client-confirm lane is a separate, currently-unsafe change and is not part of this PR.

## Test Results

Run locally (`npx vitest run app/javascript/components/Checkout/payment.test.ts`): **144 tests, 0 failures.**

Two new cases:
- `"allows pay-in-installments on the buyer-currency (FX-quoted) presentment lane"` — pins the new behavior when `checkoutPayment` carries `buyer_currency_presentment: true`.
- `"still falls back for pay-in-installments on the canonical (non-presentment) server-confirm lane"` — pins that a `payment_element` cart with `buyer_currency_presentment: false` still refuses installments (the unramped-seller shape).

### Mutation proof

Reverted `payment.ts` to this branch's pre-change state (kept the test additions) and re-ran the new "allows pay-in-installments..." case: it reddened as expected (`expected false to be true`, since the old unconditional exclusion returns `false` regardless of the flag). Restored the fix and reran the full file green (144/144).

### Typecheck / lint

- `npx tsc -p . --noEmit`: clean, no new errors.
- `npx eslint app/javascript/components/Checkout/payment.ts app/javascript/components/Checkout/payment.test.ts`: 3 pre-existing errors at line ~1226 (`checkout_path` / js-routes type stub gap), unrelated to this diff — reproduced identically against `origin/main` with this PR's changes fully reverted.

## QA steps

No new rendered surface — same reasoning as #6975/#6981: both element variants this toggles between already exist and render in checkout. Reviewer path: read the `canUseStripePaymentElement` diff (the `payInInstallments` branch now consults `buyer_currency_presentment` instead of unconditionally excluding), then run `payment.test.ts`.

## Status

- [x] Scope — gumroad-private#1312/#1322, frontend half of the #6981 backend fix
- [x] Design — mirrors the server's own `buyer_currency_presentment` decision; does not touch the client-confirm lane
- [x] Build — one conditional branch in `canUseStripePaymentElement`, two new pinning tests
- [x] QA — spec-based, no rendered surface; mutation proof included above
- [ ] Shipped — awaiting #6981 to merge first, then human review here

Not armed for auto-merge and left as **draft**: checkout/payments surface, and this depends on #6981 landing. Will assign @rmarescu for merge review once #6981 is in and CI is green here, matching the established convention on #6975/#6981.

## AI disclosure

Built with Hermes Agent, continuing the gumroad-private#1312/#1322 CardElement-removal workstream and picking up the frontend half of #6981's backend fix.
