### PR TITLE
Drop invalid taxonomy_attribute_filters tokens from Discover facets

### DIFF
--- a/app/javascript/components/Product/CardGrid.test.tsx
+++ b/app/javascript/components/Product/CardGrid.test.tsx
@@ -3,9 +3,25 @@ import { cleanup, render, screen } from "@testing-library/react";
 import * as React from "react";
 import { afterEach, describe, expect, it } from "vitest";
 
+import { SearchResults } from "$app/data/search";
+
 import { Action, CardGrid, State } from "$app/components/Product/CardGrid";
 
 afterEach(cleanup);
+
+const resultsWithFormats = (keys: string[]): SearchResults => ({
+  total: 2,
+  products: [],
+  tags_data: [],
+  filetypes_data: [],
+  taxonomy_attributes_data: [
+    {
+      name: "format",
+      label: "Format",
+      filters: keys.map((key) => ({ key, doc_count: 2, label: key })),
+    },
+  ],
+});
 
 // A cross-taxonomy or stale taxonomy_attribute_filters token (not present in the current
 // taxonomy_attributes_data) must not render as a checked facet or survive in search params —
@@ -14,19 +30,9 @@ describe("CardGrid taxonomy attribute filters", () => {
   it("drops an invalid taxonomy_attribute_filters token instead of rendering it as a checked facet", () => {
     const state: State = {
       params: { taxonomy: "design/fonts", taxonomy_attribute_filters: ["format:cross-taxonomy-value"] },
-      results: {
-        total: 2,
-        products: [],
-        tags_data: [],
-        filetypes_data: [],
-        taxonomy_attributes_data: [
-          {
-            name: "format",
-            label: "Format",
-            filters: [{ key: "format:otf", doc_count: 2, label: "OTF" }],
-          },
-        ],
-      },
+      // The reducer always records the params a response was fetched with alongside it.
+      resultsParams: { taxonomy: "design/fonts", taxonomy_attribute_filters: ["format:cross-taxonomy-value"] },
+      results: resultsWithFormats(["format:otf"]),
     };
     let lastAction: Action | undefined;
     const dispatchAction = (action: Action) => {
@@ -36,6 +42,60 @@ describe("CardGrid taxonomy attribute filters", () => {
     render(<CardGrid state={state} dispatchAction={dispatchAction} currencyCode="usd" />);
 
     expect(screen.queryByText(/cross-taxonomy-value/iu)).toBeNull();
+    expect(lastAction).toEqual({
+      type: "set-params",
+      params: { taxonomy: "design/fonts", taxonomy_attribute_filters: undefined },
+    });
+  });
+
+  // Requests are not cancelled when params change, so an older search can resolve after a newer
+  // one. Its facet set predates the newly-picked token and legitimately omits it — pruning on it
+  // would clear the filter the user just picked and re-search broadened.
+  it("does not prune when the facets on screen were fetched for different tokens", () => {
+    const state: State = {
+      // The user has just picked format:woff2; results still describe the previous search.
+      params: { taxonomy: "design/fonts", taxonomy_attribute_filters: ["format:woff2"] },
+      resultsParams: { taxonomy: "design/fonts", taxonomy_attribute_filters: ["format:otf"] },
+      results: resultsWithFormats(["format:otf"]),
+    };
+    let lastAction: Action | undefined;
+    const dispatchAction = (action: Action) => {
+      lastAction = action;
+    };
+
+    render(<CardGrid state={state} dispatchAction={dispatchAction} currencyCode="usd" />);
+
+    expect(lastAction).toBeUndefined();
+  });
+
+  it("does not prune before any response has been recorded for the current tokens", () => {
+    const state: State = {
+      params: { taxonomy: "design/fonts", taxonomy_attribute_filters: ["format:woff2"] },
+      results: resultsWithFormats(["format:otf"]),
+    };
+    let lastAction: Action | undefined;
+    const dispatchAction = (action: Action) => {
+      lastAction = action;
+    };
+
+    render(<CardGrid state={state} dispatchAction={dispatchAction} currencyCode="usd" />);
+
+    expect(lastAction).toBeUndefined();
+  });
+
+  it("still prunes when only unrelated params differ from the fetched ones", () => {
+    const state: State = {
+      params: { taxonomy: "design/fonts", taxonomy_attribute_filters: ["format:cross-taxonomy-value"], from: 10 },
+      resultsParams: { taxonomy: "design/fonts", taxonomy_attribute_filters: ["format:cross-taxonomy-value"] },
+      results: resultsWithFormats(["format:otf"]),
+    };
+    let lastAction: Action | undefined;
+    const dispatchAction = (action: Action) => {
+      lastAction = action;
+    };
+
+    render(<CardGrid state={state} dispatchAction={dispatchAction} currencyCode="usd" />);
+
     expect(lastAction).toEqual({
       type: "set-params",
       params: { taxonomy: "design/fonts", taxonomy_attribute_filters: undefined },

--- a/app/javascript/components/Product/CardGrid.test.tsx
+++ b/app/javascript/components/Product/CardGrid.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment happy-dom
+import { cleanup, render, screen } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { Action, CardGrid, State } from "$app/components/Product/CardGrid";
+
+afterEach(cleanup);
+
+// A cross-taxonomy or stale taxonomy_attribute_filters token (not present in the current
+// taxonomy_attributes_data) must not render as a checked facet or survive in search params —
+// gp6858 review, greptile P1.
+describe("CardGrid taxonomy attribute filters", () => {
+  it("drops an invalid taxonomy_attribute_filters token instead of rendering it as a checked facet", () => {
+    const state: State = {
+      params: { taxonomy: "design/fonts", taxonomy_attribute_filters: ["format:cross-taxonomy-value"] },
+      results: {
+        total: 2,
+        products: [],
+        tags_data: [],
+        filetypes_data: [],
+        taxonomy_attributes_data: [
+          {
+            name: "format",
+            label: "Format",
+            filters: [{ key: "format:otf", doc_count: 2, label: "OTF" }],
+          },
+        ],
+      },
+    };
+    let lastAction: Action | undefined;
+    const dispatchAction = (action: Action) => {
+      lastAction = action;
+    };
+
+    render(<CardGrid state={state} dispatchAction={dispatchAction} currencyCode="usd" />);
+
+    expect(screen.queryByText(/cross-taxonomy-value/i)).toBeNull();
+    expect(lastAction).toEqual({
+      type: "set-params",
+      params: { taxonomy: "design/fonts", taxonomy_attribute_filters: undefined },
+    });
+  });
+});

--- a/app/javascript/components/Product/CardGrid.test.tsx
+++ b/app/javascript/components/Product/CardGrid.test.tsx
@@ -68,6 +68,25 @@ describe("CardGrid taxonomy attribute filters", () => {
     expect(lastAction).toBeUndefined();
   });
 
+  // A stale response for a previous taxonomy can share the exact token list with the current
+  // one (e.g. format:shared retained across a category switch); its facets say nothing about
+  // whether the token is valid in the CURRENT taxonomy — greptile P1 round 2.
+  it("does not prune when the facets on screen were fetched for a different taxonomy", () => {
+    const state: State = {
+      params: { taxonomy: "design/fonts", taxonomy_attribute_filters: ["format:shared"] },
+      resultsParams: { taxonomy: "design/icons", taxonomy_attribute_filters: ["format:shared"] },
+      results: resultsWithFormats(["format:otf"]),
+    };
+    let lastAction: Action | undefined;
+    const dispatchAction = (action: Action) => {
+      lastAction = action;
+    };
+
+    render(<CardGrid state={state} dispatchAction={dispatchAction} currencyCode="usd" />);
+
+    expect(lastAction).toBeUndefined();
+  });
+
   it("does not prune before any response has been recorded for the current tokens", () => {
     const state: State = {
       params: { taxonomy: "design/fonts", taxonomy_attribute_filters: ["format:woff2"] },

--- a/app/javascript/components/Product/CardGrid.test.tsx
+++ b/app/javascript/components/Product/CardGrid.test.tsx
@@ -35,7 +35,7 @@ describe("CardGrid taxonomy attribute filters", () => {
 
     render(<CardGrid state={state} dispatchAction={dispatchAction} currencyCode="usd" />);
 
-    expect(screen.queryByText(/cross-taxonomy-value/i)).toBeNull();
+    expect(screen.queryByText(/cross-taxonomy-value/iu)).toBeNull();
     expect(lastAction).toEqual({
       type: "set-params",
       params: { taxonomy: "design/fonts", taxonomy_attribute_filters: undefined },

--- a/app/javascript/components/Product/CardGrid.tsx
+++ b/app/javascript/components/Product/CardGrid.tsx
@@ -43,13 +43,17 @@ export const SORT_BY_LABELS = {
 export type State = {
   params: SearchRequest;
   results: SearchResults | null;
+  // The params `results` was actually fetched with. Requests are not cancelled on a param
+  // change, so a slow older response can land after a newer one; anything reasoning about
+  // whether `results` describes the current params must compare against this, not `params`.
+  resultsParams?: SearchRequest | undefined;
   offset?: number | undefined;
   loading?: boolean;
 };
 
 export type Action =
   | { type: "set-params"; params: SearchRequest }
-  | { type: "set-results"; results: SearchResults }
+  | { type: "set-results"; results: SearchResults; params: SearchRequest }
   | { type: "load-more" }
   | { type: "load-error" };
 
@@ -64,10 +68,10 @@ export const useSearchReducer = (initial: Omit<State, "offset">) => {
             ...action.params,
             taxonomy: action.params.taxonomy === "discover" ? undefined : action.params.taxonomy,
           };
-          return { params, results: null, offset: action.params.from, loading: false };
+          return { params, results: null, resultsParams: undefined, offset: action.params.from, loading: false };
         }
         case "set-results":
-          return { ...state, results: action.results, loading: false };
+          return { ...state, results: action.results, resultsParams: action.params, loading: false };
         case "load-error":
           return { ...state, loading: false };
         case "load-more":
@@ -90,11 +94,13 @@ export const useSearchReducer = (initial: Omit<State, "offset">) => {
   useOnChange(
     asyncVoid(async () => {
       try {
-        const request = getSearchResults(state.params);
+        const requestParams = state.params;
+        const request = getSearchResults(requestParams);
         activeRequest.current = request;
         const results = await request.response;
         dispatch({
           type: "set-results",
+          params: requestParams,
           results:
             state.results == null
               ? results
@@ -232,11 +238,22 @@ export const CardGrid = ({
   // as a checked 0-count facet indefinitely.
   React.useEffect(() => {
     if (!results) return;
+    // Only prune against a facet set fetched for the tokens we're about to judge. Requests are
+    // not cancelled on a param change, so a slow older response can land last; its facets
+    // legitimately omit a newer token and pruning on them would silently clear the user's
+    // just-picked filter and re-search broadened.
+    const fetchedTokens = state.resultsParams?.taxonomy_attribute_filters;
+    const current = searchParams.taxonomy_attribute_filters;
+    if (!current?.length) return;
+    if (
+      !fetchedTokens ||
+      fetchedTokens.length !== current.length ||
+      fetchedTokens.some((token, i) => token !== current[i])
+    )
+      return;
     const validTokens = new Set(
       results.taxonomy_attributes_data.flatMap((attribute) => attribute.filters.map((f) => f.key)),
     );
-    const current = searchParams.taxonomy_attribute_filters;
-    if (!current?.length) return;
     const pruned = current.filter((token) => validTokens.has(token));
     if (pruned.length !== current.length)
       updateParams({ taxonomy_attribute_filters: pruned.length ? pruned : undefined });

--- a/app/javascript/components/Product/CardGrid.tsx
+++ b/app/javascript/components/Product/CardGrid.tsx
@@ -227,6 +227,21 @@ export const CardGrid = ({
     return () => observer.disconnect();
   }, [pagination, results?.products]);
 
+  // Drop taxonomy_attribute_filters tokens the server no longer recognizes for this taxonomy
+  // (stale cross-taxonomy value, category switch, malformed input) so they can't keep rendering
+  // as a checked 0-count facet indefinitely.
+  React.useEffect(() => {
+    if (!results) return;
+    const validTokens = new Set(
+      results.taxonomy_attributes_data.flatMap((attribute) => attribute.filters.map((f) => f.key)),
+    );
+    const current = searchParams.taxonomy_attribute_filters;
+    if (!current?.length) return;
+    const pruned = current.filter((token) => validTokens.has(token));
+    if (pruned.length !== current.length)
+      updateParams({ taxonomy_attribute_filters: pruned.length ? pruned : undefined });
+  }, [results]);
+
   const uid = React.useId();
   const minPriceUid = React.useId();
   const maxPriceUid = React.useId();
@@ -336,8 +351,9 @@ export const CardGrid = ({
             </CardContent>
           ) : null}
           {results?.taxonomy_attributes_data.map((attribute) => {
-            const selectedAttributeFilters = searchParams.taxonomy_attribute_filters?.filter((token) =>
-              token.startsWith(`${attribute.name}:`),
+            const validKeys = new Set(attribute.filters.map((f) => f.key));
+            const selectedAttributeFilters = searchParams.taxonomy_attribute_filters?.filter(
+              (token) => token.startsWith(`${attribute.name}:`) && validKeys.has(token),
             );
             return (
               <CardContent key={attribute.name} asChild details>

--- a/app/javascript/components/Product/CardGrid.tsx
+++ b/app/javascript/components/Product/CardGrid.tsx
@@ -238,10 +238,12 @@ export const CardGrid = ({
   // as a checked 0-count facet indefinitely.
   React.useEffect(() => {
     if (!results) return;
-    // Only prune against a facet set fetched for the tokens we're about to judge. Requests are
-    // not cancelled on a param change, so a slow older response can land last; its facets
-    // legitimately omit a newer token and pruning on them would silently clear the user's
-    // just-picked filter and re-search broadened.
+    // Only prune against a facet set fetched for the taxonomy AND tokens we're about to judge.
+    // Requests are not cancelled on a param change, so a slow older response can land last; a
+    // response for another taxonomy (or older tokens) legitimately omits a token that is valid
+    // here, and pruning on it would silently clear the user's just-picked filter and re-search
+    // broadened.
+    if (state.resultsParams?.taxonomy !== searchParams.taxonomy) return;
     const fetchedTokens = state.resultsParams?.taxonomy_attribute_filters;
     const current = searchParams.taxonomy_attribute_filters;
     if (!current?.length) return;


### PR DESCRIPTION
## What

Follow-up fix for a Greptile P1 review finding on #6858 (already merged): a
`taxonomy_attribute_filters` token was treated as selected in a Discover facet
whenever it shared the attribute-name prefix, even when it wasn't one of the
options the server actually returned for the current taxonomy.

## Why

Opening Discover with e.g. `?taxonomy_attribute_filters=format:cross-taxonomy-value`
rendered `format: cross-taxonomy-value (0)` as a checked facet and kept it in
search state on every subsequent request — a stale value from a different
taxonomy, a category switch, or a malformed token could get stuck permanently.

## Before / After

- Before: any `taxonomy_attribute_filters` token sharing an attribute's name
  prefix was accepted as selected, regardless of whether that value existed
  for the current taxonomy.
- After: only tokens present in `attribute.filters` (the server's live option
  list) render as selected; any other tokens are pruned from
  `taxonomy_attribute_filters` once results load.

## Test Results

- `npx vitest run app/javascript/components/Product/CardGrid.test.tsx` — 1
  example, 0 failures. Verified red against the pre-fix code (reverted the
  `CardGrid.tsx` change only, same test file, same run): failed on both the
  rendered-checked-facet assertion and the pruned-params assertion.
- `npx tsc --noEmit --pretty false` — pass.
- `npx eslint app/javascript/components/Product/CardGrid.tsx` — no offenses.

## QA steps

Not executed against the hosted preview app — this is a client-side state fix
with a focused component test above covering the exact input Greptile's
artifact reproduced (`format:cross-taxonomy-value`, an unknown option under
the `format` attribute).

## Status

- [x] **Scope** — fixes the single Greptile P1 finding on #6858.
- [x] **Design** — no new pattern; reuses the existing `attribute.filters` list as the source of truth for valid selection.
- [x] **Build** — done at this head.
- [x] **QA** — component test proves red-before/green-after; no rendered-surface screenshot needed for a filter-state fix.
- [ ] **Shipped** — not yet.
- [ ] **Market** — n/a; internal correctness fix, no user-facing announcement.
- [ ] **Sell** — n/a; no pricing or packaging change.

---

AI disclosure: Implemented by Hermes Agent using `claude-sonnet-5`. Prompt: verify and fix the Greptile P1 finding from review 4839346427 on antiwork/gumroad#6858.

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: the ball is back with me (CI failing: Test Slow 24), so I'm taking the assignee back and labelling `working`. I'll re-assign a human and flip to `awaiting-human` once it's genuinely ready again.
<!-- gumclaw-ownership-sweep -->
