### PR TITLE
Resolve connected-account Stripe header from the Charge, not the purchase (follow-up to #6852)

### DIFF
--- a/app/services/onetime/reconcile_stuck_stripe_disputes.rb
+++ b/app/services/onetime/reconcile_stuck_stripe_disputes.rb
@@ -96,10 +96,17 @@ module Onetime
       # (user_id nil), which carries ordinary direct charges — the bulk of this cohort and exactly
       # what we are here to book. Require a seller before refusing.
       def destination_charge?(dispute)
-        merchant_account = disputed_purchases(dispute).first&.merchant_account
+        merchant_account = resolve_merchant_account(dispute)
         return false if merchant_account.nil? || merchant_account.is_managed_by_gumroad?
 
         merchant_account.is_a_gumroad_managed_stripe_account?
+      end
+
+      # The Charge owns the Stripe account the dispute actually lives on; a purchase's
+      # merchant_account can be blank (nil for older rows) or point at a different account
+      # (e.g. an affiliate's) even though it's one of the disputed purchases. Prefer the Charge.
+      def resolve_merchant_account(dispute)
+        dispute.charge&.merchant_account || disputed_purchases(dispute).first&.merchant_account
       end
 
       # Only a dispute Stripe considers finished can be booked. `warning_*` and `needs_response`
@@ -133,7 +140,7 @@ module Onetime
       end
 
       def stripe_account_options(dispute)
-        merchant_account = disputed_purchases(dispute).first&.merchant_account
+        merchant_account = resolve_merchant_account(dispute)
         return {} unless merchant_account&.is_a_stripe_connect_account?
         return {} if merchant_account.charge_processor_merchant_id.blank?
 

--- a/spec/services/onetime/reconcile_stuck_stripe_disputes_spec.rb
+++ b/spec/services/onetime/reconcile_stuck_stripe_disputes_spec.rb
@@ -173,6 +173,35 @@ describe Onetime::ReconcileStuckStripeDisputes do
     end
   end
 
+  describe "resolving the Stripe account for a connected Charge" do
+    let(:connect_merchant_account) { create(:merchant_account_stripe_connect) }
+    let(:charge) { create(:charge, merchant_account: connect_merchant_account) }
+    # The purchase's own merchant_account is nil, the shape flagged by Greptile on #6852: the
+    # Charge is on a real connected account but the purchase row never got one assigned.
+    let!(:charge_dispute) do
+      create(:dispute, charge:, purchase: nil, state: "formalized",
+                       formalized_side_effects_finished_at: 1.year.ago,
+                       charge_processor_id: StripeChargeProcessor.charge_processor_id,
+                       charge_processor_dispute_id: "dp_connected")
+    end
+
+    before do
+      charge.purchases << create(:purchase, price_cents: 0, merchant_account: nil, chargeback_date: 1.year.ago)
+      charge.update!(disputed_at: 1.year.ago)
+    end
+
+    it "scopes the Stripe retrieval to the Charge's connected account, not the purchase's" do
+      expect(Stripe::Dispute).to receive(:retrieve)
+        .with(hash_including(id: "dp_connected"), { stripe_account: connect_merchant_account.charge_processor_merchant_id })
+        .and_return(stripe_dispute(status: "won", id: "dp_connected"))
+
+      result = described_class.process(dry_run: false, dispute_ids: [charge_dispute.id])
+
+      expect(result[:stats][:booked_won]).to eq(1)
+      expect(charge_dispute.reload.state).to eq("won")
+    end
+  end
+
   describe "scoping" do
     it "only touches the ids it was given" do
       other = create(:dispute, purchase: create(:purchase, chargeback_date: 1.year.ago),


### PR DESCRIPTION
## Stages

- [x] Scope
- [x] Design
- [x] Build
- [ ] Ship
- [ ] Market
- [ ] Sell

## What

Follow-up to #6852 (merged). Greptile's post-merge review flagged a real gap: `Onetime::ReconcileStuckStripeDisputes` resolved the Stripe Connect header from the *purchase's* `merchant_account`, but a connected Charge's associated purchase can have `merchant_account: nil` even though the Charge itself sits on a real Stripe Connect account. The retrieval then fell back to the platform account, Stripe returned "No such dispute", and the row was refused (`not_found_on_account_tried`) instead of reconciled.

Fix: resolve the merchant account from the Charge first, falling back to the purchase only when the dispute has no Charge (the ServiceCharge/legacy-purchase-only shapes this script already supports). Same resolution now backs both `destination_charge?` and `stripe_account_options`.

## Why

The original PR's own fable-5 review confirmed "Connect routing fallback to the platform" was safe because Stripe retrieval is account-scoped and a mismatch returns a caught "No such dispute" error — true, but that safety net is also what silently strands an otherwise-eligible dispute as a refusal instead of surfacing the real fix.

**Measured against production (gumroad-private#1700 cohort) before deciding severity:** of the 1,118 nonterminal Stripe disputes, 444 carry a `charge_id`. Of those, the direct scan for "Charge on a Stripe Connect account whose linked purchase has no merchant_account" and for "Charge/purchase merchant_account mismatch" both currently return **0** — this bug has no live-exposed rows today. Fixing it anyway because the alternative is a silent no-op on the exact population (connected-Charge disputes) the guard is supposed to handle, and a future backfill pass over this cohort could easily create the shape the fix now handles correctly.

## Before/After

No before/after media: this is a backend-only, one-off console service (`Onetime::ReconcileStuckStripeDisputes`) with no UI, no route, and no scheduled caller — nothing renders to a user, so there is no surface to screenshot or record. Same exemption basis the parent PR #6852 used. The diff plus the new/updated spec (asserting the exact Stripe-account argument passed to `Stripe::Dispute.retrieve`) is the reviewable artifact for this change.

## Test Results

`bundle exec rspec spec/services/onetime/reconcile_stuck_stripe_disputes_spec.rb` — 17 examples, 0 failures (run locally, Ruby 3.4.3).

New example: `resolving the Stripe account for a connected Charge` — a dispute on a Charge with a real `merchant_account_stripe_connect` account, purchase's own `merchant_account` nil, asserts `Stripe::Dispute.retrieve` is called with the Charge's `stripe_account`, not `{}`.

Mutation-verified: reverting `stripe_account_options` to read from `disputed_purchases(dispute).first&.merchant_account` (the pre-fix code) turns the new example red with the exact original symptom (`Stripe::Dispute.retrieve` called with `{}` instead of the connected account).

`bundle exec rubocop app/services/onetime/reconcile_stuck_stripe_disputes.rb spec/services/onetime/reconcile_stuck_stripe_disputes_spec.rb` — clean.

## QA steps

Preview app: https://fix-gp1700-connected-charge-disp.apps.staging.gumroad.org (no visible UI change — verify via console instead).

Same as the parent PR #6852 — this is a one-off console service with no scheduled caller. No behavior visible until someone re-runs `Onetime::ReconcileStuckStripeDisputes.process` against the cohort; the fix only changes which Stripe account a connected-Charge dispute is retrieved against.

1. On the preview console (or prod, per #6852's runbook): `Onetime::ReconcileStuckStripeDisputes.process` (dry run default). Confirm `stats[:scanned]` matches the stuck population.
2. For a connected-Charge dispute whose purchase has `merchant_account: nil`, confirm `resolve_merchant_account(dispute)` (private, but observable via the booking outcome) now resolves to the Charge's account instead of falling through to the platform account / `not_found_on_account_tried`.
3. Book one such dispute: `process(dry_run: false, dispute_ids: [<id>])`. Verify it books (`won`/`lost`) instead of refusing with `not_found_on_account_tried`.

## AI disclosure

Written by Claude (Hermes agent), triggered by Greptile's post-merge review comment on #6852. The finding was verified against `origin/main` (population-sized via the audited prod console) before writing the fix; every claim above is from an actual local test run, not predicted.
