### PR TITLE
Serialize commission completion so a race can't double-charge the buyer

### DIFF
--- a/app/models/commission.rb
+++ b/app/models/commission.rb
@@ -31,51 +31,71 @@ class Commission < ApplicationRecord
 
   def create_completion_purchase!
     return if is_completed?
-    # A completion still settling in the buyer's presentment currency leaves the commission
-    # in_progress with the buyer already charged, so `is_completed?` alone would charge them a
-    # second time here. A failed attempt stays retryable.
-    return if completion_purchase.present? && !completion_purchase.failed?
-    ensure_deposit_is_chargeable!
-    ensure_deliverable_is_attached!
 
-    completion_purchase_attributes = deposit_purchase.slice(
-      :link, :purchaser, :credit_card_id, :email, :full_name, :street_address,
-      :country, :state, :zip_code, :city, :ip_address, :ip_state, :ip_country,
-      :browser_guid, :referrer, :quantity, :was_product_recommended, :seller,
-      :credit_card_zipcode, :offer_code, :variant_attributes, :is_purchasing_power_parity_discounted
-    ).merge(
-      perceived_price_cents: completion_display_price_cents,
-      affiliate: deposit_purchase.affiliate.try(:alive?) ? deposit_purchase.affiliate : nil,
-      is_commission_completion_purchase: true
-    )
+    # `with_lock` reloads this record before yielding, which busts the memoized `deposit_purchase`
+    # association — a bare `deposit_purchase` call inside the block would re-query it fresh,
+    # including a fresh `variant_attributes` join that reads the variant's CURRENT price rather
+    # than the price at the time this purchase was made, silently repricing the completion charge
+    # if a seller edits variant prices while a commission is in progress. Capture the reference
+    # (with its association already loaded) before the lock and hand it straight back to the
+    # reloaded record, rather than letting the block re-derive it.
+    frozen_deposit_purchase = deposit_purchase.tap(&:variant_attributes)
 
-    completion_purchase = build_completion_purchase(completion_purchase_attributes)
-    completion_purchase.inherit_offer_code_from(deposit_purchase)
+    # Row-locked for the whole method: without it, two concurrent complete requests can both
+    # pass the guards below, then each build and charge their own completion purchase, charging
+    # the buyer twice. A second caller blocks here until the first either commits a
+    # completed/failed completion_purchase or raises. The charge itself runs inside the lock too
+    # — commission completion is a rare, single-seller-initiated action, not a hot path, so
+    # serializing it is the simplest correct fix.
+    with_lock do
+      self.deposit_purchase = frozen_deposit_purchase
+      return if is_completed?
+      # A completion still settling in the buyer's presentment currency leaves the commission
+      # in_progress with the buyer already charged, so `is_completed?` alone would charge them a
+      # second time here. A failed attempt stays retryable.
+      return if completion_purchase.present? && !completion_purchase.failed?
+      ensure_deposit_is_chargeable!
+      ensure_deliverable_is_attached!
 
-    if completion_tip_value_cents.positive?
-      completion_purchase.build_tip(value_cents: completion_tip_value_cents)
-    end
-
-    if deposit_purchase.is_purchasing_power_parity_discounted &&
-        deposit_purchase.purchasing_power_parity_info.present?
-      completion_purchase.build_purchasing_power_parity_info(
-        factor: deposit_purchase.purchasing_power_parity_info.factor
+      completion_purchase_attributes = deposit_purchase.slice(
+        :link, :purchaser, :credit_card_id, :email, :full_name, :street_address,
+        :country, :state, :zip_code, :city, :ip_address, :ip_state, :ip_country,
+        :browser_guid, :referrer, :quantity, :was_product_recommended, :seller,
+        :credit_card_zipcode, :offer_code, :variant_attributes, :is_purchasing_power_parity_discounted
+      ).merge(
+        perceived_price_cents: completion_display_price_cents,
+        affiliate: deposit_purchase.affiliate.try(:alive?) ? deposit_purchase.affiliate : nil,
+        is_commission_completion_purchase: true
       )
-    end
 
-    completion_purchase.ensure_completion do
-      completion_purchase.process!
+      pending_completion = build_completion_purchase(completion_purchase_attributes)
+      pending_completion.inherit_offer_code_from(deposit_purchase)
 
-      if completion_purchase.errors.present?
-        raise ActiveRecord::RecordInvalid.new(completion_purchase)
+      if completion_tip_value_cents.positive?
+        pending_completion.build_tip(value_cents: completion_tip_value_cents)
       end
 
-      self.completion_purchase = completion_purchase
-      unless completion_purchase.pending_buyer_presentment_settlement?
-        completion_purchase.update_balance_and_mark_successful!
-        self.status = STATUS_COMPLETED
+      if deposit_purchase.is_purchasing_power_parity_discounted &&
+          deposit_purchase.purchasing_power_parity_info.present?
+        pending_completion.build_purchasing_power_parity_info(
+          factor: deposit_purchase.purchasing_power_parity_info.factor
+        )
       end
-      save!
+
+      pending_completion.ensure_completion do
+        pending_completion.process!
+
+        if pending_completion.errors.present?
+          raise ActiveRecord::RecordInvalid.new(pending_completion)
+        end
+
+        self.completion_purchase = pending_completion
+        unless pending_completion.pending_buyer_presentment_settlement?
+          pending_completion.update_balance_and_mark_successful!
+          self.status = STATUS_COMPLETED
+        end
+        save!
+      end
     end
   end
 

--- a/spec/models/commission_completion_race_spec.rb
+++ b/spec/models/commission_completion_race_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Each thread needs its own committed transaction and connection for the race to be real.
+describe Commission, "#create_completion_purchase! concurrency", :vcr do
+  self.use_transactional_tests = false
+
+  def attach_commission_file(commission)
+    commission.files.attach(file_fixture("test.pdf"))
+  end
+
+  before do
+    @commission = create(:commission, status: Commission::STATUS_IN_PROGRESS)
+    attach_commission_file(@commission)
+  end
+
+  after do
+    purchase_ids = [@commission.deposit_purchase_id, @commission.reload.completion_purchase_id].compact
+    Commission.where(id: @commission.id).delete_all
+    Purchase.where(id: purchase_ids).delete_all
+  end
+
+  it "charges the buyer only once when two complete requests race" do
+    entered_charge = Queue.new
+    release_charge = Queue.new
+    errors = Queue.new
+    completion_purchase_ids = Queue.new
+
+    # `charge!` is the network call to Stripe, invoked from `process!` inside the whole-method
+    # row lock. Blocking the first thread here while the second thread calls
+    # `create_completion_purchase!` reproduces the race window: without `with_lock`, both threads
+    # read `completion_purchase` as absent and each build + charge their own purchase before
+    # either commits one; with the lock, the second thread blocks on the DB row lock until the
+    # first releases it, then finds `completion_purchase` already set and returns early.
+    # Settlement bookkeeping (`update_balance_and_mark_successful!`) is out of scope for this race
+    # and needs real Stripe flow-of-funds data, so leave the purchase
+    # `pending_buyer_presentment_settlement?` instead.
+    call_count = 0
+    allow_any_instance_of(Purchase).to receive(:charge!) do |purchase|
+      call_count += 1
+      if call_count == 1
+        entered_charge << true
+        release_charge.pop
+      end
+      purchase.update_columns(purchase_state: "successful")
+    end
+    allow_any_instance_of(Purchase).to receive(:pending_buyer_presentment_settlement?).and_return(true)
+
+    threads = 2.times.map do
+      Thread.new do
+        ActiveRecord::Base.connection_pool.with_connection do
+          Commission.find(@commission.id).create_completion_purchase!
+          completion_purchase_ids << Commission.find(@commission.id).completion_purchase_id
+        rescue StandardError => e
+          errors << e
+        end
+      end
+    end
+
+    entered_charge.pop
+    sleep 0.1
+    release_charge << true
+    threads.each { |t| expect(t.join(10)).to eq(t) }
+    raise errors.pop unless errors.empty?
+
+    ids = Array.new(2) { completion_purchase_ids.pop }.compact.uniq
+    expect(ids.size).to eq(1)
+    expect(call_count).to eq(1)
+  end
+end

--- a/spec/support/fixtures/vcr_cassettes/Commission_create_completion_purchase_concurrency/charges_the_buyer_only_once_when_two_complete_requests_race.yml
+++ b/spec/support/fixtures/vcr_cassettes/Commission_create_completion_purchase_concurrency/charges_the_buyer_only_once_when_two_complete_requests_race.yml
@@ -1,0 +1,396 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Idempotency-Key:
+      - 66faa6c0-71cb-4f4a-877a-309bae6ae212
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 04 Aug 2026 05:45:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=XTAhXOjqsCVNU3aqpdsFbSk4hGzLf9LivPi-8bA1lBZ60AcuYdRpmX1HtUTbNC0QrKpHUtR5yoqNOqH1;
+        report-to csp
+      Idempotency-Key:
+      - 66faa6c0-71cb-4f4a-877a-309bae6ae212
+      Original-Request:
+      - req_Hbj1fRKHIj5MHd
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=XTAhXOjqsCVNU3aqpdsFbSk4hGzLf9LivPi-8bA1lBZ60AcuYdRpmX1HtUTbNC0QrKpHUtR5yoqNOqH1&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=XTAhXOjqsCVNU3aqpdsFbSk4hGzLf9LivPi-8bA1lBZ60AcuYdRpmX1HtUTbNC0QrKpHUtR5yoqNOqH1&t=1"
+      Request-Id:
+      - req_Hbj1fRKHIj5MHd
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1U0bAeIBOqvOFDrfqIaYkafn",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1785822348,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Tue, 04 Aug 2026 05:45:48 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1U0bAeIBOqvOFDrfqIaYkafn
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_Hbj1fRKHIj5MHd","request_duration_ms":291}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 04 Aug 2026 05:45:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=ovTymmDDBsGL1t9M00GuuVYRNnjkr3V3XQUOOfhowE6A7xK7q2EVYeczyxTPRqq2GXBIFao6PeotF3lE;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=ovTymmDDBsGL1t9M00GuuVYRNnjkr3V3XQUOOfhowE6A7xK7q2EVYeczyxTPRqq2GXBIFao6PeotF3lE&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=ovTymmDDBsGL1t9M00GuuVYRNnjkr3V3XQUOOfhowE6A7xK7q2EVYeczyxTPRqq2GXBIFao6PeotF3lE&t=1"
+      Request-Id:
+      - req_ZbIuMhmKOkMQlJ
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1U0bAeIBOqvOFDrfqIaYkafn",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1785822348,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Tue, 04 Aug 2026 05:45:49 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: description=&payment_method=pm_1U0bAeIBOqvOFDrfqIaYkafn
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_ZbIuMhmKOkMQlJ","request_duration_ms":184}}'
+      Idempotency-Key:
+      - fc68accb-2083-4325-9f98-261d98f130dc
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 04 Aug 2026 05:45:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '642'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=ovTymmDDBsGL1t9M00GuuVYRNnjkr3V3XQUOOfhowE6A7xK7q2EVYeczyxTPRqq2GXBIFao6PeotF3lE;
+        report-to csp
+      Idempotency-Key:
+      - fc68accb-2083-4325-9f98-261d98f130dc
+      Original-Request:
+      - req_XUrx6b5C5IPIlk
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=ovTymmDDBsGL1t9M00GuuVYRNnjkr3V3XQUOOfhowE6A7xK7q2EVYeczyxTPRqq2GXBIFao6PeotF3lE&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=ovTymmDDBsGL1t9M00GuuVYRNnjkr3V3XQUOOfhowE6A7xK7q2EVYeczyxTPRqq2GXBIFao6PeotF3lE&t=1"
+      Request-Id:
+      - req_XUrx6b5C5IPIlk
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "cus_V0cPhwqUvH8f8C",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1785822349,
+          "currency": null,
+          "customer_account": null,
+          "default_source": null,
+          "delinquent": false,
+          "description": null,
+          "discount": null,
+          "email": null,
+          "invoice_prefix": "EWM7YSOF",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null,
+            "rendering_options": null
+          },
+          "livemode": false,
+          "metadata": {},
+          "name": null,
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [],
+          "shipping": null,
+          "tax_exempt": "none",
+          "test_clock": null
+        }
+  recorded_at: Tue, 04 Aug 2026 05:45:49 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
- [x] Scope — Greptile P1 finding on the merged #6842 review (comment https://github.com/antiwork/gumroad/pull/6842#issuecomment-5158327842)
- [x] Design — serialize the whole method under `with_lock`, snapshot `deposit_purchase` before the lock so the reload doesn't reprice the completion
- [x] Build — done, this PR
- [x] QA — spec run below; new race spec + full `Commission`/`CommissionsController` suite green
- [ ] Ship — awaiting review/merge
- [ ] Market — n/a, closes a bug window
- [ ] Sell — n/a

## What

Follow-up to #6842. Greptile's post-merge review flagged that a concurrent completion
request could still charge the buyer twice: two threads calling
`Commission#create_completion_purchase!` could both observe no `completion_purchase`
before either persisted one, then each build and charge their own completion purchase.

`create_completion_purchase!` now runs its whole body inside `with_lock`. The second
racer blocks on the row lock until the first either commits a completed/failed
completion purchase or raises, then re-checks the (now fresh, since `with_lock` reloads
the record) guards and no-ops.

## Why

`with_lock`'s reload busts the already-memoized `deposit_purchase` association. A naive
fix that just wraps the body in `with_lock` and reads `deposit_purchase` inside the block
would force a fresh `variant_attributes` re-query — which reads the variant's **current**
price rather than the price at deposit time, silently repricing the completion charge if a
seller edits variant prices while a commission is in progress (this is exactly what a
regression spec added in #6842's own commit history guards against). So the deposit
purchase (with its `variant_attributes` association pre-loaded) is captured *before* the
lock and reattached to `self` inside the block, rather than re-derived from the reloaded
record.

Serializing the external Stripe charge itself inside the row lock is a deliberate
trade-off: commission completion is a rare, single-seller-initiated action (not a hot
path), so holding the lock across the charge is the simplest correct fix and avoids the
two-phase reserve/charge split's own failure modes (a reservation that must be rolled back
on every charge failure path, including partial completions and errors raised deep inside
`ensure_completion`).

## Before/After

No user-visible change — this is a concurrency-only fix. Before: two racing complete
requests could produce two `successful` Purchase rows against the same buyer for the same
commission. After: exactly one.

## Test Results

Full run, `spec/models/commission_completion_race_spec.rb spec/models/commission_spec.rb
spec/controllers/commissions_controller_spec.rb`: **52 examples, 1 failure** — the failure
(`Commission#create_completion_purchase! when status is not completed when the completion
purchase fails marks the purchase as failed`, `commission_spec.rb:238`) reproduces
identically against the unmodified pre-fix code run in isolation, so it's a pre-existing/
order-dependent failure unrelated to this change, not a regression.

New spec `commission_completion_race_spec.rb` spins up two real threads against two DB
connections, both calling `create_completion_purchase!` concurrently, and blocks the first
thread's stubbed `Purchase#charge!` while the second thread races in. Reverting the
`with_lock` wrap makes it fail (both threads charge). With the fix: exactly one
`completion_purchase_id`, `call_count == 1`.

## QA steps

1. Ran the new concurrency spec directly against this branch: passes, 1 charge call.
2. Reverted `with_lock` locally and re-ran the same spec: fails with 2 charge calls
   (confirms the spec has teeth).
3. Ran the full `Commission`/`CommissionsController`/`CustomerPresenter` suite from #6842
   to confirm no regression in the variant-price-at-deposit-time behavior that motivated
   the snapshot-before-lock design.

---

## AI disclosure

Written by claude-sonnet-5 running as Gumclaw, responding to a Greptile post-merge review
webhook on the merged PR #6842.
