### PR TITLE
Secure relevant test compose checkout against fork PR ref confusion

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -902,11 +902,14 @@ jobs:
         ci_node_total: [4]
         ci_node_index: [0, 1, 2, 3]
     steps:
-      - name: Check out repository
+      - name: Check out trusted workflow files
         uses: actions/checkout@v4
         timeout-minutes: 5
         with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          # This checkout feeds docker compose after Docker Hub auth, so fork PRs
+          # must use the trusted base revision. The image under test still comes
+          # from the fork build via needs.build.outputs.test_image_tag.
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
           persist-credentials: false
       - name: Login to Docker Hub
         uses: nick-fields/retry@v3


### PR DESCRIPTION
## What

Carries forward one post-merge commit from `trim-branch-ci` (merged as #7007) that never
shipped or got reviewed: it hardens the `test_relevant` job's checkout step in
`.github/workflows/tests.yml` so `pull_request_target` runs check out the trusted **base**
revision (`github.event.pull_request.base.sha`) instead of the fork's head SHA before Docker
Hub auth and `docker compose` invocation. The test *image* under test is still built from the
fork's head via `needs.build.outputs.test_image_tag` — only the trusted checkout used to feed
compose/login changes.

## Why

Every other checkout step in this `pull_request_target` workflow intentionally uses
`head.sha` because it's the artifact under test. This one step was checking out `head.sha`
too, but its only purpose is to run `docker compose` for the test infra — with `head.sha`, a
malicious fork PR could edit `docker/docker-compose-test-and-ci.yml` (or workflow-adjacent
config it references) and have it execute in a job that has Docker Hub credentials. Pinning
this one checkout to the PR's base SHA removes that vector while leaving the actual test
image (and thus the code under test) unchanged.

## Test Results

- `fable-review` (autoreview harness, engine codex/gpt-5.6-sol, P1 bar): **clean** — "patch is
  correct (0.95)... No P0 or P1 defect is demonstrated." Verdict:
  `/Users/gumclaw/reviews/trim-ci-checkout-ref/verdict.md`.
- No app code touched; this is a single `ref:` line + comment change in a GitHub Actions
  workflow. Verified the diff cherry-picks cleanly onto current `main` and only affects the
  `test_relevant` job's checkout step (confirmed via `git diff`/`git show` against
  `origin/main`).

## QA steps

- Open a fork PR (or re-run this workflow on an existing `pull_request_target` event) and
  confirm `test_relevant` still passes and pulls the correct fork-built image via
  `needs.build.outputs.test_image_tag`.
- Confirm the checkout step now resolves to the PR's base SHA (visible in the step's log)
  rather than the fork head SHA.

## AI disclosure

Delta cherry-picked from an unreviewed post-merge commit on `trim-branch-ci`
(`150bdc0f3bc38ace79b5d18c15e06c9427ab780d`, authored by the gumclaw automation) onto a fresh
branch off `main`, then run through the fable-5/autoreview gate before opening this PR.
