### PR TITLE
Try ALGORITHM=INSTANT before sending an ALTER to pt-online-schema-change

### DIFF
--- a/config/initializers/instant_ddl_first.rb
+++ b/config/initializers/instant_ddl_first.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+# Try MySQL 8.0 ALGORITHM=INSTANT before handing a schema change to
+# pt-online-schema-change.
+#
+# Alterity routes every ALTER through pt-osc (config/initializers/alterity.rb),
+# which is the right default for anything that has to rebuild the table. But a
+# plain ADD COLUMN on MySQL 8.0 is a metadata-only change: it touches no rows and
+# finishes in milliseconds regardless of table size. Sending it through pt-osc
+# instead means copying the whole table.
+#
+# That is not just slow, it is the failure mode. On product_reviews (~6.9M rows,
+# ~1GB) the copy ran past the deployer's ~31min migration wait, a following merge
+# replaced the Nomad migration job mid-copy, and the killed run left its three
+# triggers and `_product_reviews_new` behind. PtOscLeftoverCheck then correctly
+# refused every subsequent migration and production deploys were blocked for
+# hours with 24 merged commits undeployed (antiwork/gumroad-private#1810). The
+# ALTER that caused it was:
+#
+#   ADD COLUMN seller_notified_at datetime(6)
+#
+# measured at 2.6ms with ALGORITHM=INSTANT. There was no row copy to interrupt,
+# so there was nothing for the interruption to leave behind.
+#
+# WHY TRYING IS SAFE. MySQL validates ALGORITHM=INSTANT during ALTER preparation
+# and refuses the whole statement atomically before modifying anything:
+#
+#   ADD INDEX          -> ERROR 1845 ALGORITHM=INSTANT is not supported for this operation
+#   MODIFY column type -> ERROR 1846 ... Need to rebuild the table to change column type
+#
+# So there is no half-applied state to reason about: either the change is already
+# done, or nothing happened and pt-osc runs exactly as it does today. The same
+# applies when a table exhausts its instant-column budget (InnoDB allows a bounded
+# number of instant additions before a rebuild is required) -- that surfaces as the
+# same refusal and takes the same fallback path.
+#
+# The attempt runs with a short lock_wait_timeout, matching pt-osc's
+# `--set-vars lock_wait_timeout=1`, so a busy table cannot make the probe itself
+# the thing that hangs a deploy. A timeout is treated as "could not do it
+# instantly" and falls through.
+#
+# This does not replace the leftover guard or make pt-osc unnecessary. It removes
+# the class of migration that never needed pt-osc in the first place from the set
+# that can strand leftovers.
+Rails.application.config.after_initialize do
+  next unless defined?(Alterity)
+
+  Alterity.singleton_class.prepend(Module.new do
+    private
+      def execute_alter(table, updates)
+        super unless InstantDdlFirst.attempt(table, updates)
+      end
+  end)
+end
+
+module InstantDdlFirst
+  # Errors that mean "this operation cannot be done instantly". Anything else is a
+  # real problem and must not be swallowed into a silent pt-osc fallback.
+  #
+  #   1845 ER_ALTER_OPERATION_NOT_SUPPORTED       -- operation cannot be INSTANT
+  #   1846 ER_ALTER_OPERATION_NOT_SUPPORTED_REASON -- ... with a reason
+  #   1205 ER_LOCK_WAIT_TIMEOUT                    -- could not get the metadata lock quickly
+  #   4092 ER_INNODB_MAX_ROW_VERSION               -- instant-column budget exhausted
+  NOT_INSTANT_ERROR_CODES = [1845, 1846, 1205, 4092].freeze
+
+  class << self
+    # Runs the ALTER with ALGORITHM=INSTANT. Returns true when it succeeded, false
+    # when the operation cannot be instant and the caller should fall back.
+    def attempt(table, updates)
+      return false unless eligible?(updates)
+
+      connection = ActiveRecord::Base.connection
+      sql = "ALTER TABLE #{table} #{updates}, ALGORITHM=INSTANT"
+
+      Alterity.disable do
+        previous = connection.select_value("SELECT @@SESSION.lock_wait_timeout")
+        begin
+          connection.execute("SET SESSION lock_wait_timeout = 1")
+          connection.execute(sql)
+        ensure
+          # Restore rather than leave the whole migration session at 1s, which would
+          # make unrelated later statements fail for a reason nothing explains.
+          connection.execute("SET SESSION lock_wait_timeout = #{previous.to_i}") if previous
+        end
+      end
+
+      log("Applied instantly, skipping pt-online-schema-change: ALTER TABLE #{table} #{updates}")
+      true
+    rescue ActiveRecord::StatementInvalid => e
+      raise unless not_instant?(e)
+
+      log("Not an instant operation (#{mysql_errno(e)}), falling back to pt-online-schema-change: ALTER TABLE #{table} #{updates}")
+      false
+    end
+
+    private
+      # Only single-clause ALTERs that do not already pin an algorithm. A
+      # caller-specified ALGORITHM= must win, and appending a second one would be
+      # invalid SQL. Multi-clause ALTERs are left to pt-osc: one clause being
+      # instant-capable says nothing about the others, and a partial application is
+      # exactly what must not happen.
+      def eligible?(updates)
+        text = updates.to_s
+        return false if text.blank?
+        return false if text.match?(/\bALGORITHM\s*=/i)
+        return false if text.match?(/\bLOCK\s*=/i)
+        return false if text.include?(",")
+
+        true
+      end
+
+      def not_instant?(error)
+        NOT_INSTANT_ERROR_CODES.include?(mysql_errno(error))
+      end
+
+      def mysql_errno(error)
+        cause = error.cause
+        cause.respond_to?(:error_number) ? cause.error_number : nil
+      end
+
+      def log(message)
+        Rails.logger.info("[InstantDdlFirst] #{message}")
+        puts "[InstantDdlFirst] #{message}"
+      end
+  end
+end

--- a/spec/config/initializers/instant_ddl_first_spec.rb
+++ b/spec/config/initializers/instant_ddl_first_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe InstantDdlFirst do
+  # These run real DDL against the test database, because the whole value of this
+  # initializer is what MySQL actually does with ALGORITHM=INSTANT -- a mocked
+  # connection would only prove the mock agrees with the assumption.
+  let(:connection) { ActiveRecord::Base.connection }
+  let(:table) { "instant_ddl_first_probe" }
+
+  before do
+    connection.execute("DROP TABLE IF EXISTS #{table}")
+    connection.execute(<<~SQL)
+      CREATE TABLE #{table} (
+        id BIGINT NOT NULL AUTO_INCREMENT,
+        rating INT NOT NULL,
+        PRIMARY KEY (id)
+      ) ENGINE=InnoDB
+    SQL
+    connection.execute("INSERT INTO #{table} (rating) VALUES (5), (4), (3)")
+  end
+
+  after { connection.execute("DROP TABLE IF EXISTS #{table}") }
+
+  def columns_of(name)
+    connection.select_values(<<~SQL.squish)
+      SELECT column_name FROM information_schema.columns
+      WHERE table_schema = DATABASE() AND table_name = '#{name}'
+    SQL
+  end
+
+  describe "an ADD COLUMN, which is the case that never needed pt-osc" do
+    it "applies it and reports that pt-osc can be skipped" do
+      expect(described_class.attempt(table, "ADD COLUMN seller_notified_at datetime(6)")).to be(true)
+      expect(columns_of(table)).to include("seller_notified_at")
+    end
+
+    it "leaves the existing rows alone" do
+      described_class.attempt(table, "ADD COLUMN seller_notified_at datetime(6)")
+
+      expect(connection.select_value("SELECT COUNT(*) FROM #{table}")).to eq(3)
+      expect(connection.select_value("SELECT COUNT(*) FROM #{table} WHERE seller_notified_at IS NOT NULL")).to eq(0)
+    end
+
+    it "restores the session lock_wait_timeout it lowered" do
+      before_value = connection.select_value("SELECT @@SESSION.lock_wait_timeout")
+
+      described_class.attempt(table, "ADD COLUMN seller_notified_at datetime(6)")
+
+      expect(connection.select_value("SELECT @@SESSION.lock_wait_timeout")).to eq(before_value)
+    end
+  end
+
+  describe "an operation MySQL cannot do instantly" do
+    it "falls back for ADD INDEX, without applying it" do
+      expect(described_class.attempt(table, "ADD INDEX index_probe_on_rating (rating)")).to be(false)
+
+      indexes = connection.select_values(<<~SQL.squish)
+        SELECT DISTINCT index_name FROM information_schema.statistics
+        WHERE table_schema = DATABASE() AND table_name = '#{table}'
+      SQL
+      expect(indexes).not_to include("index_probe_on_rating")
+    end
+
+    it "falls back for a column type change, leaving the column as it was" do
+      expect(described_class.attempt(table, "MODIFY COLUMN rating BIGINT NOT NULL")).to be(false)
+
+      type = connection.select_value(<<~SQL.squish)
+        SELECT column_type FROM information_schema.columns
+        WHERE table_schema = DATABASE() AND table_name = '#{table}' AND column_name = 'rating'
+      SQL
+      expect(type).to eq("int")
+    end
+  end
+
+  describe "what it declines to attempt" do
+    # A caller that already pinned an algorithm has said what it wants, and
+    # appending a second ALGORITHM= would be invalid SQL.
+    it "does not touch an ALTER that already specifies an algorithm" do
+      expect(described_class.attempt(table, "ADD COLUMN a INT, ALGORITHM=COPY")).to be(false)
+      expect(columns_of(table)).not_to include("a")
+    end
+
+    it "does not touch an ALTER that specifies a lock mode" do
+      expect(described_class.attempt(table, "ADD COLUMN b INT, LOCK=NONE")).to be(false)
+      expect(columns_of(table)).not_to include("b")
+    end
+
+    # One clause being instant-capable says nothing about the others, and a
+    # partially applied multi-clause ALTER is the thing to avoid.
+    it "does not touch a multi-clause ALTER" do
+      expect(described_class.attempt(table, "ADD COLUMN c INT, ADD COLUMN d INT")).to be(false)
+      expect(columns_of(table)).not_to include("c", "d")
+    end
+  end
+
+  describe "an error that is not about instant-ness" do
+    it "raises rather than silently falling back to pt-osc" do
+      expect do
+        described_class.attempt(table, "ADD COLUMN rating INT")
+      end.to raise_error(ActiveRecord::StatementInvalid, /Duplicate column name/)
+    end
+
+    it "raises when the table does not exist" do
+      expect do
+        described_class.attempt("no_such_table_here", "ADD COLUMN e INT")
+      end.to raise_error(ActiveRecord::StatementInvalid)
+    end
+  end
+
+  describe "the Alterity hook" do
+    it "does not re-enter Alterity while running its own ALTER" do
+      # Without Alterity.disable the ALTER would be intercepted by
+      # Alterity#process_sql_query and sent straight back to pt-osc.
+      expect(Alterity).to receive(:disable).and_call_original
+
+      described_class.attempt(table, "ADD COLUMN seller_notified_at datetime(6)")
+    end
+  end
+end


### PR DESCRIPTION
Follow-up to antiwork/gumroad-private#1810, which blocked production deploys for hours tonight.

## The failure this removes

`ADD COLUMN seller_notified_at datetime(6)` (from #6969) went through Alterity to pt-online-schema-change on `product_reviews` (6.9M rows, ~1GB). The copy started 21:54:03Z, ran past the deployer's ~31min migration wait, and a following merge replaced the Nomad `database_migration` job mid-copy. The killed run left its three triggers and `_product_reviews_new` behind, and `PtOscLeftoverCheck` (#6428) then correctly refused every subsequent migration — 24 merged commits undeployed.

The ALTER never needed pt-osc. Measured on MySQL 8.0 against the same table shape:

```
t_start  2026-08-04 03:24:38.385614
ALTER TABLE product_reviews ADD COLUMN seller_notified_at datetime(6) DEFAULT NULL, ALGORITHM=INSTANT;
t_end    2026-08-04 03:24:38.388221
```

2.6ms, metadata only. No row copy means nothing for an interruption to leave behind — this class of migration cannot strand leftovers at all.

## Why attempting it is safe

MySQL validates `ALGORITHM=INSTANT` during ALTER preparation and refuses the whole statement atomically before modifying anything. Verified, not assumed:

```
ADD INDEX idx (rating), ALGORITHM=INSTANT
  -> ERROR 1845 (0A000) ALGORITHM=INSTANT is not supported for this operation. Try ALGORITHM=COPY/INPLACE.

MODIFY COLUMN rating bigint, ALGORITHM=INSTANT
  -> ERROR 1846 (0A000) ALGORITHM=INSTANT is not supported. Reason: Need to rebuild the table to change column type.
```

So there is no half-applied state to reason about: either the change is already done, or nothing happened and pt-osc runs exactly as it does today. Same path when a table exhausts its InnoDB instant-column budget (4092) or cannot get the metadata lock quickly (1205 — the probe uses `lock_wait_timeout=1`, matching pt-osc's own `--set-vars`, so it can't become the thing that hangs a deploy).

## Deliberately narrow

- Single-clause ALTERs only. One clause being instant-capable says nothing about the others, and a partially applied multi-clause ALTER is the thing to avoid.
- Skipped when the caller already pinned `ALGORITHM=` or `LOCK=` — that choice wins, and appending a second `ALGORITHM=` would be invalid SQL.
- Errors that are **not** about instant-ness are re-raised, never swallowed into a silent pt-osc fallback.
- `Alterity.disable` wraps the attempt so it isn't re-intercepted straight back into pt-osc.
- Session `lock_wait_timeout` is restored, so unrelated later statements in the same migration session don't inherit 1s.

This does not replace the leftover guard and does not make pt-osc unnecessary. It removes the migrations that never needed pt-osc from the set that can strand leftovers.

## Tests

11 examples, real DDL against the test MySQL rather than a mocked connection — the point is what MySQL actually does. Covers: ADD COLUMN applies and leaves rows alone; ADD INDEX and a type change fall back *without* applying; the three declined shapes; a duplicate-column error raising instead of falling back; `lock_wait_timeout` restored; `Alterity.disable` used.

`spec/config/initializers/alterity_spec.rb` and `spec/lib/utilities/pt_osc_leftovers_spec.rb` still pass (22 examples, 0 failures).

## Not in this PR

The existing leftovers on `product_reviews` still need a human with prod-master DDL to drop (triggers first, then the shadow table) — see antiwork/gumroad-private#1810. This only stops the next one happening.


## Status

- [x] Scope — follow-up to antiwork/gumroad-private#1810, narrowed to single-clause ALTERs
- [x] Build — instant-first probe in the Alterity path, non-instant errors re-raised
- [x] Test Results — 11 new examples running real DDL against the test MySQL; `spec/config/initializers/alterity_spec.rb` + `spec/lib/utilities/pt_osc_leftovers_spec.rb` still green (22 examples, 0 failures)
- [x] CI green at head `0e44f3a9` — 81 SUCCESS, 0 failures, 10 skipped; MERGEABLE
- [x] QA evidence — the measured 2.6ms `ALGORITHM=INSTANT` ADD COLUMN and the two refusal transcripts above are the evidence; there is no rendered surface to screenshot
- [ ] Adversarial (fable-5) review — still owed, mine to run

Not armed for auto-merge: this changes how every production migration is executed, so the merge call is human.

## AI disclosure

Written by Hermes Agent (`claude-opus-5`) running as gumclaw. The MySQL algorithm transcripts and timings above were measured during this session against the test database, not estimated.
