### PR TITLE
Guard PayPal capture/refund error mapping against a missing details array

### DIFF
--- a/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
@@ -912,7 +912,7 @@ class PaypalChargeProcessor
       if paypal_rest_api.successful_response?(api_response)
         api_response.result
       else
-        error_message = PaypalChargeProcessor.build_error_message("Failed refund capture id - #{capture_id}", api_response.result.details[0].description)
+        error_message = PaypalChargeProcessor.build_error_message("Failed refund capture id - #{capture_id}", self.class.paypal_rejection_description(api_response))
         raise determine_refund_order_error(api_response), error_message
       end
     end

--- a/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
@@ -1045,19 +1045,16 @@ class PaypalChargeProcessor
     end
 
     def self.determine_capture_order_error(api_response)
+      issue = api_response.result.details&.first&.issue
       if api_response.result.name == "INTERNAL_ERROR"
         ChargeProcessorUnavailableError
-      elsif api_response.result.name == "UNPROCESSABLE_ENTITY" &&
-        api_response.result.details[0].issue == "AGREEMENT_ALREADY_CANCELLED"
+      elsif api_response.result.name == "UNPROCESSABLE_ENTITY" && issue == "AGREEMENT_ALREADY_CANCELLED"
         ChargeProcessorPayerCancelledBillingAgreementError
-      elsif api_response.result.name == "UNPROCESSABLE_ENTITY" &&
-        api_response.result.details[0].issue == "TRANSACTION_REFUSED"
+      elsif api_response.result.name == "UNPROCESSABLE_ENTITY" && issue == "TRANSACTION_REFUSED"
         ChargeProcessorPaymentDeclinedByPayerAccountError
-      elsif api_response.result.name == "UNPROCESSABLE_ENTITY" &&
-        api_response.result.details[0].issue == "PAYEE_ACCOUNT_RESTRICTED"
+      elsif api_response.result.name == "UNPROCESSABLE_ENTITY" && issue == "PAYEE_ACCOUNT_RESTRICTED"
         ChargeProcessorPayeeAccountRestrictedError
-      elsif api_response.result.name == "UNPROCESSABLE_ENTITY" &&
-        api_response.result.details[0].issue == "PAYER_CANNOT_PAY"
+      elsif api_response.result.name == "UNPROCESSABLE_ENTITY" && issue == "PAYER_CANNOT_PAY"
         ChargeProcessorPaymentDeclinedByPayerAccountError
       else
         ChargeProcessorInvalidRequestError
@@ -1065,13 +1062,12 @@ class PaypalChargeProcessor
     end
 
     def determine_refund_order_error(api_response)
+      issue = api_response.result.details&.first&.issue
       if api_response.result.name == "INTERNAL_ERROR"
         ChargeProcessorUnavailableError
-      elsif api_response.result.name == "UNPROCESSABLE_ENTITY" &&
-          api_response.result.details[0].issue == "CAPTURE_FULLY_REFUNDED"
+      elsif api_response.result.name == "UNPROCESSABLE_ENTITY" && issue == "CAPTURE_FULLY_REFUNDED"
         ChargeProcessorAlreadyRefundedError
-      elsif api_response.result.name == "UNPROCESSABLE_ENTITY" &&
-          api_response.result.details[0].issue == "REFUND_FAILED_INSUFFICIENT_FUNDS"
+      elsif api_response.result.name == "UNPROCESSABLE_ENTITY" && issue == "REFUND_FAILED_INSUFFICIENT_FUNDS"
         ChargeProcessorInsufficientFundsError
       else
         ChargeProcessorInvalidRequestError

--- a/spec/business/payments/charging/implementations/paypal/paypal_rejection_detail_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_rejection_detail_spec.rb
@@ -79,7 +79,7 @@ describe PaypalChargeProcessor, ".build_paypal_rejection" do
     end
   end
 
-  describe ".determine_refund_order_error" do
+  describe "#determine_refund_order_error" do
     it "falls back to invalid-request instead of raising when UNPROCESSABLE_ENTITY has no details array" do
       response = api_response(name: "UNPROCESSABLE_ENTITY")
 

--- a/spec/business/payments/charging/implementations/paypal/paypal_rejection_detail_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_rejection_detail_spec.rb
@@ -89,6 +89,22 @@ describe PaypalChargeProcessor, ".build_paypal_rejection" do
     end
   end
 
+  describe "#refund_order_purchase_unit!" do
+    it "raises the mapped error instead of NoMethodError when the rejection carries no details array" do
+      processor = described_class.new
+      allow(processor).to receive(:refund_amount_in_merchant_currency_cents).and_return(100)
+      rejection = api_response(name: "UNPROCESSABLE_ENTITY")
+      paypal_rest_api = instance_double(PaypalRestApi, refund: rejection, successful_response?: false)
+      allow(PaypalRestApi).to receive(:new).and_return(paypal_rest_api)
+      allow(described_class).to receive(:log_paypal_api_response)
+      merchant_account = instance_double(MerchantAccount, currency: "usd")
+
+      expect do
+        processor.send(:refund_order_purchase_unit!, "CAPTURE123", merchant_account, 100)
+      end.to raise_error(ChargeProcessorInvalidRequestError)
+    end
+  end
+
   describe ".paypal_rejection_description" do
     it "returns the first detail's description" do
       response = api_response(name: "UNPROCESSABLE_ENTITY", details: [detail(description: "The requested action could not be performed.")])

--- a/spec/business/payments/charging/implementations/paypal/paypal_rejection_detail_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_rejection_detail_spec.rb
@@ -63,6 +63,32 @@ describe PaypalChargeProcessor, ".build_paypal_rejection" do
     expect(error.message).to eq("Failed PayPal create order: |nope")
   end
 
+  describe ".determine_capture_order_error" do
+    it "falls back to invalid-request instead of raising when UNPROCESSABLE_ENTITY has no details array" do
+      response = api_response(name: "UNPROCESSABLE_ENTITY")
+
+      error_class = nil
+      expect { error_class = described_class.determine_capture_order_error(response) }.not_to raise_error
+      expect(error_class).to eq(ChargeProcessorInvalidRequestError)
+    end
+
+    it "still maps a named capture rejection when details are present" do
+      response = api_response(name: "UNPROCESSABLE_ENTITY", details: [detail(issue: "TRANSACTION_REFUSED")])
+
+      expect(described_class.determine_capture_order_error(response)).to eq(ChargeProcessorPaymentDeclinedByPayerAccountError)
+    end
+  end
+
+  describe ".determine_refund_order_error" do
+    it "falls back to invalid-request instead of raising when UNPROCESSABLE_ENTITY has no details array" do
+      response = api_response(name: "UNPROCESSABLE_ENTITY")
+
+      error_class = nil
+      expect { error_class = described_class.new.send(:determine_refund_order_error, response) }.not_to raise_error
+      expect(error_class).to eq(ChargeProcessorInvalidRequestError)
+    end
+  end
+
   describe ".paypal_rejection_description" do
     it "returns the first detail's description" do
       response = api_response(name: "UNPROCESSABLE_ENTITY", details: [detail(description: "The requested action could not be performed.")])


### PR DESCRIPTION
## Status

- [x] Scope — fix `NoMethodError` on missing PayPal `details` array in capture/refund error mapping (2 error-mapping methods + 1 refund error-message caller)
- [x] Design — safe-nav lookup matching `determine_create_order_error`'s existing idiom; no new abstractions
- [x] Build — pushed, `0cdd522c`
- [x] QA — spec run + mutation check against pre-fix code, see Test Results
- [ ] Shipped — open, awaiting CI + human merge
- [ ] Market — n/a (internal error-handling fix)
- [ ] Sell — n/a

## What

`determine_capture_order_error` and `determine_refund_order_error` in `PaypalChargeProcessor`
indexed `api_response.result.details[0].issue` directly, unlike `determine_create_order_error`'s
safe-nav lookup. A capture/refund rejection with `UNPROCESSABLE_ENTITY` and no `details` array
(e.g. a bare `INSTRUMENT_DECLINED`-shaped response) raised `NoMethodError` instead of falling
through to `ChargeProcessorInvalidRequestError`.

Hoists a single `issue = api_response.result.details&.first&.issue` lookup per method, matching
the safe-nav idiom `determine_create_order_error` already uses, and compares against `issue` in
place of the raw index everywhere.

`refund_order_purchase_unit!` had a second, distinct instance of the same crash class: the error
message it builds on a rejection reads `api_response.result.details[0].description` directly
instead of the nil-safe `paypal_rejection_description` helper the capture path already calls
(Greptile caught this in review). Fixed in a follow-up commit — same fallback shape, one caller
the first pass missed.

## Why

This is the exact silent-rejection class gp#1715 exists to capture: a malformed/partial PayPal
error response should degrade to a generic invalid-request failure, not crash the request handler.
Original branch (`fix/gp1715-paypal-error-detail`) had post-merge commits on #6861 that never
shipped; this PR carries that fix forward on a fresh branch off current `main`.

## Test Results

`spec/business/payments/charging/implementations/paypal/paypal_rejection_detail_spec.rb`:
**12 examples, 0 failures.** New specs cover: no-details-array fallback for both
`determine_capture_order_error` and `determine_refund_order_error`, details-present still maps to
the named error class, and `refund_order_purchase_unit!` itself raises the mapped error (not
`NoMethodError`) on a no-details rejection.

Mutation-verified the new `refund_order_purchase_unit!` spec: reverted the
`paypal_rejection_description` call back to raw `details[0].description` in-branch, re-ran —
example failed with `NoMethodError: undefined method '[]' for nil` — then restored the fix and
re-ran clean (12/12).

## QA steps

1. Ran the full rejection-detail spec file locally in a lane-borrowed worktree — 12/12 green.
2. Manually confirmed on `origin/main` (pre-fix) that both `determine_*` methods still index
   `details[0]` directly, and that `refund_order_purchase_unit!` built its error message from raw
   `details[0].description` — both bugs are live on main today.
3. Mutation-checked the new `refund_order_purchase_unit!` spec against the pre-fix line (see Test
   Results) to confirm the spec is real, not vacuous.

## Fable-5 review verdict: SHIP

Adversarial pre-merge review run against this branch (not draft-mode — full checklist: vacuous-spec,
guard-guarantee, nil-branch, behavior-preservation, AI-slop, trim-the-slop, callers, scope).

- **Vacuous spec check** — confirmed real: simulated old vs. new code against the exact spec-helper
  shapes; all new specs fail against unpatched code (raise `NoMethodError`), pass against the fix.
- **Guard-guarantee check** — confirmed nil-safe across all shapes PayPal's JSON→OpenStruct parsing
  can produce (`details` absent, `nil`, `[]`, or a detail node missing `.issue`/`.description`).
- **Nil-branch / behavior-preservation checks** — confirmed clause-by-clause identical output to
  the old code for every previously-passing case (named issue, `INTERNAL_ERROR`); the only change
  is converting a former crash into a nil fallthrough.
- **Callers check** — exactly one caller each for the two `determine_*` methods
  (`paypal_charge_processor.rb:648` and `:916`), and one caller for `refund_order_purchase_unit!`'s
  error-message line; none depend on the old crashing behavior.
- **Scope check** — diff touches only the two error-mapping methods, the refund error-message line,
  and spec.
- **P3 (fixed in this branch):** spec describe-block label used `.determine_refund_order_error`
  (class-method convention) for an instance method; the codebase convention is `#`. Fixed in
  commit `8038fd5e9`.
- **P1 (fixed in this branch, caught by Greptile):** `refund_order_purchase_unit!`'s error-message
  build still indexed `details[0].description` directly, an instance of the same crash class this
  PR exists to fix. Verified against `origin/main` and mutation-checked; fixed in `0cdd522c`.

No open P1/P2 findings.

## AI disclosure

Written by claude-sonnet-5 running as Gumclaw (cron: green-branch-no-pr watcher / GitHub webhook
responder). Original fix (`e75f3e07a`) was written in an earlier autonomous session responding to
a Greptile/T-Rex P1 on #6861; this PR cherry-picks that commit onto a fresh branch off current
`main` because the original branch (`fix/gp1715-paypal-error-detail`) had post-merge commits that
were never opened as a PR or reviewed. Fable-5 adversarial review run before opening; Greptile's
subsequent finding on the refund-message line verified and fixed in a follow-up commit.
