### PR TITLE
Retry a stale-block sweep page instead of skipping it on failure

### DIFF
--- a/app/sidekiq/alert_on_stale_blocks_holding_established_buyers_job.rb
+++ b/app/sidekiq/alert_on_stale_blocks_holding_established_buyers_job.rb
@@ -65,9 +65,6 @@ class AlertOnStaleBlocksHoldingEstablishedBuyersJob
 
       truncated = candidates.size > MAX_CANDIDATES_SCANNED
       candidates = candidates.first(MAX_CANDIDATES_SCANNED)
-      # Advance past what this run judged. Saved before the clearing work so a later failure cannot
-      # pin the cursor and re-report the same page forever.
-      save_cursor(candidates.last.id) if candidates.any?
 
       cleared = []
       held = []
@@ -107,6 +104,12 @@ class AlertOnStaleBlocksHoldingEstablishedBuyersJob
           end
         end
       end
+
+      # Advance past what this run judged. Only reached if every batch's history-count and dispute
+      # queries completed without raising — an exception mid-page propagates before this line, so
+      # Sidekiq's retry re-reads the same unmoved cursor and re-scans the failed page instead of
+      # skipping past it.
+      save_cursor(candidates.last.id) if candidates.any?
 
       { cleared: report_order(cleared), held: report_order(held), truncated: }
     end

--- a/spec/sidekiq/alert_on_stale_blocks_holding_established_buyers_job_spec.rb
+++ b/spec/sidekiq/alert_on_stale_blocks_holding_established_buyers_job_spec.rb
@@ -298,6 +298,24 @@ describe AlertOnStaleBlocksHoldingEstablishedBuyersJob do
       # Nothing past the cursor, so the sweep restarts rather than reporting nothing forever.
       expect(message).to include(email)
     end
+
+    # gp#1746 P1: the cursor used to be saved right after fetching the page, before the history
+    # queries ran, so a raise on the FIRST run would still commit an advanced cursor and the retry
+    # (or next scheduled run) would resume past the failed page rather than re-scanning it.
+    it "does not advance the cursor when a history query raises mid-page" do
+      settled_purchases(established_count)
+      block = block_email
+
+      allow(Purchase).to receive(:successful).and_raise("boom")
+
+      expect { described_class.new.perform }.to raise_error("boom")
+      expect($redis.get(RedisKey.stale_block_sweep_cursor)).to be_nil
+
+      # Retry re-scans the same block instead of skipping it, now that the query works again.
+      allow(Purchase).to receive(:successful).and_call_original
+      expect(message).to include(email)
+      expect($redis.get(RedisKey.stale_block_sweep_cursor).to_i).to eq(block.id)
+    end
   end
 
   # A truncated scan that found nothing must still report: otherwise the bound, not the platform,


### PR DESCRIPTION
- [x] Scope
- [x] Design
- [x] Build
- [x] Ship
- [ ] Market
- [ ] Sell

## Scope

Follow-up to #6895 (merged). Fixes the Greptile P1 that landed on that PR's diff after it merged — the review still has an unanswered thread on it.

## Design

Greptile flagged (review comment [3701264785](https://github.com/antiwork/gumroad/pull/6895#discussion_r3701264785), confirmed live on `origin/main`): `save_cursor` ran right after fetching a candidate page, before the history-count and dispute queries executed. If either query raised, the cursor was already advanced past that page, so Sidekiq's retry — or the next scheduled run — resumed after it instead of re-scanning it. Those blocks would not be reconsidered until the whole ~40,000-row backlog wrapped around, weeks later.

## Build

`app/sidekiq/alert_on_stale_blocks_holding_established_buyers_job.rb` — moved `save_cursor` from immediately-after-fetch to the end of `scan_for_stale_blocks`, reached only if every batch's `settled_purchase_counts`/`reject_disputed`/`linked_to_suspended_account` calls completed without raising. An exception propagates before that line, so the cursor stays at its prior value and the failed page is retried from the same starting id.

`spec/sidekiq/alert_on_stale_blocks_holding_established_buyers_job_spec.rb` — added a regression example: stubs `Purchase.successful` to raise on the first run, asserts the cursor is untouched, then lets the query succeed and asserts the retry re-scans (and reports) the same block.

## Ship

**Test Results:** `bundle exec rspec spec/sidekiq/alert_on_stale_blocks_holding_established_buyers_job_spec.rb` → **27 examples, 0 failures**.

Mutation-verified: reverted `save_cursor` to the old post-fetch call site (before the batches loop) — the new example fails (`Expected "125" to be nil`), confirming it actually pins the fix. Restored and re-ran clean.

Rubocop clean on both changed files.

**QA steps:** Sidekiq reporting job with no rendered surface — no preview/screenshot obligation. Verified by the regression spec exercising the actual failure path (an injected raise mid-page) rather than by inspection.

Premerge review: clean @ f350da94cfe1691e9349611ddb99e4e0ae034f29

---

🤖 Written by [Hermes Agent](https://github.com/NousResearch/hermes-agent) (`claude-sonnet-5`) as gumclaw.

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: the ball is back with me (still a draft — I'm building it), so I'm taking the assignee back and labelling `working`. I'll re-assign a human and flip to `awaiting-human` once it's genuinely ready again.
<!-- gumclaw-ownership-sweep -->
