### PR TITLE
Preserve payout period calendar dates

### DIFF
--- a/app/javascript/components/Admin/Payouts/Payout.test.tsx
+++ b/app/javascript/components/Admin/Payouts/Payout.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment happy-dom
+import { cleanup, render } from "@testing-library/react";
+import * as React from "react";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import Payout, { type Payout as PayoutProps } from "$app/components/Admin/Payouts/Payout";
+
+vi.stubGlobal("Routes", new Proxy({}, { get: () => () => "#" }));
+
+vi.mock("@inertiajs/react", () => ({
+  Link: ({ children, href, ...props }: { children: React.ReactNode; href: string }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("$app/components/Admin/DateTimeWithRelativeTooltip", () => ({ default: () => null }));
+vi.mock("$app/components/Admin/ActionButton", () => ({ AdminActionButton: () => null }));
+
+beforeAll(() => {
+  vi.stubEnv("TZ", "America/Los_Angeles");
+});
+
+afterAll(() => {
+  vi.unstubAllEnvs();
+});
+
+afterEach(cleanup);
+
+const payout: PayoutProps = {
+  external_id: "payout-external-id",
+  displayed_amount: "$100",
+  user: { external_id: "user-external-id", name: "Seller" },
+  processor: "paypal",
+  payout_period_end_date: "2026-08-04",
+  processor_fee_cents: 0,
+  state: "completed",
+  is_stripe_processor: false,
+  is_paypal_processor: true,
+  stripe_transfer_id: null,
+  stripe_transfer_url: null,
+  stripe_connect_account_id: null,
+  stripe_connected_account_url: null,
+  failed: false,
+  humanized_failure_reason: null,
+  bank_account: null,
+  payment_address: "seller@example.com",
+  txn_id: null,
+  correlation_id: null,
+  was_created_in_split_mode: false,
+  split_payments_info: null,
+  cancelled: false,
+  returned: false,
+  processing: false,
+  created_at: "2026-08-05T00:00:00Z",
+  unclaimed: false,
+  non_terminal_state: false,
+};
+
+describe("Payout", () => {
+  it("renders the payout period as its calendar date west of UTC", () => {
+    const { container } = render(<Payout payout={payout} />);
+    const label = Array.from(container.querySelectorAll("dt")).find(
+      (element) => element.textContent === "Payout period end date",
+    );
+
+    expect(label?.nextElementSibling?.textContent).toBe("August 4, 2026");
+  });
+});

--- a/app/javascript/components/Admin/Payouts/Payout.tsx
+++ b/app/javascript/components/Admin/Payouts/Payout.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@inertiajs/react";
-import { subDays } from "date-fns";
+import { parseISO, subDays } from "date-fns";
 import React from "react";
 
 import { formatPriceCentsWithCurrencySymbol } from "$app/utils/currency";
@@ -75,7 +75,7 @@ const Payout = ({ payout }: Props) => (
       <dt>Payout period end date</dt>
       <dd>
         {payout.payout_period_end_date
-          ? formatDate(new Date(payout.payout_period_end_date), { dateStyle: "long" })
+          ? formatDate(parseISO(payout.payout_period_end_date), { dateStyle: "long" })
           : "None"}
       </dd>
 


### PR DESCRIPTION
## What

Preserves the payout period's calendar date in the admin payout view. The date-only value now uses `parseISO`, with a colocated component regression that runs west of UTC.

## Why

`new Date("2026-08-04")` treats a date-only string as midnight UTC. In a timezone such as `America/Los_Angeles`, the admin view displayed August 3 even though the payout period ended on August 4. Local ISO calendar parsing fixes the display without changing payout data or timestamp handling elsewhere.

## QA steps

1. Use a browser timezone west of UTC, such as `America/Los_Angeles`.
2. Sign in as an admin and open a payout whose period end date is August 4, 2026.
3. Confirm `Payout period end date` displays August 4, 2026 on desktop and mobile.

---

Based on https://github.com/adityawrk/gumroad/pull/8 by @adityawrk.

AI Disclosure: Claude Opus 4.6 was used to review the original PR and import the changes.
