### PR TITLE
Fix reputation cache signature to match seller_reputation_summary's eligibility (follow-up to #7041)

### DIFF
--- a/app/services/pages/profile_data.rb
+++ b/app/services/pages/profile_data.rb
@@ -76,8 +76,15 @@ class Pages::ProfileData
   # second would produce an identical maximum(:updated_at) and serve a stale
   # cached rollup. Summing the actual counters changes whenever the rollup's
   # output could change, regardless of how many writes land in one second.
+  #
+  # Scoped to match seller_reputation_summary's eligibility exactly (Link.alive.not_draft,
+  # reviews_count != 0, display_product_reviews flag) — otherwise a review-hidden or
+  # zero-review product's writes churn this cache key without changing seller_rating.
   def self.reputation_summary_cache_signature(seller)
-    ProductReviewStat.joins(:link).where(links: { user_id: seller.id })
+    ProductReviewStat.joins(:link).merge(Link.alive.not_draft)
+      .where(links: { user_id: seller.id })
+      .where.not(reviews_count: 0)
+      .where(Arel.sql("links.flags & #{Link.flag_mapping["flags"][:display_product_reviews]} != 0"))
       .pick(Arel.sql("SUM(reviews_count), SUM(ratings_of_one_count), SUM(ratings_of_two_count), " \
                       "SUM(ratings_of_three_count), SUM(ratings_of_four_count), SUM(ratings_of_five_count), COUNT(*)"))
       &.join(",")

--- a/spec/services/pages/profile_data_spec.rb
+++ b/spec/services/pages/profile_data_spec.rb
@@ -74,6 +74,30 @@ describe Pages::ProfileData do
 
         expect(Pages::ProfileData.cache_key(seller.reload, seller_profile)).not_to eq(key_before)
       end
+
+      it "does not change the cache key when a review-hidden product's stat mutates" do
+        Feature.activate_user(:seller_reputation_summary, seller)
+        product = create(:product, user: seller, display_product_reviews: false)
+        stat = ProductReviewStat.create!(link: product, reviews_count: 1, average_rating: 5, ratings_of_five_count: 1)
+        seller_profile = SellerProfile.find_by(seller_id: seller.id)
+        key_before = Pages::ProfileData.cache_key(seller.reload, seller_profile)
+
+        stat.update!(reviews_count: 2, ratings_of_five_count: 2)
+
+        expect(Pages::ProfileData.cache_key(seller.reload, seller_profile)).to eq(key_before)
+      end
+
+      it "does not change the cache key when a zero-review stat's non-count fields mutate" do
+        Feature.activate_user(:seller_reputation_summary, seller)
+        product = create(:product, user: seller)
+        stat = ProductReviewStat.create!(link: product, reviews_count: 0)
+        seller_profile = SellerProfile.find_by(seller_id: seller.id)
+        key_before = Pages::ProfileData.cache_key(seller.reload, seller_profile)
+
+        stat.update!(average_rating: 3.2)
+
+        expect(Pages::ProfileData.cache_key(seller.reload, seller_profile)).to eq(key_before)
+      end
     end
 
     it "does not expose draft products in the public profile data payload" do


### PR DESCRIPTION
## What

Follow-up to #7041 (merged): a Greptile P2 posted after that PR's own review found the fix incomplete. `Pages::ProfileData.reputation_summary_cache_signature` summed every `ProductReviewStat` joined to the seller's links, but `seller_reputation_summary` (the method whose output the signature is supposed to track) excludes non-alive/draft links, zero-review stats, and review-hidden (`display_product_reviews: false`) links. A write to one of those excluded stats changed the profile-data cache key with no change to the emitted `seller_rating` — unnecessary cache churn, not a correctness bug on the displayed rating.

Scopes `reputation_summary_cache_signature` to the same eligibility rules `seller_reputation_summary` applies: `Link.alive.not_draft`, `reviews_count != 0`, and the `display_product_reviews` flag bit.

## Why

Confirmed live against `origin/main`: the vulnerable aggregation was unchanged since #7041 merged (`git show origin/main:app/services/pages/profile_data.rb`).

## Before/After

- Before: a review-hidden product's stat mutates → cache key changes → cached payload rebuilds even though `seller_rating` is identical.
- After: same mutation → cache key unchanged, no unnecessary rebuild. A qualifying product's stat mutation still changes the key (existing coverage in #7041 unaffected).

## Test Results

- `bundle exec rspec spec/services/pages/profile_data_spec.rb -e "does not change the cache key"` — 2 examples, 0 failures (new specs: review-hidden product's stat mutation, and a zero-review stat's non-count field mutation).
- Mutation-proved: reverted this fix in place (pre-fix code from #7041), re-ran the two new specs — the review-hidden spec failed as expected (`Expected ...2,0,0,0,0,2,1 to eq ...1,0,0,0,0,1,1`), confirming it has teeth. Restored the fix afterward and re-ran green.
- Full-file run (`spec/services/pages/profile_data_spec.rb`): 43 examples, 1 pre-existing failure (`seller_rating changes the cache key when two review-stat mutations land in the same second`) — reproduced the same failure on an unmodified `origin/main` worktree, and a targeted single-example run of the same spec passed cleanly in both worktrees. Load-dependent/environmental, unrelated to this diff (also unrelated to #7041's own fix, which that spec covers).

## QA steps

Backend-only, no rendered surface — confirmed via the specs and mutation-proof above.

## Status
- [x] Scope — one query, no new surface
- [x] Design — match the two eligibility relations
- [x] Build — done
- [x] QA — spec run + mutation-proof above
- [ ] Shipped
- [ ] Market
- [ ] Sell

---

AI disclosure: This PR was authored autonomously by an AI agent (claude-sonnet-5).
