### PR TITLE
Emit Product JSON-LD on all product pages for merchant-listings eligibility

### DIFF
--- a/app/models/concerns/product/structured_data.rb
+++ b/app/models/concerns/product/structured_data.rb
@@ -14,10 +14,8 @@ module Product::StructuredData
   def structured_data(host: nil)
     if native_type == Link::NATIVE_TYPE_EBOOK
       build_ebook_structured_data(host:)
-    elsif has_displayable_reviews?
-      build_product_structured_data(host:)
     else
-      {}
+      build_product_structured_data(host:)
     end
   end
 
@@ -37,7 +35,9 @@ module Product::StructuredData
           "name" => user.name
         },
         "description" => product_description,
-        "url" => url
+        "url" => url,
+        "image" => social_share_image.presence,
+        "sku" => unique_permalink
       }
 
       work_examples = build_book_work_examples
@@ -49,15 +49,28 @@ module Product::StructuredData
 
     def build_product_structured_data(host: nil)
       url = long_url(host:)
-      {
+      data = {
         "@context" => SCHEMA_ORG_CONTEXT,
         "@type" => "Product",
         "name" => name,
         "description" => product_description,
         "url" => url,
-        "offers" => build_offer_data(url),
-        "aggregateRating" => aggregate_rating_data
-      }.compact
+        "image" => social_share_image.presence,
+        "sku" => unique_permalink,
+        "brand" => brand_data,
+        "offers" => build_offer_data(url)
+      }
+      data["aggregateRating"] = aggregate_rating_data if has_displayable_reviews?
+      data.compact
+    end
+
+    # Seller display name only — never fall back to User#display_name, whose
+    # email fallback would leak the seller's address into public markup.
+    def brand_data
+      brand_name = user.name.presence
+      return if brand_name.nil?
+
+      { "@type" => "Brand", "name" => brand_name }
     end
 
     def build_offer_data(url)

--- a/spec/models/concerns/product/structured_data_spec.rb
+++ b/spec/models/concerns/product/structured_data_spec.rb
@@ -13,8 +13,68 @@ describe Product::StructuredData do
       end
 
       context "without reviews" do
-        it "returns an empty hash" do
-          expect(product.structured_data).to eq({})
+        it "returns a Product schema with an Offer but no aggregateRating" do
+          data = product.structured_data
+
+          expect(data["@context"]).to eq("https://schema.org")
+          expect(data["@type"]).to eq("Product")
+          expect(data["name"]).to eq("My Great Book")
+          expect(data["url"]).to eq(product.long_url)
+          expect(data).not_to have_key("aggregateRating")
+
+          offer = data["offers"]
+          expect(offer["@type"]).to eq("Offer")
+          expect(offer["priceCurrency"]).to eq("USD")
+          expect(offer["price"]).to eq(product.price_cents / 100.0)
+          expect(offer["availability"]).to eq(Product::StructuredData::AVAILABILITY_IN_STOCK)
+          expect(offer["url"]).to eq(product.long_url)
+        end
+
+        it "includes the sku as the unique permalink" do
+          expect(product.structured_data["sku"]).to eq(product.unique_permalink)
+        end
+
+        it "includes the seller name as the brand" do
+          expect(product.structured_data["brand"]).to eq({ "@type" => "Brand", "name" => "John Doe" })
+        end
+
+        context "when the seller has no name" do
+          let(:user) { create(:user, name: nil) }
+
+          it "omits brand" do
+            expect(product.structured_data).not_to have_key("brand")
+          end
+        end
+
+        context "when the product has a cover image" do
+          before do
+            allow(product).to receive(:social_share_image).and_return("https://static-2.gumroad.com/res/gumroad/assets/cover.jpg")
+          end
+
+          it "includes the image" do
+            expect(product.structured_data["image"]).to eq("https://static-2.gumroad.com/res/gumroad/assets/cover.jpg")
+          end
+        end
+
+        context "when the product has no cover image" do
+          it "omits image" do
+            expect(product.structured_data).not_to have_key("image")
+          end
+        end
+
+        context "when the product has no live price" do
+          before do
+            product.prices.alive.each(&:mark_deleted!)
+            product.reload
+          end
+
+          it "omits price but keeps the rest of the offer" do
+            offer = product.structured_data["offers"]
+
+            expect(offer).not_to have_key("price")
+            expect(offer["priceCurrency"]).to eq("USD")
+            expect(offer["availability"]).to eq(Product::StructuredData::AVAILABILITY_IN_STOCK)
+          end
         end
       end
 
@@ -26,8 +86,12 @@ describe Product::StructuredData do
                                        ratings_of_five_count: 4, ratings_of_four_count: 1)
         end
 
-        it "returns an empty hash" do
-          expect(product.structured_data).to eq({})
+        it "returns a Product schema without aggregateRating" do
+          data = product.structured_data
+
+          expect(data["@type"]).to eq("Product")
+          expect(data["offers"]["@type"]).to eq("Offer")
+          expect(data).not_to have_key("aggregateRating")
         end
       end
 


### PR DESCRIPTION
Extends `Product::StructuredData` so **every** product page emits schema.org Product JSON-LD, not just ebooks and products with displayable reviews. This is the markup half of the merchant-listings push (feed already live in Merchant Center); GSC merchant-listings eligibility requires Product+Offer markup on the page.

## Status

- [x] Implementation
- [x] Specs extended + green locally (42 examples, 0 failures)
- [x] Rendered JSON-LD validated against Google merchant-listings required props
- [ ] CI green
- [x] Premerge QA audit — Round 1 at `539ad5f503` — CLEAN (code/specs/consumers/risk all verified)

Premerge review: clean @ 539ad5f503

## What changed

- **Dropped the `else {}` branch** in `structured_data`: non-ebook products without reviews now get `Product` + `Offer` markup instead of nothing. Ebooks keep `Book`; reviewed products keep `aggregateRating`.
- **Enriched with Google-recommended merchant-listing fields**, only where real data exists (each is `.compact`ed / conditional):
  - `image` — `social_share_image` (same source as `og:image`; omitted when the product has no cover)
  - `sku` — `unique_permalink` (already public as `product:retailer_item_id` meta)
  - `brand` — seller name as `Brand` (Product only; the Book type keeps `author`). Uses `user.name` only — deliberately **not** `display_name`, whose fallback chain can leak the seller's email.
- **Unchanged, deliberately:**
  - `aggregateRating` stays strictly conditional on `has_displayable_reviews?` (fake/empty ratings = manual-action risk)
  - nil price → `price` omitted, not 0 (rent-only product whose rental price was removed)
  - `host:` threading for seller custom domains
  - description already sanitized + truncated via `product_description`
  - no invented `priceValidUntil` / `shippingDetails` / `hasMerchantReturnPolicy` for digital goods
- **Page gating:** `PageMeta::Product` only runs when the product page itself renders, so unpublished/deleted products can't emit markup; no new gate needed.

## Coverage change

Before: JSON-LD only on ebook products and products with `display_product_reviews? && reviews_count > 0`. Everything else (verified live: spikyai.gumroad.com/l/ai-art) had **zero** `ld+json` blocks.

After: every rendered product page emits Product (or Book) + Offer.

## Sample rendered JSON-LD (real output from the test env)

```json
{
  "@context": "https://schema.org",
  "@type": "Product",
  "name": "AI Art Masterclass",
  "description": "Learn to make AI art.",
  "url": "http://edgar3257d7d81.test.gumroad.com:31337/l/o",
  "image": "https://public-files.gumroad.com/variants/abc123/cover.png",
  "sku": "o",
  "brand": { "@type": "Brand", "name": "Spiky AI" },
  "offers": {
    "@type": "Offer",
    "priceCurrency": "USD",
    "availability": "https://schema.org/InStock",
    "url": "http://edgar3257d7d81.test.gumroad.com:31337/l/o",
    "price": 15.0
  }
}
```

Validation vs Google merchant-listings requirements: Product requires `name` ✓ plus one of `offers`/`review`/`aggregateRating` ✓; merchant-listing Offer requires `price` ✓ + `priceCurrency` ✓; recommended `availability` ✓, `url` ✓, `image` ✓, `brand` ✓, identifier (`sku`) ✓. No `aggregateRating` emitted without real reviews.

## Specs

`spec/models/concerns/product/structured_data_spec.rb` — 42 examples, 0 failures locally (`RSPEC_EXIT=0`). New coverage: reviewless product gets Product+Offer without aggregateRating; reviews-disabled product same; brand/sku/image present when data exists and absent when not; no-live-price product omits `price` but keeps currency/availability. Ebook and reviewed-product expectations unchanged. The custom-HTML wrapper and custom-domain canonical specs stub/exercise `structured_data` and are unaffected.
