### PR TITLE
Guard PayPal capture/refund error mapping against a missing details array

### DIFF
--- a/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
@@ -1045,19 +1045,16 @@ class PaypalChargeProcessor
     end
 
     def self.determine_capture_order_error(api_response)
+      issue = api_response.result.details&.first&.issue
       if api_response.result.name == "INTERNAL_ERROR"
         ChargeProcessorUnavailableError
-      elsif api_response.result.name == "UNPROCESSABLE_ENTITY" &&
-        api_response.result.details[0].issue == "AGREEMENT_ALREADY_CANCELLED"
+      elsif api_response.result.name == "UNPROCESSABLE_ENTITY" && issue == "AGREEMENT_ALREADY_CANCELLED"
         ChargeProcessorPayerCancelledBillingAgreementError
-      elsif api_response.result.name == "UNPROCESSABLE_ENTITY" &&
-        api_response.result.details[0].issue == "TRANSACTION_REFUSED"
+      elsif api_response.result.name == "UNPROCESSABLE_ENTITY" && issue == "TRANSACTION_REFUSED"
         ChargeProcessorPaymentDeclinedByPayerAccountError
-      elsif api_response.result.name == "UNPROCESSABLE_ENTITY" &&
-        api_response.result.details[0].issue == "PAYEE_ACCOUNT_RESTRICTED"
+      elsif api_response.result.name == "UNPROCESSABLE_ENTITY" && issue == "PAYEE_ACCOUNT_RESTRICTED"
         ChargeProcessorPayeeAccountRestrictedError
-      elsif api_response.result.name == "UNPROCESSABLE_ENTITY" &&
-        api_response.result.details[0].issue == "PAYER_CANNOT_PAY"
+      elsif api_response.result.name == "UNPROCESSABLE_ENTITY" && issue == "PAYER_CANNOT_PAY"
         ChargeProcessorPaymentDeclinedByPayerAccountError
       else
         ChargeProcessorInvalidRequestError
@@ -1065,13 +1062,12 @@ class PaypalChargeProcessor
     end
 
     def determine_refund_order_error(api_response)
+      issue = api_response.result.details&.first&.issue
       if api_response.result.name == "INTERNAL_ERROR"
         ChargeProcessorUnavailableError
-      elsif api_response.result.name == "UNPROCESSABLE_ENTITY" &&
-          api_response.result.details[0].issue == "CAPTURE_FULLY_REFUNDED"
+      elsif api_response.result.name == "UNPROCESSABLE_ENTITY" && issue == "CAPTURE_FULLY_REFUNDED"
         ChargeProcessorAlreadyRefundedError
-      elsif api_response.result.name == "UNPROCESSABLE_ENTITY" &&
-          api_response.result.details[0].issue == "REFUND_FAILED_INSUFFICIENT_FUNDS"
+      elsif api_response.result.name == "UNPROCESSABLE_ENTITY" && issue == "REFUND_FAILED_INSUFFICIENT_FUNDS"
         ChargeProcessorInsufficientFundsError
       else
         ChargeProcessorInvalidRequestError

--- a/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
@@ -912,7 +912,7 @@ class PaypalChargeProcessor
       if paypal_rest_api.successful_response?(api_response)
         api_response.result
       else
-        error_message = PaypalChargeProcessor.build_error_message("Failed refund capture id - #{capture_id}", api_response.result.details[0].description)
+        error_message = PaypalChargeProcessor.build_error_message("Failed refund capture id - #{capture_id}", PaypalChargeProcessor.paypal_rejection_description(api_response))
         raise determine_refund_order_error(api_response), error_message
       end
     end

--- a/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
@@ -1395,6 +1395,24 @@ describe PaypalChargeProcessor, :vcr do
         end
       end
 
+      context "when PayPal omits error details" do
+        it "raises the mapped invalid-request error instead of crashing while building the message" do
+          api_response = JSON.parse({ result: { name: "UNPROCESSABLE_ENTITY" } }.to_json, object_class: OpenStruct)
+          paypal_rest_api = instance_double(PaypalRestApi)
+          allow(PaypalRestApi).to receive(:new).and_return(paypal_rest_api)
+          allow(paypal_rest_api).to receive(:refund).with(capture_id: "capture-without-details",
+                                                          merchant_account:, amount: 2.0).and_return(api_response)
+          allow(paypal_rest_api).to receive(:successful_response?).with(api_response).and_return(false)
+
+          expect do
+            subject.refund!("capture-without-details",
+                            amount_cents: 200,
+                            merchant_account:,
+                            paypal_order_purchase_unit_refund: true)
+          end.to raise_error(ChargeProcessorInvalidRequestError, /Failed refund capture id - capture-without-details/)
+        end
+      end
+
       context "when it is a full refund" do
         it "refunds entire amount" do
           expect_any_instance_of(PaypalRestApi).to receive(:refund).with(capture_id: "2CL11631PW424125C",

--- a/spec/business/payments/charging/implementations/paypal/paypal_rejection_detail_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_rejection_detail_spec.rb
@@ -63,6 +63,32 @@ describe PaypalChargeProcessor, ".build_paypal_rejection" do
     expect(error.message).to eq("Failed PayPal create order: |nope")
   end
 
+  describe ".determine_capture_order_error" do
+    it "falls back to invalid-request instead of raising when UNPROCESSABLE_ENTITY has no details array" do
+      response = api_response(name: "UNPROCESSABLE_ENTITY")
+
+      error_class = nil
+      expect { error_class = described_class.determine_capture_order_error(response) }.not_to raise_error
+      expect(error_class).to eq(ChargeProcessorInvalidRequestError)
+    end
+
+    it "still maps a named capture rejection when details are present" do
+      response = api_response(name: "UNPROCESSABLE_ENTITY", details: [detail(issue: "TRANSACTION_REFUSED")])
+
+      expect(described_class.determine_capture_order_error(response)).to eq(ChargeProcessorPaymentDeclinedByPayerAccountError)
+    end
+  end
+
+  describe ".determine_refund_order_error" do
+    it "falls back to invalid-request instead of raising when UNPROCESSABLE_ENTITY has no details array" do
+      response = api_response(name: "UNPROCESSABLE_ENTITY")
+
+      error_class = nil
+      expect { error_class = described_class.new.send(:determine_refund_order_error, response) }.not_to raise_error
+      expect(error_class).to eq(ChargeProcessorInvalidRequestError)
+    end
+  end
+
   describe ".paypal_rejection_description" do
     it "returns the first detail's description" do
       response = api_response(name: "UNPROCESSABLE_ENTITY", details: [detail(description: "The requested action could not be performed.")])


### PR DESCRIPTION
## Status

- [x] Scope — follow-up fix for the P1 Greptile/T-Rex flagged on #6861 before merge (missing-`details` NoMethodError in capture/refund error mapping)
- [x] Design — mirror the existing nil-safe PayPal rejection detail helpers into capture, refund mapping, and refund message construction
- [x] Build — fix applied, cherry-picked from the original PR's fix commit onto `main`, then follow-up commit `11bb73dd0` fixed the missed refund message path Greptile flagged on this PR
- [x] QA — focused spec run, mutation proof, and local autoreview below; no rendered surface
- [ ] Shipped — pending review/merge
- [ ] Market / Sell — not applicable, backend correctness fix

## What

Follow-up to #6861 (merged without this fix): `determine_capture_order_error` and
`determine_refund_order_error` indexed `api_response.result.details[0]` directly, while
the sibling `determine_create_order_error` already used safe navigation
(`details&.first&.issue`). A capture or refund rejection with `UNPROCESSABLE_ENTITY`
and no `details` array raises a `NoMethodError` instead of recording a normal
`processor_invalid_request` failure — the exact class of silent PayPal rejection
#6861 exists to capture.

Both mapper methods now compute `issue = api_response.result.details&.first&.issue`
once and compare against that, matching the existing pattern. The refund Orders API
error-message path now also uses `PaypalChargeProcessor.paypal_rejection_description`
instead of dereferencing `details[0].description`, so a response with no `details`
reaches `determine_refund_order_error` and raises the mapped `ChargeProcessorInvalidRequestError`.

## Why

Flagged by Greptile/T-Rex on #6861 (comment
https://github.com/antiwork/gumroad/pull/6861#issuecomment-5159383412) as a P1
blocking merge; the PR merged anyway before the fix landed, so this closes the gap
on `main`. Greptile then caught the sibling refund-message dereference on this PR;
commit `11bb73dd0` fixes that path too.

## Test Results

- `ruby -c app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb && ruby -c spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb` — syntax OK.
- `DISABLE_SPRING=1 bundle exec rspec spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb:1399 spec/business/payments/charging/implementations/paypal/paypal_rejection_detail_spec.rb` — 12 examples, 0 failures. Covers the public Orders refund path with `result.name = "UNPROCESSABLE_ENTITY"` and no `details`, plus the existing capture/refund mapper helpers.
- Mutation check: temporarily restored `api_response.result.details[0].description` in `refund_order_purchase_unit!` and reran `DISABLE_SPRING=1 bundle exec rspec spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb:1399` — the new example failed with `NoMethodError "undefined method '[]' for nil"`. Restored the fix and reran the 12-example command green.
- Local autoreview on the uncommitted fix round against `origin/main` — clean; no accepted/actionable P0/P1 findings.
- Attempted full `paypal_charge_processor_spec.rb` plus `paypal_rejection_detail_spec.rb`: 152 examples, 69 failures. The failures were unrelated existing environment/fixture failures on `create(:purchase)` with `ActiveRecord::RecordInvalid: Validation failed: We couldn't charge your card`; the narrowed regression and helper specs above pass.

## QA steps

Backend-only change with no rendered surface — verified via the focused spec run,
mutation proof, and local autoreview above, not a screenshot.

---

AI disclosure: this PR was authored by autonomous agents (claude-sonnet-5 initially; follow-up fix round on this PR by gpt-5.5) responding to Greptile/T-Rex review findings.