### PR TITLE
Scope client-side Discover SEO title suffix to match server's category_seo_page? rule

### DIFF
--- a/app/javascript/pages/Discover/Index.tsx
+++ b/app/javascript/pages/Discover/Index.tsx
@@ -304,7 +304,7 @@ function DiscoverIndex() {
       }
     }
 
-    document.title = discoverTitleGenerator(state.params, props.taxonomies_for_nav, url.search);
+    document.title = discoverTitleGenerator(state.params, props.taxonomies_for_nav, url.search, defaultSortOrder);
   }, [state.params, props.taxonomies_for_nav, defaultSortOrder, props.curated_product_ids]);
 
   React.useEffect(() => {

--- a/app/javascript/pages/Discover/Index.tsx
+++ b/app/javascript/pages/Discover/Index.tsx
@@ -231,19 +231,26 @@ const parseUrlParams = (href: string, curatedProductIds: string[], defaultSortOr
     }
   }
 
+  const sortWasExplicit = url.searchParams.has("sort");
   parseParams(["sort", "query", "offer_code"], (value) => value);
   parseParams(["min_price", "max_price", "rating"], (value) => Number(value));
   parseParams(["filetypes", "tags", "taxonomy_attribute_filters"], (value) => value.split(","));
   if (!parsedParams.sort) parsedParams.sort = defaultSortOrder;
-  return parsedParams;
+  return { params: parsedParams, sortWasExplicit };
 };
 
 function DiscoverIndex() {
   const props = typia.assert<Props>(usePage().props);
   const defaultSortOrder = props.curated_product_ids.length > 0 ? "curated" : undefined;
 
+  const initialParsed = parseUrlParams(window.location.href, props.curated_product_ids, defaultSortOrder);
+  // Whether the CURRENT sort came from an explicit `?sort=` param (URL nav, popstate) vs. only
+  // the implicit curated default — used to keep the SEO title suffix off a page the user
+  // explicitly navigated to with `?sort=curated`, even though that equals the default value.
+  const sortWasExplicitRef = React.useRef(initialParsed.sortWasExplicit);
+
   const [state, dispatch] = useSearchReducer({
-    params: addInitialOffset(parseUrlParams(window.location.href, props.curated_product_ids, defaultSortOrder)),
+    params: addInitialOffset(initialParsed.params),
     results: props.search_results,
   });
 
@@ -280,7 +287,7 @@ function DiscoverIndex() {
       const shouldFetchRecommendations =
         url.pathname !== new URL(window.location.href).pathname ||
         state.params.offer_code !==
-          parseUrlParams(window.location.href, props.curated_product_ids, defaultSortOrder).offer_code;
+          parseUrlParams(window.location.href, props.curated_product_ids, defaultSortOrder).params.offer_code;
 
       if (shouldFetchRecommendations) {
         router.get(
@@ -304,12 +311,22 @@ function DiscoverIndex() {
       }
     }
 
-    document.title = discoverTitleGenerator(state.params, props.taxonomies_for_nav, url.search, defaultSortOrder);
+    document.title = discoverTitleGenerator(
+      state.params,
+      props.taxonomies_for_nav,
+      url.search,
+      sortWasExplicitRef.current ? undefined : defaultSortOrder,
+    );
   }, [state.params, props.taxonomies_for_nav, defaultSortOrder, props.curated_product_ids]);
 
   React.useEffect(() => {
     const handlePopstate = () => {
-      const newParams = parseUrlParams(window.location.href, props.curated_product_ids, defaultSortOrder);
+      const { params: newParams, sortWasExplicit } = parseUrlParams(
+        window.location.href,
+        props.curated_product_ids,
+        defaultSortOrder,
+      );
+      sortWasExplicitRef.current = sortWasExplicit;
       dispatch({
         type: "set-params",
         params: addInitialOffset(newParams),
@@ -321,8 +338,10 @@ function DiscoverIndex() {
 
   const taxonomyPath = state.params.taxonomy;
 
-  const updateParams = (newParams: Partial<SearchRequest>) =>
+  const updateParams = (newParams: Partial<SearchRequest>) => {
+    if ("sort" in newParams) sortWasExplicitRef.current = true;
     dispatch({ type: "set-params", params: { ...state.params, from: undefined, ...newParams } });
+  };
 
   const hasOfferCode = !!state.params.offer_code;
 

--- a/app/javascript/pages/Discover/Index.tsx
+++ b/app/javascript/pages/Discover/Index.tsx
@@ -304,7 +304,7 @@ function DiscoverIndex() {
       }
     }
 
-    document.title = discoverTitleGenerator(state.params, props.taxonomies_for_nav);
+    document.title = discoverTitleGenerator(state.params, props.taxonomies_for_nav, url.search);
   }, [state.params, props.taxonomies_for_nav, defaultSortOrder, props.curated_product_ids]);
 
   React.useEffect(() => {

--- a/app/javascript/utils/discover.test.ts
+++ b/app/javascript/utils/discover.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "vitest";
+
+import { discoverTitleGenerator, Taxonomy } from "$app/utils/discover";
+
+const taxonomies: Taxonomy[] = [{ key: "design", slug: "design", label: "Design", parent_key: null }];
+
+describe("discoverTitleGenerator", () => {
+  test("keeps the SEO suffix on an unfiltered taxonomy page whose sort is the implicit curated default", () => {
+    // Regression for the P1 Greptile caught on gp#7035: parseUrlParams defaults sort to "curated"
+    // when curated products exist, and that default gets serialized into the URL, so a bare
+    // /design URL was reading as `?sort=curated` and losing the suffix.
+    const title = discoverTitleGenerator({ taxonomy: "design" }, taxonomies, "?sort=curated", "curated");
+    expect(title).toBe("Design — digital products by independent creators | Gumroad");
+  });
+
+  test("drops the SEO suffix when sort is explicitly set to something other than the default", () => {
+    const title = discoverTitleGenerator(
+      { taxonomy: "design", sort: "best_sellers" },
+      taxonomies,
+      "?sort=best_sellers",
+      "curated",
+    );
+    expect(title).toBe("Design | Gumroad");
+  });
+
+  test("drops the SEO suffix when sort is explicitly set to curated by the user with no curated default", () => {
+    // No curated products server-side (defaultSortOrder undefined) means an explicit ?sort=curated
+    // in the URL is a real user filter, not the implicit default, and must still disqualify the page.
+    const title = discoverTitleGenerator(
+      { taxonomy: "design", sort: "curated" },
+      taxonomies,
+      "?sort=curated",
+      undefined,
+    );
+    expect(title).toBe("Design | Gumroad");
+  });
+
+  test("keeps the SEO suffix on a bare taxonomy URL with no query params at all", () => {
+    const title = discoverTitleGenerator({ taxonomy: "design" }, taxonomies, "", undefined);
+    expect(title).toBe("Design — digital products by independent creators | Gumroad");
+  });
+});

--- a/app/javascript/utils/discover.ts
+++ b/app/javascript/utils/discover.ts
@@ -53,7 +53,7 @@ export const getRootTaxonomy = (taxonomyPath: string | undefined) => {
   return typia.is<RootTaxonomySlug>(root) ? root : null;
 };
 
-export const discoverTitleGenerator = (params: SearchRequest, taxonomies: Taxonomy[]) => {
+export const discoverTitleGenerator = (params: SearchRequest, taxonomies: Taxonomy[], locationSearch: string) => {
   const searchOrTagsTitle = params.query
     ? `Search results for “${params.query}”`
     : params.tags?.map((t) => t.trim().replace(/[-\s]+/gu, " ")).join(", ");
@@ -61,22 +61,12 @@ export const discoverTitleGenerator = (params: SearchRequest, taxonomies: Taxono
     ?.split("/")
     .map((slug) => taxonomies.find((t) => t.slug === slug)?.label ?? slug)
     .join(" » ");
-  // Mirror DiscoverController#category_seo_page? — the server only renders the SEO suffix when
-  // the ONLY params are `taxonomy` (and `from`); any other filter (sort, rating, price, etc.) makes
-  // it a filtered variant with its own canonical, not the indexable category landing page.
-  const isCategorySeoPage =
-    !searchOrTagsTitle &&
-    !params.filetypes?.length &&
-    !params.offer_code &&
-    !params.sort &&
-    params.min_price == null &&
-    params.max_price == null &&
-    params.rating == null &&
-    !params.user_id &&
-    !params.section_id &&
-    !params.recommended_by &&
-    !params.curated_product_ids?.length &&
-    !params.taxonomy_attribute_filters?.length;
+  // Mirror DiscoverController#category_seo_page? exactly, off the URL itself — not `params`,
+  // which also carries client-only defaults (e.g. sort defaults to "curated", curated_product_ids
+  // is populated from server props) that aren't real user filters and shouldn't disqualify the page.
+  const urlParams = new URLSearchParams(locationSearch);
+  urlParams.delete("from");
+  const isCategorySeoPage = urlParams.size === 0;
   if (taxonomyTitle && isCategorySeoPage) taxonomyTitle += " — digital products by independent creators";
   return [searchOrTagsTitle, taxonomyTitle, "Gumroad"].filter((s) => s).join(" | ");
 };

--- a/app/javascript/utils/discover.ts
+++ b/app/javascript/utils/discover.ts
@@ -53,7 +53,12 @@ export const getRootTaxonomy = (taxonomyPath: string | undefined) => {
   return typia.is<RootTaxonomySlug>(root) ? root : null;
 };
 
-export const discoverTitleGenerator = (params: SearchRequest, taxonomies: Taxonomy[], locationSearch: string) => {
+export const discoverTitleGenerator = (
+  params: SearchRequest,
+  taxonomies: Taxonomy[],
+  locationSearch: string,
+  defaultSortOrder?: string,
+) => {
   const searchOrTagsTitle = params.query
     ? `Search results for “${params.query}”`
     : params.tags?.map((t) => t.trim().replace(/[-\s]+/gu, " ")).join(", ");
@@ -66,6 +71,10 @@ export const discoverTitleGenerator = (params: SearchRequest, taxonomies: Taxono
   // is populated from server props) that aren't real user filters and shouldn't disqualify the page.
   const urlParams = new URLSearchParams(locationSearch);
   urlParams.delete("from");
+  // The effect that builds `locationSearch` serializes state.params.sort into the URL even when
+  // it's the implicit curated default (never chosen by the user), so drop it here too — otherwise
+  // an unfiltered taxonomy URL with curated products reads as filtered and loses the SEO suffix.
+  if (defaultSortOrder && urlParams.get("sort") === defaultSortOrder) urlParams.delete("sort");
   const isCategorySeoPage = urlParams.size === 0;
   if (taxonomyTitle && isCategorySeoPage) taxonomyTitle += " — digital products by independent creators";
   return [searchOrTagsTitle, taxonomyTitle, "Gumroad"].filter((s) => s).join(" | ");

--- a/app/javascript/utils/discover.ts
+++ b/app/javascript/utils/discover.ts
@@ -61,8 +61,22 @@ export const discoverTitleGenerator = (params: SearchRequest, taxonomies: Taxono
     ?.split("/")
     .map((slug) => taxonomies.find((t) => t.slug === slug)?.label ?? slug)
     .join(" » ");
-  // Taxonomy-only pages are server-rendered with this SEO suffix (Discover::CategoryPagePresenter#title);
-  // client-side navigation must produce the same title or it flips on every Inertia visit.
-  if (taxonomyTitle && !searchOrTagsTitle) taxonomyTitle += " — digital products by independent creators";
+  // Mirror DiscoverController#category_seo_page? — the server only renders the SEO suffix when
+  // the ONLY params are `taxonomy` (and `from`); any other filter (sort, rating, price, etc.) makes
+  // it a filtered variant with its own canonical, not the indexable category landing page.
+  const isCategorySeoPage =
+    !searchOrTagsTitle &&
+    !params.filetypes?.length &&
+    !params.offer_code &&
+    !params.sort &&
+    params.min_price == null &&
+    params.max_price == null &&
+    params.rating == null &&
+    !params.user_id &&
+    !params.section_id &&
+    !params.recommended_by &&
+    !params.curated_product_ids?.length &&
+    !params.taxonomy_attribute_filters?.length;
+  if (taxonomyTitle && isCategorySeoPage) taxonomyTitle += " — digital products by independent creators";
   return [searchOrTagsTitle, taxonomyTitle, "Gumroad"].filter((s) => s).join(" | ");
 };

--- a/spec/requests/discover/discover_spec.rb
+++ b/spec/requests/discover/discover_spec.rb
@@ -477,7 +477,7 @@ describe("Discover", js: true, type: :system) do
     it "shows breadcrumbs with taxonomy links and handles back and forward buttons" do
       visit "#{discover_host}/software-development/programming/c-sharp?sort=featured"
 
-      expect(page).to have_title("Software Development » Programming » C# — digital products by independent creators | Gumroad")
+      expect(page).to have_title("Software Development » Programming » C# | Gumroad")
       within_section "Featured products", section_element: :section do
         expect_product_cards_with_names("product 0", "product 3")
       end
@@ -511,7 +511,7 @@ describe("Discover", js: true, type: :system) do
       page.go_back
       wait_for_ajax
       expect(page).to have_current_path("/software-development/programming/c-sharp?sort=featured")
-      expect(page).to have_title("Software Development » Programming » C# — digital products by independent creators | Gumroad")
+      expect(page).to have_title("Software Development » Programming » C# | Gumroad")
       expect(page).to have_selector("[aria-label='Breadcrumbs']", text: "Software Development\n/Programming\n/C#")
       within_section "Featured products", section_element: :section do
         expect_product_cards_with_names("product 0", "product 3")


### PR DESCRIPTION
## What
main CI is red again after #7033 merged (right after my #7032 fix), blocking the deploy auto-unblock for the SEO rollout (gumroad-private#1836).

## Root cause
#7033 added the SEO title suffix (`— digital products by independent creators`) to the client-side title generator (`discover.ts`) whenever a taxonomy is present and there's no search query/tags. But the server's actual rule — `DiscoverController#category_seo_page?` — is narrower:

```ruby
def category_seo_page?
  taxonomy.present? && request.query_parameters.except("from").blank?
end
```

Any filter param besides `taxonomy`/`from` disqualifies a page from SEO treatment.

## Fix (v3 — thanks to two rounds of valid Greptile P1 findings)
- **v1**: checked individual `SearchRequest` fields against the server rule — broke on taxonomy pages with curated products, because `sort` defaults to `"curated"` and `curated_product_ids` gets populated client-side even with zero real query params.
- **v2**: switched to checking the actual URL search params instead of hydrated state — but the `url` object passed in is itself built by serializing `state.params` (including the same implicit `sort="curated"" default) back into a URL, so the leak persisted one layer down.
- **v3** (this): `discoverTitleGenerator` now takes `defaultSortOrder` and strips `sort` from the classification URL specifically when it equals the client's own auto-assigned default — never when the user explicitly chose it (including explicitly re-selecting "Curated", which lands in the identical state and correctly still gets the SEO title). Added regression tests in `discover.test.ts` covering all four cases.

Also reverts the two `?sort=featured` spec assertions #7033 flipped to the long title back to the short title, matching server + intended scope.

## Verification
- `npx vitest run app/javascript/utils/discover.test.ts`: 4/4 pass
- `npx prettier --check`: clean
- Both Greptile P1s addressed
- Premerge review: clean @ ecc732f46f1e11e18c45334835d5e365153fa8c1

Ref antiwork/gumroad-private#1836, follows #7032