### PR TITLE
SEO: remove stale wishlist sitemap artifact when no wishlist qualifies

### DIFF
--- a/app/services/sitemap_service.rb
+++ b/app/services/sitemap_service.rb
@@ -40,6 +40,11 @@ class SitemapService
       end
     end
 
+    # sitemap_generator only writes a file when it has at least one link, so a run that
+    # finds zero qualifying wishlists leaves the PRIOR run's file (or S3 object) in place —
+    # previously-indexed URLs stay published after their wishlists drop below the gate.
+    remove_wishlist_sitemap_artifact if SitemapGenerator::Sitemap.link_count.zero?
+
     RobotsService.new.expire_sitemap_configs_cache
 
     if ping_search_engines?
@@ -92,5 +97,14 @@ class SitemapService
 
     def upload_sitemap_to_s3?
       Rails.env.production? || Rails.env.staging?
+    end
+
+    def remove_wishlist_sitemap_artifact
+      key = "#{SITEMAP_PATH_WISHLISTS}/sitemap.xml.gz"
+      if upload_sitemap_to_s3?
+        Aws::S3::Client.new.delete_object(bucket: PUBLIC_STORAGE_S3_BUCKET, key:)
+      else
+        FileUtils.rm_f(Rails.public_path.join(key))
+      end
     end
 end

--- a/app/services/sitemap_service.rb
+++ b/app/services/sitemap_service.rb
@@ -102,7 +102,13 @@ class SitemapService
     def remove_wishlist_sitemap_artifact
       key = "#{SITEMAP_PATH_WISHLISTS}/sitemap.xml.gz"
       if upload_sitemap_to_s3?
-        Aws::S3::Client.new.delete_object(bucket: PUBLIC_STORAGE_S3_BUCKET, key:)
+        # Must use the same dedicated sitemap-uploader identity as the upload path (sitemap_config
+        # above) — the default AWS credentials may not be authorized to delete from this bucket.
+        Aws::S3::Client.new(
+          access_key_id: GlobalConfig.get("S3_SITEMAP_UPLOADER_ACCESS_KEY"),
+          secret_access_key: GlobalConfig.get("S3_SITEMAP_UPLOADER_SECRET_ACCESS_KEY"),
+          region: AWS_DEFAULT_REGION
+        ).delete_object(bucket: PUBLIC_STORAGE_S3_BUCKET, key:)
       else
         FileUtils.rm_f(Rails.public_path.join(key))
       end

--- a/spec/services/sitemap_service_spec.rb
+++ b/spec/services/sitemap_service_spec.rb
@@ -115,6 +115,23 @@ describe SitemapService do
       expect(File.exist?(sitemap_file_path)).to be false
     end
 
+    it "removes a previously published sitemap once no wishlist remains indexable" do
+      seller = create(:user, username: "shrinkingseller")
+      wishlist = create(:wishlist, name: "Shrinking List", user: seller)
+      products = create_list(:wishlist_product, Wishlist::MINIMUM_SEO_INDEXABLE_PRODUCTS, wishlist: wishlist)
+
+      service.generate_wishlists
+      expect(File.exist?(sitemap_file_path)).to be true
+      xml = Zlib::GzipReader.open(sitemap_file_path, &:read)
+      expect(xml).to include(wishlist.url_slug)
+
+      products.each(&:mark_deleted!)
+
+      service.generate_wishlists
+
+      expect(File.exist?(sitemap_file_path)).to be false
+    end
+
     it "deletes /robots.txt sitemap configs cache" do
       cache_key = "sitemap_configs"
       redis_namespace = Redis::Namespace.new(:robots_redis_namespace, redis: $redis)


### PR DESCRIPTION
## Scope

- [x] Scope
- [x] Design
- [x] Build
- [ ] Ship
- [ ] Market
- [ ] Sell

## What

Follow-up to #7016 (merged): a wishlist SEO sitemap refresh that finds zero qualifying wishlists now deletes the previously-published `sitemap.xml.gz` artifact (S3 object in production/staging, local file otherwise) instead of leaving it in place.

## Why

Greptile's P1 on #7016 ([review comment](https://github.com/antiwork/gumroad/pull/7016#discussion_r3713696718)) found that `sitemap_generator` only writes a file when it has at least one link — an empty refresh silently keeps the prior run's file, so a wishlist that drops below the three-distinct-product SEO gate stays indexed indefinitely. Verified against `origin/main`: `SitemapGenerator::FileAdapter#write`/`AwsSdkAdapter#write` are called only from inside `LinkSet#finalize_sitemap!`, which is skipped entirely when the sitemap is empty (`link_set.rb:459`), so the artifact is never touched on an empty run.

## Before/After

- Before: seller trims a wishlist to 2 products → next daily refresh writes nothing → the old URL for that wishlist stays live in the public sitemap.
- After: the same refresh detects `link_count.zero?` and removes the artifact (S3 `delete_object` or local `FileUtils.rm_f`), so the stale URL drops out of the published sitemap on the next run.

## Test Results

```
DISABLE_SPRING=1 RAILS_ENV=test bundle exec rspec spec/services/sitemap_service_spec.rb
# 8 examples, 0 failures (18.26s)
```

New regression (`removes a previously published sitemap once no wishlist remains indexable`) generates a sitemap with a qualifying wishlist, marks its products deleted, re-runs `generate_wishlists`, and asserts the file is gone. Mutation-verified: reverting the `remove_wishlist_sitemap_artifact if ...` line made the new spec fail (`Expected true to equal false` — stale file still present).

Addressed Greptile's P1: the S3 delete in `remove_wishlist_sitemap_artifact` now uses the same dedicated `S3_SITEMAP_UPLOADER_*` credentials as the upload path in `sitemap_config`, instead of the default AWS identity, so deletion works wherever upload does.

Premerge review: clean @ 02e4295ce (autoreview, codex/gpt-5.6-sol — "patch is correct (0.99)", no P0/actionable findings)

## QA steps

Backend-only change, no rendered surface — covered by the spec run above, which exercises real file creation and deletion on disk.

## AI disclosure

Generated by an autonomous agent (model: claude-sonnet-5) responding to a bot review finding on the now-merged #7016.

