### PR TITLE
Clear old taxonomy's attribute values on a category-only save (follow-up to #6858)

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -510,7 +510,15 @@ class LinksController < ApplicationController
         @product.save_custom_button_text_option(product_permitted_params[:custom_button_text_option]) unless product_permitted_params[:custom_button_text_option].nil?
         @product.save_custom_summary(product_permitted_params[:custom_summary]) unless product_permitted_params[:custom_summary].nil?
         @product.save_custom_attributes((product_permitted_params[:custom_attributes] || []).filter { _1[:name].present? || _1[:description].present? })
-        @product.save_taxonomy_attribute_values(product_permitted_params[:taxonomy_attribute_values]) unless product_permitted_params[:taxonomy_attribute_values].nil?
+        # A taxonomy switch invalidates the prior taxonomy's attribute values even when the
+        # request is category-only and omits taxonomy_attribute_values entirely (e.g. older
+        # clients, the API). Re-run the save so values are normalized against the new taxonomy.
+        # `taxonomy_id_changed?` alone would miss this: the save_custom_* calls above already
+        # persisted the assigned taxonomy_id, so dirty tracking has cleared by the time we get
+        # here — saved_change_to_taxonomy_id? reads the change from that just-committed save.
+        if !product_permitted_params[:taxonomy_attribute_values].nil? || @product.taxonomy_id_changed? || @product.saved_change_to_taxonomy_id?
+          @product.save_taxonomy_attribute_values(product_permitted_params[:taxonomy_attribute_values])
+        end
         @product.save_tags!(product_permitted_params[:tags] || [])
         @product.reorder_previews((product_permitted_params[:covers] || []).map.with_index.to_h)
         if !current_seller.account_level_refund_policy_enabled?

--- a/spec/controllers/links_controller_taxonomy_attribute_update_spec.rb
+++ b/spec/controllers/links_controller_taxonomy_attribute_update_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Regression coverage for a Greptile P1 on #6858: save_taxonomy_attribute_values only
+# ran when the request included taxonomy_attribute_values, so a category-only save
+# (or an older client / API request that never sends the attributes field) changed
+# taxonomy_id while leaving the previous taxonomy's values stuck in json_data.
+describe LinksController, type: :controller do
+  let(:seller) { create(:user) }
+  let(:fonts) { Taxonomy.find_or_create_by!(slug: "fonts", parent: Taxonomy.find_or_create_by!(slug: "design")) }
+  let(:software) { Taxonomy.find_or_create_by!(slug: "software-development") }
+
+  before do
+    TaxonomyAttribute.where(taxonomy: fonts).delete_all
+    TaxonomyAttribute.create!(taxonomy: fonts, name: "format", label: "Format", value_type: "enum", values: %w[OTF TTF WOFF2], position: 0)
+    sign_in seller
+  end
+
+  def editor_save_params(product, overrides = {})
+    {
+      id: product.unique_permalink,
+      name: product.name,
+      description: "A description",
+      price_currency_type: "usd",
+      price_cents: product.price_cents,
+      customizable_price: false,
+      covers: [],
+      files: [],
+      has_same_rich_content_for_all_variants: false,
+      rich_content: [],
+      variants: [],
+      confirmed_removed_variant_ids: [],
+      confirmed_removed_rich_content_ids: [],
+      preserved_rich_content_ids: [],
+      rich_content_provenance_version: 1,
+    }.merge(overrides)
+  end
+
+  it "clears the old taxonomy's attribute values on a category-only save that omits taxonomy_attribute_values" do
+    product = create(:product, user: seller, taxonomy: fonts)
+    product.save_taxonomy_attribute_values("format" => "OTF")
+    expect(product.reload.seller_taxonomy_attribute_values).to eq("format" => "OTF")
+
+    params = editor_save_params(product, taxonomy_id: software.id)
+    post :update, params: params, as: :json
+
+    expect(response).to be_successful
+    expect(product.reload.seller_taxonomy_attribute_values).to eq({})
+  end
+
+  it "still saves submitted values when the request does include taxonomy_attribute_values" do
+    product = create(:product, user: seller, taxonomy: fonts)
+
+    params = editor_save_params(product, taxonomy_attribute_values: { format: "TTF" })
+    post :update, params: params, as: :json
+
+    expect(response).to be_successful
+    expect(product.reload.seller_taxonomy_attribute_values).to eq("format" => "TTF")
+  end
+
+  it "does not touch attribute values on a save with no taxonomy change" do
+    product = create(:product, user: seller, taxonomy: fonts)
+    product.save_taxonomy_attribute_values("format" => "OTF")
+
+    params = editor_save_params(product)
+    post :update, params: params, as: :json
+
+    expect(response).to be_successful
+    expect(product.reload.seller_taxonomy_attribute_values).to eq("format" => "OTF")
+  end
+end


### PR DESCRIPTION
## What

Fixes a Greptile P1 finding from the review of #6858 (already merged): a category-only
product save left the previous taxonomy's structured attribute values stuck in
`Link#json_data["taxonomy_attribute_values"]`.

## Why

`save_taxonomy_attribute_values` only ran when the request included
`taxonomy_attribute_values`. A request that changes `taxonomy_id` alone (older clients,
the API, or a UI flow that only sends the category picker) skipped the call entirely, so
the product kept its old taxonomy's values indexed and re-classified under the new one.

## Before / After

- Before: changing a product's taxonomy without also submitting `taxonomy_attribute_values`
  left the old taxonomy's values (e.g. `format: OTF` under Fonts) in place after switching
  to an unrelated taxonomy.
- After: `save_taxonomy_attribute_values` also runs when `taxonomy_id` changed (checked via
  `saved_change_to_taxonomy_id?`, since the preceding `save_custom_*` calls already commit
  the assignment before dirty tracking would otherwise see it), re-normalizing values
  against the new taxonomy's attribute set and clearing anything that no longer applies.

## Test Results

- `DISABLE_SPRING=1 bundle exec rspec spec/controllers/links_controller_taxonomy_attribute_update_spec.rb` — 3 examples, 0 failures, run in this worktree. New spec's headline example fails against the pre-fix code (reverted the controller change only, same file, same run): `taxonomy_id_changed?`/no fix left `format: OTF` present after the switch.
- `DISABLE_SPRING=1 bundle exec rspec spec/controllers/links_controller_update_orphaned_variants_spec.rb spec/models/concerns/product/taxonomies_classification_spec.rb spec/modules/product/searchable/taxonomy_attribute_filters_spec.rb` — 8 examples, 0 failures (no regression in adjacent taxonomy-attribute coverage).
- `ruby -c app/controllers/links_controller.rb` — Syntax OK.
- `bundle exec rubocop app/controllers/links_controller.rb spec/controllers/links_controller_taxonomy_attribute_update_spec.rb` — no offenses.

## QA steps

Backend-only fix with no rendered surface — confirmed there is genuinely no UI surface to
capture: the change is inside the editor's save transaction and is exercised by the new
controller spec's category-switch scenario (create a Fonts product with a stored `format`
value, PATCH with a different `taxonomy_id` and no `taxonomy_attribute_values`, assert the
old value is cleared).

## Status

- [x] **Scope** — the single Greptile P1 finding on #6858.
- [x] **Design** — reuses the existing `save_taxonomy_attribute_values` normalization path; no new pattern.
- [x] **Build** — done at this head.
- [x] **QA** — no rendered surface; covered by the controller spec above.
- [ ] **Shipped** — pending review/merge.
- [ ] **Market** — n/a, internal data-correctness fix.
- [ ] **Sell** — n/a, no seller/buyer-facing surface.

---

## AI disclosure

Built autonomously by Hermes Agent (Claude Sonnet 5) in response to a Greptile review finding on #6858.
