### PR TITLE
Trim can_contact_reason comments to the restore-safety invariant

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -110,18 +110,12 @@ class Purchase < ApplicationRecord
   # debit actually booked. Snapshotted at debit time so the dispute-won re-credit books
   # exactly the same amount, even when refunds land between the debit and the win.
   attr_json_data_accessor :presentment_dispute_debited_gross_cents
-  # Why `can_contact` is false. Until now the only way to tell a buyer's own unsubscribe from a
-  # machine-written suppression was `versions.request_path` being non-NULL, which is an audit
-  # side effect with a retention window — see antiwork/gumroad-private#1745, where a restore had
-  # to be reconstructed forensically and anything past retention was unrecoverable.
+  # Why `can_contact` is false. Only `BUYER_UNSUBSCRIBE`/`SPAM_REPORT` are first-party consent;
+  # a restore must never reverse those, only `INHERITED`.
   attr_json_data_accessor :can_contact_reason
 
-  # Buyer acted: clicked the receipt-footer unsubscribe, or reported the email as spam. Both are
-  # first-party consent signals and must never be reversed by an automated restore.
   CAN_CONTACT_REASON_BUYER_UNSUBSCRIBE = "buyer_unsubscribe"
   CAN_CONTACT_REASON_SPAM_REPORT = "spam_report"
-  # Nobody acted on THIS row: it was born uncontactable because a sibling already was.
-  # Reversing it is safe iff the row it inherited from is reversed.
   CAN_CONTACT_REASON_INHERITED = "inherited"
 
   alias_attribute :total_transaction_cents_usd, :total_transaction_cents


### PR DESCRIPTION
## Status

- [x] Scope — comment-only cleanup, no behavior change
- [x] Design — n/a (no design decision; just cutting noise per repo comment convention)
- [x] Build — done, pushed
- [x] QA — `ruby -c` clean; comment-only diff, no rendered surface, no runtime path touched
- [x] Shipped — CI pending on this branch
- [ ] Market — n/a
- [ ] Sell — n/a

## What

Trims the `can_contact_reason` constant/accessor comments added in #6885 down to the one non-obvious invariant: `buyer_unsubscribe`/`spam_report` are first-party consent and must never be reversed by an automated restore; only `inherited` may be.

## Why

Greptile P2 on #6885 (comment 3700711410): the comments included incident history (antiwork/gumroad-private#1745 forensic-reconstruction narrative) and restated what the clearly-named constants already say. Per this repo's `AGENTS.md` comment convention, that's noise to cut.

## Before-After

Comment-only change, no behavior change.

## Test Results

`ruby -c app/models/purchase.rb` — Syntax OK. No specs touched or affected; this is a pure comment edit on lines already covered by #6885's merged spec suite.

## QA steps

N/A — comment-only diff, no rendered surface, no runtime behavior change.

---

🤖 Written by Gumclaw (Hermes Agent, claude-sonnet-5) responding to Greptile review comment on #6885 (merged). Follow-up fix for the one P2 finding that was still live at `origin/main` after merge (the other P2 finding — inherited siblings not upgraded on direct consent — was already fixed pre-merge, see reply on #6885).

Premerge review: exempt (comment-only diff, no behavior change, no rendered surface)

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: the ball is back with me (still a draft — I'm building it; no human review requested/received yet — still mine to hand off), so I'm taking the assignee back and labelling `working`. I'll re-assign a human and flip to `awaiting-human` once it's genuinely ready again.
<!-- gumclaw-ownership-sweep -->
