### PR TITLE
Fix main: lock via class, not self, in first-row review stat creation

### DIFF
--- a/app/modules/product/review_stat.rb
+++ b/app/modules/product/review_stat.rb
@@ -47,9 +47,13 @@ module Product::ReviewStat
 
   def update_review_stat_via_rating_change(old_rating, new_rating)
     if product_review_stat.nil?
-      # Serialize only the first aggregate row creation. The locking lookup is a current read, so
-      # a callback transaction waiting here sees the row committed by the winner.
-      with_lock do
+      # Serialize only the first aggregate row creation. `with_lock` reloads `self`, and Rails
+      # refuses to reload a record carrying unpersisted changes (e.g. `content_updated_at` set by
+      # `save_files!` without a save) -- lock via the class instead so a caller's dirty instance
+      # is never touched. The locking lookup is a current read, so a callback transaction waiting
+      # here sees the row committed by the winner.
+      self.class.transaction do
+        self.class.lock.find(id)
         review_stat_association = association(:product_review_stat)
         review_stat_association.reset
         review_stat = ProductReviewStat.lock.find_by(link_id: id) || create_product_review_stat!

--- a/spec/modules/product/review_stat_dirty_link_repro_spec.rb
+++ b/spec/modules/product/review_stat_dirty_link_repro_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Regression for main red build 2026-08-04: `save_files!` sets `content_updated_at` on the link
+# without saving it. `update_review_stat_via_rating_change`'s first-row path used to call
+# `with_lock` on the link/product itself, and Rails refuses to reload a record with unpersisted
+# changes -- raising "Locking a record with unpersisted changes is not supported" the moment a
+# product's first review lands right after `save_files!` touched it in the same request.
+describe Product::ReviewStat, "first review on a dirty link" do
+  it "creates the review stat without raising when the link has unsaved in-memory changes" do
+    product = create(:product_with_files)
+    product.content_updated_at = Time.current
+    expect(product.changed?).to eq(true)
+
+    purchase = create(:purchase, link: product)
+    expect { create(:product_review, purchase:, rating: 4) }.not_to raise_error
+
+    expect(product.reload.product_review_stat).to have_attributes(reviews_count: 1)
+  end
+end


### PR DESCRIPTION
## What

Fixes main red: `update_review_stat_via_rating_change`'s first-row path (added in #7030) called `with_lock` on `self` (the `Link`/`Product`). Rails' `with_lock` reloads the record, and Rails 7.1 raises when reloading a record that carries unpersisted changes. `save_files!` sets `content_updated_at` on the link without saving it, so a product's first review landing while the link is still dirty from a file upload in the same request raised:

```
RuntimeError: Locking a record with unpersisted changes is not supported.
Use `save` to persist the changes, or `reload` to discard them explicitly.
Changed attributes: "content_updated_at".
```

This is what CI's `Product::Searchable - Indexing scenarios #as_indexed_json includes all properties` spec hit (it calls `save_files!` then creates a `product_review` in the same example) and what broke every `Tests` run on main since #7030 merged.

## Fix

Locks a fresh row via the class (`self.class.lock.find(id)`) instead of `with_lock` on `self`, inside an explicit transaction. This never touches or reloads the caller's in-memory instance, so a dirty (unsaved) link is unaffected. The concurrency guarantee from #7030 is unchanged: only the first `ProductReviewStat` row creation is serialized, and the `ProductReviewStat.lock.find_by` lookup is still a current read so a waiting transaction sees the row the winner committed.

## Why not just `reload` first

Reloading `self` would silently discard the caller's in-memory changes (e.g. the just-set `content_updated_at`) before they're saved -- correctness risk for any caller with pending attribute writes. Locking a separate row for the sole purpose of serializing insert-vs-insert avoids that entirely.

## Test Results

Added `spec/modules/product/review_stat_dirty_link_repro_spec.rb`, which reproduces the dirty-link scenario directly:

- **Before the fix**: 1 example, 1 failure -- reproduces the exact production error (`Locking a record with unpersisted changes is not supported... Changed attributes: "content_updated_at"`).
- **After the fix**: passes.

Full local run after the fix:

```
bundle exec rspec spec/modules/product/review_stat_dirty_link_repro_spec.rb \
  spec/modules/product/review_stat_concurrency_spec.rb \
  spec/modules/product/review_stat_spec.rb \
  spec/modules/product/searchable/indexing_spec.rb
# 70 examples, 0 failures
```

This includes #7030's own concurrency spec (still green -- the serialization guarantee is preserved) and the indexing spec that was failing on main.

Rubocop clean on both changed files. CI (Tests workflow) is green on this branch.

Premerge review: clean @ c6796d0a72 (codex/gpt-5.6-sol, correctness 0.94, no accepted/actionable findings)

## QA steps

Code-only concurrency fix, no user-facing behavior change. Reviewer path: read the diff (one method), confirm the concurrency spec from #7030 still passes, confirm the new regression spec fails on `with_lock` and passes on `self.class.lock.find(id)`.

---

AI disclosure: root-caused and fixed by an autonomous CI-triage agent (Hermes Agent, account `gumclaw`) in response to main's Tests workflow going red after #7030 merged. Diagnosis and fix verified by running the exact spec locally against both the broken and fixed code, and passed through autoreview (codex/gpt-5.6-sol) before opening.