### PR TITLE
Fix legacy SCA line-item mapping to key by uid, not permalink (follow-up to #6750)

### DIFF
--- a/app/javascript/data/order.test.ts
+++ b/app/javascript/data/order.test.ts
@@ -488,8 +488,8 @@ describe("startOrderCreation", () => {
         jsonResponse({
           success: true,
           line_items: {
-            "purchase-first": confirmedPurchase(firstLine.permalink),
-            "purchase-second": confirmedPurchase(secondLine.permalink),
+            [firstLine.uid]: confirmedPurchase(firstLine.permalink),
+            [secondLine.uid]: confirmedPurchase(secondLine.permalink),
           },
           can_buyer_sign_up: false,
           offer_codes: [],
@@ -498,10 +498,9 @@ describe("startOrderCreation", () => {
 
     const result = await startOrderCreation(mixedRequestData, []);
 
-    // The confirm response is keyed by our sent purchase id, not by line uid or permalink,
-    // so the only way to reassociate results is a positional map: request order in,
-    // response values out, matched by index rather than a shared field.
-    expect(Object.keys(result.lineItems)).toEqual([firstLine.uid, secondLine.uid]);
+    // Both lines share a permalink; keying by uid (not permalink) is what keeps them distinct.
+    expect(result.lineItems[firstLine.uid]).toMatchObject({ success: true, permalink: firstLine.permalink });
+    expect(result.lineItems[secondLine.uid]).toMatchObject({ success: true, permalink: secondLine.permalink });
     expect(result.lineItems[firstLine.uid]).not.toBe(result.lineItems[secondLine.uid]);
   });
 });

--- a/app/javascript/data/order.test.ts
+++ b/app/javascript/data/order.test.ts
@@ -275,8 +275,8 @@ describe("startOrderCreation", () => {
         jsonResponse({
           success: true,
           line_items: {
-            purchaseA: confirmedPurchase("product-a"),
-            purchaseB: {
+            [firstLine.uid]: confirmedPurchase("product-a"),
+            [secondLine.uid]: {
               success: false,
               permalink: "product-b",
               error_message: "Invalid variant.",
@@ -445,6 +445,64 @@ describe("startOrderCreation", () => {
     const result = await startOrderCreation(requestData, activeOfferCodes);
 
     expect(result.offerCodes).toEqual([]);
+  });
+
+  it("keeps both confirmed lines when the cart holds two variants of the same product", async () => {
+    vi.stubGlobal("Routes", {
+      orders_path: () => "/orders",
+      confirm_order_path: (id: string) => `/orders/${id}/confirm`,
+    });
+    requestMock.mockReset();
+    getStripeInstanceMock.mockReset();
+    const stripe = typia.assert<Stripe>({});
+    stripe.confirmCardPayment = vi.fn().mockResolvedValue({});
+    getStripeInstanceMock.mockResolvedValue(stripe);
+
+    const firstLine = requestData.lineItems.at(0);
+    if (!firstLine) throw new Error("Missing test line item");
+    const secondLine = { ...firstLine, uid: "variant-b " };
+    const mixedRequestData = { ...requestData, lineItems: [firstLine, secondLine] };
+    requestMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          success: true,
+          line_items: {
+            [firstLine.uid]: {
+              success: true,
+              requires_card_action: true,
+              client_secret: "pi_secret",
+              order: { id: "order-token", stripe_connect_account_id: null },
+            },
+            [secondLine.uid]: {
+              success: true,
+              requires_card_action: true,
+              client_secret: "pi_secret",
+              order: { id: "order-token", stripe_connect_account_id: null },
+            },
+          },
+          can_buyer_sign_up: false,
+          offer_codes: [],
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          success: true,
+          line_items: {
+            "purchase-first": confirmedPurchase(firstLine.permalink),
+            "purchase-second": confirmedPurchase(secondLine.permalink),
+          },
+          can_buyer_sign_up: false,
+          offer_codes: [],
+        }),
+      );
+
+    const result = await startOrderCreation(mixedRequestData, []);
+
+    // The confirm response is keyed by our sent purchase id, not by line uid or permalink,
+    // so the only way to reassociate results is a positional map: request order in,
+    // response values out, matched by index rather than a shared field.
+    expect(Object.keys(result.lineItems)).toEqual([firstLine.uid, secondLine.uid]);
+    expect(result.lineItems[firstLine.uid]).not.toBe(result.lineItems[secondLine.uid]);
   });
 });
 

--- a/app/javascript/data/order.ts
+++ b/app/javascript/data/order.ts
@@ -154,9 +154,9 @@ export const startOrderCreation = async (
         requiresCardAction,
         retryOfferCodeCandidates(requestData, retryOfferCodes),
       );
-      const lineItemResults = Object.values(orderConfirmResponse.line_items);
+      // Key by uid, not permalink, which collides when the cart holds two variants of one product.
       const lineItems = requestData.lineItems.reduce<CartPurchaseResult["lineItems"]>((lineItems, lineItem) => {
-        const resultItem = lineItemResults.find((item) => item.permalink === lineItem.permalink);
+        const resultItem = orderConfirmResponse.line_items[lineItem.uid];
         if (resultItem) lineItems[lineItem.uid] = resultItem;
         return lineItems;
       }, {});


### PR DESCRIPTION
Follow-up to #6750.

## Stages

- [x] Scope
- [x] Design
- [x] Build
- [ ] Ship
- [ ] Market
- [ ] Sell

## What

Fixes a Greptile P1 flagged on #6750 after merge (review comment [3701884484](https://github.com/antiwork/gumroad/pull/6750#discussion_r3701884484)): the legacy SCA order-confirmation path in `startOrderCreation` matched the confirm response back to cart lines by `permalink` via `Object.values(...).find(...)`. A cart with two distinct lines for the same product (two variants) has both lines share a permalink, so both selected the first match and the second line's confirmed/failed result was silently dropped.

## Why

The server (`OrdersController#offer_codes_after_payment`, `purchase_responses.dig(_1[:uid], ...)`) already keys confirm/finalize responses by cart-line `uid`, which is unique per line even when permalinks collide. Index the client-side result the same way instead of re-deriving a lookup that assumes permalink uniqueness.

## Fix

`app/javascript/data/order.ts`: `orderConfirmResponse.line_items[lineItem.uid]` replaces the `Object.values(...).find(item => item.permalink === lineItem.permalink)` scan.

`app/javascript/data/order.test.ts`: the existing "sends failed-line code candidates for server revalidation after SCA" test had its mock confirm response keyed by arbitrary strings (`purchaseA`/`purchaseB`) rather than the real line uids — a stale fixture that couldn't have caught this bug. Repointed it to the actual line uids, and added a new test ("keeps both confirmed lines when the cart holds two variants of the same product") asserting both same-permalink lines resolve to distinct results.

Round 2 (Greptile P1, addressed): the new two-variant test's confirm-response mock was itself keyed by arbitrary strings (`purchase-first`/`purchase-second`) that matched neither line's uid, so both results fell back to failure and the assertion passed without exercising the fix. Repointed the mock to the real uids and asserted both lines resolve to distinct successful results (matching the correct fixture pattern already used elsewhere in this file). Mutation-checked: reverting the fix to the old permalink-`find` lookup fails this test (32/33 pass, this one fails) while the fix keeps it green.

## Test Results

`npx vitest run app/javascript/data/order.test.ts` — 33 passed, 0 failed, at the current head (`ad508556`).

Mutation check: reverted `order.ts`'s uid lookup back to the old `Object.values(...).find(permalink match)` — 32/33 pass, with exactly the two-variant test failing (`AssertionError: expected { success: true } not to be { success: true }` — the same-permalink collision). Restored the fix; re-ran clean at 33/33.

`npx eslint app/javascript/data/order.ts app/javascript/data/order.test.ts` — pre-existing errors only (missing generated `$app/utils/routes` in this fresh worktree; confirmed environmental by running the same lint against an unmodified sibling file, `app/javascript/data/purchase.ts`, which shows the identical error class on lines never touched).

## QA steps

No rendered surface — client-side data-mapping fix inside the legacy (non-Payment-Element-client-confirm) SCA retry path. Verified via the unit test above, which exercises the exact code path with two same-permalink lines, and via the mutation check above proving the test actually pins the fix.

---

**AI disclosure:** This PR was authored autonomously by an AI agent (gumclaw, running Hermes Agent on claude-sonnet-5).

Premerge review: clean @ ad5085568dbfd39546146f0b1c32a2637c5c5d46
