### PR TITLE
Use trusted compose file in relevant CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -902,11 +902,14 @@ jobs:
         ci_node_total: [4]
         ci_node_index: [0, 1, 2, 3]
     steps:
-      - name: Check out repository
+      - name: Check out trusted workflow files
         uses: actions/checkout@v4
         timeout-minutes: 5
         with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          # This checkout feeds docker compose after Docker Hub auth, so fork PRs
+          # must use the trusted base revision. The image under test still comes
+          # from the fork build via needs.build.outputs.test_image_tag.
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
           persist-credentials: false
       - name: Login to Docker Hub
         uses: nick-fields/retry@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -911,6 +911,29 @@ jobs:
           # from the fork build via needs.build.outputs.test_image_tag.
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
           persist-credentials: false
+      - name: Check out fork fixtures
+        # The base checkout above pins Compose/workflow files, but its
+        # spec/support/fixtures is base-revision data, not what the fork
+        # image under test was built against. Fetch the fork's fixture
+        # files into a side directory (no execution of fork code) and
+        # overlay them onto the trusted checkout before Compose runs.
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v4
+        timeout-minutes: 5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+          path: fork-head-fixtures
+          sparse-checkout: |
+            spec/support/fixtures
+          sparse-checkout-cone-mode: false
+      - name: Overlay fork fixtures onto the trusted checkout
+        if: github.event_name == 'pull_request_target'
+        run: |
+          rm -rf spec/support/fixtures
+          mkdir -p spec/support
+          cp -a fork-head-fixtures/spec/support/fixtures spec/support/fixtures
+          rm -rf fork-head-fixtures
       - name: Login to Docker Hub
         uses: nick-fields/retry@v3
         with:


### PR DESCRIPTION
## What

Follow-up to #7007 and Greptile's review thread at https://github.com/antiwork/gumroad/pull/7007#discussion_r3711851895.

`test_relevant` still needs the fork-built test image, but it does not need the fork checkout after Docker Hub auth. This PR changes the credential-bearing `test_relevant` checkout to the trusted PR base SHA for `pull_request_target` runs, so `docker compose -f docker/docker-compose-test-and-ci.yml up -d` reads the base workflow/compose files instead of fork-controlled files. It also overlays the fork's `spec/support/fixtures` onto that trusted checkout (data only, no fork code execution) so fixture files a fork PR adds or changes still reach the container.

## Why

#7007 was squash-merged while the bot review was landing. The finding is real: the old `test_relevant` job checked out `github.event.pull_request.head.sha`, logged in to Docker Hub, and then ran Compose from that checkout. A fork could change the Compose file and run after Docker auth.

Greptile's follow-up review on this PR found a second-order issue: pinning the checkout to the base SHA also pins `spec/support/fixtures` (bind-mounted by Compose into the MinIO fixture-loading container) to base-revision data, while the test image under test is the fork build. A fixture the fork PR added or changed would then be missing or stale, making relevant specs fail for the wrong reason or pass without exercising the PR's fixture change.

## Before / After

Before (this PR's first version):
- Fork-PR `pull_request_target` `test_relevant` checked out `github.event.pull_request.base.sha` for the credential-bearing steps, including `spec/support/fixtures`.
- A fixture added/changed by the fork PR was invisible to the fixture-loading container.

After:
- The base checkout still supplies Compose/workflow files.
- A second sparse checkout of `spec/support/fixtures` at `github.event.pull_request.head.sha` lands in `fork-head-fixtures/` (data only — this checkout runs no code) and is copied over the base checkout's `spec/support/fixtures` before Docker Hub auth and Compose.
- The test image under test still comes from `needs.build.outputs.test_image_tag`, so the fork code is still what gets tested, now with the fork's own fixtures.

## Status

- [x] Scope — fix the merged #7007 `test_relevant` credential boundary, plus the fixture-staleness follow-up Greptile found on this PR.
- [x] Design — trusted base checkout for Compose/workflow files; fork-head fixtures overlaid via a second, non-executing sparse checkout.
- [x] Build — added the fork-fixtures checkout + overlay step ahead of Docker Hub login.
- [x] QA — parsed the workflow, verified the overlay step only touches `spec/support/fixtures` and runs before auth/Compose.
- [ ] Shipped — pending review/CI/merge.
- [ ] Market — not applicable.
- [ ] Sell — not applicable.

## Test Results

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/tests.yml"); puts "YAML OK"'` — passed.
- `git diff --check` — passed.
- Custom guard over the `test_relevant` checkout block — passed; Compose/workflow checkout uses `pull_request.base.sha`, fixtures checkout uses `pull_request.head.sha` and only touches `spec/support/fixtures`, and neither the base nor fixtures checkout persists credentials.
- `actionlint`/`prettier` — same pre-existing local-checkout blockers as before (custom runner labels, missing `prettier-plugin-tailwindcss`), not usable as a clean gate here.

## QA steps

No rendered surface.

Verified the `test_relevant` job on this branch:
- For `pull_request_target`, the trusted checkout still feeds Compose/workflow files from `pull_request.base.sha`.
- A second checkout fetches only `spec/support/fixtures` from `pull_request.head.sha` into `fork-head-fixtures/` and is deleted after the overlay copy — it executes no fork code.
- The overlay step runs before Docker Hub login and Compose, so the fixture-loading container reads fork-head fixture data.

---

AI assistance: Gumclaw used Hermes Agent (`claude-sonnet-5`) to inspect the review, make the workflow change, and run the checks above.
