### PR TITLE
Fix: dispute evidence could claim receipt opened before delivered

### DIFF
--- a/app/services/dispute_evidence/generate_access_activity_logs_service.rb
+++ b/app/services/dispute_evidence/generate_access_activity_logs_service.rb
@@ -165,6 +165,10 @@ class DisputeEvidence::GenerateAccessActivityLogsService
         sends.first.sent_at,
         [sends.filter_map(&:delivered_at).min, sends.filter_map(&:opened_at).min]
       )
+      # Each timestamp is the earliest across all sends independently, so an open from
+      # one send can beat the delivery selected from another. Drop that open rather than
+      # print it before its own delivery — it is real, it is just not attributable here.
+      opened_at = nil if opened_at.present? && delivered_at.present? && opened_at < delivered_at
 
       content = +""
       content << " A receipt was delivered at #{delivered_at}." if delivered_at.present?

--- a/app/services/dispute_evidence/generate_access_activity_logs_service.rb
+++ b/app/services/dispute_evidence/generate_access_activity_logs_service.rb
@@ -161,14 +161,15 @@ class DisputeEvidence::GenerateAccessActivityLogsService
     # needs "it was delivered and read", and a per-send claim here would be
     # evidence we cannot stand behind. Tracked in gumroad-private#1635.
     def unattributed_event_activity(sends)
-      delivered_at, opened_at = events_after(
+      delivered_at, = events_after(sends.first.sent_at, [sends.filter_map(&:delivered_at).min])
+      # The earliest open across all sends can predate the delivery selected from a
+      # different send, which would claim the receipt was read before it arrived. Pick
+      # the earliest open that is not earlier than that delivery instead of the raw min,
+      # so a later valid open still gets reported rather than discarding open activity outright.
+      opened_at, = events_after(
         sends.first.sent_at,
-        [sends.filter_map(&:delivered_at).min, sends.filter_map(&:opened_at).min]
+        [sends.filter_map(&:opened_at).select { delivered_at.blank? || _1 >= delivered_at }.min]
       )
-      # Each timestamp is the earliest across all sends independently, so an open from
-      # one send can beat the delivery selected from another. Drop that open rather than
-      # print it before its own delivery — it is real, it is just not attributable here.
-      opened_at = nil if opened_at.present? && delivered_at.present? && opened_at < delivered_at
 
       content = +""
       content << " A receipt was delivered at #{delivered_at}." if delivered_at.present?

--- a/spec/services/dispute_evidence/generate_access_activity_logs_service_spec.rb
+++ b/spec/services/dispute_evidence/generate_access_activity_logs_service_spec.rb
@@ -409,8 +409,8 @@ describe DisputeEvidence::GenerateAccessActivityLogsService do
         end
 
         # Each aggregate timestamp is the earliest across ALL sends independently, so an
-        # open from one send can beat the delivery selected from a different send —
-        # printing evidence that claims the receipt was opened before it was delivered.
+        # open from one send can beat the delivery selected from a different send. The
+        # earliest open that still lands at or after that delivery is reported instead.
         context "when the earliest open and earliest delivery come from different sends" do
           before do
             create(
@@ -431,15 +431,47 @@ describe DisputeEvidence::GenerateAccessActivityLogsService do
             )
           end
 
-          it "reports the earliest delivery but drops the unattributable earlier open" do
+          it "reports the earliest delivery and the earliest open at or after it, from either send" do
             expect(email_activity).to eq(
               "The receipt email was sent at 2024-05-07 00:00:00 UTC. The receipt was sent again at " \
-              "2024-05-12 00:00:00 UTC. A receipt was delivered at 2024-05-07 03:00:00 UTC."
+              "2024-05-12 00:00:00 UTC. A receipt was delivered at 2024-05-07 03:00:00 UTC. " \
+              "A receipt was opened at 2024-05-07 04:00:00 UTC."
             )
           end
 
           it "never claims the receipt was opened before it was delivered" do
             expect(email_activity).to_not match(/opened at 2024-05-07 01:00:00 UTC/)
+          end
+        end
+
+        # When no open from any send lands at or after the selected delivery, there is
+        # nothing attributable left to report — unlike the case above, dropping the open
+        # entirely is correct here rather than a lost later one.
+        context "when every open precedes the earliest delivery" do
+          before do
+            create(
+              :customer_email_info_opened,
+              email_name: SendgridEventInfo::RECEIPT_MAILER_METHOD,
+              purchase: purchase,
+              sent_at:,
+              delivered_at: sent_at + 3.hours,
+              opened_at: sent_at + 1.hour
+            )
+            create(
+              :customer_email_info_opened,
+              email_name: SendgridEventInfo::RECEIPT_MAILER_METHOD,
+              purchase: purchase,
+              sent_at: sent_at + 5.days,
+              delivered_at: sent_at + 5.days + 2.hours,
+              opened_at: sent_at + 2.hours
+            )
+          end
+
+          it "reports the delivery and drops all opens" do
+            expect(email_activity).to eq(
+              "The receipt email was sent at 2024-05-07 00:00:00 UTC. The receipt was sent again at " \
+              "2024-05-12 00:00:00 UTC. A receipt was delivered at 2024-05-07 03:00:00 UTC."
+            )
           end
         end
 

--- a/spec/services/dispute_evidence/generate_access_activity_logs_service_spec.rb
+++ b/spec/services/dispute_evidence/generate_access_activity_logs_service_spec.rb
@@ -408,6 +408,41 @@ describe DisputeEvidence::GenerateAccessActivityLogsService do
           end
         end
 
+        # Each aggregate timestamp is the earliest across ALL sends independently, so an
+        # open from one send can beat the delivery selected from a different send —
+        # printing evidence that claims the receipt was opened before it was delivered.
+        context "when the earliest open and earliest delivery come from different sends" do
+          before do
+            create(
+              :customer_email_info_opened,
+              email_name: SendgridEventInfo::RECEIPT_MAILER_METHOD,
+              purchase: purchase,
+              sent_at:,
+              delivered_at: sent_at + 3.hours,
+              opened_at: sent_at + 4.hours
+            )
+            create(
+              :customer_email_info_opened,
+              email_name: SendgridEventInfo::RECEIPT_MAILER_METHOD,
+              purchase: purchase,
+              sent_at: sent_at + 5.days,
+              delivered_at: sent_at + 5.days + 2.hours,
+              opened_at: sent_at + 1.hour
+            )
+          end
+
+          it "reports the earliest delivery but drops the unattributable earlier open" do
+            expect(email_activity).to eq(
+              "The receipt email was sent at 2024-05-07 00:00:00 UTC. The receipt was sent again at " \
+              "2024-05-12 00:00:00 UTC. A receipt was delivered at 2024-05-07 03:00:00 UTC."
+            )
+          end
+
+          it "never claims the receipt was opened before it was delivered" do
+            expect(email_activity).to_not match(/opened at 2024-05-07 01:00:00 UTC/)
+          end
+        end
+
         # Whichever send a provider's event routed to, the evidence reads the
         # same — so a misrouted event cannot change what we tell the card
         # network. This is the property that makes timestamp routing's


### PR DESCRIPTION
## What

Follow-up to #6741 (merged): a P1 that Greptile flagged on that PR (review [4840115489](https://github.com/antiwork/gumroad/pull/6741#pullrequestreview-4840115489), comment [3700720070](https://github.com/antiwork/gumroad/pull/6741#discussion_r3700720070)) went unreplied before merge. Verified live on `origin/main`.

`DisputeEvidence::GenerateAccessActivityLogsService#unattributed_event_activity` picks the earliest `delivered_at` and the earliest `opened_at` **independently** across all of a receipt's sends. When the earliest delivery and the earliest open come from two different sends, those two picks are not chronologically related to each other — the evidence can claim the receipt was opened before it was delivered, which is impossible and is exactly the kind of claim this evidence package cannot afford to be wrong about.

## Fix

If the selected `opened_at` precedes the selected `delivered_at`, pick the earliest open across all sends that is *not* earlier than the delivery instead — dropping only the unattributable open, not every open. (Greptile flagged that the original version of this fix discarded a later, chronologically-valid open along with the unattributable one; comment [3715882391](https://github.com/antiwork/gumroad/pull/7043#discussion_r3715882391).)

## Test Results

```
bundle exec rspec spec/services/dispute_evidence/generate_access_activity_logs_service_spec.rb
38 examples, 0 failures
```

Mutation-verified: reverting to the raw-min selection reproduces the exact P1 (loses the later valid open) and fails the corresponding new example; restored, re-ran clean (38/38).

Rubocop clean on both touched files.

## Screenshots (hosted preview app)

Backend service walkthrough (hosted preview Rails console):

https://raw.githubusercontent.com/antiwork/gumroad/e6f774e24895c0a792b47377c81d9c43b2700203/qa-media/pr-7043-dispute-evidence-walkthrough.txt

## QA steps

1. `bundle exec rspec spec/services/dispute_evidence/generate_access_activity_logs_service_spec.rb` — green.
2. Two receipt sends where opens are at 01:00 and 04:00 UTC and the selected delivery is 03:00 UTC: `DisputeEvidence::GenerateAccessActivityLogsService.perform(purchase)` reports the delivery and the 04:00 open — never the 01:00 open, and never silently drops the 04:00 open either.
3. Two sends where every open precedes the selected delivery: the service reports the delivery and drops all opens (nothing valid left to attribute).

## Status

- [x] Scope — one aggregation bug in the same service #6741 touched.
- [x] Design — select the earliest open at or after the selected delivery, rather than dropping all open activity whenever the raw-min open predates it.
- [x] Build — done, including the fix for Greptile's P1 on this PR.
- [x] QA — spec green (38/38), mutation-killed.
- [ ] Shipped — not merged.
- [ ] Market — n/a, internal correctness fix, no announceable surface.
- [ ] Sell — n/a.

---

**AI disclosure.** Written by gumclaw, an autonomous agent running on claude-sonnet-5 via the Hermes agent runtime, responding to a Greptile P1 on this PR's own diff.

Premerge review: clean @ eaf2a880eda3845bf60566471ff34faef1647fd3

Hosted-preview QA evidence added @ e6f774e24895c0a792b47377c81d9c43b2700203

