### PR TITLE
Preserve refund policy calendar dates

### DIFF
--- a/app/javascript/components/Product/index.tsx
+++ b/app/javascript/components/Product/index.tsx
@@ -1082,7 +1082,7 @@ const RefundPolicyInfo = ({ refundPolicy, permalink }: { refundPolicy: RefundPol
     }
   }, [viewingRefundPolicy]);
 
-  const formattedDate = new Date(refundPolicy.updated_at).toLocaleString(userAgentInfo.locale, { dateStyle: "medium" });
+  const formattedDate = parseISO(refundPolicy.updated_at).toLocaleString(userAgentInfo.locale, { dateStyle: "medium" });
   const lastUpdated = `Last updated ${formattedDate}`;
 
   const handleCloseModal = () => {

--- a/spec/requests/products/show/show_spec.rb
+++ b/spec/requests/products/show/show_spec.rb
@@ -362,8 +362,13 @@ describe("ProductShowScenario", type: :system, js: true) do
     let(:seller) { product.user }
 
     before do
+      page.driver.browser.execute_cdp("Emulation.setTimezoneOverride", timezoneId: "America/Los_Angeles")
       seller.update!(refund_policy_enabled: false)
       product.update!(product_refund_policy_enabled: true)
+    end
+
+    after do
+      page.driver.browser.execute_cdp("Emulation.setTimezoneOverride", timezoneId: "")
     end
 
     it "renders product-level refund policy" do


### PR DESCRIPTION
## What

Preserves a refund policy's calendar date when rendering its "Last updated" value. Date-only ISO values now use `parseISO` instead of `new Date()`.

## Why

`new Date("2023-04-17")` interprets the value as midnight UTC. Browsers west of UTC therefore rendered April 16 even though the persisted calendar date was April 17. Parsing it as a local ISO calendar date fixes the root cause without changing the API or stored value.

## QA steps

1. Use a browser timezone west of UTC, such as `America/Los_Angeles`.
2. Open a product with a refund policy updated on April 17, 2023.
3. Open the refund policy modal.
4. Confirm the footer reads `Last updated Apr 17, 2023` on desktop and mobile.

---

Based on https://github.com/adityawrk/gumroad/pull/7 by @adityawrk.

AI Disclosure: Claude Opus 4.6 was used to review the original PR and import the changes.
