### PR TITLE
Fix nested upsell card ID leaking into duplicated sections (follow-up to #6871)

### DIFF
--- a/app/javascript/components/Profile/SectionsForm.test.tsx
+++ b/app/javascript/components/Profile/SectionsForm.test.tsx
@@ -166,6 +166,44 @@ describe("ProfileSectionsForm", () => {
     });
   });
 
+  it("gives a duplicated rich text section its own upsell cards even when nested in a blockquote", () => {
+    const withNestedUpsell = props();
+    withNestedUpsell.sections = [
+      {
+        id: "section-1",
+        type: "SellerProfileRichTextSection",
+        header: "Pitch",
+        hide_header: false,
+        text: {
+          content: [
+            {
+              type: "blockquote",
+              content: [{ type: "upsellCard", attrs: { id: "upsell-1", productId: "prod-1" } }],
+            },
+          ],
+        },
+      },
+    ];
+    const tracked = trackState();
+    render(<ProfileSectionsForm {...withNestedUpsell} onChange={tracked.onChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Duplicate section" }));
+
+    const nestedCard = (section: Section): unknown => {
+      if (section.type !== "SellerProfileRichTextSection") throw new Error("expected a rich text section");
+      const content: unknown = section.text.content;
+      if (!Array.isArray(content)) throw new Error("expected rich text content");
+      const blockquote = content[0] as { content: unknown[] };
+      return blockquote.content[0];
+    };
+
+    const state = tracked.latest();
+    const copiedSection = assertDefined(state.sections.find(({ id }) => id !== "section-1"));
+    expect(nestedCard(copiedSection)).toEqual({ type: "upsellCard", attrs: { productId: "prod-1" } });
+    const originalSection = assertDefined(state.sections.find(({ id }) => id === "section-1"));
+    expect(nestedCard(originalSection)).toEqual({ type: "upsellCard", attrs: { id: "upsell-1", productId: "prod-1" } });
+  });
+
   it("creates a subscribe section with an empty heading like every other section type", () => {
     const empty = props();
     empty.tabs = [{ name: "Home", sections: [] }];

--- a/app/javascript/components/Profile/SectionsForm.test.tsx
+++ b/app/javascript/components/Profile/SectionsForm.test.tsx
@@ -189,11 +189,15 @@ describe("ProfileSectionsForm", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Duplicate section" }));
 
+    const hasArrayContent = (node: unknown): node is { content: unknown[] } =>
+      typeof node === "object" && node !== null && "content" in node && Array.isArray(node.content);
+
     const nestedCard = (section: Section): unknown => {
       if (section.type !== "SellerProfileRichTextSection") throw new Error("expected a rich text section");
       const content: unknown = section.text.content;
       if (!Array.isArray(content)) throw new Error("expected rich text content");
-      const blockquote = content[0] as { content: unknown[] };
+      const blockquote: unknown = content[0];
+      if (!hasArrayContent(blockquote)) throw new Error("expected a blockquote node with content");
       return blockquote.content[0];
     };
 

--- a/app/javascript/components/Profile/SectionsForm.tsx
+++ b/app/javascript/components/Profile/SectionsForm.tsx
@@ -206,6 +206,20 @@ const OptionRow = ({
   </Row>
 );
 
+// Strips persisted `attrs.id` from every upsellCard node, at any depth (e.g. inside a
+// blockquote), so a duplicated section never shares an Upsell row with its original — see
+// withFreshUpsellCards below for why that sharing is dangerous.
+const stripUpsellCardIds = (node: unknown): unknown => {
+  if (typeof node !== "object" || node === null) return node;
+  const record = node as Record<string, unknown>;
+  const content = Array.isArray(record.content) ? record.content.map(stripUpsellCardIds) : record.content;
+  if (isUpsellCard(record)) {
+    const { id: _id, ...attrs } = record.attrs;
+    return { ...record, attrs, ...(content !== undefined ? { content } : {}) };
+  }
+  return content !== undefined ? { ...record, content } : record;
+};
+
 const withFreshUpsellCards = (section: Section): Section => {
   if (section.type !== "SellerProfileRichTextSection") return section;
   // An upsellCard's `attrs.id` is a persisted Upsell row. SaveContentUpsellsService only mints a
@@ -218,11 +232,7 @@ const withFreshUpsellCards = (section: Section): Section => {
     ...section,
     text: {
       ...section.text,
-      content: content.map((node: unknown) => {
-        if (!isUpsellCard(node)) return node;
-        const { id: _id, ...attrs } = node.attrs;
-        return { ...node, attrs };
-      }),
+      content: content.map(stripUpsellCardIds),
     },
   };
 };

--- a/app/javascript/components/Profile/SectionsForm.tsx
+++ b/app/javascript/components/Profile/SectionsForm.tsx
@@ -209,15 +209,16 @@ const OptionRow = ({
 // Strips persisted `attrs.id` from every upsellCard node, at any depth (e.g. inside a
 // blockquote), so a duplicated section never shares an Upsell row with its original — see
 // withFreshUpsellCards below for why that sharing is dangerous.
+const isRecord = (node: unknown): node is Record<string, unknown> => typeof node === "object" && node !== null;
+
 const stripUpsellCardIds = (node: unknown): unknown => {
-  if (typeof node !== "object" || node === null) return node;
-  const record = node as Record<string, unknown>;
-  const content = Array.isArray(record.content) ? record.content.map(stripUpsellCardIds) : record.content;
-  if (isUpsellCard(record)) {
-    const { id: _id, ...attrs } = record.attrs;
-    return { ...record, attrs, ...(content !== undefined ? { content } : {}) };
+  if (!isRecord(node)) return node;
+  const content = Array.isArray(node.content) ? node.content.map(stripUpsellCardIds) : node.content;
+  if (isUpsellCard(node)) {
+    const { id: _id, ...attrs } = node.attrs;
+    return { ...node, attrs, ...(content !== undefined ? { content } : {}) };
   }
-  return content !== undefined ? { ...record, content } : record;
+  return content !== undefined ? { ...node, content } : node;
 };
 
 const withFreshUpsellCards = (section: Section): Section => {

--- a/app/services/save_content_upsells_service.rb
+++ b/app/services/save_content_upsells_service.rb
@@ -30,8 +30,8 @@ class SaveContentUpsellsService
   end
 
   def from_rich_content
-    old_upsell_ids = old_content&.filter_map { |node| node["type"] == "upsellCard" ? node.dig("attrs", "id") : nil } || []
-    new_upsell_nodes = content&.select { |node| node["type"] == "upsellCard" } || []
+    old_upsell_ids = collect_upsell_nodes(old_content).filter_map { |node| node.dig("attrs", "id") }
+    new_upsell_nodes = collect_upsell_nodes(content)
     new_upsell_ids = new_upsell_nodes.map { |node| node.dig("attrs", "id") }.compact
 
     delete_removed_upsells!(old_upsell_ids - new_upsell_ids)
@@ -50,6 +50,16 @@ class SaveContentUpsellsService
 
   private
     attr_reader :seller, :content, :old_content, :error
+
+    # Rich-content nodes nest arbitrarily (e.g. an upsellCard inside a blockquote), so a
+    # top-level-only scan misses those cards and never mints or retires their Upsell rows.
+    def collect_upsell_nodes(nodes)
+      Array(nodes).flat_map do |node|
+        next [] unless node.is_a?(Hash)
+        nested = collect_upsell_nodes(node["content"])
+        node["type"] == "upsellCard" ? [node, *nested] : nested
+      end
+    end
 
     def delete_removed_upsells!(upsell_ids)
       upsell_ids.each do |upsell_id|

--- a/spec/services/save_content_upsells_service_spec.rb
+++ b/spec/services/save_content_upsells_service_spec.rb
@@ -117,6 +117,28 @@ describe SaveContentUpsellsService do
       end
     end
 
+    context "when the upsell node is nested inside a container node" do
+      let(:old_content) { [{ "type" => "paragraph", "content" => "Old content" }] }
+      let(:content) do
+        [
+          {
+            "type" => "blockquote",
+            "content" => [
+              { "type" => "upsellCard", "attrs" => { "productId" => product.external_id } }
+            ]
+          }
+        ]
+      end
+
+      it "creates an upsell and assigns its id on the nested node" do
+        expect { service.from_rich_content }.to change(Upsell, :count).by(1)
+
+        nested_node = content.first["content"].first
+        expect(nested_node["attrs"]["id"]).to be_present
+        expect(nested_node["attrs"]["id"]).to eq(Upsell.last.external_id)
+      end
+    end
+
     context "when removing an upsell" do
       let!(:upsell) { create(:upsell, seller:, product:, is_content_upsell: true) }
       let!(:offer_code) { create(:offer_code, user: seller, product_ids: [product.id]) }


### PR DESCRIPTION
## Status

- [x] Scope — Greptile P1 on #6871: `withFreshUpsellCards` only strips top-level upsell ids on duplicate. Round 2 Greptile P1: `SaveContentUpsellsService#from_rich_content` only scanned top-level content, so a nested card's stripped id was never replaced.
- [x] Design — same function, recurse into nested `content` arrays instead of a shallow map/select (frontend + backend).
- [x] Build — branch `fix/gp6871-nested-upsell-dedup`, pushed. Round 2 fix at `538fa4d35`.
- [x] Ship — pushed at `538fa4d35`; marking ready (Sahil 2026-07-19: green CI gates merge, not draft status).
- [x] QA — no rendered surface change (pure id-stripping/minting logic); adjacent surface (Profile → Pages rich-text editor, Insert Upsell flow) confirmed unaffected on the hosted preview; behavior fix verified by executed tests + mutation-kill proofs below.
- [x] Market — n/a, internal bugfix.
- [x] Sell — n/a.

## What

Greptile's post-merge review on #6871 (P1) found that `withFreshUpsellCards` only stripped `attrs.id` from the top-level `section.text.content` array. An `upsellCard` node nested inside a container (e.g. `blockquote.content`) kept its persisted id when a section was duplicated, so both sections pointed at the same `Upsell` row — editing or removing the card in either section could then alter or soft-delete the offer used by the other.

Fixed by recursively traversing `content` at any depth and stripping `attrs.id` from every `upsellCard` node found, not just top-level ones.

**Round 2 (this PR's own review, `538fa4d35`):** Greptile correctly found that stripping the nested id was only half the fix — `SaveContentUpsellsService#from_rich_content` (the Rails side that mints a fresh `Upsell` for any id-less card on save) also only scanned the top-level `content` array via `select`/`filter_map`. A duplicated section with a nested `upsellCard` would save with the id still blank, so its public checkout URL shipped with an empty `accepted_offer_id`. Added `collect_upsell_nodes`, a recursive walk over `content` at any depth, and use it for both the old- and new-content upsell scans (creation, retirement, and matching).

## Why

#6871 merged (`bc8cf17`) before this Greptile finding landed on its branch, so it's shipped as a follow-up PR against `main`.

## Before/After

- Before round 1: duplicating a section with an `upsellCard` nested in a `blockquote` left the copy's card carrying the original's `attrs.id`.
- After round 1 / before round 2: the copy's nested card has no `id` on the client, but saving it never assigns a replacement — the persisted rich content keeps `attrs.id` blank and the live checkout URL has no `accepted_offer_id`.
- After round 2: the copy's nested card gets a fresh `Upsell` + id on save, exactly like a top-level card; the original section's card is untouched.

## Test Results

- `npx vitest run app/javascript/components/Profile/SectionsForm.test.tsx` — 7 passed (added `"gives a duplicated rich text section its own upsell cards even when nested in a blockquote"`).
- `bundle exec rspec spec/services/save_content_upsells_service_spec.rb` — 9 passed (added `"when the upsell node is nested inside a container node"`), run in a fresh detached worktree at `538fa4d35`.
- Mutation check (frontend, round 1): reverted the fix (restored the old shallow `content.map` in `withFreshUpsellCards`) and reran the same suite — the new nested-blockquote test failed exactly as expected (`attrs.id` leaked into the copy); the other 6 tests stayed green. Re-applied the fix, suite green again.
- Mutation check (backend, round 2): reverted `SaveContentUpsellsService#from_rich_content` to the old top-level-only `select`/`filter_map` and reran the spec — the new nested-container test failed exactly as expected (`Upsell.count` unchanged, id never assigned); the other 8 examples stayed green. Re-applied the fix, suite green again.

## QA steps

Preview URL: https://fix-gp6871-nested-upsell-dedup.apps.staging.gumroad.org (verified live at head `538fa4d35f19c8f4b3ed50724b49a10b59567863`; `curl -sI` shows `x-revision: 538fa4d35f19`).

This is a pure data-integrity fix inside `withFreshUpsellCards` (JS) and `SaveContentUpsellsService#from_rich_content` (Rails) — no markup, styling, or copy changed, so there is no new pixel to screenshot. What *is* verifiable on the hosted preview is that the adjacent surface these functions run inside (the Profile → Pages section editor, rich-text "Insert → Upsell" flow) still renders and behaves normally with this change live:

1. Log in as `seller@gumroad.com` / `password` on the preview above.
2. Go to Profile settings → **Pages** tab → Add page → Add section → **Rich text**.
3. In the rich-text toolbar, click **Insert → Upsell**, search/select a product (e.g. "Beautiful widget"), and Insert — the dialog and editor render normally, confirming the surface this PR's `withFreshUpsellCards`/`collect_upsell_nodes` code runs against is unaffected.
4. The actual behavior fix (nested `upsellCard` inside a `blockquote` losing/never-gaining its `attrs.id` on duplicate+save) is exercised end-to-end by the frontend/backend tests and mutation-kill checks in "Test Results" above — those are the executable proof for this change, since the nested-blockquote scenario isn't reachable through the current rich-text UI's own controls (blockquote nesting of an upsell card has to be constructed programmatically, which is exactly what the new tests do).

## AI disclosure

Builds and code in this PR were generated by claude-sonnet-5 via Hermes Agent, reviewed and pushed by an autonomous agent under human oversight.

Autoreview: clean @ 538fa4d35f19c8f4b3ed50724b49a10b59567863

