### PR TITLE
Parse PWYW price prefills exactly

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -10,6 +10,8 @@ class LinksController < ApplicationController
   include RendersCustomHtmlPages
 
   DEFAULT_PRICE = 500
+  PWYW_PRICE_MAX_LENGTH = 64
+  PWYW_PRICE_PATTERN = /\A[+-]?(?:\d+(?:\.\d*)?|\.\d+)\z/
 
   prepend_before_action :disable_third_party_analytics!, only: :cart_items_count
 
@@ -125,7 +127,7 @@ class LinksController < ApplicationController
       BasePrice::Recurrence::ALLOWED_RECURRENCES.each do |r|
         params[:recurrence] ||= r if params[r] == "true"
       end
-      params[:price] = (params[:price].to_f * 100).to_i if params[:price].present?
+      params[:price] = pwyw_price_cents(params[:price]) if params[:price].present?
       cart_item = @product.cart_item(params)
 
       unless (@product.customizable_price || cart_item[:option]&.[](:is_pwyw)) &&
@@ -798,6 +800,15 @@ class LinksController < ApplicationController
   end
 
   private
+    def pwyw_price_cents(value)
+      value = value.to_s
+      return if value.length > PWYW_PRICE_MAX_LENGTH || !value.match?(PWYW_PRICE_PATTERN)
+
+      scaling_factor = @product.single_unit_currency? ? 1 : 100
+      price_cents = (BigDecimal(value) * scaling_factor).round
+      price_cents if price_cents.in?(0..BasePrice::Shared::MAX_PRICE_CENTS)
+    end
+
     NAME_OVERRIDE_MAX = 250
     DESCRIPTION_OVERRIDE_MAX = 5_000
 

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -804,8 +804,11 @@ class LinksController < ApplicationController
       value = value.to_s
       return if value.length > PWYW_PRICE_MAX_LENGTH || !value.match?(PWYW_PRICE_PATTERN)
 
+      decimal_value = BigDecimal(value)
+      return if decimal_value.negative?
+
       scaling_factor = @product.single_unit_currency? ? 1 : 100
-      price_cents = (BigDecimal(value) * scaling_factor).round
+      price_cents = (decimal_value * scaling_factor).round
       price_cents if price_cents.in?(0..BasePrice::Shared::MAX_PRICE_CENTS)
     end
 

--- a/spec/requests/products/show/custom_pages_buyer_input_roundtrip_spec.rb
+++ b/spec/requests/products/show/custom_pages_buyer_input_roundtrip_spec.rb
@@ -82,16 +82,16 @@ describe("Custom pages buyer-input round trip", type: :system, js: true) do
   it "round-trips a PWYW price prefill (major units -> cents) to the recorded purchase" do
     product = create(:product, customizable_price: true, price_cents: 100)
 
-    visit "#{product.long_url}?wanted=true&price=9.99"
+    visit "#{product.long_url}?wanted=true&price=19.99"
 
     expect(page).to have_current_path(/^\/checkout/, wait: 10)
     within_cart_item product.name do
-      expect(page).to have_text("$9.99")
+      expect(page).to have_text("$19.99")
     end
 
     check_out(product)
 
-    expect(product.sales.successful.last.price_cents).to eq(999)
+    expect(product.sales.successful.last.price_cents).to eq(1999)
   end
 
   it "round-trips a recurrence prefill on a membership product and records the subscription recurrence" do

--- a/test/controllers/links_controller_test.rb
+++ b/test/controllers/links_controller_test.rb
@@ -5150,7 +5150,7 @@ class LinksControllerShowTest < ActionController::TestCase
   test "GET show safely rejects non-decimal and out-of-range PWYW prefills" do
     product = create_product(user: @user, customizable_price: true, price_cents: 0)
 
-    ["not-a-price", "Infinity", "NaN", "1e1000000", "9" * 65].each do |price|
+    ["not-a-price", "Infinity", "NaN", "1e1000000", "9" * 65, "-0.001", "-1"].each do |price|
       get :show, params: { id: product.to_param, wanted: "true", price: }
 
       assert_response :success, "Expected #{price.inspect} to render the product page"

--- a/test/controllers/links_controller_test.rb
+++ b/test/controllers/links_controller_test.rb
@@ -5113,11 +5113,77 @@ class LinksControllerShowTest < ActionController::TestCase
   test "GET show honors a PWYW price prefill at or above the minimum" do
     product = create_product(user: @user, customizable_price: true, price_cents: 100)
 
-    get :show, params: { id: product.to_param, wanted: "true", price: "9.99" }
+    get :show, params: { id: product.to_param, wanted: "true", price: "19.99" }
 
     assert_response :redirect
     query_params = Rack::Utils.parse_query(URI.parse(response.location).query)
-    assert(Array(query_params["price"]).all? { |value| value == "999" })
+    assert_equal ["1999"], Array(query_params["price"]).uniq
+  end
+
+  test "GET show preserves whole-unit PWYW prefills for a single-unit currency" do
+    product = create_product(user: @user, customizable_price: true, price_cents: 100, price_currency_type: "jpy")
+
+    get :show, params: { id: product.to_param, wanted: "true", price: "199" }
+
+    assert_response :redirect
+    query_params = Rack::Utils.parse_query(URI.parse(response.location).query)
+    assert_equal ["199"], Array(query_params["price"]).uniq
+  end
+
+  test "GET show rounds PWYW prefills to the product currency precision" do
+    product = create_product(user: @user, customizable_price: true, price_cents: 100)
+
+    get :show, params: { id: product.to_param, wanted: "true", price: "19.995" }
+
+    assert_response :redirect
+    query_params = Rack::Utils.parse_query(URI.parse(response.location).query)
+    assert_equal ["2000"], Array(query_params["price"]).uniq
+
+    jpy_product = create_product(user: @user, customizable_price: true, price_cents: 100, price_currency_type: "jpy")
+    get :show, params: { id: jpy_product.to_param, wanted: "true", price: "199.5" }
+
+    assert_response :redirect
+    query_params = Rack::Utils.parse_query(URI.parse(response.location).query)
+    assert_equal ["200"], Array(query_params["price"]).uniq
+  end
+
+  test "GET show safely rejects non-decimal and out-of-range PWYW prefills" do
+    product = create_product(user: @user, customizable_price: true, price_cents: 0)
+
+    ["not-a-price", "Infinity", "NaN", "1e1000000", "9" * 65].each do |price|
+      get :show, params: { id: product.to_param, wanted: "true", price: }
+
+      assert_response :success, "Expected #{price.inspect} to render the product page"
+    end
+
+    get :show, params: { id: product.to_param, wanted: "true", price: "0" }
+
+    assert_response :redirect
+    query_params = Rack::Utils.parse_query(URI.parse(response.location).query)
+    assert_equal ["0"], Array(query_params["price"]).uniq
+  end
+
+  test "GET show accepts the maximum PWYW prefill and rejects the next currency unit" do
+    product = create_product(user: @user, customizable_price: true, price_cents: 100)
+
+    get :show, params: { id: product.to_param, wanted: "true", price: "21474836.47" }
+
+    assert_response :redirect
+    query_params = Rack::Utils.parse_query(URI.parse(response.location).query)
+    assert_equal [BasePrice::Shared::MAX_PRICE_CENTS.to_s], Array(query_params["price"]).uniq
+
+    get :show, params: { id: product.to_param, wanted: "true", price: "21474836.48" }
+    assert_response :success
+
+    jpy_product = create_product(user: @user, customizable_price: true, price_cents: 100, price_currency_type: "jpy")
+    get :show, params: { id: jpy_product.to_param, wanted: "true", price: "2147483647" }
+
+    assert_response :redirect
+    query_params = Rack::Utils.parse_query(URI.parse(response.location).query)
+    assert_equal [BasePrice::Shared::MAX_PRICE_CENTS.to_s], Array(query_params["price"]).uniq
+
+    get :show, params: { id: jpy_product.to_param, wanted: "true", price: "2147483648" }
+    assert_response :success
   end
 
   test "GET show resolves a recurrence prefill on a membership product" do


### PR DESCRIPTION
## Stages

- [x] Scope
- [x] Design
- [x] Build
- [ ] Ship
- [ ] Market
- [ ] Sell

## What

Parses PWYW checkout price prefills as bounded decimal values in the product's currency precision.

- Uses `BigDecimal` instead of binary floating point
- Scales ordinary currencies to cents and single-unit currencies such as JPY by one
- Rounds at the currency precision
- Rejects malformed, non-finite, exponent, overlong, negative, and out-of-range values
- Keeps invalid prefills on the product page instead of turning them into a free checkout

## Why

The existing `to_f * 100` conversion both introduced binary float truncation and assumed every currency had cents. For example, `19.99` became 1998 cents, while JPY `199` became 19,900. Non-finite input could also raise during integer conversion, and an invalid value on a free PWYW product could be converted to zero and redirected as a free checkout.

The new parser enforces the reachable URL contract before constructing the cart item, with an explicit length bound to prevent extreme decimal input from consuming unbounded memory.

## QA steps

1. Open a USD PWYW product with `?wanted=true&price=19.99`.
2. Confirm checkout displays `$19.99`, then complete the test purchase and confirm it records 1,999 cents.
3. Confirm JPY `199` remains 199 units.
4. Confirm USD `19.995` rounds to 2,000 cents and JPY `199.5` rounds to 200.
5. Confirm malformed, exponent, overlong, negative, and above-maximum values remain on the product page.
6. Confirm a literal zero remains valid for a free PWYW product.
7. Confirm `?wanted=true&price=-0.001` and `?wanted=true&price=-1` on a free PWYW product (`price_cents: 0`) render the product page instead of redirecting to checkout.

## Test results (round 2, @ fb1495a52850337cfd3d148688b495da05be8df4)

Fixed a P1 from Greptile's review: a negative fractional prefill (e.g. `price=-0.001`) rounded to `0` cents before the sign was checked, so a free PWYW product would start checkout as though the buyer supplied a valid free price. `pwyw_price_cents` now rejects the parsed decimal when negative, before scaling/rounding.

- `bin/rails test test/controllers/links_controller_test.rb -n "/PWYW/"` — 6 runs, 25 assertions, 0 failures (includes two new negative-prefill cases, `-0.001` and `-1`, added to the existing "safely rejects" test).
- Mutation check: reverting the added `return if decimal_value.negative?` guard fails the new assertion — confirms the spec has teeth.

---

Based on https://github.com/adityawrk/gumroad/pull/10 by @adityawrk.

AI Disclosure: claude-sonnet-5 was used to review the original PR and import the changes, and to fix the negative-prefill P1 raised by Greptile's review.
