### PR TITLE
Match the browser-guid cleanup reconstruction to the live rule's lifetime window

### DIFF
--- a/app/services/onetime/clear_mistaken_buyer_blocks.rb
+++ b/app/services/onetime/clear_mistaken_buyer_blocks.rb
@@ -129,12 +129,11 @@ class Onetime::ClearMistakenBuyerBlocks
       return blocked_pairs_for(purchase) if velocity_threshold_met?(recent_email_or_browser_failures)
 
       # Purchase::Blockable#ban_fraudulent_buyer_browser_guid! blocks the browser only, and counts
-      # over all time rather than a window. Same countable scope as the live rule: counting rows
-      # it ignores would retain exactly the outage-manufactured blocks this cleanup exists to
-      # clear.
+      # over all time with no window at all — so this must too. Capping at window.end misses
+      # qualifying failures the live rule sees after this purchase, which can let it clear a block
+      # the live threshold still wants.
       if purchase.browser_guid.present?
         browser_failures = Purchase.countable_card_testing_failures
-                                   .where(created_at: ..window.end)
                                    .where(browser_guid: purchase.browser_guid)
         protected_pairs << [PlatformBlock::TYPES[:browser_guid], purchase.browser_guid] if velocity_threshold_met?(browser_failures)
       end

--- a/spec/services/onetime/clear_mistaken_buyer_blocks_spec.rb
+++ b/spec/services/onetime/clear_mistaken_buyer_blocks_spec.rb
@@ -201,10 +201,10 @@ describe Onetime::ClearMistakenBuyerBlocks do
   describe "blocks a card-testing rule also wanted" do
     # Distinct failed cards, enough of them to trip a velocity rule, that are not themselves
     # candidates for this cleanup (their decline code is not one of the fraud-related ones).
-    def create_failed_card_attempts(count:, created_at:, **attributes)
+    def create_failed_card_attempts(count:, created_at:, fingerprint_prefix: "card-tester-fingerprint", **attributes)
       count.times do |index|
         create(:purchase, purchase_state: "failed", stripe_error_code: "card_declined_insufficient_funds",
-                          stripe_fingerprint: "card-tester-fingerprint-#{index}", created_at:, **attributes)
+                          stripe_fingerprint: "#{fingerprint_prefix}-#{index}", created_at:, **attributes)
       end
     end
 
@@ -256,6 +256,24 @@ describe Onetime::ClearMistakenBuyerBlocks do
       end
 
       expect { described_class.new(dry_run: false).process }.to change { PlatformBlock.active.count }.from(3).to(0)
+    end
+
+    # ban_fraudulent_buyer_browser_guid! counts qualifying failures for a browser over ALL time,
+    # with no window at all. A reconstruction bounded by this purchase's possible_failure_window
+    # misses failures that land after it, so it can clear a browser block the live rule's lifetime
+    # count still wants. Regression for the P1 Greptile flagged on gp1701's PR: fails against a
+    # window-bounded reconstruction because the fourth qualifying failure lands after window.end.
+    it "keeps the browser block when a later failure is what trips the live lifetime threshold" do
+      create_failed_card_attempts(count: Purchase::Blockable::MAX_NUMBER_OF_FAILED_FINGERPRINTS - 2,
+                                  created_at: 30.days.ago, browser_guid: failed_purchase.browser_guid)
+      create_failed_card_attempts(count: 1, fingerprint_prefix: "later-fingerprint",
+                                  created_at: ChargeProcessor::TIME_TO_COMPLETE_SCA.from_now + 1.hour,
+                                  browser_guid: failed_purchase.browser_guid)
+
+      described_class.new(dry_run: false).process
+
+      expect(PlatformBlock.active.pluck(:object_type, :object_value))
+        .to eq([[PlatformBlock::TYPES[:browser_guid], failed_purchase.browser_guid]])
     end
   end
 


### PR DESCRIPTION
- [x] Scope — Greptile P1 on antiwork/gumroad#6853 (merged): browser-guid cleanup reconstruction can clear a block the live rule's lifetime count still wants
- [x] Design — n/a — one-line scope fix, no UI surface
- [x] Build — 9cab5585 (drop the window bound on the browser-guid reconstruction)
- [ ] Ship — merges and deploys via the release pipeline
- [x] Market — n/a — internal fraud-rule fix
- [x] Sell — n/a — no sellable surface

## What

Drops the `window.end` cap on the browser-guid check inside `Onetime::ClearMistakenBuyerBlocks#velocity_protected_pairs`, so it counts a browser's qualifying failures over all time — matching `Purchase::Blockable#ban_fraudulent_buyer_browser_guid!`, which has no window at all.

## Why

[Greptile flagged a P1](https://github.com/antiwork/gumroad/pull/6853#discussion_r3699634725) on #6853 (merged before the review posted): the live rule blocks a browser once its lifetime qualifying-failure count reaches the threshold, but the cleanup's reconstruction only counted failures up to `possible_failure_window(purchase).end`. A qualifying failure landing after that window can trip the live rule while cleanup still sees too few, clearing a block live enforcement still wants.

The comment above this code already said the reconstruction has to match the live rule's scope — this closes the one place it didn't.

## Before / after

| Scenario | Before | After |
|---|---|---|
| 4th qualifying browser failure lands after `window.end` | Cleared (cleanup counted only 3) | Kept blocked (cleanup counts all 4, matching the live rule) |
| All qualifying failures inside the window | Unchanged | Unchanged |

## Test Results

`spec/services/onetime/clear_mistaken_buyer_blocks_spec.rb` — **22 examples, 0 failures**, run locally at head (`DISABLE_SPRING=1 bundle exec rspec spec/services/onetime/clear_mistaken_buyer_blocks_spec.rb`).

New example: "keeps the browser block when a later failure is what trips the live lifetime threshold" — fails against the pre-fix code (mutant re-adding `.where(created_at: ..window.end)` reproduces the exact failure Greptile's harness reported) and passes with the fix.

`bundle exec rubocop` clean on both changed files.

## QA steps

Not applicable — backend-only change to a console-run one-off cleanup service with no rendered surface.

## AI disclosure

Written by Claude (Hermes agent), responding to a Greptile review finding on the merged parent PR.
