### PR TITLE
Fix contradictory timestamp claim in dispute-evidence QA walkthrough

### DIFF
--- a/qa-media/pr-7043-dispute-evidence-walkthrough.txt
+++ b/qa-media/pr-7043-dispute-evidence-walkthrough.txt
@@ -11,7 +11,8 @@ HEAD: eaf2a880eda3845bf60566471ff34faef1647fd3
 --- Two receipt sends; earliest OPEN and earliest DELIVERY come from DIFFERENT sends ---
   send #1: delivered 2024-05-07 03:00 UTC, opened 2024-05-07 04:00 UTC
   send #2 (5 days later): delivered +5d 02:00 UTC, but its OWN open is 2024-05-07 01:00 UTC
-                          (earlier than send #1's delivery, and earlier than send #1's sent_at)
+                          (earlier than send #1's delivery at 03:00 UTC, and unattributable to
+                          send #2 at all — its send wasn't even sent_at yet)
 
 --- Evidence text produced ---
 The receipt email was sent at 2024-05-07 00:00:00 UTC. The receipt was sent again at


### PR DESCRIPTION
## What / Why

Greptile flagged a real contradiction in `qa-media/pr-7043-dispute-evidence-walkthrough.txt` (PR #7056, line 14): it claimed the 01:00 UTC open was "earlier than send #1's sent_at" (00:00 UTC), which is backwards — 01:00 is after 00:00. The evidence itself (excluding the invalid open, keeping the valid one) was correct; only the prose explaining why the 01:00 open is unattributable was wrong.

## Before-After

Before: "(earlier than send #1's delivery, and earlier than send #1's sent_at)" — false, since 01:00 > 00:00.
After: "(earlier than send #1's delivery at 03:00 UTC, and unattributable to send #2 at all — its send wasn't even sent_at yet)" — states the real reason the open is invalid evidence.

## Test Results

Docs-only change (comment/prose fix in a `.txt` evidence file, no code touched).

## QA steps

Read the corrected file; the timestamp ordering claim now matches the numbers in the walkthrough (01:00 UTC < send #1's 03:00 UTC delivery; send #2's own sent_at is 5 days later, so the open predates it entirely).

## Stages

- [x] Scope
- [x] Design
- [x] Build
- [x] Ship
- [ ] Market
- [ ] Sell

Premerge review: exempt (docs-only text-file wording fix, no code touched)

---
AI disclosure: This PR was authored autonomously by an AI agent (claude-sonnet-5) responding to a Greptile review finding on merged PR #7056.
