### PR TITLE
Add QA walkthrough evidence for #7043

### DIFF
--- a/qa-media/pr-7043-dispute-evidence-walkthrough.txt
+++ b/qa-media/pr-7043-dispute-evidence-walkthrough.txt
@@ -1,0 +1,27 @@
+Walkthrough: antiwork/gumroad#7043 — a dispute's receipt-activity evidence must never claim
+the receipt was opened before it was delivered.
+Produced by running DisputeEvidence::GenerateAccessActivityLogsService directly on the hosted
+preview app (fix-receipt-evidence-open-before.apps.staging.gumroad.org), via the staging Rails
+console. Purchase/email-info rows created and rolled back in the same session.
+
+==============================================================================
+HEAD: eaf2a880eda3845bf60566471ff34faef1647fd3
+==============================================================================
+
+--- Two receipt sends; earliest OPEN and earliest DELIVERY come from DIFFERENT sends ---
+  send #1: delivered 2024-05-07 03:00 UTC, opened 2024-05-07 04:00 UTC
+  send #2 (5 days later): delivered +5d 02:00 UTC, but its OWN open is 2024-05-07 01:00 UTC
+                          (earlier than send #1's delivery, and earlier than send #1's sent_at)
+
+--- Evidence text produced ---
+The receipt email was sent at 2024-05-07 00:00:00 UTC. The receipt was sent again at
+2024-05-12 00:00:00 UTC. A receipt was delivered at 2024-05-07 03:00:00 UTC. A receipt was
+opened at 2024-05-07 04:00:00 UTC.
+
+--- Correctness check ---
+  Claims receipt opened BEFORE it was delivered (01:00 UTC)? false  (must be false)
+  Reports the later, chronologically-valid open (04:00 UTC)? true   (must be true — this is the
+    P1 Greptile flagged on this PR's own diff: the first version of the fix silently dropped the
+    later valid open along with the unattributable one)
+
+(transaction rolled back — no rows persisted on the preview)


### PR DESCRIPTION
## What
Adds the QA evidence media (screenshots/walkthrough) that was captured for PR #7043 but pushed to that branch AFTER the PR had already merged — so it never shipped and was never part of any reviewed diff.

## Why
The evidence files sat on a green, already-merged branch with no PR wrapping them, invisible to every PR/issue-based watcher. This PR carries them into the repo through the normal path.

## Diff
Docs/evidence-only: adds file(s) under `qa-media/`, no application code changed.

## Test Results
N/A — no code changed, nothing to run.

Premerge review: exempt (docs/evidence-only, no code changed)

## AI disclosure
Autonomously cherry-picked and opened by Gumclaw (Hermes agent) per the green-branch-no-pr recovery job.