### PR TITLE
Fix: pre-send events could suppress the undelivered-receipt alert

### DIFF
--- a/app/services/undelivered_receipt_notifier.rb
+++ b/app/services/undelivered_receipt_notifier.rb
@@ -131,7 +131,7 @@ class UndeliveredReceiptNotifier
     email_infos = purchase.receipt_email_infos.to_a
     email_infos = [purchase.receipt_email_info].compact if email_infos.empty?
     return false if email_infos.empty?
-    return false if email_infos.any? { _1.delivered_at.present? || _1.opened_at.present? }
+    return false if email_infos.any? { confirmed_delivery?(_1) }
 
     # The newest send decides timing and state: an older settled send must not make a resend that is
     # still inside its grace window reportable, and the seller acts on the latest attempt.
@@ -141,6 +141,16 @@ class UndeliveredReceiptNotifier
 
     !accessed_content?(purchase)
   end
+
+  # A delivery/open event that predates a row's own `sent_at` did not confirm that row: it landed here
+  # only because `CustomerEmailInfo.newest_sent_before` falls back to the newest row when the event
+  # predates every recorded send, not because this send earned it (gumroad-private#1635).
+  def self.confirmed_delivery?(email_info)
+    return false if email_info.sent_at.blank?
+
+    [email_info.delivered_at, email_info.opened_at].compact.any? { _1 >= email_info.sent_at }
+  end
+  private_class_method :confirmed_delivery?
 
   # Free downloads are excluded because every action this notice prescribes assumes money changed
   # hands: there is nothing to refund, and a free-checkout address the buyer typed wrong is not a

--- a/spec/services/undelivered_receipt_notifier_spec.rb
+++ b/spec/services/undelivered_receipt_notifier_spec.rb
@@ -34,12 +34,21 @@ describe UndeliveredReceiptNotifier do
       expect(described_class.undelivered?(purchase)).to eq(false)
     end
 
-    # A delivery timestamp is evidence the buyer got the email whatever the state column says, and a
-    # resend leaves exactly that shape while the row sits back at `sent`.
-    it "is false for a row back at sent that still carries a delivery timestamp" do
-      settled_receipt("sent", delivered_at: 4.days.ago)
+    # A delivery timestamp on or after the send is evidence the buyer got the email whatever the state
+    # column says, and a resend leaves exactly that shape while the row sits back at `sent`.
+    it "is false for a row back at sent that still carries a delivery timestamp on or after the send" do
+      settled_receipt("sent", delivered_at: 2.days.ago)
 
       expect(described_class.undelivered?(purchase)).to eq(false)
+    end
+
+    # `CustomerEmailInfo.newest_sent_before` falls back to the newest row when an event predates every
+    # recorded send, so a pre-send event can populate `delivered_at`/`opened_at` on a row that never
+    # earned it. That timestamp must not count as confirmation (gumroad-private#1635).
+    it "is true when the only delivery/open timestamp predates the send" do
+      settled_receipt("sent", delivered_at: 4.days.ago, opened_at: 4.days.ago)
+
+      expect(described_class.undelivered?(purchase)).to eq(true)
     end
 
     # Delivery events land in minutes but content access does not, so judging early would report a
@@ -73,14 +82,14 @@ describe UndeliveredReceiptNotifier do
     # the seller was told a delivered receipt was undelivered.
     context "with more than one send on the same receipt" do
       it "is false when an earlier send was delivered and the resend bounced" do
-        settled_receipt("delivered", delivered_at: 4.days.ago)
+        settled_receipt("delivered", delivered_at: 2.days.ago)
         settled_receipt("bounced")
 
         expect(described_class.undelivered?(purchase)).to eq(false)
       end
 
       it "is false when an earlier send was opened and the resend is still only sent" do
-        settled_receipt("opened", opened_at: 4.days.ago)
+        settled_receipt("opened", opened_at: 2.days.ago)
         settled_receipt("sent")
 
         expect(described_class.undelivered?(purchase)).to eq(false)


### PR DESCRIPTION
## What

Follow-up to #6741 (merged): a P1 Greptile flagged on that PR (review [4842813089](https://github.com/antiwork/gumroad/pull/6741#pullrequestreview-4842813089), comment [3702900698](https://github.com/antiwork/gumroad/pull/6741#discussion_r3702900698)) went unreplied before merge. Verified live on `origin/main`.

`CustomerEmailInfo.newest_sent_before` falls back to the newest row when a delivery/open event predates every recorded send. `UndeliveredReceiptNotifier.undelivered?` then read that row's `delivered_at`/`opened_at` as confirmation, so a pre-send event could suppress the seller alert for a receipt that was never actually confirmed delivered.

## Fix

`undelivered?` now only counts a delivery/open timestamp as confirmation when it is on or after that row's own `sent_at`.

## Test Results

```
bundle exec rspec spec/services/undelivered_receipt_notifier_spec.rb
29 examples, 0 failures
```

Two pre-existing fixtures in the "more than one send" context set `delivered_at`/`opened_at` before the row's own `sent_at`, which the new check correctly flags — fixed them to be temporally consistent (delivered/opened after the send, still before the resend).

Mutation-verified: reverting to the raw `.present?` check reproduces the exact P1 and fails only the new regression example; restored, re-ran clean (29/29).

Rubocop clean on both touched files.

## QA steps

1. `bundle exec rspec spec/services/undelivered_receipt_notifier_spec.rb` — green.
2. A receipt sent, then a delivery/open event stamped before that send (routed here only via the newest-row fallback): `UndeliveredReceiptNotifier.undelivered?` now returns `true` instead of `false`.

## Status

- [x] Scope — one confirmation check in `UndeliveredReceiptNotifier.undelivered?`.
- [x] Design — accept a delivery/open timestamp only when it is on or after the row's own `sent_at`.
- [x] Build — done.
- [x] QA — spec green (29/29), mutation-killed.
- [ ] Shipped — not merged.
- [ ] Market — n/a, internal correctness fix, no announceable surface.
- [ ] Sell — n/a.

---

**AI disclosure.** Written by gumclaw, an autonomous agent running on claude-sonnet-5 via the Hermes agent runtime, responding to a Greptile P1 on PR #6741's own diff that went unreplied before merge.


Premerge review: clean @ 64aa02efcbca18d6f623054aa809774a05deb44a
