### PR TITLE
Serialize initial product review stat creation

### DIFF
--- a/app/modules/product/review_stat.rb
+++ b/app/modules/product/review_stat.rb
@@ -46,13 +46,18 @@ module Product::ReviewStat
   end
 
   def update_review_stat_via_rating_change(old_rating, new_rating)
-    create_product_review_stat if product_review_stat.nil?
-    if old_rating.nil?
-      product_review_stat.update_with_added_rating(new_rating)
-    elsif new_rating.nil?
-      product_review_stat.update_with_removed_rating(old_rating)
+    if product_review_stat.nil?
+      # Serialize only the first aggregate row creation. The locking lookup is a current read, so
+      # a callback transaction waiting here sees the row committed by the winner.
+      with_lock do
+        review_stat_association = association(:product_review_stat)
+        review_stat_association.reset
+        review_stat = ProductReviewStat.lock.find_by(link_id: id) || create_product_review_stat!
+        review_stat_association.target = review_stat
+        apply_rating_change_to_review_stat(review_stat, old_rating, new_rating)
+      end
     else
-      product_review_stat.update_with_changed_rating(old_rating, new_rating)
+      apply_rating_change_to_review_stat(product_review_stat, old_rating, new_rating)
     end
     enqueue_index_update_for_reviews
   end
@@ -110,6 +115,16 @@ module Product::ReviewStat
   # /Admin methods.
 
   private
+    def apply_rating_change_to_review_stat(review_stat, old_rating, new_rating)
+      if old_rating.nil?
+        review_stat.update_with_added_rating(new_rating)
+      elsif new_rating.nil?
+        review_stat.update_with_removed_rating(old_rating)
+      else
+        review_stat.update_with_changed_rating(old_rating, new_rating)
+      end
+    end
+
     def review_stat_proxy
       product_review_stat || ProductReviewStat::TEMPLATE
     end

--- a/spec/modules/product/review_stat_concurrency_spec.rb
+++ b/spec/modules/product/review_stat_concurrency_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "timeout"
+
+# Each update needs its own committed transaction and database connection to reproduce the
+# first-row race between separate web processes.
+describe Product::ReviewStat, "concurrency" do
+  self.use_transactional_tests = false
+
+  before do
+    @seller = create(:user)
+    @product = create(:product, user: @seller)
+    @purchases = 2.times.map { create(:purchase, link: @product, seller: @seller) }
+  end
+
+  after do
+    ProductReview.where(purchase_id: @purchases).delete_all
+    Purchase.where(id: @purchases).delete_all
+    ProductReviewStat.where(link_id: @product.id).delete_all
+    Price.where(link_id: @product.id).delete_all
+    @product.destroy!
+    Affiliate.where(affiliate_user_id: @seller.id).delete_all
+    RefundPolicy.where(seller_id: @seller.id).delete_all
+    @seller.destroy!
+  end
+
+  it "counts concurrent first ratings without losing either update" do
+    ready = Queue.new
+    release = Queue.new
+    allow_any_instance_of(Link).to receive(:product_review_stat).and_wrap_original do |method, *args|
+      result = method.call(*args)
+      if Thread.current[:review_stat_concurrency] && !Thread.current[:review_stat_checked]
+        Thread.current[:review_stat_checked] = true
+        ready << true
+        release.pop
+      end
+      result
+    end
+
+    errors = Queue.new
+    observed_counts = Queue.new
+    threads = @purchases.zip([2, 5]).map do |purchase, rating|
+      Thread.new do
+        ActiveRecord::Base.connection_pool.with_connection do
+          Thread.current[:review_stat_concurrency] = true
+          review = ProductReview.create!(purchase:, link: Link.find(@product.id), rating:)
+          observed_counts << review.link.reviews_count
+        rescue => e
+          errors << e
+        end
+      end
+    end
+
+    2.times { Timeout.timeout(10) { ready.pop } }
+    2.times { release << true }
+    threads.each { expect(_1.join(20)).to be_present }
+
+    expect(errors.size).to eq(0), -> { errors.size.times.map { errors.pop.full_message }.join("\n") }
+    expect(2.times.map { observed_counts.pop }.sort).to eq([1, 2])
+    expect(@product.reload.product_review_stat).to have_attributes(
+      reviews_count: 2,
+      average_rating: 3.5,
+      ratings_of_two_count: 1,
+      ratings_of_five_count: 1
+    )
+  ensure
+    2.times { release << true } if release
+    threads&.each do |thread|
+      next if thread.join(1)
+
+      thread.kill
+      thread.join
+    end
+  end
+end


### PR DESCRIPTION
## What

Serializes creation of a product's first `ProductReviewStat` row under the product lock. Waiting callback transactions perform a locking current read, reuse the winner's row, update the association cache, and then apply their own rating delta.

## Why

Two first reviews can both observe a missing `product_review_stat` and race to insert the unique `link_id`. The loser raises `ActiveRecord::RecordNotUnique`, so its outer review transaction rolls back. A product lock is needed only for first-row creation. The locking lookup is important under MySQL `REPEATABLE READ`, because a normal association reload can retain the transaction's older snapshot after waiting for the winner.

The existing-row path remains on the current atomic SQL counters, so established concurrent update behavior is unchanged.

## QA steps

1. Start with a product that has no `ProductReviewStat` row.
2. Save two first `ProductReview` records concurrently on separate database connections.
3. Confirm both saves complete without an exception.
4. Confirm both review instances observe monotonic counts of 1 and 2.
5. Confirm the final aggregate has 2 reviews, an average rating of 3.5, and one rating in each expected bucket.

---

Based on https://github.com/adityawrk/gumroad/pull/9 by @adityawrk.

AI Disclosure: Claude Opus 4.6 was used to review the original PR and import the changes.
