### PR TITLE
Split ServiceCharge disputes out of no_disputable into their own refusal reason

### DIFF
--- a/app/services/onetime/reconcile_stuck_stripe_disputes.rb
+++ b/app/services/onetime/reconcile_stuck_stripe_disputes.rb
@@ -74,7 +74,13 @@ module Onetime
     private
       # Everything that makes a row unbookable on OUR side, checked before we spend a Stripe call.
       def internal_refusal(dispute)
-        return "no_disputable" if dispute.charge.nil? && dispute.purchase.nil?
+        if dispute.charge.nil? && dispute.purchase.nil?
+          # A service_charge dispute has a real disputable, just not one this script can book —
+          # ServiceCharge has no handle_event_dispute_won!/lost! and no seller (dispute.rb's own
+          # comment). Keep it out of no_disputable so that stat stays a signal for actual data gaps.
+          return "unsupported_disputable_type" if dispute.service_charge.present?
+          return "no_disputable"
+        end
 
         # The seller-side debit happens in the FORMALIZED side effects. A row that never got
         # there has no debit on our books, so booking WON would credit a debit that never

--- a/spec/services/onetime/reconcile_stuck_stripe_disputes_spec.rb
+++ b/spec/services/onetime/reconcile_stuck_stripe_disputes_spec.rb
@@ -93,6 +93,19 @@ describe Onetime::ReconcileStuckStripeDisputes do
       expect(result[:stats][:refused_not_found_on_account_tried]).to eq(1)
     end
 
+    # service_charge is a valid disputable per Dispute's own validation — this must not fall into
+    # no_disputable, which is reserved for a genuine data-integrity gap (neither charge nor purchase
+    # nor service_charge).
+    it "refuses a service_charge dispute as unsupported, not as no_disputable" do
+      dispute.update!(purchase: nil, service_charge: create(:service_charge))
+      expect(Stripe::Dispute).to_not receive(:retrieve)
+
+      result = described_class.process(dry_run: false)
+
+      expect(result[:stats][:refused_unsupported_disputable_type]).to eq(1)
+      expect(result[:stats][:refused_no_disputable]).to eq(0)
+    end
+
     it "refuses a dispute carrying no processor id" do
       dispute.update!(charge_processor_dispute_id: nil)
 


### PR DESCRIPTION
## What

Splits `ReconcileStuckStripeDisputes`'s `no_disputable` refusal reason into two: `no_disputable` for a genuine data-integrity gap (dispute has no charge, purchase, or service_charge at all), and `unsupported_disputable_type` for a formalized `service_charge` dispute the script deliberately doesn't book yet.

## Status

- [x] Scope — split `no_disputable` into two refusal reasons (per Greptile's #6852 review finding)
- [x] Design — reuse the existing `internal_refusal` guard, add one branch, no new booking logic
- [x] Build — done, diff is 2 files
- [x] QA — spec run + mutation-verified below (no rendered surface: backend-only stat label)
- [x] Shipped — draft PR open, CI pending
- [ ] Market / Sell — n/a, internal reconciliation tooling


## Why

Follow-up from Greptile's review on #6852 (merged): `service_charge` is a valid `Dispute` disputable, but the guard treated any dispute without a `charge` or `purchase` as `no_disputable`, burying real service-charge rows under a label meant for data-integrity gaps. `ServiceCharge` has no `handle_event_dispute_won!`/`handle_event_dispute_lost!` and no seller (`dispute.rb`'s own comment), so booking support would need new logic on `ServiceCharge`, not a guard change — this PR only splits the stat so the run's report can surface the count if the stuck cohort includes any, without requiring a follow-up audit to find out.

## Before / After

- Before: a service_charge dispute counted under `refused_no_disputable`, indistinguishable from an actual data gap.
- After: it counts under `refused_unsupported_disputable_type`; `refused_no_disputable` stays reserved for the real integrity-gap case.

## Test Results

- `bundle exec rspec spec/services/onetime/reconcile_stuck_stripe_disputes_spec.rb` — 18 examples, 0 failures (fresh worktree, `origin/main` base).
- Mutation-verified the new spec: reverting the split locally makes `refuses a service_charge dispute as unsupported, not as no_disputable` fail (`Expected 0 to eq 1`), confirming it isn't vacuous.

## QA steps

- N/A — backend-only refusal-reason label change on a one-off reconciliation service, no rendered surface. Verified via the spec run and mutation check above.

---

AI disclosure: this PR was authored autonomously by an AI agent (claude-sonnet-5) per antiwork's AI disclosure policy.
