### PR TITLE
Preserve instant payout balance dates

### DIFF
--- a/app/javascript/pages/Payouts/Index.tsx
+++ b/app/javascript/pages/Payouts/Index.tsx
@@ -1,6 +1,7 @@
 import { ArrowInDownSquareHalf, Calendar, CheckCircle, Clock, Cog } from "@boxicons/react";
 import { Link, router, usePage } from "@inertiajs/react";
 import classNames from "classnames";
+import { parseISO } from "date-fns";
 import * as React from "react";
 
 import { exportPayouts } from "$app/data/balance";
@@ -647,7 +648,7 @@ export default function PayoutsIndex() {
                   >
                     {instant_payout.payable_balances.map((balance) => (
                       <option key={balance.id} value={balance.id}>
-                        {new Date(balance.date).toLocaleDateString(userAgentInfo.locale, {
+                        {parseISO(balance.date).toLocaleDateString(userAgentInfo.locale, {
                           month: "long",
                           day: "numeric",
                           year: "numeric",

--- a/spec/requests/balance_pages_spec.rb
+++ b/spec/requests/balance_pages_spec.rb
@@ -903,6 +903,23 @@ describe "Balance Pages Scenario", js: true, type: :system do
             expect(page).to_not have_status(text: "Your balance exceeds the maximum amount for a single instant payout, so we'll automatically split your balance into multiple payouts.")
           end
         end
+
+        it "keeps date-only balance labels unchanged west of UTC" do
+          page.driver.browser.execute_cdp("Emulation.setTimezoneOverride", timezoneId: "America/Los_Angeles")
+
+          visit balance_path
+          click_on "Get paid!"
+
+          within_modal "Instant payout" do
+            expect(page).to have_select(
+              "Pay out balance up to",
+              options: ["January 3, 2025", "January 2, 2025", "January 1, 2025"],
+              selected: "January 3, 2025"
+            )
+          end
+        ensure
+          page.driver.browser.execute_cdp("Emulation.setTimezoneOverride", timezoneId: "")
+        end
       end
 
       context "when the user has a single balance that exceeds the maximum instant payout amount" do


### PR DESCRIPTION
## What

Parse instant-payout balance dates as local calendar dates before formatting their
dropdown labels.

## Why

The server sends `Balance#date`, a date-only value such as `2025-01-03`.
JavaScript's `new Date("2025-01-03")` interprets that form as UTC midnight.
Browsers west of UTC therefore display the preceding calendar day, even though the
underlying balance date did not change.

`parseISO` treats a date-only value as local midnight, preserving its civil date
while retaining the creator's locale-specific formatting.

## Before/After

Before, a January 3 balance appears as January 2 in `America/Los_Angeles`. After,
the options remain January 3, January 2, and January 1, with January 3 selected.

## Test Results (re-verified by import)

- Direct repro with `date-fns`'s `parseISO`, `TZ=America/Los_Angeles`:
  `new Date("2025-01-03").toLocaleDateString()` → **January 2, 2025** (the bug);
  `parseISO("2025-01-03").toLocaleDateString()` → **January 3, 2025** (fixed).
- `tsc --noEmit`: clean.
- `eslint app/javascript/pages/Payouts/Index.tsx`: clean.
- The contributed browser regression (`keeps date-only balance labels unchanged
  west of UTC`, `spec/requests/balance_pages_spec.rb`) is included; a shared
  esbuild/Vite transform-cache collision with a concurrent worktree on this
  machine made the full Capybara run environmentally flaky during import
  verification, so the logic proof above is what's being cited as evidence
  rather than a browser-spec run count.

## Self-review

- Confirmed `payable_balances[].date` originates from a database date column.
- Confirmed all dropdown options use the corrected parser, not only the selected
  value.
- Confirmed no API or persisted-data format changes.

---

Based on https://github.com/adityawrk/gumroad/pull/6 by @adityawrk.

AI Disclosure: Claude Opus 4.6 (1M context) was used to review the original PR, independently reproduce the timezone defect and fix in Node, and import the change.

## Screenshots (hosted preview app)

Captured on the hosted preview app (`fix-instant-payout-date-timezone.apps.staging.gumroad.org`, sha `be47bd0`) as `seller@gumroad.com`, with the browser timezone forced to `America/Los_Angeles` (the exact repro condition from the bug report). The seller's `instant_payout` Inertia prop was seeded via a route-level fixture injection (same test data shape as the included RSpec regression: three payable balances dated `2025-01-01`/`02`/`03`) since this staging account isn't otherwise eligible for instant payouts.

- ![Instant payout notice on Payouts page](https://raw.githubusercontent.com/antiwork/gumroad/be47bd01dddf5350c3920860b0372371493acff9/qa-media/pr-7001-instant-payout-notice.png)
- ![Instant payout modal, America/Los_Angeles, "Pay out balance up to" correctly selects January 3, 2025](https://raw.githubusercontent.com/antiwork/gumroad/be47bd01dddf5350c3920860b0372371493acff9/qa-media/pr-7001-instant-payout-modal-la-timezone-fixed.png)

Click path: Payouts (`/payouts`) → "Get paid!" banner button → Instant payout modal → "Pay out balance up to" dropdown shows January 3, 2025 selected (not the pre-fix January 2, 2025).
