### PR TITLE
Fix mobile embed seed to upsert Lesson 1 page on rerun

### DIFF
--- a/db/seeds/030_development/mobile_app_test_data.rb
+++ b/db/seeds/030_development/mobile_app_test_data.rb
@@ -91,11 +91,11 @@ end
 # HTTPS one — the content page turns `attrs.url` into an anchor href and RichContent rejects the
 # script-bearing schemes, so a placeholder like "embed://x" would not save.
 def create_mobile_embed_page(product:, title:)
-  existing = product.alive_rich_contents.find_by(title:)
-  return existing if existing.present?
-
-  product.alive_rich_contents.create!(
-    title:,
+  # Upsert, not create-if-missing: this page's whole purpose is to hold the mediaEmbed node, so a
+  # pre-existing page from an earlier seed run (with different content) must be overwritten rather
+  # than left stale, or the fixture silently stops exercising WebView playback.
+  page = product.alive_rich_contents.find_or_initialize_by(title:)
+  page.update!(
     description: [
       {
         "type" => "mediaEmbed",
@@ -107,6 +107,7 @@ def create_mobile_embed_page(product:, title:)
       }
     ]
   )
+  page
 end
 
 seller1 = create_mobile_user(


### PR DESCRIPTION
## What

`create_mobile_embed_page` in `db/seeds/030_development/mobile_app_test_data.rb` (from #6914,
merged) was create-if-missing: if a `Lesson 1` page already existed from an earlier seed run, its
content was left untouched on rerun. Greptile's finding on #6914 (comment
[5164973077](https://github.com/antiwork/gumroad/pull/6914#issuecomment-5164973077)) was correct
and unaddressed at merge — the PR's own body flagged this as owed work before hand-off.

## Why

The fixture's whole point is a `mediaEmbed` node for the mobile WebView-playback Maestro flow
(gumroad-mobile#342). A stale pre-existing page can silently drop that node, so the fixture stops
exercising the path it exists to test — with no error on seed run.

## Before/After

Before: `find_by(title:)` returns any existing page as-is; a stale page's content is never touched.
After: `find_or_initialize_by(title:)` + `update!` — the description is always (re)written to the
required mediaEmbed node, whether the page is new or pre-existing.

## Test Results

Ran an isolated probe against a live dev DB (not the seed file directly, to avoid mutating shared
fixtures): created a product with a pre-existing "stale" `Lesson 1` page (a plain paragraph node,
no mediaEmbed), then called the patched `create_mobile_embed_page` against it inside a rolled-back
transaction.

- `page.id == stale.id` → `true` (same row upserted, not a duplicate create)
- `node_types` → `["mediaEmbed"]`
- `contains_mediaEmbed` → `true`
- `total_pages` for the product → `1` (no duplicate page)

`ruby -c` clean on the seed file.

## QA steps

N/A — dev-only seed data, no rendered surface. Confirmed via the DB probe above that a stale
existing page is repaired to contain the required embed node on rerun.

---

Premerge review: clean @ 96710718fe94ecaa0bfefb44f50fc1f056696213

## AI disclosure

Built autonomously by Hermes Agent (claude-sonnet-5) in response to an unresolved Greptile P1 on
the now-merged #6914.

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: the ball is back with me (still a draft — I'm building it; CI still running (6 checks) — settle before handing off), so I'm taking the assignee back and labelling `working`. I'll re-assign a human and flip to `awaiting-human` once it's genuinely ready again.
<!-- gumclaw-ownership-sweep -->
