### PR TITLE
Fix main: accept ActionController::Parameters in collect_upsell_nodes

### DIFF
--- a/app/services/save_content_upsells_service.rb
+++ b/app/services/save_content_upsells_service.rb
@@ -53,9 +53,12 @@ class SaveContentUpsellsService
 
     # Rich-content nodes nest arbitrarily (e.g. an upsellCard inside a blockquote), so a
     # top-level-only scan misses those cards and never mints or retires their Upsell rows.
+    # Nodes arrive as plain Hashes from specs/services but as ActionController::Parameters
+    # from controller request params (e.g. links_controller, SellerProfileSections::SaveService) —
+    # Parameters is not a Hash subclass, so both must be accepted or the scan silently sees nothing.
     def collect_upsell_nodes(nodes)
       Array(nodes).flat_map do |node|
-        next [] unless node.is_a?(Hash)
+        next [] unless node.is_a?(Hash) || node.is_a?(ActionController::Parameters)
         nested = collect_upsell_nodes(node["content"])
         node["type"] == "upsellCard" ? [node, *nested] : nested
       end


### PR DESCRIPTION
## What broke main

#7012 added `SaveContentUpsellsService#collect_upsell_nodes` to recursively scan rich-content nodes for upsell cards, but it only accepted plain `Hash` nodes (`node.is_a?(Hash)`). Controller request params (`links_controller#update_product`, `SellerProfileSections::SaveService`) hand rich-content nodes through as `ActionController::Parameters`, which is not a Hash subclass. The recursive scan silently returned `[]` for every node reached through those paths, so no `Upsell` was ever minted from a real request — only from specs/services that pass plain hashes directly.

This broke, on `main`:
- `spec/requests/products/edit/edit_spec.rb:281` (`undefined method 'product_id' for nil` — `Upsell.last` was nil)
- `spec/controllers/settings/profile_controller_spec.rb:398` (`expect(upsell).to be_alive` — upsell never created)

## The fix

Accept both `Hash` and `ActionController::Parameters` in `collect_upsell_nodes`, matching the pattern already used elsewhere in this codebase (e.g. `links_controller.rb`, `ai/store_agent_action_executor.rb`) for exactly this Parameters-vs-Hash distinction. Minimal, surgical, one file.

## Proof

Run locally against this branch:
- `bundle exec rspec spec/services/save_content_upsells_service_spec.rb` — 9 examples, 0 failures
- `bundle exec rspec spec/controllers/settings/profile_controller_spec.rb -e "processes rich text upsell content for sections created in the batch save"" — 1 example, 0 failures

Branch CI (Tests workflow) is green: https://github.com/antiwork/gumroad/actions/runs/30928677711

## Note

Main also currently has a second, unrelated failure (a title-copy expectation in a just-merged SEO PR: `expect(page).to have_title("Software Development » Programming | Gumroad")`) — out of scope for this PR, which only fixes the `collect_upsell_nodes`/Parameters regression from #7012.

Premerge review: clean @ 1793ec2fc8ea335f455bb2020269d0365938208a
