### PR TITLE
Exclude draft products from seller_reputation_summary rollup

### DIFF
--- a/app/modules/user/reputation_summary.rb
+++ b/app/modules/user/reputation_summary.rb
@@ -23,9 +23,12 @@ module User::ReputationSummary
     counts = Hash.new(0)
     products_count = 0
     # display_product_reviews is a Link flag bit, not a column, so opted-out
-    # products are rejected in Ruby rather than in SQL.
+    # products are rejected in Ruby rather than in SQL. Link.alive omits
+    # banned/purchase-disabled/deleted but not draft, so a seller's draft
+    # products (not in the public catalog) would otherwise inflate this
+    # public-facing rollup.
     stats = ProductReviewStat.joins(:link)
-      .merge(Link.alive)
+      .merge(Link.alive.not_draft)
       .where(links: { user_id: id })
       .where.not(reviews_count: 0)
       .preload(:link)

--- a/app/modules/user/reputation_summary.rb
+++ b/app/modules/user/reputation_summary.rb
@@ -23,10 +23,8 @@ module User::ReputationSummary
     counts = Hash.new(0)
     products_count = 0
     # display_product_reviews is a Link flag bit, not a column, so opted-out
-    # products are rejected in Ruby rather than in SQL. Link.alive omits
-    # banned/purchase-disabled/deleted but not draft, so a seller's draft
-    # products (not in the public catalog) would otherwise inflate this
-    # public-facing rollup.
+    # products are rejected in Ruby rather than in SQL. Link.alive alone
+    # does not exclude drafts, hence not_draft.
     stats = ProductReviewStat.joins(:link)
       .merge(Link.alive.not_draft)
       .where(links: { user_id: id })

--- a/spec/modules/user/reputation_summary_spec.rb
+++ b/spec/modules/user/reputation_summary_spec.rb
@@ -74,6 +74,15 @@ describe User::ReputationSummary do
         expect(seller.seller_reputation_summary).to eq(average: 4.7, count: 12, products_count: 2)
       end
 
+      it "skips draft products" do
+        create_stat(product_one, five: 8)
+        create_stat(product_two, four: 4)
+        draft = create(:product, user: seller, purchase_disabled_at: nil, draft: true)
+        create_stat(draft, one: 50)
+
+        expect(seller.seller_reputation_summary).to eq(average: 4.7, count: 12, products_count: 2)
+      end
+
       it "does not count another seller's products" do
         create_stat(product_one, five: 8)
         create_stat(product_two, four: 4)


### PR DESCRIPTION
## What

Excludes draft products from `User::ReputationSummary#seller_reputation_summary`.

## Why

Greptile flagged this on #6878 (P1, confidence 4/5): the seller-level rollup used
`Link.alive`, which excludes banned/purchase-disabled/deleted products but not draft
ones. Draft products are omitted from the public catalog, so a seller's draft-product
reviews could inflate the public-facing rating, review count, and product count shown on
their profile and other products' pages. #6878 merged before the finding could be fixed
on its branch.

## Fix

`Link.alive.not_draft` (existing scope) instead of `Link.alive`.

## Tests

- `spec/modules/user/reputation_summary_spec.rb` — added "skips draft products", mirroring
  the existing deleted/opted-out exclusion specs.
- Ran the full file at this branch's head (`9c59671`): 10 examples, 0 failures.
- Mutation-verified: reverting to `Link.alive` alone makes the new spec fail red
  (`expected {..products_count: 2} got {..products_count: 3}`), confirming the spec has
  teeth.

## QA steps

- `ruby -c app/modules/user/reputation_summary.rb` — syntax OK.
- `bundle exec rspec spec/modules/user/reputation_summary_spec.rb` at this branch's head
  (`9c59671`) — 10 examples, 0 failures.

## Premerge review

Premerge review: clean @ 9c5967177 — re-audited full diff against main (not just the
follow-up commit) after this PR was mistakenly closed and reopened. Checklist covered:
vacuous-spec, guard composition (`alive`+`not_draft` is a pure AND, no filtering lost),
fixture realism, nil-branch (draft-only seller still returns nil via MIN_REVIEWS gate),
comment terseness, and a real mutation run.

- Spec run: `bundle exec rspec spec/modules/user/reputation_summary_spec.rb` → 10 examples, 0 failures.
- Mutation check: reverting `not_draft` turned the new example red
  (`got: {average: 1.7, count: 62, products_count: 3}` vs expected
  `{average: 4.7, count: 12, products_count: 2}`) — confirms the fixture's draft passes
  `alive` and is excluded solely by the new scope.
- Confirmed safe: `not_draft` maps to a real `links.draft` boolean column, composition
  with `alive` is a pure AND (no columns shared, nothing else gets un-filtered), and the
  comment states one genuine trap without bug-history narration.
- Non-finding noted: `links.draft` is nullable so `not_draft`'s underlying
  `where(draft: false)` would in theory drop a NULL row, but that's the same canonical
  scope already gating profile pages — no new exposure from this diff.

## Checklist
- [x] Scope — one-line fix + spec, scoped to the Greptile finding on #6878
- [x] Design — use the existing `not_draft` scope, no new abstraction
- [x] Build — done, see diff
- [x] QA — spec run + mutation-verified above, full pre-merge review clean
- [ ] Shipped
- [ ] Market
- [ ] Sell

## History

This PR was closed by mistake shortly after the follow-up (comment-simplification) commit
landed — CI was still green and the branch had no outstanding findings. Reopened after
verifying no part of the fix shipped elsewhere: `app/modules/user/reputation_summary.rb`
on `origin/main` still reads `Link.alive` with no `not_draft`, and no other merged PR
touches that file.

---
AI disclosure: this PR was authored autonomously by an AI agent (claude-sonnet-5, per
`model.default` in the agent's config.
EOF
)