### PR TITLE
Keep membership effective date stable

### DIFF
--- a/app/javascript/components/ProductEdit/ProductTab/TiersEditor.test.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/TiersEditor.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import * as React from "react";
+import { afterAll, afterEach, beforeAll, expect, it, vi } from "vitest";
+
+import { CurrentSellerProvider } from "$app/components/CurrentSeller";
+import { TiersEditor } from "$app/components/ProductEdit/ProductTab/TiersEditor";
+import { type Tier } from "$app/components/ProductEdit/state";
+
+const productEditContext = vi.hoisted(() => ({
+  product: {
+    name: "Membership",
+    native_type: "membership",
+    subscription_duration: null,
+    integrations: {},
+  },
+  currencyType: "usd",
+  setCurrencyType: vi.fn(),
+  uniquePermalink: "membership",
+  updateProduct: vi.fn(),
+  earliestMembershipPriceChangeDate: new Date("2026-08-12T00:00:00.000Z"),
+}));
+
+vi.mock("$app/components/ProductEdit/Layout", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("$app/components/ProductEdit/Layout")>()),
+  useProductUrl: () => "#",
+}));
+vi.mock("$app/components/ProductEdit/state", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("$app/components/ProductEdit/state")>()),
+  useProductEditContext: () => productEditContext,
+}));
+vi.mock("$app/components/RichTextEditor", () => ({ RichTextEditor: () => null }));
+vi.mock("$app/components/SortableList", () => ({
+  Drawer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ReorderingHandle: () => null,
+  SortableList: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+beforeAll(() => {
+  vi.stubEnv("TZ", "America/Los_Angeles");
+});
+
+afterAll(() => {
+  vi.unstubAllEnvs();
+});
+
+afterEach(cleanup);
+
+const tier: Tier = {
+  id: "tier-id",
+  name: "Membership",
+  description: "",
+  max_purchase_count: null,
+  integrations: { discord: false, circle: false, google_calendar: false },
+  rich_content: [],
+  customizable_price: false,
+  apply_price_changes_to_existing_memberships: false,
+  subscription_price_change_effective_date: "2026-08-12T00:00:00.000Z",
+  subscription_price_change_message: null,
+  recurrence_price_values: {
+    monthly: { enabled: true, price_cents: 1_000, suggested_price_cents: null },
+    quarterly: { enabled: false },
+    biannually: { enabled: false },
+    yearly: { enabled: false },
+    every_two_years: { enabled: false },
+  },
+};
+
+it("keeps the membership price-change date stable across rerenders", () => {
+  const onChange = vi.fn<(tiers: Tier[]) => void>();
+  const tree = () => (
+    <CurrentSellerProvider value={null}>
+      <TiersEditor tiers={[tier]} onChange={onChange} />
+    </CurrentSellerProvider>
+  );
+  const view = render(tree());
+
+  for (let rerender = 0; rerender < 5; rerender++) view.rerender(tree());
+  fireEvent.click(view.getByLabelText("Apply price changes to existing customers"));
+
+  expect(onChange.mock.lastCall?.[0]?.[0]?.subscription_price_change_effective_date).toMatch(/^2026-08-12/u);
+});

--- a/app/javascript/components/ProductEdit/ProductTab/TiersEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/TiersEditor.tsx
@@ -399,12 +399,13 @@ const PriceChangeSettings = ({ tier, updateTier }: { tier: Tier; updateTier: (up
 
   const { product, uniquePermalink, currencyType, earliestMembershipPriceChangeDate } = useProductEditContext();
 
-  const [effectiveDate, setEffectiveDate] = React.useState<{ value: Date; error?: boolean }>({
-    value: tier.subscription_price_change_effective_date
-      ? new Date(tier.subscription_price_change_effective_date)
-      : earliestMembershipPriceChangeDate,
-  });
-  effectiveDate.value = getDateWithUTCOffset(effectiveDate.value);
+  const [effectiveDate, setEffectiveDate] = React.useState<{ value: Date; error?: boolean }>(() => ({
+    value: getDateWithUTCOffset(
+      tier.subscription_price_change_effective_date
+        ? new Date(tier.subscription_price_change_effective_date)
+        : earliestMembershipPriceChangeDate,
+    ),
+  }));
   React.useEffect(
     () => updateTier({ subscription_price_change_effective_date: effectiveDate.value.toISOString() }),
     [effectiveDate],


### PR DESCRIPTION
## What

Initializes the membership price-change effective date once instead of mutating React state during every render.

- Applies the UTC display offset in a lazy `useState` initializer
- Removes render-time mutation of the stored `Date`
- Keeps the selected calendar date stable across unrelated rerenders
- Adds a regression that exercises five rerenders and the real toggle update flow

## Why

The component previously reassigned `effectiveDate.value` during render. In a negative UTC offset such as America/Los_Angeles, every rerender applied the offset again. An August 12 effective date could drift to August 14 after five rerenders and then be saved incorrectly. One-time initialization fixes the state lifecycle error without changing the persisted format or the calendar API.

## Before/after

Before, repeated rerenders could advance the effective calendar date. After, the date remains August 12 through five rerenders and the subsequent membership update.

## Screenshots (hosted preview app)

![Desktop: effective date remains 08/12/2026 after multiple harmless rerenders](https://raw.githubusercontent.com/antiwork/gumroad/271d99c93faacd2b5493340879247b6a6665f72e/qa-media/pr-7047-membership-effective-date-desktop.png)

![Mobile 375px: effective date field remains 08/12/2026](https://raw.githubusercontent.com/antiwork/gumroad/271d99c93faacd2b5493340879247b6a6665f72e/qa-media/pr-7047-membership-effective-date-mobile.png)


## QA steps

1. In America/Los_Angeles, open a membership tier with an August 12 effective date.
2. Cause several harmless editor rerenders, such as toggling neighboring controls.
3. Toggle "Apply price changes to existing customers."
4. Confirm the emitted and saved effective date remains August 12.
5. Repeat around a daylight-saving boundary and confirm no cumulative drift occurs.

---

Based on https://github.com/adityawrk/gumroad/pull/14 by @adityawrk.

AI Disclosure: Claude Opus 4.6 (1M context) was used to review the original PR and import the changes.

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: the ball is back with me (still a draft — I'm building it; CI still running (4 checks) — settle before handing off; no human review requested/received yet — still mine to hand off), so I'm taking the assignee back and labelling `working`. I'll re-assign a human and flip to `awaiting-human` once it's genuinely ready again.
<!-- gumclaw-ownership-sweep -->

Premerge review: clean @ 3c30625296424a5dfbc68409d7eaafc512dcff09 (codex/gpt-5.6-sol, 0 findings, patch-correct 0.99)

