### PR TITLE
Add S3-context regression coverage for wishlist sitemap deletion

### DIFF
--- a/spec/services/sitemap_service_spec.rb
+++ b/spec/services/sitemap_service_spec.rb
@@ -144,6 +144,32 @@ describe SitemapService do
       expect(File.exist?(sitemap_file_path)).to be false
     end
 
+    it "deletes the S3 sitemap object with the dedicated sitemap-uploader credentials when no wishlist remains indexable" do
+      allow(Rails.env).to receive(:production?).and_return(true)
+      allow(GlobalConfig).to receive(:get).and_call_original
+      allow(GlobalConfig).to receive(:get).with("S3_SITEMAP_UPLOADER_ACCESS_KEY").and_return("uploader-access-key")
+      allow(GlobalConfig).to receive(:get).with("S3_SITEMAP_UPLOADER_SECRET_ACCESS_KEY").and_return("uploader-secret-key")
+
+      s3_client = instance_double(Aws::S3::Client)
+      expect(Aws::S3::Client).to receive(:new).with(
+        access_key_id: "uploader-access-key",
+        secret_access_key: "uploader-secret-key",
+        region: AWS_DEFAULT_REGION
+      ).and_return(s3_client)
+      expect(s3_client).to receive(:delete_object).with(
+        bucket: PUBLIC_STORAGE_S3_BUCKET,
+        key: "#{SitemapService::SITEMAP_PATH_WISHLISTS}/sitemap.xml.gz"
+      )
+      # The upload path in sitemap_config also builds an AwsSdkAdapter that reads S3
+      # credentials via GlobalConfig, but that adapter never touches Aws::S3::Client
+      # directly, so this expectation binds only to the deletion call being pinned here.
+      allow(SitemapGenerator::Sitemap).to receive(:ping_search_engines)
+
+      create(:wishlist_product, wishlist: create(:wishlist, name: "Thin List"))
+
+      service.generate_wishlists
+    end
+
     it "deletes /robots.txt sitemap configs cache" do
       cache_key = "sitemap_configs"
       redis_namespace = Redis::Namespace.new(:robots_redis_namespace, redis: $redis)


### PR DESCRIPTION
## What

Add a regression spec for `SitemapService#generate_wishlists` that pins the S3 deletion
path when no wishlist remains indexable, catching a class of bug the existing regression
example couldn't: a broken S3 credentials/bucket/key wiring that would ship silently
because the prior test only exercised local filesystem cleanup.

## Why

This is the delta that shipped in gumroad#7020 (branch `wishlist-sitemap-stale-cleanup`)
*after* that PR merged — a Greptile P2 finding from the original review (only local
filesystem cleanup was covered by a regression test; the S3 `delete_object` path could
regress with wrong credentials or the wrong bucket/key and nothing would catch it) that
was addressed with a follow-up commit but never itself reviewed or shipped, because the
branch was never re-diffed against a PR. Cherry-picked here onto a fresh branch off
`main` so it goes through review and lands.

The new spec stubs `Aws::S3::Client` and asserts:
- it's constructed with the dedicated `S3_SITEMAP_UPLOADER_*` identity, not default
  credentials
- `delete_object` targets the correct bucket/key for the wishlist sitemap

Mutation-verified upstream (per the original commit message): reverting the credentials
fix in `remove_wishlist_sitemap_artifact` makes this example fail with the default
MinIO/dev credentials, confirming the guard is load-bearing.

## Test Results

Ran locally (`env -u TEST_DATABASE_NAME -u DATABASE_NAME rbenv exec bundle exec rspec
spec/services/sitemap_service_spec.rb`):

```
10 examples, 0 failures
Finished in 29.86 seconds
```

## QA steps

Backend-only spec addition; no rendered surface, nothing to screenshot.

## AI disclosure

Cherry-picked from a prior AI-authored commit (`a2bc8f63a`, "Add S3-context regression
coverage for wishlist sitemap deletion") that was pushed to `wishlist-sitemap-stale-cleanup`
after PR #7020 merged and never reviewed. This PR carries that same commit onto a fresh
branch off `main`, unmodified, so it can go through the normal review/CI gate.

Premerge review: clean @ 1673eb1dca927f524674b50039f05e016afa8b7c
