### PR TITLE
Render the Facebook domain-verification tag in the custom-HTML profile wrapper

### DIFF
--- a/app/controllers/concerns/custom_domain_config.rb
+++ b/app/controllers/concerns/custom_domain_config.rb
@@ -28,7 +28,8 @@ module CustomDomainConfig
   # set_meta_tag — both render sites read this to stay in sync.
   def facebook_domain_verification_content(user)
     return unless user&.enable_verify_domain_third_party_services? && user.facebook_meta_tag.present?
-    user.facebook_meta_tag[/content="([^"]+)"/, 1]
+    # facebook_meta_tag_is_valid (app/modules/user/validations.rb) accepts either quote style, so both must be extracted here.
+    user.facebook_meta_tag[/content=(["'])([^"']+)\1/, 2]
   end
 
   private

--- a/app/controllers/concerns/custom_domain_config.rb
+++ b/app/controllers/concerns/custom_domain_config.rb
@@ -16,13 +16,19 @@ module CustomDomainConfig
       set_user_by_domain
 
       set_meta_tag(title: @user.try(:name_or_username))
-      if @user.enable_verify_domain_third_party_services? && @user.facebook_meta_tag.present?
-        content = @user.facebook_meta_tag[/content="([^"]+)"/, 1]
-        set_meta_tag(name: "facebook-domain-verification", content:) if content
+      if (content = facebook_domain_verification_content(@user))
+        set_meta_tag(name: "facebook-domain-verification", content:)
       end
 
       @body_class = "custom-domain"
     end
+  end
+
+  # The custom-HTML wrapper builds its own <head>, so it can't rely on
+  # set_meta_tag — both render sites read this to stay in sync.
+  def facebook_domain_verification_content(user)
+    return unless user&.enable_verify_domain_third_party_services? && user.facebook_meta_tag.present?
+    user.facebook_meta_tag[/content="([^"]+)"/, 1]
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -312,6 +312,12 @@ class UsersController < ApplicationController
         share_image_tags << %(<meta property="twitter:image:alt" content="#{alt}">)
       end
       share_image_tags = share_image_tags.join("\n    ")
+      fb_verification_content = facebook_domain_verification_content(user)
+      fb_verification_tag = if fb_verification_content
+        %(<meta name="facebook-domain-verification" content="#{ERB::Util.h(fb_verification_content)}">)
+      else
+        ""
+      end
       live_reload = if current_seller_owns_profile?
         custom_html_live_reload_script(version_src: profile_landing_src(user, "version"), nonce:)
       else
@@ -329,6 +335,7 @@ class UsersController < ApplicationController
             <meta property="og:type" content="profile">
             <meta property="og:url" content="#{canonical}">
             #{share_image_tags}
+            #{fb_verification_tag}
             #{profile_custom_html_analytics_head(user)}
             <meta name="csrf-token" content="#{CsrfTokenInjector::TOKEN_PLACEHOLDER}">
             <style>html,body{margin:0;padding:0;height:100%;overflow:hidden}iframe{display:block;width:100%;height:100%;border:0}</style>

--- a/spec/controllers/users_controller_custom_html_spec.rb
+++ b/spec/controllers/users_controller_custom_html_spec.rb
@@ -67,6 +67,15 @@ describe UsersController, :vcr, type: :controller do
         expect(response.body).to include(%(src="/landing/embed"))
         expect(response.body).not_to include(%(name="facebook-domain-verification"))
       end
+
+      it "renders the tag when the saved tag uses single quotes" do
+        seller.update!(facebook_meta_tag: "<meta name='facebook-domain-verification' content='abc123verifycode' />")
+
+        get :show
+
+        expect(response.body).to include(%(src="/landing/embed"))
+        expect(response.body).to include(%(<meta name="facebook-domain-verification" content="abc123verifycode">))
+      end
     end
 
     it "embeds the trusted products-wrapper listener with the landing products endpoint" do

--- a/spec/controllers/users_controller_custom_html_spec.rb
+++ b/spec/controllers/users_controller_custom_html_spec.rb
@@ -42,6 +42,33 @@ describe UsersController, :vcr, type: :controller do
       expect(response.body).to include("STORE_HOSTNAMES")
     end
 
+    describe "facebook-domain-verification meta tag" do
+      before do
+        seller.update!(
+          enable_verify_domain_third_party_services: true,
+          facebook_meta_tag: '<meta name="facebook-domain-verification" content="abc123verifycode" />'
+        )
+        CustomDomain.create(domain: "fb-verify-wrapper.example.com", user: seller)
+        @request.host = "fb-verify-wrapper.example.com"
+      end
+
+      it "renders the tag in the hand-built wrapper head on a custom domain" do
+        get :show
+
+        expect(response.body).to include(%(src="/landing/embed"))
+        expect(response.body).to include(%(<meta name="facebook-domain-verification" content="abc123verifycode">))
+      end
+
+      it "does not render the tag when domain verification is disabled" do
+        seller.update!(enable_verify_domain_third_party_services: false)
+
+        get :show
+
+        expect(response.body).to include(%(src="/landing/embed"))
+        expect(response.body).not_to include(%(name="facebook-domain-verification"))
+      end
+    end
+
     it "embeds the trusted products-wrapper listener with the landing products endpoint" do
       get :show
       expect(response.body).to include("data-gumroad-products-wrapper")


### PR DESCRIPTION
## What

Sellers with BOTH a custom landing page (`custom_html`) AND Facebook domain verification enabled never actually serve the `facebook-domain-verification` meta tag — `render_custom_html_if_present` short-circuits `UsersController#show` with a hand-built `<head>` that skipped it entirely, while the Settings page shows the tag saved and enabled. Meta/Facebook Business Manager can't verify the domain (live case: gumroad-private#1861, seller domain confirmed serving no tag via `curl -L`).

This extracts the flag+content check from `CustomDomainConfig#set_user_and_custom_domain_config` into a shared `facebook_domain_verification_content(user)` helper and emits the tag in `profile_custom_html_wrapper_document`'s head, so both render paths read one predicate.

## Why

The upstream `set_meta_tag(name: "facebook-domain-verification", …)` only feeds the standard Rails layout head; the custom-HTML wrapper document bypasses it. Any custom-landing-page seller on a custom domain silently loses Meta domain verification with no error anywhere.

## Before → After

Served `<head>` on a custom domain for a seller with `enable_verify_domain_third_party_services: true` + `facebook_meta_tag` set + `custom_html` present (real controller render, dumped from `response.body`):

| | `<meta name="facebook-domain-verification" …>` in served head |
|---|---|
| Before (origin/main wrapper — proven by revert run below) | **absent** |
| After (this branch) | `<meta name="facebook-domain-verification" content="abc123verifycode">` (line 11 of the wrapper head) |

No pixel changes — the diff is one invisible meta tag in the wrapper `<head>`; there is genuinely no rendered surface to screenshot. The confirming evidence is the served-DOM assertion in the new specs plus the head dump above.

## Test Results

- `spec/controllers/users_controller_custom_html_spec.rb` — **37 examples, 0 failures** (includes the 2 new examples: tag renders on custom domain; tag absent when verification disabled)
- `spec/controllers/users_controller_spec.rb:310` + `:322` (pre-existing facebook-domain-verification examples on the standard profile path) — **2 examples, 0 failures** (shared-helper refactor is behavior-neutral there)
- Revert proof: removing the `#{fb_verification_tag}` interpolation from the wrapper head reddens the new positive example (`2 examples, 1 failure`) and restoring it greens — the spec pins the fix, not the fixture
- Review round (Greptile P1, fixed at `00a53149a`): the extractor only matched double-quoted `content="…"` while the model validation accepts either quote style — now matches both, with a single-quoted regression spec; facebook-domain-verification examples **3 examples, 0 failures** at head
- `ruby -c` clean on all three touched files

Premerge review: clean @ 00a53149adad1a03d673800259b3469a9ea74051

## QA steps

Backend/head-only change, no clickable surface. Reviewer path: read the diff (3 files); optionally in console for any custom-landing-page seller with the flag on, `curl -s https://<custom-domain>/ | grep facebook-domain-verification` post-deploy should return the tag. For the reported seller (zashavelle.store) that exact probe currently returns nothing and should return their saved code after deploy.

## Not in this PR

`UserPagesController#page_custom_html_wrapper_document` (slugged custom pages) and `LinksController#custom_html_wrapper_document` (product landing pages) also hand-build heads without the tag. Facebook's crawler verifies the domain root, which is the profile wrapper — those surfaces don't gate verification. The shared helper makes adding it there a one-liner if ever wanted.

---

🤖 AI-generated (claude-sonnet-5, Hermes Agent). Instructions: autonomous dev dispatcher picked up gumroad-private#1861 (Facebook domain-verification tag never renders when seller has a custom landing page); root cause was pre-diagnosed in the issue by a support investigation; fix implemented per the issue's suggestion with a shared predicate instead of duplicating the check.





