### PR TITLE
Move Merchant Center feed under the sitemap S3 prefix

### DIFF
--- a/app/services/merchant_center_feed_service.rb
+++ b/app/services/merchant_center_feed_service.rb
@@ -5,7 +5,7 @@
 # sitemaps in public storage. Eligibility intentionally mirrors Discover: a product that
 # is not recommendable there should not be advertised in Shopping either.
 class MerchantCenterFeedService
-  FEED_KEY = "merchant-center/feed.xml"
+  FEED_KEY = "sitemap/merchant-center/feed.xml"
   FEED_TITLE = "Gumroad products"
   # Google rejects descriptions over 5,000 characters.
   MAX_DESCRIPTION_LENGTH = 5_000

--- a/spec/services/merchant_center_feed_service_spec.rb
+++ b/spec/services/merchant_center_feed_service_spec.rb
@@ -132,6 +132,10 @@ describe MerchantCenterFeedService do
       expect(g_field(items(service.generate).first, "price")).to eq "500 JPY"
     end
 
+    it "keeps the feed under the sitemap uploader's allowed S3 prefix" do
+      expect(described_class::FEED_KEY).to start_with("sitemap/")
+    end
+
     it "writes to S3 with the sitemap uploader's ACL and content type when uploading" do
       create_eligible_product
       client = instance_double(Aws::S3::Client)


### PR DESCRIPTION
Ref antiwork/gumroad-private#1836

## Scope
The Merchant Center feed URL was 403 in production. Root cause: `MerchantCenterFeedService::FEED_KEY` was `merchant-center/feed.xml`, but the S3 uploader identity used for public storage is scoped to a single prefix.

Verified against live IAM (`_production_sitemap_upload_user`, inline policy `S3@allow-gumroad-public-storage-sitemap-upload`):

```
"Action": ["s3:Put*", "s3:List*", "s3:DeleteObject"],
"Resource": ["arn:aws:s3:::gumroad-public-storage/sitemap/*"]
```

Confirmed in a production console run — the upload raised:

```
User: arn:aws:iam::526234316351:user/_production_sitemap_upload_user is not authorized
to perform: s3:PutObject on resource: "arn:aws:s3:::gumroad-public-storage/merchant-center/feed.xml"
```

So the feed object was never written and the URL 403'd, even though the workers ran.

## Design
Move the key under the allowed prefix rather than widening IAM:

- `merchant-center/feed.xml` → `sitemap/merchant-center/feed.xml`

Keeping the fix in code avoids an infra change for a path we control, and keeps the uploader's blast radius as narrow as it is today. `feed_url` derives from `FEED_KEY`, so the public URL follows automatically. Nothing consumes the old URL yet (the feed has never existed in production), so there is no redirect or migration to do.

## Build
- `FEED_KEY` moved under `sitemap/`.
- Added a regression test asserting `FEED_KEY` starts with `sitemap/`, so the prefix contract cannot silently drift back out of the uploader's grant. That contract is invisible from this file otherwise — it lives in IAM.

## QA
`bin/rspec spec/services/merchant_center_feed_service_spec.rb` — 18 examples, 0 failures.

Checks exercised:
- new prefix assertion
- existing S3 upload path (bucket/key/ACL/content type)
- non-production public-path write
- feed field, escaping, truncation, and eligibility coverage

Production verification of the live feed URL is gated on deploy; I'll confirm the object is written and the URL returns 200 after this ships, then register the feed.



Premerge review: clean @ b40ec1a258a1a4fb6ba4e3643545ac6865a8969c
