### PR TITLE
Fix score-only reCAPTCHA specs stranded on the old 0.5 bar after #6982 (main is red)

### DIFF
--- a/spec/controllers/concerns/validate_recaptcha_spec.rb
+++ b/spec/controllers/concerns/validate_recaptcha_spec.rb
@@ -300,7 +300,7 @@ describe ValidateRecaptcha, type: :controller do
           allow(GlobalConfig).to receive(:get).with("RECAPTCHA_FAIL_OPEN_CHECKOUT_SCORE").and_return("false")
           low_score = instance_double(
             HTTParty::Response,
-            parsed_response: { "tokenProperties" => { "valid" => true, "hostname" => DOMAIN }, "riskAnalysis" => { "score" => 0.4 } },
+            parsed_response: { "tokenProperties" => { "valid" => true, "hostname" => DOMAIN }, "riskAnalysis" => { "score" => 0.3 } },
             code: 200
           )
           call = 0
@@ -323,7 +323,7 @@ describe ValidateRecaptcha, type: :controller do
       # establish must stay out of it.
       describe "#recaptcha_failed_on_score_only?" do
         it "is true when a valid, correctly-hosted token was refused on score alone" do
-          stub_recaptcha_response(valid: true, score: 0.4)
+          stub_recaptcha_response(valid: true, score: 0.3)
 
           post :checkout_score_fallback_action, params: { "g-recaptcha-response" => "test_token" }
 


### PR DESCRIPTION
## What

`main` is red. Two examples in `spec/controllers/concerns/validate_recaptcha_spec.rb` stub `score: 0.4` to mean "below the score bar", but #6982 lowered the `checkout_score` default threshold from 0.5 to 0.4 at 00:13Z. `0.4 >= 0.4` is a pass, so the intent inverted. Restubs both at `0.3`.

## Why main broke without either PR being wrong

Neither PR is at fault on its own — this is a semantic conflict git cannot see:

- **#6982** (merged 00:13Z) lowered the bar 0.5 → 0.4 and correctly updated every example *that existed on main at the time*.
- **#6810** (merged 04:33Z) was already in flight, and added two new examples written against the **0.5** bar, where `0.4` was safely below it.

Both were green in isolation. They touched different lines of the same file, so there was no textual conflict and nothing warned either branch. `main` went red the instant the second one landed — first failing run `30878030262` at 04:33Z on `f8243b1d7`, still failing on `af4b3bbab`.

This is the same shape as a stale-constant conflict: a PR that changes the *meaning* of a magic number invalidates in-flight branches asserting against it, and only the merge order reveals it.

## The second example was worse than red — it was vacuous

Line 325 is the one that actually fails. Line 303 (`does not carry a score failure over to a later check that ended on an infrastructure error`) still *passed* at 0.4 — but only because it had stopped testing anything. It exists to prove `@recaptcha_failed_on_score_only = false` is reset before the infra-error branch, so a score failure cannot leak its "scored as risky" copy onto a later timeout. With `0.4` no longer a score failure, the flag was never set, so the reset it guards was never exercised.

Proven by mutation, run not reasoned — deleting the reset line from `validate_recaptcha.rb`:

| Spec value | Mutant (reset deleted) | Verdict |
|---|---|---|
| `0.4` (before) | **survives** — 1 example, 0 failures | example was vacuous |
| `0.3` (after) | **killed** — 1 example, 1 failure, got the low-score copy where the ad-blocker copy was expected | example is load-bearing again |

So fixing only line 325 would have restored green while leaving a silently dead assertion on a checkout fraud path.

## Test Results

- **Baseline, unmodified `origin/main` @ `af4b3bbab`:** `45 examples, 1 failure` — `:325`, exactly matching CI. Reproduced locally before changing anything.
- **With this fix:** `bundle exec rspec spec/controllers/concerns/validate_recaptcha_spec.rb` → **45 examples, 0 failures** (5.92s).
- **Mutation proof** of the vacuity claim above, both arms run in full.
- Diff is **spec-only, 2 lines**. `validate_recaptcha.rb` was restored byte-for-byte from a pre-mutation copy and verified via `git diff --stat`; no production file is touched.

## QA steps

No rendered surface and no behavior change — the threshold shipped in #6982 and the fallback behavior in #6810 are both unchanged. Reviewer path: confirm `RECAPTCHA_SCORE_THRESHOLD_DEFAULTS[:checkout_score]` is `0.4` on main, then that `0.3` is the only stub value below it that keeps both examples exercising a score-only refusal.

## Status

- [x] Reproduced the failure on unmodified main before writing the fix
- [x] Spec file green, 45/45
- [x] Mutation proof that the fix is load-bearing, not cosmetic
- [x] CI green at head `e3befcf9a1` — 79 SUCCESS, 0 failures, 10 skipped

## AI disclosure

Written by Claude (Hermes agent) during the PR momentum sweep, which caught this as a red shard on my own PR #6989 and traced it to `main` rather than to the branch. Every number above is from a real local run.

