### PR TITLE
Signup: check all holders of an email, not just one row, before claiming it's deleted-held

### DIFF
--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -130,8 +130,10 @@ class SignupController < Devise::RegistrationsController
 
       return unless params[:user] && params[:user][:password].present? && params[:user][:email].present?
 
-      user = User.find_by(email: params[:user][:email])
-      return unless user
+      holders = User.by_email(params[:user][:email])
+      return if holders.empty?
+
+      user = holders.find { |holder| !holder.deleted? } || holders.first
 
       if !user.deleted? && user.try(:valid_password?, params[:user][:password])
         sign_in_or_prepare_for_two_factor_auth(user)
@@ -140,7 +142,9 @@ class SignupController < Devise::RegistrationsController
           format.json { render json: { success: true, redirect_location: login_path_for(user) } }
         end
       else
-        message = user.deleted? ? User::DELETED_ACCOUNT_HOLDS_EMAIL_ERROR : "An account already exists with this email."
+        # Mirror User::Validations#email_almost_unique: only claim the address is
+        # deleted-held when EVERY holder is deleted, not just the one row we picked.
+        message = holders.all?(&:deleted?) ? User::DELETED_ACCOUNT_HOLDS_EMAIL_ERROR : "An account already exists with this email."
         respond_to do |format|
           format.html { redirect_with_signup_error(message) }
           format.json { render json: { success: false, error_message: message } }

--- a/spec/controllers/signup_controller_spec.rb
+++ b/spec/controllers/signup_controller_spec.rb
@@ -166,10 +166,17 @@ describe SignupController, type: :controller, inertia: true do
         expect(response.parsed_body["error_message"]).to eq(User::DELETED_ACCOUNT_HOLDS_EMAIL_ERROR)
       end
 
-      it "still says the account already exists when a live account holds the email" do
+      # The deleted holder is created FIRST (in the outer `before`) so an unordered/
+      # single-row lookup that just inspects whichever holder it finds first would
+      # report "deleted" and hand this visitor the wrong message even though they
+      # collide with a real, live account.
+      it "still says the account already exists when the same email is also held by a live account" do
         live = create(:user, password: "password")
+        live_email = live.email
+        @deleted.update_columns(email: live_email)
+        expect(User.by_email(live_email).order(:id).pluck(:deleted_at).map(&:present?)).to eq([true, false])
 
-        post "create", params: { user: { email: live.email, password: "wrongpassword" } }
+        post "create", params: { user: { email: live_email, password: "wrongpassword" } }
 
         expect(flash[:warning]).to eq("An account already exists with this email.")
       end


### PR DESCRIPTION
## What
`SignupController#create`'s duplicate-account-message logic used `User.find_by(email:)`, which
returns a single, unordered row. When two accounts share an email (one deleted, one live), the
lookup could non-deterministically return the deleted holder and tell a colliding visitor "an
account already exists with this email — [contact support, it was deleted]" even though a live
account also holds that address.

This mirrors `User::Validations#email_almost_unique`, which already treats an address as
deleted-held only when **every** matching holder is deleted. `SignupController` did not honor
that invariant.

## Why
Cherry-picked from `gp1758-deleted-account-email-messaging` (merged as #6909) — this is a P1
found by Greptile during that PR's review and pushed after #6909 had already merged, so it was
never itself reviewed or shipped. Original branch is being deleted; this is the un-reviewed delta
taken to its own PR per policy.

## Change
- `User.by_email(email)` (existing scope) instead of `find_by`, collecting **all** holders.
- Pick the first non-deleted holder for auth; fall back to any holder only to preserve prior
  "not found" behavior.
- Claim `DELETED_ACCOUNT_HOLDS_EMAIL_ERROR` only when `holders.all?(&:deleted?)`.

## Test Results
```
bundle exec rspec spec/controllers/signup_controller_spec.rb -e "deleted"
3 examples, 0 failures
```
Includes a new case: deleted holder created first, live holder shares the same email afterward —
asserts the flash still reads "An account already exists with this email." (not the deleted-account
message).

Note: 6 unrelated pre-existing failures in this spec file are a Vite/esbuild syntax error in
`EmailConfirmationBanner.tsx` (asset pipeline, unrelated to this change, reproduces on `origin/main`
too).

## QA steps
1. Create user A, soft-delete it.
2. Create user B with the same email as A (bypassing uniqueness validation, e.g. via console) so
   both a deleted and a live holder share the address.
3. POST to `/signup` with that email and a wrong password.
4. Expect: "An account already exists with this email." — NOT the deleted-account message.

## AI disclosure
Cherry-picked and shipped autonomously by gumclaw (Hermes agent) from a pushed-but-unreviewed
commit. Verified locally by running the target specs (not merely reading them) before opening
this PR.

## Review
`autoreview` (codex/gpt-5.6-sol, `--max-priority P1`) ran clean at `fe2d683f9d5ddf43bacef646469c3a9715a4f0ed`:
"patch is correct (0.93) — consistently considers all users holding the submitted email, prefers
a non-deleted holder for authentication, and only emits the deleted-account message when every
matching holder is deleted. The added regression test directly covers the mixed deleted/live-holder
case. No P0 or P1 defect is demonstrated by the bundle." No findings to disposition.

Premerge review: clean @ fe2d683f9d5ddf43bacef646469c3a9715a4f0ed