### PR TITLE
Fix stale title expectation in Discover taxonomy spec (unblocks main CI)

### DIFF
--- a/spec/requests/discover/discover_spec.rb
+++ b/spec/requests/discover/discover_spec.rb
@@ -496,7 +496,7 @@ describe("Discover", js: true, type: :system) do
         click_on "Programming"
       end
       expect(page).to have_current_path("/software-development/programming")
-      expect(page).to have_title("Software Development » Programming | Gumroad")
+      expect(page).to have_title("Software Development » Programming — digital products by independent creators | Gumroad")
       expect(page).to have_selector("[aria-label='Breadcrumbs']", text: "Software Development\n/Programming")
 
       within_section "Featured products", section_element: :section do
@@ -522,7 +522,7 @@ describe("Discover", js: true, type: :system) do
       page.go_forward
       wait_for_ajax
       expect(page).to have_current_path("/software-development/programming")
-      expect(page).to have_title("Software Development » Programming | Gumroad")
+      expect(page).to have_title("Software Development » Programming — digital products by independent creators | Gumroad")
       expect(page).to have_selector("[aria-label='Breadcrumbs']", text: "Software Development\n/Programming")
       within_section "Featured products", section_element: :section do
         expect_product_cards_with_names("product 0", "product 2", "product 3")


### PR DESCRIPTION
## What
main CI has been red since PR #7018 merged (5 commits ago, ~2h), blocking the deploy auto-unblock — meaning #7013/#7014/#7015/#7016/#7018 (the SEO rollout, gumroad-private#1836) are merged but not live in production.

## Root cause
#7018 changed the server-rendered `<title>` on taxonomy-only category pages (no query/tags params) to `{Category} — digital products by independent creators | Gumroad` (documented in #7018's own description as the new SEO title format). `spec/requests/discover/discover_spec.rb`'s breadcrumb-navigation test still asserted the old exact title at the two taxonomy-only navigation points (clicking a breadcrumb, and browser back/forward to the taxonomy-only URL) and was never updated.

Not a flake — deterministic, same failure every run since #7018 merged:
```
expected "Software Development » Programming — digital products by independent creators | Gumroad" to include "Software Development » Programming | Gumroad"
```

## Fix
Update the two taxonomy-only-path title assertions to the new format. The other assertions in the same spec (with `?tags=` / `?sort=` query params) are untouched — #7018 explicitly scopes the new title to taxonomy-only pages so the canonical page stays the single indexable variant, and those specs already reflect that.

## Why not auto-merged under the flakiness grant
This isn't spec flakiness (nondeterministic/order-dependent) — it's a stale assertion against an intentional, documented product change. Goes through the normal review gate.

Premerge review: clean @ 5c416c3f2e97320453ab790780bf33f2e0cd0ca6

Ref antiwork/gumroad-private#1836