### PR TITLE
Block subscription restart-at-checkout for banned/purchase-disabled products

### DIFF
--- a/app/modules/subscription/restartable.rb
+++ b/app/modules/subscription/restartable.rb
@@ -2,7 +2,7 @@
 
 module Subscription::Restartable
   def restartable_for_product_and_buyer(product:, buyer:)
-    return nil unless product.is_recurring_billing
+    return nil unless product.is_recurring_billing && product.alive?
 
     where(link_id: product.id)
       .where(ended_at: nil)
@@ -15,7 +15,7 @@ module Subscription::Restartable
   end
 
   def restartable_for_product_and_email(product:, email:)
-    return nil unless product.is_recurring_billing
+    return nil unless product.is_recurring_billing && product.alive?
 
     where(link_id: product.id)
       .where(ended_at: nil)

--- a/spec/modules/subscription/restartable_spec.rb
+++ b/spec/modules/subscription/restartable_spec.rb
@@ -136,6 +136,44 @@ describe Subscription::Restartable, :sidekiq_inline do
       end
     end
 
+    context "when the product has been banned" do
+      let!(:subscription) do
+        create_subscription_with_purchase(
+          product: product,
+          purchaser: buyer,
+          cancelled_at: 1.day.ago,
+          cancelled_by_buyer: true,
+          deactivated_at: 1.day.ago
+        )
+      end
+
+      before { product.update!(banned_at: 1.day.ago) }
+
+      it "returns nil (a banned product cannot be restarted)" do
+        result = Subscription.restartable_for_product_and_buyer(product: product, buyer: buyer)
+        expect(result).to be_nil
+      end
+    end
+
+    context "when the product has purchases disabled" do
+      let!(:subscription) do
+        create_subscription_with_purchase(
+          product: product,
+          purchaser: buyer,
+          cancelled_at: 1.day.ago,
+          cancelled_by_buyer: true,
+          deactivated_at: 1.day.ago
+        )
+      end
+
+      before { product.update!(purchase_disabled_at: 1.day.ago) }
+
+      it "returns nil (purchases are disabled)" do
+        result = Subscription.restartable_for_product_and_buyer(product: product, buyer: buyer)
+        expect(result).to be_nil
+      end
+    end
+
     context "with multiple subscriptions" do
       let!(:older_subscription) do
         sub = create_subscription_with_purchase(
@@ -204,6 +242,25 @@ describe Subscription::Restartable, :sidekiq_inline do
       end
 
       it "returns nil (test subscriptions are excluded)" do
+        result = Subscription.restartable_for_product_and_email(product: product, email: buyer.email)
+        expect(result).to be_nil
+      end
+    end
+
+    context "when the product has been banned (e.g. seller suspension bans every link)" do
+      let!(:subscription) do
+        create_subscription_with_purchase(
+          product: product,
+          purchaser: buyer,
+          cancelled_at: 1.day.ago,
+          cancelled_by_buyer: true,
+          deactivated_at: 1.day.ago
+        )
+      end
+
+      before { product.update!(banned_at: 1.day.ago) }
+
+      it "returns nil (a banned product cannot be restarted)" do
         result = Subscription.restartable_for_product_and_email(product: product, email: buyer.email)
         expect(result).to be_nil
       end


### PR DESCRIPTION
## Status
- [x] Scope — engineering fix only; refund decision is a separate money call left with a human (see Scope note below)
- [x] Design — reuse `product.alive?` (covers banned + purchase-disabled + deleted) instead of adding new seller-state checks to the restart path
- [x] Build — guard added to both `restartable_for_product_and_buyer` and `restartable_for_product_and_email`
- [x] QA — spec run + mutation proof below
- [x] Shipped — draft, awaiting CI + human review before merge (money-adjacent surface)
- [ ] Market / Sell — n/a, internal fix

## What
`Subscription.restartable_for_product_and_buyer` / `_and_email` only checked `product.is_recurring_billing`. A returning buyer with a deactivated subscription could hit the restart-at-checkout path directly (old bookmarked checkout link, subscription-management email) and get charged for a product that's banned or whose seller is TOS-suspended — the normal storefront 404 for a banned product never runs on this path. This is what let a year-suspended seller's product bill a buyer on 2026-08-04 (antiwork/gumroad-private#1845).

## Why
Suspending a seller (`disable_links_and_tell_chat`) sets `banned_at` on every one of their links, so `product.alive?` (`purchase_disabled_at.nil? && banned_at.nil? && deleted_at.nil?`) is the single check that covers both the banned-product case and the suspended-seller case without duplicating seller-state logic in the restart path.

## Before / After
- Before: `restartable_for_product_and_buyer(product: banned_product, buyer:)` returns the deactivated subscription, and checkout restarts and charges it.
- After: returns `nil` for a banned/purchase-disabled product, so `Purchase::CreateService` falls through to a normal "no such purchasable subscription" failure instead of restarting.

## Test Results (captured)
Ran locally via a borrowed lane env (`lane_alloc.sh env 0`; `acquire` refused at load 79):
```
$ bundle exec rspec spec/modules/subscription/restartable_spec.rb
25 examples, 0 failures (24.22s)
```
Mutation proof — reverted the guard to `product.is_recurring_billing` only and re-ran the 3 new examples:
```
3 examples, 3 failures
```
All three (banned-product buyer-scope, purchase-disabled buyer-scope, banned-product email-scope) went red without the fix and green with it. Fix restored and full 25/25 confirmed before push.

## QA steps
- `bundle exec rspec spec/modules/subscription/restartable_spec.rb` (25 examples, 0 failures)
- Mutation check: temporarily reverted `restartable.rb` to the pre-fix condition, confirmed the 3 new examples fail, restored the fix, confirmed full suite green again.
- No rendered surface — this is a backend guard on an internal query method with no UI; confirmed by reading the call site (`Purchase::CreateService#handle_restartable_subscription`) and its error paths, no screenshot gate applies.

## Scope note
This PR covers item 1 of gp#1845 (the engineering fix). Item 2, refunding the buyer charged on the banned membership, is a money decision left with a human per gp#1845 — not touched by this PR.

---

AI disclosure: this PR was authored autonomously by Hermes Agent (model: claude-sonnet-5) in response to antiwork/gumroad-private#1845.

Premerge review: clean @ 08bb990af497e50716a403867ead9bd16533ce61 (codex/gpt-5.6-sol, 0 findings, patch-correct 0.99)

fable-5 review: clean at 08bb990af497e50716a403867ead9bd16533ce61 — independent adversarial pre-merge review (supersedes the earlier 'Premerge review: exempt' note, since removed). Verified: (1) `Link#alive?` = `purchase_disabled_at.nil? && banned_at.nil? && deleted_at.nil?` (link.rb:456) — banned, purchase-disabled, and deleted all covered; (2) `restartable_for_product_and_buyer/_email` have exactly one production caller (`Purchase::CreateService#handle_restartable_subscription`, checkout restart) — subscription-manage/magic-link/admin paths use `Subscription#alive_or_restartable?` and are untouched, so no legitimate restart path is broken; (3) both methods guarded; nil-safety unchanged (product was already dereferenced pre-fix); (4) mutation proof independently re-executed in an isolated lane (lane0_test): guard reverted → 25 examples 4 failures incl. all 3 new examples, guard restored → 25/25 green; (5) Minitest twin (`test/models/subscription_test.rb`) only pins `#alive_or_restartable?`, no old-behavior pin on `restartable_for_*`. Minor P3, non-blocking: purchase-disabled case pinned on buyer-scope only — acceptable, the guard is one shared expression.
