### PR TITLE
Merchant Center feed: use cache-only rate lookup, matching structured data

### DIFF
--- a/app/services/merchant_center_feed_service.rb
+++ b/app/services/merchant_center_feed_service.rb
@@ -136,13 +136,17 @@ class MerchantCenterFeedService
 
     # Rates are memoized per feed run: one Redis lookup per currency instead of one per
     # product, and every item in a run converts at the same rate.
+    #
+    # cached_rate, not get_rate: the landing page's structured data reads cache-only too
+    # (Product::StructuredData#usd_offer_price_cents), so a rate cache miss excludes the
+    # product from the feed instead of showing a different price there than on its own page.
     def usd_price_cents(product)
       currency = product.price_currency_type.to_s.downcase
       return product.price_cents if currency == "usd"
 
       rate = @usd_rates.fetch(currency) do
         @usd_rates[currency] = begin
-          get_rate(currency)
+          cached_rate(currency)
         rescue StandardError => e
           Rails.logger.error("MerchantCenterFeedService: no USD rate for #{currency}, excluding its products (#{e.class}: #{e.message})")
           nil

--- a/spec/services/merchant_center_feed_service_spec.rb
+++ b/spec/services/merchant_center_feed_service_spec.rb
@@ -44,8 +44,9 @@ describe MerchantCenterFeedService do
 
     it "converts non-USD prices to USD with checkout's rate source" do
       create_eligible_product(price_currency_type: "eur", price_cents: 2600)
+      Redis::Namespace.new(:currencies, redis: $redis).set("EUR", "0.81127")
 
-      # 26.00 EUR at the test-fixture rate (0.81127 EUR/USD) — same conversion
+      # 26.00 EUR at the cached rate (0.81127 EUR/USD) — same conversion
       # get_usd_cents performs at checkout.
       expect(g_field(items(service.generate).first, "price")).to eq "32.05 USD"
     end
@@ -72,9 +73,17 @@ describe MerchantCenterFeedService do
 
     it "excludes non-USD products when no conversion rate is available" do
       create_eligible_product(price_currency_type: "eur", price_cents: 2600)
-      allow(service).to receive(:get_rate).and_raise(StandardError)
+      Redis::Namespace.new(:currencies, redis: $redis).del("EUR")
 
       expect(items(service.generate)).to be_empty
+    end
+
+    it "excludes non-USD products rather than falling through to a live rate fetch on a cache miss" do
+      create_eligible_product(price_currency_type: "eur", price_cents: 2600)
+      Redis::Namespace.new(:currencies, redis: $redis).del("EUR")
+      expect(service).not_to receive(:query_rate)
+
+      service.generate
     end
 
     it "escapes XML-unsafe characters in product fields" do
@@ -163,8 +172,9 @@ describe MerchantCenterFeedService do
 
     it "converts single-unit currency prices to USD" do
       create_eligible_product(price_currency_type: "jpy", price_cents: 500)
+      Redis::Namespace.new(:currencies, redis: $redis).set("JPY", "78.3932")
 
-      # 500 JPY at the test-fixture rate (78.3932 JPY/USD).
+      # 500 JPY at the cached rate (78.3932 JPY/USD).
       expect(g_field(items(service.generate).first, "price")).to eq "6.38 USD"
     end
 


### PR DESCRIPTION
Follow-up to the merged #7062. Fixes the third Greptile P1 (bot-review-app P1, not a human ask) raised after that PR was merged: a cold rate cache let the feed publish a USD price while the landing page's JSON-LD used the same rate cache-only and fell back to the native price for the same product.

- [x] Scope
- [x] Design
- [x] Build
- [ ] Ship
- [ ] Market
- [ ] Sell

## Problem
`MerchantCenterFeedService#usd_price_cents` read the exchange rate via `CurrencyHelper#get_rate`, which fetches a live rate on a cache miss. `Product::StructuredData#usd_offer_price_cents` (added in #7062) reads the same rate via the new cache-only `cached_rate` and falls back to the product's native price/currency on a miss. So on a cold cache the feed could still emit `32.05 USD` for a €26 product while its own landing page's structured data showed `26.0 EUR` — the exact feed/landing-page price mismatch #7062 was written to eliminate.

## Fix
`usd_price_cents` now reads through `cached_rate` instead of `get_rate`. Both surfaces share one rate-availability policy: a cold cache excludes the product from the feed (fail-closed, same as before) rather than disagreeing with the product's own page. `UpdateCurrenciesWorker` keeps the cache warm, so this rarely changes feed output in practice.

## QA steps
Backend-only change with no rendered/clickable surface — `usd_price_cents` feeds an XML export consumed by Google Merchant Center, not a page a reviewer can click through. Preview app: https://gc-mc-feed-cache-only-rate.apps.staging.gumroad.org (200 OK, unchanged behavior on a warm cache — the diff only changes what happens on a cold-cache miss, which the preview's warm `UpdateCurrenciesWorker` cache does not exercise). Reviewer path: read the one-line diff in `app/services/merchant_center_feed_service.rb`, then run the spec below.

## Tests
`bundle exec rspec spec/services/merchant_center_feed_service_spec.rb` — 2 pre-existing examples updated to seed the Redis rate cache directly (`Redis::Namespace.new(:currencies, ...).set/del`) instead of relying on VCR-backed `get_rate`/mocking it to raise, plus a new example asserting `query_rate` is never called on a cache miss. `spec/models/concerns/product/structured_data_spec.rb` — 45 examples, 0 failures (unchanged by this diff, run to confirm no regression). The service spec's other 20 examples fail identically on the pre-fix head with `We couldn't charge your card` on an unrelated factory helper — not caused by this diff (same environmental failure noted in #7062).

Mutation-verified: reverting `cached_rate` back to `get_rate` in `usd_price_cents` fails the new "never calls query_rate on a cache miss" probe.

---

## AI disclosure
This PR was written autonomously by an AI agent (claude-sonnet-5) with no human review of the code before this PR was opened. Prompts given to the agent: standing instruction to act on Greptile P1 findings raised against merged PR #7062.

Premerge review: clean @ 06b6edac0fc84cdc619a75a977b41129e2e6ce46
