### PR TITLE
Fix main: align client-side Discover titles with the server-rendered SEO title

### DIFF
--- a/app/javascript/utils/discover.ts
+++ b/app/javascript/utils/discover.ts
@@ -57,9 +57,12 @@ export const discoverTitleGenerator = (params: SearchRequest, taxonomies: Taxono
   const searchOrTagsTitle = params.query
     ? `Search results for “${params.query}”`
     : params.tags?.map((t) => t.trim().replace(/[-\s]+/gu, " ")).join(", ");
-  const taxonomyTitle = params.taxonomy
+  let taxonomyTitle = params.taxonomy
     ?.split("/")
     .map((slug) => taxonomies.find((t) => t.slug === slug)?.label ?? slug)
     .join(" » ");
+  // Taxonomy-only pages are server-rendered with this SEO suffix (Discover::CategoryPagePresenter#title);
+  // client-side navigation must produce the same title or it flips on every Inertia visit.
+  if (taxonomyTitle && !searchOrTagsTitle) taxonomyTitle += " — digital products by independent creators";
   return [searchOrTagsTitle, taxonomyTitle, "Gumroad"].filter((s) => s).join(" | ");
 };

--- a/spec/requests/discover/discover_spec.rb
+++ b/spec/requests/discover/discover_spec.rb
@@ -477,7 +477,7 @@ describe("Discover", js: true, type: :system) do
     it "shows breadcrumbs with taxonomy links and handles back and forward buttons" do
       visit "#{discover_host}/software-development/programming/c-sharp?sort=featured"
 
-      expect(page).to have_title("Software Development » Programming » C# | Gumroad")
+      expect(page).to have_title("Software Development » Programming » C# — digital products by independent creators | Gumroad")
       within_section "Featured products", section_element: :section do
         expect_product_cards_with_names("product 0", "product 3")
       end
@@ -496,7 +496,7 @@ describe("Discover", js: true, type: :system) do
         click_on "Programming"
       end
       expect(page).to have_current_path("/software-development/programming")
-      expect(page).to have_title("Software Development » Programming | Gumroad")
+      expect(page).to have_title("Software Development » Programming — digital products by independent creators | Gumroad")
       expect(page).to have_selector("[aria-label='Breadcrumbs']", text: "Software Development\n/Programming")
 
       within_section "Featured products", section_element: :section do
@@ -511,7 +511,7 @@ describe("Discover", js: true, type: :system) do
       page.go_back
       wait_for_ajax
       expect(page).to have_current_path("/software-development/programming/c-sharp?sort=featured")
-      expect(page).to have_title("Software Development » Programming » C# | Gumroad")
+      expect(page).to have_title("Software Development » Programming » C# — digital products by independent creators | Gumroad")
       expect(page).to have_selector("[aria-label='Breadcrumbs']", text: "Software Development\n/Programming\n/C#")
       within_section "Featured products", section_element: :section do
         expect_product_cards_with_names("product 0", "product 3")
@@ -522,7 +522,7 @@ describe("Discover", js: true, type: :system) do
       page.go_forward
       wait_for_ajax
       expect(page).to have_current_path("/software-development/programming")
-      expect(page).to have_title("Software Development » Programming | Gumroad")
+      expect(page).to have_title("Software Development » Programming — digital products by independent creators | Gumroad")
       expect(page).to have_selector("[aria-label='Breadcrumbs']", text: "Software Development\n/Programming")
       within_section "Featured products", section_element: :section do
         expect_product_cards_with_names("product 0", "product 2", "product 3")


### PR DESCRIPTION
## What
Applies the `— digital products by independent creators` suffix from #7018's server-rendered taxonomy title to `discoverTitleGenerator`, and updates `discover_spec`'s taxonomy-only title expectations to match.

## Why
Main is red: **Test Slow 24** fails consistently (3 retries, identical) on `spec/requests/discover/discover_spec.rb:477`. #7018 changed the server-rendered title for Discover taxonomy pages but the client-side title generator used on Inertia navigation (breadcrumbs, back/forward) was not updated, so navigating rewrote the title without the suffix — a real UX/SEO inconsistency, not just a spec break: every client-side navigation flipped the document title away from the SEO title.

Suffix is applied **only to taxonomy-only views** (no query/tags), exactly matching `Discover::CategoryPagePresenter#title`'s scope — search and tag titles are unchanged.

## Test results
- `tsc --noEmit` clean, prettier applied
- `discover_spec.rb` title expectations updated for the three taxonomy-only assertions (tag/search-prefixed assertions untouched)
- Local system-spec env lacks taxonomy seeds (404s before title assertion), so the failing spec is proven on CI at this PR's head

---
AI disclosure: authored by claude-fable-5 via gumclaw.