### PR TITLE
Never auto-deactivate unowned taxonomy attribute facets in production

### DIFF
--- a/app/services/onetime/seed_taxonomy_attributes.rb
+++ b/app/services/onetime/seed_taxonomy_attributes.rb
@@ -4,18 +4,24 @@
 #
 # Existing rows are updated in place rather than recreated: `TaxonomyAttribute#name` is the ES
 # filter-token prefix, so destroying and re-inserting a row would orphan every product value
-# already indexed under it. Rows present in the DB but absent from the registry are deactivated,
-# not deleted, for the same reason.
+# already indexed under it.
+#
+# Rows present in the DB but absent from the registry are never auto-deactivated: a taxonomy can
+# carry facets this registry doesn't know about (created before it existed, or by a separate
+# rollout), and there's no ownership marker to tell those apart from ones this service created.
+# `deactivate: true` is an explicit, separate opt-in — pass it only once you've confirmed the
+# `stale_candidates` this call reports are genuinely safe to retire.
 module Onetime
   class SeedTaxonomyAttributes
-    def self.process(dry_run: true)
-      new.process(dry_run:)
+    def self.process(dry_run: true, deactivate: false)
+      new.process(dry_run:, deactivate:)
     end
 
-    def process(dry_run: true)
+    def process(dry_run: true, deactivate: false)
       created = 0
       updated = 0
       deactivated = 0
+      stale_candidates = []
 
       TaxonomyAttributeDefinitions.each_taxonomy_with_definitions do |taxonomy, definitions|
         definitions.each do |definition|
@@ -38,14 +44,19 @@ module Onetime
 
         stale = TaxonomyAttribute.where(taxonomy:, active: true).where.not(name: definitions.map { _1[:name] })
         stale.each do |attribute|
+          stale_candidates << "#{taxonomy.slug}/#{attribute.name}"
+          next unless deactivate
+
           deactivated += 1
           puts "DEACTIVATE #{taxonomy.slug}/#{attribute.name}"
           attribute.update!(active: false) unless dry_run
         end
       end
 
+      puts "STALE (not in registry, left active — pass deactivate: true to retire): #{stale_candidates.join(', ')}" if stale_candidates.any? && !deactivate
+
       puts "#{dry_run ? 'DRY RUN' : 'APPLIED'} created=#{created} updated=#{updated} deactivated=#{deactivated}"
-      { created:, updated:, deactivated: }
+      { created:, updated:, deactivated:, stale_candidates: }
     end
   end
 end

--- a/db/seeds/010_development_staging_test/taxonomy_create.rb
+++ b/db/seeds/010_development_staging_test/taxonomy_create.rb
@@ -401,5 +401,6 @@ Taxonomy.find_or_create_by!(slug: "tattoos", parent: textures)
 
 Taxonomy.find_or_create_by!(slug: "other")
 
-# Same registry the production backfill applies, so the two cannot drift.
-Onetime::SeedTaxonomyAttributes.process(dry_run: false)
+# Same registry the production backfill applies, so the two cannot drift. Deactivation is safe
+# here (unlike production) because this seed owns the whole dev/staging/test taxonomy tree.
+Onetime::SeedTaxonomyAttributes.process(dry_run: false, deactivate: true)

--- a/spec/services/onetime/seed_taxonomy_attributes_spec.rb
+++ b/spec/services/onetime/seed_taxonomy_attributes_spec.rb
@@ -44,11 +44,22 @@ describe Onetime::SeedTaxonomyAttributes do
     expect(format.active).to eq(true)
   end
 
-  it "deactivates a row the registry no longer defines instead of deleting it" do
+  it "leaves a row the registry no longer defines active by default" do
     described_class.process(dry_run: false)
     orphan = TaxonomyAttribute.create!(taxonomy: fonts, name: "retired_facet", label: "Retired", value_type: "enum", values: ["A"], position: 9, active: true)
 
+    result = described_class.process(dry_run: false)
+
+    expect(orphan.reload.active).to eq(true)
+    expect(result[:deactivated]).to eq(0)
+    expect(result[:stale_candidates]).to include("fonts/retired_facet")
+  end
+
+  it "deactivates a row the registry no longer defines instead of deleting it, when deactivate: true is passed explicitly" do
     described_class.process(dry_run: false)
+    orphan = TaxonomyAttribute.create!(taxonomy: fonts, name: "retired_facet", label: "Retired", value_type: "enum", values: ["A"], position: 9, active: true)
+
+    described_class.process(dry_run: false, deactivate: true)
 
     expect(orphan.reload.active).to eq(false)
     expect(TaxonomyAttribute.exists?(orphan.id)).to eq(true)


### PR DESCRIPTION
## Stages

- [x] Scope
- [x] Design
- [x] Build
- [ ] Ship
- [ ] Market — n/a, backend-only change
- [ ] Sell — n/a, backend-only change

## What

Follow-up to #6893 (merged): `Onetime::SeedTaxonomyAttributes` no longer auto-deactivates every active `TaxonomyAttribute` absent from the registry. Deactivation is now an explicit `deactivate: true` opt-in; a bare run reports `stale_candidates` instead of touching them.

## Why

Greptile's post-merge P1 on #6893 (comment thread on `app/services/onetime/seed_taxonomy_attributes.rb`): the reconciliation treats every active attribute on a taxonomy that isn't in the four-item registry as obsolete, with no ownership marker to distinguish a pre-registry or separately-rolled-out facet from one this service actually manages. Verified against current `main` — the finding still holds there; nothing since #6893 addressed it. Running the production backfill as originally written would deactivate any such facet, removing it from `Taxonomy#taxonomy_attributes` and the filtering experience.

Premise: Discover's other taxonomies (Music, 3D, VRChat, Software) currently have zero rows managed by this registry, so in practice this hasn't fired yet — but the production backfill in #6893's own body is the call the finding is about, and it would have run against whatever `design/fonts` looks like at that time.

The report's second P1 ("production backfill is never invoked automatically") is not a code gap: `Onetime::*` backfills in this repo are all manual runbook invocations (see e.g. `Onetime::BackfillTaxonomyAttributeClassification`, `Onetime::RestoreStrandedPaypalReversalBalances`) — there's no cron/initializer wiring for any of them. #6893's own body already names the production apply as a human-run step (`Onetime::SeedTaxonomyAttributes.process(dry_run: false)`, run once #6858 deploys). No change made for that half.

## Before-After

| | Registry run finds an active, non-registry attribute on a taxonomy |
|---|---|
| Before | Deactivated unconditionally |
| After | Left active by default; named in `stale_candidates`; deactivated only when the caller passes `deactivate: true` |

## Test Results

- `spec/services/onetime/seed_taxonomy_attributes_spec.rb` — 6 examples (was 5): replaced the old unconditional-deactivate example with two — default run leaves the orphan active and reports it in `stale_candidates`, `deactivate: true` deactivates it as before.
- `spec/models/taxonomy_attribute_definitions_spec.rb` — 6 examples, unchanged, still green.
- Full run: 13 examples, 0 failures (`DISABLE_SPRING=1 bundle exec rspec spec/services/onetime/seed_taxonomy_attributes_spec.rb spec/models/taxonomy_attribute_definitions_spec.rb`).
- Mutation-checked: reverting the `next unless deactivate` guard to unconditional deactivation reddens the new "leaves active by default" example (6 examples, 1 failure); restored and confirmed `git status --short` clean afterward.
- `rubocop` on all three changed files: no offenses. `ruby -c` on all three.

## QA steps

1. `Onetime::SeedTaxonomyAttributes.process(dry_run: false)` against a taxonomy with a non-registry active attribute → attribute stays active, `stale_candidates` names it, `deactivated: 0` in the return value.
2. Same call with `deactivate: true` → the named attribute is deactivated, matching the original (now opt-in) behavior.
3. `bin/rails db:seed` on a fresh dev DB — the dev/staging/test seed passes `deactivate: true` explicitly (it owns the whole taxonomy tree), so local dev behavior is unchanged.

No rendered surface — this is a backend safety change to a not-yet-invoked production backfill; confirmed there is no UI to screenshot.

---

🤖 Written by [Hermes Agent](https://github.com/NousResearch/hermes-agent) (`claude-sonnet-5`) as gumclaw.

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: the ball is back with me (still a draft — I'm building it), so I'm taking the assignee back and labelling `working`. I'll re-assign a human and flip to `awaiting-human` once it's genuinely ready again.
<!-- gumclaw-ownership-sweep -->
