### PR TITLE
Fix decimal Discover price filters

### DIFF
--- a/app/modules/product/searchable.rb
+++ b/app/modules/product/searchable.rb
@@ -17,6 +17,8 @@ module Product::Searchable
   MAX_TAXONOMY_ATTRIBUTE_FILTER_TOKENS = 20
   MAX_OFFER_CODES_IN_INDEX = 300
   MAX_PRICE_FILTER_CENTS = 10_000_000_000 # $100,000,000 — upper bound for ES long-typed price range filters
+  PRICE_FILTER_MAX_LENGTH = 64
+  PRICE_FILTER_PATTERN = /\A[+-]?(?:\d+(?:\.\d*)?|\.\d+)\z/
 
   ATTRIBUTE_TO_SEARCH_FIELDS_MAP = {
     "name" => ["name", "rated_as_adult"],
@@ -180,6 +182,8 @@ module Product::Searchable
       # and /products/search; `user_id` is what bounds the vocabulary, via `terms user_id:` below.
       is_alive_on_profile = ActiveModel::Type::Boolean.new.cast(params[:is_alive_on_profile])
       tags_aggregation_size = params[:user_id].present? && is_alive_on_profile ? MAX_NUMBER_OF_PROFILE_TAGS : MAX_NUMBER_OF_TAGS
+      min_price_cents = price_filter_cents(params[:min_price], rounding: :ceil) if params[:min_price].present?
+      max_price_cents = price_filter_cents(params[:max_price], rounding: :floor) if params[:max_price].present?
       search_options = Elasticsearch::DSL::Search.search do
         size params.fetch(:size, RECOMMENDED_PRODUCTS_PER_PAGE).to_i
         from (params[:from].to_i - 1).clamp(0, MAX_RESULT_WINDOW - size)
@@ -271,13 +275,11 @@ module Product::Searchable
                 end
             end
 
-            if params[:min_price].present? || params[:max_price].present?
-              min_cents = (params[:min_price].to_f * 100).to_i.clamp(0, MAX_PRICE_FILTER_CENTS) if params[:min_price].present?
-              max_cents = (params[:max_price].to_f * 100).to_i.clamp(0, MAX_PRICE_FILTER_CENTS) if params[:max_price].present?
+            if min_price_cents || max_price_cents
               filter do
                 range :available_price_cents do
-                  gte min_cents if min_cents
-                  lte max_cents if max_cents
+                  gte min_price_cents if min_price_cents
+                  lte max_price_cents if max_price_cents
                 end
               end
             end
@@ -424,6 +426,14 @@ module Product::Searchable
 
       search_options
     end
+
+    def price_filter_cents(value, rounding:)
+      value = value.to_s
+      return if value.length > PRICE_FILTER_MAX_LENGTH || !value.match?(PRICE_FILTER_PATTERN)
+
+      (BigDecimal(value) * 100).public_send(rounding).clamp(0, MAX_PRICE_FILTER_CENTS)
+    end
+    private :price_filter_cents
 
     def filetype_options(params)
       filetype_search_options = search_options(params.except(:filetypes))

--- a/spec/modules/product/searchable/search_spec.rb
+++ b/spec/modules/product/searchable/search_spec.rb
@@ -114,6 +114,24 @@ describe "Product::Searchable - Search scenarios" do
         assert_equal expected, records.map(&:id)
       end
 
+      it "converts decimal price boundaries to exact cents" do
+        search_options = Link.search_options(min_price: "19.99", max_price: "19.99")
+
+        expect(search_options.dig(:query, :bool, :filter)).to include(
+          range: { available_price_cents: { gte: 1_999, lte: 1_999 } }
+        )
+      end
+
+      it "rounds fractional-cent boundaries inward and ignores malformed values" do
+        rounded = Link.search_options(min_price: "19.991", max_price: "20.009")
+        expect(rounded.dig(:query, :bool, :filter)).to include(
+          range: { available_price_cents: { gte: 2_000, lte: 2_000 } }
+        )
+
+        malformed = Link.search_options(min_price: "not-a-price", max_price: "1e1000000")
+        expect(malformed.dig(:query, :bool, :filter)).to be_nil
+      end
+
       it "clamps extremely large price filter values to prevent Elasticsearch long overflow" do
         # Values like 2_344_444_444_444.44 would produce floats exceeding ES long max (~9.22E18)
         params = { min_price: "0", max_price: "2344444444444444" }


### PR DESCRIPTION
## What

Parses Discover minimum and maximum price filters as bounded decimal values and converts them to exact integer cents.

- Preserves exact values such as `19.99` as 1,999 cents
- Rounds fractional-cent minimums up and maximums down so the requested range is not widened
- Ignores malformed and exponent-form inputs
- Retains the existing nonnegative and maximum-price bounds

## Why

The previous `to_f * 100` conversion used binary floating point and then truncated. A public filter value of `19.99` could therefore become 1,998 cents and include or exclude the wrong products. Parsing with `BigDecimal` fixes the root cause without changing the Elasticsearch schema or public parameter names.

## Before/after

Before, exact decimal boundaries could shift down by one cent. After, exact boundaries remain exact, fractional-cent boundaries round inward, and malformed values do not emit a price range.

## Screenshots (hosted preview app)

![Discover min/max price 19.99 returns exactly the $19.99 product (and excludes the seeded $19.98 control product)](https://raw.githubusercontent.com/antiwork/gumroad/34694f6946d2c271247704548996247f6f600f1d/qa-media/pr-7044-discover-decimal-price-filter.png)


## QA steps

1. Search Discover with `min_price=19.99&max_price=19.99` and confirm the generated range is exactly 1,999 cents.
2. Use `min_price=19.991&max_price=20.009` and confirm both boundaries resolve to 2,000 cents.
3. Use malformed and exponent-form values and confirm no price range is emitted.
4. Confirm existing zero and maximum-price clamping behavior remains intact.

---

Based on https://github.com/adityawrk/gumroad/pull/11 by @adityawrk.

AI Disclosure: Claude Opus 4.6 (1M context) was used to review the original PR and import the changes.

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: the ball is back with me (still a draft — I'm building it; no human review requested/received yet — still mine to hand off), so I'm taking the assignee back and labelling `working`. I'll re-assign a human and flip to `awaiting-human` once it's genuinely ready again.
<!-- gumclaw-ownership-sweep -->

Premerge review: clean @ c6ae4934c91471a48f261cb7fdaabb76a8a2e16d (codex/gpt-5.6-sol, 0 findings, patch-correct 0.99)

