### PR TITLE
Stub a score under the 0.4 bar in the score-only refusal spec

### DIFF
--- a/spec/controllers/concerns/validate_recaptcha_spec.rb
+++ b/spec/controllers/concerns/validate_recaptcha_spec.rb
@@ -323,7 +323,7 @@ describe ValidateRecaptcha, type: :controller do
       # establish must stay out of it.
       describe "#recaptcha_failed_on_score_only?" do
         it "is true when a valid, correctly-hosted token was refused on score alone" do
-          stub_recaptcha_response(valid: true, score: 0.4)
+          stub_recaptcha_response(valid: true, score: 0.2)
 
           post :checkout_score_fallback_action, params: { "g-recaptcha-response" => "test_token" }
 


### PR DESCRIPTION
Main is red on `Test Fast 8`: `ValidateRecaptcha #recaptcha_failed_on_score_only? is true when a valid, correctly-hosted token was refused on score alone` fails with `expected false, got true` at spec/controllers/concerns/validate_recaptcha_spec.rb:330.

Semantic merge conflict between two PRs that were each green on their own branch:

- #6982 lowered `RECAPTCHA_SCORE_THRESHOLD_DEFAULTS[:checkout_score]` from 0.5 to 0.4.
- #6810 added the `#recaptcha_failed_on_score_only?` examples, stubbing a 0.4 score to represent a refusal — correct against the 0.5 bar in place when that branch was written.

Gating is `assessment[:score] >= threshold`, so once both landed a 0.4 token clears the 0.4 bar. The request succeeds, no score-only refusal ever happens, and the example asserting `success == false` fails. Neither PR is wrong; only the stub value is now stale.

Fix is the stub value alone: 0.4 -> 0.2, so the example again exercises the refusal it is named for. No production code touched, and the other five examples in the describe block are unaffected.

## Test Results

Reproduced CI's exact failure locally at `origin/main` before changing anything — `Expected true to equal false`, same line 330 — then confirmed the fix:

```
spec/controllers/concerns/validate_recaptcha_spec.rb
  45 examples, 0 failures

spec/services/checkout_recaptcha_spec.rb spec/presenters/checkout_presenter_spec.rb
  79 examples, 0 failures

bundle exec rubocop spec/controllers/concerns/validate_recaptcha_spec.rb
  1 file inspected, no offenses detected
```

Full `Tests` workflow green on this branch before opening: https://github.com/antiwork/gumroad/actions/runs/30880472921

## QA steps

No user-visible behavior changes and no runtime code in the diff, so there is no preview click-path to exercise. The reviewable claim is that the spec now matches the 0.4 threshold on main, which the CI run above establishes. To verify locally:

```
bundle exec rspec spec/controllers/concerns/validate_recaptcha_spec.rb
```

No before/after media: the diff is a single stub value in a spec file, with no rendered surface to capture.

---

Written by Claude Opus 4.5 (Hermes Agent) running as the scheduled red-main watcher. The job re-verified main was still red, pulled the `Test Fast 8` log to find the real error line, traced it to the #6982/#6810 threshold interaction, reproduced the failure locally, applied the minimal stub change, and was instructed to keep the fix surgical and revert-shaped and to prove the failing test passes locally before pushing.
