### PR TITLE
Fix seller-reputation cache key to survive same-second review-stat writes

### DIFF
--- a/app/services/pages/profile_data.rb
+++ b/app/services/pages/profile_data.rb
@@ -64,11 +64,23 @@ class Pages::ProfileData
       seller.installments.visible_on_profile.cache_key_with_version,
       seller_profile&.cache_key_with_version,
       # Review writes touch product_review_stats, not links, so the products key
-      # above never moves when a rating lands; the flag state and stat high-water
-      # mark keep the cached seller_rating honest.
+      # above never moves when a rating lands; the flag state and this signature
+      # keep the cached seller_rating honest.
       seller.reputation_summary_enabled?,
-      seller.reputation_summary_enabled? ? ProductReviewStat.joins(:link).where(links: { user_id: seller.id }).maximum(:updated_at) : nil,
+      seller.reputation_summary_enabled? ? reputation_summary_cache_signature(seller) : nil,
     ].join("/")
+  end
+
+  # A digest of the values seller_reputation_summary aggregates, not a timestamp:
+  # updated_at has second precision, so two review-stat mutations in the same
+  # second would produce an identical maximum(:updated_at) and serve a stale
+  # cached rollup. Summing the actual counters changes whenever the rollup's
+  # output could change, regardless of how many writes land in one second.
+  def self.reputation_summary_cache_signature(seller)
+    ProductReviewStat.joins(:link).where(links: { user_id: seller.id })
+      .pick(Arel.sql("SUM(reviews_count), SUM(ratings_of_one_count), SUM(ratings_of_two_count), " \
+                      "SUM(ratings_of_three_count), SUM(ratings_of_four_count), SUM(ratings_of_five_count), COUNT(*)"))
+      &.join(",")
   end
 
   def self.products(seller, base_url = seller.store_host_with_protocol, offset: 0, limit: MAX_ITEMS)

--- a/spec/services/pages/profile_data_spec.rb
+++ b/spec/services/pages/profile_data_spec.rb
@@ -58,6 +58,22 @@ describe Pages::ProfileData do
 
         expect(Pages::ProfileData.cache_key(seller.reload, seller_profile)).not_to eq(key_before)
       end
+
+      it "changes the cache key when two review-stat mutations land in the same second" do
+        # maximum(:updated_at) has second precision, so a naive timestamp-based key would
+        # reuse the same value for both writes below and silently serve the stale rollup.
+        Feature.activate_user(:seller_reputation_summary, seller)
+        product = create(:product, user: seller)
+        seller_profile = SellerProfile.find_by(seller_id: seller.id)
+        stat = ProductReviewStat.create!(link: product, reviews_count: 1, average_rating: 5, ratings_of_five_count: 1)
+        key_before = Pages::ProfileData.cache_key(seller.reload, seller_profile)
+
+        travel_to(stat.updated_at) do
+          stat.update!(reviews_count: 2, ratings_of_five_count: 1, ratings_of_one_count: 1)
+        end
+
+        expect(Pages::ProfileData.cache_key(seller.reload, seller_profile)).not_to eq(key_before)
+      end
     end
 
     it "does not expose draft products in the public profile data payload" do


### PR DESCRIPTION
## What

Fixes a P1 Greptile flagged on #6878 after it merged: `Pages::ProfileData.cache_key` used `ProductReviewStat.maximum(:updated_at)` as the invalidation token for the cached `seller_rating` payload. That column has second precision, so two review-stat mutations landing within the same second produce an identical key and the stale cached rollup keeps being served.

Replaces the timestamp with a signature built from the actual counters `seller_reputation_summary` aggregates (`SUM` of the five rating buckets + review count via `pick`), so the key changes exactly when the values it represents change — independent of write timing.

## Why

Greptile's review on #6878 (comment https://github.com/antiwork/gumroad/pull/6878#discussion_r_3700481505, posted after the PR merged) — confirmed live against `origin/main`: the vulnerable line is unchanged since merge.

## Before/After

- Before: two `ProductReviewStat` mutations in the same second → identical `cache_key` → second write's rating never reaches the cached payload until the entry expires on its own.
- After: same scenario → `cache_key` changes because the counter signature differs, even when both mutations share a timestamp.

## Test Results

- `bundle exec rspec spec/services/pages/profile_data_spec.rb` — 41 examples, 0 failures (adds one regression spec that mutates a review stat inside a `travel_to` block pinned to the first write's timestamp, then asserts the cache key still changes).
- Mutation-proved: reverted the fix locally to the pre-fix `maximum(:updated_at)` line and re-ran the new spec alone — it failed as expected (`Expected ... not to eq ...`), confirming the spec has teeth. Restored the fix afterward.
- `bundle exec rspec spec/modules/user/reputation_summary_spec.rb spec/presenters/profile_presenter_spec.rb spec/presenters/product_presenter/product_props_spec.rb` — 74 examples, 1 failure (`ProductPresenter::ProductProps ... returns the seller-level refund policy`), reproduced identically on unmodified `origin/main` in the same worktree — pre-existing/environmental, unrelated to this diff.

## QA steps

Backend-only fix, no rendered surface. As a boot sanity check, confirm the preview app boots at https://fix-reputation-cache-same-second.apps.staging.gumroad.org, log in as `seller@gumroad.com` / `password` (2FA token pre-filled), and land on `/dashboard` without error — confirming the branch's code loads cleanly. Verified 2026-08-04: login → 2FA → `/dashboard` succeeded with no console errors. The actual behavior change (cache key invalidation) is confirmed via the specs and mutation-proof above, not a UI screenshot.

## Status
- [x] Scope — one cache-key line, no new surface
- [x] Design — swap timestamp for a value signature
- [x] Build — done
- [ ] QA — spec run + mutation-proof above; awaiting CI
- [ ] Shipped
- [ ] Market
- [ ] Sell

---

AI disclosure: This PR was authored autonomously by an AI agent (claude-sonnet-5).

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: the ball is back with me (still a draft — I'm building it; no human review requested/received yet — still mine to hand off), so I'm taking the assignee back and labelling `working`. I'll re-assign a human and flip to `awaiting-human` once it's genuinely ready again.
<!-- gumclaw-ownership-sweep -->

Premerge review: clean @ 2abd10c06b22a1c51645bd13bde447aba5893106 (codex/gpt-5.6-sol, 0 findings, patch-correct 0.98)


Fable-5: clean @ 2abd10c06b22a1c51645bd13bde447aba5893106
fable-5 review: clean at 2abd10c06b22a1c51645bd13bde447aba5893106 — post-merge audit (PR was squash-merged as ce1a772a by a sibling session mid-review; squash verified byte-faithful to head). Verified: counter signature covers every input `seller_reputation_summary` consumes; eligibility flips (hide reviews, delete/draft product) mutate `links` and are already covered by the products cache-key component, so no staleness path exists. Greptile's post-merge P2 (over-invalidation from excluded products) is perf-only; fix in flight on a follow-up branch.
