### PR TITLE
Anchor the buyer library's creator filter on links.user_id, not a users join

### DIFF
--- a/app/presenters/library_presenter.rb
+++ b/app/presenters/library_presenter.rb
@@ -67,7 +67,14 @@ class LibraryPresenter
     def filtered(cards, query:, creator_ids:, bundle_ids:, show_archived_only:)
       scope = show_archived_only ? cards.is_archived : cards.not_is_archived
 
-      scope = scope.joins(link: :user).where(users: { external_id: creator_ids }) if creator_ids.any?
+      # Filtering by links.user_id (not a users join keyed on external_id) keeps MySQL's plan
+      # anchored on the cheap purchaser_id index; joining users on external_id sometimes made it
+      # drive from links/purchase_state instead, turning Pagy's COUNT(*) into a 100s+ scan
+      # (gumroad-private#1824).
+      if creator_ids.any?
+        creator_user_ids = User.where(external_id: creator_ids).pluck(:id)
+        scope = scope.joins(:link).where(links: { user_id: creator_user_ids })
+      end
 
       if bundle_ids.any?
         bundle_link_ids = bundle_ids.filter_map { Link.from_external_id(_1) }


### PR DESCRIPTION
## What

Fixes `LibraryController#index` 500s when a buyer filters their library by creator — root cause of gumroad-private#1824 (Sentry GUMROAD-17P, 1,074 events / 134 users in ~48h since #6804 deployed).

## Why

`LibraryPresenter#filtered` joined `users` on `external_id` to apply the creator filter:

```ruby
scope.joins(link: :user).where(users: { external_id: creator_ids })
```

MySQL's planner sometimes drove that query from `links`/`purchase_state` instead of the buyer's own `purchases.purchaser_id` (highly selective for most buyers), turning Pagy's `COUNT(*)` for pagination into a scan that hit the 120s `Rack::Timeout` ceiling.

Verified live in production (read-only, audited console access): for a buyer with 2,552 purchases, the old query timed out after 15s (`ActiveRecord::StatementTimeout`), while resolving `creator_ids` to `links.user_id` up front and filtering on that instead completed in 1.06s, confirmed via `EXPLAIN` (plan anchors on `index_purchases_on_purchaser_id`).

## Fix

Resolve `creator_ids` to `User` ids first, then filter on the already-indexed `links.user_id` instead of joining `users` on `external_id`:

```ruby
creator_user_ids = User.where(external_id: creator_ids).pluck(:id)
scope = scope.joins(:link).where(links: { user_id: creator_user_ids })
```

This keeps MySQL anchored on `purchaser_id`, matching the plan it already uses for the unfiltered case.

## Before/After (production console, read-only)

| | Query | Result |
|---|---|---|
| Before | `purchases ⋈ links ⋈ users` on `users.external_id` | `ActiveRecord::StatementTimeout` at 15s (bounded probe; unbounded hits 120s in prod) |
| After | `purchases` filtered on `purchaser_id` + `links.user_id` | 1.06s, 141 rows, same buyer/creator pair |

## Test Results

`DISABLE_SPRING=1 bundle exec rspec spec/presenters/library_presenter_spec.rb` in a fresh worktree off `origin/main` with the fix applied:
- Full file: 62 examples, 0 failures.
- Creator-filter examples only (`-e "creator"`): 9 examples, 0 failures — same result with the pre-fix code, since this is a query-plan fix rather than a correctness change. The regression only manifests at production data volume, which is why it's proven via the console EXPLAIN/timing above rather than a local spec.

## QA steps

- Read the live gumroad-private#1824 issue and its comment thread (@gianfrancopiana: "Fix. Confirm in prod first, you have access.").
- Confirmed via the audited production console that the reported query shape times out for a real high-volume buyer/creator pair, and that the fixed shape returns in ~1s for the same pair.
- Ran the full `library_presenter_spec.rb` suite locally against the fix: 62/62 green.

## Status

- [x] Scope — root cause confirmed live in prod (query-plan inversion on the creator-filter join), fix scoped to `LibraryPresenter#filtered`.
- [x] Design — filter on `links.user_id` instead of a `users.external_id` join; no behavior change, same result set.
- [x] Build — one-method change, comment explains why.
- [x] QA — reproduced the timeout and the fix live against production data (read-only); full local spec suite green.
- [ ] Shipped — awaiting CI + merge.
- [ ] Market — n/a, internal reliability fix.
- [ ] Sell — n/a.

---

AI disclosure: this PR's code and description were generated by an AI agent (claude-sonnet-5, via Hermes Agent), with production-console verification of the root cause and fix, and local spec runs confirming no behavior regression.
