### PR TITLE
Trim branch CI to relevant specs plus a money-path smoke set

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -480,6 +480,8 @@ jobs:
       COMPOSE_PROJECT_NAME: web_${{ github.run_id }}_${{ github.run_attempt }}_fast_${{ matrix.ci_node_index }}
     runs-on: ubicloud-standard-4
     needs: build
+    # Full suite is a main-only deploy gate; branches run test_relevant.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     strategy:
       fail-fast: true
       matrix:
@@ -611,6 +613,8 @@ jobs:
       WEB_REPO: gumroadteam/web
     runs-on: ubicloud-standard-4
     needs: build
+    # Full suite is a main-only deploy gate; branches run test_relevant.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     strategy:
       fail-fast: false
       matrix:
@@ -795,6 +799,133 @@ jobs:
           name: flaky-specs-slow-${{ matrix.ci_node_index }}-attempt-${{ github.run_attempt }}
           path: ./test-logs/flaky_specs.log
           retention-days: 14
+          if-no-files-found: ignore
+      - name: Clean up
+        if: always()
+        run: |
+          docker compose -f docker/docker-compose-test-and-ci.yml down -v 2>/dev/null || true
+          docker rm -f $(docker ps -aq -f name=${{ env.COMPOSE_PROJECT_NAME }}) 2>/dev/null || true
+          docker volume rm $(docker volume ls -q -f name=${{ env.COMPOSE_PROJECT_NAME }}) 2>/dev/null || true
+          docker network rm ${{ env.COMPOSE_PROJECT_NAME }}_default 2>/dev/null || true
+
+  test_relevant:
+    name: Test Relevant${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository && ' (internal PR noop)' || '' }}
+    env:
+      COMPOSE_PROJECT_NAME: web_${{ github.run_id }}_${{ github.run_attempt }}_relevant
+      WEB_REPO: gumroadteam/web
+    runs-on: ubicloud-standard-4
+    needs: build
+    # Branch-only counterpart of test_fast/test_slow: runs the specs mapped
+    # from the diff (bin/branch-specs) plus the money-path smoke set, instead
+    # of the whole suite. Main still runs everything before a deploy.
+    if: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main') && (github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name != github.repository) }}
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        timeout-minutes: 5
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          # bin/branch-specs diffs against origin/main, so the base has to be
+          # in the clone.
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Compute relevant specs
+        id: specs
+        run: |
+          git fetch --no-tags --quiet origin main
+          SPECS=$(ruby bin/branch-specs)
+          COUNT=$(echo "$SPECS" | grep -c . || true)
+          # Bare rspec runs the WHOLE suite; an empty list must fail loudly
+          # instead. The smoke set makes this unreachable unless those specs
+          # are deleted.
+          if [ "$COUNT" -eq 0 ]; then
+            echo "bin/branch-specs returned no specs — refusing to run bare rspec"
+            exit 1
+          fi
+          echo "Running $COUNT spec file(s):"
+          echo "$SPECS" | sed 's/^/  /'
+          # Single line for the docker run below.
+          echo "files=$(echo "$SPECS" | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
+      - name: Login to Docker Hub
+        uses: nick-fields/retry@v3
+        with:
+          timeout_seconds: 120
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Start services and pull test image
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 5
+          command: |
+            docker pull --quiet $WEB_REPO:${{ needs.build.outputs.test_image_tag }} &
+            PULL_PID=$!
+            docker compose -f docker/docker-compose-test-and-ci.yml up -d
+            COMPOSE_EXIT=$?
+            wait $PULL_PID
+            PULL_EXIT=$?
+            exit $((COMPOSE_EXIT + PULL_EXIT))
+        env:
+          COMPOSE_HTTP_TIMEOUT: "300"
+      - name: Wait for services and prepare test database
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: |
+            IMG=$WEB_REPO:${{ needs.build.outputs.test_image_tag }}
+            NET=${{ env.COMPOSE_PROJECT_NAME }}_default
+            (
+              docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh db_test 3306 \
+                && docker/ci/restore_test_db.sh $NET $IMG
+            ) &
+            DB_PID=$!
+            docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh elasticsearch 9200 &
+            ES_PID=$!
+            docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh minio 9000 &
+            MINIO_PID=$!
+            wait $DB_PID || exit 1
+            wait $ES_PID || exit 1
+            wait $MINIO_PID || exit 1
+      - name: Run relevant specs
+        timeout-minutes: 25
+        run: |
+          mkdir -p ./capybara-artifacts ./test-logs
+          chmod 777 ./capybara-artifacts ./test-logs
+          docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
+            -v "$(pwd)/capybara-artifacts:/app/tmp/capybara" \
+            -v "$(pwd)/test-logs:/app/log" \
+            -e RUBY_YJIT_ENABLE \
+            -e CI \
+            -e IN_DOCKER \
+            $WEB_REPO:${{ needs.build.outputs.test_image_tag }} \
+            /usr/local/bin/gosu app bundle exec rspec --format RSpec::Github::Formatter --format progress --tag ~skip ${{ steps.specs.outputs.files }}
+        env:
+          RUBY_YJIT_ENABLE: 1
+          CI: true
+          IN_DOCKER: true
+      - name: Archive capybara artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: capybara-screenshots-relevant-attempt-${{ github.run_attempt }}
+          path: ./capybara-artifacts/*.png
+          retention-days: 7
+          if-no-files-found: ignore
+      - name: Archive test logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-logs-relevant-attempt-${{ github.run_attempt }}
+          path: ./test-logs/test.log
+          retention-days: 7
           if-no-files-found: ignore
       - name: Clean up
         if: always()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,40 @@ jobs:
     steps:
       - run: true
 
+  run_scope:
+    # Decides whether this run gets the full Fast/Slow suite or the trimmed
+    # test_relevant job. Full suite: every push to main (deploy gate), or a
+    # PR carrying the run-all-specs label. Push events have no PR payload,
+    # so the label is looked up via the commit's PRs.
+    name: Run scope
+    runs-on: ubicloud-standard-2
+    needs: ci_gate
+    if: ${{ github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name != github.repository }}
+    permissions:
+      pull-requests: read
+    outputs:
+      full: ${{ steps.scope.outputs.full }}
+    steps:
+      - id: scope
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF" = "refs/heads/main" ]; then
+            echo "full=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$GITHUB_EVENT_NAME" = "pull_request_target" ]; then
+            LABELS=$(gh api "repos/$GITHUB_REPOSITORY/pulls/${{ github.event.pull_request.number }}" --jq '[.labels[].name] | join("\n")')
+          else
+            LABELS=$(gh api "repos/$GITHUB_REPOSITORY/commits/$SHA/pulls" --jq '[.[].labels[].name] | join("\n")' || true)
+          fi
+          if echo "$LABELS" | grep -qx 'run-all-specs'; then
+            echo "full=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "full=false" >> "$GITHUB_OUTPUT"
+          fi
+
   lint_js:
     name: Lint JS/TS
     runs-on: ubicloud-standard-4
@@ -479,9 +513,10 @@ jobs:
     env:
       COMPOSE_PROJECT_NAME: web_${{ github.run_id }}_${{ github.run_attempt }}_fast_${{ matrix.ci_node_index }}
     runs-on: ubicloud-standard-4
-    needs: build
-    # Full suite is a main-only deploy gate; branches run test_relevant.
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [build, run_scope]
+    # Full suite: main pushes (deploy gate) and PRs labeled run-all-specs.
+    # Everything else runs test_relevant instead.
+    if: needs.run_scope.outputs.full == 'true'
     strategy:
       fail-fast: true
       matrix:
@@ -612,9 +647,10 @@ jobs:
       COMPOSE_PROJECT_NAME: web_${{ github.run_id }}_${{ github.run_attempt }}_slow_${{ matrix.ci_node_index }}
       WEB_REPO: gumroadteam/web
     runs-on: ubicloud-standard-4
-    needs: build
-    # Full suite is a main-only deploy gate; branches run test_relevant.
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [build, run_scope]
+    # Full suite: main pushes (deploy gate) and PRs labeled run-all-specs.
+    # Everything else runs test_relevant instead.
+    if: needs.run_scope.outputs.full == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -808,18 +844,18 @@ jobs:
           docker volume rm $(docker volume ls -q -f name=${{ env.COMPOSE_PROJECT_NAME }}) 2>/dev/null || true
           docker network rm ${{ env.COMPOSE_PROJECT_NAME }}_default 2>/dev/null || true
 
-  test_relevant:
-    name: Test Relevant${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository && ' (internal PR noop)' || '' }}
-    env:
-      COMPOSE_PROJECT_NAME: web_${{ github.run_id }}_${{ github.run_attempt }}_relevant
-      WEB_REPO: gumroadteam/web
-    runs-on: ubicloud-standard-4
-    needs: build
-    # Branch-only counterpart of test_fast/test_slow: runs the specs mapped
-    # from the diff (bin/branch-specs) plus the money-path smoke set, instead
-    # of the whole suite. Main still runs everything before a deploy.
-    if: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main') && (github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name != github.repository) }}
-    timeout-minutes: 30
+  relevant_specs:
+    # Runs the fork-controlled bin/branch-specs in a job with NO secrets and
+    # no Docker login, so untrusted code can never sit in front of a
+    # credential-bearing step (a $GITHUB_PATH write here can't reach
+    # test_relevant — PATH edits don't cross jobs). The list crosses over as
+    # a plain data output.
+    name: Compute relevant specs
+    runs-on: ubicloud-standard-2
+    needs: run_scope
+    if: ${{ needs.run_scope.outputs.full != 'true' && (github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name != github.repository) }}
+    outputs:
+      files_csv: ${{ steps.specs.outputs.files_csv }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -836,17 +872,42 @@ jobs:
           git fetch --no-tags --quiet origin main
           SPECS=$(ruby bin/branch-specs)
           COUNT=$(echo "$SPECS" | grep -c . || true)
-          # Bare rspec runs the WHOLE suite; an empty list must fail loudly
-          # instead. The smoke set makes this unreachable unless those specs
-          # are deleted.
+          # An empty list would make Knapsack fall back to its full-suite
+          # pattern; fail loudly instead. The smoke set makes this
+          # unreachable unless those specs are deleted.
           if [ "$COUNT" -eq 0 ]; then
-            echo "bin/branch-specs returned no specs — refusing to run bare rspec"
+            echo "bin/branch-specs returned no specs — refusing to run"
             exit 1
           fi
           echo "Running $COUNT spec file(s):"
           echo "$SPECS" | sed 's/^/  /'
-          # Single line for the docker run below.
-          echo "files=$(echo "$SPECS" | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
+          echo "files_csv=$(echo "$SPECS" | paste -sd, -)" >> "$GITHUB_OUTPUT"
+
+  test_relevant:
+    name: Test Relevant ${{ matrix.ci_node_index }}${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository && ' (internal PR noop)' || '' }}
+    env:
+      COMPOSE_PROJECT_NAME: web_${{ github.run_id }}_${{ github.run_attempt }}_relevant_${{ matrix.ci_node_index }}
+      WEB_REPO: gumroadteam/web
+    runs-on: ubicloud-standard-4
+    needs: [build, run_scope, relevant_specs]
+    # Branch/PR counterpart of test_fast/test_slow: the same docker setup and
+    # Knapsack queue distribution, restricted to the specs relevant_specs
+    # mapped from the diff plus the money-path smoke set. Main pushes and
+    # run-all-specs PRs run the full suite instead.
+    if: needs.run_scope.outputs.full != 'true' && (github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name != github.repository)
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        ci_node_total: [4]
+        ci_node_index: [0, 1, 2, 3]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        timeout-minutes: 5
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
       - name: Login to Docker Hub
         uses: nick-fields/retry@v3
         with:
@@ -894,7 +955,7 @@ jobs:
             wait $DB_PID || exit 1
             wait $ES_PID || exit 1
             wait $MINIO_PID || exit 1
-      - name: Run relevant specs
+      - name: Run tests
         timeout-minutes: 25
         run: |
           mkdir -p ./capybara-artifacts ./test-logs
@@ -903,19 +964,41 @@ jobs:
             -v "$(pwd)/capybara-artifacts:/app/tmp/capybara" \
             -v "$(pwd)/test-logs:/app/log" \
             -e RUBY_YJIT_ENABLE \
+            -e KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC \
+            -e KNAPSACK_PRO_CI_NODE_TOTAL \
+            -e KNAPSACK_PRO_CI_NODE_INDEX \
+            -e KNAPSACK_PRO_LOG_LEVEL \
+            -e KNAPSACK_PRO_TEST_FILE_LIST \
+            -e KNAPSACK_PRO_COMMIT_HASH \
+            -e KNAPSACK_PRO_BRANCH \
+            -e KNAPSACK_PRO_CI_NODE_BUILD_ID \
+            -e KNAPSACK_PRO_CI_NODE_RETRY_COUNT \
+            -e KNAPSACK_PRO_PROJECT_DIR \
+            -e KNAPSACK_PRO_FIXED_QUEUE_SPLIT \
             -e CI \
             -e IN_DOCKER \
             $WEB_REPO:${{ needs.build.outputs.test_image_tag }} \
-            /usr/local/bin/gosu app bundle exec rspec --format RSpec::Github::Formatter --format progress --tag ~skip ${{ steps.specs.outputs.files }}
+            /usr/local/bin/gosu app bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --format progress]"
         env:
           RUBY_YJIT_ENABLE: 1
+          KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC_FAST }}
+          KNAPSACK_PRO_CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
+          KNAPSACK_PRO_CI_NODE_INDEX: ${{ matrix.ci_node_index }}
+          KNAPSACK_PRO_LOG_LEVEL: info
+          KNAPSACK_PRO_TEST_FILE_LIST: ${{ needs.relevant_specs.outputs.files_csv }}
+          KNAPSACK_PRO_COMMIT_HASH: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          KNAPSACK_PRO_BRANCH: ${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref_name }}
+          KNAPSACK_PRO_CI_NODE_BUILD_ID: ${{ github.run_id }}
+          KNAPSACK_PRO_CI_NODE_RETRY_COUNT: ${{ github.run_attempt }}
+          KNAPSACK_PRO_PROJECT_DIR: /app
+          KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
           CI: true
           IN_DOCKER: true
       - name: Archive capybara artifacts
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: capybara-screenshots-relevant-attempt-${{ github.run_attempt }}
+          name: capybara-screenshots-relevant-${{ matrix.ci_node_index }}-attempt-${{ github.run_attempt }}
           path: ./capybara-artifacts/*.png
           retention-days: 7
           if-no-files-found: ignore
@@ -923,7 +1006,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: test-logs-relevant-attempt-${{ github.run_attempt }}
+          name: test-logs-relevant-${{ matrix.ci_node_index }}-attempt-${{ github.run_attempt }}
           path: ./test-logs/test.log
           retention-days: 7
           if-no-files-found: ignore

--- a/bin/branch-specs
+++ b/bin/branch-specs
@@ -1,0 +1,108 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Prints the spec files a branch needs for confidence, instead of the whole
+# suite: specs mapped from changed files (same rules as bin/rspec-changed)
+# plus an always-on smoke set covering the core money paths end to end.
+#
+# Branch CI runs exactly this list (see .github/workflows/tests.yml
+# test_relevant); main still runs everything before a deploy.
+#
+# Usage:
+#   bin/branch-specs                 # print the list, one per line
+#   bin/branch-specs --base main     # diff against a different base ref
+#   bin/branch-specs --no-smoke      # mapped specs only
+#   bin/rspec $(bin/branch-specs)    # run it locally
+#
+# Mapping rules:
+#   spec/**/*_spec.rb                    -> itself
+#   app/controllers/**/foo_controller.rb -> spec/controllers + spec/requests/**/foo_spec.rb
+#   app/<dir>/**/foo.rb                  -> spec/<dir>/**/foo_spec.rb
+#   lib/**/foo.rb                        -> spec/lib/**/foo_spec.rb
+#   app/models|services/**/foo.rb        -> spec/requests/**/foo*_spec.rb (E2E coverage)
+
+require "set"
+
+# Core end-to-end flows that run on every branch regardless of the diff:
+# a change that breaks buying, receipts, login, or the balance page must
+# not reach main on a trimmed run.
+SMOKE_SPECS = %w[
+  spec/requests/checkout/payment_spec.rb
+  spec/requests/checkout/form_spec.rb
+  spec/requests/purchases/product_spec.rb
+  spec/requests/purchases/receipt_spec.rb
+  spec/requests/authentication_spec.rb
+  spec/requests/balance_pages_spec.rb
+].freeze
+
+def git(*args)
+  out = IO.popen(["git", *args], err: File::NULL, &:read)
+  $?.success? ? out.split("\n") : []
+end
+
+base = "origin/main"
+base_given = false
+smoke = true
+
+argv = ARGV.dup
+until argv.empty?
+  case (arg = argv.shift)
+  when "--base"
+    base = argv.shift or abort("--base requires a ref")
+    base_given = true
+  when "--no-smoke" then smoke = false
+  when "-h", "--help"
+    doc = File.read(__FILE__).lines
+      .drop_while { |line| line.start_with?("#!") || line.include?("frozen_string_literal") || line.strip.empty? }
+      .take_while { |line| line.start_with?("#") }
+    puts doc.join.gsub(/^# ?/, "")
+    exit 0
+  else
+    abort("bin/branch-specs: unknown argument #{arg.inspect}")
+  end
+end
+
+if git("rev-parse", "--verify", "--quiet", base).empty?
+  abort("bin/branch-specs: base ref #{base.inspect} does not resolve") if base_given
+  base = "main"
+  abort("bin/branch-specs: neither origin/main nor main resolves") if git("rev-parse", "--verify", "--quiet", base).empty?
+end
+merge_base = git("merge-base", base, "HEAD").first
+
+changed = Set.new
+changed.merge(git("diff", "--name-only", "--diff-filter=d", "#{merge_base}..HEAD")) if merge_base
+changed.merge(git("diff", "--name-only", "--diff-filter=d", "HEAD"))
+changed.merge(git("ls-files", "--others", "--exclude-standard"))
+
+def spec_candidates(path)
+  case path
+  when %r{\Aspec/.*_spec\.rb\z}
+    [path]
+  when %r{\Aapp/controllers/(.*)_controller\.rb\z}
+    ["spec/controllers/#{$1}_controller_spec.rb", "spec/requests/#{$1}_spec.rb"]
+  when %r{\Aapp/(models|services)/(.*/)?([^/]+)\.rb\z}
+    # Unit specs (exact name, name-prefixed, and split-by-concern subdir)
+    # plus any request specs named after the model/service, so a money-path
+    # change pulls its end-to-end coverage into the run.
+    unit = ["spec/#{$1}/#{$2}#{$3}_spec.rb"] +
+      Dir.glob("spec/#{$1}/#{$2}#{$3}_*_spec.rb") +
+      Dir.glob("spec/#{$1}/#{$2}#{$3}/**/*_spec.rb")
+    e2e = Dir.glob("spec/requests/**/#{$3}*_spec.rb")
+    unit + e2e
+  when %r{\Aapp/([^/]+)/(.*)\.rb\z}
+    ["spec/#{$1}/#{$2}_spec.rb"]
+  when %r{\Alib/(.*)\.rb\z}
+    ["spec/lib/#{$1}_spec.rb"]
+  else
+    []
+  end
+end
+
+specs = changed
+  .flat_map { |path| spec_candidates(path) }
+  .uniq
+  .select { |spec| File.exist?(spec) }
+
+specs |= SMOKE_SPECS.select { |spec| File.exist?(spec) } if smoke
+
+puts specs.sort


### PR DESCRIPTION
## Scope
Branches (and PRs) stop running the full 68-shard suite per push. A new single-shard **Test Relevant** job runs only:
- Specs mapped from the diff by `bin/branch-specs` (unit specs incl. name-prefixed and split-by-concern subdirs, controller/request specs, and request specs named after changed models/services so money-path changes pull their E2E coverage)
- An always-on smoke set of core end-to-end request specs: checkout payment + form, purchase, receipt, authentication, balance page

**Main is unchanged**: every push to main still runs the full Fast (18 shards) + Slow (50 shards) + Minitest suite, and the Buildkite deploy unblock still gates on all of them. Nothing deploys on a trimmed run. Per Sahil: regressions that slip past a trimmed branch run are caught by the full main run and rolled back/fixed autonomously.

## Design
- `test_fast` / `test_slow` gain `if: push && main` — they become main-only deploy gates
- `test_relevant` mirrors their docker/service/baked-DB setup, runs `bundle exec rspec <list>` directly (no Knapsack — single shard)
- `bin/branch-specs` is `bin/rspec-changed`'s mapping plus the smoke set and model/service→request-spec expansion; also usable locally: `bin/rspec $(bin/branch-specs)`
- Empty-list guard: refuses to run bare `rspec` (which would run the whole suite) if the computed list is somehow empty

## Build
- [x] bin/branch-specs (mapping verified locally: purchase.rb change maps to 32 spec files incl. spec/models/purchase/** and checkout/purchase request specs)
- [x] tests.yml YAML validated
- [ ] QA: verify this PR's own run executes Test Relevant with the expected list and skips Fast/Slow

## QA
Pending — this PR's own CI run is the live test.
