### PR TITLE
Prefilter the Canada sales report to Canadian-candidate sellers (2-3h → minutes)

### DIFF
--- a/app/sidekiq/generate_canada_sales_report_job.rb
+++ b/app/sidekiq/generate_canada_sales_report_job.rb
@@ -19,6 +19,14 @@ class GenerateCanadaSalesReportJob
         starts_at = Date.new(year, month).beginning_of_month.beginning_of_day
         ends_at = Date.new(year, month).end_of_month.end_of_day
 
+        # Canadian sales are a tiny fraction of the month's purchases, but every leg used to
+        # walk all of them and resolve the seller's country row by row (a compliance-info
+        # query plus up to two GeoIP lookups each) — which is what made this job run for
+        # hours. Restricting each leg to a precomputed superset of possibly-Canadian sellers
+        # keeps ~99% of rows from ever being loaded. determine_country_name_and_province_name
+        # below remains the only gate that decides what is reported, so output is unchanged.
+        candidate_seller_ids = canadian_candidate_seller_ids(starts_at, ends_at)
+
         # Sales leg. not_chargedback_for_tax_reporting keeps, on top of the reversed (won)
         # chargebacks the old scope kept, event-dated chargebacks (see
         # Purchase::Reportable::CHARGEBACK_REPORTING_CUTOVER): their sale stays reported in
@@ -28,6 +36,7 @@ class GenerateCanadaSalesReportJob
         Purchase.successful
           .not_fully_refunded_for_tax_reporting
           .not_chargedback_for_tax_reporting
+          .where(seller_id: candidate_seller_ids)
           .where.not(stripe_transaction_id: nil)
           .where("purchases.created_at BETWEEN ? AND ?", starts_at, ends_at)
           .find_each do |purchase|
@@ -56,6 +65,7 @@ class GenerateCanadaSalesReportJob
           .merge(
             Purchase.successful
               .not_chargedback_for_tax_reporting
+              .where(seller_id: candidate_seller_ids)
               .where.not(purchases: { stripe_transaction_id: nil })
           )
           .find_each do |refund|
@@ -75,6 +85,7 @@ class GenerateCanadaSalesReportJob
         # refund was relieved by the refund's own reporting path and is not clawed back again.
         Purchase.chargebacks_for_tax_period_reporting(starts_at, ends_at)
           .successful
+          .where(seller_id: candidate_seller_ids)
           .where.not(stripe_transaction_id: nil)
           .find_each do |purchase|
             country_name, province_name = determine_country_name_and_province_name(purchase)
@@ -92,6 +103,7 @@ class GenerateCanadaSalesReportJob
         # reversal dates are never synthesized).
         Purchase.chargeback_reversals_for_tax_period_reporting(starts_at, ends_at)
           .successful
+          .where(seller_id: candidate_seller_ids)
           .where.not(stripe_transaction_id: nil)
           .find_each do |purchase|
             won_at = purchase.chargeback_reversal_reporting_date
@@ -271,6 +283,67 @@ class GenerateCanadaSalesReportJob
         "Shipping",
         "Total"
       ]
+    end
+
+    SELLER_BATCH_SIZE = 10_000
+
+    # Every seller determine_country_name_and_province_name could resolve to Canada, and
+    # possibly more — the per-row gate makes the final call, this set only has to never miss.
+    # It deliberately ignores the per-row subtleties that could only shrink it (compliance
+    # rows are considered regardless of created_at, is_business, or deletion; both country
+    # columns are checked on every row), and GeoIP is consulted for every seller whose
+    # users.country is blank — the one condition that is necessary for the per-row chain to
+    # reach GeoIP at all. Bounded to sellers with activity in the reported window, so the
+    # resulting id list stays small enough to inline into the legs' queries.
+    def canadian_candidate_seller_ids(starts_at, ends_at)
+      candidate_ids = []
+
+      seller_ids_with_reportable_activity(starts_at, ends_at).each_slice(SELLER_BATCH_SIZE) do |seller_ids|
+        candidate_ids.concat(
+          UserComplianceInfo.where(user_id: seller_ids)
+            .where.not("country IS NULL AND business_country IS NULL")
+            .pluck(:user_id, :country, :business_country)
+            .filter_map { |user_id, country, business_country| user_id if resolves_to_canada?(country) || resolves_to_canada?(business_country) }
+        )
+
+        User.where(id: seller_ids).pluck(:id, :country, :account_created_ip).each do |id, country, account_created_ip|
+          if country.present?
+            candidate_ids << id if resolves_to_canada?(country)
+          elsif resolves_to_canada?(GeoIp.lookup(account_created_ip)&.country_name)
+            candidate_ids << id
+          end
+        end
+      end
+
+      candidate_ids.uniq
+    end
+
+    # Distinct sellers that any of the four legs could report for this window. Each pluck
+    # mirrors its leg's cheap, indexable filters only — the expensive per-row conditions
+    # stay in the legs themselves.
+    def seller_ids_with_reportable_activity(starts_at, ends_at)
+      seller_ids = Purchase.successful
+        .where.not(stripe_transaction_id: nil)
+        .where("purchases.created_at BETWEEN ? AND ?", starts_at, ends_at)
+        .distinct.pluck(:seller_id)
+      # Through the purchase rather than refunds.seller_id, because that is the column the
+      # refund leg filters on.
+      seller_ids |= Refund.for_tax_period_reporting(starts_at, ends_at)
+        .joins(:purchase).distinct.pluck("purchases.seller_id")
+      seller_ids |= Purchase.chargebacks_for_tax_period_reporting(starts_at, ends_at)
+        .distinct.pluck(:seller_id)
+      seller_ids |= Purchase.chargeback_reversals_for_tax_period_reporting(starts_at, ends_at)
+        .distinct.pluck(:seller_id)
+      seller_ids.compact
+    end
+
+    # Same resolution as the per-row gate (find_by_name matches translated and unofficial
+    # country names, not just "Canada"), memoized per distinct stored string.
+    def resolves_to_canada?(country_name)
+      @resolves_to_canada ||= Hash.new do |cache, name|
+        cache[name] = Compliance::Countries.find_by_name(name)&.common_name == Compliance::Countries::CAN.common_name
+      end
+      @resolves_to_canada[country_name]
     end
 
     def determine_country_name_and_province_name(purchase)

--- a/spec/sidekiq/generate_canada_sales_report_job_spec.rb
+++ b/spec/sidekiq/generate_canada_sales_report_job_spec.rb
@@ -362,4 +362,112 @@ describe GenerateCanadaSalesReportJob do
       expect(ids).not_to include(fully_refunded.external_id)    # zero clawback ⇒ no spurious all-zero row
     end
   end
+
+  describe "Canadian-candidate seller prefilter" do
+    let(:s3_bucket_double) do
+      s3_bucket_double = double
+      allow(Aws::S3::Resource).to receive_message_chain(:new, :bucket).and_return(s3_bucket_double)
+      s3_bucket_double
+    end
+
+    before :context do
+      @s3_object = Aws::S3::Resource.new.bucket("gumroad-specs").object("specs/canada-sales-prefilter-spec-#{SecureRandom.hex(18)}.csv")
+    end
+
+    before do
+      # The user factory assigns a random IP; pin GeoIP so a lucky Canadian resolution can't
+      # make these tests flaky. Tests that need a Canadian IP stub it per address.
+      allow(GeoIp).to receive(:lookup).and_return(nil)
+    end
+
+    let(:setup_time) { Time.find_zone("UTC").local(2022, 7, 1) }
+    let(:sale_time) { Time.find_zone("UTC").local(2022, 8, 10) }
+
+    def create_seller_with_compliance_country(country, state: nil)
+      travel_to(setup_time) do
+        create(:user).tap do |seller|
+          seller.fetch_or_build_user_compliance_info.dup_and_save! do |new_compliance_info|
+            new_compliance_info.country = country
+            new_compliance_info.state = state if state
+          end
+        end
+      end
+    end
+
+    def create_reportable_purchase(seller)
+      product = travel_to(setup_time) { create(:product, user: seller, price_cents: 100_00, native_type: "digital") }
+      travel_to(sale_time) do
+        create(:purchase, link: product, seller: seller, price_cents: 100_00, country: "Canada", state: "ON")
+      end
+    end
+
+    def perform_and_read(job = described_class.new)
+      expect(s3_bucket_double).to receive(:object).and_return(@s3_object)
+
+      job.perform(8, 2022)
+
+      temp_file = Tempfile.new("actual-file", encoding: "ascii-8bit")
+      @s3_object.get(response_target: temp_file)
+      temp_file.rewind
+      CSV.read(temp_file)
+    ensure
+      temp_file&.close(true)
+    end
+
+    it "excludes a non-Canadian seller's purchase without scanning it or running per-purchase country lookups" do
+      spain_seller = create_seller_with_compliance_country("Spain")
+      excluded_purchase = create_reportable_purchase(spain_seller)
+
+      job = described_class.new
+      scanned_purchase_ids = []
+      allow(job).to receive(:determine_country_name_and_province_name).and_wrap_original do |original, purchase|
+        scanned_purchase_ids << purchase.id
+        original.call(purchase)
+      end
+
+      per_purchase_compliance_queries = 0
+      query_counter = lambda do |_name, _start, _finish, _id, payload|
+        per_purchase_compliance_queries += 1 if payload[:sql].to_s.match?(/user_compliance_info.*created_at </m)
+      end
+
+      payload = nil
+      ActiveSupport::Notifications.subscribed(query_counter, "sql.active_record") do
+        payload = perform_and_read(job)
+      end
+
+      expect(payload.length).to eq(1) # header only
+      expect(scanned_purchase_ids).not_to include(excluded_purchase.id)
+      expect(scanned_purchase_ids).to eq([])
+      expect(per_purchase_compliance_queries).to eq(0)
+    end
+
+    it "reports a seller whose only Canada signal is users.country" do
+      seller = travel_to(setup_time) { create(:user, country: "Canada", state: "BC") }
+      purchase = create_reportable_purchase(seller)
+
+      payload = perform_and_read
+
+      expect(payload.length).to eq(2)
+      expect(payload[1][1]).to eq(purchase.external_id)
+      expect(payload[1][5]).to eq("Canada")
+      expect(payload[1][6]).to eq("British Columbia")
+    end
+
+    it "reports a seller whose only Canada signal is GeoIP on the account creation IP" do
+      canadian_ip = "24.114.0.1"
+      seller = travel_to(setup_time) { create(:user, country: nil, account_created_ip: canadian_ip) }
+      allow(GeoIp).to receive(:lookup).with(canadian_ip).and_return(
+        GeoIp::Result.new(country_name: "Canada", country_code: "CA", region_name: "BC",
+                          city_name: nil, postal_code: nil, latitude: nil, longitude: nil)
+      )
+      purchase = create_reportable_purchase(seller)
+
+      payload = perform_and_read
+
+      expect(payload.length).to eq(2)
+      expect(payload[1][1]).to eq(purchase.external_id)
+      expect(payload[1][5]).to eq("Canada")
+      expect(payload[1][6]).to eq("British Columbia")
+    end
+  end
 end


### PR DESCRIPTION
Fixes antiwork/gumroad-private#1837

## What

`GenerateCanadaSalesReportJob` walked **every** successful purchase in the month and resolved the seller's country row by row — a compliance-info query plus up to two GeoIP lookups per purchase — then threw away ~99% of the rows as non-Canadian. That scan-and-discard with N+1s is the 2–3h runtime, which is also what made this job the #1 deploy-kill victim (July + June ×3 dead entries, each needing deploy locks to re-run).

This PR resolves a **superset of possibly-Canadian sellers** once, up front, and scopes all four legs (sales / refunds / chargebacks / reversals) to `seller_id IN (candidates)` in SQL. The existing per-row `determine_country_name_and_province_name` stays as the final gate, so what gets reported is decided by exactly the same logic as before — the prefilter only keeps rows that could never pass that gate from being loaded at all.

The candidate set is the union of:

- sellers with **any** `UserComplianceInfo` row whose `country` or `business_country` resolves to Canada — deliberately ignoring `created_at`, `is_business`, and deletion, all of which could only shrink the set;
- sellers whose `users.country` resolves to Canada;
- sellers whose `users.country` is blank and whose `account_created_ip` GeoIPs to Canada — blank `users.country` is the one condition that is *necessary* for the per-row chain to reach GeoIP, so it's the only narrowing that can't drop a reportable row.

All of it is bounded to sellers with reportable activity in the window (distinct-seller plucks mirroring each leg's cheap filters), so there are no full scans of `users` or `user_compliance_info` and the final id list stays small enough to inline into the legs' queries.

## Why

- **Faithfulness over a hardcoded `country = 'Canada'` filter:** the per-row gate resolves names through `Compliance::Countries.find_by_name`, which matches translated and unofficial names ("Kanada", "Canadá", …). The prefilter therefore runs the stored strings through the *same* resolver (memoized per distinct value) instead of string-matching in SQL — a seller whose compliance row says "Kanada" is prefiltered in and reported exactly as before.
- **Superset invariant, not equivalence:** each narrowing was checked against the per-row fallback chain. E.g. the GeoIP leg is *not* narrowed by "has a compliance row" because a non-business row with only `business_country` set yields a blank `legal_entity_country` and still falls through to GeoIP.
- **Index fit:** the legs' new `seller_id IN (...)` rides the existing `(seller_id, purchase_state, created_at)` and `(seller_id, chargeback_date)` indexes on `purchases` — no schema changes (`purchases`/`users` index changes are forbidden anyway).
- **Alternative considered — daily rollups** (the finance-ledger pattern): deferred per the issue. The prefilter alone lands minutes-scale runtime, at which point the deploy locks and completion watchers for this job stop being needed; rollups would add storage and backfill churn for no additional operational win.

## Before / After

Backend/Sidekiq change with no UI surface, so no before/after screens. The observable change is the work per leg:

- **Before:** month-wide `find_each` over all sellers' purchases; per row, 1 compliance-info query + up to 2 GeoIP lookups, ~99% discarded. 2–3h.
- **After:** a handful of batched candidate-resolution queries (distinct activity sellers → sliced `user_compliance_info`/`users` lookups by id → local GeoIP for the blank-country remainder), then each leg loads Canadian-candidate rows only.

**QA steps (staging/production):** regenerate a past month, e.g. `GenerateCanadaSalesReportJob.new.perform(6, 2026)`, and diff the produced CSV against the existing June 2026 artifact in S3 (`sales-tax/ca-sales-fees-monthly/`) — the acceptance check from the issue is a byte-identical file (ignoring the random filename suffix). Runtime should drop from hours to minutes.

## Test Results

- New spec block "Canadian-candidate seller prefilter": a non-Canadian seller's purchase is excluded **without being scanned** — asserts the per-row resolver never runs and zero per-purchase compliance-info queries are issued (the exclusion test fails if the prefilter is reverted) — plus inclusion coverage for the `users.country`-only and GeoIP-only candidate paths.
- Existing output specs (happy case, chargeback event-date attribution) are unchanged.
- Local caveat: specs that `create(:purchase, …)` fail in my local environment with a pre-existing charge-processor fixture issue (they fail identically on clean `main`), so the spec file is covered by CI. To verify the logic locally I ran a test-env script exercising the real candidate resolution + sales-leg scoping against MySQL: 13/13 assertions pass, including the translated-name ("Kanada") and `business_country`-only compliance cases and prefilter/per-row-gate agreement.
- `bundle exec rubocop` on both changed files: no offenses.

---

AI disclosure: implemented with Claude Fable 5 (Claude Code). Prompt: "do this https://github.com/antiwork/gumroad-private/issues/1837".

🤖 Generated with [Claude Code](https://claude.com/claude-code)