### PR TITLE
Fix regular PayPal payout fee truncation

### DIFF
--- a/app/business/payments/payouts/processor/paypal/paypal_payout_processor.rb
+++ b/app/business/payments/payouts/processor/paypal/paypal_payout_processor.rb
@@ -470,7 +470,7 @@ class PaypalPayoutProcessor
 
     payment.with_lock do
       payment.txn_id = paypal_event["masspay_txn_id"]
-      payment.processor_fee_cents = 100 * paypal_event["mc_fee"].to_f if paypal_event["mc_fee"]
+      payment.processor_fee_cents = (paypal_event["mc_fee"].to_d * 100).to_i if paypal_event["mc_fee"]
       payment.save!
       new_payment_state = paypal_event["status"].try(:downcase)
       # PayPal is sending incorrect payment status ('Pending') in the IPN callback for some of the payments where the

--- a/spec/business/payments/payouts/processor/paypal/paypal_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/paypal/paypal_payout_processor_spec.rb
@@ -1334,6 +1334,21 @@ describe PaypalPayoutProcessor do
     end
   end
 
+  describe "IPN fee recording" do
+    it "records a regular payout's fractional fee in integer cents without truncating" do
+      payment = create(:payment, processor_fee_cents: 0)
+
+      described_class.handle_paypal_event(
+        "masspay_txn_id_0" => "sometxn",
+        "status_0" => "Completed",
+        "unique_id_0" => payment.id.to_s,
+        "mc_fee_0" => "1.15"
+      )
+
+      expect(payment.reload.processor_fee_cents).to eq 115
+    end
+  end
+
   describe ".split_payment_by_cents" do
     it "returns the value from the database if is present and less than the maximum" do
       user = create(:user, split_payment_by_cents: 5000_00)


### PR DESCRIPTION
## What

Convert a regular PayPal MassPay IPN's decimal `mc_fee` to integer cents with
decimal arithmetic before persisting it on the payout.

Split-payout accounting is deliberately unchanged; it is owned by a separate
contribution.

## Why

The regular payout handler converted PayPal's decimal fee string through
binary floating point. Values such as `"1.15"` became `114.99999999999999`
after multiplication by 100, and the integer database column persisted 114
cents rather than 115.

PayPal documents `mc_fee` as the transaction fee associated with the payment.
This payout processor is USD-only, so multiplying the exact decimal value by
100 produces the integer-cent amount Gumroad stores.

[PayPal IPN and PDT variable contract](https://developer.paypal.com/api/nvp-soap/ipn/IPNandPDTVariables/)

## Before/After

| Regular MassPay IPN fee | Before | After |
| --- | ---: | ---: |
| `mc_fee=1.15` | 114 cents | 115 cents |

## Test Results (re-verified by import)

- Failing-first: reverted only the processor code, kept the contributed spec.
  `expect(payment.reload.processor_fee_cents).to eq 115` failed with
  `Expected 114 to eq 115` on unmodified `main`.
- Fix restored: `PaypalPayoutProcessor IPN fee recording records a regular
  payout's fractional fee in integer cents without truncating` — 1 example, 0
  failures.

---

Based on https://github.com/adityawrk/gumroad/pull/5 by @adityawrk.

AI Disclosure: Claude Opus 4.6 (1M context) was used to review the original PR, verify the fix failing-first against canonical main, and import the change.