### PR TITLE
Retry subscribe preview generation when avatar decode rejects

### DIFF
--- a/app/services/subscribe_preview_generator_service.rb
+++ b/app/services/subscribe_preview_generator_service.rb
@@ -22,17 +22,19 @@ class SubscribePreviewGeneratorService
   # `complete && naturalWidth > 0` only means the bytes arrived; Chromium still
   # decodes afterwards and screenshots taken in that window get an empty circle.
   # decode() is the event that says the frame is paintable, so the poll kicks it
-  # off once and then reports the flag it sets. A rejected decode counts as done
-  # so a permanently broken avatar cannot hold the wait open.
+  # off once and then reports the flag it sets. A rejected decode is reported as
+  # "failed", not "ready" — a broken image must not look identical to a decoded
+  # one, or a normal attempt would attach an incomplete card instead of retrying.
   AVATAR_READY_SCRIPT = <<~JS
     const img = document.querySelector("[data-subscribe-preview-avatar]");
     if (!img) return false;
     if (window.__gumroadAvatarDecoded) return true;
+    if (window.__gumroadAvatarDecodeFailed) return "failed";
     if (!window.__gumroadAvatarDecodeStarted) {
       window.__gumroadAvatarDecodeStarted = true;
       img.decode()
         .then(() => { window.__gumroadAvatarDecoded = true; })
-        .catch(() => { window.__gumroadAvatarDecoded = true; });
+        .catch(() => { window.__gumroadAvatarDecodeFailed = true; });
     }
     return false;
   JS
@@ -60,7 +62,13 @@ class SubscribePreviewGeneratorService
       driver.navigate.to url
       wait = Selenium::WebDriver::Wait.new(timeout: AVATAR_WAIT_SECONDS)
       begin
-        wait.until { driver.execute_script(AVATAR_READY_SCRIPT) }
+        # A rejected decode only satisfies the wait when the avatar is optional —
+        # otherwise it must time out like a slow one, so retries get a chance
+        # before a card without an avatar is ever attached.
+        wait.until do
+          result = driver.execute_script(AVATAR_READY_SCRIPT)
+          result == true || (result == "failed" && !require_avatar)
+        end
       rescue Selenium::WebDriver::Error::TimeoutError
         raise if require_avatar
         Rails.logger.error("SubscribePreviewGeneratorService: avatar never loaded for user.id=#{user.id}, generating card without it")

--- a/spec/services/subscribe_preview_generator_service_spec.rb
+++ b/spec/services/subscribe_preview_generator_service_spec.rb
@@ -59,11 +59,52 @@ describe SubscribePreviewGeneratorService, type: :system, js: true do
       expect(images.first).to start_with("\x89PNG".b)
     end
 
+    it "raises on a rejected decode rather than attaching an incomplete card" do
+      driver = stub_subscribe_preview_driver(script_result: "failed")
+
+      expect { described_class.generate_pngs([@user1]) }.to raise_error(Selenium::WebDriver::Error::TimeoutError)
+      expect(driver).not_to have_received(:screenshot_as)
+    end
+
+    it "treats a rejected decode as settled only when the avatar is not required" do
+      stub_subscribe_preview_driver(script_result: "failed")
+
+      images = described_class.generate_pngs([@user1], require_avatar: false)
+
+      expect(images.first).to eq("\x89PNG".b)
+    end
+
     it "always quits the webdriver on error" do
       error = "FAILURE"
       expect_any_instance_of(Selenium::WebDriver::Driver).to receive(:quit)
       allow_any_instance_of(Selenium::WebDriver::Driver).to receive(:screenshot_as).and_raise(error)
       expect { described_class.generate_pngs([@user2]) }.to raise_error(error)
+    end
+
+    def stub_subscribe_preview_driver(script_result:)
+      navigate = double(to: nil)
+      window = double
+      allow(window).to receive(:size=)
+      manage = double(window:)
+      driver = instance_double(
+        Selenium::WebDriver::Driver,
+        navigate:,
+        manage:,
+        execute_script: script_result,
+        screenshot_as: "\x89PNG".b,
+        quit: nil,
+      )
+      wait = instance_double(Selenium::WebDriver::Wait)
+
+      allow(Selenium::WebDriver).to receive(:for).and_return(driver)
+      allow(Selenium::WebDriver::Wait).to receive(:new).and_return(wait)
+      allow(wait).to receive(:until) do |&block|
+        next true if block.call
+
+        raise Selenium::WebDriver::Error::TimeoutError
+      end
+
+      driver
     end
   end
 end


### PR DESCRIPTION
## Status

- [x] Scope — follow-up for Greptile's rejected-decode P1 on #6869; no wider screenshot-generator behavior changed.
- [x] Design — decode success and decode failure now produce distinct readiness states; only the explicit `require_avatar: false` fallback accepts a failed decode.
- [x] Build — implemented in `SubscribePreviewGeneratorService` with focused regression coverage.
- [x] QA — focused specs, RuboCop, syntax checks, mutation proof, and local autoreview were run locally.
- [ ] Shipped — PR is open; not merged or deployed yet.
- [x] Market — no customer-facing announcement needed; this preserves #6869's intended share-card behavior.
- [x] Sell — no sales enablement needed.

## What

Greptile flagged a real post-merge bug on #6869: a rejected `img.decode()` was treated the same as a successful decode. That meant a normal subscribe-preview attempt could attach an incomplete card instead of timing out and letting Sidekiq retry.

This follow-up keeps decode success and decode failure separate. A failed decode returns `"failed"`; the Ruby wait only accepts that result when `require_avatar: false` is already in effect from the retries-exhausted fallback.

## Why

#6869 merged before the review finding could land on its original branch, and the original branch has already been deleted. This follow-up targets fresh `origin/main` and only changes the rejected-decode branch that Greptile reproduced.

## Before / after

| Case | Before | After |
|---|---|---|
| `img.decode()` resolves | screenshot proceeds | screenshot proceeds |
| `img.decode()` rejects on a normal attempt | screenshot proceeds and may attach a card without the avatar | wait times out, raising so the job retries |
| `img.decode()` rejects after retries are exhausted | screenshot proceeds as the explicit fallback | screenshot proceeds as the explicit fallback |

No new rendered QA media applies here: this is the failure-only branch of the screenshot readiness predicate, and the visible before/after card evidence remains on #6869.

## Test Results

- `ruby -c app/services/subscribe_preview_generator_service.rb` — passed.
- `ruby -c spec/services/subscribe_preview_generator_service_spec.rb` — passed.
- `bundle exec rubocop app/services/subscribe_preview_generator_service.rb spec/services/subscribe_preview_generator_service_spec.rb` — passed, 2 files inspected, no offenses.
- `bundle exec rspec spec/services/subscribe_preview_generator_service_spec.rb:62 spec/services/subscribe_preview_generator_service_spec.rb:69` — passed, 2 examples, 0 failures.
- Mutation proof: changing the Ruby wait predicate to accept `"failed"` on normal attempts made `spec/services/subscribe_preview_generator_service_spec.rb:62` fail with `Expected exception-free block to raise Selenium::WebDriver::Error::TimeoutError`.
- `autoreview --mode branch --base origin/main --engine codex --max-priority P1` — passed; `autoreview clean: no accepted/actionable findings reported`.
- Full `spec/services/subscribe_preview_generator_service_spec.rb` was not used as the gate in this detached worktree because the unchanged real-Chrome examples fail locally with `Selenium::WebDriver::Error::SessionNotCreatedError: session not created: Chrome instance exited` after Vite was warmed; the focused regression stubs the service driver and exercises the branch under review.

## QA steps

1. Simulate the readiness script returning `"failed"` for a normal attempt.
2. Confirm `SubscribePreviewGeneratorService.generate_pngs([user])` raises `Selenium::WebDriver::Error::TimeoutError` before `screenshot_as` is called.
3. Simulate the same `"failed"` result with `require_avatar: false`.
4. Confirm the fallback path returns the PNG bytes.

---

AI assistance: Hermes Agent using `claude-sonnet-5`.