### PR TITLE
Drop retired taxonomy-attribute tokens from Discover filter params

### DIFF
--- a/app/controllers/concerns/search_products.rb
+++ b/app/controllers/concerns/search_products.rb
@@ -74,7 +74,8 @@ module SearchProducts
 
       if search_params[:taxonomy_attribute_filters].is_a?(Array)
         search_params[:taxonomy_attribute_filters] =
-          search_params[:taxonomy_attribute_filters].uniq.first(Product::Searchable::MAX_TAXONOMY_ATTRIBUTE_FILTER_TOKENS)
+          search_params[:taxonomy_attribute_filters].uniq.first(Product::Searchable::MAX_TAXONOMY_ATTRIBUTE_FILTER_TOKENS) &
+          TaxonomyAttribute.valid_filter_tokens.to_a
       end
 
       # search_options coerces each of these unconditionally (`.to_i`, `.to_f`) or hands it to ES

--- a/app/controllers/concerns/search_products.rb
+++ b/app/controllers/concerns/search_products.rb
@@ -73,9 +73,14 @@ module SearchProducts
       end
 
       if search_params[:taxonomy_attribute_filters].is_a?(Array)
+        valid_tokens = TaxonomyAttribute.valid_filter_tokens
+        # Allowlist before the cap: otherwise 20 junk tokens can push the one real token past
+        # the limit and silently widen the result set.
         search_params[:taxonomy_attribute_filters] =
-          search_params[:taxonomy_attribute_filters].uniq.first(Product::Searchable::MAX_TAXONOMY_ATTRIBUTE_FILTER_TOKENS) &
-          TaxonomyAttribute.valid_filter_tokens.to_a
+          search_params[:taxonomy_attribute_filters]
+            .uniq
+            .select { |token| valid_tokens.include?(token) }
+            .first(Product::Searchable::MAX_TAXONOMY_ATTRIBUTE_FILTER_TOKENS)
       end
 
       # search_options coerces each of these unconditionally (`.to_i`, `.to_f`) or hands it to ES

--- a/app/models/taxonomy_attribute.rb
+++ b/app/models/taxonomy_attribute.rb
@@ -6,7 +6,8 @@ class TaxonomyAttribute < ApplicationRecord
 
   belongs_to :taxonomy
 
-  scope :active_ordered, -> { where(active: true).order(:position, :id) }
+  scope :active, -> { where(active: true) }
+  scope :active_ordered, -> { active.order(:position, :id) }
 
   validates :name, presence: true, uniqueness: { scope: :taxonomy_id }, format: { with: /\A[a-z0-9_]+\z/ }
   validates :label, :value_type, presence: true
@@ -48,5 +49,18 @@ class TaxonomyAttribute < ApplicationRecord
     return value == "true" ? "Yes" : "No" if value_type == "boolean"
 
     value
+  end
+
+  # The token space a request is allowed to filter on right now. Retiring an attribute (or
+  # dropping/renaming one of its values) doesn't touch already-indexed products — see
+  # `Onetime::SeedTaxonomyAttributes` — so a stale bookmarked or hand-built URL can otherwise
+  # keep matching documents that still carry the old token.
+  def self.valid_filter_tokens
+    active.each_with_object(Set.new) do |attribute, tokens|
+      attribute.filter_options.each do |option|
+        token = attribute.filter_token_for(option)
+        tokens << token if token
+      end
+    end
   end
 end

--- a/spec/controllers/concerns/search_products_spec.rb
+++ b/spec/controllers/concerns/search_products_spec.rb
@@ -93,6 +93,9 @@ describe SearchProducts do
     context "with taxonomy attribute filter parameters" do
       before do
         routes.draw { get "index" => "anonymous#index" }
+        taxonomy = create(:taxonomy)
+        TaxonomyAttribute.create!(taxonomy:, name: "format", label: "Format", value_type: "enum", values: ["OTF"])
+        TaxonomyAttribute.create!(taxonomy:, name: "license", label: "License", value_type: "enum", values: ["Commercial"])
       end
 
       it "coerces nested taxonomy attribute filter params into scalar tokens" do
@@ -102,18 +105,35 @@ describe SearchProducts do
       end
 
       it "caps the number of tokens so a crafted URL cannot emit an unbounded number of ES clauses" do
-        tokens = (1..50).map { |i| "attr#{i}:value" }
+        valid_tokens = ["format:otf", "license:commercial"]
+        tokens = valid_tokens + (1..50).map { |i| "attr#{i}:value" }
+        get :index, params: { taxonomy_attribute_filters: tokens.join(",") }
+
+        parsed = JSON.parse(response.body)["taxonomy_attribute_filters"]
+        expect(parsed).to match_array(valid_tokens)
+      end
+
+      it "still caps once invalid tokens are removed, when the surviving set exceeds the limit" do
+        taxonomy = TaxonomyAttribute.first.taxonomy
+        many_values = (1..25).map { |i| "v#{i}" }
+        TaxonomyAttribute.create!(taxonomy:, name: "size", label: "Size", value_type: "enum", values: many_values)
+        tokens = many_values.map { |v| "size:#{v}" }
         get :index, params: { taxonomy_attribute_filters: tokens.join(",") }
 
         parsed = JSON.parse(response.body)["taxonomy_attribute_filters"]
         expect(parsed.size).to eq(Product::Searchable::MAX_TAXONOMY_ATTRIBUTE_FILTER_TOKENS)
-        expect(parsed).to eq(tokens.first(Product::Searchable::MAX_TAXONOMY_ATTRIBUTE_FILTER_TOKENS))
       end
 
       it "drops duplicate tokens before applying the cap" do
         get :index, params: { taxonomy_attribute_filters: "format:otf,format:otf,license:commercial" }
 
         expect(JSON.parse(response.body)["taxonomy_attribute_filters"]).to eq(["format:otf", "license:commercial"])
+      end
+
+      it "drops tokens for attributes/values that are no longer active" do
+        get :index, params: { taxonomy_attribute_filters: "format:otf,format:tiff" }
+
+        expect(JSON.parse(response.body)["taxonomy_attribute_filters"]).to eq(["format:otf"])
       end
     end
 

--- a/spec/controllers/concerns/search_products_spec.rb
+++ b/spec/controllers/concerns/search_products_spec.rb
@@ -130,6 +130,13 @@ describe SearchProducts do
         expect(JSON.parse(response.body)["taxonomy_attribute_filters"]).to eq(["format:otf", "license:commercial"])
       end
 
+      it "applies the allowlist before the cap so junk tokens cannot crowd out a valid one" do
+        tokens = (1..Product::Searchable::MAX_TAXONOMY_ATTRIBUTE_FILTER_TOKENS).map { |i| "attr#{i}:value" } + ["format:otf"]
+        get :index, params: { taxonomy_attribute_filters: tokens.join(",") }
+
+        expect(JSON.parse(response.body)["taxonomy_attribute_filters"]).to eq(["format:otf"])
+      end
+
       it "drops tokens for attributes/values that are no longer active" do
         get :index, params: { taxonomy_attribute_filters: "format:otf,format:tiff" }
 

--- a/spec/models/taxonomy_attribute_spec.rb
+++ b/spec/models/taxonomy_attribute_spec.rb
@@ -20,15 +20,19 @@ describe TaxonomyAttribute do
   end
 
   describe ".valid_filter_tokens" do
+    # Tokens are `name:value` and NOT taxonomy-scoped, because that is what is indexed on the
+    # product. So these names must be absent from TaxonomyAttributeDefinitions — an attribute
+    # retired in one taxonomy stays a valid token while any other taxonomy still defines it.
     it "includes tokens from active attributes/values and excludes retired ones" do
       taxonomy = create(:taxonomy)
-      described_class.create!(taxonomy:, name: "format", label: "Format", value_type: "enum", values: %w[OTF TTF])
-      retired = described_class.create!(taxonomy:, name: "license", label: "License", value_type: "enum", values: %w[Commercial], active: false)
+      described_class.create!(taxonomy:, name: "spec_only_active", label: "Active", value_type: "enum", values: %w[OTF TTF])
+      retired = described_class.create!(taxonomy:, name: "spec_only_retired", label: "Retired", value_type: "enum", values: %w[Commercial], active: false)
 
       tokens = described_class.valid_filter_tokens
 
-      expect(tokens).to include("format:otf", "format:ttf")
-      expect(tokens).not_to include(retired.filter_token_for("Commercial"))
+      expect(tokens).to include("spec_only_active:otf", "spec_only_active:ttf")
+      expect(tokens).not_to include("spec_only_retired:commercial")
+      expect(retired.filter_token_for("Commercial")).to eq("spec_only_retired:commercial")
     end
   end
 end

--- a/spec/models/taxonomy_attribute_spec.rb
+++ b/spec/models/taxonomy_attribute_spec.rb
@@ -18,4 +18,17 @@ describe TaxonomyAttribute do
       expect(styles.filter_token_for(12)).to be_nil
     end
   end
+
+  describe ".valid_filter_tokens" do
+    it "includes tokens from active attributes/values and excludes retired ones" do
+      taxonomy = create(:taxonomy)
+      described_class.create!(taxonomy:, name: "format", label: "Format", value_type: "enum", values: %w[OTF TTF])
+      retired = described_class.create!(taxonomy:, name: "license", label: "License", value_type: "enum", values: %w[Commercial], active: false)
+
+      tokens = described_class.valid_filter_tokens
+
+      expect(tokens).to include("format:otf", "format:ttf")
+      expect(tokens).not_to include(retired.filter_token_for("Commercial"))
+    end
+  end
 end


### PR DESCRIPTION
## What

Follow-up fix for a Greptile P1 review finding on #6858 (already merged): retiring a
`TaxonomyAttribute` or dropping/renaming one of its enum values doesn't reindex the
products that already carry the old filter token, so a stale bookmarked or hand-built
`?taxonomy_attribute_filters=` URL could keep filtering on it indefinitely.

## Why

`Onetime::SeedTaxonomyAttributes` deactivates (not deletes) rows the current registry no
longer defines, and there is no reindex step — deliberately, per that service's own
comment, since destroying/recreating a row would orphan every product value already
indexed under it (`TaxonomyAttribute#name` is the ES filter-token prefix). That leaves the
active-attribute-only facet rendering path disconnected from the request-time filter
path: the sidebar stops showing the retired facet, but `search_products` accepted any
submitted token directly.

## Before / After

- Before: `taxonomy_attribute_filters` request tokens were capped and deduped, but never
  checked against which attributes/values are currently active.
- After: `TaxonomyAttribute.valid_filter_tokens` (the active attribute × active value
  token space) is intersected with the request's tokens in the same normalization step,
  before the existing 20-token cap is applied.

## Test Results

`DISABLE_SPRING=1 bundle exec rspec spec/models/taxonomy_attribute_spec.rb spec/controllers/concerns/search_products_spec.rb spec/modules/product/searchable/taxonomy_attribute_filters_spec.rb` — 26 examples, 0 failures, run in this worktree.

- Added `TaxonomyAttribute.valid_filter_tokens` spec: asserts active values are included and a retired attribute's token is excluded.
- Added a `search_products` spec asserting a token for a no-longer-active attribute/value is dropped from the request.
- Updated the two existing token-cap specs to use real active attributes (they previously asserted on the pre-filter array, which is no longer the invariant).
- Mutation-verified: reverted the intersection line only, re-ran the suite — the "drops tokens for attributes/values that are no longer active" and cap spec both failed as expected, confirming the new spec has teeth.
- Red/green (full-file revert, run at head `ddfffc8`): with `search_products.rb` reverted to `origin/main` in a detached worktree, exactly the 3 allowlist examples fail on their own assertions (`search_products_spec.rb:107,133,140` — 22 examples, 3 failures); with the fix restored, 24 examples, 0 failures across both spec files.
- `rubocop app/models/taxonomy_attribute.rb app/controllers/concerns/search_products.rb spec/models/taxonomy_attribute_spec.rb spec/controllers/concerns/search_products_spec.rb` — no offenses.

## QA steps

Not executed against the hosted preview app — this is a server-side request-normalization
fix with no rendered surface of its own (the sidebar already only shows active facets;
this closes the gap where a *submitted* token for an inactive one still matched). Covered
by the specs above, which reproduce the exact failure Greptile's artifact demonstrated.

## Status

- [x] **Scope** — fixes the single Greptile P1 finding quoted above on #6858.
- [x] **Design** — no new pattern; reuses `filter_token_for`/`filter_options`, the same
  helpers the active-only facet-rendering path already uses, as the source of truth for
  "still valid."
- [x] **Build** — done, pushed.
- [ ] **QA** — no rendered surface; specs above are the evidence.
- [ ] **Shipped**
- [ ] **Market** — n/a, internal correctness fix.
- [ ] **Sell** — n/a.

---

AI disclosure: built autonomously by Hermes Agent (model: claude-sonnet-5) in response to a Greptile review comment on #6858.

