### PR TITLE
Fix time-dependent shipment validation failure in purchase_info tracking test

### DIFF
--- a/test/models/purchase_test.rb
+++ b/test/models/purchase_test.rb
@@ -3033,7 +3033,10 @@ class PurchaseTest < ActiveSupport::TestCase
 
   test "#purchase_info returns the tracking url for physical product purchase where order has been shipped with tracking" do
     link, purchase = setup_purchase_info_context
-    link.update_attribute(:is_physical, true)
+    # Shipment's create validation reads the product's paper_trail state at checkout time
+    # (required_delivery_at_checkout?), so the physical flip must land inside that window —
+    # applying it "now" makes the test time-dependent on setup speed.
+    travel_to(purchase.created_at) { link.update_attribute(:is_physical, true) }
     shipment = create_shipment(purchase:, tracking_url: "https://tools.usps.com/go/TrackConfirmAction?qtc_tLabels1=1234567890")
     shipment.mark_shipped
 


### PR DESCRIPTION
## What
`travel_to(purchase.created_at)` around the `is_physical` flip in the purchase_info tracking-url test.

## Why
PR #7051's Test Minitest 1 failed on `purchase_test.rb:3034` — **unrelated to that PR's diff** (profile_data only). #6798 made Shipment's create validation read the product's paper_trail state at checkout time (`required_delivery_at_checkout?`, a 1-second window past `created_at`). This test flips `is_physical` seconds AFTER creating the purchase, so it passes only when setup outruns the window — time-dependent, reproduced deterministically on plain origin/main locally (167s setup → 100% fail).

## Test results
- `rails test test/models/purchase_test.rb:3034`: was 1 error on origin/main locally, now 1 runs / 2 assertions / 0 failures
- Sibling purchase_info shipping tests (no shipment creation, unaffected): green

---
AI disclosure: authored by claude-fable-5 via gumclaw.

Premerge review: clean @ 79c7d734e48b26a51699876282985e002f78f73a
