### PR TITLE
Backfill Q2 2026 tax remittances from the Wise rail (gp#1100 Phase 5)

### DIFF
--- a/app/services/onetime/backfill_q2_2026_tax_remittances.rb
+++ b/app/services/onetime/backfill_q2_2026_tax_remittances.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+# Backfills the Q2 2026 international tax remittances into tax_remittances.
+# Unlike the April 2026 backfill (Onetime::BackfillAprilTaxRemittances), which
+# sourced amounts from the QBO GL because the bank feed had booked them, these
+# six payments were read directly from the Wise API (gumroad-private#1100,
+# 2026-08-03) — the QBO feed for July never booked them at all (a separate
+# reconciliation gap, gumroad-private#1181). Local-currency amounts are known
+# here because they come from the rail, not the ledger, so target_amount_cents
+# is populated — the April backfill couldn't do that.
+#
+# Switzerland is deliberately excluded: its Q2 filing was paid on 2026-08-04
+# via API (Phase 4, `attempt: 1`, status `funded`) and already has a row.
+# Backfilling it here would collide with that row under the (authority,
+# period, attempt) unique index — correctly, since it is not a second payment.
+#
+# IRAS Singapore is backfilled at only ONE of the two Q2 sends recorded on the
+# rail. The second (SGD 12,154.00, identical reference, 2026-07-31) matches
+# the exact Q1 SGD amount, which is the signature of an accidental resend
+# rather than a second liability — but intent can't be confirmed from the
+# rail alone, and inserting it as a genuine attempt-2 payment would assert a
+# double remittance that may not be real. That $9,458.73 stays unrecorded
+# pending the human disposition already asked for on the issue.
+#
+# transfer_id is left nil, same as the April backfill: it is ENRICHABLE_WHEN_LOCKED,
+# meaning it can move from nil to a value exactly once and is then frozen. Writing
+# the Wise reference string here now would burn that one enrichment and permanently
+# block the eventual Phase 3 sync from filling in the real numeric transfer ID it
+# matches from the rail. The reference lives in notes instead, purely informational.
+#
+# Idempotent like the April backfill: keyed on (authority, period, attempt: 1),
+# verified rather than silently skipped if a mismatched row already occupies
+# that slot.
+class Onetime::BackfillQ22026TaxRemittances
+  PERIOD = "2026-Q2"
+
+  # authority => [usd_cents, target_amount_cents, paid_at, transfer_reference]
+  # USD/local amounts and dates are the Wise transfer records read on
+  # 2026-08-03 (gumroad-private#1100 comment 5167307502). transfer_reference
+  # is the payment reference Wise recorded, not a raw numeric transfer ID —
+  # the rail sync (Phase 3, not yet built) can replace it with the real
+  # transfer ID once it exists, since ENRICHABLE_WHEN_LOCKED allows that.
+  Q2_2026_PAYMENTS = {
+    "Irish Revenue (EU VAT OSS)" => [64_359_570, 56_393_915, Time.utc(2026, 7, 22), "EU372030009.Q2.2026"],
+    "HMRC" => [24_456_761, 18_284_755, Time.utc(2026, 7, 22), "GB400134960 2Q2026"],
+    "Australian Taxation Office" => [7_614_969, 10_882_400, Time.utc(2026, 7, 22), "811011766943121720"],
+    "Norwegian Tax Administration" => [2_094_888, 20_207_900, Time.utc(2026, 7, 18), "2082039-Q2-2026"],
+    "Inland Revenue Department (NZ)" => [1_592_102, 2_737_221, Time.utc(2026, 7, 22), "147042426"],
+    "IRAS Singapore" => [1_023_136, 1_314_679, Time.utc(2026, 7, 31), "GST M90375350L Q2 2026"],
+  }.freeze
+
+  attr_reader :created, :skipped
+
+  def initialize
+    @created = []
+    @skipped = []
+  end
+
+  def process
+    Q2_2026_PAYMENTS.each do |authority, (usd_cents, target_cents, paid_at, reference)|
+      meta = TaxRemittance::KNOWN_AUTHORITIES.fetch(authority)
+
+      existing = TaxRemittance.find_by(authority:, period: PERIOD, attempt: 1)
+      if existing
+        verify_existing_row!(existing, usd_cents, target_cents, paid_at, meta)
+        @skipped << authority
+        next
+      end
+
+      live_later_attempt = TaxRemittance.where(authority:, period: PERIOD)
+                                        .where.not(status: TaxRemittance::RETRYABLE_STATUSES)
+                                        .first
+      if live_later_attempt
+        raise "BackfillQ22026TaxRemittances: #{authority} #{PERIOD} has a live attempt #{live_later_attempt.attempt} " \
+              "(status #{live_later_attempt.status}) but no attempt-1 row — backfilling the rail-confirmed payment " \
+              "would create two live attempts for one filing. Reconcile the filing's history manually before re-running"
+      end
+
+      begin
+        TaxRemittance.create!(
+          authority:,
+          jurisdiction: meta[:jurisdiction],
+          period: PERIOD,
+          currency: meta[:currency],
+          usd_amount_cents: usd_cents,
+          target_amount_cents: target_cents,
+          rail: "wise",
+          attempt: 1,
+          status: "completed",
+          paid_at:,
+          notes: "Backfilled from the Wise API (rail read 2026-08-03, gumroad-private#1100). " \
+                 "Wise payment reference: #{reference}. Numeric transfer_id pending the Phase 3 rail sync.",
+        )
+        @created << authority
+      rescue ActiveRecord::RecordNotUnique
+        verify_existing_row!(
+          TaxRemittance.find_by!(authority:, period: PERIOD, attempt: 1),
+          usd_cents, target_cents, paid_at, meta
+        )
+        @skipped << authority
+      end
+    end
+
+    Rails.logger.info("BackfillQ22026TaxRemittances: created=#{created.size} skipped=#{skipped.size}")
+    self
+  end
+
+  private
+    # Doesn't check transfer_id — it's deliberately left nil at insert (see the
+    # comment above) so a later Phase 3 sync can still enrich it. notes isn't
+    # checked either; it's an annotation, not a payment fact.
+    def verify_existing_row!(existing, usd_cents, target_cents, paid_at, meta)
+      mismatches = {
+        usd_amount_cents: [existing.usd_amount_cents, usd_cents],
+        target_amount_cents: [existing.target_amount_cents, target_cents],
+        jurisdiction: [existing.jurisdiction, meta[:jurisdiction]],
+        currency: [existing.currency, meta[:currency]],
+        rail: [existing.rail, "wise"],
+        status: [existing.status, "completed"],
+        paid_at: [existing.paid_at, paid_at],
+      }.select { |_field, (actual, expected)| actual != expected }
+
+      return if mismatches.empty?
+
+      details = mismatches.map { |field, (actual, expected)| "#{field}: has #{actual.inspect}, expected #{expected.inspect}" }
+      raise "BackfillQ22026TaxRemittances: existing #{existing.authority} #{PERIOD} row conflicts with backfill data (#{details.join('; ')}) — reconcile manually before re-running"
+    end
+end

--- a/spec/services/onetime/backfill_q2_2026_tax_remittances_spec.rb
+++ b/spec/services/onetime/backfill_q2_2026_tax_remittances_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Onetime::BackfillQ22026TaxRemittances do
+  it "creates the six Wise-confirmed Q2 2026 remittances as completed, with target amounts" do
+    service = described_class.new.process
+
+    expect(service.created.size).to eq(6)
+    expect(service.skipped).to be_empty
+    expect(TaxRemittance.count).to eq(6)
+
+    hmrc = TaxRemittance.find_by!(authority: "HMRC", period: "2026-Q2")
+    expect(hmrc.jurisdiction).to eq("GB")
+    expect(hmrc.currency).to eq("GBP")
+    expect(hmrc.usd_amount_cents).to eq(24_456_761)
+    expect(hmrc.target_amount_cents).to eq(18_284_755)
+    expect(hmrc.rail).to eq("wise")
+    expect(hmrc.status).to eq("completed")
+    expect(hmrc.paid_at).to eq(Time.utc(2026, 7, 22))
+    expect(hmrc.transfer_id).to be_nil # left open for the Phase 3 rail sync to enrich
+
+    oss = TaxRemittance.find_by!(jurisdiction: "EU_OSS", period: "2026-Q2")
+    expect(oss.usd_amount_cents).to eq(64_359_570)
+
+    total = TaxRemittance.for_period("2026-Q2").sum(:usd_amount_cents)
+    expect(total).to eq(101_141_426) # ~$1.01M across the six confirmed Q2 sends, matching the 2026-08-03 rail read
+  end
+
+  it "does not touch Switzerland — it is already recorded from the API-initiated Phase 4 payment" do
+    swiss = create(:tax_remittance, authority: "Eidgenössisches Finanzdepartement (Swiss VAT)",
+                                    jurisdiction: "CH", currency: "CHF", period: "2026-Q2",
+                                    usd_amount_cents: 1_764_164, target_amount_cents: 1_429_414,
+                                    status: "funded")
+
+    described_class.new.process
+
+    expect(swiss.reload.status).to eq("funded") # untouched
+    expect(TaxRemittance.where(authority: swiss.authority, period: "2026-Q2").count).to eq(1)
+  end
+
+  it "is idempotent" do
+    described_class.new.process
+    second = described_class.new.process
+
+    expect(second.created).to be_empty
+    expect(second.skipped.size).to eq(6)
+    expect(TaxRemittance.count).to eq(6)
+  end
+
+  it "raises when an existing row conflicts with the backfill data" do
+    create(:tax_remittance, :completed, period: "2026-Q2", usd_amount_cents: 1) # wrong amount
+
+    expect { described_class.new.process }.to raise_error(/HMRC 2026-Q2 row conflicts/)
+  end
+
+  it "does not mistake a later attempt for the historical first payment" do
+    later_attempt = create(:tax_remittance, :failed, period: "2026-Q2", attempt: 2)
+
+    service = described_class.new.process
+
+    expect(service.created.size).to eq(6)
+    hmrc_first = TaxRemittance.find_by!(authority: "HMRC", period: "2026-Q2", attempt: 1)
+    expect(hmrc_first.status).to eq("completed")
+    expect(later_attempt.reload.attempt).to eq(2)
+  end
+
+  it "raises a descriptive error when a later attempt is live and attempt 1 is missing" do
+    create(:tax_remittance, status: "draft", period: "2026-Q2", attempt: 2)
+
+    expect { described_class.new.process }.to raise_error(/HMRC 2026-Q2 has a live attempt 2 \(status draft\)/)
+    expect(TaxRemittance.find_by(authority: "HMRC", period: "2026-Q2", attempt: 1)).to be_nil
+  end
+end

--- a/spec/services/onetime/backfill_q2_2026_tax_remittances_spec.rb
+++ b/spec/services/onetime/backfill_q2_2026_tax_remittances_spec.rb
@@ -13,15 +13,27 @@ describe Onetime::BackfillQ22026TaxRemittances do
     hmrc = TaxRemittance.find_by!(authority: "HMRC", period: "2026-Q2")
     expect(hmrc.jurisdiction).to eq("GB")
     expect(hmrc.currency).to eq("GBP")
-    expect(hmrc.usd_amount_cents).to eq(24_456_761)
-    expect(hmrc.target_amount_cents).to eq(18_284_755)
     expect(hmrc.rail).to eq("wise")
     expect(hmrc.status).to eq("completed")
-    expect(hmrc.paid_at).to eq(Time.utc(2026, 7, 22))
     expect(hmrc.transfer_id).to be_nil # left open for the Phase 3 rail sync to enrich
 
-    oss = TaxRemittance.find_by!(jurisdiction: "EU_OSS", period: "2026-Q2")
-    expect(oss.usd_amount_cents).to eq(64_359_570)
+    # Every remittance's amounts and date, individually — a shared total or a
+    # single spot-checked row can stay green while any other row is wrong
+    # (gp#6990 review, nyomanjyotisa: all six passed with ATO's target wrong).
+    expected = {
+      "Irish Revenue (EU VAT OSS)" => [64_359_570, 56_393_915, Time.utc(2026, 7, 22)],
+      "HMRC" => [24_456_761, 18_284_755, Time.utc(2026, 7, 22)],
+      "Australian Taxation Office" => [7_614_969, 10_882_400, Time.utc(2026, 7, 22)],
+      "Norwegian Tax Administration" => [2_094_888, 20_207_900, Time.utc(2026, 7, 18)],
+      "Inland Revenue Department (NZ)" => [1_592_102, 2_737_221, Time.utc(2026, 7, 22)],
+      "IRAS Singapore" => [1_023_136, 1_314_679, Time.utc(2026, 7, 31)],
+    }
+    expected.each do |authority, (usd_cents, target_cents, paid_at)|
+      row = TaxRemittance.find_by!(authority:, period: "2026-Q2")
+      expect(row.usd_amount_cents).to eq(usd_cents), "#{authority}: usd_amount_cents"
+      expect(row.target_amount_cents).to eq(target_cents), "#{authority}: target_amount_cents"
+      expect(row.paid_at).to eq(paid_at), "#{authority}: paid_at"
+    end
 
     total = TaxRemittance.for_period("2026-Q2").sum(:usd_amount_cents)
     expect(total).to eq(101_141_426) # ~$1.01M across the six confirmed Q2 sends, matching the 2026-08-03 rail read


### PR DESCRIPTION
## Stages

- [x] Scope
- [x] Design
- [x] Build
- [ ] Ship
- [ ] Market
- [ ] Sell

## What

A one-off backfill service (`Onetime::BackfillQ22026TaxRemittances`) that records the six confirmed Q2 2026 international tax remittances (EU OSS/HMRC/ATO/Norway/NZ/Singapore) into `tax_remittances`, using the amounts and dates read directly from the Wise API on 2026-08-03. Switzerland is excluded — its Q2 payment went through the API-initiated Phase 4 flow on 2026-08-04 and already has a row.

## Why

Per gp#1100 comment 5174871931 (@slavingia): "Open PRs for phase 3, 5 as needed and assign to @nyomanjyotisa." This is Phase 5 (the Q2 backfill, analogous to the merged April/Q1 backfill in #6116). The QBO GL bank feed for these payments never booked (a separate reconciliation gap, gp#1181), so unlike the April backfill this one sources amounts from the rail, not the ledger — which also means `target_amount_cents` (the local-currency amount actually sent) is populated here, where the April backfill couldn't fill it in.

IRAS Singapore was paid twice on the rail at an identical reference; the second amount matches Q1's SGD figure exactly, the signature of an accidental resend rather than a second liability. Intent can't be confirmed from the rail alone, so only the first Singapore payment is backfilled — the duplicate stays a question for whoever holds the filing calendar (already flagged on the issue, comment 5167307502).

## Before/After

Before: the six Q2 payments exist only on Wise's transfer history and in an issue comment table — no row in `tax_remittances`, no reconciliation surface.

After: six `completed` rows exist for period `2026-Q2`, matching `TaxRemittance::KNOWN_AUTHORITIES`, each with `usd_amount_cents` and `target_amount_cents` populated and `transfer_id` left nil for the future Phase 3 rail sync to enrich (it's write-once per the model's `ENRICHABLE_WHEN_LOCKED`).

## Test Results

```
bundle exec rspec spec/services/onetime/backfill_q2_2026_tax_remittances_spec.rb
6 examples, 0 failures
```

Covers: creates all six with correct amounts/dates/target amounts individually asserted per authority (Round 2, this PR's review — nyomanjyotisa found the total+HMRC-only assertion let a wrong ATO target pass), leaves an existing Switzerland row untouched, idempotent re-run, raises on a conflicting existing row, doesn't mistake a later attempt for the historical one, raises when a later attempt is live with no attempt-1 row. Mutation-verified: a wrong ATO target now fails the spec (mutated locally, reran red, restored, reran green — diff confirmed byte-identical to the pushed commit).

`bundle exec rubocop` on the spec: no offenses. Round 2 at `a8318417a`.

## QA steps

This is a backend-only data-backfill service with no rendered surface — there is no UI to screenshot. QA is the spec run above plus a manual read of the six literal amounts against the table posted in gp#1100 comment 5167307502 (byte-for-byte match).

Not yet run in production — this PR only adds the service; running it against prod is a follow-up console step once merged, same pattern as the April backfill (#6116).

---

AI disclosure: built autonomously with AI assistance.

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Still a draft and still mine. **Correction to the previous stanza:** the "CI failing" shards it cited were not this branch's defect — they were `validate_recaptcha_spec.rb:325` inherited from a red `main` (see the comment below). Fixed on main by #6992 and merged in here; the full suite is re-running clean so far. Once it lands green this is ready to hand off.
<!-- gumclaw-ownership-sweep -->


