### PR TITLE
Treat unparseable Wise created timestamps as nonmatching instead of crashing the batch

### DIFF
--- a/app/services/tax_remittances/wise_transfer_matcher.rb
+++ b/app/services/tax_remittances/wise_transfer_matcher.rb
@@ -131,7 +131,10 @@ class TaxRemittances::WiseTransferMatcher
     end
 
     def within_tolerance?(transfer, remittance)
-      return false unless transfer[:created] && (transfer_time(transfer) - remittance.paid_at).abs <= DATE_WINDOW
+      # Malformed `created` values parse to nil; treat them as nonmatching so one
+      # bad transfer surfaces in unclaimed_transfers instead of aborting the batch.
+      time = transfer_time(transfer)
+      return false unless time && (time - remittance.paid_at).abs <= DATE_WINDOW
 
       target_amount = remittance.target_amount_cents
       # No recorded target amount (the April backfill's rows): compare the
@@ -150,6 +153,8 @@ class TaxRemittances::WiseTransferMatcher
 
     def transfer_time(transfer)
       Time.zone.parse(transfer[:created].to_s)
+    rescue ArgumentError
+      nil
     end
 
     def cents(major_units)

--- a/spec/services/tax_remittances/wise_transfer_matcher_spec.rb
+++ b/spec/services/tax_remittances/wise_transfer_matcher_spec.rb
@@ -171,6 +171,18 @@ describe TaxRemittances::WiseTransferMatcher do
     expect(result.unmatched.size).to eq(1)
   end
 
+  it "treats a transfer with an unparseable created timestamp as nonmatching, reporting it unclaimed" do
+    create(:tax_remittance, :completed, currency: "GBP", period: "2026-Q2",
+                                        target_amount_cents: 18_284_755, paid_at: Time.utc(2026, 7, 22),
+                                        transfer_id: nil)
+    malformed = hmrc_transfer.merge(id: 900_777, created: "definitely-not-a-time")
+
+    result = described_class.new("2026-Q2").process([malformed])
+
+    expect(result.matched).to be_empty
+    expect(result.unclaimed_transfers).to eq([malformed])
+  end
+
   it "reports a sent transfer no remittance ever candidated for as unclaimed, instead of dropping it" do
     create(:tax_remittance, :completed, currency: "GBP", period: "2026-Q2",
                                         target_amount_cents: 18_284_755, paid_at: Time.utc(2026, 7, 22),

--- a/spec/services/tax_remittances/wise_transfer_matcher_spec.rb
+++ b/spec/services/tax_remittances/wise_transfer_matcher_spec.rb
@@ -175,12 +175,18 @@ describe TaxRemittances::WiseTransferMatcher do
     create(:tax_remittance, :completed, currency: "GBP", period: "2026-Q2",
                                         target_amount_cents: 18_284_755, paid_at: Time.utc(2026, 7, 22),
                                         transfer_id: nil)
-    malformed = hmrc_transfer.merge(id: 900_777, created: "definitely-not-a-time")
 
-    result = described_class.new("2026-Q2").process([malformed])
+    # "definitely-not-a-time" parses to nil; "2026-13-45 10:00:00" raises ArgumentError —
+    # both halves of transfer_time's handling need pinning.
+    ["definitely-not-a-time", "2026-13-45 10:00:00"].each do |created|
+      malformed = hmrc_transfer.merge(id: 900_777, created:)
 
-    expect(result.matched).to be_empty
-    expect(result.unclaimed_transfers).to eq([malformed])
+      result = described_class.new("2026-Q2").process([malformed])
+
+      expect(result.matched).to be_empty
+      expect(result.unmatched.size).to eq(1)
+      expect(result.unclaimed_transfers).to eq([malformed])
+    end
   end
 
   it "reports a sent transfer no remittance ever candidated for as unclaimed, instead of dropping it" do


### PR DESCRIPTION
# Treat unparseable Wise `created` timestamps as nonmatching instead of crashing the batch

Follow-up to #6993 (merged), fixing the Greptile P1 posted after the final push there ([comment](https://github.com/antiwork/gumroad/pull/6993#discussion_r3711253213)): a non-empty but malformed `created` value on a Wise transfer passed the `transfer[:created]` presence check while `Time.zone.parse` returned `nil` (or raised `ArgumentError`), so `(nil - paid_at)` raised `NoMethodError` and aborted `process` for the **whole** transfer batch.

## What

`WiseTransferMatcher#within_tolerance?` now parses the timestamp once and treats an unparseable value as nonmatching; `transfer_time` rescues `ArgumentError` to `nil`. A malformed transfer now surfaces in `unclaimed_transfers` (the reporting path #6993 added) instead of killing reconciliation for every other transfer in the batch.

## Why

The matcher feeds the tax_remittances reconciliation (gp#1100). One bad row from the Wise API should degrade to "this transfer is reported unclaimed", never to "the entire quarterly reconciliation run raised".

## Before / After

| Input | Before | After |
|---|---|---|
| `created: "2026-07-22 10:00:00"` | matched | matched (unchanged) |
| `created: "definitely-not-a-time"` | `NoMethodError: undefined method '-' for nil` — whole batch aborts | transfer reported in `unclaimed_transfers`; rest of batch reconciles |

## Test Results

- `ruby -c` clean on both files
- `bundle exec rspec spec/services/tax_remittances/wise_transfer_matcher_spec.rb` — 15 examples, 0 failures (all 14 pre-existing examples plus the new one)
- Revert proof: with the fix reverted (`git show HEAD~1:` of the service), the new example fails red with the exact `NoMethodError` the finding describes; green with the fix
- Both failure modes pinned (fable-5 P1 fix, `c875ae6d`): the example now loops over a nil-parsing input AND an out-of-range one (`"2026-13-45 10:00:00"`, which raises `ArgumentError`); deleting the `rescue ArgumentError` clause alone makes the spec fail red (mutation-verified), and `result.unmatched` is asserted so the remittance is reported rather than silently vanishing

## QA steps

Backend-only service change with no rendered surface — review the diff and run the spec file above. No preview app applies.

---

## AI disclosure

Written by gumclaw (Hermes Agent, model `claude-sonnet-5`) as an autonomous follow-up: #6993 merged while Greptile's final-round P1 was still open, so the fix ships as its own scoped PR per the post-merge review triage rule.

