### PR TITLE
Prevent community read marker regression

### DIFF
--- a/app/models/last_read_community_chat_message.rb
+++ b/app/models/last_read_community_chat_message.rb
@@ -10,11 +10,23 @@ class LastReadCommunityChatMessage < ApplicationRecord
   validates :user_id, uniqueness: { scope: :community_id }
 
   def self.set!(user_id:, community_id:, community_chat_message_id:)
-    record = find_or_initialize_by(user_id:, community_id:)
+    message = CommunityChatMessage.find_by!(id: community_chat_message_id, community_id:)
+    record = find_by(user_id:, community_id:)
+    unless record
+      begin
+        record = create!(user_id:, community_id:, community_chat_message: message)
+      rescue ActiveRecord::RecordInvalid => error
+        record = find_by(user_id:, community_id:)
+        raise error unless record && error.record.errors.added?(:user_id, :taken)
+      rescue ActiveRecord::RecordNotUnique
+        record = find_by!(user_id:, community_id:)
+      end
+    end
 
-    if record.new_record? ||
-      (record.community_chat_message.created_at < CommunityChatMessage.find(community_chat_message_id).created_at)
-      record.update!(community_chat_message_id:)
+    record.with_lock do
+      if record.community_chat_message.created_at < message.created_at
+        record.update!(community_chat_message: message)
+      end
     end
 
     record

--- a/spec/models/last_read_community_chat_message_concurrency_spec.rb
+++ b/spec/models/last_read_community_chat_message_concurrency_spec.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "timeout"
+
+RSpec.describe LastReadCommunityChatMessage, ".set! concurrency" do
+  self.use_transactional_tests = false
+
+  before do
+    @seller = create(:user)
+    @reader = create(:user)
+    @product = create(:product, user: @seller)
+    @community = create(:community, seller: @seller, resource: @product)
+    @first_message = create(:community_chat_message, community: @community, user: @seller, created_at: 3.minutes.ago)
+    @older_message = create(:community_chat_message, community: @community, user: @seller, created_at: 2.minutes.ago)
+    @newer_message = create(:community_chat_message, community: @community, user: @seller, created_at: 1.minute.ago)
+    create(
+      :last_read_community_chat_message,
+      user: @reader,
+      community: @community,
+      community_chat_message: @first_message
+    )
+  end
+
+  after do
+    @community.destroy!
+    @product.destroy!
+    RefundPolicy.where(seller_id: @seller.id).delete_all
+    @reader.destroy!
+    @seller.destroy!
+  end
+
+  it "keeps the newest marker when concurrent updates finish out of order" do
+    ready = Queue.new
+    initial_reads = Queue.new
+    read_resumed = Queue.new
+    releases = {
+      @older_message.id => Queue.new,
+      @newer_message.id => Queue.new,
+    }
+    read_releases = {
+      @older_message.id => Queue.new,
+      @newer_message.id => Queue.new,
+    }
+    subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |_name, _start, _finish, _id, payload|
+      message_id = Thread.current[:last_read_message_id]
+      next unless message_id && payload[:sql].include?("FROM `last_read_community_chat_messages`") &&
+        !payload[:sql].include?("FOR UPDATE")
+
+      Thread.current[:last_read_message_id] = nil
+      initial_reads << message_id
+      read_releases.fetch(message_id).pop
+      read_resumed << message_id
+    end
+    allow_any_instance_of(described_class).to receive(:update!).and_wrap_original do |method, attributes|
+      message_id = attributes[:community_chat_message_id] || attributes.fetch(:community_chat_message).id
+      ready << message_id
+      releases.fetch(message_id).pop
+      method.call(attributes)
+    end
+
+    errors = Queue.new
+    threads = {}
+    start_update = lambda do |message|
+      thread = Thread.new do
+        ActiveRecord::Base.connection_pool.with_connection do
+          Thread.current[:last_read_message_id] = message.id
+          described_class.set!(
+            user_id: @reader.id,
+            community_id: @community.id,
+            community_chat_message_id: message.id
+          )
+        rescue => e
+          errors << e
+        end
+      end
+      threads[message.id] = thread
+    end
+
+    start_update.call(@older_message)
+    start_update.call(@newer_message)
+    expect(2.times.map { Timeout.timeout(10) { initial_reads.pop } }).to contain_exactly(
+      @older_message.id,
+      @newer_message.id
+    )
+
+    read_releases.fetch(@older_message.id) << true
+    expect(Timeout.timeout(10) { read_resumed.pop }).to eq(@older_message.id)
+    expect(Timeout.timeout(10) { ready.pop }).to eq(@older_message.id)
+    read_releases.fetch(@newer_message.id) << true
+    expect(Timeout.timeout(10) { read_resumed.pop }).to eq(@newer_message.id)
+
+    second_update_reached_write = begin
+      Timeout.timeout(1) { ready.pop }
+    rescue Timeout::Error
+      nil
+    end
+
+    if second_update_reached_write
+      expect(second_update_reached_write).to eq(@newer_message.id)
+      releases.fetch(@newer_message.id) << true
+      expect(threads.fetch(@newer_message.id).join(10)).to be_present
+      releases.fetch(@older_message.id) << true
+    else
+      releases.fetch(@older_message.id) << true
+      expect(Timeout.timeout(10) { ready.pop }).to eq(@newer_message.id)
+      releases.fetch(@newer_message.id) << true
+    end
+    threads.each_value { expect(_1.join(10)).to be_present }
+
+    expect(errors.size).to eq(0), -> { errors.size.times.map { errors.pop.full_message }.join("\n") }
+    expect(described_class.find_by!(user: @reader, community: @community).community_chat_message_id).to eq(@newer_message.id)
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+    read_releases&.each_value { _1 << true }
+    releases&.each_value { _1 << true }
+    threads&.each_value do |thread|
+      next if thread.join(1)
+
+      thread.kill
+      thread.join
+    end
+  end
+
+  it "creates one newest marker when the first updates are concurrent" do
+    described_class.delete_all
+    ready = Queue.new
+    release = Queue.new
+    allow(described_class).to receive(:create!).and_wrap_original do |method, *args|
+      ready << true
+      release.pop
+      method.call(*args)
+    end
+
+    errors = Queue.new
+    threads = [@older_message, @newer_message].map do |message|
+      Thread.new do
+        ActiveRecord::Base.connection_pool.with_connection do
+          described_class.set!(
+            user_id: @reader.id,
+            community_id: @community.id,
+            community_chat_message_id: message.id
+          )
+        rescue => e
+          errors << e
+        end
+      end
+    end
+
+    2.times { Timeout.timeout(10) { ready.pop } }
+    2.times { release << true }
+    threads.each { expect(_1.join(10)).to be_present }
+
+    expect(errors.size).to eq(0), -> { errors.size.times.map { errors.pop.full_message }.join("\n") }
+    expect(described_class.where(user: @reader, community: @community).count).to eq(1)
+    expect(described_class.find_by!(user: @reader, community: @community).community_chat_message_id).to eq(@newer_message.id)
+  ensure
+    2.times { release << true } if defined?(release) && release
+    threads&.each do |thread|
+      next if thread.join(1)
+
+      thread.kill
+      thread.join
+    end
+  end
+end

--- a/spec/models/last_read_community_chat_message_spec.rb
+++ b/spec/models/last_read_community_chat_message_spec.rb
@@ -31,6 +31,58 @@ RSpec.describe LastReadCommunityChatMessage do
           )
         end.to change(described_class, :count).by(1)
       end
+
+      it "uses the winning record when validation detects a concurrent insert" do
+        winning_record = create(
+          :last_read_community_chat_message,
+          user:,
+          community:,
+          community_chat_message: message1
+        )
+        losing_record = build(
+          :last_read_community_chat_message,
+          user:,
+          community:,
+          community_chat_message: message2
+        )
+        losing_record.errors.add(:user_id, :taken)
+
+        allow(described_class).to receive(:find_by).with(user_id: user.id, community_id: community.id)
+          .and_return(nil, winning_record)
+        allow(described_class).to receive(:create!).and_raise(ActiveRecord::RecordInvalid.new(losing_record))
+
+        result = described_class.set!(
+          user_id: user.id,
+          community_id: community.id,
+          community_chat_message_id: message2.id
+        )
+
+        expect(result).to eq(winning_record)
+        expect(winning_record.reload.community_chat_message).to eq(message2)
+      end
+
+      it "uses the winning record when the unique index detects a concurrent insert" do
+        winning_record = create(
+          :last_read_community_chat_message,
+          user:,
+          community:,
+          community_chat_message: message1
+        )
+
+        allow(described_class).to receive(:find_by).with(user_id: user.id, community_id: community.id).and_return(nil)
+        allow(described_class).to receive(:create!).and_raise(ActiveRecord::RecordNotUnique)
+        allow(described_class).to receive(:find_by!).with(user_id: user.id, community_id: community.id)
+          .and_return(winning_record)
+
+        result = described_class.set!(
+          user_id: user.id,
+          community_id: community.id,
+          community_chat_message_id: message2.id
+        )
+
+        expect(result).to eq(winning_record)
+        expect(winning_record.reload.community_chat_message).to eq(message2)
+      end
     end
 
     context "when record already exists" do


### PR DESCRIPTION
## What

Makes community last-read markers monotonic under concurrent requests.

- Locks the existing marker before comparing message timestamps
- Handles simultaneous first-row creation through both validation and unique-index races
- Scopes the target message lookup to the supplied community
- Keeps older messages from moving an already newer marker backward

## Why

The previous implementation compared before taking a lock. Two requests could both observe the same old marker, then the newer request could finish first and the older request could overwrite it last. That regressed unread state and made already-read messages appear unread again. Comparing inside `with_lock` fixes the root race while preserving the single marker per user and community.

## Before/after

Before, out-of-order completion could leave the older message as the last-read marker. After, concurrent updates retain the newest message, including when both requests race to create the first marker.

## Screenshots (hosted preview app)

![Community chat remains on the newest seeded marker after exercising newer-then-older `LastReadCommunityChatMessage.set!` calls in the preview console](https://raw.githubusercontent.com/antiwork/gumroad/ba31fbca541bda01bb9d34bfb656cc4a62b32728/qa-media/pr-7046-community-last-read-chat.png)


## QA steps

1. Start two last-read updates for the same user and community, one older and one newer.
2. Force both requests to complete their initial marker read before allowing writes.
3. Release them in the adverse order and confirm the stored marker remains the newer message.
4. Delete the initial marker, race two first writes, and confirm one row remains with the newer message.
5. Confirm normal controller updates still create, advance, and refuse to regress markers.

---

Based on https://github.com/adityawrk/gumroad/pull/13 by @adityawrk.

AI Disclosure: Claude Opus 4.6 (1M context) was used to review the original PR and import the changes.

Premerge review: clean @ 0058df379825bfe7ada5a7b12ce769eeb8a0dba9

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: the ball is back with me (still a draft — I'm building it; CI still running (4 checks) — settle before handing off; no human review requested/received yet — still mine to hand off), so I'm taking the assignee back and labelling `working`. I'll re-assign a human and flip to `awaiting-human` once it's genuinely ready again.
<!-- gumclaw-ownership-sweep -->

